### PR TITLE
adding `no_cuda` flag

### DIFF
--- a/extract_features.py
+++ b/extract_features.py
@@ -211,6 +211,7 @@ def main():
     parser.add_argument("--do_lower_case", default=True, action='store_true', 
                         help="Whether to lower case the input text. Should be True for uncased "
                             "models and False for cased models.")
+    parser.add_argument("--no_cuda", default=False, type=bool, help="Is cuda available?")
     parser.add_argument("--batch_size", default=32, type=int, help="Batch size for predictions.")
     parser.add_argument("--local_rank",
                         type=int,


### PR DESCRIPTION
The `--no_cuda` flag is missing from the flagset in `extract_features.py`. On running the current code, the following error occurs.

```
(py3.5) [rahul pytorch-pretrained-BERT]$ python extract_features.py \
>   --input_file=./input.txt \
>   --output_file=./output.jsonl \
>   --vocab_file=$BERT_BASE_DIR/vocab.txt \
>   --bert_config_file=$BERT_BASE_DIR/bert_config.json \
>   --init_checkpoint=$BERT_BASE_DIR/pytorch_model.bin \
>   --layers=-4 \
>   --max_seq_length=128 \
>   --batch_size=8
Traceback (most recent call last):
  File "extract_features.py", line 306, in <module>
    main()
  File "extract_features.py", line 223, in main
    device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
AttributeError: 'Namespace' object has no attribute 'no_cuda'
```