### PR TITLE
:bug: #2120 in model.from_pretrained, PosixPath crashes at "albert" check

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -46,3 +46,4 @@ wcwidth==0.1.7
 Werkzeug==0.16.0
 wrapt==1.11.2
 zipp==0.6.0
+pathlib==1.0.1

--- a/transformers/modeling_utils.py
+++ b/transformers/modeling_utils.py
@@ -319,7 +319,7 @@ class PreTrainedModel(nn.Module):
 
         """
         if pretrained_model_name_or_path is not None and (
-                "albert" in pretrained_model_name_or_path and "v2" in pretrained_model_name_or_path):
+                "albert" in str(pretrained_model_name_or_path) and "v2" in str(pretrained_model_name_or_path)):
             logger.warning("There is currently an upstream reproducibility issue with ALBERT v2 models. Please see " +
                            "https://github.com/google-research/google-research/issues/119 for more information.")
 

--- a/transformers/tests/modeling_common_test.py
+++ b/transformers/tests/modeling_common_test.py
@@ -562,6 +562,16 @@ class CommonTestCases:
                 inputs_dict["inputs_embeds"] = wte(input_ids)
                 outputs = model(**inputs_dict)
 
+        def test_from_pretrained_with_posix_path(self):
+            """Check that loading a pretrained model from a non-existing PosixPath raises an OSError as expected"""
+            from pathlib import Path
+            path = Path("/toto") / "tata"
+            for model_class in self.all_model_classes:
+                with self.assertRaises(OSError):
+                    model_class.from_pretrained(path)
+
+
+
 
     class GPTModelTester(CommonModelTester):
 


### PR DESCRIPTION
- `pretrained_model_name_or_path` is now stringified to allow the "albert" and "v2" checks with PosixPath (or any other path representation that isn't iterable).
- If `pretrained_model_name_or_path` is None, it gives string "None" which doesn't contain "albert" so it's OK.
- 2 x `str(pretrained_model_name_or_path)` doesn't impact performances as it's called only once per program and `and` operator will generally fail at left side.
- added a test to check non-regression