### PR TITLE
change in run_classifier.py

### DIFF
--- a/examples/run_classifier.py
+++ b/examples/run_classifier.py
@@ -558,7 +558,7 @@ def main():
 
     # Load a trained model that you have fine-tuned
     model_state_dict = torch.load(output_model_file)
-    model = BertForSequenceClassification.from_pretrained(args.bert_model, state_dict=model_state_dict)
+    model = BertForSequenceClassification.from_pretrained(args.bert_model, state_dict=model_state_dict, num_labels =num_labels)
     model.to(device)
 
     if args.do_eval and (args.local_rank == -1 or torch.distributed.get_rank() == 0):


### PR DESCRIPTION
while running the dev set for multi-label classification (more than two), it gives an assertion error. Specifying the num_labels while creating the model again for eval testing solves this problem. Thus the only change is while running classification for multi label is in the starting dict of num labels and specifying the base classes in DataProcessor class that is chosen.