### PR TITLE
[WIP] Raise error if larger sequences

### DIFF
--- a/transformers/modeling_bert.py
+++ b/transformers/modeling_bert.py
@@ -159,6 +159,8 @@ class BertEmbeddings(nn.Module):
     def forward(self, input_ids, token_type_ids=None, position_ids=None):
         seq_length = input_ids.size(1)
         if position_ids is None:
+            if seq_length > self.position_embeddings.num_embeddings:
+                raise ValueError("Sequence length is larger that number of positional embeddings")
             position_ids = torch.arange(seq_length, dtype=torch.long, device=input_ids.device)
             position_ids = position_ids.unsqueeze(0).expand_as(input_ids)
         if token_type_ids is None:


### PR DESCRIPTION
Hi, 

I suggest to improve a bit user experience when using pretrained models by raising more errors if some of parameters are incoherent.
For example, in this PR, there is a suggestion to raise error and thus inform user about potential error as "RuntimeError: cublas runtime error ..." which can be harder to find if running on GPU.

What do you think ?