### PR TITLE
fix repetition penalty mask in tf

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -70,7 +70,7 @@ class PretrainedConfig(object):
         # Parameters for sequence generation
         self.max_length = kwargs.pop("max_length", 20)
         self.do_sample = kwargs.pop("do_sample", False)
-        self.do_sample = kwargs.pop("early_stopping", False)
+        self.early_stopping = kwargs.pop("early_stopping", False)
         self.num_beams = kwargs.pop("num_beams", 1)
         self.temperature = kwargs.pop("temperature", 1.0)
         self.top_k = kwargs.pop("top_k", 50)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -70,6 +70,7 @@ class PretrainedConfig(object):
         # Parameters for sequence generation
         self.max_length = kwargs.pop("max_length", 20)
         self.do_sample = kwargs.pop("do_sample", False)
+        self.do_sample = kwargs.pop("early_stopping", False)
         self.num_beams = kwargs.pop("num_beams", 1)
         self.temperature = kwargs.pop("temperature", 1.0)
         self.top_k = kwargs.pop("top_k", 50)


### PR DESCRIPTION
Fixed bug with TF 2.0 `repetition_penalty` when doing generation add make `early_stopping` an argument to the function `generate()`.