### PR TITLE
Issue#324: warmup linear fixes

### DIFF
--- a/pytorch_pretrained_bert/optimization.py
+++ b/pytorch_pretrained_bert/optimization.py
@@ -26,14 +26,18 @@ def warmup_cosine(x, warmup=0.002):
     return 0.5 * (1.0 + torch.cos(math.pi * x))
 
 def warmup_constant(x, warmup=0.002):
+    """ Linearly increases learning rate over `warmup`*`t_total` (as provided to BertAdam) training steps.
+        Learning rate is 1. afterwards. """
     if x < warmup:
         return x/warmup
     return 1.0
 
 def warmup_linear(x, warmup=0.002):
+    """ Specifies a triangular learning rate schedule where peak is reached at `warmup`*`t_total`-th (as provided to BertAdam) training step.
+        After `t_total`-th training step, learning rate is zero. """
     if x < warmup:
         return x/warmup
-    return 1.0 - x
+    return max(1.0 - x, 0)
 
 SCHEDULES = {
     'warmup_cosine':warmup_cosine,

--- a/pytorch_pretrained_bert/optimization.py
+++ b/pytorch_pretrained_bert/optimization.py
@@ -83,7 +83,7 @@ class BertAdam(Optimizer):
                         max_grad_norm=max_grad_norm)
         super(BertAdam, self).__init__(params, defaults)
         # warning for t_total exceeded
-        self._warned_for_t_total_at_progress = -1 if schedule == "warmup_linear" else float("inf")
+        self._warned_for_t_total_at_progress = -1 if schedule == "warmup_linear" else float("inf")      # warning is not active with other schedules (since it doesn't break them)
 
     def get_lr(self):
         lr = []

--- a/pytorch_pretrained_bert/optimization.py
+++ b/pytorch_pretrained_bert/optimization.py
@@ -19,6 +19,9 @@ import torch
 from torch.optim import Optimizer
 from torch.optim.optimizer import required
 from torch.nn.utils import clip_grad_norm_
+import logging
+
+logger = logging.getLogger(__name__)
 
 def warmup_cosine(x, warmup=0.002):
     if x < warmup:
@@ -37,6 +40,8 @@ def warmup_linear(x, warmup=0.002):
         After `t_total`-th training step, learning rate is zero. """
     if x < warmup:
         return x/warmup
+    if x > 1:
+        logger.warning("Training beyond specified 't_total' steps. Learning rate set to zero. Please set 't_total' of BertAdam correctly.")
     return max((x-1.)/(warmup-1.), 0)
 
 SCHEDULES = {

--- a/pytorch_pretrained_bert/optimization.py
+++ b/pytorch_pretrained_bert/optimization.py
@@ -154,15 +154,15 @@ class BertAdam(Optimizer):
 
                 if group['t_total'] != -1:
                     schedule_fct = SCHEDULES[group['schedule']]
-                    # warning for exceeding t_total (only active with warmup_linear
                     progress = state['step']/group['t_total']
+                    lr_scheduled = group['lr'] * schedule_fct(progress, group['warmup'])
+                    # warning for exceeding t_total (only active with warmup_linear
                     if progress > 1. and progress > self._warned_for_t_total_at_progress:
                         logger.warning(
-                            "Training beyond specified 't_total' steps. Learning rate set to zero. "
-                            "Please set 't_total' of {} correctly.".format(self.__class__.__name__))
+                            "Training beyond specified 't_total' steps. Learning rate set to {}. "
+                            "Please set 't_total' of {} correctly.".format(lr_scheduled, self.__class__.__name__))
                         self._warned_for_t_total_at_progress = progress
                     # end warning
-                    lr_scheduled = group['lr'] * schedule_fct(progress, group['warmup'])
                 else:
                     lr_scheduled = group['lr']
 

--- a/pytorch_pretrained_bert/optimization.py
+++ b/pytorch_pretrained_bert/optimization.py
@@ -35,19 +35,28 @@ def warmup_constant(x, warmup=0.002):
         return x/warmup
     return 1.0
 
+class Warmup_Linear_with_Warning(object):
+    def __init__(self, **kw):
+        super(Warmup_Linear_with_Warning, self).__init__()
+        self.warned_at_x = -1
+
+    def __call__(self, x, warmup=0.002):
+        if x > 1 and x > self.warned_at_x:
+            logger.warning("Training beyond specified 't_total' steps. Learning rate set to zero. Please set 't_total' of BertAdam correctly.")
+            self.warned_at_x = x
+        return warmup_linear(x, warmup=warmup)
+
 def warmup_linear(x, warmup=0.002):
     """ Specifies a triangular learning rate schedule where peak is reached at `warmup`*`t_total`-th (as provided to BertAdam) training step.
         After `t_total`-th training step, learning rate is zero. """
     if x < warmup:
         return x/warmup
-    if x > 1:
-        logger.warning("Training beyond specified 't_total' steps. Learning rate set to zero. Please set 't_total' of BertAdam correctly.")
     return max((x-1.)/(warmup-1.), 0)
 
 SCHEDULES = {
     'warmup_cosine':warmup_cosine,
     'warmup_constant':warmup_constant,
-    'warmup_linear':warmup_linear,
+    'warmup_linear': Warmup_Linear_with_Warning(), #warmup_linear,
 }
 
 

--- a/pytorch_pretrained_bert/optimization.py
+++ b/pytorch_pretrained_bert/optimization.py
@@ -37,7 +37,7 @@ def warmup_linear(x, warmup=0.002):
         After `t_total`-th training step, learning rate is zero. """
     if x < warmup:
         return x/warmup
