### PR TITLE
fix a bug of saving added tokens

### DIFF
--- a/pytorch_transformers/tokenization_utils.py
+++ b/pytorch_transformers/tokenization_utils.py
@@ -266,7 +266,7 @@ class PreTrainedTokenizer(object):
 
         with open(added_tokens_file, 'w', encoding='utf-8') as f:
             if self.added_tokens_encoder:
-                out_str = json.dumps(self.added_tokens_decoder, ensure_ascii=False)
+                out_str = json.dumps(self.added_tokens_encoder, ensure_ascii=False)
             else:
                 out_str = u"{}"
             f.write(out_str)


### PR DESCRIPTION
Refer to the code that loads `added_tokens.json`:
`added_tok_encoder = json.load(open(added_tokens_file, encoding="utf-8"))`
We can see that `added_tokens_encoder` should be saved in `added_tokens.json`. But the original code saved `added_tokens_decoder`. 
