### PR TITLE
added tokens may split a normal token into halves

### DIFF
--- a/pytorch_transformers/tokenization_utils.py
+++ b/pytorch_transformers/tokenization_utils.py
@@ -216,7 +216,7 @@ class PreTrainedTokenizer(object):
             logger.error("Using additional_special_tokens, but it is not set yet.")
         return self.convert_tokens_to_ids(self._additional_special_tokens)
 
-    def __init__(self, max_len=None, **kwargs):
+    def __init__(self, max_len=None, split_added_on_word_boundary=False, **kwargs):
         self._bos_token = None
         self._eos_token = None
         self._unk_token = None
@@ -227,7 +227,8 @@ class PreTrainedTokenizer(object):
         self._additional_special_tokens = []
 
         self.max_len = max_len if max_len is not None else int(1e12)
-
+        self.split_added_on_word_boundary = split_added_on_word_boundary
+        
         # Added tokens
         self.added_tokens_encoder = {}
         self.added_tokens_decoder = {}
@@ -599,7 +600,11 @@ class PreTrainedTokenizer(object):
         """
         def split_on_token(tok, text):
             result = []
-            split_text = re.split(r'\b%s\b' %tok, text)
+            if self.split_added_on_word_boundary:
+                split_text = re.split(r'\b%s\b' %tok, text)
+            else:
+                split_text = text.split(tok)
+                
             for i, sub_text in enumerate(split_text):
                 sub_text = sub_text.strip()
                 if i == 0 and not sub_text:

--- a/pytorch_transformers/tokenization_utils.py
+++ b/pytorch_transformers/tokenization_utils.py
@@ -18,6 +18,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import logging
 import os
+import re
 import json
 import six
 import copy
@@ -598,7 +599,7 @@ class PreTrainedTokenizer(object):
         """
         def split_on_token(tok, text):
             result = []
-            split_text = text.split(tok)
+            split_text = re.split(r'\b%s\b' %tok, text)
             for i, sub_text in enumerate(split_text):
                 sub_text = sub_text.strip()
                 if i == 0 and not sub_text:


### PR DESCRIPTION
In the tokenizer base class, split_on_token() attempts to split input text by each of the added tokens. Because it uses text.split(tok), it may accidentally split a token at the middle. 

For example a new token "ht" is added to the vocabulary. Then "light" will be split into "lig" and "". But as "light" is in the original vocabulary, it should be left intact to be processed by self._tokenize(). 

Hence I'd suggest to replace it with re.split, which will split only at word boundaries ([0-9a-zA-Z_]). 

But in languages whose word boundaries are different from English, this behavior may be undesirable and the user can revert to the old text.split(). It is controlled by a newly added flag split_added_on_word_boundary. 
