### PR TITLE
Fix the gpt2 quickstart example

### DIFF
--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -154,6 +154,9 @@ logging.basicConfig(level=logging.INFO)
 # Load pre-trained model tokenizer (vocabulary)
 tokenizer = GPT2Tokenizer.from_pretrained('gpt2')
 
+# Add seperator token
+tokenizer.add_special_tokens({'sep_token': '[SEP]'})
+
 # Encode a text inputs
 text = "Who was Jim Henson ? Jim Henson was a"
 indexed_tokens = tokenizer.encode(text)


### PR DESCRIPTION
You need to add the SEP (seperator) token to the tokenizer, otherwise the tokenizer.decode will fail with this error:
`ERROR:pytorch_transformers.tokenization_utils:Using sep_token, but it is not set yet.`