### PR TITLE
modified method simple_accuracy(), before:(preds == labels).mean() This…

### DIFF
--- a/src/transformers/data/metrics/__init__.py
+++ b/src/transformers/data/metrics/__init__.py
@@ -16,7 +16,7 @@
 
 try:
     from scipy.stats import pearsonr, spearmanr
-    from sklearn.metrics import matthews_corrcoef, f1_score
+    from sklearn.metrics import matthews_corrcoef, f1_score, accuracy_score
 
     _has_sklearn = True
 except (AttributeError, ImportError):
@@ -30,7 +30,7 @@ def is_sklearn_available():
 if _has_sklearn:
 
     def simple_accuracy(preds, labels):
-        return (preds == labels).mean()
+        return accuracy_score(labels,preds)
 
     def acc_and_f1(preds, labels):
         acc = simple_accuracy(preds, labels)


### PR DESCRIPTION
modified method simple_accuracy(),
before:
        it's (preds == labels).mean() 
        This will cause an exception[AttributeError: 'bool' object has no attribute 'mean'],
then after update:
        change to accuracy_score(labels,preds), 
        use this method accuracy_score() in package sklearn.metrics