### PR TITLE
Add local_files_only parameter to pretrained items

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -198,6 +198,7 @@ class PretrainedConfig(object):
         force_download = kwargs.pop("force_download", False)
         resume_download = kwargs.pop("resume_download", False)
         proxies = kwargs.pop("proxies", None)
+        disable_outgoing = kwargs.pop("disable_outgoing", False)
 
         if pretrained_config_archive_map is None:
             pretrained_config_archive_map = cls.pretrained_config_archive_map
@@ -219,6 +220,7 @@ class PretrainedConfig(object):
                 force_download=force_download,
                 proxies=proxies,
                 resume_download=resume_download,
+                disable_outgoing=disable_outgoing,
             )
             # Load config dict
             if resolved_config_file is None:

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -198,7 +198,7 @@ class PretrainedConfig(object):
         force_download = kwargs.pop("force_download", False)
         resume_download = kwargs.pop("resume_download", False)
         proxies = kwargs.pop("proxies", None)
-        disable_outgoing = kwargs.pop("disable_outgoing", False)
+        local_files_only = kwargs.pop("local_files_only", False)
 
         if pretrained_config_archive_map is None:
             pretrained_config_archive_map = cls.pretrained_config_archive_map
@@ -220,7 +220,7 @@ class PretrainedConfig(object):
                 force_download=force_download,
                 proxies=proxies,
                 resume_download=resume_download,
-                disable_outgoing=disable_outgoing,
+                local_files_only=local_files_only,
             )
             # Load config dict
             if resolved_config_file is None:

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -214,6 +214,7 @@ def cached_path(
     user_agent=None,
     extract_compressed_file=False,
     force_extract=False,
+    disable_outgoing=False,
 ) -> Optional[str]:
     """
     Given something that might be a URL (or might be a local path),
@@ -250,6 +251,7 @@ def cached_path(
             proxies=proxies,
             resume_download=resume_download,
             user_agent=user_agent,
+            disable_outgoing=disable_outgoing,
         )
     elif os.path.exists(url_or_filename):
         # File, and it exists.
@@ -378,7 +380,14 @@ def http_get(url, temp_file, proxies=None, resume_size=0, user_agent=None):
 
 
 def get_from_cache(
-    url, cache_dir=None, force_download=False, proxies=None, etag_timeout=10, resume_download=False, user_agent=None
+    url,
+    cache_dir=None,
+    force_download=False,
+    proxies=None,
+    etag_timeout=10,
+    resume_download=False,
+    user_agent=None,
+    disable_outgoing=False,
 ) -> Optional[str]:
     """
     Given a URL, look for the corresponding file in the local cache.
@@ -395,18 +404,19 @@ def get_from_cache(
 
     os.makedirs(cache_dir, exist_ok=True)
 
-    # Get eTag to add to filename, if it exists.
-    if url.startswith("s3://"):
-        etag = s3_etag(url, proxies=proxies)
-    else:
-        try:
-            response = requests.head(url, allow_redirects=True, proxies=proxies, timeout=etag_timeout)
-            if response.status_code != 200:
-                etag = None
-            else:
-                etag = response.headers.get("ETag")
-        except (EnvironmentError, requests.exceptions.Timeout):
-            etag = None
+    etag = None
+    if not disable_outgoing:
+        # Get eTag to add to filename, if it exists.
+        if url.startswith("s3://"):
+            etag = s3_etag(url, proxies=proxies)
+        else:
+            try:
+                response = requests.head(url, allow_redirects=True, proxies=proxies, timeout=etag_timeout)
+                if response.status_code == 200:
+                    etag = response.headers.get("ETag")
+            except (EnvironmentError, requests.exceptions.Timeout):
+                # etag is already None
+                pass
 
     filename = url_to_filename(url, etag)
 
@@ -427,6 +437,15 @@ def get_from_cache(
             if len(matching_files) > 0:
                 return os.path.join(cache_dir, matching_files[-1])
             else:
+                # If files cannot be found and disable_outgoing=True,
+                # the models might've been found if disable_outgoing=False
+                # Notify the user about that
+                if disable_outgoing:
+                    raise ValueError(
+                        "Cannot find the requested files in the cached path and outgoing traffic has been"
+                        " disabled. To enable model look-ups and downloads online, set 'disable_outgoing'"
+                        " to False."
+                    )
                 return None
 
     # From now on, etag is not None.

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -214,7 +214,7 @@ def cached_path(
     user_agent=None,
     extract_compressed_file=False,
     force_extract=False,
-    disable_outgoing=False,
+    local_files_only=False,
 ) -> Optional[str]:
     """
     Given something that might be a URL (or might be a local path),
@@ -251,7 +251,7 @@ def cached_path(
             proxies=proxies,
             resume_download=resume_download,
             user_agent=user_agent,
-            disable_outgoing=disable_outgoing,
+            local_files_only=local_files_only,
         )
     elif os.path.exists(url_or_filename):
         # File, and it exists.
@@ -387,7 +387,7 @@ def get_from_cache(
     etag_timeout=10,
     resume_download=False,
     user_agent=None,
-    disable_outgoing=False,
+    local_files_only=False,
 ) -> Optional[str]:
     """
     Given a URL, look for the corresponding file in the local cache.
@@ -405,7 +405,7 @@ def get_from_cache(
     os.makedirs(cache_dir, exist_ok=True)
 
     etag = None
-    if not disable_outgoing:
+    if not local_files_only:
         # Get eTag to add to filename, if it exists.
         if url.startswith("s3://"):
             etag = s3_etag(url, proxies=proxies)
@@ -437,13 +437,13 @@ def get_from_cache(
             if len(matching_files) > 0:
                 return os.path.join(cache_dir, matching_files[-1])
             else:
-                # If files cannot be found and disable_outgoing=True,
-                # the models might've been found if disable_outgoing=False
+                # If files cannot be found and local_files_only=True,
+                # the models might've been found if local_files_only=False
                 # Notify the user about that
-                if disable_outgoing:
+                if local_files_only:
                     raise ValueError(
                         "Cannot find the requested files in the cached path and outgoing traffic has been"
-                        " disabled. To enable model look-ups and downloads online, set 'disable_outgoing'"
+                        " disabled. To enable model look-ups and downloads online, set 'local_files_only'"
                         " to False."
                     )
                 return None

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -463,7 +463,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             resolved_archive_file = None
 
         # Instantiate model.
-        print(model_kwargs)
         model = cls(config, *model_args, **model_kwargs)
 
         if state_dict is None and not from_tf:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -376,7 +376,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         resume_download = kwargs.pop("resume_download", False)
         proxies = kwargs.pop("proxies", None)
         output_loading_info = kwargs.pop("output_loading_info", False)
-        disable_outgoing = kwargs.pop("disable_outgoing", False)
+        local_files_only = kwargs.pop("local_files_only", False)
 
         # Load config if we don't provide a configuration
         if not isinstance(config, PretrainedConfig):
@@ -389,7 +389,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 force_download=force_download,
                 resume_download=resume_download,
                 proxies=proxies,
-                disable_outgoing=disable_outgoing,
+                local_files_only=local_files_only,
                 **kwargs,
             )
         else:
@@ -437,7 +437,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                     force_download=force_download,
                     proxies=proxies,
                     resume_download=resume_download,
-                    disable_outgoing=disable_outgoing,
+                    local_files_only=local_files_only,
                 )
             except EnvironmentError:
                 if pretrained_model_name_or_path in cls.pretrained_model_archive_map:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -376,6 +376,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         resume_download = kwargs.pop("resume_download", False)
         proxies = kwargs.pop("proxies", None)
         output_loading_info = kwargs.pop("output_loading_info", False)
+        disable_outgoing = kwargs.pop("disable_outgoing", False)
 
         # Load config if we don't provide a configuration
         if not isinstance(config, PretrainedConfig):
@@ -388,6 +389,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 force_download=force_download,
                 resume_download=resume_download,
                 proxies=proxies,
+                disable_outgoing=disable_outgoing,
                 **kwargs,
             )
         else:
@@ -435,6 +437,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                     force_download=force_download,
                     proxies=proxies,
                     resume_download=resume_download,
+                    disable_outgoing=disable_outgoing,
                 )
             except EnvironmentError:
                 if pretrained_model_name_or_path in cls.pretrained_model_archive_map:
