### PR TITLE
removing torch.cuda.empty_cache() from TF function

### DIFF
--- a/examples/benchmarks.py
+++ b/examples/benchmarks.py
@@ -414,7 +414,6 @@ def _compute_tensorflow(model_names, dictionary, average_over, amp):
                         dictionary[model_name]["results"][batch_size][slice_size] = average_time
                     except tf.errors.ResourceExhaustedError as e:
                         print("Doesn't fit on GPU.", e)
-                        torch.cuda.empty_cache()
                         dictionary[model_name]["results"][batch_size][slice_size] = "N/A"
     return dictionary
 


### PR DESCRIPTION
torch.cuda.empty_cache() was being called from a TF function (even when torch is unavailable)
not sure any replacement is needed if TF OOMs

simply running the benchmarks on a GPU with lower HBM will reproduce this error