### PR TITLE
fix tokenize(): potential bug of splitting pretrained tokens with newly added tokens

### DIFF
--- a/transformers/tests/tokenization_bert_test.py
+++ b/transformers/tests/tokenization_bert_test.py
@@ -118,13 +118,13 @@ class BertTokenizationTest(CommonTestCases.CommonTokenizerTester):
         self.assertEqual(added_toks, len(new_toks))
         self.assertEqual(all_size_2, all_size + len(new_toks))
 
-        tokens = tokenizer.encode("ant want running", split_additional_on_word_boundaries=True)
+        tokens = tokenizer.encode("ant want running", additional_tokens_as_full_words_only=True)
         out_string = tokenizer.decode(tokens)
         self.assertGreaterEqual(len(tokens), 3)
         self.assertGreater(tokens[0], tokenizer.vocab_size - 1)
         self.assertLess(tokens[-2], tokenizer.vocab_size - 1)
         
-        tokens = tokenizer.encode("ant want running", split_additional_on_word_boundaries=False)
+        tokens = tokenizer.encode("ant want running", additional_tokens_as_full_words_only=False)
         out_string = tokenizer.decode(tokens)
         self.assertGreaterEqual(len(tokens), 4)
         self.assertGreater(tokens[0], tokenizer.vocab_size - 1)

--- a/transformers/tests/tokenization_bert_test.py
+++ b/transformers/tests/tokenization_bert_test.py
@@ -99,6 +99,37 @@ class BertTokenizationTest(CommonTestCases.CommonTokenizerTester):
         self.assertListEqual(
             tokenizer.tokenize("unwantedX running"), ["[UNK]", "runn", "##ing"])
 
+        def test_add_partial_tokens_tokenizer(self):
+            tokenizer = self.get_tokenizer()
+
+            vocab_size = tokenizer.vocab_size
+            all_size = len(tokenizer)
+
+            self.assertNotEqual(vocab_size, 0)
+            self.assertEqual(vocab_size, all_size)
+
+            new_toks = ["ant", "run"]
+            added_toks = tokenizer.add_tokens(new_toks)
+            vocab_size_2 = tokenizer.vocab_size
+            all_size_2 = len(tokenizer)
+
+            self.assertNotEqual(vocab_size_2, 0)
+            self.assertEqual(vocab_size, vocab_size_2)
+            self.assertEqual(added_toks, len(new_toks))
+            self.assertEqual(all_size_2, all_size + len(new_toks))
+
+            tokens = tokenizer.encode("ant want running", split_additional_on_word_boundaries=True)
+            out_string = tokenizer.decode(tokens)
+            self.assertGreaterEqual(len(tokens), 3)
+            self.assertGreater(tokens[0], tokenizer.vocab_size - 1)
+            self.assertLess(tokens[-2], tokenizer.vocab_size - 1)
+            
+            tokens = tokenizer.encode("ant want running", split_additional_on_word_boundaries=False)
+            out_string = tokenizer.decode(tokens)
+            self.assertGreaterEqual(len(tokens), 4)
+            self.assertGreater(tokens[0], tokenizer.vocab_size - 1)
+            self.assertGreater(tokens[-2], tokenizer.vocab_size - 1)
+
     def test_is_whitespace(self):
         self.assertTrue(_is_whitespace(u" "))
         self.assertTrue(_is_whitespace(u"\t"))

--- a/transformers/tests/tokenization_bert_test.py
+++ b/transformers/tests/tokenization_bert_test.py
@@ -99,36 +99,36 @@ class BertTokenizationTest(CommonTestCases.CommonTokenizerTester):
         self.assertListEqual(
             tokenizer.tokenize("unwantedX running"), ["[UNK]", "runn", "##ing"])
 
-        def test_add_partial_tokens_tokenizer(self):
-            tokenizer = self.get_tokenizer()
+    def test_add_partial_tokens_tokenizer(self):
+        tokenizer = self.get_tokenizer()
 
-            vocab_size = tokenizer.vocab_size
-            all_size = len(tokenizer)
+        vocab_size = tokenizer.vocab_size
+        all_size = len(tokenizer)
 
-            self.assertNotEqual(vocab_size, 0)
-            self.assertEqual(vocab_size, all_size)
+        self.assertNotEqual(vocab_size, 0)
+        self.assertEqual(vocab_size, all_size)
 
-            new_toks = ["ant", "run"]
-            added_toks = tokenizer.add_tokens(new_toks)
-            vocab_size_2 = tokenizer.vocab_size
-            all_size_2 = len(tokenizer)
+        new_toks = ["ant", "run"]
+        added_toks = tokenizer.add_tokens(new_toks)
+        vocab_size_2 = tokenizer.vocab_size
+        all_size_2 = len(tokenizer)
 
-            self.assertNotEqual(vocab_size_2, 0)
-            self.assertEqual(vocab_size, vocab_size_2)
-            self.assertEqual(added_toks, len(new_toks))
-            self.assertEqual(all_size_2, all_size + len(new_toks))
+        self.assertNotEqual(vocab_size_2, 0)
+        self.assertEqual(vocab_size, vocab_size_2)
+        self.assertEqual(added_toks, len(new_toks))
+        self.assertEqual(all_size_2, all_size + len(new_toks))
 
