### PR TITLE
Clean special token init in modeling_....py

### DIFF
--- a/examples/summarization/bart/evaluate_cnn.py
+++ b/examples/summarization/bart/evaluate_cnn.py
@@ -35,7 +35,7 @@ def generate_summaries(lns, out_file, batch_size=8, device=DEFAULT_DEVICE):
             min_length=min_length + 1,  # +1 from original because we start at step=1
             no_repeat_ngram_size=3,
             early_stopping=True,
-            decoder_start_token_id=model.config.eos_token_ids[0],
+            decoder_start_token_id=model.config.eos_token_id,
         )
         dec = [tokenizer.decode(g, skip_special_tokens=True, clean_up_tokenization_spaces=False) for g in summaries]
         for hypothesis in dec:

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -223,7 +223,7 @@ if is_torch_available():
         BartForSequenceClassification,
         BartModel,
         BartForConditionalGeneration,
-        BART_PRETRAINED_MODEL_ARCHIVE_MAP
+        BART_PRETRAINED_MODEL_ARCHIVE_MAP,
     )
     from .modeling_roberta import (
         RobertaForMaskedLM,

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -223,6 +223,7 @@ if is_torch_available():
         BartForSequenceClassification,
         BartModel,
         BartForConditionalGeneration,
+        BART_PRETRAINED_MODEL_ARCHIVE_MAP
     )
     from .modeling_roberta import (
         RobertaForMaskedLM,

--- a/src/transformers/configuration_albert.py
+++ b/src/transformers/configuration_albert.py
@@ -124,9 +124,17 @@ class AlbertConfig(PretrainedConfig):
         initializer_range=0.02,
         layer_norm_eps=1e-12,
         classifier_dropout_prob=0.1,
+        pad_token_id=0,
+        bos_token_id=2,
+        eos_token_id=3,
         **kwargs
     ):
-        super().__init__(**kwargs)
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            **kwargs
+        )
 
         self.vocab_size = vocab_size
         self.embedding_size = embedding_size

--- a/src/transformers/configuration_albert.py
+++ b/src/transformers/configuration_albert.py
@@ -129,12 +129,7 @@ class AlbertConfig(PretrainedConfig):
         eos_token_id=3,
         **kwargs
     ):
