### PR TITLE
Possible improvement of padding logic in generate

### DIFF
--- a/src/transformers/configuration_gpt2.py
+++ b/src/transformers/configuration_gpt2.py
@@ -134,6 +134,8 @@ class GPT2Config(PretrainedConfig):
         summary_activation=None,
         summary_proj_to_labels=True,
         summary_first_dropout=0.1,
+        bos_token_id=50256,
+        eos_token_id=50256,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -154,6 +156,9 @@ class GPT2Config(PretrainedConfig):
         self.summary_activation = summary_activation
         self.summary_first_dropout = summary_first_dropout
         self.summary_proj_to_labels = summary_proj_to_labels
+
+        self.bos_token_id = bos_token_id
+        self.eos_token_ids = [eos_token_id]
 
     @property
     def max_position_embeddings(self):

--- a/src/transformers/configuration_transfo_xl.py
+++ b/src/transformers/configuration_transfo_xl.py
@@ -149,6 +149,7 @@ class TransfoXLConfig(PretrainedConfig):
         proj_init_std=0.01,
         init_std=0.02,
         layer_norm_epsilon=1e-5,
+        eos_token_id=0,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -185,6 +186,8 @@ class TransfoXLConfig(PretrainedConfig):
         self.proj_init_std = proj_init_std
         self.init_std = init_std
         self.layer_norm_epsilon = layer_norm_epsilon
+
+        self.eos_token_ids = [eos_token_id]
 
     @property
     def max_position_embeddings(self):

--- a/src/transformers/configuration_xlm.py
+++ b/src/transformers/configuration_xlm.py
@@ -193,6 +193,8 @@ class XLMConfig(PretrainedConfig):
         end_n_top=5,
         mask_token_id=0,
         lang_id=0,
+        bos_token_id=0,
+        pad_token_id=2,
         **kwargs
     ):
         """Constructs XLMConfig.
@@ -232,6 +234,9 @@ class XLMConfig(PretrainedConfig):
 
         if "n_words" in kwargs:
             self.n_words = kwargs["n_words"]
+
+        self.bos_token_id = bos_token_id
+        self.pad_token_id = pad_token_id
 
     @property
     def n_words(self):  # For backward compatibility

--- a/src/transformers/configuration_xlnet.py
+++ b/src/transformers/configuration_xlnet.py
@@ -155,6 +155,9 @@ class XLNetConfig(PretrainedConfig):
         summary_last_dropout=0.1,
         start_n_top=5,
         end_n_top=5,
+        bos_token_id=1,
+        pad_token_id=5,
+        eos_token_id=2,
         **kwargs
     ):
         """Constructs XLNetConfig.
@@ -187,6 +190,10 @@ class XLNetConfig(PretrainedConfig):
         self.summary_last_dropout = summary_last_dropout
         self.start_n_top = start_n_top
         self.end_n_top = end_n_top
+
+        self.bos_token_id = bos_token_id
+        self.pad_token_id = pad_token_id
+        self.eos_token_ids = [eos_token_id]
 
     @property
     def max_position_embeddings(self):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -191,7 +191,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                     The pad_token_id as it was added to the tokenizer. It is used to
                     make sure that the pad_token_id matches it's corresponding `token_embedding_id`,
                     which is equal to the `new_num_tokens`
-            
+
             Return: ``torch.nn.Embeddings``
                 Pointer to the input tokens Embeddings Module of the model
         """
@@ -206,14 +206,14 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
     def add_bos_token_embedding(self, bos_token_id):
         """ Resizes the token embeddings and sets the pad token id to new token embedding
             The bos_token_id should correspond to the current self.config.vocab_size.
-            This function should be used when a <BOS> token was added to the tokenizer. 
+            This function should be used when a <BOS> token was added to the tokenizer.
 
             Arguments:
                 bos_token_id: int:
-                    The bos_token_id as it was added to the tokenizer. It is used to 
+                    The bos_token_id as it was added to the tokenizer. It is used to
                     make sure that the bos_token_id matches it's corresponding `token_embedding_id`,
                     which is equal to the `new_num_tokens`
-            
+
             Return: ``torch.nn.Embeddings``
                 Pointer to the input tokens Embeddings Module of the model
         """
@@ -228,14 +228,14 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
     def add_eos_token_embedding(self, eos_token_id):
         """ Resizes the token embeddings and sets the pad token id to new token embedding
             The eos_token_id should correspond to the current self.config.vocab_size.
-            This function should be used when a <EOS> token was added to the tokenizer. 
+            This function should be used when a <EOS> token was added to the tokenizer.
 
             Arguments:
                 eos_token_id: int:
-                    The eos_token_id as it was added to the tokenizer. It is used to 
+                    The eos_token_id as it was added to the tokenizer. It is used to
                     make sure that the eos_token_id matches it's corresponding `token_embedding_id`,
                     which is equal to the `new_num_tokens`
-            
+
             Return: ``torch.nn.Embeddings``
                 Pointer to the input tokens Embeddings Module of the model
         """
@@ -741,7 +741,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
 
             tokenizer = AutoTokenizer.from_pretrained('distilgpt2')   # Initialize tokenizer
             model = AutoModelWithLMHead.from_pretrained('distilgpt2')    # Download model and configuration from S3 and cache.
-            outputs = model.generate(max_length=40, bos_token_id=tokenizer.bos_token_id, eos_token_ids=tokenizer.eos_token_id, do_sample=False)  # do greedy decoding
+            outputs = model.generate(max_length=40, do_sample=False)  # do greedy decoding
             print('Generated: {}'.format(tokenizer.decode(outputs[0], skip_special_tokens=True)))
 
             tokenizer = AutoTokenizer.from_pretrained('openai-gpt')   # Initialize tokenizer
@@ -756,7 +756,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             model = AutoModelWithLMHead.from_pretrained('distilgpt2')    # Download model and configuration from S3 and cache.
             input_context = 'The dog'
             input_ids = torch.tensor(tokenizer.encode(input_context)).unsqueeze(0)  # encode input context
-            outputs = model.generate(input_ids=input_ids, max_length=40, temperature=0.7, bos_token_id=tokenizer.bos_token_id, pad_token_id=tokenizer.pad_token_id, eos_token_ids=tokenizer.eos_token_id, num_return_sequences=3)  # 3 generate sequences using by sampling
+            outputs = model.generate(input_ids=input_ids, max_length=40, temperature=0.7, num_return_sequences=3)  # 3 generate sequences using by sampling
             for i in range(3): #  3 output sequences were generated
                 print('Generated {}: {}'.format(i, tokenizer.decode(outputs[i], skip_special_tokens=True)))
 
@@ -834,7 +834,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             pad_token_id is not None
         ), """ <PAD> token has to be defined to generate langugae. For models that don't have a <PAD> token. Please add a <PAD> token to the tokenizer and model before via:
         `tokenizer.add_special_tokens({'pad_token': '<PAD>'})`
