### PR TITLE
Updates to the templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/---new-benchmark.md
+++ b/.github/ISSUE_TEMPLATE/---new-benchmark.md
@@ -1,17 +1,17 @@
 ---
 name: "\U0001F5A5 New Benchmark"
-about: You benchmark a part of this library and would like to share your results
+about: Benchmark a part of this library and share your results
 title: "[Benchmark]"
 labels: ''
 assignees: ''
 
 ---
 
-# Benchmarking Transformers
+# Benchmarking `transformers`
 
 ## Benchmark
 
-Which part of Transformers did you benchmark?
+Which part of `transformers` did you benchmark?
 
 ## Set-up
 

--- a/.github/ISSUE_TEMPLATE/---new-benchmark.md
+++ b/.github/ISSUE_TEMPLATE/---new-benchmark.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F5A5 New Benchmark"
+name: "\U0001F5A5 New benchmark"
 about: Benchmark a part of this library and share your results
 title: "[Benchmark]"
 labels: ''
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-# Benchmarking `transformers`
+# 🖥 Benchmarking `transformers`
 
 ## Benchmark
 

--- a/.github/ISSUE_TEMPLATE/--new-model-addition.md
+++ b/.github/ISSUE_TEMPLATE/--new-model-addition.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F31FNew model addition"
+name: "\U0001F31F New model addition"
 about: Submit a proposal/request to implement a new Transformer-based model
 title: ''
 labels: ''
@@ -18,7 +18,3 @@ assignees: ''
 * [ ] the model implementation is available: (give details)
 * [ ] the model weights are available: (give details)
 * [ ] who are the authors: (mention them, if possible by @gh-username)
-
-## Additional context
-
-<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/--new-model-addition.md
+++ b/.github/ISSUE_TEMPLATE/--new-model-addition.md
@@ -7,17 +7,17 @@ assignees: ''
 
 ---
 
-# 🌟New model addition
+# 🌟 New model addition
 
 ## Model description
 
 <!-- Important information -->
 
-## Open Source status
+## Open source status
 
 * [ ] the model implementation is available: (give details)
 * [ ] the model weights are available: (give details)
-* [ ] who are the authors: (mention them)
+* [ ] who are the authors: (mention them, if possible by @gh-username)
 
 ## Additional context
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,9 +7,9 @@ assignees: ''
 
 ---
 
-## 🐛 Bug
+# 🐛 Bug
 
-<!-- Important information -->
+## Information
 
 Model I am using (Bert, XLNet ...):
 
@@ -48,7 +48,3 @@ Steps to reproduce the behavior:
 * Using GPU ?
 * Distributed or parallel setup ?
 * Any other relevant information:
-
-## Additional context
-
-<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,6 +1,6 @@
 ---
 name: "\U0001F41B Bug Report"
-about: Submit a bug report to help us improve PyTorch Transformers
+about: Submit a bug report to help us improve transformers
 title: ''
 labels: ''
 assignees: ''
@@ -11,19 +11,19 @@ assignees: ''
 
 <!-- Important information -->
 
-Model I am using (Bert, XLNet....):
+Model I am using (Bert, XLNet ...):
 
-Language I am using the model on (English, Chinese....):
+Language I am using the model on (English, Chinese ...):
 
-The problem arise when using:
-* [ ] the official example scripts: (give details)
-* [ ] my own modified scripts: (give details)
+The problem arises when using:
+* [ ] the official example scripts: (give details below)
+* [ ] my own modified scripts: (give details below)
 
 The tasks I am working on is:
 * [ ] an official GLUE/SQUaD task: (give the name)
-* [ ] my own task or dataset: (give details)
+* [ ] my own task or dataset: (give details below)
 
-## To Reproduce
+## To reproduce
 
 Steps to reproduce the behavior:
 
@@ -31,18 +31,20 @@ Steps to reproduce the behavior:
 2.
 3.
 
-<!-- If you have a code sample, error messages, stack traces, please provide it here as well. -->
+<!-- If you have code snippets, error messages, stack traces please provide them here as well.
+     Important! Use code tags to correctly format your code. See https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting
+     Do not use screenshots, as they are hard to read and (more importantly) don't allow others to copy-and-paste your code.-->
 
 ## Expected behavior
 
-<!-- A clear and concise description of what you expected to happen. -->
+<!-- A clear and concise description of what you would expect to happen. -->
 
 ## Environment
 
 * OS:
 * Python version:
 * PyTorch version:
