### PR TITLE
[WIP] Adapt lm generate fn for seq 2 seq models

### DIFF
--- a/src/transformers/configuration_bart.py
+++ b/src/transformers/configuration_bart.py
@@ -59,6 +59,7 @@ class BartConfig(PretrainedConfig):
         classifier_dropout=0.0,
         output_past=False,
         num_labels=3,
+        is_encoder_decoder=True,
         **common_kwargs
     ):
         r"""
@@ -91,6 +92,9 @@ class BartConfig(PretrainedConfig):
 
         # Classifier stuff
         self.classif_dropout = classifier_dropout
+
+        # set encoder-decoder flag
+        self.is_encoder_decoder = is_encoder_decoder
 
     @property
     def num_attention_heads(self):

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -66,6 +66,7 @@ class PretrainedConfig(object):
 
         # Is decoder is used in encoder-decoder models to differentiate encoder from decoder
         self.is_decoder = kwargs.pop("is_decoder", False)
+        self.is_encoder_decoder = kwargs.pop("is_encoder_decoder", False)
 
         # Parameters for sequence generation
         self.max_length = kwargs.pop("max_length", 20)

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -939,7 +939,7 @@ class BartForMaskedLM(PretrainedBartModel):
         return outputs
 
     @staticmethod
-    def prepare_inputs_for_generation(decoder_input_ids, past, encoder_inputs, encoder_outputs, **wwargs):
+    def prepare_inputs_for_generation(decoder_input_ids, past, encoder_inputs, encoder_outputs, **kwargs):
         # if encoder_outputs are not defined, the decoder input should be none, since it's the first decoding step
         if encoder_outputs is None:
             decoder_input_ids = None

--- a/src/transformers/modeling_ctrl.py
+++ b/src/transformers/modeling_ctrl.py
@@ -454,14 +454,12 @@ class CTRLLMHeadModel(CTRLPreTrainedModel):
     def get_output_embeddings(self):
         return self.lm_head
 
-    def prepare_inputs_for_generation(self, input_ids, **kwargs):
-        # only last token for inputs_ids if past is defined in kwargs
-        if "past" in kwargs and kwargs["past"]:
+    def prepare_inputs_for_generation(self, input_ids, past, **kwargs):
+        # only last token for inputs_ids if past is defined
+        if past is not None:
             input_ids = input_ids[:, -1].unsqueeze(-1)
 
-        inputs = {"input_ids": input_ids}
-        inputs.update(kwargs)
-        return inputs
+        return {"input_ids": input_ids, "past": past}
 
     @add_start_docstrings_to_callable(CTRL_INPUTS_DOCSTRING)
     def forward(

--- a/src/transformers/modeling_gpt2.py
+++ b/src/transformers/modeling_gpt2.py
@@ -519,14 +519,12 @@ class GPT2LMHeadModel(GPT2PreTrainedModel):
     def get_output_embeddings(self):
         return self.lm_head
 
-    def prepare_inputs_for_generation(self, input_ids, **kwargs):
-        # only last token for inputs_ids if past is defined in kwargs
-        if "past" in kwargs and kwargs["past"]:
+    def prepare_inputs_for_generation(self, input_ids, past, **kwargs):
+        # only last token for inputs_ids if past is defined
+        if past is not None:
             input_ids = input_ids[:, -1].unsqueeze(-1)
 
-        inputs = {"input_ids": input_ids}
-        inputs.update(kwargs)
-        return inputs
+        return {"input_ids": input_ids, "past": past}
 
     @add_start_docstrings_to_callable(GPT2_INPUTS_DOCSTRING)
     def forward(

--- a/src/transformers/modeling_transfo_xl.py
+++ b/src/transformers/modeling_transfo_xl.py
@@ -935,11 +935,11 @@ class TransfoXLLMHeadModel(TransfoXLPreTrainedModel):
         else:
             return self.crit.out_layers[-1]
 
-    def prepare_inputs_for_generation(self, input_ids, **model_kwargs):
+    def prepare_inputs_for_generation(self, input_ids, past, **kwargs):
         inputs = {"input_ids": input_ids}
 
-        # if past is defined in model kwargs then use it for faster decoding
-        if "past" in model_kwargs and model_kwargs["past"]:
-            inputs["mems"] = model_kwargs["past"]
+        # if past is defined then use it for faster decoding
+        if past is not None:
+            inputs["mems"] = past
 
         return inputs

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -570,6 +570,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
     def prepare_inputs_for_generation(self, input_ids, **kwargs):
         return {"input_ids": input_ids}
 
+        # TODO (PVP): Shouldn't be needed if named tuples are implemented
+
+    def postprocess_outputs_for_generation(self, outputs, **kwargs):
+        return (outputs[0], outputs[1], None)
+
     def _do_output_past(self, outputs):
         has_output_past = hasattr(self.config, "output_past") and self.config.output_past
         has_mem_len = hasattr(self.config, "mem_len") and self.config.mem_len
@@ -750,8 +755,17 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             pad_token_id = eos_token_ids[0]
 
         # current position and vocab size
-        # cur_len = input_ids.shape[1] TODO FOR SEQ-2-SEQ: This doesn't work for seq-2-seq models as the input_ids will be encoded and not prepended to the output. Proposal:
-        cur_len = 0 if self._is_seq_to_seq() else input_ids.shape[0]
+        #  NOTE: FOR SEQ-2-SEQ: This doesn't work for seq-2-seq models as the input_ids will be encoded and not prepended to the output. Proposal:
+        if self.config.is_encoder_decoder:
+            assert bos_token_id is not None, "Encoder Decoder Models need to have a bos_token_id"
+            encoder_inputs = input_ids
+            input_ids = torch.full(
+                (batch_size, 1), bos_token_id, dtype=torch.long, device=next(self.parameters()).device
+            )
+            cur_len = 1  # bos_token_id counts for 1
+        else:
+            encoder_inputs = None
+            cur_len = input_ids.shape[0]
 
         vocab_size = self.config.vocab_size
 
@@ -781,6 +795,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 length_penalty,
                 num_beams,
                 vocab_size,
+                encoder_inputs,
             )
         else:
             output = self._generate_no_beam_search(
@@ -795,6 +810,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 pad_token_id,
                 eos_token_ids,
                 effective_batch_size,
+                encoder_inputs,
             )
 
         return output
@@ -812,6 +828,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         pad_token_id,
         eos_token_ids,
         batch_size,
+        encoder_inputs,
     ):
         """ Generate sequences for each example without beam search (num_beams == 1).
             All returned sequence are generated independantly.
