### PR TITLE
Fix circleci cuInit error on Tensorflow >= 2.1.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
         parallelism: 1
         steps:
             - checkout
-            - run: sudo pip install .[sklearn,tf,torch,testing]
+            - run: sudo pip install .[sklearn,tf-cpu,torch,testing]
             - run: sudo pip install codecov pytest-cov
             - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/ --cov
             - run: codecov
@@ -26,7 +26,7 @@ jobs:
         parallelism: 1
         steps:
             - checkout
-            - run: sudo pip install .[mecab,sklearn,tf,torch,testing]
+            - run: sudo pip install .[mecab,sklearn,tf-cpu,torch,testing]
             - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/
     run_tests_torch:
         working_directory: ~/transformers
@@ -52,7 +52,7 @@ jobs:
         parallelism: 1
         steps:
             - checkout
-            - run: sudo pip install .[sklearn,tf,testing]
+            - run: sudo pip install .[sklearn,tf-cpu,testing]
             - run: sudo pip install codecov pytest-cov
             - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/ --cov
             - run: codecov

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ extras = {}
 extras["mecab"] = ["mecab-python3"]
 extras["sklearn"] = ["scikit-learn"]
 extras["tf"] = ["tensorflow"]
+extras["tf-cpu"] = ["tensorflow-cpu"]
 extras["torch"] = ["torch"]
 
 extras["serving"] = ["pydantic", "uvicorn", "fastapi", "starlette"]


### PR DESCRIPTION
Tensorflow 2.1.0 introduce a new dependency model where `pip install tensorflow` would install tf **with GPU support**. Before 2.1.0 it would just install with CPU support only.

CircleCI machines are running without GPU hardware so, at initialisation, TensorFlow tests are looking for NVidia driver version but fails as their is no NVidia Driver running.

This PR introduces an extra (optional) dependency **tf-cpu** which explicitly requires **tensorflow-cpu** and makes sure it `pip install tf-cpu` instead of `pip install tf` while running unit tests.

It should remove the following error on CircleCI: 

```bash
tests/test_modeling_tf_bert.py::TFBertModelTest::test_attention_outputs 2020-02-10 11:14:08.280770: W tensorflow/stream_executor/platform/default/dso_loader.cc:55] Could not load dynamic library 'libcuda.so.1'; dlerror: libcuda.so.1: cannot open shared object file: No such file or directory
2020-02-10 11:14:08.280808: E tensorflow/stream_executor/cuda/cuda_driver.cc:351] failed call to cuInit: UNKNOWN ERROR (303)
2020-02-10 11:14:08.280837: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:156] kernel driver does not appear to be running on this host (40403e139ccb): /proc/driver/nvidia/version does not exist
2020-02-10 11:14:08.281093: I tensorflow/core/platform/cpu_feature_guard.cc:142] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 AVX512F FMA
```

Signed-off-by: Morgan Funtowicz <morgan@huggingface.co>