@@ -460,6 +463,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             resolved_archive_file = None
 
         # Instantiate model.
+        print(model_kwargs)
         model = cls(config, *model_args, **model_kwargs)
 
         if state_dict is None and not from_tf:

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -380,6 +380,7 @@ class PreTrainedTokenizer(object):
         force_download = kwargs.pop("force_download", False)
         resume_download = kwargs.pop("resume_download", False)
         proxies = kwargs.pop("proxies", None)
+        disable_outgoing = kwargs.pop("disable_outgoing", False)
 
         s3_models = list(cls.max_model_input_sizes.keys())
         vocab_files = {}
@@ -447,6 +448,7 @@ class PreTrainedTokenizer(object):
                         force_download=force_download,
                         proxies=proxies,
                         resume_download=resume_download,
+                        disable_outgoing=disable_outgoing,
                     )
         except EnvironmentError:
             if pretrained_model_name_or_path in s3_models:

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -380,7 +380,7 @@ class PreTrainedTokenizer(object):
         force_download = kwargs.pop("force_download", False)
         resume_download = kwargs.pop("resume_download", False)
         proxies = kwargs.pop("proxies", None)
-        disable_outgoing = kwargs.pop("disable_outgoing", False)
+        local_files_only = kwargs.pop("local_files_only", False)
 
         s3_models = list(cls.max_model_input_sizes.keys())
         vocab_files = {}
@@ -448,7 +448,7 @@ class PreTrainedTokenizer(object):
                         force_download=force_download,
                         proxies=proxies,
                         resume_download=resume_download,
-                        disable_outgoing=disable_outgoing,
+                        local_files_only=local_files_only,
                     )
         except EnvironmentError:
             if pretrained_model_name_or_path in s3_models:


### PR DESCRIPTION
closes https://github.com/huggingface/transformers/issues/2867

Setting local_files_only=True disables outgoing traffic:
- etags are not looked up
- files are not downloaded (config, tokenizer, model)

An appropriate error is thrown when this argument may be the cause why a model cannot be loaded.

```python
import pyinstrument
from transformers import DistilBertConfig, DistilBertModel, DistilBertTokenizer


class TreeProfiler():
    def __init__(self, show_all=False):
        self.profiler = pyinstrument.Profiler()
        self.show_all = show_all # verbose output of pyinstrument profiler

    def __enter__(self):
        print("WITH TREE_PROFILER:")
        self.profiler.start()

    def __exit__(self, *args):
        self.profiler.stop()
        print(self.profiler.output_text(unicode=True, color=True, show_all=self.show_all))


def main():
    with TreeProfiler(show_all=True):
        config = DistilBertConfig.from_pretrained('distilbert-base-uncased', local_files_only=True)
        model = DistilBertModel.from_pretrained('distilbert-base-uncased', local_files_only=True)
        tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-uncased', local_files_only=True)


if __name__ == '__main__':
    main()
```

The above snippet will throw an error message when the expected files are not present in the cache.  When they are, though, everything is loaded fine without the need of any additional lookups.