### PR TITLE
Change masking to direct labeling for TPU support.

### DIFF
--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -1394,13 +1394,12 @@ class BertForTokenClassification(BertPreTrainedModel):
 
         outputs = (logits,) + outputs[2:]  # add hidden states and attention if they are here
         if labels is not None:
-            ignore_index = -100
-            loss_fct = CrossEntropyLoss(ignore_index=ignore_index)
+            loss_fct = CrossEntropyLoss()
             # Only keep active parts of the loss
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1
                 active_logits = logits.view(-1, self.num_labels)
-                active_labels = torch.where(active_loss, labels.view(-1), torch.tensor(ignore_index).type_as(labels))
+                active_labels = torch.where(active_loss, labels.view(-1), torch.tensor(loss_fct.ignore_index).type_as(labels))
                 loss = loss_fct(active_logits, active_labels)
             else:
                 loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))

--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -1400,8 +1400,7 @@ class BertForTokenClassification(BertPreTrainedModel):
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1
                 active_logits = logits.view(-1, self.num_labels)
-                active_labels = torch.where(active_loss, labels.view(-1),
-                                            torch.tensor(ignore_index).type_as(labels))
+                active_labels = torch.where(active_loss, labels.view(-1), torch.tensor(ignore_index).type_as(labels))
                 loss = loss_fct(active_logits, active_labels)
             else:
                 loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))

--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -1394,12 +1394,14 @@ class BertForTokenClassification(BertPreTrainedModel):
 
         outputs = (logits,) + outputs[2:]  # add hidden states and attention if they are here
         if labels is not None:
-            loss_fct = CrossEntropyLoss()
+            ignore_index = -100
+            loss_fct = CrossEntropyLoss(ignore_index=ignore_index)
             # Only keep active parts of the loss
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1
-                active_logits = logits.view(-1, self.num_labels)[active_loss]
-                active_labels = labels.view(-1)[active_loss]
+                active_logits = logits.view(-1, self.num_labels)
+                active_labels = torch.where(active_loss, labels.view(-1),
+                                            torch.tensor(ignore_index).type_as(labels))
                 loss = loss_fct(active_logits, active_labels)
             else:
                 loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))

--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -1399,7 +1399,9 @@ class BertForTokenClassification(BertPreTrainedModel):
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1
                 active_logits = logits.view(-1, self.num_labels)
-                active_labels = torch.where(active_loss, labels.view(-1), torch.tensor(loss_fct.ignore_index).type_as(labels))
+                active_labels = torch.where(
+                    active_loss, labels.view(-1), torch.tensor(loss_fct.ignore_index).type_as(labels)
+                )
                 loss = loss_fct(active_logits, active_labels)
             else:
                 loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))

--- a/src/transformers/modeling_distilbert.py
+++ b/src/transformers/modeling_distilbert.py
@@ -824,8 +824,7 @@ class DistilBertForTokenClassification(DistilBertPreTrainedModel):
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1
                 active_logits = logits.view(-1, self.num_labels)
-                active_labels = torch.where(active_loss, labels.view(-1),
-                                            torch.tensor(ignore_index).type_as(labels))
+                active_labels = torch.where(active_loss, labels.view(-1), torch.tensor(ignore_index).type_as(labels))
                 loss = loss_fct(active_logits, active_labels)
             else:
                 loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))

--- a/src/transformers/modeling_distilbert.py
+++ b/src/transformers/modeling_distilbert.py
@@ -823,7 +823,9 @@ class DistilBertForTokenClassification(DistilBertPreTrainedModel):
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1
                 active_logits = logits.view(-1, self.num_labels)
-                active_labels = torch.where(active_loss, labels.view(-1), torch.tensor(loss_fct.ignore_index).type_as(labels))
+                active_labels = torch.where(
+                    active_loss, labels.view(-1), torch.tensor(loss_fct.ignore_index).type_as(labels)
+                )
                 loss = loss_fct(active_logits, active_labels)
             else:
                 loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))

