### PR TITLE
Fix error when `bert_model` param is path or url.

### DIFF
--- a/examples/run_squad.py
+++ b/examples/run_squad.py
@@ -855,7 +855,7 @@ def main():
     global_step = 0
     if args.do_train:
         cached_train_features_file = args.train_file+'_{0}_{1}_{2}_{3}'.format(
-            args.bert_model, str(args.max_seq_length), str(args.doc_stride), str(args.max_query_length))
+            list(filter(None, args.bert_model.split('/'))).pop(), str(args.max_seq_length), str(args.doc_stride), str(args.max_query_length))
         train_features = None
         try:
             with open(cached_train_features_file, "rb") as reader:


### PR DESCRIPTION
Error occurs when `bert_model` param is path or url. Therefore, if it is path, specify the last path to prevent error.