### PR TITLE
Shared tokenizer interface

### DIFF
--- a/examples/run_transfo_xl.py
+++ b/examples/run_transfo_xl.py
@@ -112,8 +112,7 @@ def main():
         with torch.no_grad():
             mems = None
             for idx, (data, target, seq_len) in enumerate(eval_iter):
-                ret = model(data, target, mems)
-                loss, mems = ret
+                loss, mems = model(data, target, mems)
                 loss = loss.mean()
                 total_loss += seq_len * loss.item()
                 total_len += seq_len

--- a/pytorch_pretrained_bert/tokenization.py
+++ b/pytorch_pretrained_bert/tokenization.py
@@ -129,6 +129,13 @@ class BertTokenizer(Tokenizer):
     def encode(self, text):
         return self.tokenize(text)
 
+    def decode(self, tokens):
+        # Confusing language here: the input "tokens" in the superclass decode()
+        # refer to the int tokens. So this step takes us from "int tokens" back
+        # to "text tokens".
+        tokens = self.convert_ids_to_tokens(tokens)
+        return " ".join(tokens)
+
     def convert_tokens_to_ids(self, tokens):
         """Converts a sequence of tokens into ids using the vocab."""
         ids = []

--- a/pytorch_pretrained_bert/tokenization.py
+++ b/pytorch_pretrained_bert/tokenization.py
@@ -127,7 +127,7 @@ class BertTokenizer(Tokenizer):
         return split_tokens
 
     def encode(self, text):
-        self.tokenize(text)
+        return self.tokenize(text)
 
     def convert_tokens_to_ids(self, tokens):
         """Converts a sequence of tokens into ids using the vocab."""

--- a/pytorch_pretrained_bert/tokenization.py
+++ b/pytorch_pretrained_bert/tokenization.py
@@ -71,7 +71,19 @@ def whitespace_tokenize(text):
     return tokens
 
 
-class BertTokenizer(object):
+class Tokenizer(object):
+    """
+    Tokenizer superclass
+    """
+
+    def encode(self, text):
+        raise NotImplementedError("Implement encode() in Tokenizer subclass")
+
+    def decode(self, tokens):
+        raise NotImplementedError("Implement decode() in Tokenizer subclass")
+
+
+class BertTokenizer(Tokenizer):
     """Runs end-to-end tokenization: punctuation splitting + wordpiece"""
 
     def __init__(self, vocab_file, do_lower_case=True, max_len=None, do_basic_tokenize=True,
@@ -113,6 +125,9 @@ class BertTokenizer(object):
         else:
           split_tokens = self.wordpiece_tokenizer.tokenize(text)
         return split_tokens
+
+    def encode(self, text):
+        self.tokenize(text)
 
     def convert_tokens_to_ids(self, tokens):
         """Converts a sequence of tokens into ids using the vocab."""

--- a/pytorch_pretrained_bert/tokenization_gpt2.py
+++ b/pytorch_pretrained_bert/tokenization_gpt2.py
@@ -21,6 +21,7 @@ import logging
 import os
 import regex as re
 from io import open
+from .tokenization import Tokenizer
 
 try:
     from functools import lru_cache
@@ -80,7 +81,7 @@ def get_pairs(word):
         prev_char = char
     return pairs
 
-class GPT2Tokenizer(object):
+class GPT2Tokenizer(Tokenizer):
     """
     GPT-2 BPE tokenizer. Peculiarities:
         - Byte-level BPE

--- a/pytorch_pretrained_bert/tokenization_openai.py
+++ b/pytorch_pretrained_bert/tokenization_openai.py
@@ -26,7 +26,7 @@ from io import open
 from tqdm import tqdm
 
 from .file_utils import cached_path
-from .tokenization import BasicTokenizer
+from .tokenization import BasicTokenizer, Tokenizer
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ def text_standardize(text):
     text = re.sub(r'[^\S\n]+', ' ', text)
     return text.strip()
 
-class OpenAIGPTTokenizer(object):
+class OpenAIGPTTokenizer(Tokenizer):
     """
     BPE tokenizer. Peculiarities:
         - lower case all inputs
@@ -250,7 +250,10 @@ class OpenAIGPTTokenizer(object):
                 tokens.append(self.decoder[i])
         return tokens
 
-    def decode(self, ids, skip_special_tokens=False, clean_up_tokenization_spaces=False):
+    def encode(self, text):
+        self.convert_tokens_to_ids(self.tokenize(text))
+
+    def decode(self, ids, skip_special_tokens=False, clean_up_tokenization_spaces=True):
         """Converts a sequence of ids in a string."""
         tokens = self.convert_ids_to_tokens(ids, skip_special_tokens=skip_special_tokens)
         out_string = ''.join(tokens).replace('</w>', ' ').strip()

--- a/pytorch_pretrained_bert/tokenization_openai.py
+++ b/pytorch_pretrained_bert/tokenization_openai.py
@@ -251,7 +251,7 @@ class OpenAIGPTTokenizer(Tokenizer):
         return tokens
 
     def encode(self, text):
-        self.convert_tokens_to_ids(self.tokenize(text))
+        return self.convert_tokens_to_ids(self.tokenize(text))
 
     def decode(self, ids, skip_special_tokens=False, clean_up_tokenization_spaces=True):
         """Converts a sequence of ids in a string."""

--- a/pytorch_pretrained_bert/tokenization_transfo_xl.py
+++ b/pytorch_pretrained_bert/tokenization_transfo_xl.py
@@ -26,6 +26,7 @@ import sys
 from collections import Counter, OrderedDict
 from io import open
 import unicodedata
+from .tokenization import Tokenizer
 
 import torch
 import numpy as np
@@ -50,7 +51,7 @@ PRETRAINED_CORPUS_ARCHIVE_MAP = {
 }
 CORPUS_NAME = 'corpus.bin'
 
-class TransfoXLTokenizer(object):
+class TransfoXLTokenizer(Tokenizer):
     """
     Transformer-XL tokenizer adapted from Vocab class in https://github.com/kimiyoung/transformer-xl
     """
@@ -192,6 +193,10 @@ class TransfoXLTokenizer(object):
             encoded = torch.cat(encoded)
 
         return encoded
+
+    def encode(self, text):
+        result = self.encode_sents([text])
+        return result[0]
 
     def add_special(self, sym):
         if sym not in self.sym2idx:


### PR DESCRIPTION
Up to this point, `tokenize()` and `encode()` mean different places. In GPT-land, `tokenize` doesn't get us all the way to token IDs. Idteally, he tokenizers would share a common interface so that they can be plugged in and out of places just like the models.

I don't know if you want breaking changes, so I just created `encode()` and `decode()` as aliases on tokenizers that did not adhere to that spec already.

There is more cleanup to do. Since it seems that non-BERT models were added on later on, the BERT files should probably be renamed into `tokenizer_bert`, etc., but I left that in place to maintain compatibility. BERT is still missing `decode`.

Please advise and I can clean it up.