-        super().__init__(
-            pad_token_id=pad_token_id,
-            bos_token_id=bos_token_id,
-            eos_token_id=eos_token_id,
-            **kwargs
-        )
+        super().__init__(pad_token_id=pad_token_id, bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
 
         self.vocab_size = vocab_size
         self.embedding_size = embedding_size

--- a/src/transformers/configuration_bart.py
+++ b/src/transformers/configuration_bart.py
@@ -41,9 +41,6 @@ class BartConfig(PretrainedConfig):
         activation_dropout=0.0,
         activation_function="gelu",
         vocab_size=50265,
-        bos_token_id=0,
-        pad_token_id=1,
-        eos_token_id=2,
         d_model=1024,
         encoder_ffn_dim=4096,
         encoder_layers=12,
@@ -61,6 +58,9 @@ class BartConfig(PretrainedConfig):
         output_past=False,
         num_labels=3,
         is_encoder_decoder=True,
+        pad_token_id=1,
+        bos_token_id=0,
+        eos_token_id=2,
         **common_kwargs
     ):
         r"""

--- a/src/transformers/configuration_bart.py
+++ b/src/transformers/configuration_bart.py
@@ -43,7 +43,7 @@ class BartConfig(PretrainedConfig):
         vocab_size=50265,
         bos_token_id=0,
         pad_token_id=1,
-        eos_token_ids=[2],
+        eos_token_id=2,
         d_model=1024,
         encoder_ffn_dim=4096,
         encoder_layers=12,
@@ -74,7 +74,7 @@ class BartConfig(PretrainedConfig):
             output_past=output_past,
             pad_token_id=pad_token_id,
             bos_token_id=bos_token_id,
-            eos_token_ids=eos_token_ids,
+            eos_token_id=eos_token_id,
             is_encoder_decoder=is_encoder_decoder,
             **common_kwargs,
         )

--- a/src/transformers/configuration_bert.py
+++ b/src/transformers/configuration_bert.py
@@ -127,10 +127,7 @@ class BertConfig(PretrainedConfig):
         pad_token_id=0,
         **kwargs
     ):
-        super().__init__(
-            pad_token_id=pad_token_id,
-            **kwargs
-        )
+        super().__init__(pad_token_id=pad_token_id, **kwargs)
 
         self.vocab_size = vocab_size
         self.hidden_size = hidden_size

--- a/src/transformers/configuration_bert.py
+++ b/src/transformers/configuration_bert.py
@@ -124,9 +124,13 @@ class BertConfig(PretrainedConfig):
         type_vocab_size=2,
         initializer_range=0.02,
         layer_norm_eps=1e-12,
+        pad_token_id=0,
         **kwargs
     ):
-        super().__init__(**kwargs)
+        super().__init__(
+            pad_token_id=pad_token_id,
+            **kwargs
+        )
 
         self.vocab_size = vocab_size
         self.hidden_size = hidden_size

--- a/src/transformers/configuration_distilbert.py
+++ b/src/transformers/configuration_distilbert.py
@@ -113,9 +113,10 @@ class DistilBertConfig(PretrainedConfig):
         initializer_range=0.02,
         qa_dropout=0.1,
         seq_classif_dropout=0.2,
+        pad_token_id=0,
         **kwargs
     ):
-        super().__init__(**kwargs)
+        super().__init__(**kwargs, pad_token_id=pad_token_id)
         self.vocab_size = vocab_size
         self.max_position_embeddings = max_position_embeddings
         self.sinusoidal_pos_embds = sinusoidal_pos_embds

--- a/src/transformers/configuration_flaubert.py
+++ b/src/transformers/configuration_flaubert.py
@@ -148,10 +148,6 @@ class FlaubertConfig(XLMConfig):
     def __init__(self, layerdrop=0.0, pre_norm=False, pad_token_id=2, bos_token_id=0, **kwargs):
         """Constructs FlaubertConfig.
         """
-        super().__init__(
-            pad_token_id=pad_token_id,
-            bos_token_id=bos_token_id,
-            **kwargs
-        )
+        super().__init__(pad_token_id=pad_token_id, bos_token_id=bos_token_id, **kwargs)
         self.layerdrop = layerdrop
         self.pre_norm = pre_norm

--- a/src/transformers/configuration_flaubert.py
+++ b/src/transformers/configuration_flaubert.py
@@ -145,9 +145,13 @@ class FlaubertConfig(XLMConfig):
     pretrained_config_archive_map = FLAUBERT_PRETRAINED_CONFIG_ARCHIVE_MAP
     model_type = "flaubert"
 
-    def __init__(self, layerdrop=0.0, pre_norm=False, **kwargs):
+    def __init__(self, layerdrop=0.0, pre_norm=False, pad_token_id=2, bos_token_id=0, **kwargs):
         """Constructs FlaubertConfig.
         """
-        super().__init__(**kwargs)
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            **kwargs
+        )
         self.layerdrop = layerdrop
         self.pre_norm = pre_norm

--- a/src/transformers/configuration_gpt2.py
+++ b/src/transformers/configuration_gpt2.py
@@ -163,7 +163,7 @@ class GPT2Config(PretrainedConfig):
         self.summary_proj_to_labels = summary_proj_to_labels
 
         self.bos_token_id = bos_token_id
-        self.eos_token_ids = [eos_token_id]
+        self.eos_token_id = eos_token_id
 
     @property
     def max_position_embeddings(self):

--- a/src/transformers/configuration_gpt2.py
+++ b/src/transformers/configuration_gpt2.py
@@ -142,7 +142,11 @@ class GPT2Config(PretrainedConfig):
         eos_token_id=50256,
         **kwargs
     ):
-        super().__init__(**kwargs)
+        super().__init__(
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            **kwargs
+        )
 
         self.vocab_size = vocab_size
         self.n_ctx = n_ctx

--- a/src/transformers/configuration_gpt2.py
+++ b/src/transformers/configuration_gpt2.py
@@ -142,11 +142,7 @@ class GPT2Config(PretrainedConfig):
         eos_token_id=50256,
         **kwargs
     ):
-        super().__init__(
-            bos_token_id=bos_token_id,
-            eos_token_id=eos_token_id,
-            **kwargs
-        )
+        super().__init__(bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
 
         self.vocab_size = vocab_size
         self.n_ctx = n_ctx

--- a/src/transformers/configuration_roberta.py
+++ b/src/transformers/configuration_roberta.py
@@ -70,9 +70,4 @@ class RobertaConfig(BertConfig):
     def __init__(self, pad_token_id=1, bos_token_id=0, eos_token_id=2, **kwargs):
         """Constructs FlaubertConfig.
         """
-        super().__init__(
-            pad_token_id=pad_token_id,
-            bos_token_id=bos_token_id,
-            eos_token_id=eos_token_id,
-            **kwargs
-        )
+        super().__init__(pad_token_id=pad_token_id, bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)

--- a/src/transformers/configuration_roberta.py
+++ b/src/transformers/configuration_roberta.py
@@ -66,3 +66,13 @@ class RobertaConfig(BertConfig):
     """
     pretrained_config_archive_map = ROBERTA_PRETRAINED_CONFIG_ARCHIVE_MAP
     model_type = "roberta"
