### PR TITLE
Fixes #1263, add tokenization_with_offsets, gets tokens with offsets in the original text

### DIFF
--- a/pytorch_transformers/tests/regression_test_tokenization_with_offsets.py
+++ b/pytorch_transformers/tests/regression_test_tokenization_with_offsets.py
@@ -1,0 +1,162 @@
+import logging
+import json
+import random
+import unicodedata
+import sys
+import regex as re
+
+from pytorch_transformers import AutoTokenizer, PreTrainedTokenizer
+from pytorch_transformers.modeling_bert import BERT_PRETRAINED_MODEL_ARCHIVE_MAP
+from pytorch_transformers.modeling_gpt2 import GPT2_PRETRAINED_MODEL_ARCHIVE_MAP
+from pytorch_transformers.modeling_xlnet import XLNET_PRETRAINED_MODEL_ARCHIVE_MAP
+from pytorch_transformers.modeling_roberta import ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP
+from pytorch_transformers.modeling_xlm import XLM_PRETRAINED_MODEL_ARCHIVE_MAP
+
+logging.basicConfig(format='%(filename)s:%(lineno)d - %(message)s',
+                    datefmt='%m/%d/%Y %H:%M:%S',
+                    level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def ignore_variations(tokens):
+    # xlnet can tokenize '111' as '1', '11' or '11', '1'
+    # merge tokens that are all one character to not report this error
+    merged_tokens = []
+    prev_char_set = None
+    for t in tokens:
+        char_set = set(t)
+        if prev_char_set and len(prev_char_set) == 1 and prev_char_set == char_set:
+            merged_tokens[-1] = merged_tokens[-1] + t
+        else:
+            merged_tokens.append(t)
+        prev_char_set = char_set
+    return merged_tokens
+
+
+class TokenizationCheck:
+    def __init__(self, equiv_required=True):
+        self.equiv_required = equiv_required
+        self.limit_warn = 2
+        self.show_diff = 2
+        self.diffs_passed = 0
+        self.diffs_failed = 0
+        self.equiv_passed = 0
+        self.equiv_failed = 0
+
+    def tokens_vs_spans(self, tokenizer: PreTrainedTokenizer, tokens, offsets, text):
+        def normalize(token):
+            # normalize tokens, just to compare our spans in original text to the tokens
+            token = unicodedata.normalize('NFKD', token)
+            token = ''.join([c for c in token if not unicodedata.combining(c)])
+            # unicode spaces
+            token = re.sub(r'[\xa0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000]', ' ', token)
+            return token.lower().strip()
+
+        def samey(tok, txt):
+            return normalize(tok) == normalize(txt) or tok == '[UNK]' or tok == '�'
+
+        tok_strs = [tokenizer._detokenize_for_offsets(t) for t in tokens]
+        text_strs = [text[offsets[i, 0]:offsets[i, 1]] for i in range(len(tokens))]
+        if all([samey(tok, txt) for tok, txt in zip(tok_strs, text_strs)]):
+            self.diffs_passed += 1
+            return True
+        if self.show_diff > 0:
+            line_length_limit = 100
+            tok_list = []
+            txt_list = []
+            cur_line_len = -1
+            print('\nTokens and text spans have a difference:')
+            print('=' * line_length_limit)
+            print(text.replace('\n', ' '))
+            print('=' * line_length_limit)
+            for tok_str, text_str in zip(tok_strs, text_strs):
+                if normalize(tok_str) == normalize(text_str):
+                    tok_list.append(tok_str)
+                    txt_list.append(' '*len(tok_str))
+                else:
+                    tlen = max(len(tok_str), len(text_str))
+                    tok_list.append("'"+tok_str+' '*(tlen-len(tok_str))+"'")
+                    txt_list.append("'"+text_str+' '*(tlen-len(text_str))+"'")
+                cur_line_len += 1+len(tok_list[-1])
+                if cur_line_len > line_length_limit:
+                    print('-'*line_length_limit)
+                    print(' '.join(tok_list[0:-1]))
+                    print(' '.join(txt_list[0:-1]))
+                    tok_list = tok_list[-1:]
+                    txt_list = txt_list[-1:]
+                    cur_line_len = len(tok_list[-1])
+            print('-' * line_length_limit)
+            print(' '.join(tok_list))
+            print(' '.join(txt_list))
+            print('-' * line_length_limit)
+            self.show_diff -= 1
+        self.diffs_failed += 1
+        return False
+
+    def mask_a_token(self, text, mask_token):
+        if len(text) < 30:
+            return text
+        sndx = random.randint(0, len(text)-10)
+        start = text.find(' ', sndx)
+        while start < len(text) and text[start].isspace():
+            start += 1
+        end = text.find(' ', start+1)
+        if start == -1 or end == -1:
+            return text
+        return text[:start] + mask_token + text[end:]
+
+    def check_same_tokens(self, tokenizer: PreTrainedTokenizer, text: str, strict=False):
+        # also check if we are handling special tokens ([MASK] etc) the same way
+        if random.random() < 0.5:
+            text = self.mask_a_token(text, tokenizer.mask_token)
+        tokens_orig = tokenizer.tokenize(text)
+        tokens_offs, offsets = tokenizer.tokenize_with_offsets(text)
+        if tokens_orig != tokens_offs and (strict or ignore_variations(tokens_orig) != ignore_variations(tokens_offs)):
+            self.equiv_failed += 1
+            if self.limit_warn > 0:
+                linetext = text.replace('\n', ' ')
+                print(f'tokenization is different for "{linetext}"\n  {tokens_orig}\n  {tokens_offs}')
+                self.limit_warn -= 1
+            if self.equiv_required:
+                raise ValueError
+        else:
+            self.equiv_passed += 1
+        # we do expect some differences here, so this only shows a sample
+        if random.random() < 0.01:
+            self.tokens_vs_spans(tokenizer, tokens_offs, offsets, text)
+
+    def show_stats(self):
+        print(f'equivalence with tokenize {self.equiv_passed} passed and {self.equiv_failed} failed')
+        print(f'subword tokens match text {self.diffs_passed} passed and {self.diffs_failed} failed')
+
+
+if __name__ == "__main__":
+    # python regression_test_tokenization_with_offsets.py tokenize_offset_test_data.jsonl
+    # tokenize_offset_test_data.jsonl at https://ibm.box.com/s/228183fe95ptn8eb9n0zq4i2y7picq4r
+    #   (Wikipedia paragraphs)
+    # TODO: more model maps once other tokenization_* are adapted
+    model_maps = [
+        BERT_PRETRAINED_MODEL_ARCHIVE_MAP,
+        ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP,
+        GPT2_PRETRAINED_MODEL_ARCHIVE_MAP,
+        XLNET_PRETRAINED_MODEL_ARCHIVE_MAP,
+        XLM_PRETRAINED_MODEL_ARCHIVE_MAP,
+    ]
+    still_need_work = [
+        XLM_PRETRAINED_MODEL_ARCHIVE_MAP,
+    ]
+    for model_map in model_maps:
+        for model_name in list(model_map.keys())[:1]:
+            tokenizer = AutoTokenizer.from_pretrained(model_name)
+            # iterate over a jsonl test file, try tokenizing each document both with and without offsets
+            # verify that they give the same tokens
+            # also show differences in 'detokenized' tokens vs. the substring of text indicated by the offsets
+            tokenizer_check = TokenizationCheck(equiv_required=(model_map not in still_need_work))
+            with open(sys.argv[1], 'r') as f:
+                line_count = 0
+                for line in f:
+                    jobj = json.loads(line)
+                    tokenizer_check.check_same_tokens(tokenizer, jobj['contents'])
+                    line_count += 1
+            tokenizer_check.show_stats()
+            logger.info(f'tested {model_name} on {line_count} paragraphs')

--- a/pytorch_transformers/tests/regression_test_tokenization_with_offsets.py
+++ b/pytorch_transformers/tests/regression_test_tokenization_with_offsets.py
@@ -14,6 +14,9 @@ from pytorch_transformers.modeling_gpt2 import GPT2_PRETRAINED_MODEL_ARCHIVE_MAP
 from pytorch_transformers.modeling_xlnet import XLNET_PRETRAINED_MODEL_ARCHIVE_MAP
 from pytorch_transformers.modeling_roberta import ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP
 from pytorch_transformers.modeling_xlm import XLM_PRETRAINED_MODEL_ARCHIVE_MAP
+from pytorch_transformers.modeling_openai import OPENAI_GPT_PRETRAINED_MODEL_ARCHIVE_MAP
+from pytorch_transformers.modeling_transfo_xl import TRANSFO_XL_PRETRAINED_MODEL_ARCHIVE_MAP
+from pytorch_transformers.modeling_distilbert import DISTILBERT_PRETRAINED_MODEL_ARCHIVE_MAP
 
 logging.basicConfig(format='%(filename)s:%(lineno)d - %(message)s',
                     datefmt='%m/%d/%Y %H:%M:%S',
@@ -140,8 +143,11 @@ def main(test_file):
     # tokenize_offset_test_data.jsonl at https://ibm.box.com/s/228183fe95ptn8eb9n0zq4i2y7picq4r
     #   (Wikipedia paragraphs)
     # Note that GPT2 (and therefore RoBERTa do not work in python 2
-    # TODO: more model maps once other tokenization_* are adapted
+    # also have issue with XLNet in python 2
     model_maps = [
+        OPENAI_GPT_PRETRAINED_MODEL_ARCHIVE_MAP,
+        TRANSFO_XL_PRETRAINED_MODEL_ARCHIVE_MAP,
+        DISTILBERT_PRETRAINED_MODEL_ARCHIVE_MAP,
         BERT_PRETRAINED_MODEL_ARCHIVE_MAP,
         ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP,
         GPT2_PRETRAINED_MODEL_ARCHIVE_MAP,
@@ -149,7 +155,8 @@ def main(test_file):
         XLM_PRETRAINED_MODEL_ARCHIVE_MAP,
     ]
     still_need_work = [
-        XLM_PRETRAINED_MODEL_ARCHIVE_MAP,
+        OPENAI_GPT_PRETRAINED_MODEL_ARCHIVE_MAP,  # omits '\n</w>' tokens
+        XLM_PRETRAINED_MODEL_ARCHIVE_MAP,         # non-sentence final periods '... inc. reported ...'
     ]
     for model_map in model_maps:
         for model_name in list(model_map.keys())[:1]:

--- a/pytorch_transformers/tests/regression_test_tokenization_with_offsets.py
+++ b/pytorch_transformers/tests/regression_test_tokenization_with_offsets.py
@@ -34,8 +34,9 @@ def ignore_variations(tokens):
 
 
 class TokenizationCheck:
-    def __init__(self, equiv_required=True):
+    def __init__(self, mask_token, equiv_required=True):
         self.equiv_required = equiv_required
+        self.mask_token = mask_token
         self.limit_warn = 2
         self.show_diff = 2
         self.diffs_passed = 0
@@ -107,8 +108,8 @@ class TokenizationCheck:
 
     def check_same_tokens(self, tokenizer: PreTrainedTokenizer, text: str, strict=False):
         # also check if we are handling special tokens ([MASK] etc) the same way
-        if random.random() < 0.5:
-            text = self.mask_a_token(text, tokenizer.mask_token)
+        if self.mask_token and random.random() < 0.5:
+            text = self.mask_a_token(text, self.mask_token)
         tokens_orig = tokenizer.tokenize(text)
         tokens_offs, offsets = tokenizer.tokenize_with_offsets(text)
         if tokens_orig != tokens_offs and (strict or ignore_variations(tokens_orig) != ignore_variations(tokens_offs)):
@@ -151,7 +152,7 @@ if __name__ == "__main__":
             # iterate over a jsonl test file, try tokenizing each document both with and without offsets
             # verify that they give the same tokens
             # also show differences in 'detokenized' tokens vs. the substring of text indicated by the offsets
-            tokenizer_check = TokenizationCheck(equiv_required=(model_map not in still_need_work))
+            tokenizer_check = TokenizationCheck(tokenizer.mask_token, equiv_required=(model_map not in still_need_work))
             with open(sys.argv[1], 'r') as f:
                 line_count = 0
                 for line in f:

--- a/pytorch_transformers/tests/tokenization_bert_test.py
+++ b/pytorch_transformers/tests/tokenization_bert_test.py
@@ -52,7 +52,11 @@ class BertTokenizationTest(CommonTestCases.CommonTokenizerTester):
     def test_full_tokenizer(self):
         tokenizer = self.tokenizer_class(self.vocab_file)
 
-        tokens = tokenizer.tokenize(u"UNwant\u00E9d,running")
+        text = u"UNwant\u00E9d,running"
+        tokens = tokenizer.tokenize(text)
+        tokens_wo, offsets = tokenizer.tokenize_with_offsets(text)
+        self.assertEqual(len(tokens_wo), offsets.shape[0])
+        self.assertListEqual(tokens, tokens_wo)
         self.assertListEqual(tokens, ["un", "##want", "##ed", ",", "runn", "##ing"])
         self.assertListEqual(tokenizer.convert_tokens_to_ids(tokens), [7, 4, 5, 10, 8, 9])
 

--- a/pytorch_transformers/tests/tokenization_gpt2_test.py
+++ b/pytorch_transformers/tests/tokenization_gpt2_test.py
@@ -60,6 +60,9 @@ class GPT2TokenizationTest(CommonTestCases.CommonTokenizerTester):
         text = "lower newer"
         bpe_tokens = ["\u0120low", "er", "\u0120", "n", "e", "w", "er"]
         tokens = tokenizer.tokenize(text)
+        tokens_wo, offsets = tokenizer.tokenize_with_offsets(text)
+        self.assertEqual(len(tokens_wo), offsets.shape[0])
+        self.assertListEqual(tokens, tokens_wo)
         self.assertListEqual(tokens, bpe_tokens)
 
         input_tokens = tokens + [tokenizer.unk_token]

--- a/pytorch_transformers/tests/tokenization_offsets_test.py
+++ b/pytorch_transformers/tests/tokenization_offsets_test.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+import numpy as np
+
+from pytorch_transformers.tokenization_offsets import whitespace_reduce, match_back_by_length, match_back_by_text
+
+
+class TokenizeWithOffsetsTester(unittest.TestCase):
+    def test_whitespace_reduce(self):
+        offsets = np.array([[0, 3], [3, 7], [7, 9]])
+        offsets_orig = np.array(offsets, copy=True)
+        text = 'He saw it\n'
+        whitespace_reduce(offsets, text)
+        for i in range(offsets.shape[0]):
+            self.assertEqual(text[offsets[i, 0]:offsets[i, 1]], text[offsets_orig[i, 0]:offsets_orig[i, 1]].strip())
+
+    def test_match_back_by_length(self):
+        chunk = 'capitalization'
+        tokens = ['cap', 'it', 'aliza', 'tion']
+        offsets = np.array([[0, len(chunk)]]*len(tokens))
+        tlens = [len(t) for t in tokens]
+        match_back_by_length(tlens, offsets, 0, len(tokens))
+        for i in range(offsets.shape[0]):
+            self.assertEqual(chunk[offsets[i, 0]:offsets[i, 1]], tokens[i])
+
+    def test_match_back_by_text(self):
+        chunk = 'capitalization'
+        tokens = ['cap', 'it', 'aliza', 'tion']
+        offsets = np.array([[0, len(chunk)]] * len(tokens))
+        tlens = [len(t) for t in tokens]
+        match_back_by_text(tokens, chunk, tlens, offsets, 0, len(tokens))
+        for i in range(offsets.shape[0]):
+            self.assertEqual(chunk[offsets[i, 0]:offsets[i, 1]], tokens[i])

--- a/pytorch_transformers/tests/tokenization_openai_test.py
+++ b/pytorch_transformers/tests/tokenization_openai_test.py
@@ -60,6 +60,9 @@ class OpenAIGPTTokenizationTest(CommonTestCases.CommonTokenizerTester):
         text = "lower"
         bpe_tokens = ["low", "er</w>"]
         tokens = tokenizer.tokenize(text)
+        tokens_wo, offsets = tokenizer.tokenize_with_offsets(text)
+        self.assertEqual(len(tokens_wo), offsets.shape[0])
+        self.assertListEqual(tokens, tokens_wo)
         self.assertListEqual(tokens, bpe_tokens)
 
         input_tokens = tokens + ["<unk>"]

--- a/pytorch_transformers/tests/tokenization_roberta_test.py
+++ b/pytorch_transformers/tests/tokenization_roberta_test.py
@@ -59,6 +59,9 @@ class RobertaTokenizationTest(CommonTestCases.CommonTokenizerTester):
         text = "lower newer"
         bpe_tokens = ["\u0120low", "er", "\u0120", "n", "e", "w", "er"]
         tokens = tokenizer.tokenize(text)
+        tokens_wo, offsets = tokenizer.tokenize_with_offsets(text)
+        self.assertEqual(len(tokens_wo), offsets.shape[0])
+        self.assertListEqual(tokens, tokens_wo)
         self.assertListEqual(tokens, bpe_tokens)
 
         input_tokens = tokens + [tokenizer.unk_token]

--- a/pytorch_transformers/tests/tokenization_transfo_xl_test.py
+++ b/pytorch_transformers/tests/tokenization_transfo_xl_test.py
@@ -49,7 +49,11 @@ class TransfoXLTokenizationTest(CommonTestCases.CommonTokenizerTester):
     def test_full_tokenizer(self):
         tokenizer = TransfoXLTokenizer(vocab_file=self.vocab_file, lower_case=True)
 
-        tokens = tokenizer.tokenize(u"<unk> UNwanted , running")
+        text = u"<unk> UNwanted , running"
+        tokens = tokenizer.tokenize(text)
+        tokens_wo, offsets = tokenizer.tokenize_with_offsets(text)
+        self.assertEqual(len(tokens_wo), offsets.shape[0])
+        self.assertListEqual(tokens, tokens_wo)
         self.assertListEqual(tokens, ["<unk>", "unwanted", ",", "running"])
 
         self.assertListEqual(

--- a/pytorch_transformers/tests/tokenization_xlm_test.py
+++ b/pytorch_transformers/tests/tokenization_xlm_test.py
@@ -59,6 +59,9 @@ class XLMTokenizationTest(CommonTestCases.CommonTokenizerTester):
         text = "lower"
         bpe_tokens = ["low", "er</w>"]
         tokens = tokenizer.tokenize(text)
+        tokens_wo, offsets = tokenizer.tokenize_with_offsets(text)
+        self.assertEqual(len(tokens_wo), offsets.shape[0])
+        self.assertListEqual(tokens, tokens_wo)
         self.assertListEqual(tokens, bpe_tokens)
 
         input_tokens = tokens + ["<unk>"]

--- a/pytorch_transformers/tests/tokenization_xlnet_test.py
+++ b/pytorch_transformers/tests/tokenization_xlnet_test.py
@@ -47,7 +47,11 @@ class XLNetTokenizationTest(CommonTestCases.CommonTokenizerTester):
     def test_full_tokenizer(self):
         tokenizer = XLNetTokenizer(SAMPLE_VOCAB, keep_accents=True)
 
-        tokens = tokenizer.tokenize(u'This is a test')
+        text = u'This is a test'
+        tokens = tokenizer.tokenize(text)
+        tokens_wo, offsets = tokenizer.tokenize_with_offsets(text)
+        self.assertEqual(len(tokens_wo), offsets.shape[0])
+        self.assertListEqual(tokens, tokens_wo)
         self.assertListEqual(tokens, [u'▁This', u'▁is', u'▁a', u'▁t', u'est'])
 
         self.assertListEqual(

--- a/pytorch_transformers/tokenization_bert.py
+++ b/pytorch_transformers/tokenization_bert.py
@@ -193,7 +193,7 @@ class BertTokenizer(PreTrainedTokenizer):
     def _detokenize_for_offsets(self, tok: str):
         if tok.startswith('##'):
             return tok[2:]
-        return tok
+        return tok.strip()
 
     def add_special_tokens_single_sentence(self, token_ids):
         """

--- a/pytorch_transformers/tokenization_bert.py
+++ b/pytorch_transformers/tokenization_bert.py
@@ -20,6 +20,7 @@ import collections
 import logging
 import os
 import unicodedata
+import regex as re
 from io import open
 
 from .tokenization_utils import PreTrainedTokenizer
@@ -159,6 +160,8 @@ class BertTokenizer(PreTrainedTokenizer):
                                                   never_split=never_split,
                                                   tokenize_chinese_chars=tokenize_chinese_chars)
         self.wordpiece_tokenizer = WordpieceTokenizer(vocab=self.vocab, unk_token=self.unk_token)
+        # basic, pre-wordpiece splitting
+        self.splitter_pat = re.compile(r"""[^\s]+""")
 
     @property
     def vocab_size(self):
@@ -186,6 +189,11 @@ class BertTokenizer(PreTrainedTokenizer):
         """ Converts a sequence of tokens (string) in a single string. """
         out_string = ' '.join(tokens).replace(' ##', '').strip()
         return out_string
+
+    def _detokenize_for_offsets(self, tok: str):
+        if tok.startswith('##'):
+            return tok[2:]
+        return tok
 
     def add_special_tokens_single_sentence(self, token_ids):
         """

--- a/pytorch_transformers/tokenization_bert.py
+++ b/pytorch_transformers/tokenization_bert.py
@@ -190,7 +190,7 @@ class BertTokenizer(PreTrainedTokenizer):
         out_string = ' '.join(tokens).replace(' ##', '').strip()
         return out_string
 
-    def _detokenize_for_offsets(self, tok: str):
+    def _detokenize_for_offsets(self, tok):
         if tok.startswith('##'):
             return tok[2:]
         return tok.strip()

--- a/pytorch_transformers/tokenization_offsets.py
+++ b/pytorch_transformers/tokenization_offsets.py
@@ -1,0 +1,137 @@
+import numpy as np
+
+
+# even when tokens themselves have whitespace, for most tasks we want our offsets to not include the whitespace
+def whitespace_reduce(offsets, text):
+    for ti in range(offsets.shape[0]):
+        nstart = offsets[ti, 0]
+        nend = offsets[ti, 1]
+        while nstart < nend and text[nstart].isspace():
+            nstart += 1
+        while nstart < nend and text[nend - 1].isspace():
+            nend -= 1
+        if nstart < nend:
+            # assert text[offsets[ti, 0]:offsets[ti, 1]].strip() == text[nstart:nend]
+            offsets[ti, 0] = nstart
+            offsets[ti, 1] = nend
+
+
+UNMATCHABLE_TOKENS = ['�']  # consider putting in tokenization_utils, so subclasses can override
+
+
+def match_back_by_length(tlens, offsets, tstart, tend):
+    # split the chunk, dividing the chunk's span proportionally among the tokens
+    if tend - tstart <= 1:
+        return
+    # when this is called, all offsets[tstart:tend] are the same (the same chunk)
+    text_end = offsets[tstart, 1]
+    prev_end = offsets[tstart, 0]
+    tok_len_remaining = sum(tlens[tstart:tend]) + 1
+    for ci in range(tstart, tend):
+        text_remaining = text_end - prev_end
+        token_len = tlens[ci] + 1/(tend-tstart)
+        offsets[ci, 0] = prev_end
+        if ci < tend - 1:
+            scale = text_remaining / tok_len_remaining
+            leni = int(round(scale * token_len))
+            offsets[ci, 1] = min(text_end, offsets[ci, 0] + leni)
+            prev_end = offsets[ci, 1]
+        tok_len_remaining -= token_len
+
+
+def match_back_by_text(tokens, text, tlens, offsets, tstart, tend):
+    match_start = tstart
+    match_end = tend - 1
+    txt_start = offsets[match_start, 0]
+    txt_end = offsets[match_end, 1]
+    orig_txt_start = txt_start
+    orig_txt_end = txt_end
+    # try to find the token strings in the original text
+    text = text.lower()  # any other length preserving normalizing?
+    while match_start <= match_end and txt_start < txt_end:
+        findndx = text.find(tokens[match_start].lower(), txt_start, txt_end)
+        pre_skip = findndx - txt_start
+        rfindndx = text.rfind(tokens[match_end].lower(), txt_start, txt_end)
+        post_skip = txt_end - rfindndx - len(tokens[match_end])
+        # do we skip more of the text by matching the first token or the last token?
+        # we want to greedily make good matches
+        if findndx != -1 and (rfindndx == -1 or pre_skip <= post_skip):
+            offsets[match_start, 0] = findndx
+            offsets[match_start, 1] = offsets[match_start, 0] + len(tokens[match_start])
+            txt_start = offsets[match_start, 1]
+            match_start += 1
+        elif rfindndx != -1:
+            offsets[match_end, 0] = rfindndx
+            offsets[match_end, 1] = offsets[match_end, 0] + len(tokens[match_end])
+            txt_end = offsets[match_end, 0]
+            match_end -= 1
+        else:
+            break
+    # we matched everything. good job!
+    if match_start > match_end:
+        return
+    # we messed up, hand it all to the match_by_length
+    if txt_start > txt_end or sum(tlens[match_start:match_end+1]) > txt_end - txt_start:
+        txt_start = orig_txt_start
+        txt_end = orig_txt_end
+        match_start = tstart
+        match_end = tend-1
+    # anything leftover we match by length
+    for leftover in range(match_start, match_end + 1):
+        offsets[leftover, 0] = txt_start
+        offsets[leftover, 1] = txt_end
+    match_back_by_length(tlens, offsets, match_start, match_end + 1)
+    # DEBUG: show what we came up with
+    # print('*' * 10)
+    # print(f'{text[offsets[tstart, 0]:offsets[tend-1, 1]]}')
+    # for ti in range(tstart, tend):
+    #    print(f'"{tokens[ti]}" "{text[offsets[ti, 0]:offsets[ti, 1]]}"')
+    # print('*' * 10)
+
+
+# when a chunk becomes multiple tokens, we find what spans of the chunk each token corresponds to
+def multitoken_chunk_offsets(tokens, text, tlens, offsets, tstart, tend):
+    if tend - tstart <= 1:
+        return
+    if offsets[tstart, 1] - offsets[tstart, 0] == sum(tlens[tstart:tend]):
+        # the sum of token length is the chunk length, just chop it up
+        match_back_by_length(tlens, offsets, tstart, tend)
+    else:
+        # try matching the token text from the start and end, then punt on the middle
+        match_back_by_text(tokens, text, tlens, offsets, tstart, tend)
+
+
+# handle chunks that have multiple tokens
+def tokens_in_chunks(tokens, text, offsets):
+    assert len(tokens) == offsets.shape[0]
+    same_chunk_start = 0
+    tlens = [len(t) if t not in UNMATCHABLE_TOKENS else 0 for t in tokens]
+    for i in range(1, len(tokens)):
+        if not np.array_equal(offsets[same_chunk_start, :], offsets[i, :]):
+            multitoken_chunk_offsets(tokens, text, tlens, offsets, same_chunk_start, i)
+            same_chunk_start = i
+    multitoken_chunk_offsets(tokens, text, tlens, offsets, same_chunk_start, len(tokens))
+
+
+def finalize_token_offsets(detokenized_tokens, text, offsets):
+    """
+    detokenized_tokens are tokens that can usually be matched by to the text (best effort).
+    The text is just the original text, before any cleaning by the tokenizer.
+    The offsets are currently chunk offsets, multiple tokens have the same offsets.
+    We will give the tokens non-overlapping offsets that match the text as closely as possible.
+    :param detokenized_tokens: tokens from the tokenizer, with artifacts removed to match the original text better
+    :param text: the original text, before our preprocessing got its hands on it
+    :param offsets: len(tokens) x 2, giving start and end for each token,
+                    initially this is the start and end of the chunk
+    :return: the numpy array of offsets is modified
+    """
+    # adjust token offsets to not include leading/trailing whitespace
+    whitespace_reduce(offsets, text)
+    # find offsets for sub-chunk tokens
+    tokens_in_chunks(detokenized_tokens, text, offsets)
+
+    # asserts on non-overlapping spans with start <= end
+    for i in range(offsets.shape[0]):
+        assert offsets[i, 0] <= offsets[i, 1]
+        if i > 0:
+            assert offsets[i-1, 1] <= offsets[i, 0]

--- a/pytorch_transformers/tokenization_offsets.py
+++ b/pytorch_transformers/tokenization_offsets.py
@@ -26,10 +26,10 @@ def match_back_by_length(tlens, offsets, tstart, tend):
     # when this is called, all offsets[tstart:tend] are the same (the same chunk)
     text_end = offsets[tstart, 1]
     prev_end = offsets[tstart, 0]
-    tok_len_remaining = sum(tlens[tstart:tend]) + 1
+    tok_len_remaining = sum(tlens[tstart:tend]) + 0.1
     for ci in range(tstart, tend):
         text_remaining = text_end - prev_end
-        token_len = tlens[ci] + 1/(tend-tstart)
+        token_len = tlens[ci] + 0.1/(tend-tstart)
         offsets[ci, 0] = prev_end
         if ci < tend - 1:
             scale = text_remaining / tok_len_remaining

--- a/pytorch_transformers/tokenization_offsets.py
+++ b/pytorch_transformers/tokenization_offsets.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+from __future__ import (absolute_import, division, print_function, unicode_literals)
+
 import numpy as np
 
 
@@ -16,7 +19,7 @@ def whitespace_reduce(offsets, text):
             offsets[ti, 1] = nend
 
 
-UNMATCHABLE_TOKENS = ['�']  # consider putting in tokenization_utils, so subclasses can override
+UNMATCHABLE_TOKENS = [u'�']  # consider putting in tokenization_utils, so subclasses can override
 
 
 def match_back_by_length(tlens, offsets, tstart, tend):

--- a/pytorch_transformers/tokenization_openai.py
+++ b/pytorch_transformers/tokenization_openai.py
@@ -21,6 +21,7 @@ import logging
 import os
 import re
 from io import open
+import regex
 
 from .tokenization_utils import PreTrainedTokenizer
 from .tokenization_bert import BasicTokenizer
@@ -108,6 +109,8 @@ class OpenAIGPTTokenizer(PreTrainedTokenizer):
         self.bpe_ranks = dict(zip(merges, range(len(merges))))
         self.cache = {}
 
+        self.splitter_pat = regex.compile(r"""[^\s]+""")  # TODO: and support \n</w>
+
     @property
     def vocab_size(self):
         return len(self.encoder)
@@ -182,6 +185,9 @@ class OpenAIGPTTokenizer(PreTrainedTokenizer):
         """ Converts a sequence of tokens (string) in a single string. """
         out_string = ''.join(tokens).replace('</w>', ' ').strip()
         return out_string
+
+    def _detokenize_for_offsets(self, tok):
+        return tok.replace('</w>', ' ').strip()
 
     def save_vocabulary(self, save_directory):
         """Save the tokenizer vocabulary and merge files to a directory."""

--- a/pytorch_transformers/tokenization_transfo_xl.py
+++ b/pytorch_transformers/tokenization_transfo_xl.py
@@ -28,6 +28,7 @@ from io import open
 
 import torch
 import numpy as np
+import regex
 
 from .file_utils import cached_path
 from .tokenization_utils import PreTrainedTokenizer
@@ -100,6 +101,8 @@ class TransfoXLTokenizer(PreTrainedTokenizer):
 
         if vocab_file is not None:
             self.build_vocab()
+
+        self.splitter_pat = regex.compile(r"""[^\s]+""")
 
     def count_file(self, path, verbose=False, add_eos=False):
         if verbose: logger.info('counting file {} ...'.format(path))

--- a/pytorch_transformers/tokenization_utils.py
+++ b/pytorch_transformers/tokenization_utils.py
@@ -653,6 +653,7 @@ class PreTrainedTokenizer(object):
           in TransfoXLTokenizer
              test add_eos=False, add_double_eos=False
         :param text: the text to tokenize
+        :param initial_space: should we include an initial_space when tokenizing the text?
         :param kwargs: passed to the underlying tokenization implementation
         :return: tokens, offsets; offsets is len(tokens) x 2 numpy array of character offsets [begin,one-past-end)
         """

--- a/pytorch_transformers/tokenization_utils.py
+++ b/pytorch_transformers/tokenization_utils.py
@@ -647,7 +647,7 @@ class PreTrainedTokenizer(object):
         We know our offsets will never be terrible, since we know the chunk the token comes from.
         If multiple tokens come back for a chunk, we divide the span up proportional to token length.
         Known issues:
-          in XLMTokenizer we lose '\n</w>'
+          in OpenAIGPTTokenizer, XLMTokenizer we lose '\n</w>'
              compare 'hello \n there'
              possible solution: remove the .strip() in the preprocessing OR surround input with special tokens
           in TransfoXLTokenizer

--- a/pytorch_transformers/tokenization_xlm.py
+++ b/pytorch_transformers/tokenization_xlm.py
@@ -23,6 +23,7 @@ import re
 import sys
 import unicodedata
 from io import open
+import regex
 
 import sacremoses as sm
 
@@ -571,6 +572,8 @@ class XLMTokenizer(PreTrainedTokenizer):
         self.bpe_ranks = dict(zip(merges, range(len(merges))))
         self.cache = {}
 
+        self.splitter_pat = regex.compile(r"""[^\s]+""")
+
     def moses_punct_norm(self, text, lang):
         if lang not in self.cache_moses_punct_normalizer:
             punct_normalizer = sm.MosesPunctNormalizer(lang=lang)
@@ -753,6 +756,9 @@ class XLMTokenizer(PreTrainedTokenizer):
         """ Converts a sequence of tokens (string) in a single string. """
         out_string = ''.join(tokens).replace('</w>', ' ').strip()
         return out_string
+
+    def _detokenize_for_offsets(self, tok):
+        return tok.replace('</w>', ' ').strip()
 
     def add_special_tokens_single_sentence(self, token_ids):
         """


### PR DESCRIPTION
This is similar to the utils_squad approach to getting offsets for the tokens but can also be used in other places where the tokens should have a correspondence to the original text to fix #1263.
