### PR TITLE
removing unused argument eval_batch_size from LM finetuning #256

### DIFF
--- a/examples/run_lm_finetuning.py
+++ b/examples/run_lm_finetuning.py
@@ -501,8 +501,8 @@ def main():
     if n_gpu > 0:
         torch.cuda.manual_seed_all(args.seed)
 
-    if not args.do_train and not args.do_eval:
-        raise ValueError("At least one of `do_train` or `do_eval` must be True.")
+    if not args.do_train:
+        raise ValueError("Training is currently the only implemented execution option. Please set `do_train`.")
 
     if os.path.exists(args.output_dir) and os.listdir(args.output_dir):
         raise ValueError("Output directory ({}) already exists and is not empty.".format(args.output_dir))

--- a/examples/run_lm_finetuning.py
+++ b/examples/run_lm_finetuning.py
@@ -432,10 +432,6 @@ def main():
                         default=32,
                         type=int,
                         help="Total batch size for training.")
-    parser.add_argument("--eval_batch_size",
-                        default=8,
-                        type=int,
-                        help="Total batch size for eval.")
     parser.add_argument("--learning_rate",
                         default=3e-5,
                         type=float,


### PR DESCRIPTION
Removing unused eval_batch_size argument for simplification. As requested in #256. 