+
+    def __init__(self, pad_token_id=1, bos_token_id=0, eos_token_id=2, **kwargs):
+        """Constructs FlaubertConfig.
+        """
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            **kwargs
+        )

--- a/src/transformers/configuration_t5.py
+++ b/src/transformers/configuration_t5.py
@@ -81,10 +81,7 @@ class T5Config(PretrainedConfig):
         **kwargs
     ):
         super().__init__(
-            pad_token_id=pad_token_id,
-            eos_token_id=eos_token_id,
-            is_encoder_decoder=is_encoder_decoder,
-            **kwargs,
+            pad_token_id=pad_token_id, eos_token_id=eos_token_id, is_encoder_decoder=is_encoder_decoder, **kwargs,
         )
         self.vocab_size = vocab_size
         self.n_positions = n_positions

--- a/src/transformers/configuration_t5.py
+++ b/src/transformers/configuration_t5.py
@@ -77,11 +77,14 @@ class T5Config(PretrainedConfig):
         initializer_factor=1.0,
         is_encoder_decoder=True,
         pad_token_id=0,
-        eos_token_ids=[1],
+        eos_token_id=1,
         **kwargs
     ):
         super().__init__(
-            is_encoder_decoder=is_encoder_decoder, **kwargs,
+            pad_token_id=pad_token_id,
+            eos_token_id=eos_token_id,
+            is_encoder_decoder=is_encoder_decoder,
+            **kwargs,
         )
         self.vocab_size = vocab_size
         self.n_positions = n_positions

--- a/src/transformers/configuration_transfo_xl.py
+++ b/src/transformers/configuration_transfo_xl.py
@@ -152,7 +152,7 @@ class TransfoXLConfig(PretrainedConfig):
         eos_token_id=0,
         **kwargs
     ):
-        super().__init__(**kwargs)
+        super().__init__(eos_token_id=eos_token_id, **kwargs)
 
         self.vocab_size = vocab_size
         self.cutoffs = []
@@ -186,8 +186,6 @@ class TransfoXLConfig(PretrainedConfig):
         self.proj_init_std = proj_init_std
         self.init_std = init_std
         self.layer_norm_epsilon = layer_norm_epsilon
-
-        self.eos_token_id = eos_token_id
 
     @property
     def max_position_embeddings(self):

--- a/src/transformers/configuration_transfo_xl.py
+++ b/src/transformers/configuration_transfo_xl.py
@@ -187,7 +187,7 @@ class TransfoXLConfig(PretrainedConfig):
         self.init_std = init_std
         self.layer_norm_epsilon = layer_norm_epsilon
 
-        self.eos_token_ids = [eos_token_id]
+        self.eos_token_id = eos_token_id
 
     @property
     def max_position_embeddings(self):

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -80,7 +80,7 @@ class PretrainedConfig(object):
         self.repetition_penalty = kwargs.pop("repetition_penalty", 1.0)
         self.bos_token_id = kwargs.pop("bos_token_id", None)
         self.pad_token_id = kwargs.pop("pad_token_id", None)
-        self.eos_token_ids = kwargs.pop("eos_token_ids", None)
+        self.eos_token_id = kwargs.pop("eos_token_id", None)
         self.length_penalty = kwargs.pop("length_penalty", 1.0)
         self.no_repeat_ngram_size = kwargs.pop("no_repeat_ngram_size", 0)
         self.num_return_sequences = kwargs.pop("num_return_sequences", 1)

