### PR TITLE
Force einsum to run in fp16

### DIFF
--- a/examples/run_squad.py
+++ b/examples/run_squad.py
@@ -138,8 +138,8 @@ def train(args, train_dataset, model, tokenizer):
             model.train()
             batch = tuple(t.to(args.device) for t in batch)
             inputs = {'input_ids':       batch[0],
-                      'attention_mask':  batch[1], 
-                      'start_positions': batch[3], 
+                      'attention_mask':  batch[1],
+                      'start_positions': batch[3],
                       'end_positions':   batch[4]}
             if args.model_type != 'distilbert':
                 inputs['token_type_ids'] = None if args.model_type == 'xlm' else batch[2]
@@ -480,6 +480,16 @@ def main():
     model.to(args.device)
 
     logger.info("Training/evaluation parameters %s", args)
+
+    # Before we do anything with models, we want to ensure that we get fp16 execution of torch.einsum if args.fp16 is set.
+    # Otherwise it'll default to "promote" mode, and we'll get fp32 operations. Note that running `--fp16_opt_level="O2"` will
+    # remove the need for this code, but it is still valid.
+    if args.fp16:
+        try:
+            import apex
+            apex.amp.register_half_function(torch, 'einsum')
+        except ImportError:
+            raise ImportError("Please install apex from https://www.github.com/nvidia/apex to use fp16 training.")
 
     # Training
     if args.do_train:


### PR DESCRIPTION
As noted in the comments, this will force `torch.einsum` to run in fp16 for the squad finetuning task (it should be valid for other tasks, but I haven't verified that) when run with `--fp16_opt_level="O1"` which is the default.

Otherwise, `torch.einsum` is treated as a "promote" operation by `apex.amp`, and if any argument is fp32, all arguments will be cast to fp32, and the answer will return in fp32. This will happen at any point when a parameter is used (XLNet in particular suffers here). Given all uses I've seen for einsum are to express gemm, batched-gemm and transpose, operations we'd normally consider to be safe in fp16, this should be a safe change. From a performance standpoint it allows TensorCore usage which can significantly boost achieved performance.

This change doesn't affect accuracy in my testing, and gives ~20-25% higher throughput on XLNet-based finetuning.