### PR TITLE
Changed vocabulary save function. Variable name was inconsistent

### DIFF
--- a/src/transformers/tokenization_transfo_xl.py
+++ b/src/transformers/tokenization_transfo_xl.py
@@ -159,6 +159,8 @@ class TransfoXLTokenizer(PreTrainedTokenizer):
         """Save the tokenizer vocabulary to a directory or file."""
         if os.path.isdir(vocab_path):
             vocab_file = os.path.join(vocab_path, VOCAB_FILES_NAMES["pretrained_vocab_file"])
+        else:
+            vocab_file = vocab_path
         torch.save(self.__dict__, vocab_file)
         return (vocab_file,)
 


### PR DESCRIPTION
Caused an error to be thrown when passing a file name instead of a directory. 

UnboundLocalError: local variable 'vocab_file' referenced before assignment

Associated with issue #2753 