--- a/src/transformers/configuration_xlm.py
+++ b/src/transformers/configuration_xlm.py
@@ -194,13 +194,17 @@ class XLMConfig(PretrainedConfig):
         end_n_top=5,
         mask_token_id=0,
         lang_id=0,
-        bos_token_id=0,
         pad_token_id=2,
+        bos_token_id=0,
         **kwargs
     ):
         """Constructs XLMConfig.
         """
-        super().__init__(**kwargs)
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            **kwargs
+        )
         self.vocab_size = vocab_size
         self.emb_dim = emb_dim
         self.n_layers = n_layers
@@ -235,9 +239,6 @@ class XLMConfig(PretrainedConfig):
 
         if "n_words" in kwargs:
             self.n_words = kwargs["n_words"]
-
-        self.bos_token_id = bos_token_id
-        self.pad_token_id = pad_token_id
 
     @property
     def n_words(self):  # For backward compatibility

--- a/src/transformers/configuration_xlm.py
+++ b/src/transformers/configuration_xlm.py
@@ -200,11 +200,7 @@ class XLMConfig(PretrainedConfig):
     ):
         """Constructs XLMConfig.
         """
-        super().__init__(
-            pad_token_id=pad_token_id,
-            bos_token_id=bos_token_id,
-            **kwargs
-        )
+        super().__init__(pad_token_id=pad_token_id, bos_token_id=bos_token_id, **kwargs)
         self.vocab_size = vocab_size
         self.emb_dim = emb_dim
         self.n_layers = n_layers

--- a/src/transformers/configuration_xlnet.py
+++ b/src/transformers/configuration_xlnet.py
@@ -162,12 +162,7 @@ class XLNetConfig(PretrainedConfig):
     ):
         """Constructs XLNetConfig.
         """
-        super().__init__(
-            pad_token_id=pad_token_id,
-            bos_token_id=bos_token_id,
-            eos_token_id=eos_token_id,
-            **kwargs
-        )
+        super().__init__(pad_token_id=pad_token_id, bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
         self.vocab_size = vocab_size
         self.d_model = d_model
         self.n_layer = n_layer

--- a/src/transformers/configuration_xlnet.py
+++ b/src/transformers/configuration_xlnet.py
@@ -155,14 +155,19 @@ class XLNetConfig(PretrainedConfig):
         summary_last_dropout=0.1,
         start_n_top=5,
         end_n_top=5,
-        bos_token_id=1,
         pad_token_id=5,
+        bos_token_id=1,
         eos_token_id=2,
         **kwargs
     ):
         """Constructs XLNetConfig.
         """
-        super().__init__(**kwargs)
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            **kwargs
+        )
         self.vocab_size = vocab_size
         self.d_model = d_model
         self.n_layer = n_layer

--- a/src/transformers/configuration_xlnet.py
+++ b/src/transformers/configuration_xlnet.py
@@ -193,7 +193,7 @@ class XLNetConfig(PretrainedConfig):
 
         self.bos_token_id = bos_token_id
         self.pad_token_id = pad_token_id
-        self.eos_token_ids = [eos_token_id]
+        self.eos_token_id = eos_token_id
 
     @property
     def max_position_embeddings(self):

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -906,8 +906,8 @@ class BartForConditionalGeneration(PretrainedBartModel):
     def prepare_scores_for_generation(self, scores, cur_len, max_length):
         if cur_len == 1:
             self._force_token_ids_generation(scores, self.config.bos_token_id)
-        if cur_len == max_length - 1 and self.config.eos_token_ids[0] is not None:
-            self._force_token_ids_generation(scores, self.config.eos_token_ids[0])
+        if cur_len == max_length - 1 and self.config.eos_token_id is not None:
+            self._force_token_ids_generation(scores, self.config.eos_token_id)
         return scores
 
     @staticmethod
@@ -1003,7 +1003,7 @@ class BartForSequenceClassification(PretrainedBartModel):
             encoder_outputs=encoder_outputs,
         )
         x = outputs[0]  # last hidden state
