### PR TITLE
Fix RobertaEmbeddings

### DIFF
--- a/pytorch_transformers/modeling_bert.py
+++ b/pytorch_transformers/modeling_bert.py
@@ -193,6 +193,7 @@ class BertConfig(PretrainedConfig):
                  type_vocab_size=2,
                  initializer_range=0.02,
                  layer_norm_eps=1e-12,
+                 padding_idx=0,
                  **kwargs):
         super(BertConfig, self).__init__(**kwargs)
         if isinstance(vocab_size_or_config_json_file, str) or (sys.version_info[0] == 2
@@ -214,6 +215,7 @@ class BertConfig(PretrainedConfig):
             self.type_vocab_size = type_vocab_size
             self.initializer_range = initializer_range
             self.layer_norm_eps = layer_norm_eps
+            self.padding_idx = padding_idx
         else:
             raise ValueError("First argument must be either a vocabulary size (int)"
                              "or the path to a pretrained model config file (str)")

--- a/pytorch_transformers/modeling_roberta.py
+++ b/pytorch_transformers/modeling_roberta.py
@@ -70,12 +70,11 @@ class RobertaEmbeddings(nn.Module):
         if position_ids is None:
             # Position numbers begin at padding_idx+1. Padding symbols are ignored.
             # cf. fairseq's `utils.make_positions`
-            # position_ids.masked_fill_(mask,self.padding_idx)
             # fairseq version for ONNX and XLA compatiblity
             mask = input_ids.ne(self.padding_idx).int()
             position_ids = (torch.cumsum(mask, dim=1).type_as(mask) * mask).long() + self.padding_idx
 
-        if self.token_type_embeddings is not None and self.token_type_ids is None:
+        if self.token_type_embeddings is not None and token_type_ids is None:
             token_type_ids = torch.zeros_like(input_ids,dtype=torch.long, device=input_ids.device)
 
         words_embeddings = self.word_embeddings(input_ids)


### PR DESCRIPTION
First of all, the original implementation can define `segment_embeddings` depending on `num_segments` argument. Actually, their model(Roberta) didn't use `segment_embeddings` because they found the effectiveness of `FULL/DOC SENTENCE` setting of inputs. 

And `position_embeddings` should use `padding_idx` to ignore padded inputs. Also the embedding matrix's size should be `padding_idx + max_seq_length + 1`. (e.g If `padding_idx=1` and `max_seq_length=512`, `maxtrix size = (1 + 512 + 1) = 514`.

Last, `position_ids` should be made by considering the previous feature. Below is simple test to make `position_ids` to reflect `padding_idx` of `input_ids`
```
input_ids = torch.randint(0,1000,(3,10))
padding_idx = 0

### dummy padded input
input_ids[:,-2] = padding_idx
input_ids[:,-1] = padding_idx
input_ids[0][-3] = padding_idx
input_ids[-1][-3] = padding_idx

input_ids
>>> tensor([[946, 783, 399, 951, 496, 400, 350,   0,   0,   0],
            [905, 445, 410, 406, 526,   1, 255, 811,   0,   0],
            [815, 669, 813, 708, 475, 232, 190,   0,   0,   0]])

```

```
mask = input_ids.ne(padding_idx).int()
position_ids = (torch.cumsum(mask, dim=1).type_as(mask) * mask).long() + padding_idx

position_ids
>>> tensor([[1, 2, 3, 4, 5, 6, 7, 0, 0, 0],
            [1, 2, 3, 4, 5, 6, 7, 8, 0, 0],
            [1, 2, 3, 4, 5, 6, 7, 0, 0, 0]])

```