### PR TITLE
Allow do_eval to be used without do_train and to use the pretrained model in the output folder

### DIFF
--- a/examples/run_classifier.py
+++ b/examples/run_classifier.py
@@ -430,8 +430,8 @@ def main():
 
     if not args.do_train and not args.do_eval:
         raise ValueError("At least one of `do_train` or `do_eval` must be True.")
-
-    if os.path.exists(args.output_dir) and os.listdir(args.output_dir):
+        
+    if os.path.exists(args.output_dir) and os.listdir(args.output_dir) and args.do_train:
         raise ValueError("Output directory ({}) already exists and is not empty.".format(args.output_dir))
     os.makedirs(args.output_dir, exist_ok=True)
 
@@ -554,7 +554,8 @@ def main():
     # Save a trained model
     model_to_save = model.module if hasattr(model, 'module') else model  # Only save the model it-self
     output_model_file = os.path.join(args.output_dir, "pytorch_model.bin")
-    torch.save(model_to_save.state_dict(), output_model_file)
+    if args.do_train:
+        torch.save(model_to_save.state_dict(), output_model_file)
 
     # Load a trained model that you have fine-tuned
     model_state_dict = torch.load(output_model_file)

--- a/examples/run_classifier.py
+++ b/examples/run_classifier.py
@@ -503,6 +503,7 @@ def main():
                              t_total=t_total)
 
     global_step = 0
+    nb_tr_steps = 0
     tr_loss = 0
     if args.do_train:
         train_features = convert_examples_to_features(
@@ -565,6 +566,7 @@ def main():
 
     if args.do_eval and (args.local_rank == -1 or torch.distributed.get_rank() == 0):
         eval_examples = processor.get_dev_examples(args.data_dir)
+        # should tokenize this too. 
         eval_features = convert_examples_to_features(
             eval_examples, label_list, args.max_seq_length, tokenizer)
         logger.info("***** Running evaluation *****")

--- a/examples/run_classifier.py
+++ b/examples/run_classifier.py
@@ -566,7 +566,6 @@ def main():
 
     if args.do_eval and (args.local_rank == -1 or torch.distributed.get_rank() == 0):
         eval_examples = processor.get_dev_examples(args.data_dir)
-        # should tokenize this too. 
         eval_features = convert_examples_to_features(
             eval_examples, label_list, args.max_seq_length, tokenizer)
         logger.info("***** Running evaluation *****")


### PR DESCRIPTION
If you wanted to use the pre-trained model to redo evaluation without training, it errors because the output directory already exists (the output directory that contains the pre-trained model that one might like to evaluate). 

Additionally, a couple of fields are not initialised if one does not train and only evaluates.


 