### PR TITLE
Fix examples/run_tf_ner.py label encoding error #2559 

### DIFF
--- a/examples/run_tf_ner.py
+++ b/examples/run_tf_ner.py
@@ -315,7 +315,7 @@ def train(
 def evaluate(args, strategy, model, tokenizer, labels, pad_token_label_id, mode):
     eval_batch_size = args["per_device_eval_batch_size"] * args["n_device"]
     eval_dataset, size = load_and_cache_examples(
-        args, tokenizer, labels, pad_token_label_id, eval_batch_size, mode=mode
+        args, tokenizer, ['[PAD]']+labels, pad_token_label_id, eval_batch_size, mode=mode
     )
     eval_dataset = strategy.experimental_distribute_dataset(eval_dataset)
     preds = None
@@ -537,7 +537,7 @@ def main(_):
 
         train_batch_size = args["per_device_train_batch_size"] * args["n_device"]
         train_dataset, num_train_examples = load_and_cache_examples(
-            args, tokenizer, labels, pad_token_label_id, train_batch_size, mode="train"
+            args, tokenizer, ['[PAD]']+labels, pad_token_label_id, train_batch_size, mode="train"
         )
         train_dataset = strategy.experimental_distribute_dataset(train_dataset)
         train(

--- a/examples/run_tf_ner.py
+++ b/examples/run_tf_ner.py
@@ -315,7 +315,7 @@ def train(
 def evaluate(args, strategy, model, tokenizer, labels, pad_token_label_id, mode):
     eval_batch_size = args["per_device_eval_batch_size"] * args["n_device"]
     eval_dataset, size = load_and_cache_examples(
-        args, tokenizer, ['[PAD]']+labels, pad_token_label_id, eval_batch_size, mode=mode
+        args, tokenizer, ["[PAD]"] + labels, pad_token_label_id, eval_batch_size, mode=mode
     )
     eval_dataset = strategy.experimental_distribute_dataset(eval_dataset)
     preds = None
@@ -537,7 +537,7 @@ def main(_):
 
         train_batch_size = args["per_device_train_batch_size"] * args["n_device"]
         train_dataset, num_train_examples = load_and_cache_examples(
-            args, tokenizer, ['[PAD]']+labels, pad_token_label_id, train_batch_size, mode="train"
+            args, tokenizer, ["[PAD]"] + labels, pad_token_label_id, train_batch_size, mode="train"
         )
         train_dataset = strategy.experimental_distribute_dataset(train_dataset)
         train(
@@ -613,10 +613,6 @@ def main(_):
     if args["do_predict"]:
         tokenizer = tokenizer_class.from_pretrained(args["output_dir"], do_lower_case=args["do_lower_case"])
         model = model_class.from_pretrained(args["output_dir"])
-        eval_batch_size = args["per_device_eval_batch_size"] * args["n_device"]
-        predict_dataset, _ = load_and_cache_examples(
-            args, tokenizer, labels, pad_token_label_id, eval_batch_size, mode="test"
-        )
         y_true, y_pred, pred_loss = evaluate(args, strategy, model, tokenizer, labels, pad_token_label_id, mode="test")
         output_test_results_file = os.path.join(args["output_dir"], "test_results.txt")
         output_test_predictions_file = os.path.join(args["output_dir"], "test_predictions.txt")


### PR DESCRIPTION
This is an explanation and a proposed fix for #2559 
The code set `pad_token_label_id = 0`, and increase the total number of labels `num_labels = len(labels) + 1`, but made no change to the label list. Thus the first label in label list has the same index as pad_token_label_id.

Following instructions in README take GermEval 2014 as an example, for one sentence in test dataset the token `Aachen` is labeled as `B-LOC` (`B-LOC` is the first label in label list), yet because of the collision with pad_token_label_id, both pad tokens and `Aachen` are encoded as 0:
![image](https://user-images.githubusercontent.com/1331543/72657322-bb90fa00-3957-11ea-980d-33ac12e54545.png)
And the test_predictions.txt is also off by one:
```
1951 I-PERpart
bis I-PERpart
1953 I-PERpart
wurde I-PERpart
...
```

The fix adds a placeholder label `[PAD]` at position 0 when loading the datasets and all labels positions are shifted by 1. The resulting encoding for the same sample sentence:
![image](https://user-images.githubusercontent.com/1331543/72657627-5e974300-395b-11ea-905e-4a3028f4b5c4.png)

And the test_predictions.txt thus has correct index:
```
1951 O
bis O
1953 O
wurde O
...
```
