### PR TITLE
Add method to directly load TF Checkpoints for Bert models

### DIFF
--- a/pytorch_pretrained_bert/modeling.py
+++ b/pytorch_pretrained_bert/modeling.py
@@ -667,7 +667,7 @@ class BertPreTrainedModel(nn.Module):
         TensorFlow checkpoint file, instead of an archive / folder.
 
         Params:
-            bert_config_path: a path to a locally saved `bert_config.json`
+            config_file: a path to a locally saved `bert_config.json`
             tf_ckpt_path: path to a locally saved TensorFlow checkpoint:
                     (ex: `/full/path/to/folder/model.ckpt-240000`)
             *inputs, **kwargs: additional input for the specific Bert class


### PR DESCRIPTION
## Summary
In this PR, I changed some documentation, and added `from_tf_ckpt()` method to `BertPreTrainedModel`.

This method allows users to directly load TensorFlow checkpoints (e.g. `model.ckpt-XXXX` files) for a task specific Bert model like `BertForTokenClassification` or `BertForSequenceClassification`.

**For example:**
```python
model = BertForSequenceClassification.from_tf_ckpt("/path/to/bert/bert_config.json",
                                                   "/path/to/bert/model.ckpt-12000",
                                                   num_labels=num_labels)
```

## Why this is needed:
This functionality has been requested by a number of people, like #676, https://github.com/huggingface/pytorch-pretrained-BERT/issues/676#issuecomment-501778493, #580, https://github.com/huggingface/pytorch-pretrained-BERT/issues/580#issuecomment-497286535, https://github.com/huggingface/pytorch-pretrained-BERT/issues/438#issuecomment-479405364