### PR TITLE
[BART] generation_mode as a kwarg not a class attribute

### DIFF
--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -982,7 +982,7 @@ class BartForConditionalGeneration(PretrainedBartModel):
             "decoder_cached_states": decoder_cached_states,
             "decoder_input_ids": decoder_input_ids,
             "attention_mask": attention_mask,
-            'generation_mode': True,
+            "generation_mode": True,
         }
 
     def prepare_scores_for_generation(self, scores, cur_len, max_length):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1500,7 +1500,7 @@ class TFSequenceSummary(tf.keras.layers.Layer):
         if self.has_last_dropout:
             output = self.last_dropout(output, training=training)
 
-        return output
+        return outputrate
 
 
 def shape_list(x):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1500,7 +1500,7 @@ class TFSequenceSummary(tf.keras.layers.Layer):
         if self.has_last_dropout:
             output = self.last_dropout(output, training=training)
 
-        return outputrate
+        return output
 
 
 def shape_list(x):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -909,6 +909,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 attention_mask=attention_mask,
             )
 
+        if hasattr(self.model, "decoder") and hasattr(self.model.decoder, "generation_mode"):
+            self.model.decoder.generation_mode = False
+
         return output
 
     def _generate_no_beam_search(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -846,7 +846,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             attention_mask = attention_mask.contiguous().view(
                 effective_batch_size * num_beams, input_ids_len
             )  # shape: (batch_size * num_return_sequences * num_beams, cur_len)
-
+        has_generation_mode = self.config.is_encoder_decoder  and hasattr(self.model, "decoder") and hasattr(self.model.decoder, "generation_mode")
         if self.config.is_encoder_decoder:
             assert bos_token_id is not None, "Encoder Decoder Models need to have a bos_token_id"
             # encoder decoder need to start with empty input_ids and copy the input_ids to encoder_inputs
@@ -860,7 +860,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             cur_len = 1
 
             # put model in generation mode if it has one
-            if hasattr(self.model, "decoder") and hasattr(self.model.decoder, "generation_mode"):
+            if has_generation_mode:
                 self.model.decoder.generation_mode = True
         else:
             encoder_inputs = None
@@ -909,7 +909,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 attention_mask=attention_mask,
             )
 
-        if hasattr(self.model, "decoder") and hasattr(self.model.decoder, "generation_mode"):
+        if has_generation_mode:
             self.model.decoder.generation_mode = False
 
         return output

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -846,7 +846,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             attention_mask = attention_mask.contiguous().view(
                 effective_batch_size * num_beams, input_ids_len
             )  # shape: (batch_size * num_return_sequences * num_beams, cur_len)
-        has_generation_mode = self.config.is_encoder_decoder  and hasattr(self.model, "decoder") and hasattr(self.model.decoder, "generation_mode")
+        has_generation_mode = (
+            self.config.is_encoder_decoder
+            and hasattr(self.model, "decoder")
+            and hasattr(self.model.decoder, "generation_mode")
+        )
         if self.config.is_encoder_decoder:
             assert bos_token_id is not None, "Encoder Decoder Models need to have a bos_token_id"
             # encoder decoder need to start with empty input_ids and copy the input_ids to encoder_inputs

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -846,11 +846,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             attention_mask = attention_mask.contiguous().view(
                 effective_batch_size * num_beams, input_ids_len
             )  # shape: (batch_size * num_return_sequences * num_beams, cur_len)
-        has_generation_mode = (
-            self.config.is_encoder_decoder
-            and hasattr(self.model, "decoder")
-            and hasattr(self.model.decoder, "generation_mode")
-        )
         if self.config.is_encoder_decoder:
             assert bos_token_id is not None, "Encoder Decoder Models need to have a bos_token_id"
             # encoder decoder need to start with empty input_ids and copy the input_ids to encoder_inputs
@@ -863,9 +858,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             )
             cur_len = 1
 
-            # put model in generation mode if it has one
-            if has_generation_mode:
-                self.model.decoder.generation_mode = True
         else:
             encoder_inputs = None
             cur_len = input_ids.shape[-1]
@@ -912,9 +904,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 encoder_inputs=encoder_inputs,
                 attention_mask=attention_mask,
             )
-
-        if has_generation_mode:
-            self.model.decoder.generation_mode = False
 
         return output
 


### PR DESCRIPTION
Currently, we set it to `BartModel.decoder.generation_mode = True` and then never unset it, which is confusing in the the rare case where you try to finetune or extract features after generating.
We can encapsulate bart specific logic to modeling_bart.py by just using a kwarg.
