### PR TITLE
Progress indicator improvements when downloading pre-trained models.

### DIFF
--- a/transformers/file_utils.py
+++ b/transformers/file_utils.py
@@ -21,7 +21,7 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
 import requests
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from contextlib import contextmanager
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -245,7 +245,7 @@ def http_get(url, temp_file, proxies=None, resume_size=0):
         return
     content_length = response.headers.get('Content-Length')
     total = resume_size + int(content_length) if content_length is not None else None
-    progress = tqdm(unit="B", total=total, initial=resume_size)
+    progress = tqdm(unit="B", unit_scale=True, total=total, initial=resume_size, desc="Downloading")
     for chunk in response.iter_content(chunk_size=1024):
         if chunk: # filter out keep-alive new chunks
             progress.update(len(chunk))


### PR DESCRIPTION
Downloading GPT2-XL can take a while.  If you're not expecting it, the current progress bar can be confusing.  It looks like this:

```
  4%|▉                       | 257561600/6431878936 [00:33<16:12, 6351328.14B/s]
```

With this change, the progress bar is much more readable:


```
Downloading:   3%|▋                         | 166M/6.43G [00:30<12:34, 8.31MB/s]
```

Also, by importing from `tqdm.auto` you will get a nice graphical progress bar if you're running in a jupyter notebook.  (Unless you're using jupyter lab and you don't have widgets set up properly, but that's it's own ball of wax.)
 