### PR TITLE
Fix possible risks of bpe on special tokens

### DIFF
--- a/pytorch_pretrained_bert/tokenization_openai.py
+++ b/pytorch_pretrained_bert/tokenization_openai.py
@@ -223,7 +223,10 @@ class OpenAIGPTTokenizer(object):
             # Using BERT's BasicTokenizer
             text = self.nlp.tokenize(text)
             for token in text:
-                split_tokens.extend([t for t in self.bpe(token).split(' ')])
+                if token not in self.special_tokens:
+                    split_tokens.extend([t for t in self.bpe(token).split(' ')])
+                else:
+                    split_tokens.append(token)
         else:
             # Using SpaCy & ftfy (original tokenization process of OpenAI GPT)
             text = self.nlp(text_standardize(self.fix_text(text)))


### PR DESCRIPTION
Hi developers !

When I use the openai tokenizer, I find it hard to handle the `special tokens` correctly (my library version is v0.6.1) , even though I have already defined them and told the tokenizer NEVER SPLIT them. It is because all tokens, including the special ones will be processed by BPE. So I add one line for avoiding BPE on special tokens.

But there still are some problems when we use `spacy` as the tokenizer. I will try to add special tokens to the vocabulary of `spacy` and pull another request. Thanks for code review :)