-        `model.add_pad_token_embedding(len(tokenizer))`
+        `model.add_pad_token_embedding(pad_token_id=len(tokenizer)-1)`
         ."""
 
         # current position and vocab size

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -64,7 +64,11 @@ class ModuleUtilsMixin:
         """
         Get number of (optionally, trainable) parameters in the module.
         """
-        params = filter(lambda x: x.requires_grad, self.parameters()) if only_trainable else self.parameters()
+        params = (
+            filter(lambda x: x.requires_grad, self.parameters())
+            if only_trainable
+            else self.parameters()
+        )
         return sum(p.numel() for p in params)
 
 
@@ -174,12 +178,80 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         if hasattr(output_embeddings, "bias") and output_embeddings.bias is not None:
             output_embeddings.bias.data = torch.nn.functional.pad(
                 output_embeddings.bias.data,
-                (0, output_embeddings.weight.shape[0] - output_embeddings.bias.shape[0]),
+                (
+                    0,
+                    output_embeddings.weight.shape[0] - output_embeddings.bias.shape[0],
+                ),
                 "constant",
                 0,
             )
-        if hasattr(output_embeddings, "out_features") and hasattr(input_embeddings, "num_embeddings"):
+        if hasattr(output_embeddings, "out_features") and hasattr(
+            input_embeddings, "num_embeddings"
+        ):
             output_embeddings.out_features = input_embeddings.num_embeddings
+
+    def add_pad_token_embedding(self, pad_token_id):
+        """ Resizes the token embeddings and sets the pad token id to new token embedding
+            The pad_token_id should correspond to the current self.config.vocab_size.
+            This function should be used when a <PAD> token was ended to the tokenizer. 
+
+            Arguments:
+                pad_token_id: int:
+                    The pad_token_id as it was added to the tokenizer. It is used to 
+                    make sure that the pad_token_id matches it's corresponding `token_embedding_id`,
+                    which is equal to the `new_num_tokens`
+            
+            Return: ``torch.nn.Embeddings``
+                Pointer to the input tokens Embeddings Module of the model
+        """
+        assert pad_token_id == self.config.vocab_size, 
+        self.config.pad_token_id = self.config.vocab_size
+        return self.resize_token_embeddings(self.config.vocab_size + 1)
+
+    def add_bos_token_embedding(self, bos_token_id):
+        """ Resizes the token embeddings and sets the pad token id to new token embedding
+            The bos_token_id should correspond to the current self.config.vocab_size.
+            This function should be used when a <BOS> token was added to the tokenizer. 
+
+            Arguments:
+                bos_token_id: int:
+                    The bos_token_id as it was added to the tokenizer. It is used to 
+                    make sure that the bos_token_id matches it's corresponding `token_embedding_id`,
+                    which is equal to the `new_num_tokens`
+            
+            Return: ``torch.nn.Embeddings``
+                Pointer to the input tokens Embeddings Module of the model
+        """
+        assert bos_token_id == self.config.vocab_size, 
+        self.config.bos_token_id = self.config.vocab_size
+        return self.resize_token_embeddings(self.config.vocab_size + 1)
+
+    def add_eos_token_embedding(self, eos_token_id):
+        """ Resizes the token embeddings and sets the pad token id to new token embedding
+            The eos_token_id should correspond to the current self.config.vocab_size.
+            This function should be used when a <EOS> token was added to the tokenizer. 
+
+            Arguments:
+                eos_token_id: int:
+                    The eos_token_id as it was added to the tokenizer. It is used to 
+                    make sure that the eos_token_id matches it's corresponding `token_embedding_id`,
+                    which is equal to the `new_num_tokens`
+            
+            Return: ``torch.nn.Embeddings``
+                Pointer to the input tokens Embeddings Module of the model
+        """
+        assert eos_token_id == self.config.vocab_size, 
+
+        if self.config.eos_token_ids is not None and type(self.config.eos_token_ids) is list:
+            self.config.eos_token_ids.append(eos_token_id)
+        elif self.config.eos_token_ids is not None and isinstance(self.config.eos_token_ids, int):
+            self.config.eos_token_ids = [self.config.eos_token_ids, eos_token_id]
+        elif self.config.eos_token_ids is None:
+            self.config.eos_token_ids = [eos_token_id]
+        else:
+            raise ValueError("You should check your `model.config.eos_token_ids`. Its value is {} which is the wrong type!".format(self.config.eos_token_ids))
+
+        return self.resize_token_embeddings(self.config.vocab_size + 1)
 
     def resize_token_embeddings(self, new_num_tokens=None):
         """ Resize input token embeddings matrix of the model if new_num_tokens != config.vocab_size.
