### PR TITLE
Fix tsv read error in Windows

### DIFF
--- a/examples/run_classifier.py
+++ b/examples/run_classifier.py
@@ -95,7 +95,7 @@ class DataProcessor(object):
     @classmethod
     def _read_tsv(cls, input_file, quotechar=None):
         """Reads a tab separated value file."""
-        with open(input_file, "r") as f:
+        with open(input_file, "r", encoding="utf-8") as f:
             reader = csv.reader(f, delimiter="\t", quotechar=quotechar)
             lines = []
             for line in reader:


### PR DESCRIPTION
The initial version suffers from the error of `UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position` when loading the `.tsv` filein **Windows** System, as indicated in https://github.com/huggingface/pytorch-pretrained-BERT/issues/52

It is solved by adding `encoding='utf-8'` when reading the `.tsv` file.