-* PyTorch Transformers version (or branch):
+* `transformers` version (or branch):
 * Using GPU ?
 * Distributed or parallel setup ?
 * Any other relevant information:

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F680 Feature Request"
+name: "\U0001F680 Feature request"
 about: Submit a proposal/request for a new transformers feature
 title: ''
 labels: ''
@@ -7,18 +7,19 @@ assignees: ''
 
 ---
 
-## 🚀 Feature
+# 🚀 Feature request
 
-<!-- A clear and concise description of the feature proposal. Please provide a link to the paper and code in case they exist. -->
+<!-- A clear and concise description of the feature proposal.
+     Please provide a link to the paper and code in case they exist. -->
 
 ## Motivation
 
-<!-- Please outline the motivation for the proposal. Is your feature request related to a problem? e.g., I'm always frustrated when [...]. If this is related to another GitHub issue, please link here too. -->
+<!-- Please outline the motivation for the proposal. Is your feature request
+     related to a problem? e.g., I'm always frustrated when [...]. If this is related
+     to another GitHub issue, please link here too. -->
 
 ## Your contribution
 
-<!-- Is there any way that you could help, e.g. by submitting a PR? Make sure to read the CONTRIBUTING.MD readme: https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md -->
-
-## Additional context
-
-<!-- Add any other context or screenshots about the feature request here. If you have code to share, use code tags rather than screenshots: https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting -->
+<!-- Is there any way that you could help, e.g. by submitting a PR?
+     Make sure to read the CONTRIBUTING.MD readme:
+     https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,6 +1,6 @@
 ---
 name: "\U0001F680 Feature Request"
-about: Submit a proposal/request for a new PyTorch Transformers feature
+about: Submit a proposal/request for a new transformers feature
 title: ''
 labels: ''
 assignees: ''
@@ -15,6 +15,10 @@ assignees: ''
 
 <!-- Please outline the motivation for the proposal. Is your feature request related to a problem? e.g., I'm always frustrated when [...]. If this is related to another GitHub issue, please link here too. -->
 
+## Your contribution
+
+<!-- Is there any way that you could help, e.g. by submitting a PR? Make sure to read the CONTRIBUTING.MD readme: https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md -->
+
 ## Additional context
 
-<!-- Add any other context or screenshots about the feature request here. -->
+<!-- Add any other context or screenshots about the feature request here. If you have code to share, use code tags rather than screenshots: https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting -->

--- a/.github/ISSUE_TEMPLATE/migration.md
+++ b/.github/ISSUE_TEMPLATE/migration.md
@@ -7,7 +7,9 @@ assignees: ''
 
 ---
 
-## 📚 Migration
+# 📚 Migration
+
+## Information
 
 <!-- Important information -->
 
@@ -23,7 +25,7 @@ The tasks I am working on is:
 * [ ] an official GLUE/SQUaD task: (give the name)
 * [ ] my own task or dataset: (give details below)
 
-Details of the issue:
+## Details
 
 <!-- A clear and concise description of the migration issue.
     If you have code snippets, please provide it here as well.
