### PR TITLE
:zip: #2106 tokenizer.tokenize speed improvement (3-8x) by caching added_tokens in a Set

### DIFF
--- a/transformers/tokenization_utils.py
+++ b/transformers/tokenization_utils.py
@@ -231,6 +231,7 @@ class PreTrainedTokenizer(object):
         
         # Added tokens
         self.added_tokens_encoder = {}
+        self.unique_added_tokens_encoder = set()
         self.added_tokens_decoder = {}
 
         # inputs and kwargs for saving and re-loading (see ``from_pretrained`` and ``save_pretrained``)
@@ -550,6 +551,7 @@ class PreTrainedTokenizer(object):
         added_tok_encoder = dict((tok, len(self) + i) for i, tok in enumerate(to_add_tokens))
         added_tok_decoder = {v:k for k, v in added_tok_encoder.items()}
         self.added_tokens_encoder.update(added_tok_encoder)
+        self.unique_added_tokens_encoder = set(self.added_tokens_encoder.keys()).union(set(self.all_special_tokens))
         self.added_tokens_decoder.update(added_tok_decoder)
 
         return len(to_add_tokens)
@@ -627,6 +629,7 @@ class PreTrainedTokenizer(object):
 
         return added_tokens
 
+
     def tokenize(self, text, **kwargs):
         """ Converts a string in a sequence of tokens (string), using the tokenizer.
             Split in words for word-based vocabulary or sub-words for sub-word-based
@@ -681,18 +684,17 @@ class PreTrainedTokenizer(object):
             for tok in tok_list:
                 tokenized_text = []
                 for sub_text in text_list:
-                    if sub_text not in self.added_tokens_encoder \
-                            and sub_text not in all_special_tokens:
+                    if sub_text not in self.unique_added_tokens_encoder:
                         tokenized_text += split_on_token(tok, sub_text)
                     else:
                         tokenized_text += [sub_text]
                 text_list = tokenized_text
 
-            return list(itertools.chain.from_iterable((self._tokenize(token, **kwargs) if token not \
-                    in self.added_tokens_encoder and token not in all_special_tokens \
+            return list(itertools.chain.from_iterable((self._tokenize(token, **kwargs) \
+                    if token not in self.unique_added_tokens_encoder
                     else [token] for token in tokenized_text)))
 
-        added_tokens = list(self.added_tokens_encoder.keys()) + all_special_tokens
+        added_tokens = self.unique_added_tokens_encoder
         tokenized_text = split_on_tokens(added_tokens, text)
         return tokenized_text
 


### PR DESCRIPTION
in #2106, we see that adding tokens to tokenizer decreases progressively tokenization performance which is not really a surprise as you need to go through the list of tokens which grows. But it sounds that this increase is not linear.

By having a quick look at code, I've seen that:
- `added_tokens` list is built for every calls of tokenize,
- `all_special_tokens` is a python property that is reevaluated every time
- `split_on_tokens` is going 2x in both `all_special_tokens` and `added_tokens_encoder` lists which is `O(n)`.

I've tried to replace those by a simple cached Set of `added_tokens_encoder.keys() + all_special_tokens` that is reevaluated at each call of `add_tokens`. firstly, it avoids rebuilding the list at every call. Secondly, searching in a Set is `O(1)` in average and `O(n)` in worst case.

On RobertaTokenizer, the result is a significant speed improvement (testing on for 100.000 calls):
- for 0 added token, `tokenizer.tokenize` is >3x faster
- for 200 tokens, `tokenizer.tokenize` is >7x faster

Here are a few interesting plots.

### Execution time when adding more tokens between old code and new
<img width="404" alt="Screenshot 2019-12-14 at 15 34 22" src="https://user-images.githubusercontent.com/77193/70850213-167e8f80-1e88-11ea-8339-334ada7e5f37.png">

We see here that old code is not linear and the execution time is impacted when more tokens are added.
New code seems to behave linearly (up to 200 at least)

### Rate of speed increase between old code and new
<img width="372" alt="Screenshot 2019-12-14 at 15 33 09" src="https://user-images.githubusercontent.com/77193/70850210-036bbf80-1e88-11ea-9778-d59e1e3e83c7.png">

We see that new code is 3x faster by default and this advantage grows when adding more tokens (>7x for 200)

### Execution time between old code and new in a bar plot

<img width="399" alt="Screenshot 2019-12-14 at 15 33 14" src="https://user-images.githubusercontent.com/77193/70850206-fe0e7500-1e87-11ea-808e-1c9043a5ec4b.png">

Same as previous plot.

I know you're working on Rust tokenizers that will be much faster in theory. But until it's ready, what do you think about this basic correction (and maybe others) that already improves the speed drastically?

Don't hesitate to tell if you see that this modification would be very bad for other cases.

