### PR TITLE
[FIX] #2658 Inconsistent values returned by batch_encode_plus and enc…

### DIFF
--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -3,7 +3,6 @@ from argparse import ArgumentParser, Namespace
 from typing import Any, List, Optional
 
 from starlette.responses import JSONResponse
-
 from transformers import Pipeline
 from transformers.commands import BaseTransformersCLICommand
 from transformers.pipelines import SUPPORTED_TASKS, pipeline

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -1001,7 +1001,7 @@ class PreTrainedTokenizer(object):
                 if key != "input_len":
                     # Padding handle
                     padded_value = [
-                        v + [self.pad_token_id if key == "input_ids" else 1] * (max_seq_len - len(v))
+                        v + [self.pad_token_id if key == "input_ids" else 0] * (max_seq_len - len(v))
                         for v in padded_value
                     ]
 

--- a/tests/test_tokenizer_batch.py
+++ b/tests/test_tokenizer_batch.py
@@ -16,12 +16,14 @@
 
 import unittest
 
-from transformers import AutoTokenizer
-from transformers import is_torch_available
+from transformers import AutoTokenizer, is_torch_available
+
 from .utils import require_torch
+
 
 if is_torch_available():
     import torch
+
 
 @require_torch
 class TokenizerUtilsBatchTest(unittest.TestCase):

--- a/tests/test_tokenizer_batch.py
+++ b/tests/test_tokenizer_batch.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+# Copyright 2020 HuggingFace Inc..
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest
+
+import torch
+
+from transformers import AutoTokenizer
+
+from .utils import require_torch
+
+
+@require_torch
+class TokenizerUtilsBatchTest(unittest.TestCase):
+    def test_batch_tokenizers(self):
+        pretrained = "bert-base-uncased"
+        tokenizer = AutoTokenizer.from_pretrained(pretrained)
+        text = "My"
+        text1 = "features are ok"
+
+        batch = [text, text1]
+
+        batch_encoding = tokenizer.batch_encode_plus(batch, return_tensors="pt", add_special_tokens=False)
+
+        text_encoding = tokenizer.encode_plus(
+            text, return_tensors="pt", add_special_tokens=False, max_length=3, pad_to_max_length=True
+        )
+
+        self.assertTrue(torch.all(batch_encoding["token_type_ids"][0].eq(text_encoding["token_type_ids"][0])))

--- a/tests/test_tokenizer_batch.py
+++ b/tests/test_tokenizer_batch.py
@@ -16,12 +16,12 @@
 
 import unittest
 
-import torch
-
 from transformers import AutoTokenizer
-
+from transformers import is_torch_available
 from .utils import require_torch
 
+if is_torch_available():
+    import torch
 
 @require_torch
 class TokenizerUtilsBatchTest(unittest.TestCase):


### PR DESCRIPTION
As ticket describe, when using batch_encode_plus, instead of encode_plus, tokens type and mask are different. They should be the same using batch processing or not. Proposed fix here solve the issue