### PR TITLE
Fix GPT2 config set to trainable

### DIFF
--- a/src/transformers/modeling_tf_gpt2.py
+++ b/src/transformers/modeling_tf_gpt2.py
@@ -198,7 +198,7 @@ class TFBlock(tf.keras.layers.Layer):
 
 class TFGPT2MainLayer(tf.keras.layers.Layer):
     def __init__(self, config, *inputs, **kwargs):
-        super().__init__(config, *inputs, **kwargs)
+        super().__init__(*inputs, **kwargs)
         self.output_hidden_states = config.output_hidden_states
         self.output_attentions = config.output_attentions
         self.num_hidden_layers = config.n_layer


### PR DESCRIPTION
There's currently a bug in the GPT2 model which prevents it from being saved. This is caused by setting the trainable parameter to the GPT2 config, which cannot be packaged later in the save pipeline. Gotta love python...

Here is a simple script which you can use to reproduce this bug (and check the fix):
```
from transformers import (TFGPT2Model)

if __name__ == '__main__':
    _base_model = TFGPT2Model.from_pretrained("gpt2")
    print(base_model._layers[0].trainable)
```