### PR TITLE
make save_pretrained do the right thing with added tokens

### DIFF
--- a/pytorch_transformers/tokenization_utils.py
+++ b/pytorch_transformers/tokenization_utils.py
@@ -266,7 +266,7 @@ class PreTrainedTokenizer(object):
 
         with open(added_tokens_file, 'w', encoding='utf-8') as f:
             if self.added_tokens_encoder:
-                out_str = json.dumps(self.added_tokens_decoder, ensure_ascii=False)
+                out_str = json.dumps(self.added_tokens_encoder, ensure_ascii=False)
             else:
                 out_str = u"{}"
             f.write(out_str)


### PR DESCRIPTION
right now it's dumping the *decoder* when it should be dumping the *encoder*. and then (for obvious reasons) you get an error when you try to load "from_pretrained" using that dump.

this PR fixes that.