@@ -194,7 +266,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         Return: ``torch.nn.Embeddings``
             Pointer to the input tokens Embeddings Module of the model
         """
-        base_model = getattr(self, self.base_model_prefix, self)  # get the base model if needed
+        base_model = getattr(
+            self, self.base_model_prefix, self
+        )  # get the base model if needed
         model_embeds = base_model._resize_token_embeddings(new_num_tokens)
         if new_num_tokens is None:
             return model_embeds
@@ -244,7 +318,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
 
         # Copy word embeddings from the previous weights
         num_tokens_to_copy = min(old_num_tokens, new_num_tokens)
-        new_embeddings.weight.data[:num_tokens_to_copy, :] = old_embeddings.weight.data[:num_tokens_to_copy, :]
+        new_embeddings.weight.data[:num_tokens_to_copy, :] = old_embeddings.weight.data[
+            :num_tokens_to_copy, :
+        ]
 
         return new_embeddings
 
@@ -271,7 +347,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         # save new sets of pruned heads as union of previously stored pruned heads and newly pruned heads
         for layer, heads in heads_to_prune.items():
             union_heads = set(self.config.pruned_heads.get(layer, [])) | set(heads)
-            self.config.pruned_heads[layer] = list(union_heads)  # Unfortunately we have to store it as list for JSON
+            self.config.pruned_heads[layer] = list(
+                union_heads
+            )  # Unfortunately we have to store it as list for JSON
 
         self.base_model._prune_heads(heads_to_prune)
 
@@ -380,7 +458,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
 
         # Load config if we don't provide a configuration
         if not isinstance(config, PretrainedConfig):
-            config_path = config if config is not None else pretrained_model_name_or_path
+            config_path = (
+                config if config is not None else pretrained_model_name_or_path
+            )
             config, model_kwargs = cls.config_class.from_pretrained(
                 config_path,
                 *model_args,
@@ -398,24 +478,47 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         # Load model
         if pretrained_model_name_or_path is not None:
             if pretrained_model_name_or_path in cls.pretrained_model_archive_map:
-                archive_file = cls.pretrained_model_archive_map[pretrained_model_name_or_path]
+                archive_file = cls.pretrained_model_archive_map[
+                    pretrained_model_name_or_path
+                ]
             elif os.path.isdir(pretrained_model_name_or_path):
-                if from_tf and os.path.isfile(os.path.join(pretrained_model_name_or_path, TF_WEIGHTS_NAME + ".index")):
+                if from_tf and os.path.isfile(
+                    os.path.join(
+                        pretrained_model_name_or_path, TF_WEIGHTS_NAME + ".index"
+                    )
+                ):
                     # Load from a TF 1.0 checkpoint
-                    archive_file = os.path.join(pretrained_model_name_or_path, TF_WEIGHTS_NAME + ".index")
-                elif from_tf and os.path.isfile(os.path.join(pretrained_model_name_or_path, TF2_WEIGHTS_NAME)):
+                    archive_file = os.path.join(
+                        pretrained_model_name_or_path, TF_WEIGHTS_NAME + ".index"
+                    )
+                elif from_tf and os.path.isfile(
+                    os.path.join(pretrained_model_name_or_path, TF2_WEIGHTS_NAME)
+                ):
                     # Load from a TF 2.0 checkpoint
-                    archive_file = os.path.join(pretrained_model_name_or_path, TF2_WEIGHTS_NAME)
-                elif os.path.isfile(os.path.join(pretrained_model_name_or_path, WEIGHTS_NAME)):
+                    archive_file = os.path.join(
+                        pretrained_model_name_or_path, TF2_WEIGHTS_NAME
+                    )
+                elif os.path.isfile(
+                    os.path.join(pretrained_model_name_or_path, WEIGHTS_NAME)
+                ):
                     # Load from a PyTorch checkpoint
-                    archive_file = os.path.join(pretrained_model_name_or_path, WEIGHTS_NAME)
+                    archive_file = os.path.join(
+                        pretrained_model_name_or_path, WEIGHTS_NAME
+                    )
                 else:
                     raise EnvironmentError(
                         "Error no file named {} found in directory {} or `from_tf` set to False".format(
-                            [WEIGHTS_NAME, TF2_WEIGHTS_NAME, TF_WEIGHTS_NAME + ".index"], pretrained_model_name_or_path
+                            [
+                                WEIGHTS_NAME,
+                                TF2_WEIGHTS_NAME,
+                                TF_WEIGHTS_NAME + ".index",
+                            ],
+                            pretrained_model_name_or_path,
                         )
                     )
-            elif os.path.isfile(pretrained_model_name_or_path) or is_remote_url(pretrained_model_name_or_path):
+            elif os.path.isfile(pretrained_model_name_or_path) or is_remote_url(
+                pretrained_model_name_or_path
+            ):
                 archive_file = pretrained_model_name_or_path
             elif os.path.isfile(pretrained_model_name_or_path + ".index"):
                 assert (
@@ -426,7 +529,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 archive_file = pretrained_model_name_or_path + ".index"
             else:
                 archive_file = hf_bucket_url(
-                    pretrained_model_name_or_path, postfix=(TF2_WEIGHTS_NAME if from_tf else WEIGHTS_NAME)
+                    pretrained_model_name_or_path,
+                    postfix=(TF2_WEIGHTS_NAME if from_tf else WEIGHTS_NAME),
                 )
 
             # redirect to the cache, if necessary
@@ -441,7 +545,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 )
             except EnvironmentError:
                 if pretrained_model_name_or_path in cls.pretrained_model_archive_map:
-                    msg = "Couldn't reach server at '{}' to download pretrained weights.".format(archive_file)
+                    msg = "Couldn't reach server at '{}' to download pretrained weights.".format(
+                        archive_file
+                    )
                 else:
                     msg = (
                         "Model name '{}' was not found in model name list ({}). "
@@ -458,7 +564,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             if resolved_archive_file == archive_file:
                 logger.info("loading weights file {}".format(archive_file))
             else:
-                logger.info("loading weights file {} from cache at {}".format(archive_file, resolved_archive_file))
+                logger.info(
+                    "loading weights file {} from cache at {}".format(
+                        archive_file, resolved_archive_file
+                    )
+                )
         else:
             resolved_archive_file = None
 
@@ -481,13 +591,17 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         if from_tf:
             if resolved_archive_file.endswith(".index"):
                 # Load from a TensorFlow 1.X checkpoint - provided by original authors
-                model = cls.load_tf_weights(model, config, resolved_archive_file[:-6])  # Remove the '.index'
+                model = cls.load_tf_weights(
+                    model, config, resolved_archive_file[:-6]
+                )  # Remove the '.index'
             else:
                 # Load from our TensorFlow 2.0 checkpoints
                 try:
                     from transformers import load_tf2_checkpoint_in_pytorch_model
 
-                    model = load_tf2_checkpoint_in_pytorch_model(model, resolved_archive_file, allow_missing_keys=True)
+                    model = load_tf2_checkpoint_in_pytorch_model(
+                        model, resolved_archive_file, allow_missing_keys=True
+                    )
                 except ImportError:
                     logger.error(
                         "Loading a TensorFlow model in PyTorch, requires both PyTorch and TensorFlow to be installed. Please see "
@@ -519,9 +633,17 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             # PyTorch's `_load_from_state_dict` does not copy parameters in a module's descendants
             # so we need to apply the function recursively.
             def load(module: nn.Module, prefix=""):
-                local_metadata = {} if metadata is None else metadata.get(prefix[:-1], {})
+                local_metadata = (
+                    {} if metadata is None else metadata.get(prefix[:-1], {})
+                )
                 module._load_from_state_dict(
-                    state_dict, prefix, local_metadata, True, missing_keys, unexpected_keys, error_msgs
+                    state_dict,
+                    prefix,
+                    local_metadata,
+                    True,
+                    missing_keys,
+                    unexpected_keys,
+                    error_msgs,
                 )
                 for name, child in module._modules.items():
                     if child is not None:
@@ -565,7 +687,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         model.eval()
 
         if output_loading_info:
-            loading_info = {"missing_keys": missing_keys, "unexpected_keys": unexpected_keys, "error_msgs": error_msgs}
+            loading_info = {
+                "missing_keys": missing_keys,
+                "unexpected_keys": unexpected_keys,
+                "error_msgs": error_msgs,
+            }
             return model, loading_info
 
         return model
@@ -574,7 +700,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         return {"input_ids": input_ids}
 
     def _do_output_past(self, outputs):
-        has_output_past = hasattr(self.config, "output_past") and self.config.output_past
+        has_output_past = (
+            hasattr(self.config, "output_past") and self.config.output_past
+        )
         has_mem_len = hasattr(self.config, "mem_len") and self.config.mem_len
 
         if has_output_past and not has_mem_len and len(outputs) > 1:
@@ -695,16 +823,32 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         max_length = max_length if max_length is not None else self.config.max_length
         do_sample = do_sample if do_sample is not None else self.config.do_sample
         num_beams = num_beams if num_beams is not None else self.config.num_beams
-        temperature = temperature if temperature is not None else self.config.temperature
+        temperature = (
+            temperature if temperature is not None else self.config.temperature
+        )
         top_k = top_k if top_k is not None else self.config.top_k
         top_p = top_p if top_p is not None else self.config.top_p
-        repetition_penalty = repetition_penalty if repetition_penalty is not None else self.config.repetition_penalty
-        bos_token_id = bos_token_id if bos_token_id is not None else self.config.bos_token_id
-        pad_token_id = pad_token_id if pad_token_id is not None else self.config.pad_token_id
-        eos_token_ids = eos_token_ids if eos_token_ids is not None else self.config.eos_token_ids
-        length_penalty = length_penalty if length_penalty is not None else self.config.length_penalty
+        repetition_penalty = (
+            repetition_penalty
+            if repetition_penalty is not None
+            else self.config.repetition_penalty
+        )
+        bos_token_id = (
+            bos_token_id if bos_token_id is not None else self.config.bos_token_id
+        )
+        pad_token_id = (
+            pad_token_id if pad_token_id is not None else self.config.pad_token_id
+        )
+        eos_token_ids = (
+            eos_token_ids if eos_token_ids is not None else self.config.eos_token_ids
+        )
+        length_penalty = (
+            length_penalty if length_penalty is not None else self.config.length_penalty
+        )
         num_return_sequences = (
-            num_return_sequences if num_return_sequences is not None else self.config.num_return_sequences
+            num_return_sequences
+            if num_return_sequences is not None
+            else self.config.num_return_sequences
         )
 
         if input_ids is not None:
@@ -714,11 +858,17 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         if isinstance(eos_token_ids, int):
             eos_token_ids = [eos_token_ids]
 
-        assert isinstance(max_length, int) and max_length > 0, "`max_length` should be a strictely positive integer."
+        assert (
+            isinstance(max_length, int) and max_length > 0
+        ), "`max_length` should be a strictely positive integer."
         assert isinstance(do_sample, bool), "`do_sample` should be a boolean."
-        assert isinstance(num_beams, int) and num_beams > 0, "`num_beams` should be a strictely positive integer."
+        assert (
+            isinstance(num_beams, int) and num_beams > 0
+        ), "`num_beams` should be a strictely positive integer."
         assert temperature > 0, "`temperature` should be strictely positive."
-        assert isinstance(top_k, int) and top_k >= 0, "`top_k` should be a positive integer."
+        assert (
+            isinstance(top_k, int) and top_k >= 0
+        ), "`top_k` should be a positive integer."
         assert 0 <= top_p <= 1, "`top_p` should be between 0 and 1."
         assert repetition_penalty >= 1.0, "`repetition_penalty` should be >= 1."
         assert input_ids is not None or (
@@ -728,7 +878,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             isinstance(pad_token_id, int) and (pad_token_id >= 0)
         ), "`pad_token_id` should be a positive integer."
         assert (eos_token_ids is None) or (
-            isinstance(eos_token_ids, (list, tuple)) and ((isinstance(e, int) and e >= 0) for e in eos_token_ids)
+            isinstance(eos_token_ids, (list, tuple))
+            and ((isinstance(e, int) and e >= 0) for e in eos_token_ids)
         ), "`eos_token_ids` should be a positive integer or a list/tuple of positive integers."
         assert length_penalty > 0, "`length_penalty` should be strictely positive."
         assert (
@@ -741,16 +892,23 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 "or a `bos_token_id` (integer >= 0) as a first token to start the generation."
             )
             input_ids = torch.full(
-                (batch_size, 1), bos_token_id, dtype=torch.long, device=next(self.parameters()).device
+                (batch_size, 1),
+                bos_token_id,
+                dtype=torch.long,
+                device=next(self.parameters()).device,
             )
         else:
-            assert input_ids.dim() == 2, "Input prompt should be of shape (batch_size, sequence length)."
+            assert (
+                input_ids.dim() == 2
+            ), "Input prompt should be of shape (batch_size, sequence length)."
 
-        if pad_token_id is None and eos_token_ids is not None:
-            logger.warning(
-                "Setting `pad_token_id` to {} (first `eos_token_id`) to generate sequence".format(eos_token_ids[0])
-            )
-            pad_token_id = eos_token_ids[0]
+        assert (
+            pad_token_id is not None
+        ), """ <PAD> token has to be defined to generate langugae. For models that don't have a <PAD> token. Please add a <PAD> token to the tokenizer and model before via:
+        `tokenizer.add_special_tokens({'pad_token': '<PAD>'})`
+        `model.config.pad_token_id = len(tokenizer) - 1`
+        `model.resize_token_embeddings(len(tokenizer))`
+        ."""
 
         # current position and vocab size
         cur_len = input_ids.shape[1]
@@ -758,7 +916,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
 
         if num_return_sequences != 1:
             # Expand input to num return sequences
-            input_ids = input_ids.unsqueeze(1).expand(batch_size, num_return_sequences, cur_len)
+            input_ids = input_ids.unsqueeze(1).expand(
+                batch_size, num_return_sequences, cur_len
+            )
             input_ids = input_ids.contiguous().view(
                 batch_size * num_return_sequences, cur_len
             )  # (batch_size * num_return_sequences, cur_len)
@@ -842,24 +1002,29 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                         else:
                             next_token_logits[i, previous_token] /= repetition_penalty
 
+            # set probability to generate <PAD> token to 0
+            next_token_logits[:, pad_token_id] = -float("Inf")
+
             if do_sample:
                 # Temperature (higher temperature => more likely to sample low probability tokens)
                 if temperature != 1.0:
                     next_token_logits = next_token_logits / temperature
                 # Top-p/top-k filtering
-                next_token_logits = top_k_top_p_filtering(next_token_logits, top_k=top_k, top_p=top_p)
+                next_token_logits = top_k_top_p_filtering(
+                    next_token_logits, top_k=top_k, top_p=top_p
+                )
                 # Sample
-                next_token = torch.multinomial(F.softmax(next_token_logits, dim=-1), num_samples=1).squeeze(1)
+                next_token = torch.multinomial(
+                    F.softmax(next_token_logits, dim=-1), num_samples=1
+                ).squeeze(1)
             else:
                 # Greedy decoding
                 next_token = torch.argmax(next_token_logits, dim=-1)
 
-            # update generations and finished sentences
-            if eos_token_ids is not None:
-                # pad finished sentences if eos_token_ids exist
-                tokens_to_add = next_token * unfinished_sents + (pad_token_id) * (1 - unfinished_sents)
-            else:
-                tokens_to_add = next_token
+            # pad finished sentences
+            tokens_to_add = next_token * unfinished_sents + (pad_token_id) * (
+                1 - unfinished_sents
+            )
 
             input_ids = torch.cat([input_ids, tokens_to_add.unsqueeze(-1)], dim=-1)
 
@@ -867,8 +1032,12 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 for eos_token_id in eos_token_ids:
                     eos_in_sents = tokens_to_add == eos_token_id
                     # if sentence is unfinished and the token to add is eos, sent_lengths is filled with current length
-                    is_sents_unfinished_and_token_to_add_is_eos = unfinished_sents.mul(eos_in_sents.long()).bool()
-                    sent_lengths.masked_fill_(is_sents_unfinished_and_token_to_add_is_eos, cur_len + 1)
+                    is_sents_unfinished_and_token_to_add_is_eos = unfinished_sents.mul(
+                        eos_in_sents.long()
+                    ).bool()
+                    sent_lengths.masked_fill_(
+                        is_sents_unfinished_and_token_to_add_is_eos, cur_len + 1
+                    )
                     # unfinished_sents is set to zero if eos in sentence
                     unfinished_sents.mul_((~eos_in_sents).long())
 
@@ -878,18 +1047,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             if unfinished_sents.max() == 0:
                 break
 
-        # if there are different sentences lengths in the batch, some batches have to be padded
-        if sent_lengths.min().item() != sent_lengths.max().item():
-            assert pad_token_id is not None, "`Pad_token_id` has to be defined if batches have different lengths"
-            # finished sents are filled with pad_token
-            decoded = input_ids.new(batch_size, sent_lengths.max().item()).fill_(pad_token_id)
-        else:
-            decoded = input_ids
-
-        for hypo_idx, hypo in enumerate(input_ids):
-            decoded[hypo_idx, : sent_lengths[hypo_idx]] = hypo[: sent_lengths[hypo_idx]]
-
-        return decoded
+        return input_ids
 
     def _generate_beam_search(
         self,
@@ -912,15 +1070,20 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         """
         # Expand input to num beams
         input_ids = input_ids.unsqueeze(1).expand(batch_size, num_beams, cur_len)
