### PR TITLE
Remove redundant hidden states

### DIFF
--- a/src/transformers/modeling_encoder_decoder.py
+++ b/src/transformers/modeling_encoder_decoder.py
@@ -232,7 +232,7 @@ class PreTrainedEncoderDecoder(nn.Module):
             encoder_outputs = ()
 
         kwargs_decoder["encoder_hidden_states"] = encoder_hidden_states
-        decoder_outputs = self.decoder(decoder_input_ids, encoder_hidden_states, **kwargs_decoder)
+        decoder_outputs = self.decoder(decoder_input_ids, **kwargs_decoder)
 
         return decoder_outputs + encoder_outputs
 


### PR DESCRIPTION
The quickstart showcasing the usage of the Model2Model currently fails. This is due to a positional argument that should be a named argument.

As I understand it, the `encoder_hidden_states` are already present in the `kwargs_decoder` dictionary, there is therefore no need to pass it to the decoder forward call.

With the current quickstart example this crashes as the position of the `encoder_hidden_states` means it's passed as an `attention_mask`.

Please correct me if I'm wrong @rlouf @thomwolf 