### PR TITLE
[WIP] Refactor Tokenizers creation to support in-memory initialization

### DIFF
--- a/pytorch_transformers/tests/tokenization_bert_test.py
+++ b/pytorch_transformers/tests/tokenization_bert_test.py
@@ -50,7 +50,8 @@ class BertTokenizationTest(CommonTestCases.CommonTokenizerTester):
         return input_text, output_text
 
     def test_full_tokenizer(self):
-        tokenizer = self.tokenizer_class(self.vocab_file)
+        tokenizer_vocab = self.tokenizer_class.vocab_class.from_pretrained(self.vocab_file)
+        tokenizer = self.tokenizer_class(tokenizer_vocab)
 
         tokens = tokenizer.tokenize(u"UNwant\u00E9d,running")
         self.assertListEqual(tokens, ["un", "##want", "##ed", ",", "runn", "##ing"])

--- a/pytorch_transformers/tests/tokenization_gpt2_test.py
+++ b/pytorch_transformers/tests/tokenization_gpt2_test.py
@@ -53,7 +53,8 @@ class GPT2TokenizationTest(CommonTestCases.CommonTokenizerTester):
         return input_text, output_text
 
     def test_full_tokenizer(self):
-        tokenizer = GPT2Tokenizer(self.vocab_file, self.merges_file, **self.special_tokens_map)
+        tokenizer_vocab = GPT2Tokenizer.vocab_class.from_pretrained(self.vocab_file, self.merges_file)
+        tokenizer = GPT2Tokenizer(tokenizer_vocab, **self.special_tokens_map)
         text = "lower"
         bpe_tokens = ["low", "er"]
         tokens = tokenizer.tokenize(text)

--- a/pytorch_transformers/tests/tokenization_openai_test.py
+++ b/pytorch_transformers/tests/tokenization_openai_test.py
@@ -55,7 +55,8 @@ class OpenAIGPTTokenizationTest(CommonTestCases.CommonTokenizerTester):
 
 
     def test_full_tokenizer(self):
-        tokenizer = OpenAIGPTTokenizer(self.vocab_file, self.merges_file)
+        tokenizer_vocab = OpenAIGPTTokenizer.vocab_class.from_pretrained(self.vocab_file, self.merges_file)
+        tokenizer = OpenAIGPTTokenizer(tokenizer_vocab)
 
         text = "lower"
         bpe_tokens = ["low", "er</w>"]

--- a/pytorch_transformers/tests/tokenization_roberta_test.py
+++ b/pytorch_transformers/tests/tokenization_roberta_test.py
@@ -52,7 +52,8 @@ class RobertaTokenizationTest(CommonTestCases.CommonTokenizerTester):
         return input_text, output_text
 
     def test_full_tokenizer(self):
-        tokenizer = RobertaTokenizer(self.vocab_file, self.merges_file, **self.special_tokens_map)
+        tokenizer_vocab = RobertaTokenizer.vocab_class.from_pretrained(self.vocab_file, self.merges_file)
+        tokenizer = RobertaTokenizer(tokenizer_vocab, **self.special_tokens_map)
         text = "lower"
         bpe_tokens = ["low", "er"]
         tokens = tokenizer.tokenize(text)

--- a/pytorch_transformers/tests/tokenization_transfo_xl_test.py
+++ b/pytorch_transformers/tests/tokenization_transfo_xl_test.py
@@ -46,7 +46,8 @@ class TransfoXLTokenizationTest(CommonTestCases.CommonTokenizerTester):
         return input_text, output_text
 
     def test_full_tokenizer(self):
-        tokenizer = TransfoXLTokenizer(vocab_file=self.vocab_file, lower_case=True)
+        tokenizer_vocab = TransfoXLTokenizer.vocab_class.from_pretrained(self.vocab_file)
+        tokenizer = TransfoXLTokenizer(tokenizer_vocab, lower_case=True)
 
         tokens = tokenizer.tokenize(u"<unk> UNwanted , running")
         self.assertListEqual(tokens, ["<unk>", "unwanted", ",", "running"])
@@ -55,14 +56,14 @@ class TransfoXLTokenizationTest(CommonTestCases.CommonTokenizerTester):
             tokenizer.convert_tokens_to_ids(tokens), [0, 4, 8, 7])
 
     def test_full_tokenizer_lower(self):
