### PR TITLE
Complete merge Seq-2-Seq generation into default generation

### DIFF
--- a/examples/summarization/bart/evaluate_cnn.py
+++ b/examples/summarization/bart/evaluate_cnn.py
@@ -20,6 +20,10 @@ def generate_summaries(lns, out_file, batch_size=8, device=DEFAULT_DEVICE):
     fout = Path(out_file).open("w")
     model = BartForConditionalGeneration.from_pretrained("bart-large-cnn", output_past=True,).to(device)
     tokenizer = BartTokenizer.from_pretrained("bart-large")
+
+    max_length = 140
+    min_length = 55
+
     for batch in tqdm(list(chunks(lns, batch_size))):
         dct = tokenizer.batch_encode_plus(batch, max_length=1024, return_tensors="pt", pad_to_max_length=True)
         summaries = model.generate(
@@ -27,11 +31,12 @@ def generate_summaries(lns, out_file, batch_size=8, device=DEFAULT_DEVICE):
             attention_mask=dct["attention_mask"].to(device),
             num_beams=4,
             length_penalty=2.0,
-            max_length=142,  # +2 from original because we start at step=1 and stop before max_length
-            min_length=56,  # +1 from original because we start at step=1
+            max_length=max_length + 2,  # +2 from original because we start at step=1 and stop before max_length
+            min_length=min_length + 1,  # +1 from original because we start at step=1
             no_repeat_ngram_size=3,
             early_stopping=True,
             do_sample=False,
+            decoder_start_token_id=model.config.eos_token_ids[0]
         )
         dec = [tokenizer.decode(g, skip_special_tokens=True, clean_up_tokenization_spaces=False) for g in summaries]
         for hypothesis in dec:

--- a/examples/summarization/bart/evaluate_cnn.py
+++ b/examples/summarization/bart/evaluate_cnn.py
@@ -36,7 +36,7 @@ def generate_summaries(lns, out_file, batch_size=8, device=DEFAULT_DEVICE):
             no_repeat_ngram_size=3,
             early_stopping=True,
             do_sample=False,
-            decoder_start_token_id=model.config.eos_token_ids[0]
+            decoder_start_token_id=model.config.eos_token_ids[0],
         )
         dec = [tokenizer.decode(g, skip_special_tokens=True, clean_up_tokenization_spaces=False) for g in summaries]
         for hypothesis in dec:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -845,7 +845,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             encoder_inputs = input_ids
             input_ids = torch.full(
                 (effective_batch_size * num_beams, 1),
-                bos_token_id,
+                bos_token_id,  # TODO: wait for results of Bart CNN summarization
                 dtype=torch.long,
                 device=next(self.parameters()).device,
             )
@@ -1082,7 +1082,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
 
             scores = F.log_softmax(next_token_logits, dim=-1)  # (batch_size * num_beams, vocab_size)
             if self.config.is_encoder_decoder and do_sample is False:
-                # TODO(PVP) to be refactored later - do we need this boolean flag here? Also Only add for beam_search or also for no_beam_search? The prepare scores fn is ugly here
+                # TODO: maybe give better naming
                 scores = self.prepare_scores_for_generation(scores, cur_len, max_length)
 
             # set eos token prob to zero if min_length is not reached
@@ -1276,7 +1276,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             decoded = torch.stack(best).type(torch.long).to(next(self.parameters()).device)
 
         if self.config.is_encoder_decoder:
-            # do not return first <EOS> token
             return decoded[:, 1:]
         return decoded
 

--- a/tests/test_modeling_bart.py
+++ b/tests/test_modeling_bart.py
@@ -61,7 +61,7 @@ class ModelTester:
         self.hidden_dropout_prob = 0.1
         self.attention_probs_dropout_prob = 0.1
         self.max_position_embeddings = 20
-        self.eos_token_id = 2
+        self.eos_token_ids = [2]
         self.pad_token_id = 1
         self.bos_token_id = 0
         torch.manual_seed(0)
@@ -436,7 +436,7 @@ class BartModelIntegrationTest(unittest.TestCase):
             num_beams=4,
             max_length=extra_len + 2,
             do_sample=False,
