### PR TITLE
[WIP] deleted special tokens as attributes from model config

### DIFF
--- a/src/transformers/configuration_bart.py
+++ b/src/transformers/configuration_bart.py
@@ -41,8 +41,6 @@ class BartConfig(PretrainedConfig):
         self,
         activation_dropout=0.0,
         vocab_size=50265,
-#        pad_token_id=1,
-#        eos_token_id=2,
         d_model=1024,
         encoder_ffn_dim=4096,
         encoder_layers=12,

--- a/src/transformers/configuration_bart.py
+++ b/src/transformers/configuration_bart.py
@@ -41,8 +41,8 @@ class BartConfig(PretrainedConfig):
         self,
         activation_dropout=0.0,
         vocab_size=50265,
-        pad_token_id=1,
-        eos_token_id=2,
+#        pad_token_id=1,
+#        eos_token_id=2,
         d_model=1024,
         encoder_ffn_dim=4096,
         encoder_layers=12,
@@ -67,11 +67,10 @@ class BartConfig(PretrainedConfig):
                 config = BartConfig.from_pretrained('bart-large')
                 model = BartModel(config)
         """
-        super().__init__(num_labels=num_labels, output_past=output_past, pad_token_id=pad_token_id, **common_kwargs)
+        super().__init__(num_labels=num_labels, output_past=output_past, **common_kwargs)
 
         self.vocab_size = vocab_size
         self.d_model = d_model  # encoder_embed_dim and decoder_embed_dim
-        self.eos_token_id = eos_token_id
 
         self.encoder_ffn_dim = encoder_ffn_dim
         self.encoder_layers = self.num_hidden_layers = encoder_layers

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -75,9 +75,6 @@ class PretrainedConfig(object):
         self.top_k = kwargs.pop("top_k", 50)
         self.top_p = kwargs.pop("top_p", 1.0)
         self.repetition_penalty = kwargs.pop("repetition_penalty", 1.0)
-        self.bos_token_id = kwargs.pop("bos_token_id", None)
-        self.pad_token_id = kwargs.pop("pad_token_id", None)
-        self.eos_token_ids = kwargs.pop("eos_token_ids", None)
         self.length_penalty = kwargs.pop("length_penalty", 1.0)
         self.num_return_sequences = kwargs.pop("num_return_sequences", 1)
 

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -800,7 +800,6 @@ class BartModel(PretrainedBartModel):
         self.output_attentions = config.output_attentions
         self.output_hidden_states = config.output_hidden_states
 
-        padding_idx, vocab_size = config.pad_token_id, config.vocab_size
         self.shared = nn.Embedding(vocab_size, config.d_model, padding_idx)
 
         self.encoder = BartEncoder(config, self.shared)

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -68,12 +68,11 @@ LARGE_NEGATIVE = -1e4
 
 
 def _prepare_bart_decoder_inputs(
-    config, input_ids, decoder_input_ids=None, decoder_attn_mask=None,
+    config, input_ids, decoder_input_ids=None, decoder_attn_mask=None, pad_token_id=None,
 ):
     """Prepare masks that ignore padding tokens  decoder and a causal lm mask for the decoder if
     none are provided. This mimics the default behavior in fairseq. To override it pass in masks.
     """
-    pad_token_id = config.pad_token_id
     need_causal_mask = not config.output_past
     if decoder_input_ids is None:
         decoder_input_ids = shift_tokens_right(input_ids, pad_token_id)
@@ -965,6 +964,7 @@ class BartForSequenceClassification(PretrainedBartModel):
         decoder_input_ids=None,
         decoder_attention_mask=None,
         labels=None,
+        eos_token_id=None,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`, defaults to :obj:`None`):
@@ -1010,7 +1010,7 @@ class BartForSequenceClassification(PretrainedBartModel):
             encoder_outputs=encoder_outputs,
         )
         x = outputs[0]  # last hidden state
-        eos_mask = input_ids.eq(self.config.eos_token_id)
+        eos_mask = input_ids.eq(eos_token_id)
         if len(torch.unique(eos_mask.sum(1))) > 1:
             raise ValueError("All examples must have the same number of <eos> tokens.")
         sentence_representation = x[eos_mask, :].view(x.size(0), -1, x.size(-1))[:, -1, :]

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -699,9 +699,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         top_k = top_k if top_k is not None else self.config.top_k
         top_p = top_p if top_p is not None else self.config.top_p
         repetition_penalty = repetition_penalty if repetition_penalty is not None else self.config.repetition_penalty
-        bos_token_id = bos_token_id if bos_token_id is not None else self.config.bos_token_id
-        pad_token_id = pad_token_id if pad_token_id is not None else self.config.pad_token_id
-        eos_token_ids = eos_token_ids if eos_token_ids is not None else self.config.eos_token_ids
+        bos_token_id = bos_token_id if bos_token_id is not None else None
+        pad_token_id = pad_token_id if pad_token_id is not None else None
+        eos_token_ids = eos_token_ids if eos_token_ids is not None else None
         length_penalty = length_penalty if length_penalty is not None else self.config.length_penalty
         num_return_sequences = (
             num_return_sequences if num_return_sequences is not None else self.config.num_return_sequences


### PR DESCRIPTION
Given our conversation in #3011 , I thought about deleting all model special config attributes to make sure that no data is duplicated between the tokenizer of a model and the model. 

There are two instances where config special attributes were used (e.g. self.config.pad_token_id)

1. the generate() function. But the generate function also takes all those tokens as attributes, so it should not at all rely on self.config.pad_token_id. This one is trivial to fix.

2. the bart model. It seems like the pad_token_id is actually an integral part of the bart model itself, so to me it seems very hard to disentangle the pad_token_id from the bart model. 

I see three options:

1) Leave the code as it is and leave default attributes self.config.pad_token_id, self.config.bos_token_id, self.config.eos_token_id = None in the PretrainedConfig class.

2) Remove the self.config.pad_token_id, ... from the PretrainedConfig class, make the generate function independent of those variables, but add those variables to the BartConfig only.

3) Make the models completely independent from all special tokens. This probably would mean that the bart model class needs quite a lot of changes. 

I tend to option 2) or 3). I like the idea of separation token ids from internal model behavior completely, but I cannot really estimate whether this is feasible for Bart (@sshleifer you probably have a better opinion on this).

What do you think? @LysandreJik , @julien-c , @thomwolf , @sshleifer  