-        tokenizer = TransfoXLTokenizer(lower_case=True)
+        tokenizer = TransfoXLTokenizer(TransfoXLTokenizer.vocab_class.empty(), lower_case=True)
 
         self.assertListEqual(
             tokenizer.tokenize(u" \tHeLLo ! how  \n Are yoU ?  "),
             ["hello", "!", "how", "are", "you", "?"])
 
     def test_full_tokenizer_no_lower(self):
-        tokenizer = TransfoXLTokenizer(lower_case=False)
+        tokenizer = TransfoXLTokenizer(TransfoXLTokenizer.vocab_class.empty(), lower_case=False)
 
         self.assertListEqual(
             tokenizer.tokenize(u" \tHeLLo ! how  \n Are yoU ?  "),

--- a/pytorch_transformers/tests/tokenization_xlm_test.py
+++ b/pytorch_transformers/tests/tokenization_xlm_test.py
@@ -54,7 +54,8 @@ class XLMTokenizationTest(CommonTestCases.CommonTokenizerTester):
 
     def test_full_tokenizer(self):
         """ Adapted from Sennrich et al. 2015 and https://github.com/rsennrich/subword-nmt """
-        tokenizer = XLMTokenizer(self.vocab_file, self.merges_file)
+        tokenizer_vocab = XLMTokenizer.vocab_class.from_pretrained(self.vocab_file, self.merges_file)
+        tokenizer = XLMTokenizer(tokenizer_vocab)
 
         text = "lower"
         bpe_tokens = ["low", "er</w>"]

--- a/pytorch_transformers/tests/tokenization_xlnet_test.py
+++ b/pytorch_transformers/tests/tokenization_xlnet_test.py
@@ -32,7 +32,8 @@ class XLNetTokenizationTest(CommonTestCases.CommonTokenizerTester):
         super(XLNetTokenizationTest, self).setUp()
 
         # We have a SentencePiece fixture for testing
-        tokenizer = XLNetTokenizer(SAMPLE_VOCAB, keep_accents=True)
+        tokenizer_vocab = XLNetTokenizer.vocab_class.from_pretrained(SAMPLE_VOCAB)
+        tokenizer = XLNetTokenizer(tokenizer_vocab, keep_accents=True)
         tokenizer.save_pretrained(self.tmpdirname)
 
     def get_tokenizer(self):
@@ -45,7 +46,8 @@ class XLNetTokenizationTest(CommonTestCases.CommonTokenizerTester):
 
 
     def test_full_tokenizer(self):
-        tokenizer = XLNetTokenizer(SAMPLE_VOCAB, keep_accents=True)
+        tokenizer_vocab = XLNetTokenizer.vocab_class.from_pretrained(SAMPLE_VOCAB)
+        tokenizer = XLNetTokenizer(tokenizer_vocab, keep_accents=True)
 
         tokens = tokenizer.tokenize(u'This is a test')
         self.assertListEqual(tokens, [u'▁This', u'▁is', u'▁a', u'▁t', u'est'])
@@ -73,7 +75,8 @@ class XLNetTokenizationTest(CommonTestCases.CommonTokenizerTester):
                                         u'<unk>', u'.'])
 
     def test_tokenizer_lower(self):
