### PR TITLE
Add feature #1572 which gives support for multiple candidate sequences

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -100,7 +100,7 @@ class ExamplesTests(unittest.TestCase):
         testargs = ["run_generation.py",
                     "--prompt=Hello",
                     "--length=10",
-                    "--seed=42"
+                    "--seed=42",
                     "--num_samples=2"]
         model_type, model_name = ("--model_type=openai-gpt",
                                   "--model_name_or_path=openai-gpt")

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -100,12 +100,15 @@ class ExamplesTests(unittest.TestCase):
         testargs = ["run_generation.py",
                     "--prompt=Hello",
                     "--length=10",
-                    "--seed=42"]
+                    "--seed=42"
+                    "--num_samples=2"]
         model_type, model_name = ("--model_type=openai-gpt",
                                   "--model_name_or_path=openai-gpt")
         with patch.object(sys, 'argv', testargs + [model_type, model_name]):
-            result = run_generation.main()
-            self.assertGreaterEqual(len(result), 10)
-
+            results = run_generation.main()
+            for result in results:
+                self.assertGreaterEqual(len(result), 10)
+            self.assertEqual(len(results), 2)
+            
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Multiple candidate sequences can be generated by setting ```num_samples  >  1``` (still 1 by default).**

EXAMPLE with ```num_samples == 2``` for a GPT2 model:

```
INPUT:
Why did the chicken

OUTPUT:
 cross the road <eoq>  To go to the other side. <eoa>  
 eat food <eoq>  Because it was hungry <eoa>

```
(above is illustrative w some words changed from the actual output)

**UPDATE:** Multiple candidate sequences can now be generated with _repetition penalty_ and ```top_k_top_p_filtering``` applied separately to each candidate. This allows for independent probability distributions across candidate sequences.

~Samples are generated with replacement to allow for sequences that have similar tokens at the same index (e.g. [CLS], stopwords, punctuations).~

~When ```temperature == 0```, the tokens returned are the top ```num_samples``` logits (first sample gets top 1, second gets top 2, and so on). I realize this might not be the best implementation because it doesn't allow for similar tokens at the same index across samples. I will consider later changing this to just returning ```num_samples``` copies of the top 1 logits (argmax).~