### PR TITLE
Fix missing warmup_linear in run_classifier.py example

### DIFF
--- a/examples/run_classifier.py
+++ b/examples/run_classifier.py
@@ -38,7 +38,7 @@ from sklearn.metrics import matthews_corrcoef, f1_score
 from pytorch_pretrained_bert.file_utils import PYTORCH_PRETRAINED_BERT_CACHE, WEIGHTS_NAME, CONFIG_NAME
 from pytorch_pretrained_bert.modeling import BertForSequenceClassification, BertConfig
 from pytorch_pretrained_bert.tokenization import BertTokenizer
-from pytorch_pretrained_bert.optimization import BertAdam, warmup_linear
+from pytorch_pretrained_bert.optimization import BertAdam, WarmupLinearSchedule
 
 logger = logging.getLogger(__name__)
 
@@ -794,6 +794,7 @@ def main():
     global_step = 0
     nb_tr_steps = 0
     tr_loss = 0
+    warmup_linear_schedule = WarmupLinearSchedule(warmup=args.warmup_proportion)
     if args.do_train:
         train_features = convert_examples_to_features(
             train_examples, label_list, args.max_seq_length, tokenizer, output_mode)
@@ -852,7 +853,7 @@ def main():
                     if args.fp16:
                         # modify learning rate with special warm up BERT uses
                         # if args.fp16 is False, BertAdam is used that handles this automatically
-                        lr_this_step = args.learning_rate * warmup_linear(global_step/num_train_optimization_steps, args.warmup_proportion)
+                        lr_this_step = args.learning_rate * warmup_linear_schedule.get_lr_(global_step/num_train_optimization_steps)
                         for param_group in optimizer.param_groups:
                             param_group['lr'] = lr_this_step
                     optimizer.step()


### PR DESCRIPTION
Replaced warmup_linear function call with WarmupLinearSchedule