### PR TITLE
Add lower bound to tqdm for tqdm.auto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         # for downloading models over HTTPS
         "requests",
         # progress bars in model download and training scripts
-        "tqdm",
+        "tqdm >= 4.27",
         # for OpenAI GPT
         "regex != 2019.12.17",
         # for XLNet


### PR DESCRIPTION
- It appears that `tqdm` only introduced `tqdm.auto` in 4.27.
- See https://github.com/tqdm/tqdm/releases/tag/v4.27.0.
- Without a lower bound I received an error when importing `transformers` in an environment where I already had `tqdm` installed.
- `transformers` version:
```
$ pip list | grep transformers
transformers                  2.3.0
```
- repro:
```
$ pip install tqdm==4.23
$ ipython
Python 3.6.7 |Anaconda, Inc.| (default, Oct 23 2018, 19:16:44)
Type 'copyright', 'credits' or 'license' for more information
IPython 6.4.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import transformers
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-1-279c49635b32> in <module>()
----> 1 import transformers

~/anaconda3/envs/allennlp/lib/python3.6/site-packages/transformers/__init__.py in <module>()
     18
     19 # Files and general utilities
---> 20 from .file_utils import (TRANSFORMERS_CACHE, PYTORCH_TRANSFORMERS_CACHE, PYTORCH_PRETRAINED_BERT_CACHE,
     21                          cached_path, add_start_docstrings, add_end_docstrings,
     22                          WEIGHTS_NAME, TF2_WEIGHTS_NAME, TF_WEIGHTS_NAME, CONFIG_NAME, MODEL_CARD_NAME,

~/anaconda3/envs/allennlp/lib/python3.6/site-packages/transformers/file_utils.py in <module>()
     22 from botocore.exceptions import ClientError
     23 import requests
---> 24 from tqdm.auto import tqdm
     25 from contextlib import contextmanager
     26 from . import __version__

ModuleNotFoundError: No module named 'tqdm.auto'
```