### PR TITLE
forgot to add regex to requirements.txt :(

### DIFF
--- a/pytorch_pretrained_bert/__init__.py
+++ b/pytorch_pretrained_bert/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 from .tokenization import BertTokenizer, BasicTokenizer, WordpieceTokenizer
 from .tokenization_openai import OpenAIGPTTokenizer
 from .tokenization_transfo_xl import (TransfoXLTokenizer, TransfoXLCorpus)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ tqdm
 boto3
 # Used for downloading models over HTTP
 requests
+# For OpenAI GPT
+regex

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pytorch_pretrained_bert",
-    version="0.6.0",
+    version="0.6.1",
     author="Thomas Wolf, Victor Sanh, Tim Rault, Google AI Language Team Authors, Open AI team Authors",
     author_email="thomas@huggingface.co",
     description="PyTorch version of Google AI BERT model with script to load Google pre-trained models",
@@ -53,7 +53,8 @@ setup(
                       'numpy',
                       'boto3',
                       'requests',
-                      'tqdm'],
+                      'tqdm',
+                      'regex'],
     entry_points={
       'console_scripts': [
         "pytorch_pretrained_bert=pytorch_pretrained_bert.__main__:main",


### PR DESCRIPTION
Updating requirements to add `regex` for GPT-2 tokenizer.
A test on OpenAI GPT-2 tokenizer module would have caught that.
But (byte-level) BPE tokenization tests are such a pain to make properly.
Let's add one in the next release, after the ACL deadline.