### PR TITLE
[WIP] Fixes for TF Roberta (and other models WIP)

### DIFF
--- a/transformers/modeling_tf_roberta.py
+++ b/transformers/modeling_tf_roberta.py
@@ -65,6 +65,7 @@ class TFRobertaMainLayer(TFBertMainLayer):
         super(TFRobertaMainLayer, self).__init__(config, **kwargs)
         self.embeddings = TFRobertaEmbeddings(config, name='embeddings')
 
+    @tf.function()
     def call(self, inputs, **kwargs):
         # Check that input_ids starts with control token
         if isinstance(inputs, (tuple, list)):

--- a/transformers/modeling_tf_xlm.py
+++ b/transformers/modeling_tf_xlm.py
@@ -63,7 +63,6 @@ def gelu(x):
     cdf = 0.5 * (1.0 + tf.math.erf(x / tf.math.sqrt(2.0)))
     return x * cdf
 
-
 def get_masks(slen, lengths, causal, padding_mask=None, dtype=tf.float32):
     """
     Generate hidden states mask, and optionally an attention mask.
@@ -84,7 +83,7 @@ def get_masks(slen, lengths, causal, padding_mask=None, dtype=tf.float32):
         attn_mask = mask
 
     # sanity check
-    assert shape_list(mask) == [bs, slen]
+    tf.debugging.assert_equal(shape_list(mask), [bs, slen])
     assert causal is False or shape_list(attn_mask) == [bs, slen, slen]
 
     mask = tf.cast(mask, dtype=dtype)
@@ -318,7 +317,7 @@ class TFXLMMainLayer(tf.keras.layers.Layer):
 
         # check inputs
         bs, slen = shape_list(input_ids)
-        assert shape_list(lengths)[0] == bs
+        tf.debugging.assert_equal(shape_list(lengths)[0], bs)
         # assert lengths.max().item() <= slen
         # input_ids = input_ids.transpose(0, 1)  # batch size as dimension 0
         # assert (src_enc is None) == (src_len is None)

--- a/transformers/modeling_tf_xlnet.py
+++ b/transformers/modeling_tf_xlnet.py
@@ -539,7 +539,7 @@ class TFXLNetMainLayer(tf.keras.layers.Layer):
         assert input_mask is None or attention_mask is None, "You can only use one of input_mask (uses 1 for padding) " \
             "or attention_mask (uses 0 for padding, added for compatbility with BERT). Please choose one."
         if input_mask is None and attention_mask is not None:
-            input_mask = 1.0 - attention_mask
+            input_mask = 1 - attention_mask
         if input_mask is not None and perm_mask is not None:
             data_mask = input_mask[None] + perm_mask
         elif input_mask is not None and perm_mask is None:
@@ -552,7 +552,8 @@ class TFXLNetMainLayer(tf.keras.layers.Layer):
         if data_mask is not None:
             # all mems can be attended to
             mems_mask = tf.zeros([tf.shape(data_mask)[0], mlen, bsz],
-                                dtype=dtype_float)
+                                dtype=tf.int32)
+            data_mask = tf.cast(data_mask, dtype=tf.int32)
             data_mask = tf.concat([mems_mask, data_mask], axis=1)
             if attn_mask is None:
                 attn_mask = data_mask[:, :, :, None]
@@ -902,7 +903,7 @@ class TFXLNetForSequenceClassification(TFXLNetPreTrainedModel):
         self.logits_proj = tf.keras.layers.Dense(config.num_labels,
                                                  kernel_initializer=get_initializer(config.initializer_range),
                                                  name='logits_proj')
-
+    @tf.function
     def call(self, inputs, **kwargs):
         transformer_outputs = self.transformer(inputs, **kwargs)
         output = transformer_outputs[0]


### PR DESCRIPTION
When converting the `run_tf_glue.py` example to the same format at `benchmarks.py` to create a standardized benchmark for training, I ran into errors with **training** the non-BERT models with the normal `model.fit()` method. I am attempting to resolve all the errors I encountered in this PR. In particular, I have fixed the errors I have encountered with `TFRobertaForSequenceClassification`, `TFXLMForSequenceClassification`, and `TFXLNetForSequenceClassification`.

### Changes

**Roberta**

* Roberta requires `@tf.function()` on `TFRobertaMainLayer.call()`
* Otherwise, errors encountered:
  * `TypeError: You are attempting to use Python control flow in a layer that was not declared to be dynamic. Pass 'dynamic=True' to the class constructor.`
  * `OperatorNotAllowedInGraphError: using a 'tf.Tensor' as a Python 'bool' is not allowed in Graph execution. Use Eager execution or decorate this function with @tf.function.`
* Issues:
  * Fails test `TFRobertaModelTest.test_pt_tf_model_equivalence`: `AssertionError: layer.0.attention.self.query.weight not found in PyTorch model`.

**XLM**

* XLX requires changing some Python `assert` statements to `tf.debugging.assert_equal` both in `TFXLMMainLayer.call()` and `gen_mask()`
* Otherwise, errors encountered:
  * `TypeError: You are attempting to use Python control flow in a layer that was not declared to be dynamic. Pass 'dynamic=True' to the class constructor.`
  * `OperatorNotAllowedInGraphError: using a 'tf.Tensor' as a Python 'bool' is not allowed in Graph execution. Use Eager execution or decorate this function with @tf.function.`

**XLNet**

* XLNet had a dtype error (float vs int) in line `input_mask = 1.0 - attention_mask`. Since `input_mask` and `attention_mask` are both supposed (afaik) to be int32, I've replace `1.0` with `1`. 
* Still has shape error (see below) that I have not managed to track down. **This is particularly confusion because the training works in eager mode!**
* Solution is to simply provide a workaround `model.run_eagerly = True`.
* Of course, this will make the model train much slower (~140s for first epoch). Decorating `TFXLNetForSequenceClassification`'s `call()` method with `tf.function` works, and results in ~80s per first epoch. We cannot decorate the individual `call()` methods (aka create "overlapping" `tf.function`) as that will cause model saving to not work.
* Irregardless of my changes, there is a warning `gradients do not exist for variables ['transformer/mask_emb:0'] when minimizing the loss.` But from my observation the model trains fine. Is this embedding supposed to be trainable in the first place?
* Issues:
  * Fails test `TFXLNetModelTest.test_pt_tf_model_equivalence`: `AssertionError: mask_emb not found in PyTorch model`.

Shape error: 

```
tensorflow.python.framework.errors_impl.InvalidArgumentError:  Incompatible shapes: [128,128,16,12] vs. [128,255,16,12]
         [[node tfxl_net_for_sequence_classification/transformer/layer_._0/rel_attn/add_3 (defined at /opt/conda/lib/python3.6/site-packages/tensorflow_core/python/framework/ops.py:1751) ]] [Op:__inference_distributed_function_72170]
```

Do let me know if there are any feedback on the changes I made.