### PR TITLE
[bug fix] args.do_lower_case is always True

### DIFF
--- a/examples/run_squad2.py
+++ b/examples/run_squad2.py
@@ -818,7 +818,6 @@ def main():
                         default=1,
                         help="Number of updates steps to accumulate before performing a backward/update pass.")
     parser.add_argument("--do_lower_case",
-                        default=True,
                         action='store_true',
                         help="Whether to lower case the input text. True for uncased models, False for cased models.")
     parser.add_argument("--local_rank",


### PR DESCRIPTION
The "default=True" makes args.do_lower_case always True.

```python
parser.add_argument("--do_lower_case",
                        default=True,
                        action='store_true')
```