### PR TITLE
Fix distributed barrier hang

### DIFF
--- a/examples/run_glue.py
+++ b/examples/run_glue.py
@@ -251,7 +251,7 @@ def evaluate(args, model, tokenizer, prefix=""):
 
 
 def load_and_cache_examples(args, task, tokenizer, evaluate=False):
-    if args.local_rank not in [-1, 0]:
+    if args.local_rank not in [-1, 0] and not evaluate:
         torch.distributed.barrier()  # Make sure only the first process in distributed training process the dataset, and the others will use the cache
 
     processor = processors[task]()
@@ -286,7 +286,7 @@ def load_and_cache_examples(args, task, tokenizer, evaluate=False):
             logger.info("Saving features into cached file %s", cached_features_file)
             torch.save(features, cached_features_file)
 
-    if args.local_rank == 0:
+    if args.local_rank == 0 and not evaluate:
         torch.distributed.barrier()  # Make sure only the first process in distributed training process the dataset, and the others will use the cache
 
     # Convert to Tensors and build dataset

--- a/examples/run_squad.py
+++ b/examples/run_squad.py
@@ -272,7 +272,7 @@ def evaluate(args, model, tokenizer, prefix=""):
 
 
 def load_and_cache_examples(args, tokenizer, evaluate=False, output_examples=False):
-    if args.local_rank not in [-1, 0]:
+    if args.local_rank not in [-1, 0] and not evaluate:
         torch.distributed.barrier()  # Make sure only the first process in distributed training process the dataset, and the others will use the cache
 
     # Load data features from cache or dataset file
@@ -299,7 +299,7 @@ def load_and_cache_examples(args, tokenizer, evaluate=False, output_examples=Fal
             logger.info("Saving features into cached file %s", cached_features_file)
             torch.save(features, cached_features_file)
 
-    if args.local_rank == 0:
+    if args.local_rank == 0 and not evaluate:
         torch.distributed.barrier()  # Make sure only the first process in distributed training process the dataset, and the others will use the cache
 
     # Convert to Tensors and build dataset


### PR DESCRIPTION
This is bug reported in issue #998 (and is also valid for `run_squad.py`).

What is happening?
When launching a distributed training on one of the task of the GLUE benchmark (for instance this suggested command in the README [here](https://github.com/huggingface/pytorch-transformers#fine-tuning-bert-model-on-the-mrpc-classification-task) for GLUE or [here](https://github.com/huggingface/pytorch-transformers#run_squadpy-fine-tuning-on-squad-for-question-answering) for SQUAD), the training is performed in a distributed setting (expected behavior). Evaluation can be tricky for certain metrics in a distributed setting so the evaluation is performed solely by the master process (cf L476: `if args.do_eval and args.local_rank in [-1, 0]:`).

During the evaluation, the process hangs/gets stucked at L290 (`torch.distributed.barrier()`). It turns out that all the processes except the master one already exit at L476 and thus never enter the symmetric `torch.distributed.barrier()` at L254-255. It means that the master process is waiting at L290 for his process friends who already left the party without telling him (printing a `torch.distributed.get_world_size()` at L290 during evaluation reveals torch is expecting `$NGPU` processes). 

Adding a `and not evaluate` condition both at L254 and L289 is a solution to fix the bug (the master process is the only surviving process at evaluation, so no need to wait for others...)
