### PR TITLE
fix compatibility with python 3.5.2

### DIFF
--- a/pytorch_pretrained_bert/file_utils.py
+++ b/pytorch_pretrained_bert/file_utils.py
@@ -23,8 +23,8 @@ import requests
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-PYTORCH_PRETRAINED_BERT_CACHE = str(Path(os.getenv('PYTORCH_PRETRAINED_BERT_CACHE',
-                                               Path.home() / '.pytorch_pretrained_bert')))
+PYTORCH_PRETRAINED_BERT_CACHE = Path(os.getenv('PYTORCH_PRETRAINED_BERT_CACHE',
+                                               Path.home() / '.pytorch_pretrained_bert'))
 
 
 def url_to_filename(url: str, etag: str = None) -> str:
@@ -45,13 +45,15 @@ def url_to_filename(url: str, etag: str = None) -> str:
     return filename
 
 
-def filename_to_url(filename: str, cache_dir: str = None) -> Tuple[str, str]:
+def filename_to_url(filename: str, cache_dir: Union[str, Path] = None) -> Tuple[str, str]:
     """
     Return the url and etag (which may be ``None``) stored for `filename`.
     Raise ``FileNotFoundError`` if `filename` or its stored metadata do not exist.
     """
     if cache_dir is None:
         cache_dir = PYTORCH_PRETRAINED_BERT_CACHE
+    if isinstance(cache_dir, Path):
+        cache_dir = str(cache_dir)
 
     cache_path = os.path.join(cache_dir, filename)
     if not os.path.exists(cache_path):
@@ -69,7 +71,7 @@ def filename_to_url(filename: str, cache_dir: str = None) -> Tuple[str, str]:
     return url, etag
 
 
-def cached_path(url_or_filename: Union[str, Path], cache_dir: str = None) -> str:
+def cached_path(url_or_filename: Union[str, Path], cache_dir: Union[str, Path] = None) -> str:
     """
     Given something that might be a URL (or might be a local path),
     determine which. If it's a URL, download the file and cache it, and
@@ -80,6 +82,8 @@ def cached_path(url_or_filename: Union[str, Path], cache_dir: str = None) -> str
         cache_dir = PYTORCH_PRETRAINED_BERT_CACHE
     if isinstance(url_or_filename, Path):
         url_or_filename = str(url_or_filename)
+    if isinstance(cache_dir, Path):
+        cache_dir = str(cache_dir)
 
     parsed = urlparse(url_or_filename)
 
@@ -158,13 +162,15 @@ def http_get(url: str, temp_file: IO) -> None:
     progress.close()
 
 
-def get_from_cache(url: str, cache_dir: str = None) -> str:
+def get_from_cache(url: str, cache_dir: Union[str, Path] = None) -> str:
     """
     Given a URL, look for the corresponding dataset in the local cache.
     If it's not there, download it. Then return the path to the cached file.
     """
     if cache_dir is None:
         cache_dir = PYTORCH_PRETRAINED_BERT_CACHE
+    if isinstance(cache_dir, Path):
+        cache_dir = str(cache_dir)
 
     os.makedirs(cache_dir, exist_ok=True)
 

--- a/pytorch_pretrained_bert/file_utils.py
+++ b/pytorch_pretrained_bert/file_utils.py
@@ -23,8 +23,8 @@ import requests
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-PYTORCH_PRETRAINED_BERT_CACHE = Path(os.getenv('PYTORCH_PRETRAINED_BERT_CACHE',
-                                               Path.home() / '.pytorch_pretrained_bert'))
+PYTORCH_PRETRAINED_BERT_CACHE = str(Path(os.getenv('PYTORCH_PRETRAINED_BERT_CACHE',
+                                               Path.home() / '.pytorch_pretrained_bert')))
 
 
 def url_to_filename(url: str, etag: str = None) -> str:


### PR DESCRIPTION
When I run the following command on python 3.5.2

```
python3 extract_features.py --input_file input.txt --output_file output.txt --bert_model bert-base-uncased --do_lower_case
```

Get this error:

```
Traceback (most recent call last):
  File "extract_features.py", line 298, in <module>
    main()
  File "extract_features.py", line 231, in main
    tokenizer = BertTokenizer.from_pretrained(args.bert_model, do_lower_case=args.do_lower_case)
  File "/home/huangfei/.local/lib/python3.5/site-packages/pytorch_pretrained_bert/tokenization.py", line 117, in from_pretrained
    resolved_vocab_file = cached_path(vocab_file, cache_dir=cache_dir)
  File "/home/huangfei/.local/lib/python3.5/site-packages/pytorch_pretrained_bert/file_utils.py", line 88, in cached_path
    return get_from_cache(url_or_filename, cache_dir)
  File "/home/huangfei/.local/lib/python3.5/site-packages/pytorch_pretrained_bert/file_utils.py", line 169, in get_from_cache
    os.makedirs(cache_dir, exist_ok=True)
  File "/usr/lib/python3.5/os.py", line 226, in makedirs
    head, tail = path.split(name)
  File "/usr/lib/python3.5/posixpath.py", line 103, in split
    i = p.rfind(sep) + 1
AttributeError: 'PosixPath' object has no attribute 'rfind'
```

I find makedirs didn't support PosixPath in python3.5, so I make a change to fix this.