### PR TITLE
few changes due to the torch version inconsistency in summarization example

### DIFF
--- a/examples/summarization/modeling_bertabs.py
+++ b/examples/summarization/modeling_bertabs.py
@@ -29,7 +29,7 @@ from torch.nn.init import xavier_uniform_
 
 from configuration_bertabs import BertAbsConfig
 from transformers import BertConfig, BertModel, PreTrainedModel
-
+from packaging.version import parse as parse_version
 
 MAX_SIZE = 5000
 
@@ -325,7 +325,10 @@ class TransformerDecoderLayer(nn.Module):
             * all_input `[batch_size x current_step x model_dim]`
 
         """
-        dec_mask = torch.gt(tgt_pad_mask + self.mask[:, : tgt_pad_mask.size(1), : tgt_pad_mask.size(1)], 0)
+        if parse_version(torch.__version__)<parse_version('1.2.0'):
+            dec_mask = torch.gt(tgt_pad_mask+ self.mask[:, : tgt_pad_mask.size(1), : tgt_pad_mask.size(1)], 0)
+        else:
+            dec_mask = torch.gt(tgt_pad_mask.int() + (self.mask[:, : tgt_pad_mask.size(1), : tgt_pad_mask.size(1)]).int(), 0)
         input_norm = self.layer_norm_1(inputs)
         all_input = input_norm
         if previous_input is not None:

--- a/examples/summarization/run_summarization.py
+++ b/examples/summarization/run_summarization.py
@@ -110,6 +110,7 @@ def save_summaries(summaries, path, original_document_name):
     """
     for summary, document_name in zip(summaries, original_document_name):
         # Prepare the summary file's name
+        document_name=os.path.basename(document_name)
         if "." in document_name:
             bare_document_name = ".".join(document_name.split(".")[:-1])
             extension = document_name.split(".")[-1]


### PR DESCRIPTION
This small change intends to fix the issue #2297.
it's generally a version inconsistent issue.
in ver 1.1.0, torch.gt outputs:

_torch.gt(torch.tensor([[1, 2], [3, 4]]), torch.tensor([[1, 1], [4, 4]]))
tensor([[ 0, 1],
[ 0, 0]], dtype=torch.uint8)_

while in ver 1.2.0, it outputs:

_torch.ge(torch.tensor([[1, 2], [3, 4]]), torch.tensor([[1, 1], [4, 4]]))
tensor([[True, True], [False, True]])_

Thus, I added a version checking function, and revise the tensor type in tensor.gt()