### PR TITLE
Fix ineffective no_decay bug when using BERTAdam

### DIFF
--- a/examples/run_classifier.py
+++ b/examples/run_classifier.py
@@ -503,8 +503,8 @@ def main():
         param_optimizer = list(model.named_parameters())
     no_decay = ['bias', 'gamma', 'beta']
     optimizer_grouped_parameters = [
-        {'params': [p for n, p in param_optimizer if n not in no_decay], 'weight_decay_rate': 0.01},
-        {'params': [p for n, p in param_optimizer if n in no_decay], 'weight_decay_rate': 0.0}
+        {'params': [p for n, p in param_optimizer if not any(nd in n for nd in no_decay)], 'weight_decay_rate': 0.01},
+        {'params': [p for n, p in param_optimizer if any(nd in n for nd in no_decay)], 'weight_decay_rate': 0.0}
         ]
     optimizer = BertAdam(optimizer_grouped_parameters,
                          lr=args.learning_rate,


### PR DESCRIPTION
With the original code, all parameters are decayed because the condition "parameter_name in no_decay" will never be satisfied.