### PR TITLE
Make RobertaForMaskedLM implementation identical to fairseq

### DIFF
--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -20,7 +20,8 @@ import logging
 
 import torch
 import torch.nn as nn
-from torch.nn import functional as F, CrossEntropyLoss, MSELoss
+from torch.nn import CrossEntropyLoss, MSELoss
+from torch.nn import functional as F
 
 from .configuration_roberta import RobertaConfig
 from .file_utils import add_start_docstrings, add_start_docstrings_to_callable

--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -21,7 +21,6 @@ import logging
 import torch
 import torch.nn as nn
 from torch.nn import CrossEntropyLoss, MSELoss
-from torch.nn import functional as F
 
 from .configuration_roberta import RobertaConfig
 from .file_utils import add_start_docstrings, add_start_docstrings_to_callable

--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -260,9 +260,10 @@ class RobertaLMHead(nn.Module):
         super().__init__()
         self.dense = nn.Linear(config.hidden_size, config.hidden_size)
         self.layer_norm = BertLayerNorm(config.hidden_size, eps=config.layer_norm_eps)
-        if weight is None:
-            weight = nn.Linear(config.hidden_size, config.vocab_size, bias=False).weight
-        self.weight = weight
+        self.decoder = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        if weight is not None:
+            self.decoder.weight = weight
+
         self.bias = nn.Parameter(torch.zeros(config.vocab_size))
 
     def forward(self, features, **kwargs):
@@ -271,7 +272,7 @@ class RobertaLMHead(nn.Module):
         x = self.layer_norm(x)
 
         # project back to size of vocabulary with bias
-        x = F.linear(x, self.weight) + self.bias
+        x = self.decoder(x) + self.bias
 
         return x
 

--- a/tests/test_modeling_roberta.py
+++ b/tests/test_modeling_roberta.py
@@ -349,9 +349,9 @@ class RobertaModelIntegrationTest(unittest.TestCase):
         """
         model = RobertaForMaskedLM.from_pretrained("roberta-base")
 
-        input_ids = torch.tensor([[0, 1308, 2674, 1907, 9, 7134,   16,  821, 6998,  102,  328, 2]])
+        input_ids = torch.tensor([[0, 1308, 2674, 1907, 9, 7134, 16, 821, 6998, 102, 328, 2]])
         output = model(input_ids)[0]
-        expected_tensor = torch.tensor([[35.4675, -3.9585, 22.8375],
-                                        [ 1.6043, -4.0382, 11.2205],
-                                        [-0.7618, -4.3771, 12.1674]])
+        expected_tensor = torch.tensor(
+            [[35.4675, -3.9585, 22.8375], [1.6043, -4.0382, 11.2205], [-0.7618, -4.3771, 12.1674]]
+        )
         self.assertTrue(torch.allclose(output[0, :3, :3], expected_tensor, atol=1e-3))


### PR DESCRIPTION
closes https://github.com/huggingface/transformers/issues/1874

The implementation of RoBERTa in `transformers` differs from the original implementation in [fairseq](https://github.com/pytorch/fairseq/tree/master/fairseq/models/roberta), as results showed (cf. https://github.com/huggingface/transformers/issues/1874). I have documented my findings here https://github.com/huggingface/transformers/issues/1874#issuecomment-588359143 and made the corresponding changes accordingly in this PR.

Someone should check, however, that removing `get_output_embeddings()` does not have any adverse side-effects.

In addition, someone who is knowledgeable about Tensorflow should check the TF implementation of RoBERTa, too.