### PR TITLE
Minor Bug Fix for Running Roberta on Glue

### DIFF
--- a/src/transformers/data/processors/glue.py
+++ b/src/transformers/data/processors/glue.py
@@ -90,7 +90,9 @@ def glue_convert_examples_to_features(
         if ex_index % 10000 == 0:
             logger.info("Writing example %d/%d" % (ex_index, len_examples))
 
-        inputs = tokenizer.encode_plus(example.text_a, example.text_b, add_special_tokens=True, max_length=max_length,)
+        inputs = tokenizer.encode_plus(
+                example.text_a, example.text_b, add_special_tokens=True, max_length=max_length,
+                return_token_type_ids=True,)
         input_ids, token_type_ids = inputs["input_ids"], inputs["token_type_ids"]
 
         # The mask has 1 for real tokens and 0 for padding tokens. Only real

--- a/src/transformers/data/processors/glue.py
+++ b/src/transformers/data/processors/glue.py
@@ -90,8 +90,7 @@ def glue_convert_examples_to_features(
         if ex_index % 10000 == 0:
             logger.info("Writing example %d/%d" % (ex_index, len_examples))
 
-        inputs = tokenizer.encode_plus(
-                example.text_a, example.text_b, add_special_tokens=True, max_length=max_length,
+        inputs = tokenizer.encode_plus(example.text_a, example.text_b, add_special_tokens=True, max_length=max_length,
                 return_token_type_ids=True,)
         input_ids, token_type_ids = inputs["input_ids"], inputs["token_type_ids"]
 

--- a/src/transformers/data/processors/glue.py
+++ b/src/transformers/data/processors/glue.py
@@ -90,8 +90,9 @@ def glue_convert_examples_to_features(
         if ex_index % 10000 == 0:
             logger.info("Writing example %d/%d" % (ex_index, len_examples))
 
-        inputs = tokenizer.encode_plus(example.text_a, example.text_b, add_special_tokens=True, max_length=max_length,
-                return_token_type_ids=True,)
+        inputs = tokenizer.encode_plus(
+            example.text_a, example.text_b, add_special_tokens=True, max_length=max_length, return_token_type_ids=True,
+        )
         input_ids, token_type_ids = inputs["input_ids"], inputs["token_type_ids"]
 
         # The mask has 1 for real tokens and 0 for padding tokens. Only real


### PR DESCRIPTION
Since `RobertaTokenizer`  does not generate `return_type_ids`, running Glue with Roberta throws errors. This fix overwrites the default behaviour of the tokenizers, and forces them to generate `return_type_ids`.