-        eos_mask = input_ids.eq(self.config.eos_token_ids[0])
+        eos_mask = input_ids.eq(self.config.eos_token_id)
         if len(torch.unique(eos_mask.sum(1))) > 1:
             raise ValueError("All examples must have the same number of <eos> tokens.")
         sentence_representation = x[eos_mask, :].view(x.size(0), -1, x.size(-1))[:, -1, :]

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -831,7 +831,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         assert pad_token_id is None or (
             isinstance(pad_token_id, int) and (pad_token_id >= 0)
         ), "`pad_token_id` should be a positive integer."
-        assert decoder_start_token_id is not None or self.config.is_encoder_decoder is False, "`decoder_start_token_id` has to be defined if model is encoder-decoder model"
+        assert (
+            decoder_start_token_id is not None or self.config.is_encoder_decoder is False
+        ), "`decoder_start_token_id` has to be defined if model is encoder-decoder model"
         assert (eos_token_id is None) or (
             isinstance(eos_token_id, int) and (eos_token_id >= 0)
         ), "`eos_token_id` should be a positive integer."

--- a/tests/test_modeling_bart.py
+++ b/tests/test_modeling_bart.py
@@ -82,7 +82,7 @@ class ModelTester:
             dropout=self.hidden_dropout_prob,
             attention_dropout=self.attention_probs_dropout_prob,
             max_position_embeddings=self.max_position_embeddings,
-            eos_token_ids=self.eos_token_ids,
+            eos_token_id=self.eos_token_id,
             bos_token_id=self.bos_token_id,
             pad_token_id=self.pad_token_id,
         )
@@ -214,7 +214,7 @@ class BartHeadTests(unittest.TestCase):
             decoder_ffn_dim=32,
             max_position_embeddings=48,
             output_past=output_past,
-            eos_token_ids=[2],
+            eos_token_id=2,
             pad_token_id=1,
             bos_token_id=0,
         )
@@ -274,7 +274,7 @@ class BartHeadTests(unittest.TestCase):
             decoder_ffn_dim=32,
             max_position_embeddings=48,
             output_past=True,
-            eos_token_ids=[2],
+            eos_token_id=2,
             pad_token_id=1,
             bos_token_id=0,
         )

--- a/tests/test_modeling_bart.py
+++ b/tests/test_modeling_bart.py
@@ -61,7 +61,7 @@ class ModelTester:
         self.hidden_dropout_prob = 0.1
         self.attention_probs_dropout_prob = 0.1
         self.max_position_embeddings = 20
-        self.eos_token_ids = [2]
+        self.eos_token_id = 2
         self.pad_token_id = 1
         self.bos_token_id = 0
         torch.manual_seed(0)
@@ -483,7 +483,7 @@ class BartModelIntegrationTests(unittest.TestCase):
             no_repeat_ngram_size=3,
             do_sample=False,
             early_stopping=True,
-            decoder_start_token_id=hf.config.eos_token_ids[0],
+            decoder_start_token_id=hf.config.eos_token_id,
         )
 
         decoded = [

--- a/tests/test_modeling_gpt2.py
+++ b/tests/test_modeling_gpt2.py
@@ -132,7 +132,7 @@ class GPT2ModelTest(ModelTesterMixin, unittest.TestCase):
                 # type_vocab_size=self.type_vocab_size,
                 # initializer_range=self.initializer_range
                 bos_token_id=self.bos_token_id,
-                eos_token_ids=self.eos_token_id,
+                eos_token_id=self.eos_token_id,
             )
 
             head_mask = ids_tensor([self.num_hidden_layers, self.num_attention_heads], 2)

--- a/tests/test_modeling_tf_gpt2.py
+++ b/tests/test_modeling_tf_gpt2.py
@@ -130,7 +130,7 @@ class TFGPT2ModelTest(TFModelTesterMixin, unittest.TestCase):
                 # type_vocab_size=self.type_vocab_size,
                 # initializer_range=self.initializer_range
                 bos_token_id=self.bos_token_id,
-                eos_token_ids=self.eos_token_id,
+                eos_token_id=self.eos_token_id,
             )
 
             head_mask = ids_tensor([self.num_hidden_layers, self.num_attention_heads], 2)

