### PR TITLE
Fix for case of multi-gpu

### DIFF
--- a/examples/run_language_modeling.py
+++ b/examples/run_language_modeling.py
@@ -274,8 +274,10 @@ def train(args, train_dataset, model: PreTrainedModel, tokenizer: PreTrainedToke
         and os.path.isfile(os.path.join(args.model_name_or_path, "scheduler.pt"))
     ):
         # Load in optimizer and scheduler states
-        optimizer.load_state_dict(torch.load(os.path.join(args.model_name_or_path, "optimizer.pt")))
-        scheduler.load_state_dict(torch.load(os.path.join(args.model_name_or_path, "scheduler.pt")))
+        optimizer.load_state_dict(torch.load(os.path.join(args.model_name_or_path, "optimizer.pt"),
+                                             map_location=args.device))
+        scheduler.load_state_dict(torch.load(os.path.join(args.model_name_or_path, "scheduler.pt"),
+                                             map_location=args.device))
 
     if args.fp16:
         try:


### PR DESCRIPTION
When loading the optimizer and the scheduler in a multi gpu, the loading will put the optimizer and scheduler in cuda:0, it might not have enough mem to temporary store them (until the to.device below).