### PR TITLE
Updated examples/README and parser for run_summarization_finetuning

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -596,10 +596,10 @@ export DATA_PATH=/path/to/dataset/
 
 python run_summarization_finetuning.py \
     --output_dir=output \
-    --model_type=bert2bert \
-    --model_name_or_path=bert2bert \
+    --model_type=bert \
+    --model_name_or_path=bert-base-cased \
     --do_train \
-    --data_path=$DATA_PATH \
+    --data_dir=$DATA_PATH \
 ```
 
 ## XNLI

--- a/examples/run_summarization_finetuning.py
+++ b/examples/run_summarization_finetuning.py
@@ -360,7 +360,11 @@ def main():
         default=False,
         help="Run model evaluation on out-of-sample data.",
     )
-    parser.add_argument("--do_train", type=bool, default=False, help="Run training.")
+    parser.add_argument(
+        "--do_train", 
+        action='store_true', 
+        help="Whether to run training.",
+    )
     parser.add_argument(
         "--do_overwrite_output_dir",
         type=bool,

--- a/examples/utils_summarization.py
+++ b/examples/utils_summarization.py
@@ -139,11 +139,11 @@ def encode_for_summarization(story_lines, summary_lines, tokenizer):
     sentences.
     """
     story_lines_token_ids = [
-        tokenizer.add_special_tokens_single_sequence(tokenizer.encode(line))
+        tokenizer.build_inputs_with_special_tokens(tokenizer.encode(line))
         for line in story_lines
     ]
     summary_lines_token_ids = [
-        tokenizer.add_special_tokens_single_sequence(tokenizer.encode(line))
+        tokenizer.build_inputs_with_special_tokens(tokenizer.encode(line))
         for line in summary_lines
     ]
 


### PR DESCRIPTION
1. Updated `examples/README.md` to change default `--model_type` and `--model_name_or_path` to `bert` and `bert_base_cased` because `bert2bert` just won't work
2. Updated `examples/run_summarization_finetuning.py` parser to take in `--do-train` instead of `--do-train=True` for consistency with other examples and `--model_type` + `--model_name_or_path`
3. Changed `add_special_tokens_single_sequence` to `build_inputs_with_special_tokens` in `examples/utils_summarization.py`  