### PR TITLE
elementwise_mean -> mean (thinking ahead to pytorch 1.0)

### DIFF
--- a/tests/optimization_test.py
+++ b/tests/optimization_test.py
@@ -32,7 +32,7 @@ class OptimizationTest(unittest.TestCase):
     def test_adam(self):
         w = torch.tensor([0.1, -0.2, -0.1], requires_grad=True)
         target = torch.tensor([0.4, 0.2, -0.5])
-        criterion = torch.nn.MSELoss(reduction='elementwise_mean')
+        criterion = torch.nn.MSELoss(reduction='mean')
         # No warmup, constant schedule, no gradient clipping
         optimizer = BertAdam(params=[w], lr=2e-1,
                                           weight_decay_rate=0.0,


### PR DESCRIPTION
under the pytorch 1.0 nightly this test generates 

```
UserWarning: reduction='elementwise_mean' is deprecated, please use reduction='mean' instead.
```

so this PR fixes that.