### PR TITLE
Fix Roberta on TPU

### DIFF
--- a/transformers/modeling_tf_roberta.py
+++ b/transformers/modeling_tf_roberta.py
@@ -75,7 +75,7 @@ class TFRobertaMainLayer(TFBertMainLayer):
             input_ids = inputs
 
         if tf.not_equal(tf.reduce_sum(input_ids[:, 0]), 0):
-            tf.print("A sequence with no special tokens has been passed to the RoBERTa model. "
+            logger.error("A sequence with no special tokens has been passed to the RoBERTa model. "
                            "This model requires special tokens in order to work. "
                            "Please specify add_special_tokens=True in your encoding.")
 


### PR DESCRIPTION
Fixes #1569 
- Revert tf.print() to logger , since tf.print() is an unsupported TPU ops.