### PR TITLE
Fixed UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ from pytorch_pretrained_bert import BertTokenizer, BertModel, BertForMaskedLM
 tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
 
 # Tokenized input
-tokenized_text = "Who was Jim Henson ? Jim Henson was a puppeteer"
+text = "Who was Jim Henson ? Jim Henson was a puppeteer"
 tokenized_text = tokenizer.tokenize(text)
 
 # Mask a token that we will try to predict back with `BertForMaskedLM`

--- a/pytorch_pretrained_bert/tokenization.py
+++ b/pytorch_pretrained_bert/tokenization.py
@@ -65,7 +65,7 @@ def load_vocab(vocab_file):
     """Loads a vocabulary file into a dictionary."""
     vocab = collections.OrderedDict()
     index = 0
-    with open(vocab_file, "r") as reader:
+    with open(vocab_file, "r", encoding="utf8") as reader:
         while True:
             token = convert_to_unicode(reader.readline())
             if not token:


### PR DESCRIPTION
I encountered `UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 3793: ordinal not in range(128)`  when running the starter example shown under the Usage section. It turned out to be related to the `load_vocab` function in `tokenization.py`. Forcing `open` to use encoding `utf8` solved this issue on my machine. 