-    return max(1.0 - x, 0)
+    return max((x-1.)/(warmup-1.), 0)
 
 SCHEDULES = {
     'warmup_cosine':warmup_cosine,

--- a/pytorch_pretrained_bert/optimization.py
+++ b/pytorch_pretrained_bert/optimization.py
@@ -159,8 +159,8 @@ class BertAdam(Optimizer):
                     # warning for exceeding t_total (only active with warmup_linear
                     if group['schedule'] == "warmup_linear" and progress > 1. and not warned_for_t_total:
                         logger.warning(
-                            "Training beyond specified 't_total' steps. Learning rate set to {}. "
-                            "Please set 't_total' of {} correctly.".format(lr_scheduled, self.__class__.__name__))
+                            "Training beyond specified 't_total' steps with schedule '{}'. Learning rate set to {}. "
+                            "Please set 't_total' of {} correctly.".format(group['schedule'], lr_scheduled, self.__class__.__name__))
                         warned_for_t_total = True
                     # end warning
                 else:

--- a/pytorch_pretrained_bert/optimization_openai.py
+++ b/pytorch_pretrained_bert/optimization_openai.py
@@ -21,16 +21,23 @@ from torch.optim.optimizer import required
 from torch.nn.utils import clip_grad_norm_
 
 def warmup_cosine(x, warmup=0.002):
-    s = 1 if x <= warmup else 0
-    return s*(x/warmup) + (1-s)*(0.5 * (1 + torch.cos(math.pi * x)))
+    if x < warmup:
+        return x/warmup
+    return 0.5 * (1.0 + torch.cos(math.pi * x))
 
 def warmup_constant(x, warmup=0.002):
-    s = 1 if x <= warmup else 0
-    return s*(x/warmup) + (1-s)*1
+    """ Linearly increases learning rate over `warmup`*`t_total` (as provided to BertAdam) training steps.
+        Learning rate is 1. afterwards. """
+    if x < warmup:
+        return x/warmup
+    return 1.0
 
 def warmup_linear(x, warmup=0.002):
-    s = 1 if x <= warmup else 0
-    return (s*(x/warmup) + (1-s))*(1-x)
+    """ Specifies a triangular learning rate schedule where peak is reached at `warmup`*`t_total`-th (as provided to BertAdam) training step.
+        After `t_total`-th training step, learning rate is zero. """
+    if x < warmup:
+        return x/warmup
+    return max(1.0 - x, 0)
 
 SCHEDULES = {
     'warmup_cosine':warmup_cosine,

--- a/pytorch_pretrained_bert/optimization_openai.py
+++ b/pytorch_pretrained_bert/optimization_openai.py
@@ -71,8 +71,6 @@ class OpenAIAdam(Optimizer):
                         b1=b1, b2=b2, e=e, weight_decay=weight_decay, vector_l2=vector_l2,
                         max_grad_norm=max_grad_norm)
         super(OpenAIAdam, self).__init__(params, defaults)
-        # warning for t_total exceeded
-        self._warned_for_t_total_at_progress = -1 if schedule == "warmup_linear" else float("inf")      # warning is not active with other schedules (since it doesn't break them)
 
     def get_lr(self):
         lr = []
@@ -99,6 +97,8 @@ class OpenAIAdam(Optimizer):
         loss = None
         if closure is not None:
             loss = closure()
+
+        warned_for_t_total = False
 
         for group in self.param_groups:
             for p in group['params']:
@@ -140,11 +140,11 @@ class OpenAIAdam(Optimizer):
                     progress = state['step']/group['t_total']
                     lr_scheduled = group['lr'] * schedule_fct(progress, group['warmup'])
                     # warning for exceeding t_total (only active with warmup_linear
-                    if progress > 1. and progress > self._warned_for_t_total_at_progress:
+                    if group['schedule'] == "warmup_linear" and progress > 1. and not warned_for_t_total:
                         logger.warning(
                             "Training beyond specified 't_total' steps. Learning rate set to {}. "
                             "Please set 't_total' of {} correctly.".format(lr_scheduled, self.__class__.__name__))
-                        self._warned_for_t_total_at_progress = progress
+                        warned_for_t_total = True
                     # end warning
                 else:
                     lr_scheduled = group['lr']

--- a/pytorch_pretrained_bert/optimization_openai.py
+++ b/pytorch_pretrained_bert/optimization_openai.py
@@ -19,6 +19,9 @@ import torch
 from torch.optim import Optimizer
 from torch.optim.optimizer import required
 from torch.nn.utils import clip_grad_norm_
+import logging
+
+logger = logging.getLogger(__name__)
 
 def warmup_cosine(x, warmup=0.002):
     if x < warmup:
