### PR TITLE
Token indices sequence length is longer than the specified maximum sequence length for this model

### DIFF
--- a/transformers/tokenization_utils.py
+++ b/transformers/tokenization_utils.py
@@ -671,10 +671,6 @@ class PreTrainedTokenizer(object):
         ids = []
         for token in tokens:
             ids.append(self._convert_token_to_id_with_added_voc(token))
-        if len(ids) > self.max_len:
-            logger.warning("Token indices sequence length is longer than the specified maximum sequence length "
-                           "for this model ({} > {}). Running this sequence through the model will result in "
-                           "indexing errors".format(len(ids), self.max_len))
         return ids
 
     def _convert_token_to_id_with_added_voc(self, token):
@@ -877,6 +873,11 @@ class PreTrainedTokenizer(object):
             encoded_inputs["token_type_ids"] = encoded_inputs["token_type_ids"][:max_length]
             encoded_inputs["special_tokens_mask"] = encoded_inputs["special_tokens_mask"][:max_length]
 
+        if max_length is None and len(encoded_inputs["input_ids"]) > self.max_len:
+            logger.warning("Token indices sequence length is longer than the specified maximum sequence length "
+                           "for this model ({} > {}). Running this sequence through the model will result in "
+                           "indexing errors".format(len(ids), self.max_len))
+                           
         return encoded_inputs
 
     def truncate_sequences(self, ids, pair_ids=None, num_tokens_to_remove=0, truncation_strategy='longest_first', stride=0):


### PR DESCRIPTION
As of now the tokenizers output a specific warning when an encoded sequence is longer than the maximum specified sequence length, which is model-specific:

```
Token indices sequence length is longer than the specified maximum sequence length for this model (X > 1024). Running this sequence through the model will result in indexing errors
```

It is currently in the `convert_tokens_to_ids` and this leads to two issues:

- using `encode` or `encode_plus` methods with a `max_length` specified will still output that warning as the `convert_tokens_to_ids` method is used before the truncation is done. (cf #1791)
- since `prepare_for_model` was introduced, I personally feel that all modifications related to the model should happen in that method and not in `tokenize` or `convert_tokens_to_ids`. 

This PR aims to slightly change the behavior so that both aforementioned issues may be solved by putting the warning in the `prepare_for_model` method if no `max_length` is specified.