### PR TITLE
Fixing the commentary of the `SquadExample` class.

### DIFF
--- a/examples/run_squad.py
+++ b/examples/run_squad.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 
 class SquadExample(object):
-    """A single training/test example for simple sequence classification."""
+    """A single training/test example for the Squad dataset."""
 
     def __init__(self,
                  qas_id,


### PR DESCRIPTION
Fixing the commentary of `SquadExample` that have been copy-pasted from `InputExample`.