--- a/src/transformers/modeling_distilbert.py
+++ b/src/transformers/modeling_distilbert.py
@@ -818,7 +818,7 @@ class DistilBertForTokenClassification(DistilBertPreTrainedModel):
 
         outputs = (logits,) + outputs[2:]  # add hidden states and attention if they are here
         if labels is not None:
-            loss_fct = CrossEntropyLoss(ignore_index=ignore_index)
+            loss_fct = CrossEntropyLoss()
             # Only keep active parts of the loss
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1

--- a/src/transformers/modeling_distilbert.py
+++ b/src/transformers/modeling_distilbert.py
@@ -818,13 +818,12 @@ class DistilBertForTokenClassification(DistilBertPreTrainedModel):
 
         outputs = (logits,) + outputs[2:]  # add hidden states and attention if they are here
         if labels is not None:
-            ignore_index = -100
             loss_fct = CrossEntropyLoss(ignore_index=ignore_index)
             # Only keep active parts of the loss
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1
                 active_logits = logits.view(-1, self.num_labels)
-                active_labels = torch.where(active_loss, labels.view(-1), torch.tensor(ignore_index).type_as(labels))
+                active_labels = torch.where(active_loss, labels.view(-1), torch.tensor(loss_fct.ignore_index).type_as(labels))
                 loss = loss_fct(active_logits, active_labels)
             else:
                 loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))

--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -553,13 +553,16 @@ class RobertaForTokenClassification(BertPreTrainedModel):
         logits = self.classifier(sequence_output)
 
         outputs = (logits,) + outputs[2:]  # add hidden states and attention if they are here
+        
         if labels is not None:
-            loss_fct = CrossEntropyLoss()
+            ignore_index = -100
+            loss_fct = CrossEntropyLoss(ignore_index=ignore_index)
             # Only keep active parts of the loss
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1
-                active_logits = logits.view(-1, self.num_labels)[active_loss]
-                active_labels = labels.view(-1)[active_loss]
+                active_logits = logits.view(-1, self.num_labels)
+                active_labels = torch.where(active_loss, labels.view(-1),
+                                            torch.tensor(ignore_index).type_as(labels))
                 loss = loss_fct(active_logits, active_labels)
             else:
                 loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))

--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -555,13 +555,12 @@ class RobertaForTokenClassification(BertPreTrainedModel):
         outputs = (logits,) + outputs[2:]  # add hidden states and attention if they are here
 
         if labels is not None:
-            ignore_index = -100
             loss_fct = CrossEntropyLoss(ignore_index=ignore_index)
             # Only keep active parts of the loss
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1
                 active_logits = logits.view(-1, self.num_labels)
-                active_labels = torch.where(active_loss, labels.view(-1), torch.tensor(ignore_index).type_as(labels))
+                active_labels = torch.where(active_loss, labels.view(-1), torch.tensor(loss_fct.ignore_index).type_as(labels))
                 loss = loss_fct(active_logits, active_labels)
             else:
                 loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))

--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -555,7 +555,7 @@ class RobertaForTokenClassification(BertPreTrainedModel):
         outputs = (logits,) + outputs[2:]  # add hidden states and attention if they are here
 
         if labels is not None:
-            loss_fct = CrossEntropyLoss(ignore_index=ignore_index)
+            loss_fct = CrossEntropyLoss()
             # Only keep active parts of the loss
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1

--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -560,7 +560,9 @@ class RobertaForTokenClassification(BertPreTrainedModel):
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1
                 active_logits = logits.view(-1, self.num_labels)
-                active_labels = torch.where(active_loss, labels.view(-1), torch.tensor(loss_fct.ignore_index).type_as(labels))
+                active_labels = torch.where(
+                    active_loss, labels.view(-1), torch.tensor(loss_fct.ignore_index).type_as(labels)
+                )
                 loss = loss_fct(active_logits, active_labels)
             else:
                 loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))

