### PR TITLE
Fix GPT2 crash on special quotes in Python 3

### DIFF
--- a/pytorch_pretrained_bert/tokenization_gpt2.py
+++ b/pytorch_pretrained_bert/tokenization_gpt2.py
@@ -221,7 +221,8 @@ class GPT2Tokenizer(object):
         """ Tokenize a string. """
         bpe_tokens = []
         for token in re.findall(self.pat, text):
-            token = ''.join(self.byte_encoder[ord(b)] for b in token)
+            token_ord = [ord(b) for b in token] if sys.version_info[0] == 2 else token.encode('utf-8')
+            token = ''.join(self.byte_encoder[o] for o in token_ord)
             bpe_tokens.extend(bpe_token for bpe_token in self.bpe(token).split(' '))
         return bpe_tokens
 


### PR DESCRIPTION
In Python 3 the line
https://github.com/huggingface/pytorch-pretrained-BERT/blob/b832d5bb8a6dfc5965015b828e577677eace601e/pytorch_pretrained_bert/tokenization_gpt2.py#L224
splits `token` into full characters, not UTF-8 bytes, so for example the right single quote ’ gives `ord('’') == 8217`. That causes a crash since it's a much larger key than any in `self.byte_encoder`. The official GPT2 repo uses `token.encode('utf-8')` but it doesn't work the same in Python 2. I've suggested a fix that uses `token.encode` only in Python 3.

Tested on Python 3.7 but not Python 2.

Thanks for this very useful repo!