### PR TITLE
add BertTokenizer flag to skip basic tokenization

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ where
 Examples:
 ```python
 # BERT
-tokenizer = BertTokenizer.from_pretrained('bert-base-uncased', do_lower_case=True)
+tokenizer = BertTokenizer.from_pretrained('bert-base-uncased', do_lower_case=True, do_basic_tokenize=True)
 model = BertForSequenceClassification.from_pretrained('bert-base-uncased')
 
 # OpenAI GPT
@@ -803,11 +803,12 @@ This model *outputs*:
 
 `BertTokenizer` perform end-to-end tokenization, i.e. basic tokenization followed by WordPiece tokenization.
 
-This class has four arguments:
+This class has five arguments:
 
 - `vocab_file`: path to a vocabulary file.
 - `do_lower_case`: convert text to lower-case while tokenizing. **Default = True**.
 - `max_len`: max length to filter the input of the Transformer. Default to pre-trained value for the model if `None`. **Default = None**
+- `do_basic_tokenize`: Do basic tokenization before wordpice tokenization. Set to false if text is pre-tokenized. **Default = True**.
 - `never_split`: a list of tokens that should not be splitted during tokenization. **Default = `["[UNK]", "[SEP]", "[PAD]", "[CLS]", "[MASK]"]`**
 
 and three methods:

--- a/pytorch_pretrained_bert/tokenization.py
+++ b/pytorch_pretrained_bert/tokenization.py
@@ -79,8 +79,16 @@ class BertTokenizer(object):
         """Constructs a BertTokenizer.
 
         Args:
-          do_lower_case: Whether to lower case the input.
-          do_wordpiece_only: Whether to do basic tokenization before wordpiece.
+          vocab_file: Path to a one-wordpiece-per-line vocabulary file
+          do_lower_case: Whether to lower case the input
+                         Only has an effect when do_wordpiece_only=False
+          do_basic_tokenize: Whether to do basic tokenization before wordpiece.
+          max_len: An artificial maximum length to truncate tokenized sequences to;
+                         Effective maximum length is always the minimum of this
+                         value (if specified) and the underlying BERT model's
+                         sequence length.
+          never_split: List of tokens which will never be split during tokenization.
+                         Only has an effect when do_wordpiece_only=False
         """
         if not os.path.isfile(vocab_file):
             raise ValueError(


### PR DESCRIPTION
When tokenization is done before text hits this package (e.g., when tokenization is specified as part of the dataset) there exists a use case for skipping the `BasicTokenizer` step, going right to `WordpieceTokenizer`.

When one still wants to use the `BertTokenizer.from_pretrained` helper function, they have been able to do this (without claiming this is necessarily the best way) by

```
text = "[CLS]  `` Truly , pizza is delicious , '' said Mx. Caily."
bert_tokenizer = BertTokenizer.from_pretrained('bert-base-cased')
tokenized_text = bert_tokenizer.wordpiece_tokenizer.tokenize(text)
```

With this PR, we instead use
```
text = "[CLS]  `` Truly , pizza is delicious , '' said Mx. Caily."
bert_tokenizer = BertTokenizer.from_pretrained('bert-base-cased', do_basic_tokenize=False)
tokenized_text = bert_tokenizer.tokenize(text)
```

a flag for which I add documentation in the docstring and README, hopefully making it clear that this is possible. 
