### PR TITLE
Fix bug in run_squad.py

### DIFF
--- a/examples/run_squad.py
+++ b/examples/run_squad.py
@@ -344,21 +344,22 @@ def convert_examples_to_features(examples, tokenizer, max_seq_length,
                     logger.info(
                         "answer: %s" % (answer_text))
 
-            features.append(
-                InputFeatures(
-                    unique_id=unique_id,
-                    example_index=example_index,
-                    doc_span_index=doc_span_index,
-                    tokens=tokens,
-                    token_to_orig_map=token_to_orig_map,
-                    token_is_max_context=token_is_max_context,
-                    input_ids=input_ids,
-                    input_mask=input_mask,
-                    segment_ids=segment_ids,
-                    start_position=start_position,
-                    end_position=end_position,
-                    is_impossible=example.is_impossible))
-            unique_id += 1
+            if not start_position == end_position == 0:
+                features.append(
+                    InputFeatures(
+                        unique_id=unique_id,
+                        example_index=example_index,
+                        doc_span_index=doc_span_index,
+                        tokens=tokens,
+                        token_to_orig_map=token_to_orig_map,
+                        token_is_max_context=token_is_max_context,
+                        input_ids=input_ids,
+                        input_mask=input_mask,
+                        segment_ids=segment_ids,
+                        start_position=start_position,
+                        end_position=end_position,
+                        is_impossible=example.is_impossible))
+                unique_id += 1
 
     return features
 


### PR DESCRIPTION
I fired an issue in Google's repo, https://github.com/google-research/bert/issues/540#issue-428344784

After testing, I found it is indeed a bug.
We should not put these chunks with `start_position==0` and `end_position==0` into training set.

Thanks for code review.