### PR TITLE
fix sklearn release circle ci [temporary]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ if stale_egg_info.exists():
 extras = {}
 
 extras["mecab"] = ["mecab-python3"]
-extras["sklearn"] = ["scikit-learn"]
+extras["sklearn"] = ["scikit-learn==0.22.1"]
 extras["tf"] = ["tensorflow"]
 extras["tf-cpu"] = ["tensorflow-cpu"]
 extras["torch"] = ["torch"]


### PR DESCRIPTION
new sklearn release (https://github.com/scikit-learn/scikit-learn/releases) seems to be broken or leads to errors for PR since this morning - go back to previous version for now to avoid circle ci errors