### PR TITLE
Checkpoint rotation

### DIFF
--- a/examples/run_lm_finetuning.py
+++ b/examples/run_lm_finetuning.py
@@ -27,6 +27,8 @@ import logging
 import os
 import pickle
 import random
+import re
+import shutil
 
 import numpy as np
 import torch
@@ -222,6 +224,24 @@ def train(args, train_dataset, model, tokenizer):
                     logging_loss = tr_loss
 
                 if args.local_rank in [-1, 0] and args.save_steps > 0 and global_step % args.save_steps == 0:
+                    if args.save_total_limit and args.save_total_limit > 0:
+                        # Check if we should delete older checkpoint(s)
+                        glob_checkpoints = glob.glob(os.path.join(args.output_dir, 'checkpoint-*'))
+                        if len(glob_checkpoints) + 1 > args.save_total_limit:
+                            checkpoints_sorted = []
+                            for path in glob_checkpoints:
+                                regex_match = re.match('.*checkpoint-([0-9]+)', path)
+                                if regex_match and regex_match.groups():
+                                    checkpoints_sorted.append((int(regex_match.groups()[0]), path))
+
+                            checkpoints_sorted = sorted(checkpoints_sorted)
+                            checkpoints_sorted = [checkpoint[1] for checkpoint in checkpoints_sorted]
+                            number_of_checkpoints_to_delete = max(0, len(checkpoints_sorted) + 1 - args.save_total_limit)
+                            checkpoints_to_be_deleted = checkpoints_sorted[:number_of_checkpoints_to_delete]
+                            for checkpoint in checkpoints_to_be_deleted:
+                                logger.info("Deleting older checkpoint [{}] due to args.save_total_limit".format(checkpoint))
+                                shutil.rmtree(checkpoint)
+
                     # Save model checkpoint
                     output_dir = os.path.join(args.output_dir, 'checkpoint-{}'.format(global_step))
                     if not os.path.exists(output_dir):
@@ -359,6 +379,8 @@ def main():
                         help="Log every X updates steps.")
     parser.add_argument('--save_steps', type=int, default=50,
                         help="Save checkpoint every X updates steps.")