-        input_ids = input_ids.contiguous().view(batch_size * num_beams, cur_len)  # (batch_size * num_beams, cur_len)
+        input_ids = input_ids.contiguous().view(
+            batch_size * num_beams, cur_len
+        )  # (batch_size * num_beams, cur_len)
 
         # generated hypotheses
         generated_hyps = [
-            BeamHypotheses(num_beams, max_length, length_penalty, early_stopping=False) for _ in range(batch_size)
+            BeamHypotheses(num_beams, max_length, length_penalty, early_stopping=False)
+            for _ in range(batch_size)
         ]
 
         # scores for each sentence in the beam
-        beam_scores = torch.zeros((batch_size, num_beams), dtype=torch.float, device=input_ids.device)
+        beam_scores = torch.zeros(
+            (batch_size, num_beams), dtype=torch.float, device=input_ids.device
+        )
         beam_scores[:, 1:] = -1e9
         beam_scores = beam_scores.view(-1)  # shape (batch_size * num_beams,)
 
@@ -932,7 +1095,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
 
         while cur_len < max_length:
             model_inputs = self.prepare_inputs_for_generation(input_ids, past=past)
-            outputs = self(**model_inputs)  # (batch_size * num_beams, cur_len, vocab_size)
+            outputs = self(
+                **model_inputs
+            )  # (batch_size * num_beams, cur_len, vocab_size)
             scores = outputs[0][:, -1, :]  # (batch_size * num_beams, vocab_size)
 
             # if model has past, then set the past variable to speed up decoding
@@ -949,6 +1114,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                         else:
                             scores[i, previous_token] /= repetition_penalty
 
+            # set probability to generate <PAD> token to 0
+            scores[:, pad_token_id] = -float("Inf")
+
             if do_sample:
                 # Temperature (higher temperature => more likely to sample low probability tokens)
                 if temperature != 1.0:
@@ -958,25 +1126,47 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                     scores, top_k=top_k, top_p=top_p, min_tokens_to_keep=2
                 )  # (batch_size * num_beams, vocab_size)
                 # Sample 2 next words for each beam (so we have some spare tokens and match output of greedy beam search)
