### PR TITLE
Fix GPT2LMHeadModel.from_pretrained(from_tf=True)

### DIFF
--- a/transformers/modeling_gpt2.py
+++ b/transformers/modeling_gpt2.py
@@ -69,6 +69,10 @@ def load_tf_weights_in_gpt2(model, config, gpt2_checkpoint_path):
         name = name[6:]  # skip "model/"
         name = name.split('/')
         pointer = model
+        
+        if isinstance(model, GPT2LMHeadModel):
+            pointer = model.transformer
+            
         for m_name in name:
             if re.fullmatch(r'[A-Za-z]+\d+', m_name):
                 l = re.split(r'(\d+)', m_name)


### PR DESCRIPTION
GPT2LMHeadModel.from_pretrained(from_tf=True) doesn't work because pointer points to the GPT2LMHeadModel instance, not the GPT2Model instance. 

This bug causes errors like:

'GPT2LMHeadModel' object has no attribute 'h'