### PR TITLE
Add special tokens to documentation for bert examples to resolve issue: #1561

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -100,7 +100,7 @@ class ExamplesTests(unittest.TestCase):
         testargs = ["run_generation.py",
                     "--prompt=Hello",
                     "--length=10",
-                    "--seed=42"
+                    "--seed=42",
                     "--num_samples=2"]
         model_type, model_name = ("--model_type=openai-gpt",
                                   "--model_name_or_path=openai-gpt")

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -100,12 +100,15 @@ class ExamplesTests(unittest.TestCase):
         testargs = ["run_generation.py",
                     "--prompt=Hello",
                     "--length=10",
-                    "--seed=42"]
+                    "--seed=42"
+                    "--num_samples=2"]
         model_type, model_name = ("--model_type=openai-gpt",
                                   "--model_name_or_path=openai-gpt")
         with patch.object(sys, 'argv', testargs + [model_type, model_name]):
-            result = run_generation.main()
-            self.assertGreaterEqual(len(result), 10)
-
+            results = run_generation.main()
+            for result in results:
+                self.assertGreaterEqual(len(result), 10)
+            self.assertEqual(len(results), 2)
+            
 if __name__ == "__main__":
     unittest.main()

--- a/transformers/modeling_bert.py
+++ b/transformers/modeling_bert.py
@@ -557,7 +557,7 @@ class BertModel(BertPreTrainedModel):
 
         tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
         model = BertModel.from_pretrained('bert-base-uncased')
-        input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute")).unsqueeze(0)  # Batch size 1
+        input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute", add_special_tokens=True)).unsqueeze(0)  # Batch size 1
         outputs = model(input_ids)
         last_hidden_states = outputs[0]  # The last hidden-state is the first element of the output tuple
 
@@ -667,7 +667,7 @@ class BertForPreTraining(BertPreTrainedModel):
 
         tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
         model = BertForPreTraining.from_pretrained('bert-base-uncased')
-        input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute")).unsqueeze(0)  # Batch size 1
+        input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute", add_special_tokens=True)).unsqueeze(0)  # Batch size 1
         outputs = model(input_ids)
         prediction_scores, seq_relationship_scores = outputs[:2]
 
@@ -739,7 +739,7 @@ class BertForMaskedLM(BertPreTrainedModel):
 
         tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
         model = BertForMaskedLM.from_pretrained('bert-base-uncased')
-        input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute")).unsqueeze(0)  # Batch size 1
+        input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute", add_special_tokens=True)).unsqueeze(0)  # Batch size 1
         outputs = model(input_ids, masked_lm_labels=input_ids)
         loss, prediction_scores = outputs[:2]
 
@@ -808,7 +808,7 @@ class BertForNextSentencePrediction(BertPreTrainedModel):
 
         tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
         model = BertForNextSentencePrediction.from_pretrained('bert-base-uncased')
-        input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute")).unsqueeze(0)  # Batch size 1
+        input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute", add_special_tokens=True)).unsqueeze(0)  # Batch size 1
         outputs = model(input_ids)
         seq_relationship_scores = outputs[0]
 
@@ -871,7 +871,7 @@ class BertForSequenceClassification(BertPreTrainedModel):
 
         tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
         model = BertForSequenceClassification.from_pretrained('bert-base-uncased')
-        input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute")).unsqueeze(0)  # Batch size 1
+        input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute", add_special_tokens=True)).unsqueeze(0)  # Batch size 1
         labels = torch.tensor([1]).unsqueeze(0)  # Batch size 1
         outputs = model(input_ids, labels=labels)
         loss, logits = outputs[:2]
@@ -945,7 +945,7 @@ class BertForMultipleChoice(BertPreTrainedModel):
         tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
         model = BertForMultipleChoice.from_pretrained('bert-base-uncased')
         choices = ["Hello, my dog is cute", "Hello, my cat is amazing"]
-        input_ids = torch.tensor([tokenizer.encode(s) for s in choices]).unsqueeze(0)  # Batch size 1, 2 choices
+        input_ids = torch.tensor([tokenizer.encode(s, add_special_tokens=True) for s in choices]).unsqueeze(0)  # Batch size 1, 2 choices
         labels = torch.tensor(1).unsqueeze(0)  # Batch size 1
         outputs = model(input_ids, labels=labels)
         loss, classification_scores = outputs[:2]
@@ -1017,7 +1017,7 @@ class BertForTokenClassification(BertPreTrainedModel):
 
         tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
         model = BertForTokenClassification.from_pretrained('bert-base-uncased')
-        input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute")).unsqueeze(0)  # Batch size 1
+        input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute", add_special_tokens=True)).unsqueeze(0)  # Batch size 1
         labels = torch.tensor([1] * input_ids.size(1)).unsqueeze(0)  # Batch size 1
         outputs = model(input_ids, labels=labels)
         loss, scores = outputs[:2]


### PR DESCRIPTION
**Currently the BERT examples only show the strings encoded without the inclusion of special tokens (e.g. [CLS] and [SEP]) as illustrated below:**

```
tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
sentence = "Hello there, General Kenobi!"
print(tokenizer.encode(sentence))
print(tokenizer.cls_token_id, tokenizer.sep_token_id)

# [7592, 2045, 1010, 2236, 6358, 16429, 2072, 999]
# 101 102
```

**In this pull request i set ```add_special_tokens=True``` in order to include special tokens in the documented examples as illustrated below:**
```
tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
sentence = "Hello there, General Kenobi!"
print(tokenizer.encode(sentence, add_special_tokens=True))
print(tokenizer.cls_token_id, tokenizer.sep_token_id)
# [101, 7592, 2045, 1010, 2236, 6358, 16429, 2072, 999, 102]
# 101 102
```