### PR TITLE
Add preprocessing step for transfo-xl tokenization to avoid tokenizing words followed by punction to <unk>

### DIFF
--- a/examples/run_generation.py
+++ b/examples/run_generation.py
@@ -214,7 +214,9 @@ def main():
     if requires_preprocessing:
         prepare_input = PREPROCESSING_FUNCTIONS.get(args.model_type)
         preprocessed_prompt_text = prepare_input(args, model, tokenizer, prompt_text)
-        encoded_prompt = tokenizer.encode(preprocessed_prompt_text, add_special_tokens=False, return_tensors="pt", add_space_before_punct_symbol=True)
+        encoded_prompt = tokenizer.encode(
+            preprocessed_prompt_text, add_special_tokens=False, return_tensors="pt", add_space_before_punct_symbol=True
+        )
     else:
         encoded_prompt = tokenizer.encode(prompt_text, add_special_tokens=False, return_tensors="pt")
     encoded_prompt = encoded_prompt.to(args.device)

--- a/examples/run_generation.py
+++ b/examples/run_generation.py
@@ -59,7 +59,7 @@ MODEL_CLASSES = {
 # Padding text to help Transformer-XL and XLNet with short prompts as proposed by Aman Rusia
 # in https://github.com/rusiaaman/XLNet-gen#methodology
 # and https://medium.com/@amanrusia/xlnet-speaks-comparison-to-gpt-2-ea1a4e9ba39e
-PADDING_TEXT = """ In 1991, the remains of Russian Tsar Nicholas II and his family
+PADDING_TEXT = """In 1991, the remains of Russian Tsar Nicholas II and his family
 (except for Alexei and Maria) are discovered.
 The voice of Nicholas's young son, Tsarevich Alexei Nikolaevich, narrates the
 remainder of the story. 1883 Western Siberia,
@@ -214,7 +214,7 @@ def main():
     if requires_preprocessing:
         prepare_input = PREPROCESSING_FUNCTIONS.get(args.model_type)
         preprocessed_prompt_text = prepare_input(args, model, tokenizer, prompt_text)
-        encoded_prompt = tokenizer.encode(preprocessed_prompt_text, add_special_tokens=False, return_tensors="pt")
+        encoded_prompt = tokenizer.encode(preprocessed_prompt_text, add_special_tokens=False, return_tensors="pt", add_space_before_punct_symbol=True)
     else:
         encoded_prompt = tokenizer.encode(prompt_text, add_special_tokens=False, return_tensors="pt")
     encoded_prompt = encoded_prompt.to(args.device)

--- a/src/transformers/tokenization_transfo_xl.py
+++ b/src/transformers/tokenization_transfo_xl.py
@@ -299,15 +299,17 @@ class TransfoXLTokenizer(PreTrainedTokenizer):
 
     def prepare_for_tokenization(self, text, **kwargs):
 
-        look_ahead_for_special_token = '(?=[{}])'.format(self.punctuation_symbols)
-        look_ahead_to_match_all_except_space = '(?=[^\s])'  # noqa: W605
-        punction_without_space_before = '[^\s][{}]'.format(self.punctuation_symbols)  # noqa: W605
+        look_ahead_for_special_token = "(?=[{}])".format(self.punctuation_symbols)
+        look_ahead_to_match_all_except_space = "(?=[^\s])"  # noqa: W605
+        punction_without_space_before = "[^\s][{}]".format(self.punctuation_symbols)  # noqa: W605
         # add spaces before punctuation symbols as should be done in transfo-xl
         if "add_space_before_punct_symbol" in kwargs and kwargs["add_space_before_punct_symbol"]:
-            text = re.sub(r'' + look_ahead_for_special_token + look_ahead_to_match_all_except_space, r' ', text)
+            text = re.sub(r"" + look_ahead_for_special_token + look_ahead_to_match_all_except_space, r" ", text)
         elif re.search(punction_without_space_before, text):
             # searches until the first occurence of a punctuation symbol without surrounding spaces
-            logger.warning('You might want to consider setting `add_space_before_punct_symbol=True` as an argument to the `tokenizer.encode()` to avoid tokenizing words with punctuation symbols to the `<unk>` token')
+            logger.warning(
+                "You might want to consider setting `add_space_before_punct_symbol=True` as an argument to the `tokenizer.encode()` to avoid tokenizing words with punctuation symbols to the `<unk>` token"
+            )
         return text
 
 

--- a/src/transformers/tokenization_transfo_xl.py
+++ b/src/transformers/tokenization_transfo_xl.py
@@ -115,7 +115,9 @@ class TransfoXLTokenizer(PreTrainedTokenizer):
         self.delimiter = delimiter
         self.vocab_file = vocab_file
         self.never_split = never_split
-        self.punctuation_symbols = '!"#$%&\()*+,-./:;<=>?@[\\]^_`{|}~'  # noqa: W605
+        self.punctuation_symbols = '!"#$%&()*+,-./\:;<=>?@[\\]^_`{|}~'  # noqa: W605
+        self.punction_without_space_before_pattern = re.compile(r"[^\s][{}]".format(self.punctuation_symbols))
+        self.punctuation_with_space_around_pattern = self._compile_space_around_punctuation_pattern()
 
         if pretrained_vocab_file is not None:
             # Hack because, honestly this tokenizer was not made to be used
@@ -127,6 +129,11 @@ class TransfoXLTokenizer(PreTrainedTokenizer):
 
         if vocab_file is not None:
             self.build_vocab()
+
+    def _compile_space_around_punctuation_pattern(self):
+        look_ahead_for_special_token = "(?=[{}])".format(self.punctuation_symbols)
+        look_ahead_to_match_all_except_space = "(?=[^\s])"  # noqa: W605
+        return re.compile(r"" + look_ahead_for_special_token + look_ahead_to_match_all_except_space)
 
     def count_file(self, path, verbose=False, add_eos=False):
         if verbose:
@@ -298,18 +305,16 @@ class TransfoXLTokenizer(PreTrainedTokenizer):
             return symbols
 
     def prepare_for_tokenization(self, text, **kwargs):
-
-        look_ahead_for_special_token = "(?=[{}])".format(self.punctuation_symbols)
-        look_ahead_to_match_all_except_space = "(?=[^\s])"  # noqa: W605
-        punction_without_space_before = "[^\s][{}]".format(self.punctuation_symbols)  # noqa: W605
         # add spaces before punctuation symbols as should be done in transfo-xl
+
         if "add_space_before_punct_symbol" in kwargs and kwargs["add_space_before_punct_symbol"]:
-            text = re.sub(r"" + look_ahead_for_special_token + look_ahead_to_match_all_except_space, r" ", text)
-        elif re.search(punction_without_space_before, text):
+            text = self.punctuation_with_space_around_pattern.sub(r" ", text)
+        elif self.punction_without_space_before_pattern.search(text):
             # searches until the first occurence of a punctuation symbol without surrounding spaces
             logger.warning(
                 "You might want to consider setting `add_space_before_punct_symbol=True` as an argument to the `tokenizer.encode()` to avoid tokenizing words with punctuation symbols to the `<unk>` token"
             )
+
         return text
 
 

--- a/src/transformers/tokenization_transfo_xl.py
+++ b/src/transformers/tokenization_transfo_xl.py
@@ -295,6 +295,15 @@ class TransfoXLTokenizer(PreTrainedTokenizer):
         else:
             return symbols
 
+    def prepare_for_tokenization(self, text, **kwargs):
+        if "add_space_before_punct_symbol" in kwargs and kwargs["add_space_before_punct_symbol"]:
+            import re
+            punctuation = '!"#$%&\()*+,-./:;<=>?@[\\]^_`{|}~'  # noqa: W605
+            look_ahead_for_special_token = '(?=[{}])'.format(punctuation)
+            look_ahead_to_match_all_except_space = '(?=[^\s])'  # noqa: W605
+            text = re.sub(r'' + look_ahead_for_special_token + look_ahead_to_match_all_except_space, r' ', text)
+        return text
+
 
 class _TransfoXLDelimiterLookupTokenizer(BaseTokenizer):
     def __init__(


### PR DESCRIPTION
The problem is well shown in Issue #2000 .
This PR adds a preprocessing step to transfo-xl tokenization to better deal with the problem.
