### PR TITLE
Edit a way to get `projected_context_layer`

### DIFF
--- a/src/transformers/modeling_albert.py
+++ b/src/transformers/modeling_albert.py
@@ -255,7 +255,7 @@ class AlbertAttention(BertSelfAttention):
         #)
         #b = self.dense.bias.to(context_layer.dtype)
         #projected_context_layer = torch.einsum("bfnd,ndh->bfh", context_layer, w) + b
-		projected_context_layer = self.dense(self.merge_last_ndims(context_layer, 2))
+        projected_context_layer = self.dense(self.merge_last_ndims(context_layer, 2))
         projected_context_layer_dropout = self.dropout(projected_context_layer)
         layernormed_context_layer = self.LayerNorm(input_ids + projected_context_layer_dropout)
         return (layernormed_context_layer, attention_probs) if self.output_attentions else (layernormed_context_layer,)

--- a/src/transformers/modeling_albert.py
+++ b/src/transformers/modeling_albert.py
@@ -211,6 +211,7 @@ class AlbertAttention(BertSelfAttention):
         self.all_head_size = self.attention_head_size * self.num_attention_heads
         self.pruned_heads = self.pruned_heads.union(heads)
 
+	# got from https://github.com/graykode/ALBERT-Pytorch/blob/master/utils.py
     def merge_last_ndims(self, x, n_dims):
         s = x.size()
         assert n_dims > 1 and n_dims < len(s)


### PR DESCRIPTION
I edited a way to get `projected_context_layer`.

Instead of doing
'''
w = (
    self.dense.weight.t()
    .view(self.num_attention_heads, self.attention_head_size, self.hidden_size)
    .to(context_layer.dtype)
)
b = self.dense.bias.to(context_layer.dtype)
projected_context_layer = torch.einsum("bfnd,ndh->bfh", context_layer, w) + b
'''

I added `self.merge_last_ndims` at `AlbertAttention`.
'''
def merge_last_ndims(self, x, n_dims):
    s = x.size()
    assert n_dims > 1 and n_dims < len(s)
    return x.view(*s[:-n_dims], -1)
'''

I commited this one yesterday, but that one didn't pass the tests, so I re-wrote my code and re-committing now.