### PR TITLE
Update Mish activation function to use torchscript JIT

### DIFF
--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -145,8 +145,27 @@ def swish(x):
     return x * torch.sigmoid(x)
 
 
-def mish(x):
-    return x * torch.tanh(nn.functional.softplus(x))
+@torch.jit.script
+def _mish_jit_fwd(x): return x.mul(torch.tanh(nn.functional.softplus(x)))
+
+@torch.jit.script
+def _mish_jit_bwd(x, grad_output):
+    x_sigmoid = torch.sigmoid(x)
+    x_tanh_sp = nn.functional.softplus(x).tanh()
+    return grad_output.mul(x_tanh_sp + x * x_sigmoid * (1 - x_tanh_sp * x_tanh_sp))
+
+class MishJitAutoFn(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x):
+        ctx.save_for_backward(x)
+        return _mish_jit_fwd(x)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x = ctx.saved_variables[0]
+        return _mish_jit_bwd(x, grad_output)
+
+def mish(x): return MishJitAutoFn.apply(x)
 
 
 ACT2FN = {"gelu": gelu, "relu": torch.nn.functional.relu, "swish": swish, "gelu_new": gelu_new, "mish": mish}

--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -146,13 +146,16 @@ def swish(x):
 
 
 @torch.jit.script
-def _mish_jit_fwd(x): return x.mul(torch.tanh(nn.functional.softplus(x)))
+def _mish_jit_fwd(x):
+    return x.mul(torch.tanh(nn.functional.softplus(x)))
+
 
 @torch.jit.script
 def _mish_jit_bwd(x, grad_output):
     x_sigmoid = torch.sigmoid(x)
     x_tanh_sp = nn.functional.softplus(x).tanh()
     return grad_output.mul(x_tanh_sp + x * x_sigmoid * (1 - x_tanh_sp * x_tanh_sp))
+
 
 class MishJitAutoFn(torch.autograd.Function):
     @staticmethod
@@ -165,7 +168,9 @@ class MishJitAutoFn(torch.autograd.Function):
         x = ctx.saved_variables[0]
         return _mish_jit_bwd(x, grad_output)
 
-def mish(x): return MishJitAutoFn.apply(x)
+
+def mish(x):
+    return MishJitAutoFn.apply(x)
 
 
 ACT2FN = {"gelu": gelu, "relu": torch.nn.functional.relu, "swish": swish, "gelu_new": gelu_new, "mish": mish}


### PR DESCRIPTION
This PR modifies the implementation of Mish to match that of the [fastai library](https://github.com/fastai/fastai_dev/blob/0f613ba3205990c83de9dba0c8798a9eec5452ce/dev/local/layers.py#L441). A discussion of the benefits of JIT for the Mish function can be found on the [fastai forums](https://forums.fast.ai/t/meet-mish-new-activation-function-possible-successor-to-relu/53299/587).