### PR TITLE
Remove unnecessary `del` in run_tf_glue.py example

### DIFF
--- a/examples/run_tf_glue.py
+++ b/examples/run_tf_glue.py
@@ -99,9 +99,6 @@ if TASK == "mrpc":
     inputs_1 = tokenizer.encode_plus(sentence_0, sentence_1, add_special_tokens=True, return_tensors="pt")
     inputs_2 = tokenizer.encode_plus(sentence_0, sentence_2, add_special_tokens=True, return_tensors="pt")
 
-    del inputs_1["special_tokens_mask"]
-    del inputs_2["special_tokens_mask"]
-
     pred_1 = pytorch_model(**inputs_1)[0].argmax().item()
     pred_2 = pytorch_model(**inputs_2)[0].argmax().item()
     print("sentence_1 is", "a paraphrase" if pred_1 else "not a paraphrase", "of sentence_0")


### PR DESCRIPTION
Platform: Ubuntu 18.04 (Linux-4.15.0-1054-aws-x86_64-with-Ubuntu-18.04-bionic)
Python: 3.6.9
PyTorch: 1.4.0
TensorFlow: 2.0.0

Running `./examples/run_tf_glue.py` gives `KeyError: 'special_tokens_mask'`.

Diving into the code, it looks like there's an optional keyword argument in [`encode_plus()`](https://github.com/huggingface/transformers/blob/9d87eafd118739a4c121d69d7cff425264f01e1c/src/transformers/tokenization_utils.py#L834) named `return_special_tokens_mask` that defaults to False. I'm guessing that this argument was added recently and the example just needs to be updated?