### PR TITLE
Fix documentation in ProjectedAdaptiveLogSoftmax

### DIFF
--- a/src/transformers/modeling_transfo_xl_utilities.py
+++ b/src/transformers/modeling_transfo_xl_utilities.py
@@ -90,9 +90,9 @@ class ProjectedAdaptiveLogSoftmax(nn.Module):
                 labels :: [len*bsz]
             Return:
                 if labels is None:
-                    out :: [len*bsz] Negative log likelihood
-                else:
                     out :: [len*bsz x n_tokens] log probabilities of tokens over the vocabulary
+                else:
+                    out :: [len*bsz] Negative log likelihood
             We could replace this implementation by the native PyTorch one
             if their's had an option to set bias on all clusters in the native one.
             here: https://github.com/pytorch/pytorch/blob/dbe6a7a9ff1a364a8706bf5df58a1ca96d2fd9da/torch/nn/modules/adaptive.py#L138


### PR DESCRIPTION
The shape of outputs for forward in ProjectedAdaptiveLogSoftmax is flipped in the documentation: it should be log probabilities when `labels` is `None` and NLLs otherwise. This is what the code does, but the docstring has them flipped.