### PR TITLE
Delete [dev] behind pip install -e .

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Follow these steps to start contributing:
 4. Set up a development environment by running the following command in a virtual environment:
 
    ```bash
-   $ pip install -e .[dev]
+   $ pip install -e .
    ```
 
    (If transformers was already installed in the virtual environment, remove


### PR DESCRIPTION
I might be wrong here, but I think it should simply be 
```bash
$ pip install -e .
``` 
without the [dev] 
When executing 
```bash
$ pip install -e .[dev]
``` 
in my terminal I get the error: 
`no matches found: .[dev]`