### PR TITLE
Updated model token sizing to replace removed parameter `num_special_…

### DIFF
--- a/examples/single_model_scripts/run_openai_gpt.py
+++ b/examples/single_model_scripts/run_openai_gpt.py
@@ -155,7 +155,8 @@ def main():
     special_tokens = ['_start_', '_delimiter_', '_classify_']
     tokenizer = OpenAIGPTTokenizer.from_pretrained(args.model_name, special_tokens=special_tokens)
     special_tokens_ids = list(tokenizer.convert_tokens_to_ids(token) for token in special_tokens)
-    model = OpenAIGPTDoubleHeadsModel.from_pretrained(args.model_name, num_special_tokens=len(special_tokens))
+    model = OpenAIGPTDoubleHeadsModel.from_pretrained(args.model_name)
+    model.resize_token_embeddings(new_num_tokens=len(tokenizer))
     model.to(device)
 
     # Load and encode the datasets


### PR DESCRIPTION
…tokens`

`num_special_tokens` seems to no longer be implemented.  Replaced with `model.resize_token_embeddings(new_num_tokens=len(tokenizer))` which resizes (non-destructively, I think) the embeddings to include the new tokens.