@@ -821,28 +838,31 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         sent_lengths = input_ids.new(batch_size).fill_(max_length)
 
         past = None
-        # TODO: FOR SEQ-2-SEQ: the original input_ids have to be saved somewhere since they are always given as encoder_inputs. Also we need to keep track of the encoder_outputs for the decoder
-        if self._is_seq_to_seq():
-            encoder_inputs = input_ids
-            encoder_outputs = None  # If general postprocess_outputs_for_generation fn (see below) should be used for all models then encoder_outputs = None should be set for all models to None (as it is done with the variable 'past')
+
+        if self.config.is_encoder_decoder:
+            encoder_outputs = None  #
+            # If general postprocess_outputs_for_generation fn (see below) should be used for all models then encoder_outputs = None should be set for all models to None (as it is done with the variable 'past')
 
         while cur_len < max_length:
-            # TODO: FOR SEQ-2-SEQ: This function might need a different signature because we need to input
+            # NOTE: FOR SEQ-2-SEQ: This function might need a different signature because we need to input
             # 1) always the original inputs to be encoded
             # 2) the changing decoder_inputs (which are decoded auto-regressively
             # 3) the cached_past
-            # Proposal:
 
-            model_inputs = self.prepare_inputs_for_generation(input_ids, past=past, encoder_inputs=encoder_inputs)
-            # TODO: FOR SEQ-2-SEQ: the input_ids should be the encoder_inputs and the decoder_input_ids should be the input_ids (which should be set to None or empty tensor by the prepare_inputs_for_generation fn in the respective seq-to-seq models).
+            model_inputs = self.prepare_inputs_for_generation(
+                input_ids, past=past, encoder_inputs=encoder_inputs, encoder_outputs=encoder_outputs
+            )
+            # NOTE: FOR SEQ-2-SEQ: the input_ids should be the encoder_inputs and the decoder_input_ids should be the input_ids (which should be set to None or empty tensor by the prepare_inputs_for_generation fn in the respective seq-to-seq models for the first decoding step).
 
             outputs = self(**model_inputs)
 
-            # TODO: FOR SEQ-2-SEQ - the next_token_logits should come from the decoder_outputs
+            # NOTE: FOR SEQ-2-SEQ - the next_token_logits should come from the decoder_outputs
             # Maybe need a separate function for this which is implemented in the SEQ-2-SEQ model file:
             # Proposal:
-            if self._is_seq_to_seq():
-                next_token_logits, past, encoder_outputs = self.postprocess_outputs_for_generatio(outputs)
+            # UPDATE: the if-else statement could be very much simplified if named tuples are used instead of tuples.
+            # TODO (PVP): Need to also treat LMs such as DoubleHead LMs which are not encoder_decoder models but also have a different order
+            if self.config.is_encoder_decoder:
+                next_token_logits, encoder_outputs, past = self.postprocess_outputs_for_generation(outputs)
             else:
                 next_token_logits = outputs[0][:, -1, :]
 
@@ -850,7 +870,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 if self._do_output_past(outputs):
                     past = outputs[1]
 
