### PR TITLE
Fix squad answer start and end position

### DIFF
--- a/examples/run_squad.py
+++ b/examples/run_squad.py
@@ -277,9 +277,9 @@ def convert_examples_to_features(examples, tokenizer, max_seq_length,
                 # we throw it out, since there is nothing to predict.
                 doc_start = doc_span.start
                 doc_end = doc_span.start + doc_span.length - 1
-                if (example.start_position < doc_start or
-                        example.end_position < doc_start or
-                        example.start_position > doc_end or example.end_position > doc_end):
+                if (tok_start_position < doc_start or
+                        tok_end_position < doc_start or
+                        tok_start_position > doc_end or tok_end_position > doc_end):
                     continue
 
                 doc_offset = len(query_tokens) + 2

--- a/examples/run_squad2.py
+++ b/examples/run_squad2.py
@@ -301,9 +301,9 @@ def convert_examples_to_features(examples, tokenizer, max_seq_length,
                 doc_start = doc_span.start
                 doc_end = doc_span.start + doc_span.length - 1
                 out_of_span = False 
-                if (example.start_position < doc_start or
-                        example.end_position < doc_start or
-                        example.start_position > doc_end or example.end_position > doc_end):
+                if (tok_start_position < doc_start or
+                        tok_end_position < doc_start or
+                        tok_start_position > doc_end or tok_end_position > doc_end):
                     out_of_span = True
                 if out_of_span:
                     start_position = 0


### PR DESCRIPTION
Previous version might miss some overlong answer start and end indices (which should be 0), and sometimes the start/end positions would be outside the model inputs.

Doc_start and doc_end are based on tokenized subword sequences while example.start_position and example.end_position are indices in original word-level, which are usually shorter than the subword sequences. Why not use tok_start_position and tok_end_position for comparison?