@@ -37,6 +40,8 @@ def warmup_linear(x, warmup=0.002):
         After `t_total`-th training step, learning rate is zero. """
     if x < warmup:
         return x/warmup
+    if x > 1:
+        logger.warning("Training beyond specified 't_total' steps. Learning rate set to zero. Please set 't_total' of BertAdam correctly.")
     return max((x-1.)/(warmup-1.), 0)
 
 SCHEDULES = {

--- a/pytorch_pretrained_bert/optimization_openai.py
+++ b/pytorch_pretrained_bert/optimization_openai.py
@@ -37,7 +37,7 @@ def warmup_linear(x, warmup=0.002):
         After `t_total`-th training step, learning rate is zero. """
     if x < warmup:
         return x/warmup
-    return max(1.0 - x, 0)
+    return max((x-1.)/(warmup-1.), 0)
 
 SCHEDULES = {
     'warmup_cosine':warmup_cosine,

--- a/pytorch_pretrained_bert/optimization_openai.py
+++ b/pytorch_pretrained_bert/optimization_openai.py
@@ -72,7 +72,7 @@ class OpenAIAdam(Optimizer):
                         max_grad_norm=max_grad_norm)
         super(OpenAIAdam, self).__init__(params, defaults)
         # warning for t_total exceeded
-        self._warned_for_t_total_at_progress = -1 if schedule == "warmup_linear" else float("inf")
+        self._warned_for_t_total_at_progress = -1 if schedule == "warmup_linear" else float("inf")      # warning is not active with other schedules (since it doesn't break them)
 
     def get_lr(self):
         lr = []

--- a/pytorch_pretrained_bert/optimization_openai.py
+++ b/pytorch_pretrained_bert/optimization_openai.py
@@ -29,14 +29,14 @@ def warmup_cosine(x, warmup=0.002):
     return 0.5 * (1.0 + torch.cos(math.pi * x))
 
 def warmup_constant(x, warmup=0.002):
-    """ Linearly increases learning rate over `warmup`*`t_total` (as provided to BertAdam) training steps.
+    """ Linearly increases learning rate over `warmup`*`t_total` (as provided to OpenAIAdam) training steps.
         Learning rate is 1. afterwards. """
     if x < warmup:
         return x/warmup
     return 1.0
 
 def warmup_linear(x, warmup=0.002):
-    """ Specifies a triangular learning rate schedule where peak is reached at `warmup`*`t_total`-th (as provided to BertAdam) training step.
+    """ Specifies a triangular learning rate schedule where peak is reached at `warmup`*`t_total`-th (as provided to OpenAIAdam) training step.
         After `t_total`-th training step, learning rate is zero. """
     if x < warmup:
         return x/warmup
@@ -142,8 +142,8 @@ class OpenAIAdam(Optimizer):
                     # warning for exceeding t_total (only active with warmup_linear
                     if group['schedule'] == "warmup_linear" and progress > 1. and not warned_for_t_total:
                         logger.warning(
-                            "Training beyond specified 't_total' steps. Learning rate set to {}. "
-                            "Please set 't_total' of {} correctly.".format(lr_scheduled, self.__class__.__name__))
+                            "Training beyond specified 't_total' steps with schedule '{}'. Learning rate set to {}. "
+                            "Please set 't_total' of {} correctly.".format(group['schedule'], lr_scheduled, self.__class__.__name__))
                         warned_for_t_total = True
                     # end warning
                 else:

--- a/pytorch_pretrained_bert/optimization_openai.py
+++ b/pytorch_pretrained_bert/optimization_openai.py
@@ -137,15 +137,15 @@ class OpenAIAdam(Optimizer):
 
                 if group['t_total'] != -1:
                     schedule_fct = SCHEDULES[group['schedule']]
-                    # warning for exceeding t_total (only active with warmup_linear
                     progress = state['step']/group['t_total']
+                    lr_scheduled = group['lr'] * schedule_fct(progress, group['warmup'])
+                    # warning for exceeding t_total (only active with warmup_linear
                     if progress > 1. and progress > self._warned_for_t_total_at_progress:
                         logger.warning(
-                            "Training beyond specified 't_total' steps. Learning rate set to zero. "
-                            "Please set 't_total' of {} correctly.".format(self.__class__.__name__))
+                            "Training beyond specified 't_total' steps. Learning rate set to {}. "
+                            "Please set 't_total' of {} correctly.".format(lr_scheduled, self.__class__.__name__))
                         self._warned_for_t_total_at_progress = progress
                     # end warning
-                    lr_scheduled = group['lr'] * schedule_fct(progress, group['warmup'])
                 else:
                     lr_scheduled = group['lr']
 


### PR DESCRIPTION
Fixes for [Issue#324](https://github.com/huggingface/pytorch-pretrained-BERT/issues/324).

- Using the same schedule functions in BertAdam and OpenAIAdam, fixing `warmup_linear` of OpenAIAdam
- fix for negative learning rate after t_total for `warmup_linear`
- some more docstrings
- warning when t_total is exceeded with `warmup_linear`, implemented inside `.step()` of the optimizer (maybe not that nice). Warning is printed on every batch update.