### PR TITLE
Correct tokenization for special and added tokens

### DIFF
--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -469,6 +469,9 @@ class PreTrainedTokenizer(object):
         tokenizer.init_inputs = init_inputs
         tokenizer.init_kwargs = init_kwargs
 
+        # update unique_added_tokens_encoder with special tokens for correct tokenization
+        tokenizer.unique_added_tokens_encoder.update(set(tokenizer.all_special_tokens))
+
         # Add supplementary tokens.
         if added_tokens_file is not None:
             with open(added_tokens_file, encoding="utf-8") as added_tokens_handle:
@@ -476,7 +479,7 @@ class PreTrainedTokenizer(object):
             added_tok_decoder = {v: k for k, v in added_tok_encoder.items()}
             tokenizer.added_tokens_encoder.update(added_tok_encoder)
             tokenizer.added_tokens_decoder.update(added_tok_decoder)
-            tokenizer.unique_added_tokens_encoder.update(set(tokenizer.added_tokens_encoder.keys()).union(set(tokenizer.all_special_tokens)))
+            tokenizer.unique_added_tokens_encoder.update(set(tokenizer.added_tokens_encoder.keys()))
 
         return tokenizer
 

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -476,6 +476,7 @@ class PreTrainedTokenizer(object):
             added_tok_decoder = {v: k for k, v in added_tok_encoder.items()}
             tokenizer.added_tokens_encoder.update(added_tok_encoder)
             tokenizer.added_tokens_decoder.update(added_tok_decoder)
+            tokenizer.unique_added_tokens_encoder.update(set(tokenizer.added_tokens_encoder.keys()).union(set(tokenizer.all_special_tokens)))
 
         return tokenizer
 


### PR DESCRIPTION
When a tokenizer is being loaded with `PreTrainedTokenizer._from_pretrained`, it should set `added_tokens` and `all_special_tokens` to `unique_added_tokens_encoder`. 
If we don't do it, it will corrupt the tokenization. 

Example:
```
import transformers
tokenizer = transformers.BertTokenizer.from_pretrained("bert-base-uncased")
tokenizer.tokenize("[CLS] token should not be splitted.")
# correct output
# ['[CLS]', 'token', 'should', 'not', 'be', 'split', '##ted', '.']
# incorrect output
# ['[', '[UNK]', ']', 'token', 'should', 'not', 'be', 'split', '##ted', '.']
```
