### PR TITLE
Fixed typo in migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ loss = outputs[0]
 # In pytorch-transformers you can also have access to the logits:
 loss, logits = outputs[:2]
 
-# And even the attention weigths if you configure the model to output them (and other outputs too, see the docstrings and documentation)
+# And even the attention weights if you configure the model to output them (and other outputs too, see the docstrings and documentation)
 model = BertForSequenceClassification.from_pretrained('bert-base-uncased', output_attentions=True)
 outputs = model(input_ids, labels=labels)
 loss, logits, attentions = outputs


### PR DESCRIPTION
This PR fixes a minor typo in the migration guide. `weights` was misspelled as `weigths`