### PR TITLE
[BART] cleanup: remove redundant kwargs, improve docstrings

### DIFF
--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -271,7 +271,7 @@ class BartEncoder(nn.Module):
                   shape `(src_len, batch, embed_dim)`
                 - **encoder_states** (List[Tensor]): all intermediate
                   hidden states of shape `(src_len, batch, embed_dim)`.
-                  Only populated if * elf.output_hidden_states:* is True.
+                  Only populated if *self.output_hidden_states:* is True.
                 - **all_attentions** (List[Tensor]): Attention weights for each layer.
                 During training might not be of length n_layers because of layer dropout.
         """

--- a/tests/test_modeling_bart.py
+++ b/tests/test_modeling_bart.py
@@ -330,6 +330,17 @@ class BartHeadTests(unittest.TestCase):
         lm_model = BartForConditionalGeneration(config).eval().to(torch_device).half()
         lm_model(input_ids, attention_mask=attention_mask)
 
+    def test_default_generate_kwargs(self):
+        config, input_ids, _ = self._get_config_and_data(output_past=True)
+        model = BartForConditionalGeneration(config).eval().to(torch_device)
+        model.generate(input_ids)
+        model.generate(num_beams=4, do_sample=True, early_stopping=False, num_return_sequences=3)
+
+    def test_dummy_inputs(self):
+        config, *_ = self._get_config_and_data(output_past=True)
+        model = BartForConditionalGeneration(config).eval().to(torch_device)
+        model(**model.dummy_inputs)
+
     def test_prepare_bart_decoder_inputs(self):
         config, *_ = self._get_config_and_data(output_past=False)
         input_ids = _long_tensor(([4, 4, 2]))  # only used for .device if decoder_input_ids is passed


### PR DESCRIPTION
Small Bart code cleanups before pip release.

### Cleanup
- Deletes unused `value` argument for SelfAttention. (`value` is always the same as `key`.) This might be moderately controversial as most attention modules take query, key, value as arguments, but this change reduces the signature to just query and key (since key always the same as value).
- Deletes redundant `static_kv` argument for SelfAttention. It is always the same as `self.encoder_decoder_attention`. 
  - Context: the `static_kv` variable decides whether we want to extend the keys and values in the cache or, if `True`, use them without modification. 
  - This PR keeps a local `static_kv` variable because that variable name describes the purpose of the variable better than `self.encoder_decoder_attention`. But `static_kv` is no longer a kwarg. This simplifies the API and avoids having the same logic in two places.

#### Two new fast tests
- test coverage for `dummy_inputs` (previously broken)
- test coverage for the default generate kwargs.