### PR TITLE
Fix Tokenizer.from_pretrained `raise OSError`

### DIFF
--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -460,7 +460,7 @@ class PreTrainedTokenizer(object):
         try:
             tokenizer = cls(*init_inputs, **init_kwargs)
         except OSError:
-            OSError(
+            raise OSError(
                 "Unable to load vocabulary from file. "
                 "Please check that the provided vocabulary is accessible and not corrupted."
             )


### PR DESCRIPTION
`raise` before OSError seems to be forgotten.