### PR TITLE
fix adding special tokens

### DIFF
--- a/pytorch_transformers/tokenization_utils.py
+++ b/pytorch_transformers/tokenization_utils.py
@@ -676,7 +676,7 @@ class PreTrainedTokenizer(object):
         all_toks = []
         set_attr = self.special_tokens_map
         for attr_value in set_attr.values():
-            all_toks = all_toks + (attr_value if isinstance(attr_value, (list, tuple)) else [attr_value])
+            all_toks = all_toks + (list(attr_value) if isinstance(attr_value, (list, tuple)) else [attr_value])
         all_toks = list(set(all_toks))
         return all_toks
 


### PR DESCRIPTION
Currently there is a bug when adding `additional_special_tokens` in the form of a tuple, instead of a list. To reproduce:

```python
from pytorch_transformers import AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained("xlnet-base-cased")
tokenizer.add_special_tokens({"additional_special_tokens": ("@a@", "@b@")})
tokenizer.all_special_tokens
```

Results in:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-81549ce398a5> in <module>()
----> 1 tokenizer.all_special_tokens

~/GitHub/pytorch-transformers/pytorch_transformers/tokenization_utils.py in
all_special_tokens(self)
    677         set_attr = self.special_tokens_map
    678         for attr_value in set_attr.values():
--> 679             all_toks = all_toks + (attr_value if isinstance(attr_val
ue, (list, tuple)) else [attr_value])
    680         all_toks = list(set(all_toks))
    681         return all_toks

TypeError: can only concatenate list (not "tuple") to list
```