### PR TITLE
XLNet bias fix on resize embeddings (cf #1124)

### DIFF
--- a/pytorch_transformers/modeling_utils.py
+++ b/pytorch_transformers/modeling_utils.py
@@ -327,7 +327,7 @@ class PreTrainedModel(nn.Module):
         else:
             first_module.weight = second_module.weight
 
-        if hasattr(first_module, 'bias'):
+        if hasattr(first_module, 'bias') and first_module.bias is not None:
             first_module.bias.data = torch.nn.functional.pad(
                 first_module.bias.data,
                 (0, first_module.weight.shape[0] - first_module.bias.shape[0]),

--- a/pytorch_transformers/modeling_utils.py
+++ b/pytorch_transformers/modeling_utils.py
@@ -327,6 +327,14 @@ class PreTrainedModel(nn.Module):
         else:
             first_module.weight = second_module.weight
 
+        if hasattr(first_module, 'bias'):
+            first_module.bias.data = torch.nn.functional.pad(
+                first_module.bias.data,
+                (0, first_module.weight.shape[0] - first_module.bias.shape[0]),
+                'constant',
+                0
+            )
+
     def resize_token_embeddings(self, new_num_tokens=None):
         """ Resize input token embeddings matrix of the model if new_num_tokens != config.vocab_size.
         Take care of tying weights embeddings afterwards if the model class has a `tie_weights()` method.


### PR DESCRIPTION
Fixed an issue where the linear layer bias wouldn't be resized along the weight resize when there was an embedding matrix resize with XLNet (cf #1124).

This fix works for any model that needs to tie its weights between an embedding layer & a linear layer if . that linear layer has a bias.