### PR TITLE
[WIP] Remove tokenizers dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ make test-examples
 
 For details, refer to the [contributing guide](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#tests).
 
+### Do you want to try out the new, blazingly fast tokenizers?
+
+The [`tokenizers`](https://github.com/huggingface/tokenizers) is currently being integrated into `transformers`. For large parts of the library, you can already try it out! To do so, simply install `tokenizers` and load a _fast_ tokenizer, for instance by using `AutoTokenizer`:
+
+```python
+tokenizer = AutoTokenizer.from_pretrained('bert-base-uncased', use_fast=True)
+``` 
+
 ### Do you want to run a Transformer model on a mobile device?
 
 You should check out our [`swift-coreml-transformers`](https://github.com/huggingface/swift-coreml-transformers) repo.

--- a/setup.py
+++ b/setup.py
@@ -91,8 +91,7 @@ setup(
     package_dir={"": "src"},
     packages=find_packages("src"),
     install_requires=[
-        "numpy",
-        "tokenizers == 0.5.2",
+        "numpy"
         # accessing files from S3 directly
         "boto3",
         # filesystem locks e.g. to prevent parallel downloads

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
     package_dir={"": "src"},
     packages=find_packages("src"),
     install_requires=[
-        "numpy"
+        "numpy",
         # accessing files from S3 directly
         "boto3",
         # filesystem locks e.g. to prevent parallel downloads

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -82,6 +82,14 @@ except (AttributeError, ImportError):
         "PYTORCH_TRANSFORMERS_CACHE", os.getenv("PYTORCH_PRETRAINED_BERT_CACHE", default_cache_path)
     )
 
+try:
+    import tokenizers
+    _tokenizers_available = True  # pylint: disable=invalid-name
+    logger.info("Tokenizers version {} available.".format(tokenizers.__version__))
+except ImportError:
+    logger.info("Fast tokenizers not available")
+    _tokenizers_available = False  # pylint: disable=invalid-name
+
 PYTORCH_TRANSFORMERS_CACHE = PYTORCH_PRETRAINED_BERT_CACHE  # Kept for backward compatibility
 TRANSFORMERS_CACHE = PYTORCH_PRETRAINED_BERT_CACHE  # Kept for backward compatibility
 
@@ -107,6 +115,8 @@ def is_torch_available():
 def is_tf_available():
     return _tf_available
 
+def is_tokenizers_available():
+    return _tokenizers_available
 
 def add_start_docstrings(*docstr):
     def docstring_decorator(fn):

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -84,6 +84,7 @@ except (AttributeError, ImportError):
 
 try:
     import tokenizers
+
     _tokenizers_available = True  # pylint: disable=invalid-name
     logger.info("Tokenizers version {} available.".format(tokenizers.__version__))
 except ImportError:
@@ -115,8 +116,10 @@ def is_torch_available():
 def is_tf_available():
     return _tf_available
 
+
 def is_tokenizers_available():
     return _tokenizers_available
+
 
 def add_start_docstrings(*docstr):
     def docstring_decorator(fn):

--- a/src/transformers/tokenization_auto.py
+++ b/src/transformers/tokenization_auto.py
@@ -37,6 +37,7 @@ from .configuration_auto import (
     XLNetConfig,
 )
 from .configuration_utils import PretrainedConfig
+from .file_utils import is_tokenizers_available
 from .tokenization_albert import AlbertTokenizer
 from .tokenization_bart import BartTokenizer
 from .tokenization_bert import BertTokenizer, BertTokenizerFast
@@ -53,8 +54,6 @@ from .tokenization_transfo_xl import TransfoXLTokenizer, TransfoXLTokenizerFast
 from .tokenization_xlm import XLMTokenizer
 from .tokenization_xlm_roberta import XLMRobertaTokenizer
 from .tokenization_xlnet import XLNetTokenizer
-
-from .file_utils import is_tokenizers_available
 
 
 logger = logging.getLogger(__name__)

--- a/src/transformers/tokenization_auto.py
+++ b/src/transformers/tokenization_auto.py
@@ -54,6 +54,8 @@ from .tokenization_xlm import XLMTokenizer
 from .tokenization_xlm_roberta import XLMRobertaTokenizer
 from .tokenization_xlnet import XLNetTokenizer
 
+from .file_utils import is_tokenizers_available
+
 
 logger = logging.getLogger(__name__)
 
@@ -186,7 +188,7 @@ class AutoTokenizer:
         use_fast = kwargs.pop("use_fast", False)
         for config_class, (tokenizer_class_py, tokenizer_class_fast) in TOKENIZER_MAPPING.items():
             if isinstance(config, config_class):
-                if tokenizer_class_fast and use_fast:
+                if tokenizer_class_fast and use_fast and is_tokenizers_available():
                     return tokenizer_class_fast.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
                 else:
                     return tokenizer_class_py.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)

--- a/src/transformers/tokenization_auto.py
+++ b/src/transformers/tokenization_auto.py
@@ -159,7 +159,7 @@ class AutoTokenizer:
                 The proxies are used on each request.
 
             use_fast: (`optional`) boolean, default False:
-                Indicate if transformers should try to load the fast version of the tokenizer (True) or use the Python one (False).
+                Indicate if transformers should try to load the fast version of the tokenizer (True) or use the Python one (False). Requires the ``tokenizers`` library to be installed.
 
             inputs: (`optional`) positional arguments: will be passed to the Tokenizer ``__init__`` method.
 
@@ -175,6 +175,9 @@ class AutoTokenizer:
 
             # If vocabulary files are in a directory (e.g. tokenizer was saved using `save_pretrained('./test/saved_model/')`)
             tokenizer = AutoTokenizer.from_pretrained('./test/bert_saved_model/')
+
+            # Use fast tokenizer when available:
+            tokenizer = AutoTokenizer.from_pretrained('bert-base-uncased', use_fast=True)
 
         """
         config = kwargs.pop("config", None)

--- a/src/transformers/tokenization_bert.py
+++ b/src/transformers/tokenization_bert.py
@@ -20,9 +20,14 @@ import logging
 import os
 import unicodedata
 
-from tokenizers import BertWordPieceTokenizer
+
+from .file_utils import is_tokenizers_available
 
 from .tokenization_utils import PreTrainedTokenizer, PreTrainedTokenizerFast
+
+
+if is_tokenizers_available():
+    from tokenizers import BertWordPieceTokenizer
 
 
 logger = logging.getLogger(__name__)
@@ -559,6 +564,10 @@ class BertTokenizerFast(PreTrainedTokenizerFast):
         wordpieces_prefix="##",
         **kwargs
     ):
+        if not is_tokenizers_available():
+            raise ImportError(
+                "Install `tokenizers` to use the fast tokenizers. See https://github.com/huggingface/tokenizers")
+
         super().__init__(
             BertWordPieceTokenizer(
                 vocab_file=vocab_file,

--- a/src/transformers/tokenization_bert.py
+++ b/src/transformers/tokenization_bert.py
@@ -20,9 +20,7 @@ import logging
 import os
 import unicodedata
 
-
 from .file_utils import is_tokenizers_available
-
 from .tokenization_utils import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 
@@ -566,7 +564,8 @@ class BertTokenizerFast(PreTrainedTokenizerFast):
     ):
         if not is_tokenizers_available():
             raise ImportError(
-                "Install `tokenizers` to use the fast tokenizers. See https://github.com/huggingface/tokenizers")
+                "Install `tokenizers` to use the fast tokenizers. See https://github.com/huggingface/tokenizers"
+            )
 
         super().__init__(
             BertWordPieceTokenizer(

--- a/src/transformers/tokenization_gpt2.py
+++ b/src/transformers/tokenization_gpt2.py
@@ -23,11 +23,13 @@ from functools import lru_cache
 import regex as re
 
 from .file_utils import is_tokenizers_available
+from .tokenization_utils import PreTrainedTokenizer, PreTrainedTokenizerFast
+
+
 if is_tokenizers_available():
     from tokenizers import ByteLevelBPETokenizer
 
 
-from .tokenization_utils import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 
 logger = logging.getLogger(__name__)

--- a/src/transformers/tokenization_gpt2.py
+++ b/src/transformers/tokenization_gpt2.py
@@ -21,7 +21,11 @@ import os
 from functools import lru_cache
 
 import regex as re
-from tokenizers import ByteLevelBPETokenizer
+
+from .file_utils import is_tokenizers_available
+if is_tokenizers_available():
+    from tokenizers import ByteLevelBPETokenizer
+
 
 from .tokenization_utils import PreTrainedTokenizer, PreTrainedTokenizerFast
 

--- a/src/transformers/tokenization_openai.py
+++ b/src/transformers/tokenization_openai.py
@@ -21,15 +21,22 @@ import os
 import re
 from typing import List, Optional, Union
 
-from tokenizers import Tokenizer
-from tokenizers.decoders import BPEDecoder
-from tokenizers.implementations import BaseTokenizer
-from tokenizers.models import BPE
-from tokenizers.normalizers import BertNormalizer, Sequence, unicode_normalizer_from_str
-from tokenizers.pre_tokenizers import BertPreTokenizer
-from tokenizers.trainers import BpeTrainer
-
 from .tokenization_bert import BasicTokenizer
+from .file_utils import is_tokenizers_available
+if is_tokenizers_available():
+    from tokenizers import Tokenizer
+    from tokenizers.decoders import BPEDecoder
+    from tokenizers.implementations import BaseTokenizer
+    from tokenizers.models import BPE
+    from tokenizers.normalizers import BertNormalizer, Sequence, unicode_normalizer_from_str
+    from tokenizers.pre_tokenizers import BertPreTokenizer
+    from tokenizers.trainers import BpeTrainer
+else:
+    # only to please the tests, BaseTokenizer is never
+    # actually replaced by BasicTokenizer
+    BaseTokenizer = BasicTokenizer
+
+
 from .tokenization_utils import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 
@@ -311,6 +318,10 @@ class OpenAIGPTTokenizerFast(PreTrainedTokenizerFast):
     max_model_input_sizes = PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES
 
     def __init__(self, vocab_file, merges_file, unk_token="<unk>", **kwargs):
+        if not is_tokenizers_available():
+            raise ImportError(
+                "Install `tokenizers` to use the fast tokenizers. See https://github.com/huggingface/tokenizers")
+
         kwargs.setdefault("unk_token", unk_token)
         super().__init__(
             _OpenAIGPTCharBPETokenizer(vocab_file=vocab_file, merges_file=merges_file, unk_token=unk_token), **kwargs

--- a/src/transformers/tokenization_openai.py
+++ b/src/transformers/tokenization_openai.py
@@ -21,8 +21,11 @@ import os
 import re
 from typing import List, Optional, Union
 
-from .tokenization_bert import BasicTokenizer
 from .file_utils import is_tokenizers_available
+from .tokenization_bert import BasicTokenizer
+from .tokenization_utils import PreTrainedTokenizer, PreTrainedTokenizerFast
+
+
 if is_tokenizers_available():
     from tokenizers import Tokenizer
     from tokenizers.decoders import BPEDecoder
@@ -37,7 +40,6 @@ else:
     BaseTokenizer = BasicTokenizer
 
 
-from .tokenization_utils import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 
 logger = logging.getLogger(__name__)
@@ -320,7 +322,8 @@ class OpenAIGPTTokenizerFast(PreTrainedTokenizerFast):
     def __init__(self, vocab_file, merges_file, unk_token="<unk>", **kwargs):
         if not is_tokenizers_available():
             raise ImportError(
-                "Install `tokenizers` to use the fast tokenizers. See https://github.com/huggingface/tokenizers")
+                "Install `tokenizers` to use the fast tokenizers. See https://github.com/huggingface/tokenizers"
+            )
 
         kwargs.setdefault("unk_token", unk_token)
         super().__init__(

--- a/src/transformers/tokenization_roberta.py
+++ b/src/transformers/tokenization_roberta.py
@@ -16,8 +16,11 @@
 
 
 import logging
+from .file_utils import is_tokenizers_available
 
-from tokenizers.processors import RobertaProcessing
+if is_tokenizers_available():
+    from tokenizers.processors import RobertaProcessing
+
 
 from .tokenization_gpt2 import GPT2Tokenizer, GPT2TokenizerFast
 

--- a/src/transformers/tokenization_roberta.py
+++ b/src/transformers/tokenization_roberta.py
@@ -16,13 +16,15 @@
 
 
 import logging
+
 from .file_utils import is_tokenizers_available
+from .tokenization_gpt2 import GPT2Tokenizer, GPT2TokenizerFast
+
 
 if is_tokenizers_available():
     from tokenizers.processors import RobertaProcessing
 
 
-from .tokenization_gpt2 import GPT2Tokenizer, GPT2TokenizerFast
 
 
 logger = logging.getLogger(__name__)

--- a/src/transformers/tokenization_transfo_xl.py
+++ b/src/transformers/tokenization_transfo_xl.py
@@ -28,8 +28,11 @@ from typing import List, Optional, Tuple, Union
 
 import numpy as np
 
-from .file_utils import cached_path, is_torch_available, is_tokenizers_available
+from .file_utils import cached_path, is_tokenizers_available, is_torch_available
 from .tokenization_bert import BasicTokenizer
+from .tokenization_utils import PreTrainedTokenizer, PreTrainedTokenizerFast
+
+
 if is_tokenizers_available():
     from tokenizers import Encoding, Tokenizer
     from tokenizers.implementations import BaseTokenizer
@@ -44,7 +47,6 @@ else:
     # to pass the tests: 'Encoding' is used in typing
     Encoding = None
 
-from .tokenization_utils import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 
 if is_torch_available():
@@ -436,7 +438,8 @@ class TransfoXLTokenizerFast(PreTrainedTokenizerFast):
     ):
         if not is_tokenizers_available():
             raise ImportError(
-                "Install `tokenizers` to use the fast tokenizers. See https://github.com/huggingface/tokenizers")
+                "Install `tokenizers` to use the fast tokenizers. See https://github.com/huggingface/tokenizers"
+            )
         super().__init__(
             _TransfoXLDelimiterLookupTokenizer(
                 vocab_file=vocab_file or pretrained_vocab_file,

--- a/src/transformers/tokenization_transfo_xl.py
+++ b/src/transformers/tokenization_transfo_xl.py
@@ -27,14 +27,23 @@ from collections import Counter, OrderedDict
 from typing import List, Optional, Tuple, Union
 
 import numpy as np
-from tokenizers import Encoding, Tokenizer
-from tokenizers.implementations import BaseTokenizer
-from tokenizers.models import WordLevel
-from tokenizers.normalizers import Lowercase, Sequence, unicode_normalizer_from_str
-from tokenizers.pre_tokenizers import CharDelimiterSplit, WhitespaceSplit
-from tokenizers.processors import BertProcessing
 
-from .file_utils import cached_path, is_torch_available
+from .file_utils import cached_path, is_torch_available, is_tokenizers_available
+from .tokenization_bert import BasicTokenizer
+if is_tokenizers_available():
+    from tokenizers import Encoding, Tokenizer
+    from tokenizers.implementations import BaseTokenizer
+    from tokenizers.models import WordLevel
+    from tokenizers.normalizers import Lowercase, Sequence, unicode_normalizer_from_str
+    from tokenizers.pre_tokenizers import CharDelimiterSplit, WhitespaceSplit
+    from tokenizers.processors import BertProcessing
+else:
+    # only to please the tests, BaseTokenizer is never
+    # actually replaced by BasicTokenizer
+    BaseTokenizer = BasicTokenizer
+    # to pass the tests: 'Encoding' is used in typing
+    Encoding = None
+
 from .tokenization_utils import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 
@@ -425,7 +434,9 @@ class TransfoXLTokenizerFast(PreTrainedTokenizerFast):
         normalization=None,
         **kwargs
     ):
-
+        if not is_tokenizers_available():
+            raise ImportError(
+                "Install `tokenizers` to use the fast tokenizers. See https://github.com/huggingface/tokenizers")
         super().__init__(
             _TransfoXLDelimiterLookupTokenizer(
                 vocab_file=vocab_file or pretrained_vocab_file,

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -23,8 +23,15 @@ import re
 from collections import defaultdict
 from contextlib import contextmanager
 
+from .file_utils import (
+    cached_path,
+    hf_bucket_url,
+    is_remote_url,
+    is_tf_available,
+    is_tokenizers_available,
+    is_torch_available,
+)
 
-from .file_utils import cached_path, hf_bucket_url, is_remote_url, is_tf_available, is_torch_available, is_tokenizers_available
 
 if is_tf_available():
     import tensorflow as tf
@@ -1611,7 +1618,9 @@ class PreTrainedTokenizer(object):
 class PreTrainedTokenizerFast(PreTrainedTokenizer):
     def __init__(self, tokenizer: BaseTokenizer, **kwargs):
         if not is_tokenizers_available():
-            raise ImportError("Install `tokenizers` to use the fast tokenizers. See https://github.com/huggingface/tokenizers")
+            raise ImportError(
+                "Install `tokenizers` to use the fast tokenizers. See https://github.com/huggingface/tokenizers"
+            )
 
         if tokenizer is None:
             raise ValueError("Provided tokenizer cannot be None")

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -23,15 +23,18 @@ import re
 from collections import defaultdict
 from contextlib import contextmanager
 
-from tokenizers.implementations import BaseTokenizer
 
-from .file_utils import cached_path, hf_bucket_url, is_remote_url, is_tf_available, is_torch_available
-
+from .file_utils import cached_path, hf_bucket_url, is_remote_url, is_tf_available, is_torch_available, is_tokenizers_available
 
 if is_tf_available():
     import tensorflow as tf
 if is_torch_available():
     import torch
+if is_tokenizers_available():
+    from tokenizers.implementations import BaseTokenizer
+else:
+    # To make PEP happy
+    BaseTokenizer = object()
 
 logger = logging.getLogger(__name__)
 
@@ -1607,6 +1610,9 @@ class PreTrainedTokenizer(object):
 
 class PreTrainedTokenizerFast(PreTrainedTokenizer):
     def __init__(self, tokenizer: BaseTokenizer, **kwargs):
+        if not is_tokenizers_available():
+            raise ImportError("Install `tokenizers` to use the fast tokenizers. See https://github.com/huggingface/tokenizers")
+
         if tokenizer is None:
             raise ValueError("Provided tokenizer cannot be None")
         self._tokenizer = tokenizer

--- a/src/transformers/tokenization_xlm_roberta.py
+++ b/src/transformers/tokenization_xlm_roberta.py
@@ -19,7 +19,7 @@ import logging
 import os
 from shutil import copyfile
 
-from transformers.tokenization_utils import PreTrainedTokenizer
+from .tokenization_utils import PreTrainedTokenizer
 
 from .tokenization_xlnet import SPIECE_UNDERLINE
 

--- a/src/transformers/tokenization_xlm_roberta.py
+++ b/src/transformers/tokenization_xlm_roberta.py
@@ -20,7 +20,6 @@ import os
 from shutil import copyfile
 
 from .tokenization_utils import PreTrainedTokenizer
-
 from .tokenization_xlnet import SPIECE_UNDERLINE
 
 


### PR DESCRIPTION
In v2.5.1 the tokenizers don't default to the fast implementations (as introduced in v2.5.0), which I think is a good thing when looking at the issues that have arisen from it. Even though the performance of the new tokenizers is phenomenal (and I complement everyone who has been working on it!), it seems a bit premature to make `tokenizers` a dependency. (In addition, see for instance this topic concerning installation issues: https://github.com/huggingface/transformers/issues/2980.)

Even though the fast implementation isn't the default any more, it is still part of the dependencies in setup.py. This PR removes `tokenizers` from the dependency list but indicates in the documentation that having `tokenizers` installed and using `use_fast` can result in great performance improvements.

Generally, I am not satisfied with how this PR has been implemented (quite some duplication across the different tokenizers), but I don't really see another way. Alternative ideas are definitely welcome. If, on the other hand, you decide to keep the dependency, that is fine too.

Note: my flake8 keeps failing with an obscure error so can't do the manual code checking now. Might try again later.

Note: tests will fail for the fast tokenizers (and perhaps on some other imports). I'll look further into this if you decide that this PR is welcome.