+    parser.add_argument('--save_total_limit', type=int, default=None,
+                        help='Limit the total amount of checkpoints, delete the older checkpoints in the output_dir, does not delete by default')
     parser.add_argument("--eval_all_checkpoints", action='store_true',
                         help="Evaluate all checkpoints starting with the same prefix as model_name_or_path ending and ending with step number")
     parser.add_argument("--no_cuda", action='store_true',

--- a/examples/run_lm_finetuning.py
+++ b/examples/run_lm_finetuning.py
@@ -117,16 +117,16 @@ def _rotate_checkpoints(args, checkpoint_prefix, use_mtime=False):
     if len(glob_checkpoints) <= args.save_total_limit:
         return
 
-    checkpoints_sorted = []
+    ordering_and_checkpoint_path = []
     for path in glob_checkpoints:
-        regex_match = re.match('.*{}-([0-9]+)'.format(checkpoint_prefix), path)
-        if regex_match and regex_match.groups():
-            if use_mtime:
-                checkpoints_sorted.append((os.path.getmtime(path), path))
-            else:
-                checkpoints_sorted.append((int(regex_match.groups()[0]), path))
+        if use_mtime:
+            ordering_and_checkpoint_path.append((os.path.getmtime(path), path))
+        else:
+            regex_match = re.match('.*{}-([0-9]+)'.format(checkpoint_prefix), path)
+            if regex_match and regex_match.groups():
+                ordering_and_checkpoint_path.append((int(regex_match.groups()[0]), path))
 
-    checkpoints_sorted = sorted(checkpoints_sorted)
+    checkpoints_sorted = sorted(ordering_and_checkpoint_path)
     checkpoints_sorted = [checkpoint[1] for checkpoint in checkpoints_sorted]
     number_of_checkpoints_to_delete = max(0, len(checkpoints_sorted) - args.save_total_limit)
     checkpoints_to_be_deleted = checkpoints_sorted[:number_of_checkpoints_to_delete]

--- a/examples/run_lm_finetuning.py
+++ b/examples/run_lm_finetuning.py
@@ -106,6 +106,26 @@ def set_seed(args):
         torch.cuda.manual_seed_all(args.seed)
 
 
+def rotate_checkpoints(args):
+    if args.save_total_limit and args.save_total_limit > 0:
+        # Check if we should delete older checkpoint(s)
+        glob_checkpoints = glob.glob(os.path.join(args.output_dir, 'checkpoint-*'))
+        if len(glob_checkpoints) > args.save_total_limit:
+            checkpoints_sorted = []
+            for path in glob_checkpoints:
+                regex_match = re.match('.*checkpoint-([0-9]+)', path)
+                if regex_match and regex_match.groups():
+                    checkpoints_sorted.append((int(regex_match.groups()[0]), path))
+
+            checkpoints_sorted = sorted(checkpoints_sorted)
+            checkpoints_sorted = [checkpoint[1] for checkpoint in checkpoints_sorted]
+            number_of_checkpoints_to_delete = max(0, len(checkpoints_sorted) - args.save_total_limit)
+            checkpoints_to_be_deleted = checkpoints_sorted[:number_of_checkpoints_to_delete]
+            for checkpoint in checkpoints_to_be_deleted:
+                logger.info("Deleting older checkpoint [{}] due to args.save_total_limit".format(checkpoint))
+                shutil.rmtree(checkpoint)
+
+
 def mask_tokens(inputs, tokenizer, args):
     """ Prepare masked tokens inputs/labels for masked language modeling: 80% MASK, 10% random, 10% original. """
     labels = inputs.clone()
@@ -233,23 +253,7 @@ def train(args, train_dataset, model, tokenizer):
                     torch.save(args, os.path.join(output_dir, 'training_args.bin'))
                     logger.info("Saving model checkpoint to %s", output_dir)
 
-                    if args.save_total_limit and args.save_total_limit > 0:
-                        # Check if we should delete older checkpoint(s)
-                        glob_checkpoints = glob.glob(os.path.join(args.output_dir, 'checkpoint-*'))
-                        if len(glob_checkpoints) > args.save_total_limit:
-                            checkpoints_sorted = []
-                            for path in glob_checkpoints:
-                                regex_match = re.match('.*checkpoint-([0-9]+)', path)
-                                if regex_match and regex_match.groups():
-                                    checkpoints_sorted.append((int(regex_match.groups()[0]), path))
-
-                            checkpoints_sorted = sorted(checkpoints_sorted)
-                            checkpoints_sorted = [checkpoint[1] for checkpoint in checkpoints_sorted]
-                            number_of_checkpoints_to_delete = max(0, len(checkpoints_sorted) - args.save_total_limit)
-                            checkpoints_to_be_deleted = checkpoints_sorted[:number_of_checkpoints_to_delete]
-                            for checkpoint in checkpoints_to_be_deleted:
-                                logger.info("Deleting older checkpoint [{}] due to args.save_total_limit".format(checkpoint))
-                                shutil.rmtree(checkpoint)
+                    rotate_checkpoints(args)
 
             if args.max_steps > 0 and global_step > args.max_steps:
                 epoch_iterator.close()

--- a/examples/run_lm_finetuning.py
+++ b/examples/run_lm_finetuning.py
@@ -114,23 +114,25 @@ def _rotate_checkpoints(args, checkpoint_prefix, use_mtime=False):
 
     # Check if we should delete older checkpoint(s)
     glob_checkpoints = glob.glob(os.path.join(args.output_dir, '{}-*'.format(checkpoint_prefix)))
-    if len(glob_checkpoints) > args.save_total_limit:
-        checkpoints_sorted = []
-        for path in glob_checkpoints:
-            regex_match = re.match('.*{}-([0-9]+)'.format(checkpoint_prefix), path)
-            if regex_match and regex_match.groups():
-                if use_mtime:
-                    checkpoints_sorted.append((os.path.getmtime(path), path))
-                else:
-                    checkpoints_sorted.append((int(regex_match.groups()[0]), path))
+    if len(glob_checkpoints) <= args.save_total_limit:
+        return
 
-        checkpoints_sorted = sorted(checkpoints_sorted)
-        checkpoints_sorted = [checkpoint[1] for checkpoint in checkpoints_sorted]
-        number_of_checkpoints_to_delete = max(0, len(checkpoints_sorted) - args.save_total_limit)
-        checkpoints_to_be_deleted = checkpoints_sorted[:number_of_checkpoints_to_delete]
-        for checkpoint in checkpoints_to_be_deleted:
-            logger.info("Deleting older checkpoint [{}] due to args.save_total_limit".format(checkpoint))
-            shutil.rmtree(checkpoint)
+    checkpoints_sorted = []
+    for path in glob_checkpoints:
+        regex_match = re.match('.*{}-([0-9]+)'.format(checkpoint_prefix), path)
+        if regex_match and regex_match.groups():
+            if use_mtime:
+                checkpoints_sorted.append((os.path.getmtime(path), path))
+            else:
+                checkpoints_sorted.append((int(regex_match.groups()[0]), path))
+
+    checkpoints_sorted = sorted(checkpoints_sorted)
+    checkpoints_sorted = [checkpoint[1] for checkpoint in checkpoints_sorted]
+    number_of_checkpoints_to_delete = max(0, len(checkpoints_sorted) - args.save_total_limit)
+    checkpoints_to_be_deleted = checkpoints_sorted[:number_of_checkpoints_to_delete]
+    for checkpoint in checkpoints_to_be_deleted:
+        logger.info("Deleting older checkpoint [{}] due to args.save_total_limit".format(checkpoint))
+        shutil.rmtree(checkpoint)
 
 
 def mask_tokens(inputs, tokenizer, args):


### PR DESCRIPTION
By default, no change in existing behavior. However, if you pass in an argument with `save_total_limit` flag and a natural number as value, then, your machine might not run out of space when fine-tuning. Because, it will only keep the latest `save_total_limit` number of checkpoints and delete the older checkpoints.