### PR TITLE
loads the tokenizer for each checkpoint, to solve the reproducability…

### DIFF
--- a/examples/run_glue.py
+++ b/examples/run_glue.py
@@ -463,6 +463,7 @@ def main():
         for checkpoint in checkpoints:
             global_step = checkpoint.split('-')[-1] if len(checkpoints) > 1 else ""
             model = model_class.from_pretrained(checkpoint)
+            tokenizer = tokenizer_class.from_pretrained(checkpoint)
             model.to(args.device)
             result = evaluate(args, model, tokenizer, prefix=global_step)
             result = dict((k + '_{}'.format(global_step), v) for k, v in result.items())


### PR DESCRIPTION
Hi
I observed that if you run "run_glue" code with the same parameters in the following ways:
1) run with both --do_train and --do_eval
2) run without --do_train but only --do_eval, but set the modelpath to use the trained models from step 1

The obtained evaluation results in these two cases are not the same, and to make the results reproducible it is needed to reload tokenizer from checkpoints.
 
Thanks.