### PR TITLE
Adding --do_lower_case for all uncased BERTs examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ python run_squad.py \
   --bert_model bert-base-uncased \
   --do_train \
   --do_predict \
+  --do_lower_case \
   --train_file $SQUAD_DIR/train-v1.1.json \
   --predict_file $SQUAD_DIR/dev-v1.1.json \
   --train_batch_size 12 \
@@ -438,6 +439,7 @@ python ./run_squad.py \
   --bert_model bert-large-uncased \
   --do_train \
   --do_predict \
+  --do_lower_case \
   --train_file $SQUAD_TRAIN \
   --predict_file $SQUAD_EVAL \
   --learning_rate 3e-5 \
@@ -458,6 +460,7 @@ python ./run_squad.py \
   --bert_model bert-large-uncased \
   --do_train \
   --do_predict \
+  --do_lower_case \
   --train_file $SQUAD_TRAIN \
   --predict_file $SQUAD_EVAL \
   --learning_rate 3e-5 \


### PR DESCRIPTION
I had missed those, it should make sense to use them