### PR TITLE
Fix FileNotFoundError when running on SQuAD-v1.1

### DIFF
--- a/examples/run_squad.py
+++ b/examples/run_squad.py
@@ -234,7 +234,7 @@ def evaluate(args, model, tokenizer, prefix=""):
     # Compute predictions
     output_prediction_file = os.path.join(args.output_dir, "predictions_{}.json".format(prefix))
     output_nbest_file = os.path.join(args.output_dir, "nbest_predictions_{}.json".format(prefix))
-    output_null_log_odds_file = os.path.join(args.output_dir, "null_odds_{}.json".format(prefix))
+    output_null_log_odds_file = os.path.join(args.output_dir, "null_odds_{}.json".format(prefix)) if args.version_2_with_negative else None
 
     if args.model_type in ['xlnet', 'xlm']:
         # XLNet uses a more complex post-processing procedure


### PR DESCRIPTION
At "utils_squad_evaluate.py" line 291, no matter version_2_with_negative is True or False, it tries to load "output_null_log_odds_file" which is not saved when version_2_with_negative is False.