### PR TITLE
Adds failing tests for the fast tokenizers

### DIFF
--- a/tests/test_tokenization_fast.py
+++ b/tests/test_tokenization_fast.py
@@ -717,3 +717,11 @@ class FastTokenizerMatchingTest(unittest.TestCase):
 
         self.assertEqual([e[1] for e in expected_results], tokenizer.convert_ids_to_tokens(tokens["input_ids"]))
         self.assertEqual([e[0] for e in expected_results], tokens["offset_mapping"])
+
+    def test_encode_plus_with_ids(self):
+        from transformers import AutoTokenizer
+        for fast in [False, True]:
+            with self.subTest(fast=fast):
+                tokenizer = AutoTokenizer.from_pretrained("bert-base-cased", use_fast=fast)
+                results = tokenizer.encode_plus([1000])
+                self.assertEqual([101, 1000, 102], results['input_ids'])

--- a/tests/test_tokenization_fast.py
+++ b/tests/test_tokenization_fast.py
@@ -540,25 +540,16 @@ class FastTokenizerMatchingTest(unittest.TestCase):
     def test_embedded_special_tokens(self):
         sentence = "A, <mask> AllenNLP sentence."
         from transformers import AutoTokenizer
-        tokenizer_r = AutoTokenizer.from_pretrained(
-            "roberta-base",
-            add_special_tokens=True,
-            use_fast=True)
-        tokenizer_p = AutoTokenizer.from_pretrained(
-            "roberta-base",
-            use_fast=False)
 
-        tokens_r = tokenizer_r.encode_plus(
-            sentence,
-            return_attention_mask=False,
-            return_token_type_ids=True)
+        tokenizer_r = AutoTokenizer.from_pretrained("roberta-base", add_special_tokens=True, use_fast=True)
+        tokenizer_p = AutoTokenizer.from_pretrained("roberta-base", use_fast=False)
+
+        tokens_r = tokenizer_r.encode_plus(sentence, return_attention_mask=False, return_token_type_ids=True)
         tokens_p = tokenizer_p.encode_plus(
-            sentence,
-            add_special_tokens=True,
-            return_attention_mask=False,
-            return_token_type_ids=True)
-        type_ids_r = tokens_r['token_type_ids']
-        type_ids_p = tokens_p['token_type_ids']
+            sentence, add_special_tokens=True, return_attention_mask=False, return_token_type_ids=True
+        )
+        type_ids_r = tokens_r["token_type_ids"]
+        type_ids_p = tokens_p["token_type_ids"]
 
         expected_tokens = [
             "<s>",
@@ -574,8 +565,8 @@ class FastTokenizerMatchingTest(unittest.TestCase):
             "</s>",
         ]
 
-        tokens_r = tokenizer_r.convert_ids_to_tokens(tokens_r['input_ids'])
-        tokens_p = tokenizer_p.convert_ids_to_tokens(tokens_p['input_ids'])
+        tokens_r = tokenizer_r.convert_ids_to_tokens(tokens_r["input_ids"])
+        tokens_p = tokenizer_p.convert_ids_to_tokens(tokens_p["input_ids"])
         self.assertEqual(expected_tokens, tokens_r)
         self.assertEqual(expected_tokens, tokens_p)
 
@@ -586,25 +577,18 @@ class FastTokenizerMatchingTest(unittest.TestCase):
         sentence_1 = "A, [MASK] AllenNLP sentence."
         sentence_2 = "A sentence."
         from transformers import AutoTokenizer
-        tokenizer_r = AutoTokenizer.from_pretrained(
-            "bert-base-cased",
-            add_special_tokens=True,
-            use_fast=True)
-        tokenizer_p = AutoTokenizer.from_pretrained(
-            "bert-base-cased",
-            use_fast=False)
+
+        tokenizer_r = AutoTokenizer.from_pretrained("bert-base-cased", add_special_tokens=True, use_fast=True)
+        tokenizer_p = AutoTokenizer.from_pretrained("bert-base-cased", use_fast=False)
 
         tokens_r = tokenizer_r.encode_plus(
-            sentence_1, sentence_2,
-            return_attention_mask=False,
-            return_token_type_ids=True)
+            sentence_1, sentence_2, return_attention_mask=False, return_token_type_ids=True
+        )
         tokens_p = tokenizer_p.encode_plus(
-            sentence_1, sentence_2,
-            add_special_tokens=True,
-            return_attention_mask=False,
-            return_token_type_ids=True)
-        type_ids_r = tokens_r['token_type_ids']
-        type_ids_p = tokens_p['token_type_ids']
+            sentence_1, sentence_2, add_special_tokens=True, return_attention_mask=False, return_token_type_ids=True
+        )
+        type_ids_r = tokens_r["token_type_ids"]
+        type_ids_p = tokens_p["token_type_ids"]
 
         expected_result = [
             (0, "[CLS]"),
@@ -623,8 +607,8 @@ class FastTokenizerMatchingTest(unittest.TestCase):
             (1, "[SEP]"),
         ]
 
