### PR TITLE
Fix output name

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ loss, logits, attentions = outputs
 
 ### Using hidden states
 
-By enabling the configuration option `output_hidden_states`, it was possible to retrieve the last hidden states of the encoder. In `pytorch-transformers` as well as `transformers` the return value has changed slightly: `all_hidden_states` now also includes the hidden state of the embeddings in addition to those of the encoding layers. This allows users to easily access the embeddings final state.
+By enabling the configuration option `output_hidden_states`, it was possible to retrieve the last hidden states of the encoder. In `pytorch-transformers` as well as `transformers` the return value has changed slightly: `hidden_states` now also includes the hidden state of the embeddings in addition to those of the encoding layers. This allows users to easily access the embeddings final state.
 
 ### Serialization
 


### PR DESCRIPTION
Output variable name `all_hidden_states` found in README is inconsistent with documentation's `hidden_states`: https://huggingface.co/transformers/model_doc/bert.html#bertmodel