-            tokens = tokenizer.encode("ant want running", split_additional_on_word_boundaries=True)
-            out_string = tokenizer.decode(tokens)
-            self.assertGreaterEqual(len(tokens), 3)
-            self.assertGreater(tokens[0], tokenizer.vocab_size - 1)
-            self.assertLess(tokens[-2], tokenizer.vocab_size - 1)
-            
-            tokens = tokenizer.encode("ant want running", split_additional_on_word_boundaries=False)
-            out_string = tokenizer.decode(tokens)
-            self.assertGreaterEqual(len(tokens), 4)
-            self.assertGreater(tokens[0], tokenizer.vocab_size - 1)
-            self.assertGreater(tokens[-2], tokenizer.vocab_size - 1)
+        tokens = tokenizer.encode("ant want running", split_additional_on_word_boundaries=True)
+        out_string = tokenizer.decode(tokens)
+        self.assertGreaterEqual(len(tokens), 3)
+        self.assertGreater(tokens[0], tokenizer.vocab_size - 1)
+        self.assertLess(tokens[-2], tokenizer.vocab_size - 1)
+        
+        tokens = tokenizer.encode("ant want running", split_additional_on_word_boundaries=False)
+        out_string = tokenizer.decode(tokens)
+        self.assertGreaterEqual(len(tokens), 4)
+        self.assertGreater(tokens[0], tokenizer.vocab_size - 1)
+        self.assertGreater(tokens[-2], tokenizer.vocab_size - 1)
 
     def test_is_whitespace(self):
         self.assertTrue(_is_whitespace(u" "))

--- a/transformers/tokenization_utils.py
+++ b/transformers/tokenization_utils.py
@@ -610,7 +610,7 @@ class PreTrainedTokenizer(object):
 
         return added_tokens
 
-    def tokenize(self, text, split_additional_on_word_boundaries=False, **kwargs):
+    def tokenize(self, text, additional_tokens_as_full_words_only=False, **kwargs):
         """ Converts a string in a sequence of tokens (string), using the tokenizer.
             Split in words for word-based vocabulary or sub-words for sub-word-based
             vocabularies (BPE/SentencePieces/WordPieces).
@@ -618,7 +618,7 @@ class PreTrainedTokenizer(object):
             Take care of added tokens.
             
             Args:
-                split_additional_on_word_boundaries: (`optional`) boolean, default False:
+                additional_tokens_as_full_words_only: (`optional`) boolean, default False:
                     When splitting text with additional tokens, try to split only at word
                     boundaries ([^A-Za-z0-9_] in regular expression). Otherwise when an 
                     additional token is part of a token in the pretrained vocabulary, for 
@@ -643,7 +643,7 @@ class PreTrainedTokenizer(object):
 
         def split_on_token(tok, text):
             result = []
-            if split_additional_on_word_boundaries:
+            if additional_tokens_as_full_words_only:
                 split_text = re.split(r'\b%s\b' %tok, text)
             else:
                 split_text = text.split(tok)

--- a/transformers/tokenization_utils.py
+++ b/transformers/tokenization_utils.py
@@ -621,11 +621,12 @@ class PreTrainedTokenizer(object):
                 split_additional_on_word_boundaries: (`optional`) boolean, default False:
                     When splitting text with additional tokens, try to split only at word
                     boundaries ([^A-Za-z0-9_] in regular expression). Otherwise when an 
-                    additional token is part of a preexisting token, for example "ht" is 
-                    part of "light", then the preexisting token will be split into halves
-                    ("light" => ["lig", ""]), which is undesirable. When the language has 
-                    no or different word boundaries as above (such as Chinese or Japanese), 
-                    this argument should remain False.
+                    additional token is part of a token in the pretrained vocabulary, for 
+                    example "ht" is part of "light", then the latter token will be split 
+                    into halves ("light" => ["lig", ""]), which is undesirable. When the 
+                    language has no or different word boundaries as above (such as Chinese 
+                    or Japanese), this argument should remain False, and the old text.split()
+                    will be used.
         """
         def lowercase_text(t):
             # convert non-special tokens to lowercase


### PR DESCRIPTION
In the tokenizer base class, `split_on_token()` attempts to split input text by each of the added tokens. Because it uses `text.split(tok)`, it may accidentally split a token in the pretrained vocabulary at the middle.

For example a new token "ht" is added to the vocabulary. Then "light" will be split into `["lig", ""]`. But as "light" is a token in the pretrained vocabulary, it probably should be left intact to be processed by `self._tokenize()`.

Hence in this pull request, `text.split()` is replaced with `re.split()`, which will split only at word boundaries (`[^A-Za-z0-9_]` in regular expression). This behavior can be enabled by specifying a new `tokenize()` argument: `additional_tokens_as_full_words_only=True` (default: False). If it's specified in `tokenizer.encode(text, ...)`, it will still take effect, as this argument will be passed down to `tokenize()`.

On languages that have no or different word boundaries as above (such as Chinese or Japanese), this behavior may produce undesirable results, and the user can revert to the old `text.split()` by not specifying `additional_tokens_as_full_words_only` (it will take the default value `False`).

An explanation of the argument `additional_tokens_as_full_words_only` has been added to the docstring of `tokenize()`. A test function `test_add_partial_tokens_tokenizer()` has been added to `tokenization_bert_test.py`.