@@ -48,7 +50,3 @@ Details of the issue:
  ([pytorch-transformers](https://github.com/huggingface/transformers#migrating-from-pytorch-transformers-to-transformers);
   [pytorch-pretrained-bert](https://github.com/huggingface/transformers#migrating-from-pytorch-pretrained-bert-to-transformers))
 - [ ] I checked if a related official extension example runs on my machine.
-
-## Additional context
-
-<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/migration.md
+++ b/.github/ISSUE_TEMPLATE/migration.md
@@ -1,6 +1,6 @@
 ---
-name: "\U0001F4DA Migration from PyTorch-pretrained-Bert"
-about: Report a problem when migrating from PyTorch-pretrained-Bert to Transformers
+name: "\U0001F4DA Migration from pytorch-pretrained-bert or pytorch-transformers"
+about: Report a problem when migrating from pytorch-pretrained-bert or pytorch-transformers to transformers
 title: ''
 labels: ''
 assignees: ''
@@ -11,35 +11,42 @@ assignees: ''
 
 <!-- Important information -->
 
-Model I am using (Bert, XLNet....):
+Model I am using (Bert, XLNet ...):
 
-Language I am using the model on (English, Chinese....):
+Language I am using the model on (English, Chinese ...):
 
-The problem arise when using:
-* [ ] the official example scripts: (give details)
-* [ ] my own modified scripts: (give details)
+The problem arises when using:
+* [ ] the official example scripts: (give details below)
+* [ ] my own modified scripts: (give details below)
 
 The tasks I am working on is:
 * [ ] an official GLUE/SQUaD task: (give the name)
-* [ ] my own task or dataset: (give details)
+* [ ] my own task or dataset: (give details below)
 
 Details of the issue:
 
-<!-- A clear and concise description of the migration issue. If you have code snippets, please provide it here as well. -->
+<!-- A clear and concise description of the migration issue.
+    If you have code snippets, please provide it here as well.
+    Important! Use code tags to correctly format your code. See https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting
+    Do not use screenshots, as they are hard to read and (more importantly) don't allow others to copy-and-paste your code.
+    -->
 
 ## Environment
 
 * OS:
 * Python version:
 * PyTorch version:
-* PyTorch Transformers version (or branch):
-* Using GPU ?
-* Distributed or parallel setup ?
+* `pytorch-transformers` or `pytorch-pretrained-bert` version (or branch):
+* `transformers` version (or branch):
+* Using GPU?
+* Distributed or parallel setup?
 * Any other relevant information:
 
 ## Checklist
 
 - [ ] I have read the migration guide in the readme.
+ ([pytorch-transformers](https://github.com/huggingface/transformers#migrating-from-pytorch-transformers-to-transformers);
+  [pytorch-pretrained-bert](https://github.com/huggingface/transformers#migrating-from-pytorch-pretrained-bert-to-transformers))
 - [ ] I checked if a related official extension example runs on my machine.
 
 ## Additional context

--- a/.github/ISSUE_TEMPLATE/question-help.md
+++ b/.github/ISSUE_TEMPLATE/question-help.md
@@ -1,6 +1,6 @@
 ---
 name: "❓Questions & Help"
-about: Start a general discussion related to PyTorch Transformers
+about: Post your general questions on Stack Overflow tagged huggingface-transformers
 title: ''
 labels: ''
 assignees: ''
@@ -9,4 +9,20 @@ assignees: ''
 
 ## ❓ Questions & Help
 
-<!-- A clear and concise description of the question. -->
+<!-- The GitHub issue tracker is primarly intended for bugs, feature requests,
+     new models and benchmarks, and migration questions. For all other questions,
+     we direct you to Stack Overflow (SO) where a whole community of PyTorch and
+     Tensorflow enthusiast can help you out. Make sure to tag your question with the
+     right deep learning framework as well as the huggingface-transformers tag: 
+     https://stackoverflow.com/questions/tagged/huggingface-transformers 
+     
+     If your question wasn't answered after a period of time on Stack Overflow, you
+     can always open a question on GitHub. You should then link to the SO question 
+     that you posted.
+     -->
+
+<!-- Description of your issue -->
+
+<!-- You should first ask your question on SO, and only if
+     you didn't get an answer ask it here on GitHub.
+The original question on Stack Overflow: 

--- a/.github/ISSUE_TEMPLATE/question-help.md
+++ b/.github/ISSUE_TEMPLATE/question-help.md
@@ -25,4 +25,4 @@ assignees: ''
 
 <!-- You should first ask your question on SO, and only if
      you didn't get an answer ask it here on GitHub.
-The original question on Stack Overflow: 
+A link to original question on Stack Overflow: 

--- a/.github/ISSUE_TEMPLATE/question-help.md
+++ b/.github/ISSUE_TEMPLATE/question-help.md
@@ -1,5 +1,5 @@
 ---
-name: "❓Questions & Help"
+name: "❓ Questions & Help"
 about: Post your general questions on Stack Overflow tagged huggingface-transformers
 title: ''
 labels: ''
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-## ❓ Questions & Help
+# ❓ Questions & Help
 
 <!-- The GitHub issue tracker is primarly intended for bugs, feature requests,
      new models and benchmarks, and migration questions. For all other questions,
@@ -21,8 +21,9 @@ assignees: ''
      that you posted.
      -->
 
+## Details
 <!-- Description of your issue -->
 
 <!-- You should first ask your question on SO, and only if
-     you didn't get an answer ask it here on GitHub.
-A link to original question on Stack Overflow: 
+     you didn't get an answer ask it here on GitHub. -->
+**A link to original question on Stack Overflow**: 


### PR DESCRIPTION
This PR updates the existing GitHub templates. Main changes are:

- motivate users to post general question on Stack Overflow, tagged [huggingface-transformers](https://stackoverflow.com/questions/tagged/huggingface-transformers)
- removing the 'additional context' section as it might not add much and just bloats the template
- changed references to pytorch-transformers to transformers

closes https://github.com/huggingface/transformers/issues/2529