-                next_words = torch.multinomial(F.softmax(scores, dim=-1), num_samples=2)  # (batch_size * num_beams, 2)
+                next_words = torch.multinomial(
+                    F.softmax(scores, dim=-1), num_samples=2
+                )  # (batch_size * num_beams, 2)
                 # Compute next scores
-                _scores = F.log_softmax(scores, dim=-1)  # (batch_size * num_beams, vocab_size)
-                _scores = torch.gather(_scores, -1, next_words)  # (batch_size * num_beams, 2)
-                next_scores = _scores + beam_scores[:, None].expand_as(_scores)  # (batch_size * num_beams, 2)
+                _scores = F.log_softmax(
+                    scores, dim=-1
+                )  # (batch_size * num_beams, vocab_size)
+                _scores = torch.gather(
+                    _scores, -1, next_words
+                )  # (batch_size * num_beams, 2)
+                next_scores = _scores + beam_scores[:, None].expand_as(
+                    _scores
+                )  # (batch_size * num_beams, 2)
                 # Match shape of greedy beam search
-                next_words = next_words.view(batch_size, 2 * num_beams)  # (batch_size, 2 * num_beams)
-                next_scores = next_scores.view(batch_size, 2 * num_beams)  # (batch_size, 2 * num_beams)
+                next_words = next_words.view(
+                    batch_size, 2 * num_beams
+                )  # (batch_size, 2 * num_beams)
+                next_scores = next_scores.view(
+                    batch_size, 2 * num_beams
+                )  # (batch_size, 2 * num_beams)
             else:
                 # do greedy beam search
-                scores = F.log_softmax(scores, dim=-1)  # (batch_size * num_beams, vocab_size)
+                scores = F.log_softmax(
+                    scores, dim=-1
+                )  # (batch_size * num_beams, vocab_size)
                 assert scores.size() == (batch_size * num_beams, vocab_size)
                 # Add the log prob of the new beams to the log prob of the beginning of the sequence (sum of logs == log of the product)
-                _scores = scores + beam_scores[:, None].expand_as(scores)  # (batch_size * num_beams, vocab_size)
+                _scores = scores + beam_scores[:, None].expand_as(
+                    scores
+                )  # (batch_size * num_beams, vocab_size)
                 # re-organize to group the beam together (we are keeping top hypothesis accross beams)
-                _scores = _scores.view(batch_size, num_beams * vocab_size)  # (batch_size, num_beams * vocab_size)
-                next_scores, next_words = torch.topk(_scores, 2 * num_beams, dim=1, largest=True, sorted=True)
+                _scores = _scores.view(
+                    batch_size, num_beams * vocab_size
+                )  # (batch_size, num_beams * vocab_size)
+                next_scores, next_words = torch.topk(
+                    _scores, 2 * num_beams, dim=1, largest=True, sorted=True
+                )
 
-            assert next_scores.size() == next_words.size() == (batch_size, 2 * num_beams)
+            assert (
+                next_scores.size() == next_words.size() == (batch_size, 2 * num_beams)
+            )
 
             # next batch beam content
             # list of (batch_size * num_beams) tuple(next hypothesis score, next word, current position in the batch)
@@ -992,11 +1182,15 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 if done[batch_idx]:
                     assert (
                         len(generated_hyps[batch_idx]) >= num_beams
-                    ), "Batch can only be done if at least {} beams have been generated".format(num_beams)
+                    ), "Batch can only be done if at least {} beams have been generated".format(
+                        num_beams
+                    )
                     assert (
                         eos_token_ids is not None and pad_token_id is not None
                     ), "generated beams >= num_beams -> eos_token_id and pad_token have to be defined"
-                    next_batch_beam.extend([(0, pad_token_id, 0)] * num_beams)  # pad the batch
+                    next_batch_beam.extend(
+                        [(0, pad_token_id, 0)] * num_beams
+                    )  # pad the batch
                     continue
 
                 # next sentence beam content
@@ -1012,11 +1206,16 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                     # add to generated hypotheses if end of sentence or last iteration
                     if eos_token_ids is not None and word_id.item() in eos_token_ids:
                         generated_hyps[batch_idx].add(
-                            input_ids[batch_idx * num_beams + beam_id, :cur_len].clone(), score.item()
+                            input_ids[
+                                batch_idx * num_beams + beam_id, :cur_len
+                            ].clone(),
+                            score.item(),
                         )
                     else:
                         # add next predicted word if it is not eos_token
-                        next_sent_beam.append((score, word_id, batch_idx * num_beams + beam_id))
+                        next_sent_beam.append(
+                            (score, word_id, batch_idx * num_beams + beam_id)
+                        )
 
                     # the beam for next step is full
                     if len(next_sent_beam) == num_beams:
@@ -1043,7 +1242,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 for layer_past in past:
                     # get the correct batch idx from layer past batch dim
                     # batch dim of `past` and `mems` is at 2nd position
-                    reordered_layer_past = [layer_past[:, i].unsqueeze(1).clone().detach() for i in beam_idx]
+                    reordered_layer_past = [
+                        layer_past[:, i].unsqueeze(1).clone().detach() for i in beam_idx
+                    ]
                     reordered_layer_past = torch.cat(reordered_layer_past, dim=1)
                     # check that shape matches
                     assert reordered_layer_past.shape == layer_past.shape
@@ -1066,7 +1267,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                     beam_id = idx // vocab_size
                     word_id = idx % vocab_size
                     generated_hyps[batch_idx].add(
-                        input_ids[batch_idx * num_beams + beam_id, :cur_len].clone(), score.item()
+                        input_ids[batch_idx * num_beams + beam_id, :cur_len].clone(),
+                        score.item(),
                     )
 
         # select the best hypotheses
@@ -1078,26 +1280,21 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             sent_lengths[i] = len(best_hyp)
             best.append(best_hyp)
 
-        # shorter batches are filled with pad_token
-        if sent_lengths.min().item() != sent_lengths.max().item():
-            assert pad_token_id is not None, "`Pad_token_id` has to be defined"
-            sent_max_len = min(sent_lengths.max().item() + 1, max_length)
-            decoded = input_ids.new(batch_size, sent_max_len).fill_(pad_token_id)
+        sent_max_len = min(sent_lengths.max().item() + 1, max_length)
+        decoded = input_ids.new(batch_size, sent_max_len).fill_(pad_token_id)
 
-            # fill with hypothesis and eos_token_id if necessary
-            for i, hypo in enumerate(best):
-                decoded[i, : sent_lengths[i]] = hypo
-                if sent_lengths[i] < max_length:
-                    decoded[i, sent_lengths[i]] = eos_token_ids[0]
-        else:
-            # none of the hypotheses have an eos_token
-            assert (len(hypo) == max_length for hypo in best)
-            decoded = torch.stack(best).type(torch.long).to(next(self.parameters()).device)
+        # fill with hypothesis and eos_token_id if necessary
+        for i, hypo in enumerate(best):
+            decoded[i, : sent_lengths[i]] = hypo
+            if sent_lengths[i] < max_length:
+                decoded[i, sent_lengths[i]] = eos_token_ids[0]
 
         return decoded
 
 
