### PR TITLE
Add "Train on Valohai" buttons to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@
         <img alt="GitHub release" src="https://img.shields.io/github/release/huggingface/transformers.svg">
     </a>
 </p>
+<p align="center">
+    <a href="https://app.valohai.com/projects/create/?template=huggingface-transformers">
+        <img alt="Train on Valohai" src="https://static.valohai.com/buttons/train.svg">
+    </a>
+</p>
 
 <h3 align="center">
 <p>State-of-the-art Natural Language Processing for TensorFlow 2.0 and PyTorch
@@ -97,6 +102,14 @@ git clone https://github.com/huggingface/transformers
 cd transformers
 pip install [--editable] .
 ```
+
+Alternatively, you can use [Valohai machine learning platform](https://valohai.com/) to automatically setup the project and run the examples within. 
+
+Click on the "Train on Valohai" button below, login/register, follow the instructions and get started. 
+
+<a href="https://app.valohai.com/projects/create/?template=huggingface-transformers">
+    <img alt="Train on Valohai" src="https://static.valohai.com/buttons/train.svg">
+</a>
 
 ### Tests
 

--- a/valohai.yaml
+++ b/valohai.yaml
@@ -1,7 +1,10 @@
 ---
 
 - step:
-    name: Execute python examples/run_glue.py
+    name: run-glue
+    description: |
+      An example fine-tuning Bert, XLNet and XLM on nine different GLUE tasks (sequence-level classification).
+      For configuration details, see https://github.com/huggingface/transformers#run_gluepy-fine-tuning-on-glue-tasks-for-sequence-classification
     image: pytorch/pytorch:nightly-devel-cuda10.0-cudnn7
     command:
       - python /valohai/repository/utils/download_glue_data.py --data_dir=/glue_data


### PR DESCRIPTION
This pull request adds two "Train on Valohai" buttons to README:

![Screenshot from 2019-12-19 16-59-54](https://user-images.githubusercontent.com/2681608/71184210-1284b000-2282-11ea-8bb8-72bf93014672.png)

and...

![Screenshot from 2019-12-19 17-00-07](https://user-images.githubusercontent.com/2681608/71184213-13b5dd00-2282-11ea-84c7-393afbbae7ea.png)

When clicked, it will automatically create a project on Valohai and let you run the project examples without any further setup. Effectively the same as "Deploy to Heroku" button if you are familiar with that.

## The flow looks like this (after login):

![Screenshot from 2019-12-19 17-00-19](https://user-images.githubusercontent.com/2681608/71184512-88891700-2282-11ea-855b-5a187ef2e700.png)
![Screenshot from 2019-12-19 17-00-34](https://user-images.githubusercontent.com/2681608/71184528-8d4dcb00-2282-11ea-8228-6322236360a9.png)
![Screenshot from 2019-12-19 17-05-31](https://user-images.githubusercontent.com/2681608/71184531-8e7ef800-2282-11ea-970a-aefa5d127069.png)
![Screenshot from 2019-12-19 17-06-18](https://user-images.githubusercontent.com/2681608/71184536-9048bb80-2282-11ea-98b0-7fd371a78677.png)
