### PR TITLE
Add cached past for language generation

### DIFF
--- a/src/transformers/modeling_ctrl.py
+++ b/src/transformers/modeling_ctrl.py
@@ -490,6 +490,14 @@ class CTRLLMHeadModel(CTRLPreTrainedModel):
     def get_output_embeddings(self):
         return self.lm_head
 
+    def prepare_inputs_for_generation(self, input_ids, **kwargs):
+        # inputs_ids contain only last token if past is in kwargs and defined
+        input_ids = input_ids[:, -1].unsqueeze(-1) if 'past' in kwargs and kwargs['past'] else input_ids
+
+        inputs = {"input_ids": input_ids}
+        inputs.update(kwargs)
+        return inputs
+
     def forward(
         self,
         input_ids=None,

--- a/src/transformers/modeling_ctrl.py
+++ b/src/transformers/modeling_ctrl.py
@@ -491,8 +491,9 @@ class CTRLLMHeadModel(CTRLPreTrainedModel):
         return self.lm_head
 
     def prepare_inputs_for_generation(self, input_ids, **kwargs):
-        # inputs_ids should only be composed of last token if past is in kwargs and defined
-        input_ids = input_ids[:, -1].unsqueeze(-1) if 'past' in kwargs and kwargs['past'] else input_ids
+        # only last token for inputs_ids if past is defined in kwargs
+        if 'past' in kwargs and kwargs['past']:
+            input_ids = input_ids[:, -1].unsqueeze(-1)
 
         inputs = {"input_ids": input_ids}
         inputs.update(kwargs)

--- a/src/transformers/modeling_ctrl.py
+++ b/src/transformers/modeling_ctrl.py
@@ -491,7 +491,7 @@ class CTRLLMHeadModel(CTRLPreTrainedModel):
         return self.lm_head
 
     def prepare_inputs_for_generation(self, input_ids, **kwargs):
-        # inputs_ids contain only last token if past is in kwargs and defined
+        # inputs_ids should only be composed of last token if past is in kwargs and defined
         input_ids = input_ids[:, -1].unsqueeze(-1) if 'past' in kwargs and kwargs['past'] else input_ids
 
         inputs = {"input_ids": input_ids}

--- a/src/transformers/modeling_ctrl.py
+++ b/src/transformers/modeling_ctrl.py
@@ -492,7 +492,7 @@ class CTRLLMHeadModel(CTRLPreTrainedModel):
 
     def prepare_inputs_for_generation(self, input_ids, **kwargs):
         # only last token for inputs_ids if past is defined in kwargs
-        if 'past' in kwargs and kwargs['past']:
+        if "past" in kwargs and kwargs["past"]:
             input_ids = input_ids[:, -1].unsqueeze(-1)
 
         inputs = {"input_ids": input_ids}

--- a/src/transformers/modeling_gpt2.py
+++ b/src/transformers/modeling_gpt2.py
@@ -560,7 +560,7 @@ class GPT2LMHeadModel(GPT2PreTrainedModel):
         return self.lm_head
 
     def prepare_inputs_for_generation(self, input_ids, **kwargs):
-        # inputs_ids contain only last token if past is in kwargs and defined
+        # inputs_ids should only be composed of last token if past is in kwargs and defined
         input_ids = input_ids[:, -1].unsqueeze(-1) if 'past' in kwargs and kwargs['past'] else input_ids
 
         inputs = {"input_ids": input_ids}

--- a/src/transformers/modeling_gpt2.py
+++ b/src/transformers/modeling_gpt2.py
@@ -561,7 +561,7 @@ class GPT2LMHeadModel(GPT2PreTrainedModel):
 
     def prepare_inputs_for_generation(self, input_ids, **kwargs):
         # only last token for inputs_ids if past is defined in kwargs
-        if 'past' in kwargs and kwargs['past']:
+        if "past" in kwargs and kwargs["past"]:
             input_ids = input_ids[:, -1].unsqueeze(-1)
 
         inputs = {"input_ids": input_ids}

--- a/src/transformers/modeling_gpt2.py
+++ b/src/transformers/modeling_gpt2.py
@@ -559,6 +559,14 @@ class GPT2LMHeadModel(GPT2PreTrainedModel):
     def get_output_embeddings(self):
         return self.lm_head
 
+    def prepare_inputs_for_generation(self, input_ids, **kwargs):
+        # inputs_ids contain only last token if past is in kwargs and defined
+        input_ids = input_ids[:, -1].unsqueeze(-1) if 'past' in kwargs and kwargs['past'] else input_ids
+
+        inputs = {"input_ids": input_ids}
+        inputs.update(kwargs)
+        return inputs
+
     def forward(
         self,
         input_ids=None,

--- a/src/transformers/modeling_gpt2.py
+++ b/src/transformers/modeling_gpt2.py
@@ -560,8 +560,9 @@ class GPT2LMHeadModel(GPT2PreTrainedModel):
         return self.lm_head
 
     def prepare_inputs_for_generation(self, input_ids, **kwargs):
-        # inputs_ids should only be composed of last token if past is in kwargs and defined
-        input_ids = input_ids[:, -1].unsqueeze(-1) if 'past' in kwargs and kwargs['past'] else input_ids
+        # only last token for inputs_ids if past is defined in kwargs
+        if 'past' in kwargs and kwargs['past']:
+            input_ids = input_ids[:, -1].unsqueeze(-1)
 
         inputs = {"input_ids": input_ids}
         inputs.update(kwargs)

--- a/src/transformers/modeling_transfo_xl.py
+++ b/src/transformers/modeling_transfo_xl.py
@@ -930,3 +930,12 @@ class TransfoXLLMHeadModel(TransfoXLPreTrainedModel):
             return self.out_layer
         else:
             return self.crit.out_layers[-1]
+
+    def prepare_inputs_for_generation(self, input_ids, **model_kwargs):
+        inputs = {"input_ids": input_ids}
+
+        # if past is defined in model kwargs then use it for faster decoding
+        if 'past' in model_kwargs and model_kwargs['past']:
+            inputs['mems'] = model_kwargs['past']
+
+        return inputs

--- a/src/transformers/modeling_transfo_xl.py
+++ b/src/transformers/modeling_transfo_xl.py
@@ -935,7 +935,7 @@ class TransfoXLLMHeadModel(TransfoXLPreTrainedModel):
         inputs = {"input_ids": input_ids}
 
         # if past is defined in model kwargs then use it for faster decoding
-        if 'past' in model_kwargs and model_kwargs['past']:
-            inputs['mems'] = model_kwargs['past']
+        if "past" in model_kwargs and model_kwargs["past"]:
+            inputs["mems"] = model_kwargs["past"]
 
         return inputs

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -540,8 +540,8 @@ class PreTrainedModel(nn.Module):
         return {"input_ids": input_ids}
 
     def _do_output_past(self, outputs):
-        has_output_past = hasattr(self.config, 'output_past') and self.config.output_past
-        has_mem_len = hasattr(self.config, 'mem_len') and self.config.mem_len
+        has_output_past = hasattr(self.config, "output_past") and self.config.output_past
+        has_mem_len = hasattr(self.config, "mem_len") and self.config.mem_len
 
         if has_output_past and not has_mem_len and len(outputs) > 1:
             return True

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -18,7 +18,6 @@
 
 import logging
 import os
-import ipdb
 
 import torch
 from torch import nn
@@ -794,7 +793,6 @@ class PreTrainedModel(nn.Module):
     ):
         """ Generate sequences for each example with beam search.
         """
-        ipdb.set_trace()
         # Expand input to num beams
         input_ids = input_ids.unsqueeze(1).expand(batch_size, num_beams, cur_len)
         input_ids = input_ids.contiguous().view(batch_size * num_beams, cur_len)  # (batch_size * num_beams, cur_len)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -923,7 +923,10 @@ class PreTrainedModel(nn.Module):
                 for layer_past in past:
                     # copy the relevant beam idx past to past
                     reordered_layer_past = [layer_past[:, i].unsqueeze(1).clone().detach() for i in beam_idx]
-                    reordered_past.append(torch.cat(reordered_layer_past, dim=1))
+                    reordered_layer_past = torch.cat(reordered_layer_past, dim=1)
+                    # check that shape matches
+                    assert reordered_layer_past.shape == layer_past.shape
+                    reordered_past.append(reordered_layer_past)
                 past = tuple(reordered_past)
 
             # update current length

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -732,6 +732,7 @@ class PreTrainedModel(nn.Module):
             outputs = self(**model_inputs)
             next_token_logits = outputs[0][:, -1, :]
 
+            # if model has past, then set the past parameter to speed up decoding
             if self._has_past(outputs):
                 past = outputs[1]
 
@@ -819,6 +820,7 @@ class PreTrainedModel(nn.Module):
             outputs = self(**model_inputs)  # (batch_size * num_beams, cur_len, vocab_size)
             scores = outputs[0][:, -1, :]  # (batch_size * num_beams, vocab_size)
 
+            # if model has past, then set the past parameter to speed up decoding
             if self._has_past(outputs):
                 past = outputs[1]
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -731,7 +731,7 @@ class PreTrainedModel(nn.Module):
             outputs = self(**model_inputs)
             next_token_logits = outputs[0][:, -1, :]
 
-            # if model has past, then set the past parameter to speed up decoding
+            # if model has past, then set the past variable to speed up decoding
             if self._has_past(outputs):
                 past = outputs[1]
 
@@ -818,7 +818,7 @@ class PreTrainedModel(nn.Module):
             outputs = self(**model_inputs)  # (batch_size * num_beams, cur_len, vocab_size)
             scores = outputs[0][:, -1, :]  # (batch_size * num_beams, vocab_size)
 
-            # if model has past, then set the past parameter to speed up decoding
+            # if model has past, then set the past variable to speed up decoding
             if self._has_past(outputs):
                 past = outputs[1]
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -540,8 +540,8 @@ class PreTrainedModel(nn.Module):
         return {"input_ids": input_ids}
 
     def _do_output_past(self, outputs):
-        # TODO: might be better to write a self.do_output_past method for each individual class as is done for
-        # prepare_inputs_for_generation
+        # TODO: might be better to write a self.do_output_past method for each
+        # individual class as is done for prepare_inputs_for_generation
         has_output_past = hasattr(self.config, 'output_past') and self.config.output_past
         has_multiple_outputs = len(outputs) > 1
         has_mem_len = hasattr(self, 'mem_len')

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -542,7 +542,11 @@ class PreTrainedModel(nn.Module):
     def _do_output_past(self, outputs):
         # TODO: might be better to write a self.do_output_past method for each individual class as is done for
         # prepare_inputs_for_generation
-        if hasattr(self.config, 'output_past') and self.config.output_past and len(outputs) > 1 and not hasattr(self, 'mem_len'):
+        has_output_past = hasattr(self.config, 'output_past') and self.config.output_past
+        has_multiple_outputs = len(outputs) > 1
+        has_mem_len = hasattr(self, 'mem_len')
+
+        if has_output_past and has_multiple_outputs and not has_mem_len:
             return True
         # TODO: Add cases for (xlnet, transfo_xl) using mem_len
         return False

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -539,10 +539,10 @@ class PreTrainedModel(nn.Module):
     def prepare_inputs_for_generation(self, input_ids, **kwargs):
         return {"input_ids": input_ids}
 
-    def _has_past(self, outputs):
-        # TODO: might be better to write a self.has_past method for each individual class as is done for
+    def _do_output_past(self, outputs):
+        # TODO: might be better to write a self.do_output_past method for each individual class as is done for
         # prepare_inputs_for_generation
-        if hasattr(self, 'output_past') and self.output_past and len(outputs) > 1:
+        if hasattr(self.config, 'output_past') and self.config.output_past and len(outputs) > 1 and not hasattr(self, 'mem_len'):
             return True
         # TODO: Add cases for (xlnet, transfo_xl) using mem_len
         return False
@@ -732,7 +732,7 @@ class PreTrainedModel(nn.Module):
             next_token_logits = outputs[0][:, -1, :]
 
             # if model has past, then set the past variable to speed up decoding
-            if self._has_past(outputs):
+            if self._do_output_past(outputs):
                 past = outputs[1]
 
             # repetition penalty from CTRL paper (https://arxiv.org/abs/1909.05858)
@@ -819,7 +819,7 @@ class PreTrainedModel(nn.Module):
             scores = outputs[0][:, -1, :]  # (batch_size * num_beams, vocab_size)
 
             # if model has past, then set the past variable to speed up decoding
-            if self._has_past(outputs):
+            if self._do_output_past(outputs):
                 past = outputs[1]
 
             # repetition penalty (from CTRL paper https://arxiv.org/abs/1909.05858)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -544,7 +544,7 @@ class PreTrainedModel(nn.Module):
         # individual class as is done for prepare_inputs_for_generation
         has_output_past = hasattr(self.config, 'output_past') and self.config.output_past
         has_multiple_outputs = len(outputs) > 1
-        has_mem_len = hasattr(self, 'mem_len')
+        has_mem_len = hasattr(self.config, 'mem_len')
 
         if has_output_past and has_multiple_outputs and not has_mem_len:
             return True

--- a/src/transformers/modeling_xlnet.py
+++ b/src/transformers/modeling_xlnet.py
@@ -1031,8 +1031,8 @@ class XLNetLMHeadModel(XLNetPreTrainedModel):
         inputs = {"input_ids": input_ids, "perm_mask": perm_mask, "target_mapping": target_mapping}
 
         # if past is defined in model kwargs then use it for faster decoding
-        if 'past' in model_kwargs and model_kwargs['past']:
-            inputs['mems'] = model_kwargs['past']
+        if "past" in model_kwargs and model_kwargs["past"]:
+            inputs["mems"] = model_kwargs["past"]
 
         return inputs
 

--- a/src/transformers/modeling_xlnet.py
+++ b/src/transformers/modeling_xlnet.py
@@ -1028,7 +1028,13 @@ class XLNetLMHeadModel(XLNetPreTrainedModel):
         )
         target_mapping[0, 0, -1] = 1.0
 
-        return {"input_ids": input_ids, "perm_mask": perm_mask, "target_mapping": target_mapping}
+        inputs = {"input_ids": input_ids, "perm_mask": perm_mask, "target_mapping": target_mapping}
+
+        # if past is defined in model kwargs then use it for faster decoding
+        if 'past' in model_kwargs and model_kwargs['past']:
+            inputs['mems'] = model_kwargs['past']
+
+        return inputs
 
     def forward(
         self,


### PR DESCRIPTION
add past input for gpt2 and ctrl for faster decoding for language generation.

1. add `prepare_inputs_for_generation` fn for gpt2 and ctrl 
2. add private `_do_output_past` fn for PretrainModel class to check whether model outputs past key-value states 
      - fn only covers cases for gpt2 and ctrl for the moment and needs to add 'xlnet' and 'transfo_xl' via `mem_len`
      - might be better to move `_do_output_past` to each individual LMHeadModel
3. rename `pasts` to `past`

can also add dummy tests for language generation