### PR TITLE
remove leftover usage of DUMMY_INPUTS

### DIFF
--- a/transformers/modeling_tf_pytorch_utils.py
+++ b/transformers/modeling_tf_pytorch_utils.py
@@ -198,7 +198,7 @@ def load_tf2_checkpoint_in_pytorch_model(pt_model, tf_checkpoint_path, tf_inputs
     tf_model = tf_model_class(pt_model.config)
 
     if tf_inputs is None:
-        tf_inputs = tf.constant(DUMMY_INPUTS)
+        tf_inputs = tf_model.dummy_inputs
 
     if tf_inputs is not None:
         tfo = tf_model(tf_inputs, training=False)  # Make sure model is built


### PR DESCRIPTION
Hey @thomwolf  
This change https://github.com/huggingface/transformers/commit/da26bae61b8c1e741fdc6735d46c61b43f649561#diff-8ddce309e88e8eb5b4d02228fd8881daL28 removed the constant `DUMMY_INPUTS`, but one usage of that constant remains in the code.

So any call to `load_tf2_checkpoint_in_pytorch_model` is currently throwing: `NameError: name 'DUMMY_INPUTS' is not defined`

```
/usr/local/lib/python3.6/dist-packages/transformers/modeling_tf_pytorch_utils.py in load_tf2_checkpoint_in_pytorch_model(pt_model, tf_checkpoint_path, tf_inputs, allow_missing_keys)
    199 
    200     if tf_inputs is None:
--> 201         tf_inputs = tf.constant(DUMMY_INPUTS)
    202 
    203     if tf_inputs is not None:

NameError: name 'DUMMY_INPUTS' is not defined
```