### PR TITLE
Add dropout to WordpieceTokenizer and BPE

### DIFF
--- a/src/transformers/tokenization_bert.py
+++ b/src/transformers/tokenization_bert.py
@@ -18,8 +18,8 @@
 import collections
 import logging
 import os
-import unicodedata
 import random
+import unicodedata
 
 from .tokenization_utils import PreTrainedTokenizer
 

--- a/src/transformers/tokenization_bert.py
+++ b/src/transformers/tokenization_bert.py
@@ -464,7 +464,7 @@ class WordpieceTokenizer(object):
                 continue
             if dropout == 1:
                 output_tokens.append(chars[0])
-                output_tokens.extend(f"##{char}" for char in chars[1:])
+                output_tokens.extend("##{}".format(char) for char in chars[1:])
                 continue
 
             is_bad = False

--- a/src/transformers/tokenization_bert.py
+++ b/src/transformers/tokenization_bert.py
@@ -462,6 +462,10 @@ class WordpieceTokenizer(object):
             if len(chars) > self.max_input_chars_per_word:
                 output_tokens.append(self.unk_token)
                 continue
+            if dropout == 1:
+                output_tokens.append(chars[0])
+                output_tokens.extend(f"##{char}" for char in chars[1:])
+                continue
 
             is_bad = False
             start = 0
@@ -473,7 +477,7 @@ class WordpieceTokenizer(object):
                     substr = "".join(chars[start:end])
                     if start > 0:
                         substr = "##" + substr
-                    if substr in self.vocab and random.random() > dropout:
+                    if substr in self.vocab and random.random() >= dropout:
                         cur_substr = substr
                         break
                     end -= 1

--- a/src/transformers/tokenization_gpt2.py
+++ b/src/transformers/tokenization_gpt2.py
@@ -163,8 +163,6 @@ class GPT2Tokenizer(PreTrainedTokenizer):
 
         while True:
             bigram = min(pairs, key=lambda pair: self.bpe_ranks.get(pair, float("inf")))
-            if bigram not in self.bpe_ranks:
-                break
             first, second = bigram
             new_word = []
             i = 0

--- a/src/transformers/tokenization_gpt2.py
+++ b/src/transformers/tokenization_gpt2.py
@@ -157,26 +157,9 @@ class GPT2Tokenizer(PreTrainedTokenizer):
             return self.cache[token]
 
         word = tuple(token)
-        if dropout != 1:
-            pairs = [pair for pair in get_pairs(word) if random.random() >= dropout and pair in self.bpe_ranks]
-        else:
-            # we should merge space byte with first token char
-            new_word = []
-            token_index = 0
-            while token_index < len(token):
-                if token[token_index] != self.byte_encoder[32]:
-                    new_word.append(token[token_index])
-                    token_index += 1
-                else:
-                    new_word.append(token[token_index : token_index + 2])
-                    token_index += 2
+        pairs = [pair for pair in get_pairs(word) if random.random() >= dropout and pair in self.bpe_ranks]
 
-            return " ".join(new_word)
-
-        if not pairs:
-            return token
-
-        while True:
+        while pairs:
             bigram = min(pairs, key=lambda pair: self.bpe_ranks.get(pair, float("inf")))
             first, second = bigram
             new_word = []
@@ -203,8 +186,7 @@ class GPT2Tokenizer(PreTrainedTokenizer):
                 break
             else:
                 pairs = [pair for pair in get_pairs(word) if random.random() >= dropout and pair in self.bpe_ranks]
-                if not pairs:
-                    break
+
         word = " ".join(word)
         if dropout == 0:
             self.cache[token] = word

--- a/src/transformers/tokenization_gpt2.py
+++ b/src/transformers/tokenization_gpt2.py
@@ -168,7 +168,7 @@ class GPT2Tokenizer(PreTrainedTokenizer):
                     new_word.append(token[token_index])
                     token_index += 1
                 else:
-                    new_word.append(token[token_index:token_index + 2])
+                    new_word.append(token[token_index : token_index + 2])
                     token_index += 2
 
             return " ".join(new_word)

--- a/src/transformers/tokenization_gpt2.py
+++ b/src/transformers/tokenization_gpt2.py
@@ -206,7 +206,8 @@ class GPT2Tokenizer(PreTrainedTokenizer):
                 if not pairs:
                     break
         word = " ".join(word)
-        self.cache[token] = word
+        if dropout == 0:
+            self.cache[token] = word
         return word
 
     def _tokenize(self, text, add_prefix_space=False, **kwargs):


### PR DESCRIPTION
We can add dropout not only to model weights but and to a tokenizer. The paper, proposed by Ivan Provilkov (2019, https://arxiv.org/pdf/1910.13267.pdf), describes all benefits from this approach and shows that it's almost always better to use dropout during tokenization. (use only for training, for inference dropout should be equal to 0)

Example:
```
import transformers
tokenizer = transformers.RobertaTokenizer.from_pretrained("roberta-base")
tokenizer.tokenize("Dropout is very important")
# default value is 0
# ['Drop', 'out', 'Ġis', 'Ġvery', 'Ġimportant']
tokenizer.tokenize("Dropout is very important", dropout=0.1)
# ['Drop', 'out', 'Ġis', 'Ġvery', 'Ġimport', 'ant']
```