### PR TITLE
distillation: fix ModuleNotFoundError error in token counts script

### DIFF
--- a/examples/distillation/scripts/token_counts.py
+++ b/examples/distillation/scripts/token_counts.py
@@ -19,7 +19,7 @@ from collections import Counter
 import argparse
 import pickle
 
-from utils import logger
+from examples.distillation.utils import logger
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Token Counts for smoothing the masking probabilities in MLM (cf XLM/word2vec)")


### PR DESCRIPTION
Hi,

I'm currently trying out "distillation" 😅

This PR a `ModuleNotFoundError` message in the `token_counts.py` script (same error was recently fixed in 803c1cc4eacd38f1b854578d7d717b5e4a1ada47 🤗