### PR TITLE
Enable 'from transformers import AlbertMLMHead'

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -251,6 +251,7 @@ if is_torch_available():
         AlbertForMaskedLM,
         AlbertForSequenceClassification,
         AlbertForQuestionAnswering,
+        AlbertMLMHead,
         load_tf_weights_in_albert,
         ALBERT_PRETRAINED_MODEL_ARCHIVE_MAP,
     )
@@ -408,6 +409,7 @@ if is_tf_available():
         TFAlbertModel,
         TFAlbertForMaskedLM,
         TFAlbertForSequenceClassification,
+        TFAlbertMLMHead,
         TF_ALBERT_PRETRAINED_MODEL_ARCHIVE_MAP,
     )
 


### PR DESCRIPTION
Discussed at https://github.com/huggingface/transformers/issues/2894

I'm writing a custom pretraining script that incorporates both the masked language modeling (MLM) and sentence order prediction (SOP) objectives. I'm able to use the TFAlbertForMaskedLM model for the MLM objective, but need access to the last_hidden_state to write my SOP objective. I can do this if I have a raw TFAlbertModel and write my own MLM objective, but would prefer to just create my own model from pre-existing modularized components.

I know that there's a lot of care taken in API design, and the team may have explicitly decided against this. But if it is an option, it would make the transformers repo much more extensible for research.