### PR TITLE
BertForSequenceClassification() model TF to pytorch conversion

### DIFF
--- a/transformers/convert_bert_seqclass_tf_checkpoint_to_pytorch.py
+++ b/transformers/convert_bert_seqclass_tf_checkpoint_to_pytorch.py
@@ -1,0 +1,65 @@
+# coding=utf-8
+# Copyright 2018 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Convert BERT checkpoint."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import torch
+
+from transformers import BertConfig, BertForSequenceClassification, load_tf_weights_in_bert
+
+import logging
+logging.basicConfig(level=logging.INFO)
+
+def convert_tf_checkpoint_to_pytorch(tf_checkpoint_path, bert_config_file, pytorch_dump_path):
+    # Initialise PyTorch model
+    config = BertConfig.from_json_file(bert_config_file)
+    print("Building PyTorch model from configuration: {}".format(str(config)))
+    model = BertForSequenceClassification(config)
+
+    # Load weights from tf checkpoint
+    load_tf_weights_in_bert(model, config, tf_checkpoint_path)
+
+    # Save pytorch-model
+    print("Save PyTorch model to {}".format(pytorch_dump_path))
+    torch.save(model.state_dict(), pytorch_dump_path)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    ## Required parameters
+    parser.add_argument("--tf_checkpoint_path",
+                        default = None,
+                        type = str,
+                        required = True,
+                        help = "Path to the TensorFlow checkpoint path.")
+    parser.add_argument("--bert_config_file",
+                        default = None,
+                        type = str,
+                        required = True,
+                        help = "The config json file corresponding to the pre-trained BERT model. \n"
+                            "This specifies the model architecture.")
+    parser.add_argument("--pytorch_dump_path",
+                        default = None,
+                        type = str,
+                        required = True,
+                        help = "Path to the output PyTorch model.")
+    args = parser.parse_args()
+    convert_tf_checkpoint_to_pytorch(args.tf_checkpoint_path,
+                                     args.bert_config_file,
+                                     args.pytorch_dump_path)

--- a/transformers/modeling_bert.py
+++ b/transformers/modeling_bert.py
@@ -82,7 +82,7 @@ def load_tf_weights_in_bert(model, config, tf_checkpoint_path):
         name = name.split('/')
         # adam_v and adam_m are variables used in AdamWeightDecayOptimizer to calculated m and v
         # which are not required for using pretrained model
-        if any(n in ["adam_v", "adam_m", "global_step"] for n in name):
+        if any(n in ["adam_v", "adam_m", "global_step", "bad_steps", "good_steps", "loss_scale"] for n in name):
             logger.info("Skipping {}".format("/".join(name)))
             continue
         pointer = model
@@ -94,9 +94,17 @@ def load_tf_weights_in_bert(model, config, tf_checkpoint_path):
             if l[0] == 'kernel' or l[0] == 'gamma':
                 pointer = getattr(pointer, 'weight')
             elif l[0] == 'output_bias' or l[0] == 'beta':
-                pointer = getattr(pointer, 'bias')
+                try:
+                    pointer = getattr(pointer, 'bias')
+                except:
+                    pointer = getattr(pointer, 'classifier')
+                    pointer = getattr(pointer, 'bias')
             elif l[0] == 'output_weights':
-                pointer = getattr(pointer, 'weight')
+                try:
+                    pointer = getattr(pointer, 'weight')
+                except:
+                    pointer = getattr(pointer, 'classifier')
+                    pointer = getattr(pointer, 'weight')
             elif l[0] == 'squad':
                 pointer = getattr(pointer, 'classifier')
             else:


### PR DESCRIPTION
I added a script convert_bert_seqclass_tf_checkpoint_to_pytorch.py for the conversion a trained BertForSequenceClassification model from TF to pytorch.
I had to modify modeling_bert.py to support it, as well.