### PR TITLE
Use entry-points instead of scripts

### DIFF
--- a/bin/pytorch_pretrained_bert
+++ b/bin/pytorch_pretrained_bert
@@ -1,2 +1,0 @@
-#!/bin/sh
-python -m pytorch_pretrained_bert "$@"

--- a/pytorch_pretrained_bert/__main__.py
+++ b/pytorch_pretrained_bert/__main__.py
@@ -1,5 +1,5 @@
 # coding: utf8
-if __name__ == '__main__':
+def main():
     import sys
     try:
         from .convert_tf_checkpoint_to_pytorch import convert_tf_checkpoint_to_pytorch
@@ -17,3 +17,6 @@ if __name__ == '__main__':
         TF_CONFIG = sys.argv.pop()
         TF_CHECKPOINT = sys.argv.pop()
         convert_tf_checkpoint_to_pytorch(TF_CHECKPOINT, TF_CONFIG, PYTORCH_DUMP_OUTPUT)
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,11 @@ setup(
                       'boto3',
                       'requests',
                       'tqdm'],
-    scripts=["bin/pytorch_pretrained_bert"],
+    entry_points={
+      'console_scripts': [
+        "pytorch_pretrained_bert=pytorch_pretrained_bert.__main__:main"
+      ]
+    },
     python_requires='>=3.5.0',
     tests_require=['pytest'],
     classifiers=[


### PR DESCRIPTION
The recommended approach to create launch scripts is to use entry_points 
   and console_scripts.

   xref:
   https://packaging.python.org/guides/distributing-packages-using-setuptools/#scripts