### PR TITLE
handle ImportError exception when used from projects outside

### DIFF
--- a/pytorch_pretrained_bert/modeling.py
+++ b/pytorch_pretrained_bert/modeling.py
@@ -32,7 +32,10 @@ import torch
 from torch import nn
 from torch.nn import CrossEntropyLoss
 
-from .file_utils import cached_path
+try:
+    from .file_utils import cached_path
+except ImportError: # handle the case when the module is used from another project
+    from file_utils import cached_path
 
 logger = logging.getLogger(__name__)
 

--- a/pytorch_pretrained_bert/modeling_openai.py
+++ b/pytorch_pretrained_bert/modeling_openai.py
@@ -32,8 +32,12 @@ import torch.nn as nn
 from torch.nn import CrossEntropyLoss
 from torch.nn.parameter import Parameter
 
-from .file_utils import cached_path
-from .modeling import BertLayerNorm as LayerNorm
+try:
+    from .file_utils import cached_path
+    from .modeling import BertLayerNorm as LayerNorm
+except ImportError: # handle the case when the module is used from another project
+    from file_utils import cached_path
+    from modeling import BertLayerNorm as LayerNorm
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
The relative path that starts with . does not work when a file is used from an outside project. I added a safe code to handle the ImportError exception in this case, so I can use the source file without having to make local changes to it.