### PR TITLE
DistillBert Documentation Code Example fixes

### DIFF
--- a/transformers/modeling_distilbert.py
+++ b/transformers/modeling_distilbert.py
@@ -649,7 +649,7 @@ class DistilBertForQuestionAnswering(DistilBertPreTrainedModel):
         start_positions = torch.tensor([1])
         end_positions = torch.tensor([3])
         outputs = model(input_ids, start_positions=start_positions, end_positions=end_positions)
-        loss, start_scores, end_scores = outputs[:2]
+        loss, start_scores, end_scores = outputs[:3]
 
     """
     def __init__(self, config):

--- a/transformers/modeling_tf_distilbert.py
+++ b/transformers/modeling_tf_distilbert.py
@@ -603,7 +603,7 @@ class TFDistilBertForMaskedLM(TFDistilBertPreTrainedModel):
         tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-uncased')
         model = TFDistilBertForMaskedLM.from_pretrained('distilbert-base-uncased')
         input_ids = tf.constant(tokenizer.encode("Hello, my dog is cute"))[None, :]  # Batch size 1
-        outputs = model(input_ids, masked_lm_labels=input_ids)
+        outputs = model(input_ids)
         prediction_scores = outputs[0]
 
     """
@@ -715,9 +715,7 @@ class TFDistilBertForQuestionAnswering(TFDistilBertPreTrainedModel):
         tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-uncased')
         model = TFDistilBertForQuestionAnswering.from_pretrained('distilbert-base-uncased')
         input_ids = tf.constant(tokenizer.encode("Hello, my dog is cute"))[None, :]  # Batch size 1
-        start_positions = tf.constant([1])
-        end_positions = tf.constant([3])
-        outputs = model(input_ids, start_positions=start_positions, end_positions=end_positions)
+        outputs = model(input_ids)
         start_scores, end_scores = outputs[:2]
 
     """


### PR DESCRIPTION
Following code examples in the documentation are throwing errors:-

1. [DistilBertForQuestionAnswering](https://huggingface.co/transformers/model_doc/distilbert.html#transformers.DistilBertForQuestionAnswering)

```
tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-uncased')
model = DistilBertForQuestionAnswering.from_pretrained('distilbert-base-uncased')
input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute")).unsqueeze(0)  # Batch size 1
start_positions = torch.tensor([1])
end_positions = torch.tensor([3])
outputs = model(input_ids, start_positions=start_positions, end_positions=end_positions)
loss, start_scores, end_scores = outputs[:2]
```
> ValueError: not enough values to unpack (expected 3, got 2)


2. [TFDistilBertForMaskedLM](https://huggingface.co/transformers/model_doc/distilbert.html#transformers.TFDistilBertForMaskedLM)

```
import tensorflow as tf
from transformers import DistilBertTokenizer, TFDistilBertForMaskedLM

tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-uncased')
model = TFDistilBertForMaskedLM.from_pretrained('distilbert-base-uncased')
input_ids = tf.constant(tokenizer.encode("Hello, my dog is cute"))[None, :]  # Batch size 1
outputs = model(input_ids, masked_lm_labels=input_ids)
prediction_scores = outputs[0]

```
> TypeError: call() got an unexpected keyword argument 'masked_lm_labels'

3. [TFDistilBertForQuestionAnswering](https://huggingface.co/transformers/model_doc/distilbert.html#transformers.TFDistilBertForQuestionAnswering)

```
import tensorflow as tf
from transformers import BertTokenizer, TFDistilBertForQuestionAnswering

tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-uncased')
model = TFDistilBertForQuestionAnswering.from_pretrained('distilbert-base-uncased')
input_ids = tf.constant(tokenizer.encode("Hello, my dog is cute"))[None, :]  # Batch size 1
start_positions = tf.constant([1])
end_positions = tf.constant([3])
outputs = model(input_ids, start_positions=start_positions, end_positions=end_positions)
start_scores, end_scores = outputs[:2]
```
> TypeError: call() got an unexpected keyword argument 'start_positions'

The first issue is just list indexing issue. Second and Third are due to implementation difference between Tensorflow and Pytorch DistillBERT. Tensorflow implementation doesn't have loss calculation inside `call`, but We do in `forward` for Pytorch.  I have updated code examples in the docstring.

Let me know if you will be interested in a pull request for making same function API structure for Tensorflow implementation via adding loss calculation in `call function` similar to Pytorch.

This is my first issue. Let me know if you require any changes on pull request.

Regards 😃 
Dharmendra 