-def top_k_top_p_filtering(logits, top_k=0, top_p=1.0, filter_value=-float("Inf"), min_tokens_to_keep=1):
+def top_k_top_p_filtering(
+    logits, top_k=0, top_p=1.0, filter_value=-float("Inf"), min_tokens_to_keep=1
+):
     """ Filter a distribution of logits using top-k and/or nucleus (top-p) filtering
         Args:
             logits: logits distribution shape (batch size, vocabulary size)
@@ -1127,7 +1324,9 @@ def top_k_top_p_filtering(logits, top_k=0, top_p=1.0, filter_value=-float("Inf")
         sorted_indices_to_remove[..., 0] = 0
 
         # scatter sorted tensors to original indexing
-        indices_to_remove = sorted_indices_to_remove.scatter(1, sorted_indices, sorted_indices_to_remove)
+        indices_to_remove = sorted_indices_to_remove.scatter(
+            1, sorted_indices, sorted_indices_to_remove
+        )
         logits[indices_to_remove] = filter_value
     return logits
 
@@ -1158,7 +1357,9 @@ class BeamHypotheses(object):
         if len(self) < self.num_beams or score > self.worst_score:
             self.beams.append((score, hyp))
             if len(self) > self.num_beams:
-                sorted_scores = sorted([(s, idx) for idx, (s, _) in enumerate(self.beams)])
+                sorted_scores = sorted(
+                    [(s, idx) for idx, (s, _) in enumerate(self.beams)]
+                )
                 del self.beams[sorted_scores[0][1]]
                 self.worst_score = sorted_scores[1][0]
             else:
@@ -1174,7 +1375,10 @@ class BeamHypotheses(object):
         elif self.early_stopping:
             return True
         else:
-            return self.worst_score >= best_sum_logprobs / self.max_length ** self.length_penalty
+            return (
+                self.worst_score
+                >= best_sum_logprobs / self.max_length ** self.length_penalty
+            )
 
 
 class Conv1D(nn.Module):
@@ -1231,7 +1435,9 @@ class PoolerEndLogits(nn.Module):
         self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
         self.dense_1 = nn.Linear(config.hidden_size, 1)
 
-    def forward(self, hidden_states, start_states=None, start_positions=None, p_mask=None):
+    def forward(
+        self, hidden_states, start_states=None, start_positions=None, p_mask=None
+    ):
         """ Args:
             One of ``start_states``, ``start_positions`` should be not None.
             If both are set, ``start_positions`` overrides ``start_states``.
@@ -1249,8 +1455,12 @@ class PoolerEndLogits(nn.Module):
         ), "One of start_states, start_positions should be not None"
         if start_positions is not None:
             slen, hsz = hidden_states.shape[-2:]
-            start_positions = start_positions[:, None, None].expand(-1, -1, hsz)  # shape (bsz, 1, hsz)
-            start_states = hidden_states.gather(-2, start_positions)  # shape (bsz, 1, hsz)
+            start_positions = start_positions[:, None, None].expand(
+                -1, -1, hsz
+            )  # shape (bsz, 1, hsz)
+            start_states = hidden_states.gather(
+                -2, start_positions
+            )  # shape (bsz, 1, hsz)
             start_states = start_states.expand(-1, slen, -1)  # shape (bsz, slen, hsz)
 
         x = self.dense_0(torch.cat([hidden_states, start_states], dim=-1))
@@ -1276,7 +1486,9 @@ class PoolerAnswerClass(nn.Module):
         self.activation = nn.Tanh()
         self.dense_1 = nn.Linear(config.hidden_size, 1, bias=False)
 
