### PR TITLE
Fix compatibility issue with PyTorch 1.2

### DIFF
--- a/transformers/modeling_xlnet.py
+++ b/transformers/modeling_xlnet.py
@@ -733,7 +733,7 @@ class XLNetModel(XLNetPreTrainedModel):
         assert input_mask is None or attention_mask is None, "You can only use one of input_mask (uses 1 for padding) "
         "or attention_mask (uses 0 for padding, added for compatbility with BERT). Please choose one."
         if input_mask is None and attention_mask is not None:
-            input_mask = 1.0 - attention_mask
+            input_mask = ~attention_mask
         if input_mask is not None and perm_mask is not None:
             data_mask = input_mask[None] + perm_mask
         elif input_mask is not None and perm_mask is None:


### PR DESCRIPTION
Using PyTorch 1.2.0 give an error when running XLNet.
We should use the new way to reverse mask : instead of using `1 - mask`, we should use `~mask`