### PR TITLE
Make activation functions available from modeling_utils (PyTorch)

### DIFF
--- a/transformers/modeling_openai.py
+++ b/transformers/modeling_openai.py
@@ -30,7 +30,7 @@ import torch.nn as nn
 from torch.nn import CrossEntropyLoss
 from torch.nn.parameter import Parameter
 
-from .modeling_utils import PreTrainedModel, Conv1D, prune_conv1d_layer, SequenceSummary
+from .modeling_utils import ACT2FN, PreTrainedModel, Conv1D, prune_conv1d_layer, SequenceSummary
 from .configuration_openai import OpenAIGPTConfig
 from .file_utils import add_start_docstrings
 
@@ -112,18 +112,6 @@ def load_tf_weights_in_openai_gpt(model, config, openai_checkpoint_folder_path):
         logger.info("Initialize PyTorch weight {}".format(name))
         pointer.data = torch.from_numpy(array)
     return model
-
-
-def gelu(x):
-    return 0.5 * x * (1 + torch.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * torch.pow(x, 3))))
-
-
-def swish(x):
-    return x * torch.sigmoid(x)
-
-
-ACT_FNS = {"relu": nn.ReLU, "swish": swish, "gelu": gelu}
-
 
 class Attention(nn.Module):
     def __init__(self, nx, n_ctx, config, scale=False):
@@ -225,7 +213,8 @@ class MLP(nn.Module):
         nx = config.n_embd
         self.c_fc = Conv1D(n_state, nx)
         self.c_proj = Conv1D(nx, n_state)
-        self.act = ACT_FNS[config.afn]
+        # gelu activation for openai refers to the 'new' gelu version
+        self.act = ACT2FN["gelu_new"] if config.afn == "gelu" else ACT2FN[config.afn]
         self.dropout = nn.Dropout(config.resid_pdrop)
 
     def forward(self, x):

--- a/transformers/modeling_roberta.py
+++ b/transformers/modeling_roberta.py
@@ -24,7 +24,8 @@ import torch
 import torch.nn as nn
 from torch.nn import CrossEntropyLoss, MSELoss
 
-from .modeling_bert import BertEmbeddings, BertLayerNorm, BertModel, BertPreTrainedModel, gelu
+from .modeling_bert import BertEmbeddings, BertLayerNorm, BertModel, BertPreTrainedModel
+from .modeling_utils import ACT2FN
 from .configuration_roberta import RobertaConfig
 from .file_utils import add_start_docstrings
 
@@ -261,7 +262,7 @@ class RobertaLMHead(nn.Module):
 
     def forward(self, features, **kwargs):
         x = self.dense(features)
-        x = gelu(x)
+        x = ACT2FN['gelu'](x)
         x = self.layer_norm(x)
 
         # project back to size of vocabulary with bias

--- a/transformers/modeling_utils.py
+++ b/transformers/modeling_utils.py
@@ -62,14 +62,6 @@ def gelu_new(x):
 def swish(x):
     return x * torch.sigmoid(x)
 
-
-ACT2FN = {"gelu_new": gelu_new,
-          "log_softmax": F.log_softmax,
-          "relu": F.relu,
-          "softmax": F.softmax,
-          "swish": swish,
-          "tanh": torch.tanh}
-
 try:
     from torch.nn.functional import gelu
 except AttributeError:
@@ -81,7 +73,13 @@ except AttributeError:
         """
         return x * 0.5 * (1.0 + torch.erf(x / math.sqrt(2.0)))
 
-ACT2FN['gelu'] = gelu
+ACT2FN = {"gelu": gelu,
+          "gelu_new": gelu_new,
+          "log_softmax": F.log_softmax,
+          "relu": F.relu,
+          "softmax": F.softmax,
+          "swish": swish,
+          "tanh": torch.tanh}
 
 
 # Base utility classes


### PR DESCRIPTION
* This commit replaces references to PyTorch activation functions/modules by a dict of functions that lives in `modeling_utils`. This ensures that all activation functions are available to all modules, praticularly custom functions such as swish and new_gelu.
* In addition, when available (PT1.2) the native PyTorch gelu function will be used - it supports a CPP/CUDA implementation.

**NOTE** that this replaces all `nn.Module`'s by bare functions except for one which was required for testing to be of the type `nn.Module`. If requested, this can be reverted so that only function calls are replaced by ACT2FN functions, and that existing `nn.Module`s are untouched.

**NOTE** that one would thus also expect that _all_ usages of activation functions are taken from `ACT2FN` for consistency's sake.

**NOTE** since the Module counter-part of PyTorch's GeLU [isn't available (yet)](https://github.com/pytorch/pytorch/pull/20665#issuecomment-536359684), it might be worth waiting to implement this pull, and then use Modules and functions in the right places where one would expect, i.e. `Module` when part of architecture, function when processing other kinds of data.