### PR TITLE
Fix multi-gpu evaluation in run_glue.py example

### DIFF
--- a/examples/run_glue.py
+++ b/examples/run_glue.py
@@ -305,7 +305,7 @@ def evaluate(args, model, tokenizer, prefix=""):
         eval_dataloader = DataLoader(eval_dataset, sampler=eval_sampler, batch_size=args.eval_batch_size)
 
         # multi-gpu eval
-        if args.n_gpu > 1:
+        if args.n_gpu > 1 and not isinstance(model, torch.nn.DataParallel):
             model = torch.nn.DataParallel(model)
 
         # Eval!


### PR DESCRIPTION
Fix multi-gpu evaluation while training in `examples/run_glue.py`