### PR TITLE
Add tie_weights to XLNetForSequenceClassification

### DIFF
--- a/pytorch_pretrained_bert/modeling_xlnet.py
+++ b/pytorch_pretrained_bert/modeling_xlnet.py
@@ -1268,6 +1268,11 @@ class XLNetForSequenceClassification(XLNetPreTrainedModel):
 
         self.apply(self.init_xlnet_weights)
         self.tie_weights()
+        
+    def tie_weights(self):
+        """ Make sure we are sharing the embeddings
+        """
+        self.lm_loss.weight = self.transformer.word_embedding.weight
 
     def forward(self, inp_k, seg_id=None, input_mask=None,
                 mems=None, perm_mask=None, target_mapping=None, inp_q=None,


### PR DESCRIPTION
XLNetForSequenceClassification doesn't have tie_weights() but initialization will call it, or we can made a function in XLNetPretrainedModel?