### PR TITLE
XLM-R Tokenizer now passes common tests + Integration tests

### DIFF
--- a/src/transformers/tokenization_xlm_roberta.py
+++ b/src/transformers/tokenization_xlm_roberta.py
@@ -162,7 +162,7 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
         # The first "real" token "," has position 4 in the original fairseq vocab and position 3 in the spm vocab
         self.fairseq_offset = 1
 
-        self.fairseq_tokens_to_ids["<mask>"] = len(self.sp_model) + len(self.fairseq_tokens_to_ids)
+        self.fairseq_tokens_to_ids["<mask>"] = len(self.sp_model) + self.fairseq_offset
         self.fairseq_ids_to_tokens = {v: k for k, v in self.fairseq_tokens_to_ids.items()}
 
     def __getstate__(self):
@@ -268,7 +268,7 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
 
     @property
     def vocab_size(self):
-        return len(self.sp_model) + self.fairseq_offset
+        return len(self.sp_model) + self.fairseq_offset + 1  # Add the <mask> token
 
     def get_vocab(self):
         vocab = {self.convert_ids_to_tokens(i): i for i in range(self.vocab_size)}

--- a/src/transformers/tokenization_xlm_roberta.py
+++ b/src/transformers/tokenization_xlm_roberta.py
@@ -105,6 +105,7 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
     vocab_files_names = VOCAB_FILES_NAMES
     pretrained_vocab_files_map = PRETRAINED_VOCAB_FILES_MAP
     max_model_input_sizes = PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES
+    model_input_names = ["attention_mask"]
 
     def __init__(
         self,
@@ -296,7 +297,7 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
 
     def _convert_token_to_id(self, token):
         """ Converts a token (str) in an id using the vocab. """
-G        if token in self.fairseq_tokens_to_ids:
+        if token in self.fairseq_tokens_to_ids:
             return self.fairseq_tokens_to_ids[token]
         spm_id = self.sp_model.PieceToId(token)
 

--- a/src/transformers/tokenization_xlm_roberta.py
+++ b/src/transformers/tokenization_xlm_roberta.py
@@ -110,9 +110,6 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
     def __init__(
         self,
         vocab_file,
-        do_lower_case=False,
-        remove_space=True,
-        keep_accents=False,
         bos_token="<s>",
         eos_token="</s>",
         sep_token="</s>",
@@ -144,9 +141,6 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
             )
             raise
 
-        self.do_lower_case = do_lower_case
-        self.remove_space = remove_space
-        self.keep_accents = keep_accents
         self.sp_model = spm.SentencePieceProcessor()
         self.sp_model.Load(str(vocab_file))
         self.vocab_file = vocab_file
@@ -276,23 +270,7 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
         vocab.update(self.added_tokens_encoder)
         return vocab
 
-    def preprocess_text(self, inputs):
-        if self.remove_space:
-            outputs = " ".join(inputs.strip().split())
-        else:
-            outputs = inputs
-        outputs = outputs.replace("``", '"').replace("''", '"')
-
-        if not self.keep_accents:
-            outputs = unicodedata.normalize("NFKD", outputs)
-            outputs = "".join([c for c in outputs if not unicodedata.combining(c)])
-        if self.do_lower_case:
-            outputs = outputs.lower()
-
-        return outputs
-
     def _tokenize(self, text):
-        text = self.preprocess_text(text)
         return self.sp_model.EncodeAsPieces(text)
 
     def _convert_token_to_id(self, token):

--- a/src/transformers/tokenization_xlm_roberta.py
+++ b/src/transformers/tokenization_xlm_roberta.py
@@ -17,9 +17,9 @@
 
 import logging
 import os
+import unicodedata
 from shutil import copyfile
 from typing import List, Optional
-import unicodedata
 
 from transformers.tokenization_utils import PreTrainedTokenizer
 

--- a/src/transformers/tokenization_xlm_roberta.py
+++ b/src/transformers/tokenization_xlm_roberta.py
@@ -17,7 +17,6 @@
 
 import logging
 import os
-import unicodedata
 from shutil import copyfile
 from typing import List, Optional
 

--- a/tests/test_tokenization_xlm_roberta.py
+++ b/tests/test_tokenization_xlm_roberta.py
@@ -121,66 +121,6 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             ],
         )
 