-            # TODO: Another idea would be to use a postprocess_outputs_for_generation fn for all models then the 'self._do_output_past is also not needed anymore, whereas past and encoder_outputs would just always be set to None by all not seq-to-seq models. Something like:
+            # NOTE: Another idea would be to use a postprocess_outputs_for_generation fn for all models then the 'self._do_output_past is also not needed anymore, whereas past and encoder_outputs would just always be set to None by all not seq-to-seq models. Something like:
             #            next_token_logits, past, encoder_outputs = self.postprocess_outputs_for_generation(ouputs)
 
             # repetition penalty from CTRL paper (https://arxiv.org/abs/1909.05858)
@@ -928,9 +948,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         length_penalty,
         num_beams,
         vocab_size,
+        encoder_inputs,
     ):
         """ Generate sequences for each example with beam search.
         """
+        # TODO (PVP): Need to implement changes for encoder decoder models in this function as well!
         # Expand input to num beams
         input_ids = input_ids.unsqueeze(1).expand(batch_size, num_beams, cur_len)
         input_ids = input_ids.contiguous().view(batch_size * num_beams, cur_len)  # (batch_size * num_beams, cur_len)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -570,9 +570,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
     def prepare_inputs_for_generation(self, input_ids, **kwargs):
         return {"input_ids": input_ids}
 
-        # TODO (PVP): Shouldn't be needed if named tuples are implemented
-
     def postprocess_outputs_for_generation(self, outputs, **kwargs):
+        # TODO (PVP): Whole fn shouldn't be necessary if named tuples are implemented
         return (outputs[0], outputs[1], None)
 
     def _do_output_past(self, outputs):
@@ -756,14 +755,17 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
 
         # current position and vocab size
         #  NOTE: FOR SEQ-2-SEQ: This doesn't work for seq-2-seq models as the input_ids will be encoded and not prepended to the output. Proposal:
+
         if self.config.is_encoder_decoder:
             assert bos_token_id is not None, "Encoder Decoder Models need to have a bos_token_id"
+            # encoder decoder need to start with empty input_ids and copy the input_ids to encoder_inputs
             encoder_inputs = input_ids
             input_ids = torch.full(
                 (batch_size, 1), bos_token_id, dtype=torch.long, device=next(self.parameters()).device
             )
             cur_len = 1  # bos_token_id counts for 1
         else:
+            # current position and vocab size
             encoder_inputs = None
             cur_len = input_ids.shape[0]
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -851,7 +851,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                     past = outputs[1]
 
             # TODO: Another idea would be to use a postprocess_outputs_for_generation fn for all models then the 'self._do_output_past is also not needed anymore, whereas past and encoder_outputs would just always be set to None by all not seq-to-seq models. Something like:
-#            next_token_logits, past, encoder_outputs = self.postprocess_outputs_for_generation(ouputs)
+            #            next_token_logits, past, encoder_outputs = self.postprocess_outputs_for_generation(ouputs)
 
             # repetition penalty from CTRL paper (https://arxiv.org/abs/1909.05858)
             if repetition_penalty != 1.0:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -840,10 +840,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         sent_lengths = input_ids.new(batch_size).fill_(max_length)
 
         past = None
-
-        if self.config.is_encoder_decoder:
-            encoder_outputs = None  #
-            # If general postprocess_outputs_for_generation fn (see below) should be used for all models then encoder_outputs = None should be set for all models to None (as it is done with the variable 'past')
+        # If general postprocess_outputs_for_generation fn (see below) should be used for all models then encoder_outputs = None should be set for all models to None (as it is done with the variable 'past')
+        encoder_outputs = None  #
 
         while cur_len < max_length:
             # NOTE: FOR SEQ-2-SEQ: This function might need a different signature because we need to input

--- a/src/transformers/modeling_xlnet.py
+++ b/src/transformers/modeling_xlnet.py
@@ -934,7 +934,7 @@ class XLNetLMHeadModel(XLNetPreTrainedModel):
     def get_output_embeddings(self):
         return self.lm_loss
 
-    def prepare_inputs_for_generation(self, input_ids, **model_kwargs):
+    def prepare_inputs_for_generation(self, input_ids, past, **kwargs):
         # Add dummy token at the end (no attention on this one)
 
         effective_batch_size = input_ids.shape[0]
@@ -957,8 +957,8 @@ class XLNetLMHeadModel(XLNetPreTrainedModel):
         inputs = {"input_ids": input_ids, "perm_mask": perm_mask, "target_mapping": target_mapping}
 
         # if past is defined in model kwargs then use it for faster decoding
-        if "past" in model_kwargs and model_kwargs["past"]:
-            inputs["mems"] = model_kwargs["past"]
+        if past is not None:
+            inputs["mems"] = past
 
         return inputs
 


### PR DESCRIPTION
From looking at the soon-to-be-added Bart model, I though the language generation could be conceptually adapted as shown below to be able to produce language from seq-to-seq models (Bart & T5). 

So far this is not tested at all and only adapted for the `_generate_no_beam_search()` function. Also it still has to be checked whether this is compatible with T5.

Would be happy about feedback @sshleifer, @thomwolf 