### PR TITLE
Fix "No such file or directory" for SQuAD v1.1

### DIFF
--- a/examples/run_squad.py
+++ b/examples/run_squad.py
@@ -264,9 +264,14 @@ def evaluate(args, model, tokenizer, prefix=""):
                         args.version_2_with_negative, args.null_score_diff_threshold)
 
     # Evaluate with the official SQuAD script
-    evaluate_options = EVAL_OPTS(data_file=args.predict_file,
-                                 pred_file=output_prediction_file,
-                                 na_prob_file=output_null_log_odds_file)
+    if args.version_2_with_negative:
+        evaluate_options = EVAL_OPTS(data_file=args.predict_file,
+                                     pred_file=output_prediction_file,
+                                     na_prob_file=output_null_log_odds_file)
+    else:
+        evaluate_options = EVAL_OPTS(data_file=args.predict_file,
+                                     pred_file=output_prediction_file,
+                                     na_prob_file="")
     results = evaluate_on_squad(evaluate_options)
     return results
 


### PR DESCRIPTION
This solves the exception for SQuAD v1.1 evaluation without predicted null_odds file.

Traceback (most recent call last):
  File "./examples/run_squad.py", line 521, in <module>
  File "./examples/run_squad.py", line 510, in main
    for checkpoint in checkpoints:
  File "./examples/run_squad.py", line 257, in evaluate
    na_prob_file=output_null_log_odds_file)
  File "/home/zhangzs/pytorch-transformers-master/examples/utils_squad_evaluate.py", line 291, in main
    with open(OPTS.na_prob_file) as f:
FileNotFoundError: [Errno 2] No such file or directory: 'squad/squad-debug/null_odds_.json'