### PR TITLE
Fix python syntax in examples/run_gpt2.py

### DIFF
--- a/examples/run_gpt2.py
+++ b/examples/run_gpt2.py
@@ -107,25 +107,25 @@ def run_model():
                     print("=" * 40 + " SAMPLE " + str(generated) + " " + "=" * 40)
                     print(text)
             print("=" * 80)
-      if args.unconditional:
-          generated = 0
-          for _ in range(args.nsamples // args.batch_size):
-              out = sample_sequence(
-                  model=model, length=args.length,
-                  context=None,
-                  start_token=enc.encoder['<|endoftext|>'],
-                  batch_size=args.batch_size,
-                  temperature=args.temperature, top_k=args.top_k, device=device
-              )
-              out = out[:,1:].tolist()
-              for i in range(args.batch_size):
-                  generated += 1
-                  text = enc.decode(out[i])
-                  print("=" * 40 + " SAMPLE " + str(generated) + " " + "=" * 40)
-                  print(text)
-          print("=" * 80)
-          if args.unconditional:
-              break
+        else:
+            generated = 0
+            for _ in range(args.nsamples // args.batch_size):
+                out = sample_sequence(
+                    model=model, length=args.length,
+                    context=None,
+                    start_token=enc.encoder['<|endoftext|>'],
+                    batch_size=args.batch_size,
+                    temperature=args.temperature, top_k=args.top_k, device=device
+                )
+                out = out[:,1:].tolist()
+                for i in range(args.batch_size):
+                    generated += 1
+                    text = enc.decode(out[i])
+                    print("=" * 40 + " SAMPLE " + str(generated) + " " + "=" * 40)
+                    print(text)
+            print("=" * 80)
+            if args.unconditional:
+                break
 
 if __name__ == '__main__':
     run_model()

--- a/pytorch_pretrained_bert/tokenization_openai.py
+++ b/pytorch_pretrained_bert/tokenization_openai.py
@@ -223,7 +223,10 @@ class OpenAIGPTTokenizer(object):
             # Using BERT's BasicTokenizer
             text = self.nlp.tokenize(text)
             for token in text:
-                split_tokens.extend([t for t in self.bpe(token).split(' ')])
+                if token not in self.special_tokens:
+                    split_tokens.extend([t for t in self.bpe(token).split(' ')])
+                else:
+                    split_tokens.append(token)
         else:
             # Using SpaCy & ftfy (original tokenization process of OpenAI GPT)
             text = self.nlp(text_standardize(self.fix_text(text)))


### PR DESCRIPTION
As the title, we will never reach the code from line 115 to 131 because the space before `if args.unconditional` is not enough. 