-        tokenizer = XLNetTokenizer(SAMPLE_VOCAB, do_lower_case=True)
+        tokenizer_vocab = XLNetTokenizer.vocab_class.from_pretrained(SAMPLE_VOCAB)
+        tokenizer = XLNetTokenizer(tokenizer_vocab, do_lower_case=True)
         tokens = tokenizer.tokenize(u"I was born in 92000, and this is falsé.")
         self.assertListEqual(tokens, [SPIECE_UNDERLINE + u'', u'i', SPIECE_UNDERLINE + u'was', SPIECE_UNDERLINE + u'b',
                                       u'or', u'n', SPIECE_UNDERLINE + u'in', SPIECE_UNDERLINE + u'',
@@ -82,7 +85,8 @@ class XLNetTokenizationTest(CommonTestCases.CommonTokenizerTester):
         self.assertListEqual(tokenizer.tokenize(u"H\u00E9llo"), [u"▁he", u"ll", u"o"])
 
     def test_tokenizer_no_lower(self):
-        tokenizer = XLNetTokenizer(SAMPLE_VOCAB, do_lower_case=False)
+        tokenizer_vocab = XLNetTokenizer.vocab_class.from_pretrained(SAMPLE_VOCAB)
+        tokenizer = XLNetTokenizer(tokenizer_vocab, do_lower_case=False)
         tokens = tokenizer.tokenize(u"I was born in 92000, and this is falsé.")
         self.assertListEqual(tokens, [SPIECE_UNDERLINE + u'I', SPIECE_UNDERLINE + u'was', SPIECE_UNDERLINE + u'b', u'or',
                                       u'n', SPIECE_UNDERLINE + u'in', SPIECE_UNDERLINE + u'',

--- a/pytorch_transformers/tokenization_auto.py
+++ b/pytorch_transformers/tokenization_auto.py
@@ -25,6 +25,7 @@ from .tokenization_transfo_xl import TransfoXLTokenizer
 from .tokenization_xlnet import XLNetTokenizer
 from .tokenization_xlm import XLMTokenizer
 from .tokenization_roberta import RobertaTokenizer
+from .tokenization_distilbert import DistilBertTokenizer
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +40,8 @@ class AutoTokenizer(object):
 
         The tokenizer class to instantiate is selected as the first pattern matching
         in the `pretrained_model_name_or_path` string (in the following order):
+            - contains `distilbert`: DistilBertTokenizer (DistilBert model)
+            - contains `roberta`: RobertaTokenizer (RoBERTa model)
             - contains `bert`: BertTokenizer (Bert model)
             - contains `openai-gpt`: OpenAIGPTTokenizer (OpenAI GPT model)
             - contains `gpt2`: GPT2Tokenizer (OpenAI GPT-2 model)

--- a/pytorch_transformers/tokenization_bert.py
+++ b/pytorch_transformers/tokenization_bert.py
@@ -28,7 +28,7 @@ from .tokenization_utils import PreTrainedTokenizer, PreTrainedTokenizerVocab
 
 logger = logging.getLogger(__name__)
 
-VOCAB_FILES_NAMES = {'vocab_file_path': 'vocab.txt'}
+VOCAB_FILES_NAMES = {'vocab_file': 'vocab.txt'}
 
 PRETRAINED_VOCAB_FILES_MAP = {
     'vocab_file':

--- a/pytorch_transformers/tokenization_bert.py
+++ b/pytorch_transformers/tokenization_bert.py
@@ -19,6 +19,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import collections
 import logging
 import os
+
+import six
 import unicodedata
 from io import open
 
@@ -140,7 +142,7 @@ class BertTokenizer(PreTrainedTokenizer):
         self.max_len_sentences_pair = self.max_len - 3  # take into account special tokens
 
         if not isinstance(vocab_or_filepath, BertTokenizerVocab):
-            if isinstance(vocab_or_filepath, str):
+            if isinstance(vocab_or_filepath, str) or (six.PY2 and isinstance(vocab_or_filepath, unicode)):
                 self.vocab = BertTokenizerVocab.from_pretrained(vocab_or_filepath)
             else:
                 raise ValueError(

--- a/pytorch_transformers/tokenization_bert.py
+++ b/pytorch_transformers/tokenization_bert.py
@@ -149,9 +149,8 @@ class BertTokenizer(PreTrainedTokenizer):
                 "vocab_or_filepath should be instance of BertTokenizerVocab "
                 "(got: {})".format(type(vocabs).__name__)
             )
-        else:
-            self.vocabs = vocabs
 
+        self.vocabs = vocabs
         self.ids_to_tokens = collections.OrderedDict(
             [(ids, tok) for tok, ids in self.vocabs.vocab.items()])
         self.do_basic_tokenize = do_basic_tokenize

--- a/pytorch_transformers/tokenization_bert.py
+++ b/pytorch_transformers/tokenization_bert.py
@@ -142,7 +142,7 @@ class BertTokenizer(PreTrainedTokenizer):
         if not isinstance(vocabs, BertTokenizerVocab):
             raise ValueError(
                 "vocab_or_filepath should be instance of BertTokenizerVocab "
-                "or str (got: {})".format(type(vocabs).__name__)
+                "(got: {})".format(type(vocabs).__name__)
             )
         else:
             self.vocabs = vocabs

--- a/pytorch_transformers/tokenization_bert.py
+++ b/pytorch_transformers/tokenization_bert.py
@@ -86,9 +86,8 @@ def whitespace_tokenize(text):
 
 class BertTokenizerVocab(object):
     """Constructs a BertTokenizerVocab from a wordpiece vocab dictionary"""
-    def __init__(self, vocab):
-        super().__init__()
 
+    def __init__(self, vocab):
         self.vocab = vocab
 
     @classmethod

--- a/pytorch_transformers/tokenization_bert.py
+++ b/pytorch_transformers/tokenization_bert.py
@@ -115,7 +115,7 @@ class BertTokenizer(PreTrainedTokenizer):
     pretrained_vocab_files_map = PRETRAINED_VOCAB_FILES_MAP
     max_model_input_sizes = PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES
 
-    def __init__(self, vocab_or_filepath, do_lower_case=True, do_basic_tokenize=True, never_split=None,
+    def __init__(self, vocab_file, do_lower_case=True, do_basic_tokenize=True, never_split=None,
                  unk_token="[UNK]", sep_token="[SEP]", pad_token="[PAD]", cls_token="[CLS]",
                  mask_token="[MASK]", tokenize_chinese_chars=True, **kwargs):
         """Constructs a BertTokenizer.
@@ -141,16 +141,16 @@ class BertTokenizer(PreTrainedTokenizer):
         self.max_len_single_sentence = self.max_len - 2  # take into account special tokens
         self.max_len_sentences_pair = self.max_len - 3  # take into account special tokens
 
-        if not isinstance(vocab_or_filepath, BertTokenizerVocab):
-            if isinstance(vocab_or_filepath, str) or (six.PY2 and isinstance(vocab_or_filepath, unicode)):
-                self.vocab = BertTokenizerVocab.from_pretrained(vocab_or_filepath)
+        if not isinstance(vocab_file, BertTokenizerVocab):
+            if isinstance(vocab_file, str) or (six.PY2 and isinstance(vocab_file, unicode)):
+                self.vocab = BertTokenizerVocab.from_pretrained(vocab_file)
             else:
                 raise ValueError(
                     "vocab_or_filepath should be instance of BertTokenizerVocab "
-                    "or str (got: {})".format(type(vocab_or_filepath).__name__)
+                    "or str (got: {})".format(type(vocab_file).__name__)
                 )
         else:
-            self.vocab = vocab_or_filepath
+            self.vocab = vocab_file
 
         self.ids_to_tokens = collections.OrderedDict(
             [(ids, tok) for tok, ids in self.vocab.vocab.items()])

--- a/pytorch_transformers/tokenization_bert.py
+++ b/pytorch_transformers/tokenization_bert.py
@@ -119,7 +119,7 @@ class BertTokenizer(PreTrainedTokenizer):
         """Constructs a BertTokenizer.
 
         Args:
-            **vocab*: Instance of BertTokenizerVocab
+            **vocab_or_filepath**: BertTokenizerVocab or str pointing to a one-wordpiece-per-line vocabulary file
             **do_lower_case**: (`optional`) boolean (default True)
                 Whether to lower case the input
                 Only has an effect when do_basic_tokenize=True

--- a/pytorch_transformers/tokenization_bert.py
+++ b/pytorch_transformers/tokenization_bert.py
@@ -89,7 +89,12 @@ class BertTokenizerVocab(PreTrainedTokenizerVocab):
 
     @classmethod
     def from_pretrained(cls, vocab_file, merges_file=None):
-        """Loads the wordpiece vocab from disk"""
+        """
+        Creates a BertTokenizerVocab instance from stored wordpiece vocab
+        :param vocab_file: Path to wordpiece vocabulary file
+        :param merges_file: Ignored.
+        :return: BertTokenizerVocab instance
+        """
         return cls(load_vocab(vocab_file))
 
 class BertTokenizer(PreTrainedTokenizer):

--- a/pytorch_transformers/tokenization_distilbert.py
+++ b/pytorch_transformers/tokenization_distilbert.py
@@ -22,7 +22,7 @@ import os
 import unicodedata
 from io import open
 
-from .tokenization_bert import BertTokenizer
+from .tokenization_bert import BertTokenizer, BertTokenizerVocab
 
 logger = logging.getLogger(__name__)
 
@@ -60,3 +60,5 @@ class DistilBertTokenizer(BertTokenizer):
     vocab_files_names = VOCAB_FILES_NAMES
     pretrained_vocab_files_map = PRETRAINED_VOCAB_FILES_MAP
     max_model_input_sizes = PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES
+
+    vocab_class = BertTokenizerVocab

--- a/pytorch_transformers/tokenization_gpt2.py
+++ b/pytorch_transformers/tokenization_gpt2.py
@@ -100,6 +100,12 @@ class GPT2TokenizerVocab(PreTrainedTokenizerVocab):
 
     @classmethod
     def from_pretrained(cls, vocab_file, merges_file=None):
+        """
+        Creates a GPT2TokenizerVocab instance from stored vocabulary files
+        :param vocab_file:
+        :param merges_file:
+        :return: GPT2TokenizerVocab instance
+        """
         if merges_file is None:
             raise ValueError("merges_file_path cannot be None")
 

--- a/pytorch_transformers/tokenization_gpt2.py
+++ b/pytorch_transformers/tokenization_gpt2.py
@@ -132,6 +132,12 @@ class GPT2Tokenizer(PreTrainedTokenizer):
         self.max_len_single_sentence = self.max_len # no default special tokens - you can update this value if you add special tokens
         self.max_len_sentences_pair = self.max_len # no default special tokens - you can update this value if you add special tokens
 
+        if not isinstance(vocabs, GPT2TokenizerVocab):
+            raise ValueError(
+                "vocab should be instance of GPT2TokenizerVocab"
+                "(got: {})".format(type(vocabs).__name__)
+            )
+
         self.encoder = vocabs.vocab
         self.decoder = {v: k for k, v in self.encoder.items()}
         self.errors = errors # how to handle errors in decoding

--- a/pytorch_transformers/tokenization_openai.py
+++ b/pytorch_transformers/tokenization_openai.py
@@ -122,6 +122,12 @@ class OpenAIGPTTokenizer(PreTrainedTokenizer):
             self.nlp = BasicTokenizer(do_lower_case=True)
             self.fix_text = None
 
+        if not isinstance(vocabs, OpenAIGPTTokenizerVocab):
+            raise ValueError(
+                "vocab should be instance of OpenAIGPTTokenizerVocab"
+                "(got: {})".format(type(vocabs).__name__)
+            )
+
         self.encoder = vocabs.vocab
         self.decoder = {v: k for k, v in self.encoder.items()}
         self.bpe_ranks = dict(zip(vocabs.merges, range(len(vocabs.merges))))

--- a/pytorch_transformers/tokenization_openai.py
+++ b/pytorch_transformers/tokenization_openai.py
@@ -78,6 +78,12 @@ class OpenAIGPTTokenizerVocab(PreTrainedTokenizerVocab):
 
     @classmethod
     def from_pretrained(cls, vocab_file, merges_file=None):
+        """
+        Creates a OpenAIGPTTokenizerVocab instance from stored vocabulary files
+        :param vocab_file:
+        :param merges_file:
+        :return: OpenAIGPTTokenizerVocab instance
+        """
         if merges_file is None:
             raise ValueError("merges_file_path cannot be None")
 

--- a/pytorch_transformers/tokenization_roberta.py
+++ b/pytorch_transformers/tokenization_roberta.py
@@ -66,6 +66,12 @@ class RobertaTokenizerVocab(PreTrainedTokenizerVocab):
 
     @classmethod
     def from_pretrained(cls, vocab_file, merges_file=None):
+        """
+        Creates a RobertaTokenizerVocab instance from stored vocabulary files
+        :param vocab_file:
+        :param merges_file:
+        :return: RobertaTokenizerVocab instance
+        """
         return cls(
             json.load(open(vocab_file, encoding="utf-8")),
             [tuple(merge.split()) for merge in open(merges_file, encoding='utf-8').read().split('\n')[1:-1]]

--- a/pytorch_transformers/tokenization_roberta.py
+++ b/pytorch_transformers/tokenization_roberta.py
@@ -97,6 +97,12 @@ class RobertaTokenizer(PreTrainedTokenizer):
         self.max_len_single_sentence = self.max_len - 2  # take into account special tokens
         self.max_len_sentences_pair = self.max_len - 4  # take into account special tokens
 
+        if not isinstance(vocabs, RobertaTokenizerVocab):
+            raise ValueError(
+                "vocab should be instance of RobertaTokenizerVocab"
+                "(got: {})".format(type(vocabs).__name__)
+            )
+
         self.encoder = vocabs.vocab
         self.decoder = {v: k for k, v in self.encoder.items()}
         self.errors = errors  # how to handle errors in decoding

--- a/pytorch_transformers/tokenization_transfo_xl.py
+++ b/pytorch_transformers/tokenization_transfo_xl.py
@@ -122,6 +122,12 @@ class TransfoXLTokenizer(PreTrainedTokenizer):
         self.vocabs = vocabs
         self.never_split = never_split
 
+        if not isinstance(vocabs, TransfoXLTokenizerVocab):
+            raise ValueError(
+                "vocab should be instance of TransfoXLTokenizerVocab"
+                "(got: {})".format(type(vocabs).__name__)
+            )
+
         if vocabs.merges is not None:
             # Hack because, honestly this tokenizer was not made to be used
             # in a library like ours, at all.

--- a/pytorch_transformers/tokenization_transfo_xl.py
+++ b/pytorch_transformers/tokenization_transfo_xl.py
@@ -66,7 +66,14 @@ class TransfoXLTokenizerVocab(PreTrainedTokenizerVocab):
             return [line.strip().split()[0] for line in f]
 
     @classmethod
-    def from_pretrained(cls, vocab_file, pretrained_vocab_file=None):
+    def from_pretrained(cls, vocab_file=None, pretrained_vocab_file=None):
+        """
+        Creates a TransfoXLTokenizerVocab instance from stored vocabulary files.
+        In case of both arguments are None this method is equivalent to TransfoXLTokenizerVocab.empty().
+        :param vocab_file: (str) Path to load the tokenizer symbols (optional)
+        :param pretrained_vocab_file: Path to load a previously stored vocabulary (optional)
+        :return: TransfoXLTokenizerVocab instance
+        """
         return cls(
             TransfoXLTokenizerVocab.read_tokenizer_symbols(vocab_file) if vocab_file else None,
             torch.load(pretrained_vocab_file) if pretrained_vocab_file else None
@@ -74,6 +81,10 @@ class TransfoXLTokenizerVocab(PreTrainedTokenizerVocab):
 
     @classmethod
     def empty(cls):
+        """
+        Creates a TransfoXLTokenizerVocab without any predefined vocabulary.
+        :return:
+        """
         return cls(None, None)
 
 

--- a/pytorch_transformers/tokenization_transfo_xl.py
+++ b/pytorch_transformers/tokenization_transfo_xl.py
@@ -30,7 +30,7 @@ import torch
 import numpy as np
 
 from .file_utils import cached_path
-from .tokenization_utils import PreTrainedTokenizer
+from .tokenization_utils import PreTrainedTokenizer, PreTrainedTokenizerVocab
 
 if sys.version_info[0] == 2:
     import cPickle as pickle
@@ -58,6 +58,13 @@ PRETRAINED_CORPUS_ARCHIVE_MAP = {
 }
 CORPUS_NAME = 'corpus.bin'
 
+class TransfoXLTokenizerVocab(PreTrainedTokenizerVocab):
+
+    @classmethod
+    def from_pretrained(cls, vocab_file, merges_file=None):
+        pass
+
+
 class TransfoXLTokenizer(PreTrainedTokenizer):
     """
     Transformer-XL tokenizer adapted from Vocab class in https://github.com/kimiyoung/transformer-xl
@@ -65,6 +72,8 @@ class TransfoXLTokenizer(PreTrainedTokenizer):
     vocab_files_names = VOCAB_FILES_NAMES
     pretrained_vocab_files_map = PRETRAINED_VOCAB_FILES_MAP
     max_model_input_sizes = PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES
+
+    vocab_class = TransfoXLTokenizerVocab
 
     def __init__(self, special=None, min_freq=0, max_size=None, lower_case=False,
                  delimiter=None, vocab_file=None, pretrained_vocab_file=None,

--- a/pytorch_transformers/tokenization_xlm.py
+++ b/pytorch_transformers/tokenization_xlm.py
@@ -104,7 +104,7 @@ class XLMTokenizerVocab(PreTrainedTokenizerVocab):
 
         return cls(
             json.load(open(vocab_file, encoding="utf-8")),
-            [tuple(merge.split()) for merge in open(merges_file, encoding='utf-8').read().split('\n')[1:-1]]
+            [tuple(merge.split()[:2]) for merge in open(merges_file, encoding='utf-8').read().split('\n')[:-1]]
         )
 
 class XLMTokenizer(PreTrainedTokenizer):

--- a/pytorch_transformers/tokenization_xlm.py
+++ b/pytorch_transformers/tokenization_xlm.py
@@ -157,6 +157,12 @@ class XLMTokenizer(PreTrainedTokenizer):
             self.nlp = BasicTokenizer(do_lower_case=True)
             self.fix_text = None
 
+        if not isinstance(vocabs, XLMTokenizerVocab):
+            raise ValueError(
+                "vocab should be instance of XLMTokenizerVocab"
+                "(got: {})".format(type(vocabs).__name__)
+            )
+
         self.encoder = vocabs.vocab
         self.decoder = {v: k for k, v in self.encoder.items()}
         self.bpe_ranks = dict(zip(vocabs.merges, range(len(vocabs.merges))))

--- a/pytorch_transformers/tokenization_xlm.py
+++ b/pytorch_transformers/tokenization_xlm.py
@@ -99,6 +99,12 @@ class XLMTokenizerVocab(PreTrainedTokenizerVocab):
 
     @classmethod
     def from_pretrained(cls, vocab_file, merges_file=None):
+        """
+        Creates a XLMTokenizerVocab instance from stored vocabulary files
+        :param vocab_file:
+        :param merges_file:
+        :return: XLMTokenizerVocab instance
+        """
         if merges_file is None:
             raise ValueError("merges_file_path cannot be None")
 

--- a/pytorch_transformers/tokenization_xlnet.py
+++ b/pytorch_transformers/tokenization_xlnet.py
@@ -107,6 +107,12 @@ class XLNetTokenizer(PreTrainedTokenizer):
         self.remove_space = remove_space
         self.keep_accents = keep_accents
 
+        if not isinstance(vocabs, XLNetTokenizerVocab):
+            raise ValueError(
+                "vocab should be instance of XLNetTokenizerVocab"
+                "(got: {})".format(type(vocabs).__name__)
+            )
+
         self.vocabs = vocabs
         self.sp_model = vocabs.vocab
 

--- a/pytorch_transformers/tokenization_xlnet.py
+++ b/pytorch_transformers/tokenization_xlnet.py
@@ -52,6 +52,7 @@ SEG_ID_SEP = 3
 SEG_ID_PAD = 4
 
 class XLNetTokenizerVocab(PreTrainedTokenizerVocab):
+
     def __init__(self, vocabs, vocab_file):
         super(XLNetTokenizerVocab, self).__init__(vocabs, None)
 
@@ -59,6 +60,12 @@ class XLNetTokenizerVocab(PreTrainedTokenizerVocab):
 
     @classmethod
     def from_pretrained(cls, vocab_file, merges_file=None):
+        """
+        Creates XLNetTokenizerVocab instance from stored vocabulary files
+        :param vocab_file: (str) Path to load the sentence piece vocabulary
+        :param merges_file: Not used.
+        :return: XLNetTokenizerVocab instance
+        """
         try:
             import sentencepiece as spm
         except ImportError:


### PR DESCRIPTION
As pointed out in #916 currently tokenizers ask for the path from where they'll load the required vocabulary files.

This PR allows tokenizers to take their vocab from data living in-memory and cold-storage.

Implementations details:

- All tokenizer now have a specific ${TokenizerName}Vocab dataclass holding all the required information to run the model.
- All ${TokenizerName}Vocab dataclass provide a from_pretrained method in charge of reading necessary files 
- All tokenizer now take as first argument vocabs which has to ${TokenizerName}Vocab instance. 
- All model now have a static member vocab_class which points to the desired ${TokenizerName}Vocab data class 

- Some ${TokenizerName}Vocab.from_pretrained share loading routines and thus code is currently duplicated across all of them. It might be possible to refactor to use a generic method that handles such loading. 

- [x] Bert
- [x] Transformer XL
- [x] GPT
- [x] GPT-2
- [x] XLNet
- [x] XLM
- [x] RoBERTa
- [x] DistilBERT