### PR TITLE
Add license to source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
The `LICENSE` file in the git repository contains the Apache license text
but it not included the source `.tar.gz` distribution. 

This PR adds a `MANIFEST.in` file with a directive to include the LICENSE.