### PR TITLE
Fix for computing t_total in examples

### DIFF
--- a/examples/lm_finetuning/simple_lm_finetuning.py
+++ b/examples/lm_finetuning/simple_lm_finetuning.py
@@ -22,6 +22,7 @@ import logging
 import os
 import random
 from io import open
+import math
 
 import numpy as np
 import torch
@@ -515,7 +516,7 @@ def main():
         train_dataset = BERTDataset(args.train_corpus, tokenizer, seq_len=args.max_seq_length,
                                     corpus_lines=None, on_memory=args.on_memory)
         num_train_optimization_steps = int(
-            len(train_dataset) / args.train_batch_size / args.gradient_accumulation_steps) * args.num_train_epochs
+            math.ceil(float(len(train_dataset)) / args.train_batch_size) / args.gradient_accumulation_steps) * args.num_train_epochs
         if args.local_rank != -1:
             num_train_optimization_steps = num_train_optimization_steps // torch.distributed.get_world_size()
 

--- a/examples/run_classifier.py
+++ b/examples/run_classifier.py
@@ -23,6 +23,7 @@ import logging
 import os
 import random
 import sys
+import math
 
 import numpy as np
 import torch
@@ -740,7 +741,7 @@ def main():
     if args.do_train:
         train_examples = processor.get_train_examples(args.data_dir)
         num_train_optimization_steps = int(
-            len(train_examples) / args.train_batch_size / args.gradient_accumulation_steps) * args.num_train_epochs
+            math.ceil(len(train_examples) / args.train_batch_size) / args.gradient_accumulation_steps) * args.num_train_epochs
         if args.local_rank != -1:
             num_train_optimization_steps = num_train_optimization_steps // torch.distributed.get_world_size()
 

--- a/examples/run_classifier.py
+++ b/examples/run_classifier.py
@@ -23,6 +23,7 @@ import logging
 import os
 import random
 import sys
+import math
 
 import numpy as np
 import torch
@@ -740,7 +741,7 @@ def main():
     if args.do_train:
         train_examples = processor.get_train_examples(args.data_dir)
         num_train_optimization_steps = int(
-            len(train_examples) / args.train_batch_size / args.gradient_accumulation_steps) * args.num_train_epochs
+            math.ceil(float(len(train_examples)) / args.train_batch_size) / args.gradient_accumulation_steps) * args.num_train_epochs
         if args.local_rank != -1:
             num_train_optimization_steps = num_train_optimization_steps // torch.distributed.get_world_size()
 

--- a/examples/run_classifier.py
+++ b/examples/run_classifier.py
@@ -741,7 +741,7 @@ def main():
     if args.do_train:
         train_examples = processor.get_train_examples(args.data_dir)
         num_train_optimization_steps = int(
-            math.ceil(len(train_examples) / args.train_batch_size) / args.gradient_accumulation_steps) * args.num_train_epochs
+            math.ceil(float(len(train_examples)) / args.train_batch_size) / args.gradient_accumulation_steps) * args.num_train_epochs
         if args.local_rank != -1:
             num_train_optimization_steps = num_train_optimization_steps // torch.distributed.get_world_size()
 

--- a/examples/run_openai_gpt.py
+++ b/examples/run_openai_gpt.py
@@ -189,7 +189,7 @@ def main():
         {'params': [p for n, p in param_optimizer if not any(nd in n for nd in no_decay)], 'weight_decay': 0.01},
         {'params': [p for n, p in param_optimizer if any(nd in n for nd in no_decay)], 'weight_decay': 0.0}
         ]
-    num_train_optimization_steps = len(train_data) * args.num_train_epochs // args.train_batch_size
+    num_train_optimization_steps = len(train_dataloader) * args.num_train_epochs
     optimizer = OpenAIAdam(optimizer_grouped_parameters,
                            lr=args.learning_rate,
                            warmup=args.warmup_proportion,

--- a/examples/run_squad.py
+++ b/examples/run_squad.py
@@ -900,7 +900,7 @@ def main():
         train_examples = read_squad_examples(
             input_file=args.train_file, is_training=True, version_2_with_negative=args.version_2_with_negative)
         num_train_optimization_steps = int(
-            len(train_examples) / args.train_batch_size / args.gradient_accumulation_steps) * args.num_train_epochs
+            math.ceil(float(len(train_examples)) / args.train_batch_size) / args.gradient_accumulation_steps) * args.num_train_epochs
         if args.local_rank != -1:
             num_train_optimization_steps = num_train_optimization_steps // torch.distributed.get_world_size()
 

--- a/examples/run_swag.py
+++ b/examples/run_swag.py
@@ -24,6 +24,7 @@ import os
 import random
 import sys
 from io import open
+import math
 
 import numpy as np
 import torch
@@ -363,7 +364,7 @@ def main():
     if args.do_train:
         train_examples = read_swag_examples(os.path.join(args.data_dir, 'train.csv'), is_training = True)
         num_train_optimization_steps = int(
-            len(train_examples) / args.train_batch_size / args.gradient_accumulation_steps) * args.num_train_epochs
+            math.ceil(float(len(train_examples)) / args.train_batch_size) / args.gradient_accumulation_steps) * args.num_train_epochs
         if args.local_rank != -1:
             num_train_optimization_steps = num_train_optimization_steps // torch.distributed.get_world_size()
 


### PR DESCRIPTION
Examples had wrongly computed t_total, resulting in warning messages (Issue #556 )

Added fixes in several examples but:
- only tested MRPC in `run_classifier.py` so far
- `finetune_on_pregenerated.py` still needs fixing (not sure why lines 221-227 are as they are)