-            decoder_start_token_id=hf.config.eos_token_id,
+            decoder_start_token_id=hf.config.eos_token_ids[0],
         )  # repetition_penalty=10.,
         expected_result = "<s>The Palestinian Authority officially became the 123rd member of the International Criminal Court on Wednesday."
         generated = [tok.decode(g,) for g in gen_tokens]
@@ -481,7 +481,7 @@ class BartModelIntegrationTest(unittest.TestCase):
             no_repeat_ngram_size=3,
             do_sample=False,
             early_stopping=True,
-            decoder_start_token_id=hf.config.eos_token_id,
+            decoder_start_token_id=hf.config.eos_token_ids[0],
         )
 
         decoded = [

--- a/tests/test_modeling_bart.py
+++ b/tests/test_modeling_bart.py
@@ -432,7 +432,11 @@ class BartModelIntegrationTest(unittest.TestCase):
         tokens = tok.encode(text, return_tensors="pt").to(torch_device)
         extra_len = 20
         gen_tokens = hf.generate(
-            tokens, num_beams=4, max_length=extra_len + 2, do_sample=False
+            tokens,
+            num_beams=4,
+            max_length=extra_len + 2,
+            do_sample=False,
+            decoder_start_token_id=hf.config.eos_token_id,
         )  # repetition_penalty=10.,
         expected_result = "<s>The Palestinian Authority officially became the 123rd member of the International Criminal Court on Wednesday."
         generated = [tok.decode(g,) for g in gen_tokens]
@@ -477,6 +481,7 @@ class BartModelIntegrationTest(unittest.TestCase):
             no_repeat_ngram_size=3,
             do_sample=False,
             early_stopping=True,
+            decoder_start_token_id=hf.config.eos_token_id,
         )
 
         decoded = [

--- a/tests/test_modeling_bart.py
+++ b/tests/test_modeling_bart.py
@@ -82,7 +82,7 @@ class ModelTester:
             dropout=self.hidden_dropout_prob,
             attention_dropout=self.attention_probs_dropout_prob,
             max_position_embeddings=self.max_position_embeddings,
-            eos_token_ids=[self.eos_token_id],
+            eos_token_ids=[2],
             bos_token_id=self.bos_token_id,
             pad_token_id=self.pad_token_id,
         )


### PR DESCRIPTION
This is a follow-up PR to finalize #3140 .

There was still no conclusion on how to handle the fairseq tricks for generation. To summarize: 

I think we have three options:

1. Remove all faiseq tricks. Here the ROUGE score is: **20.285**
2. Implement the fairseq tricks EXCEPT leaving the starting decoding_inputs_tokens to be the BOS token instead of EOS. Here the ROUGE score is: **19.369**
3. Add all fairseq tricks and maybe add a new argument to `generate()` which is called `decoder_start_token_id=bos_token_id` , but can be overriden to be the `eos_token_id` in the case of Bart. Here the ROUGE score is: **21.072**

ROUGE scores from @sshleifer

For comparison: 

![76256460-5b675780-6226-11ea-8516-28d0427251ca](https://user-images.githubusercontent.com/23423619/76422619-cdb27600-63a5-11ea-82c7-f36addb7fefb.png)

UPDATE:

Given the above scores, option 1. was chosen for the moment to have the same scores as fairseq. 
This means that we have to start the decoder ids with a EOS token (which might be weird and fairseq specific). Therefore, a new argument `decoder_start_token_id` was added to the generate function that defaults to the `bos_token_id`. When using Bart generate this argument should be set to the `eos_token_id` to have good results. To see how `Bart.generate()` should be used take a look at: 
https://github.com/huggingface/transformers/blob/2e81b9d8d76a4d41a13f74eb5e0f4a65d8143cab/tests/test_modeling_bart.py#L470

At the moment option 2. is implemented which seems to give the worst results and is also not the cleanest option. 
This PR implements option 3. 

For me either option 1. or option 3. is fine. Up to discuss @thomwolf , @julien-c , @LysandreJik @sshleifer 
