### PR TITLE
Update modeling_utils.py by adding "DUMMY_INPUTS" after "logger" variable.

### DIFF
--- a/transformers/modeling_utils.py
+++ b/transformers/modeling_utils.py
@@ -35,6 +35,7 @@ from .file_utils import cached_path, WEIGHTS_NAME, TF_WEIGHTS_NAME, TF2_WEIGHTS_
 
 logger = logging.getLogger(__name__)
 
+DUMMY_INPUTS = [[7, 6, 0, 0, 1], [1, 2, 3, 0, 0], [0, 0, 0, 4, 5]]
 
 try:
     from torch.nn import Identity


### PR DESCRIPTION
This Pull Request fixes a probable bug found using Transformers in Anaconda, using TFBertForSequenceClassification, Tensorflow 2.0.0b0, according to:

https://github.com/huggingface/transformers/issues/1810#issuecomment-554572471