-        tokens_r = tokenizer_r.convert_ids_to_tokens(tokens_r['input_ids'])
-        tokens_p = tokenizer_p.convert_ids_to_tokens(tokens_p['input_ids'])
+        tokens_r = tokenizer_r.convert_ids_to_tokens(tokens_r["input_ids"])
+        tokens_p = tokenizer_p.convert_ids_to_tokens(tokens_p["input_ids"])
         self.assertEqual([e[1] for e in expected_result], tokens_r)
         self.assertEqual([e[1] for e in expected_result], tokens_p)
 
@@ -635,25 +619,18 @@ class FastTokenizerMatchingTest(unittest.TestCase):
         sentence_1 = "A, <mask> AllenNLP sentence."
         sentence_2 = "A sentence."
         from transformers import AutoTokenizer
-        tokenizer_r = AutoTokenizer.from_pretrained(
-            "roberta-base",
-            add_special_tokens=True,
-            use_fast=True)
-        tokenizer_p = AutoTokenizer.from_pretrained(
-            "roberta-base",
-            use_fast=False)
+
+        tokenizer_r = AutoTokenizer.from_pretrained("roberta-base", add_special_tokens=True, use_fast=True)
+        tokenizer_p = AutoTokenizer.from_pretrained("roberta-base", use_fast=False)
 
         tokens_r = tokenizer_r.encode_plus(
-            sentence_1, sentence_2,
-            return_attention_mask=False,
-            return_token_type_ids=True)
+            sentence_1, sentence_2, return_attention_mask=False, return_token_type_ids=True
+        )
         tokens_p = tokenizer_p.encode_plus(
-            sentence_1, sentence_2,
-            add_special_tokens=True,
-            return_attention_mask=False,
-            return_token_type_ids=True)
-        type_ids_r = tokens_r['token_type_ids']
-        type_ids_p = tokens_p['token_type_ids']
+            sentence_1, sentence_2, add_special_tokens=True, return_attention_mask=False, return_token_type_ids=True
+        )
+        type_ids_r = tokens_r["token_type_ids"]
+        type_ids_p = tokens_p["token_type_ids"]
 
         expected_tokens = [
             "<s>",
@@ -674,8 +651,8 @@ class FastTokenizerMatchingTest(unittest.TestCase):
             "</s>",
         ]
 
-        tokens_r = tokenizer_r.convert_ids_to_tokens(tokens_r['input_ids'])
-        tokens_p = tokenizer_p.convert_ids_to_tokens(tokens_p['input_ids'])
+        tokens_r = tokenizer_r.convert_ids_to_tokens(tokens_r["input_ids"])
+        tokens_p = tokenizer_p.convert_ids_to_tokens(tokens_p["input_ids"])
         self.assertEqual(expected_tokens, tokens_r)
         self.assertEqual(expected_tokens, tokens_p)
 
@@ -684,19 +661,15 @@ class FastTokenizerMatchingTest(unittest.TestCase):
 
     def test_offsets_with_special_characters(self):
         from transformers import AutoTokenizer
+
         sentence = "A, naïve [MASK] AllenNLP sentence."
         for model in ["bert-base-cased", "bert-base-uncased"]:
             with self.subTest(model=model):
-                tokenizer = AutoTokenizer.from_pretrained(
-                    model,
-                    add_special_tokens=True,
-                    use_fast=True)
+                tokenizer = AutoTokenizer.from_pretrained(model, add_special_tokens=True, use_fast=True)
 
                 tokens = tokenizer.encode_plus(
-                    sentence,
-                    return_attention_mask=False,
-                    return_token_type_ids=False,
-                    return_offsets_mapping=True)
+                    sentence, return_attention_mask=False, return_token_type_ids=False, return_offsets_mapping=True
+                )
 
                 expected_results = [
                     (None, "[CLS]"),
@@ -709,37 +682,29 @@ class FastTokenizerMatchingTest(unittest.TestCase):
                     ((24, 25), "##P"),
                     ((26, 34), "sentence"),
                     ((35, 36), "."),
-                    (None, "[SEP]")
+                    (None, "[SEP]"),
                 ]
 
                 self.assertEqual(
-                    [e[1] for e in expected_results],
-                    tokenizer.convert_ids_to_tokens(tokens["input_ids"])
+                    [e[1] for e in expected_results], tokenizer.convert_ids_to_tokens(tokens["input_ids"])
                 )
