### PR TITLE
Split on punc should receive never_split list

### DIFF
--- a/transformers/tokenization_bert.py
+++ b/transformers/tokenization_bert.py
@@ -315,7 +315,7 @@ class BasicTokenizer(object):
             if self.do_lower_case and token not in never_split:
                 token = token.lower()
                 token = self._run_strip_accents(token)
-            split_tokens.extend(self._run_split_on_punc(token))
+            split_tokens.extend(self._run_split_on_punc(token, never_split))
 
         output_tokens = whitespace_tokenize(" ".join(split_tokens))
         return output_tokens


### PR DESCRIPTION
When tokenizing when a never_split token that contains any punctuation, such as [ or ] they currently get split when they shouldn't be.