### PR TITLE
Fix beam search when sampling in language generation

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -834,9 +834,13 @@ class PreTrainedModel(nn.Module):
                 )  # (batch_size * num_beams, vocab_size)
 
                 # re-organize to group the beam together so that words from multiple beam idxs are sampled
-                _scores = scores.contiguous().view(batch_size, num_beams * vocab_size)  # (batch_size, num_beams * vocab_size)
+                _scores = scores.contiguous().view(
+                    batch_size, num_beams * vocab_size
+                )  # (batch_size, num_beams * vocab_size)
                 # Sample 2 next words for each beam (so we have some spare tokens and match output of greedy beam search)
-                next_words = torch.multinomial(F.softmax(_scores, dim=-1), num_samples=2 * num_beams)  # (batch_size, 2 * num_beams)
+                next_words = torch.multinomial(
+                    F.softmax(_scores, dim=-1), num_samples=2 * num_beams
+                )  # (batch_size, 2 * num_beams)
                 # Compute next scores
                 next_scores = torch.gather(_scores, -1, next_words)  # (batch_size, 2 * num_beams)
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -793,7 +793,7 @@ class PreTrainedModel(nn.Module):
 
         # scores for each sentence in the beam
         beam_scores = torch.zeros((batch_size, num_beams), dtype=torch.float, device=input_ids.device)
-        # if greedy decoding we make sure that only the first beam is relevant for the first top_k
+        # For greedy decoding we make sure that only words of the first beam are considered to avoid sampling the exact same words for all num_beams
         if not do_sample:
             beam_scores[:, 1:] = -1e9
         beam_scores = beam_scores.view(-1)  # shape (batch_size * num_beams,)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -793,7 +793,9 @@ class PreTrainedModel(nn.Module):
 
         # scores for each sentence in the beam
         beam_scores = torch.zeros((batch_size, num_beams), dtype=torch.float, device=input_ids.device)
-        beam_scores[:, 1:] = -1e9
+        # if greedy decoding we make sure that only the first beam is relevant for the first top_k
+        if not do_sample:
+            beam_scores[:, 1:] = -1e9
         beam_scores = beam_scores.view(-1)  # shape (batch_size * num_beams,)
 
         # cache compute states
@@ -821,19 +823,23 @@ class PreTrainedModel(nn.Module):
                 # Temperature (higher temperature => more likely to sample low probability tokens)
                 if temperature > 0 and temperature != 1.0:
                     scores = scores / temperature
+
+                # add previous beam_scores
+                scores = F.log_softmax(scores, dim=-1)  # (batch_size * num_beams, vocab_size)
+                scores = scores + beam_scores[:, None].expand_as(scores)
+
                 # Top-p/top-k filtering
                 scores = top_k_top_p_filtering(
                     scores, top_k=top_k, top_p=top_p, min_tokens_to_keep=2
                 )  # (batch_size * num_beams, vocab_size)
+
+                # re-organize to group the beam together so that words from multiple beam idxs are sampled
+                _scores = scores.contiguous().view(batch_size, num_beams * vocab_size)  # (batch_size, num_beams * vocab_size)
                 # Sample 2 next words for each beam (so we have some spare tokens and match output of greedy beam search)
-                next_words = torch.multinomial(F.softmax(scores, dim=-1), num_samples=2)  # (batch_size * num_beams, 2)
+                next_words = torch.multinomial(F.softmax(_scores, dim=-1), num_samples=2 * num_beams)  # (batch_size, 2 * num_beams)
                 # Compute next scores
-                _scores = F.log_softmax(scores, dim=-1)  # (batch_size * num_beams, vocab_size)
-                _scores = torch.gather(_scores, -1, next_words)  # (batch_size * num_beams, 2)
-                next_scores = _scores + beam_scores[:, None].expand_as(_scores)  # (batch_size * num_beams, 2)
-                # Match shape of greedy beam search
-                next_words = next_words.view(batch_size, 2 * num_beams)  # (batch_size, 2 * num_beams)
-                next_scores = next_scores.view(batch_size, 2 * num_beams)  # (batch_size, 2 * num_beams)
+                next_scores = torch.gather(_scores, -1, next_words)  # (batch_size, 2 * num_beams)
+
             else:
                 # do greedy beam search
                 scores = F.log_softmax(scores, dim=-1)  # (batch_size * num_beams, vocab_size)


### PR DESCRIPTION
I think there is a problem with beam search when setting `do_sample=True` 
As it was implemented before, the variable `next_words` in previous line 829 would always contains 
word ids < `vocab_size` which forces all `beam_idx` to always be == 0.
This way all words would actually always be appended to the `input_ids` of the first beam. 

In the proposed PR, the words are sampled over the scores of size `(batch_size, num_beams * vocab_size)`, which is similar to what is done in greedy decoding. 

I tried generating a couple of sequences with the proposed change and it seems to be important that the temperature is set relatively high (~1.5) to avoid repeating words. 

Not 100% whether the proposed PR is the best fix. In general, beam search seems to work better when doing greedy decoding.