--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -553,7 +553,7 @@ class RobertaForTokenClassification(BertPreTrainedModel):
         logits = self.classifier(sequence_output)
 
         outputs = (logits,) + outputs[2:]  # add hidden states and attention if they are here
-        
+
         if labels is not None:
             ignore_index = -100
             loss_fct = CrossEntropyLoss(ignore_index=ignore_index)
@@ -561,8 +561,7 @@ class RobertaForTokenClassification(BertPreTrainedModel):
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1
                 active_logits = logits.view(-1, self.num_labels)
-                active_labels = torch.where(active_loss, labels.view(-1),
-                                            torch.tensor(ignore_index).type_as(labels))
+                active_labels = torch.where(active_loss, labels.view(-1), torch.tensor(ignore_index).type_as(labels))
                 loss = loss_fct(active_logits, active_labels)
             else:
                 loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))

--- a/src/transformers/modeling_xlnet.py
+++ b/src/transformers/modeling_xlnet.py
@@ -1264,8 +1264,7 @@ class XLNetForTokenClassification(XLNetPreTrainedModel):
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1
                 active_logits = logits.view(-1, self.num_labels)
-                active_labels = torch.where(active_loss, labels.view(-1),
-                                            torch.tensor(ignore_index).type_as(labels))
+                active_labels = torch.where(active_loss, labels.view(-1), torch.tensor(ignore_index).type_as(labels))
                 loss = loss_fct(active_logits, active_labels)
             else:
                 loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))

--- a/src/transformers/modeling_xlnet.py
+++ b/src/transformers/modeling_xlnet.py
@@ -1258,13 +1258,12 @@ class XLNetForTokenClassification(XLNetPreTrainedModel):
 
         outputs = (logits,) + outputs[1:]  # Keep mems, hidden states, attentions if there are in it
         if labels is not None:
-            ignore_index = -100
             loss_fct = CrossEntropyLoss(ignore_index=ignore_index)
             # Only keep active parts of the loss
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1
                 active_logits = logits.view(-1, self.num_labels)
-                active_labels = torch.where(active_loss, labels.view(-1), torch.tensor(ignore_index).type_as(labels))
+                active_labels = torch.where(active_loss, labels.view(-1), torch.tensor(loss_fct.ignore_index).type_as(labels))
                 loss = loss_fct(active_logits, active_labels)
             else:
                 loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))

--- a/src/transformers/modeling_xlnet.py
+++ b/src/transformers/modeling_xlnet.py
@@ -1263,7 +1263,9 @@ class XLNetForTokenClassification(XLNetPreTrainedModel):
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1
                 active_logits = logits.view(-1, self.num_labels)
-                active_labels = torch.where(active_loss, labels.view(-1), torch.tensor(loss_fct.ignore_index).type_as(labels))
+                active_labels = torch.where(
+                    active_loss, labels.view(-1), torch.tensor(loss_fct.ignore_index).type_as(labels)
+                )
                 loss = loss_fct(active_logits, active_labels)
             else:
                 loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))

--- a/src/transformers/modeling_xlnet.py
+++ b/src/transformers/modeling_xlnet.py
@@ -1258,7 +1258,7 @@ class XLNetForTokenClassification(XLNetPreTrainedModel):
 
         outputs = (logits,) + outputs[1:]  # Keep mems, hidden states, attentions if there are in it
         if labels is not None:
-            loss_fct = CrossEntropyLoss(ignore_index=ignore_index)
+            loss_fct = CrossEntropyLoss()
             # Only keep active parts of the loss
             if attention_mask is not None:
                 active_loss = attention_mask.view(-1) == 1


### PR DESCRIPTION
Torch XLA conversion is very sensitive to certain core pytorch operations. These result in TPU being slower than CPU operation. The most obvious are binary masking and calls to item(). 

https://github.com/pytorch/xla/blob/master/TROUBLESHOOTING.md

This PR replaces some of these calls that are in the example/NER pathway. 
