### PR TITLE
Fix to prevent crashing on assert len(tokens_b)>=1

### DIFF
--- a/examples/lm_finetuning/pregenerate_training_data.py
+++ b/examples/lm_finetuning/pregenerate_training_data.py
@@ -329,7 +329,8 @@ def main():
                     doc = []
                 else:
                     tokens = tokenizer.tokenize(line)
-                    doc.append(tokens)
+                    if tokens:
+                        doc.append(tokens)
             if doc:
                 docs.add_document(doc)  # If the last doc didn't end on a newline, make sure it still gets added
         if len(docs) <= 1:


### PR DESCRIPTION
Thank you for the awesome library! One little issue that I have sometimes with somewhat "noisy" text is that Bert tokenizer fails to process some weird stuff. In such a case, one unexpectedly gets no tokens and the converter fails on assert with a message like this one:
```
Epoch:   0%|          | 0/1 [00:00<?, ?it/s]                      Traceback (most recent call last):
  File "../pytorch-transformers/examples/lm_finetuning/pregenerate_training_data.py", line 354, in <module>
    main()
  File "../pytorch-transformers/examples/lm_finetuning/pregenerate_training_data.py", line 350, in main
    create_training_file(docs, vocab_list, args, epoch)
  File "../pytorch-transformers/examples/lm_finetuning/pregenerate_training_data.py", line 276, in create_training_file
    whole_word_mask=args.do_whole_word_mask, vocab_list=vocab_list)
  File "../pytorch-transformers/examples/lm_finetuning/pregenerate_training_data.py", line 244, in create_instances_from_document   
    assert len(tokens_b) >= 1
AssertionError

```