### PR TITLE
Releasing file lock

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -385,8 +385,6 @@ def get_from_cache(
                 else:
                     http_get(url, temp_file, proxies=proxies, resume_size=resume_size, user_agent=user_agent)
 
-                # we are copying the file before closing it, so flush to avoid truncation
-                temp_file.flush()
 
             logger.info("storing %s in cache at %s", url, cache_path)
             os.rename(temp_file.name, cache_path)

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -388,13 +388,13 @@ def get_from_cache(
                 # we are copying the file before closing it, so flush to avoid truncation
                 temp_file.flush()
 
-                logger.info("storing %s in cache at %s", url, cache_path)
-                os.rename(temp_file.name, cache_path)
+            logger.info("storing %s in cache at %s", url, cache_path)
+            os.rename(temp_file.name, cache_path)
 
-                logger.info("creating metadata file for %s", cache_path)
-                meta = {"url": url, "etag": etag}
-                meta_path = cache_path + ".json"
-                with open(meta_path, "w") as meta_file:
-                    json.dump(meta, meta_file)
+            logger.info("creating metadata file for %s", cache_path)
+            meta = {"url": url, "etag": etag}
+            meta_path = cache_path + ".json"
+            with open(meta_path, "w") as meta_file:
+                json.dump(meta, meta_file)
 
     return cache_path

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -385,7 +385,6 @@ def get_from_cache(
                 else:
                     http_get(url, temp_file, proxies=proxies, resume_size=resume_size, user_agent=user_agent)
 
-
             logger.info("storing %s in cache at %s", url, cache_path)
             os.rename(temp_file.name, cache_path)
 


### PR DESCRIPTION
`With` scope creates a file lock, which leads to the following error:

INFO:filelock:Lock 1408081097608 released on C:\Users\dimag\.cache\torch\transformers\26bc1ad6c0ac742e9b52263248f6d0f00068293b33709fae12320c0e35ccfbbb.542ce4285a40d23a559526243235df47c5f75c197f04f37d1a0c124c32c9a084.lock
Traceback (most recent call last):
  File "C:\Users\dimag\Anaconda3\envs\pytorch\lib\site-packages\transformers\tokenization_utils.py", line 398, in _from_pretrained
    resume_download=resume_download,
  File "C:\Users\dimag\Anaconda3\envs\pytorch\lib\site-packages\transformers\file_utils.py", line 212, in cached_path
    user_agent=user_agent,
  File "C:\Users\dimag\Anaconda3\envs\pytorch\lib\site-packages\transformers\file_utils.py", line 392, in get_from_cache
    os.rename(temp_file.name, cache_path)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\dimag\\.cache\\torch\\transformers\\tmpnhzxze8u' -> 'C:\\Users\\dimag\\.cache\\torch\\transformers\\26bc1ad6c0ac742e9b52263248f6d0f00068293b33709fae12320c0e35ccfbbb.542ce4285a40d23a559526243235df47c5f75c197f04f37d1a0c124c32c9a084'