-                self.assertEqual(
-                    [e[0] for e in expected_results],
-                    tokens["offset_mapping"]
-                )
+                self.assertEqual([e[0] for e in expected_results], tokens["offset_mapping"])
 
     def test_offsets_with_special_characters_roberta(self):
         from transformers import AutoTokenizer
+
         sentence = "A, naïve <mask> AllenNLP sentence."
-        tokenizer = AutoTokenizer.from_pretrained(
-            "roberta-base",
-            add_special_tokens=True,
-            use_fast=True)
+        tokenizer = AutoTokenizer.from_pretrained("roberta-base", add_special_tokens=True, use_fast=True)
 
         tokens = tokenizer.encode_plus(
-            sentence,
-            return_attention_mask=False,
-            return_token_type_ids=False,
-            return_offsets_mapping=True)
+            sentence, return_attention_mask=False, return_token_type_ids=False, return_offsets_mapping=True
+        )
 
         expected_results = [
             (None, "<s>"),
             ((0, 1), "A"),
             ((1, 2), ","),
-            ((3, 8), "ĠnaÃ¯ve"),    # RoBERTa mangles this
+            ((3, 8), "ĠnaÃ¯ve"),  # RoBERTa mangles this
             ((8, 9), "Ġ"),
             ((9, 15), "<mask>"),
             ((16, 21), "ĠAllen"),
@@ -747,14 +712,8 @@ class FastTokenizerMatchingTest(unittest.TestCase):
             ((23, 25), "LP"),
             ((26, 34), "Ġsentence"),
             ((35, 36), "."),
-            (None, "</s>")
+            (None, "</s>"),
         ]
 
-        self.assertEqual(
-            [e[1] for e in expected_results],
-            tokenizer.convert_ids_to_tokens(tokens["input_ids"])
-        )
-        self.assertEqual(
-            [e[0] for e in expected_results],
-            tokens["offset_mapping"]
-        )
+        self.assertEqual([e[1] for e in expected_results], tokenizer.convert_ids_to_tokens(tokens["input_ids"]))
+        self.assertEqual([e[0] for e in expected_results], tokens["offset_mapping"])

--- a/tests/test_tokenization_fast.py
+++ b/tests/test_tokenization_fast.py
@@ -725,3 +725,11 @@ class FastTokenizerMatchingTest(unittest.TestCase):
                 tokenizer = AutoTokenizer.from_pretrained("bert-base-cased", use_fast=fast)
                 results = tokenizer.encode_plus([1000])
                 self.assertEqual([101, 1000, 102], results['input_ids'])
+
+    def test_empty_input(self):
+        from transformers import AutoTokenizer
+        for fast in [False, True]:
+            with self.subTest(fast=fast):
+                tokenizer = AutoTokenizer.from_pretrained("bert-base-cased", use_fast=fast, add_special_tokens=False)
+                results = tokenizer.encode_plus(" ", add_special_tokens=False)
+                self.assertEqual([], results['input_ids'])

--- a/tests/test_tokenization_fast.py
+++ b/tests/test_tokenization_fast.py
@@ -720,16 +720,18 @@ class FastTokenizerMatchingTest(unittest.TestCase):
 
     def test_encode_plus_with_ids(self):
         from transformers import AutoTokenizer
+
         for fast in [False, True]:
             with self.subTest(fast=fast):
                 tokenizer = AutoTokenizer.from_pretrained("bert-base-cased", use_fast=fast)
                 results = tokenizer.encode_plus([1000])
-                self.assertEqual([101, 1000, 102], results['input_ids'])
+                self.assertEqual([101, 1000, 102], results["input_ids"])
 
     def test_empty_input(self):
         from transformers import AutoTokenizer
+
         for fast in [False, True]:
             with self.subTest(fast=fast):
                 tokenizer = AutoTokenizer.from_pretrained("bert-base-cased", use_fast=fast, add_special_tokens=False)
                 results = tokenizer.encode_plus(" ", add_special_tokens=False)
-                self.assertEqual([], results['input_ids'])
+                self.assertEqual([], results["input_ids"])


### PR DESCRIPTION
This ports some of the tests over that started failing on the AllenNLP side when the new fast tokenizers came out.

Note: These tests are failing right now. They will need updates to the fast transformers before this can be merged. Maybe it would be better to merge this branch into the branch where the tokenizers are being fixed?