### PR TITLE
TensorFlow XLM doesn't accept NumPy arrays for the attention mask

### DIFF
--- a/src/transformers/modeling_tf_xlm.py
+++ b/src/transformers/modeling_tf_xlm.py
@@ -365,6 +365,8 @@ class TFXLMMainLayer(tf.keras.layers.Layer):
         #     assert src_enc.size(0) == bs
 
         # generate masks
+        if attention_mask is not None:
+            attention_mask = tf.cast(attention_mask, tf.int32)
         mask, attn_mask = get_masks(slen, lengths, self.causal, padding_mask=attention_mask)
         # if self.is_decoder and src_enc is not None:
         #     src_mask = torch.arange(src_len.max(), dtype=torch.long, device=lengths.device) < src_len[:, None]


### PR DESCRIPTION
Convert NumPy attention mask to a TensorFlow tensor so that the mask creation doesn't crash

closes #2729 