--- a/tests/test_modeling_tf_transfo_xl.py
+++ b/tests/test_modeling_tf_transfo_xl.py
@@ -107,7 +107,7 @@ class TFTransfoXLModelTest(TFModelTesterMixin, unittest.TestCase):
                 d_inner=self.d_inner,
                 div_val=self.div_val,
                 n_layer=self.num_hidden_layers,
-                eos_token_ids=self.eos_token_id,
+                eos_token_id=self.eos_token_id,
             )
 
             return (config, input_ids_1, input_ids_2, lm_labels)

--- a/tests/test_modeling_transfo_xl.py
+++ b/tests/test_modeling_transfo_xl.py
@@ -103,7 +103,7 @@ class TransfoXLModelTest(ModelTesterMixin, unittest.TestCase):
                 d_inner=self.d_inner,
                 div_val=self.div_val,
                 n_layer=self.num_hidden_layers,
-                eos_token_ids=self.eos_token_id,
+                eos_token_id=self.eos_token_id,
             )
 
             return (config, input_ids_1, input_ids_2, lm_labels)


### PR DESCRIPTION
#### INTRO:
This PR is a follow-up from PR #3011. 

After discussion with @thomwolf today, we decided that the variable `eos_token_ids` in all models causes more confusion and ugly code than it helps. 

#### BACKGROUND: 
All models now have `pad_token_id`, `bos_token_id` and `eos_token_id` as default values. The reasons are discussed and explained in #3011.

Originally, we had the `list` variable `eos_token_ids`. The idea behind was that a model could have multiple `eos_token_ids` if the user wants to finish at certain tokens besides the standard EOS token. But this caused a lot of unclean code AND is not consistent with `tokenizers` which all has a `tokenizer.eos_token_id` int variable. So, we return to `eos_token_id` for moders as well and might in the future have a variable `forbidden_tokens` or `special_stop_tokens`. 

#### THIS PR DOES:
- Replace all list `eos_token_ids` with `eos_token_id`
- Add default `eos_token_id, pad_token_id, bos_token_id` to all models

#### TESTS: 
I tested that the `pretrained Config` has now the same special tokens as the `pretrained Tokenizer` for all model identifier names (e.g. `gpt2-large`) with the following code:

```
for model_id_name in ALL_PRETRAINED_MODEL_ARCHIVE_MAP.keys():
    tok = AutoTokenizer.from_pretrained(model_id_name)
    conf = AutoConfig.from_pretrained(model_id_name)

    pad_equal = tok.pad_token_id == conf.pad_token_id
    eos_equal = tok.eos_token_id == conf.eos_token_id
    bos_equal = tok.bos_token_id == conf.bos_token_id

    if not pad_equal:
        print("PAD not equal for {}!".format(model_id_name))
        print("TOK: {} | CONF: {}".format(tok.pad_token_id, conf.pad_token_id))

    if not eos_equal:
        print("EOS not equal for {}!".format(model_id_name))
        print("TOK: {} | CONF: {}".format(tok.eos_token_id, conf.eos_token_id))

    if not bos_equal:
        print("BOS not equal for {}!".format(model_id_name))
        print("TOK: {} | CONF: {}".format(tok.bos_token_id, conf.bos_token_id))
```

which gives the following result: 

```
PAD not equal for bert-base-dutch-cased!
TOK: 3 | CONF: 0
BOS not equal for distilbert-base-cased!
TOK: None | CONF: 0
BOS not equal for distilbert-base-cased-distilled-squad!
TOK: None | CONF: 0
```

This means that: 
- `bert-base-dutch-cased` has a different `pad_token_id` in its tokenizer config than the `pad_token_id` in default Bert tokenizer, so that we will have to update the `bert-base-dutch-cased-config.json` file on AWS (Best option in my opinion).
- `distilbert-base-cased` and `distilbert-base-cased-distilled-squad` have hard coded `bos_token_id` in their config.json file on AWS (I checked), but the distilbert tokenizer doesn`t even have it -> is that correct? @VictorSanh 

#### TODO: 

- [x] Is the approach good for you? @thomwolf @julien-c @LysandreJik @mfuntowicz @sshleifer 
- [ ] Should we also check all community models whether their tokenizer differs from the default one? 
- [ ] I think the test I wrote is quite useful, but it uses Config and Tokenizer Classes in the same file, which is not in line with the current test files, which is why I didn't add it. Should we add a test like this? If yes, how? 