-    def test_tokenizer_lower(self):
-        tokenizer = XLMRobertaTokenizer(SAMPLE_VOCAB, do_lower_case=True)
-        tokens = tokenizer.tokenize("I was born in 92000, and this is falsé.")
-        self.assertListEqual(
-            tokens,
-            [
-                SPIECE_UNDERLINE + "",
-                "i",
-                SPIECE_UNDERLINE + "was",
-                SPIECE_UNDERLINE + "b",
-                "or",
-                "n",
-                SPIECE_UNDERLINE + "in",
-                SPIECE_UNDERLINE + "",
-                "9",
-                "2",
-                "0",
-                "0",
-                "0",
-                ",",
-                SPIECE_UNDERLINE + "and",
-                SPIECE_UNDERLINE + "this",
-                SPIECE_UNDERLINE + "is",
-                SPIECE_UNDERLINE + "f",
-                "al",
-                "se",
-                ".",
-            ],
-        )
-        self.assertListEqual(tokenizer.tokenize("H\u00E9llo"), ["▁he", "ll", "o"])
-
-    def test_tokenizer_no_lower(self):
-        tokenizer = XLMRobertaTokenizer(SAMPLE_VOCAB, do_lower_case=False)
-        tokens = tokenizer.tokenize("I was born in 92000, and this is falsé.")
-        self.assertListEqual(
-            tokens,
-            [
-                SPIECE_UNDERLINE + "I",
-                SPIECE_UNDERLINE + "was",
-                SPIECE_UNDERLINE + "b",
-                "or",
-                "n",
-                SPIECE_UNDERLINE + "in",
-                SPIECE_UNDERLINE + "",
-                "9",
-                "2",
-                "0",
-                "0",
-                "0",
-                ",",
-                SPIECE_UNDERLINE + "and",
-                SPIECE_UNDERLINE + "this",
-                SPIECE_UNDERLINE + "is",
-                SPIECE_UNDERLINE + "f",
-                "al",
-                "se",
-                ".",
-            ],
-        )
-
     @slow
     def test_tokenization_base_easy_symbols(self):
         tokenizer = XLMRobertaTokenizer.from_pretrained("xlm-roberta-base")

--- a/tests/test_tokenization_xlm_roberta.py
+++ b/tests/test_tokenization_xlm_roberta.py
@@ -81,7 +81,7 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 "s",
                 "é",
                 ".",
-                ],
+            ],
         )
         ids = tokenizer.convert_tokens_to_ids(tokens)
         self.assertListEqual(
@@ -118,7 +118,7 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 "s",
                 "<unk>",
                 ".",
-                ],
+            ],
         )
 
     def test_tokenizer_lower(self):
@@ -148,7 +148,7 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 "al",
                 "se",
                 ".",
-                ],
+            ],
         )
         self.assertListEqual(tokenizer.tokenize("H\u00E9llo"), ["▁he", "ll", "o"])
 
@@ -178,7 +178,7 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 "al",
                 "se",
                 ".",
-                ],
+            ],
         )
 
     @slow
@@ -251,8 +251,8 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             # 4426, # What fairseq tokenizes from "<unk>": "_<"
             # 3678, # What fairseq tokenizes from "<unk>": "unk"
             # 2740, # What fairseq tokenizes from "<unk>": ">"
-            3,      # What we tokenize from "<unk>": "<unk>"
-            6,      # Residue from the tokenization: an extra sentencepiece underline
+            3,  # What we tokenize from "<unk>": "<unk>"
+            6,  # Residue from the tokenization: an extra sentencepiece underline
             4,
             6044,
             237,

--- a/tests/test_tokenization_xlm_roberta.py
+++ b/tests/test_tokenization_xlm_roberta.py
@@ -14,14 +14,173 @@
 # limitations under the License.
 
 
+import os
 import unittest
 
-from transformers.tokenization_xlm_roberta import XLMRobertaTokenizer
+from transformers.tokenization_xlm_roberta import SPIECE_UNDERLINE, XLMRobertaTokenizer
 
+from .test_tokenization_common import TokenizerTesterMixin
 from .utils import slow
 
 
