### PR TITLE
Make the hyperlink of NVIDIA Apex clickable

### DIFF
--- a/pytorch_pretrained_bert/modeling.py
+++ b/pytorch_pretrained_bert/modeling.py
@@ -217,7 +217,7 @@ class BertConfig(object):
 try:
     from apex.normalization.fused_layer_norm import FusedLayerNorm as BertLayerNorm
 except ImportError:
-    logger.info("Better speed can be achieved with apex installed from https://www.github.com/nvidia/apex.")
+    logger.info("Better speed can be achieved with apex installed from https://www.github.com/nvidia/apex .")
     class BertLayerNorm(nn.Module):
         def __init__(self, hidden_size, eps=1e-12):
             """Construct a layernorm module in the TF style (epsilon inside the square root).


### PR DESCRIPTION
In the case of the ImportError in modeling.py [here](https://github.com/huggingface/pytorch-pretrained-BERT/blob/7cc35c31040d8bdfcadc274c087d6a73c2036210/pytorch_pretrained_bert/modeling.py#L219), make the hyperlink to NVIDIA Apex redirect properly by spacing the '.'