-    def forward(self, hidden_states, start_states=None, start_positions=None, cls_index=None):
+    def forward(
+        self, hidden_states, start_states=None, start_positions=None, cls_index=None
+    ):
         """
         Args:
             One of ``start_states``, ``start_positions`` should be not None.
@@ -1298,12 +1510,20 @@ class PoolerAnswerClass(nn.Module):
             start_states is not None or start_positions is not None
         ), "One of start_states, start_positions should be not None"
         if start_positions is not None:
-            start_positions = start_positions[:, None, None].expand(-1, -1, hsz)  # shape (bsz, 1, hsz)
-            start_states = hidden_states.gather(-2, start_positions).squeeze(-2)  # shape (bsz, hsz)
+            start_positions = start_positions[:, None, None].expand(
+                -1, -1, hsz
+            )  # shape (bsz, 1, hsz)
+            start_states = hidden_states.gather(-2, start_positions).squeeze(
+                -2
+            )  # shape (bsz, hsz)
 
         if cls_index is not None:
-            cls_index = cls_index[:, None, None].expand(-1, -1, hsz)  # shape (bsz, 1, hsz)
-            cls_token_state = hidden_states.gather(-2, cls_index).squeeze(-2)  # shape (bsz, hsz)
+            cls_index = cls_index[:, None, None].expand(
+                -1, -1, hsz
+            )  # shape (bsz, 1, hsz)
+            cls_token_state = hidden_states.gather(-2, cls_index).squeeze(
+                -2
+            )  # shape (bsz, hsz)
         else:
             cls_token_state = hidden_states[:, -1, :]  # shape (bsz, hsz)
 
@@ -1365,7 +1585,13 @@ class SQuADHead(nn.Module):
         self.answer_class = PoolerAnswerClass(config)
 
     def forward(
-        self, hidden_states, start_positions=None, end_positions=None, cls_index=None, is_impossible=None, p_mask=None
+        self,
+        hidden_states,
+        start_positions=None,
+        end_positions=None,
+        cls_index=None,
+        is_impossible=None,
+        p_mask=None,
     ):
         outputs = ()
 
@@ -1378,7 +1604,9 @@ class SQuADHead(nn.Module):
                     x.squeeze_(-1)
 
             # during training, compute the end logits based on the ground truth of the start position
-            end_logits = self.end_logits(hidden_states, start_positions=start_positions, p_mask=p_mask)
+            end_logits = self.end_logits(
+                hidden_states, start_positions=start_positions, p_mask=p_mask
+            )
 
             loss_fct = CrossEntropyLoss()
             start_loss = loss_fct(start_logits, start_positions)
@@ -1387,7 +1615,9 @@ class SQuADHead(nn.Module):
 
             if cls_index is not None and is_impossible is not None:
                 # Predict answerability from the representation of CLS and START
-                cls_logits = self.answer_class(hidden_states, start_positions=start_positions, cls_index=cls_index)
+                cls_logits = self.answer_class(
+                    hidden_states, start_positions=start_positions, cls_index=cls_index
+                )
                 loss_fct_cls = nn.BCEWithLogitsLoss()
                 cls_loss = loss_fct_cls(cls_logits, is_impossible)
 
@@ -1404,27 +1634,47 @@ class SQuADHead(nn.Module):
             start_top_log_probs, start_top_index = torch.topk(
                 start_log_probs, self.start_n_top, dim=-1
             )  # shape (bsz, start_n_top)
-            start_top_index_exp = start_top_index.unsqueeze(-1).expand(-1, -1, hsz)  # shape (bsz, start_n_top, hsz)
-            start_states = torch.gather(hidden_states, -2, start_top_index_exp)  # shape (bsz, start_n_top, hsz)
-            start_states = start_states.unsqueeze(1).expand(-1, slen, -1, -1)  # shape (bsz, slen, start_n_top, hsz)
+            start_top_index_exp = start_top_index.unsqueeze(-1).expand(
+                -1, -1, hsz
+            )  # shape (bsz, start_n_top, hsz)
+            start_states = torch.gather(
+                hidden_states, -2, start_top_index_exp
+            )  # shape (bsz, start_n_top, hsz)
+            start_states = start_states.unsqueeze(1).expand(
+                -1, slen, -1, -1
+            )  # shape (bsz, slen, start_n_top, hsz)
 
             hidden_states_expanded = hidden_states.unsqueeze(2).expand_as(
                 start_states
             )  # shape (bsz, slen, start_n_top, hsz)
             p_mask = p_mask.unsqueeze(-1) if p_mask is not None else None
-            end_logits = self.end_logits(hidden_states_expanded, start_states=start_states, p_mask=p_mask)
-            end_log_probs = F.softmax(end_logits, dim=1)  # shape (bsz, slen, start_n_top)
+            end_logits = self.end_logits(
+                hidden_states_expanded, start_states=start_states, p_mask=p_mask
+            )
+            end_log_probs = F.softmax(
+                end_logits, dim=1
+            )  # shape (bsz, slen, start_n_top)
 
             end_top_log_probs, end_top_index = torch.topk(
                 end_log_probs, self.end_n_top, dim=1
             )  # shape (bsz, end_n_top, start_n_top)
-            end_top_log_probs = end_top_log_probs.view(-1, self.start_n_top * self.end_n_top)
+            end_top_log_probs = end_top_log_probs.view(
+                -1, self.start_n_top * self.end_n_top
+            )
             end_top_index = end_top_index.view(-1, self.start_n_top * self.end_n_top)
 
             start_states = torch.einsum("blh,bl->bh", hidden_states, start_log_probs)
-            cls_logits = self.answer_class(hidden_states, start_states=start_states, cls_index=cls_index)
+            cls_logits = self.answer_class(
+                hidden_states, start_states=start_states, cls_index=cls_index
+            )
 
-            outputs = (start_top_log_probs, start_top_index, end_top_log_probs, end_top_index, cls_logits) + outputs
+            outputs = (
+                start_top_log_probs,
+                start_top_index,
+                end_top_log_probs,
+                end_top_index,
+                cls_logits,
+            ) + outputs
 
         # return start_top_log_probs, start_top_index, end_top_log_probs, end_top_index, cls_logits
         # or (if labels are provided) (total_loss,)
@@ -1459,7 +1709,11 @@ class SequenceSummary(nn.Module):
 
         self.summary = Identity()
         if hasattr(config, "summary_use_proj") and config.summary_use_proj:
-            if hasattr(config, "summary_proj_to_labels") and config.summary_proj_to_labels and config.num_labels > 0:
+            if (
+                hasattr(config, "summary_proj_to_labels")
+                and config.summary_proj_to_labels
+                and config.num_labels > 0
+            ):
                 num_classes = config.num_labels
             else:
                 num_classes = config.hidden_size
@@ -1471,7 +1725,10 @@ class SequenceSummary(nn.Module):
         )  # type: typing.Callable
 
         self.first_dropout = Identity()
-        if hasattr(config, "summary_first_dropout") and config.summary_first_dropout > 0:
+        if (
+            hasattr(config, "summary_first_dropout")
+            and config.summary_first_dropout > 0
+        ):
             self.first_dropout = nn.Dropout(config.summary_first_dropout)
 
         self.last_dropout = Identity()
@@ -1493,12 +1750,20 @@ class SequenceSummary(nn.Module):
             output = hidden_states.mean(dim=1)
         elif self.summary_type == "cls_index":
             if cls_index is None:
-                cls_index = torch.full_like(hidden_states[..., :1, :], hidden_states.shape[-2] - 1, dtype=torch.long)
+                cls_index = torch.full_like(
+                    hidden_states[..., :1, :],
+                    hidden_states.shape[-2] - 1,
+                    dtype=torch.long,
+                )
             else:
                 cls_index = cls_index.unsqueeze(-1).unsqueeze(-1)
-                cls_index = cls_index.expand((-1,) * (cls_index.dim() - 1) + (hidden_states.size(-1),))
+                cls_index = cls_index.expand(
+                    (-1,) * (cls_index.dim() - 1) + (hidden_states.size(-1),)
+                )
             # shape of cls_index: (bsz, XX, 1, hidden_size) where XX are optional leading dim of hidden_states
-            output = hidden_states.gather(-2, cls_index).squeeze(-2)  # shape (bsz, XX, hidden_size)
+            output = hidden_states.gather(-2, cls_index).squeeze(
+                -2
+            )  # shape (bsz, XX, hidden_size)
         elif self.summary_type == "attn":
             raise NotImplementedError
 
@@ -1538,7 +1803,9 @@ def prune_linear_layer(layer, index, dim=0):
             b = layer.bias[index].clone().detach()
     new_size = list(layer.weight.size())
     new_size[dim] = len(index)
-    new_layer = nn.Linear(new_size[1], new_size[0], bias=layer.bias is not None).to(layer.weight.device)
+    new_layer = nn.Linear(new_size[1], new_size[0], bias=layer.bias is not None).to(
+        layer.weight.device
+    )
     new_layer.weight.requires_grad = False
     new_layer.weight.copy_(W.contiguous())
     new_layer.weight.requires_grad = True

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -19,7 +19,6 @@ import os.path
 import random
 import tempfile
 import unittest
-import ipdb
 
 from transformers import is_torch_available
 
@@ -466,13 +465,13 @@ class ModelTesterMixin:
             )
 
     def test_add_pad_token(self):
-        self._check_add_special_tokens('pad_token_id')
+        self._check_add_special_tokens("pad_token_id")
 
     def test_add_bos_token(self):
-        self._check_add_special_tokens('bos_token_id')
+        self._check_add_special_tokens("bos_token_id")
 
     def test_add_eos_token(self):
-        self._check_add_special_tokens('eos_token_ids')
+        self._check_add_special_tokens("eos_token_ids")
 
     def _check_add_special_tokens(self, special_token):
         original_config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
@@ -493,14 +492,14 @@ class ModelTesterMixin:
             prev_model_embed = model.resize_token_embeddings(prev_model_vocab_size)
             prev_model_embed_weight = prev_model_embed.weight.clone()
 
-            if special_token == 'pad_token_id':
+            if special_token == "pad_token_id":
                 model_embed = model.add_pad_token_embedding(special_token_id)
-            elif special_token == 'bos_token_id':
+            elif special_token == "bos_token_id":
                 model_embed = model.add_bos_token_embedding(special_token_id)
-            elif special_token == 'eos_token_ids':
+            elif special_token == "eos_token_ids":
                 model_embed = model.add_eos_token_embedding(special_token_id)
             else:
-                raise ValueError('{} does not exist'.format(special_token))
+                raise ValueError("{} does not exist".format(special_token))
 
             # Check that special token is correctly set
             set_special_token = getattr(model.config, special_token)
@@ -669,8 +668,7 @@ class ModelTesterMixin:
 
             # if model has no pad_token_id it should be resized before
             if model.config.pad_token_id is None:
-                model.config.pad_token_id = model.config.vocab_size
-                model.resize_token_embeddings(model.config.vocab_size + 1)
+                model.add_pad_token_embedding(model.config.vocab_size)
                 self.model_tester.vocab_size = model.config.vocab_size
 
             if config.bos_token_id is None:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -607,6 +607,11 @@ class ModelTesterMixin:
             model.to(torch_device)
             model.eval()
 
+            # if model has no pad_token_id it should be resized before
+            if model.config.pad_token_id is None:
+                model.config.pad_token_id = model.config.vocab_size
+                model.resize_token_embeddings(model.config.vocab_size + 1)
+
             if config.bos_token_id is None:
                 with self.assertRaises(AssertionError):
                     model.generate(max_length=5)

--- a/tests/test_modeling_ctrl.py
+++ b/tests/test_modeling_ctrl.py
@@ -244,5 +244,8 @@ class CTRLModelLanguageGenerationTest(unittest.TestCase):
         ]  # Legal My neighbor is refusing to pay rent after 2 years and we are having to force him to pay
         torch.manual_seed(0)
 
+        # add padding token to avoid assert statement
+        model.add_pad_token_embedding(model.config.vocab_size)
         output_ids = model.generate(input_ids)
+
         self.assertListEqual(output_ids[0].tolist(), expected_output_ids)

--- a/tests/test_modeling_gpt2.py
+++ b/tests/test_modeling_gpt2.py
@@ -263,13 +263,7 @@ class GPT2ModelTest(ModelTesterMixin, unittest.TestCase):
             self.assertIsNotNone(model)
 
 
-def prepare_generation_special_tokens():
-    return {"bos_token_id": 50256, "eos_token_id": 50256}
-
-
 class GPT2ModelLanguageGenerationTest(unittest.TestCase):
-
-    special_tokens = prepare_generation_special_tokens()
 
     @slow
     def test_lm_generate_gpt2(self):
@@ -299,11 +293,9 @@ class GPT2ModelLanguageGenerationTest(unittest.TestCase):
         ]  # The dog is cute too. It likes to rub on me and is good for me (the dog
         torch.manual_seed(0)
 
-        output_ids = model.generate(
-            input_ids,
-            bos_token_id=self.special_tokens["bos_token_id"],
-            eos_token_ids=self.special_tokens["eos_token_id"],
-        )
+        # add padding token to avoid assert statement
+        model.add_pad_token_embedding(model.config.vocab_size)
+        output_ids = model.generate(input_ids)
 
         self.assertListEqual(output_ids[0].tolist(), expected_output_ids)
 
@@ -335,10 +327,8 @@ class GPT2ModelLanguageGenerationTest(unittest.TestCase):
         ]  # The dog is cute though he can sometimes just walk in the park. It is not very nice to
         torch.manual_seed(0)
 
-        output_ids = model.generate(
-            input_ids,
-            bos_token_id=self.special_tokens["bos_token_id"],
-            eos_token_ids=self.special_tokens["eos_token_id"],
-        )
+        # add padding token to avoid assert statement
+        model.add_pad_token_embedding(model.config.vocab_size)
+        output_ids = model.generate(input_ids)
 
         self.assertListEqual(output_ids[0].tolist(), expected_output_ids)

--- a/tests/test_modeling_openai.py
+++ b/tests/test_modeling_openai.py
@@ -241,8 +241,7 @@ class OPENAIGPTModelLanguageGenerationTest(unittest.TestCase):
         torch.manual_seed(0)
 
         # add padding token to avoid assert statement
-        model.config.pad_token_id = model.config.vocab_size
-        model.add_pad_token_embedding(model.config.pad_token_id)
+        model.add_pad_token_embedding(model.config.vocab_size)
         output_ids = model.generate(input_ids)
 
         self.assertListEqual(output_ids[0].tolist(), expected_output_ids)

--- a/tests/test_modeling_openai.py
+++ b/tests/test_modeling_openai.py
@@ -242,7 +242,7 @@ class OPENAIGPTModelLanguageGenerationTest(unittest.TestCase):
 
         # add padding token to avoid assert statement
         model.config.pad_token_id = model.config.vocab_size
-        model.resize_token_embeddings(model.config.pad_token_id + 1)
+        model.add_pad_token_embedding(model.config.pad_token_id)
         output_ids = model.generate(input_ids)
 
         self.assertListEqual(output_ids[0].tolist(), expected_output_ids)

--- a/tests/test_modeling_openai.py
+++ b/tests/test_modeling_openai.py
@@ -240,5 +240,9 @@ class OPENAIGPTModelLanguageGenerationTest(unittest.TestCase):
         ]  # the dog is cute when you're annoyed : if he's really stupid, he 'll stop fighting you
         torch.manual_seed(0)
 
+        # add padding token to avoid assert statement
+        model.config.pad_token_id = model.config.vocab_size
+        model.resize_token_embeddings(model.config.pad_token_id + 1)
         output_ids = model.generate(input_ids)
+
         self.assertListEqual(output_ids[0].tolist(), expected_output_ids)

--- a/tests/test_modeling_transfo_xl.py
+++ b/tests/test_modeling_transfo_xl.py
@@ -214,13 +214,7 @@ class TransfoXLModelTest(ModelTesterMixin, unittest.TestCase):
             self.assertIsNotNone(model)
 
 
-def prepare_generation_special_tokens():
-    return {"eos_token_id": 0}
-
-
 class TransfoXLModelLanguageGenerationTest(unittest.TestCase):
-
-    special_tokens = prepare_generation_special_tokens()
 
     @slow
     def test_lm_generate_transfo_xl_wt103(self):
@@ -578,6 +572,8 @@ class TransfoXLModelLanguageGenerationTest(unittest.TestCase):
 
         torch.manual_seed(0)
 
-        output_ids = model.generate(input_ids, eos_token_ids=self.special_tokens["eos_token_id"], max_length=200)
+        # add padding token to avoid assert statement
+        model.add_pad_token_embedding(model.config.vocab_size)
+        output_ids = model.generate(input_ids, max_length=200)
 
         self.assertListEqual(output_ids[0].tolist(), expected_output_ids)

--- a/tests/test_modeling_xlm.py
+++ b/tests/test_modeling_xlm.py
@@ -399,13 +399,7 @@ class XLMModelTest(ModelTesterMixin, unittest.TestCase):
             self.assertIsNotNone(model)
 
 
-def prepare_generation_special_tokens():
-    return {"bos_token_id": 0, "pad_token_id": 2}
-
-
 class XLMModelLanguageGenerationTest(unittest.TestCase):
-
-    special_tokens = prepare_generation_special_tokens()
 
     @slow
     def test_lm_generate_xlm_mlm_en_2048(self):
@@ -435,10 +429,6 @@ class XLMModelLanguageGenerationTest(unittest.TestCase):
         ]  # The dog is nothing is it!!!!!!!!!!!! TODO (PVP): this sentence (and others I tried) does not make much sense, there seems to be a problem with xlm language generation.
         torch.manual_seed(0)
 
-        output_ids = model.generate(
-            input_ids,
-            bos_token_id=self.special_tokens["bos_token_id"],
-            pad_token_id=self.special_tokens["pad_token_id"],
-        )
+        output_ids = model.generate(input_ids)
 
         self.assertListEqual(output_ids[0].tolist(), expected_output_ids)

--- a/tests/test_modeling_xlnet.py
+++ b/tests/test_modeling_xlnet.py
@@ -513,13 +513,7 @@ class XLNetModelTest(ModelTesterMixin, unittest.TestCase):
             self.assertIsNotNone(model)
 
 
-def prepare_generation_special_tokens():
-    return {"bos_token_id": 1, "pad_token_id": 5, "eos_token_id": 2}
-
-
 class XLNetModelLanguageGenerationTest(unittest.TestCase):
-
-    special_tokens = prepare_generation_special_tokens()
 
     @slow
     def test_lm_generate_xlnet_base_cased(self):
@@ -917,12 +911,6 @@ class XLNetModelLanguageGenerationTest(unittest.TestCase):
         #  Since, however, he has had difficulty walking with Maria
 
         torch.manual_seed(0)
-        output_ids = model.generate(
-            input_ids,
-            bos_token_id=self.special_tokens["bos_token_id"],
-            pad_token_id=self.special_tokens["pad_token_id"],
-            eos_token_ids=self.special_tokens["eos_token_id"],
-            max_length=200,
-        )
+        output_ids = model.generate(input_ids, max_length=200)
 
         self.assertListEqual(output_ids[0].tolist(), expected_output_ids)


### PR DESCRIPTION
I wanted to try out a approach to the padding logic (previously discussed with @thomwolf and @mfuntowicz) which is **different** to what is currently done (see #2885 description). 

Instead of setting the `pad_token_id` to `eos_token_id` if `pad_token_id` is not defined and `eos_token_id` is defined, the following logic could be applied:

If there is no `pad_token_id`, the user has to add the `pad_token_id` to the tokenizer and resize the model token embedding matrix to add an additional token vector to the weight matrix.

During my PR today, I encountered two problems:

1. Adding a token embedding vector causes some pretrained model (`gpt2` and `openai-gpt`) often generate the newly added token embedding vector (since input & output token embeddings are tied). A remedy for this is to simply always set the produced logits of the pad_token_id to -Inf. This works as it doesn't generate the `pad_token`, but it changes the internal behavior of `gpt2` and `openai-gpt` however. 

2. TransfoXL uses an adaptive token embedding matrix, which means that the function `resize_embedding_matrix` produces an error when used with `TransfoXLHeadModel`. This means the `token_embedding_matrix` of TransfoXL cannot be changed! Therefore, this approach doesn't work at all for TransfoXL (which is a pity as TransfoXL generates very good language). 

In the current PR, some tests fail (TransfoXL and the slow tests of gpt2 and openai-gpt). I wanted to hear your opinion on this logic vs. the logic that is implemented now (see #2885) @thomwolf, @LysandreJik and @mfuntowicz 
