### PR TITLE
docs: correct number of layers for various xlm models

### DIFF
--- a/docs/source/pretrained_models.rst
+++ b/docs/source/pretrained_models.rst
@@ -75,13 +75,13 @@ Here is the full list of the currently provided pretrained models together with 
 | XLM               | ``xlm-mlm-en-2048``                                        | 12-layer, 1024-hidden, 8-heads                                                                                            |
 |                   |                                                            | XLM English model                                                                                                         |
 |                   +------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------+
-|                   | ``xlm-mlm-ende-1024``                                      | 12-layer, 1024-hidden, 8-heads                                                                                            |
+|                   | ``xlm-mlm-ende-1024``                                      | 6-layer, 1024-hidden, 8-heads                                                                                             |
 |                   |                                                            | XLM English-German Multi-language model                                                                                   |
 |                   +------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------+
-|                   | ``xlm-mlm-enfr-1024``                                      | 12-layer, 1024-hidden, 8-heads                                                                                            |
+|                   | ``xlm-mlm-enfr-1024``                                      | 6-layer, 1024-hidden, 8-heads                                                                                             |
 |                   |                                                            | XLM English-French Multi-language model                                                                                   |
 |                   +------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------+
-|                   | ``xlm-mlm-enro-1024``                                      | 12-layer, 1024-hidden, 8-heads                                                                                            |
+|                   | ``xlm-mlm-enro-1024``                                      | 6-layer, 1024-hidden, 8-heads                                                                                             |
 |                   |                                                            | XLM English-Romanian Multi-language model                                                                                 |
 |                   +------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------+
 |                   | ``xlm-mlm-xnli15-1024``                                    | 12-layer, 1024-hidden, 8-heads                                                                                            |
@@ -90,10 +90,10 @@ Here is the full list of the currently provided pretrained models together with 
 |                   | ``xlm-mlm-tlm-xnli15-1024``                                | 12-layer, 1024-hidden, 8-heads                                                                                            |
 |                   |                                                            | XLM Model pre-trained with MLM + TLM on the `15 XNLI languages <https://github.com/facebookresearch/XNLI>`__.             |
 |                   +------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------+
-|                   | ``xlm-clm-enfr-1024``                                      | 12-layer, 1024-hidden, 8-heads                                                                                            |
+|                   | ``xlm-clm-enfr-1024``                                      | 6-layer, 1024-hidden, 8-heads                                                                                             |
 |                   |                                                            | XLM English model trained with CLM (Causal Language Modeling)                                                             |
 |                   +------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------+
-|                   | ``xlm-clm-ende-1024``                                      | 12-layer, 1024-hidden, 8-heads                                                                                            |
+|                   | ``xlm-clm-ende-1024``                                      | 6-layer, 1024-hidden, 8-heads                                                                                             |
 |                   |                                                            | XLM English-German Multi-language model trained with CLM (Causal Language Modeling)                                       |
 +-------------------+------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------+
 


### PR DESCRIPTION
Hi,

during some NER experiments I found out, that the number of reported layers in the documentation is different compared to the model configuration for some XLM models.

This PR fixes the documentation :)