### PR TITLE
distilbert: fix number of hidden_size

### DIFF
--- a/pytorch_transformers/modeling_distilbert.py
+++ b/pytorch_transformers/modeling_distilbert.py
@@ -95,7 +95,7 @@ class DistilBertConfig(PretrainedConfig):
                              " or the path to a pretrained model config file (str)")
     @property
     def hidden_size(self):
-        return self.hidden_dim
+        return self.dim
 
     @property
     def num_attention_heads(self):


### PR DESCRIPTION
Hi,

this PR corrects the return value of the `hidden_size` function (which should be the dimension size, as it is used in all other models) :)