-class XLMRobertaTokenizationIntegrationTest(unittest.TestCase):
+SAMPLE_VOCAB = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures/test_sentencepiece.model")
+
+
+class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+
+    tokenizer_class = XLMRobertaTokenizer
+
+    def setUp(self):
+        super().setUp()
+
+        # We have a SentencePiece fixture for testing
+        tokenizer = XLMRobertaTokenizer(SAMPLE_VOCAB, keep_accents=True)
+        tokenizer.save_pretrained(self.tmpdirname)
+
+    def get_tokenizer(self, **kwargs):
+        return XLMRobertaTokenizer.from_pretrained(self.tmpdirname, **kwargs)
+
+    def get_input_output_texts(self):
+        input_text = "This is a test"
+        output_text = "This is a test"
+        return input_text, output_text
+
+    def test_full_tokenizer(self):
+        tokenizer = XLMRobertaTokenizer(SAMPLE_VOCAB, keep_accents=True)
+
+        tokens = tokenizer.tokenize("This is a test")
+        self.assertListEqual(tokens, ["▁This", "▁is", "▁a", "▁t", "est"])
+
+        self.assertListEqual(
+            tokenizer.convert_tokens_to_ids(tokens),
+            [value + tokenizer.fairseq_offset for value in [285, 46, 10, 170, 382]],
+        )
+
+        tokens = tokenizer.tokenize("I was born in 92000, and this is falsé.")
+        self.assertListEqual(
+            tokens,
+            [
+                SPIECE_UNDERLINE + "I",
+                SPIECE_UNDERLINE + "was",
+                SPIECE_UNDERLINE + "b",
+                "or",
+                "n",
+                SPIECE_UNDERLINE + "in",
+                SPIECE_UNDERLINE + "",
+                "9",
+                "2",
+                "0",
+                "0",
+                "0",
+                ",",
+                SPIECE_UNDERLINE + "and",
+                SPIECE_UNDERLINE + "this",
+                SPIECE_UNDERLINE + "is",
+                SPIECE_UNDERLINE + "f",
+                "al",
+                "s",
+                "é",
+                ".",
+                ],
+        )
+        ids = tokenizer.convert_tokens_to_ids(tokens)
+        self.assertListEqual(
+            ids,
+            [
+                value + tokenizer.fairseq_offset
+                for value in [8, 21, 84, 55, 24, 19, 7, 2, 602, 347, 347, 347, 3, 12, 66, 46, 72, 80, 6, 2, 4]
+                #                                       ^ unk: 2 + 1 = 3                  unk: 2 + 1 = 3 ^
+            ],
+        )
+
+        back_tokens = tokenizer.convert_ids_to_tokens(ids)
+        self.assertListEqual(
+            back_tokens,
+            [
+                SPIECE_UNDERLINE + "I",
+                SPIECE_UNDERLINE + "was",
+                SPIECE_UNDERLINE + "b",
+                "or",
+                "n",
+                SPIECE_UNDERLINE + "in",
+                SPIECE_UNDERLINE + "",
+                "<unk>",
+                "2",
+                "0",
+                "0",
+                "0",
+                ",",
+                SPIECE_UNDERLINE + "and",
+                SPIECE_UNDERLINE + "this",
+                SPIECE_UNDERLINE + "is",
+                SPIECE_UNDERLINE + "f",
+                "al",
+                "s",
+                "<unk>",
+                ".",
+                ],
+        )
+
+    def test_tokenizer_lower(self):
+        tokenizer = XLMRobertaTokenizer(SAMPLE_VOCAB, do_lower_case=True)
+        tokens = tokenizer.tokenize("I was born in 92000, and this is falsé.")
+        self.assertListEqual(
+            tokens,
+            [
+                SPIECE_UNDERLINE + "",
+                "i",
+                SPIECE_UNDERLINE + "was",
+                SPIECE_UNDERLINE + "b",
+                "or",
+                "n",
+                SPIECE_UNDERLINE + "in",
+                SPIECE_UNDERLINE + "",
+                "9",
+                "2",
+                "0",
+                "0",
+                "0",
+                ",",
+                SPIECE_UNDERLINE + "and",
+                SPIECE_UNDERLINE + "this",
+                SPIECE_UNDERLINE + "is",
+                SPIECE_UNDERLINE + "f",
+                "al",
+                "se",
+                ".",
+                ],
+        )
+        self.assertListEqual(tokenizer.tokenize("H\u00E9llo"), ["▁he", "ll", "o"])
+
+    def test_tokenizer_no_lower(self):
+        tokenizer = XLMRobertaTokenizer(SAMPLE_VOCAB, do_lower_case=False)
+        tokens = tokenizer.tokenize("I was born in 92000, and this is falsé.")
+        self.assertListEqual(
+            tokens,
+            [
+                SPIECE_UNDERLINE + "I",
+                SPIECE_UNDERLINE + "was",
+                SPIECE_UNDERLINE + "b",
+                "or",
+                "n",
+                SPIECE_UNDERLINE + "in",
+                SPIECE_UNDERLINE + "",
+                "9",
+                "2",
+                "0",
+                "0",
+                "0",
+                ",",
+                SPIECE_UNDERLINE + "and",
+                SPIECE_UNDERLINE + "this",
+                SPIECE_UNDERLINE + "is",
+                SPIECE_UNDERLINE + "f",
+                "al",
+                "se",
+                ".",
+                ],
+        )
+
     @slow
     def test_tokenization_base_easy_symbols(self):
         tokenizer = XLMRobertaTokenizer.from_pretrained("xlm-roberta-base")
@@ -89,9 +248,11 @@ class XLMRobertaTokenizationIntegrationTest(unittest.TestCase):
             1098,
             29367,
             47,
-            4426,
-            3678,
-            2740,
+            # 4426, # What fairseq tokenizes from "<unk>": "_<"
+            # 3678, # What fairseq tokenizes from "<unk>": "unk"
+            # 2740, # What fairseq tokenizes from "<unk>": ">"
+            3,      # What we tokenize from "<unk>": "<unk>"
+            6,      # Residue from the tokenization: an extra sentencepiece underline
             4,
             6044,
             237,


### PR DESCRIPTION
XLM-R Tokenizer had a lot of issues that were not identified as no testing was done on it.

closes #2993 
closes #2795
closes #2741
closes #2727
closes #2508

This fixes all the above issues, and works for all official checkpoints as well as other SPM files.

However, there are a few things I dislike about the way things stands, which I'm detailing in the comments below.