### PR TITLE
[BART] Remove unused kwargs

### DIFF
--- a/examples/summarization/bertabs/modeling_bertabs.py
+++ b/examples/summarization/bertabs/modeling_bertabs.py
@@ -844,7 +844,7 @@ class Translator(object):
             dec_out, dec_states = self.model.decoder(decoder_input, src_features, dec_states, step=step)
 
             # Generator forward.
-            log_probs = self.generator.forward(dec_out.transpose(0, 1).squeeze(0))
+            log_probs = self.generator(dec_out.transpose(0, 1).squeeze(0))
             vocab_size = log_probs.size(-1)
 
             if step < min_length:


### PR DESCRIPTION
This doesn't change anything, 
- k_dim and v_dim kwargs are there for other models in fairseq but we don't need them.
- attention weights are returned by the AttentionModule (and ignored later) no matter what