### PR TITLE
Fix loading of question answering bert from tf weights.

### DIFF
--- a/pytorch_transformers/modeling_bert.py
+++ b/pytorch_transformers/modeling_bert.py
@@ -109,7 +109,10 @@ def load_tf_weights_in_bert(model, config, tf_checkpoint_path):
             elif l[0] == 'output_weights':
                 pointer = getattr(pointer, 'weight')
             elif l[0] == 'squad':
-                pointer = getattr(pointer, 'classifier')
+                try:
+                    pointer = getattr(pointer, 'classifier')
+                except AttributeError:
+                    pointer = getattr(pointer, 'qa_outputs')
             else:
                 try:
                     pointer = getattr(pointer, l[0])


### PR DESCRIPTION
I've got an attribute error when loading pretrained tf weights for question answering (bert) in `load_tf_weights_in_bert` at:
```
elif l[0] == 'squad':
     pointer = getattr(pointer, 'classifier')
```
since `BertForQuestionAnswering` does not have a 'classifier' attribute but `qa_outputs`. I've added a try except, which resolves the error.  