### PR TITLE
[Generate] Add bad words list argument to the generate function

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -80,6 +80,7 @@ class PretrainedConfig(object):
         self.repetition_penalty = kwargs.pop("repetition_penalty", 1.0)
         self.length_penalty = kwargs.pop("length_penalty", 1.0)
         self.no_repeat_ngram_size = kwargs.pop("no_repeat_ngram_size", 0)
+        self.bad_words_tokens = kwargs.pop("bad_words_tokens", None)
         self.num_return_sequences = kwargs.pop("num_return_sequences", 1)
 
         # Fine-tuning task arguments

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -80,7 +80,7 @@ class PretrainedConfig(object):
         self.repetition_penalty = kwargs.pop("repetition_penalty", 1.0)
         self.length_penalty = kwargs.pop("length_penalty", 1.0)
         self.no_repeat_ngram_size = kwargs.pop("no_repeat_ngram_size", 0)
-        self.bad_words_tokens = kwargs.pop("bad_words_tokens", None)
+        self.bad_words_ids = kwargs.pop("bad_words_ids", None)
         self.num_return_sequences = kwargs.pop("num_return_sequences", 1)
 
         # Fine-tuning task arguments

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -467,7 +467,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
         top_k=None,
         top_p=None,
         repetition_penalty=None,
-        bad_words_tokens=None,
+        bad_words_ids=None,
         bos_token_id=None,
         pad_token_id=None,
         eos_token_id=None,
@@ -533,8 +533,8 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
             no_repeat_ngram_size: (`optional`) int
                 If set to int > 0, all ngrams of size `no_repeat_ngram_size` can only occur once.
 
-            bad_words_tokens: (`optional`) list of lists of int
-                `bad_words_tokens` contains tokens that are not allowed to be generated. In order to get the tokens of the words that should not appear in the generated text, use `tokenizer.encode(bad_word, add_prefix_space=True)`.
+            bad_words_ids: (`optional`) list of lists of int
+                `bad_words_ids` contains tokens that are not allowed to be generated. In order to get the tokens of the words that should not appear in the generated text, use `tokenizer.encode(bad_word, add_prefix_space=True)`.
 
             num_return_sequences: (`optional`) int
                 The number of independently computed returned sequences for each element in the batch. Default to 1.
@@ -589,9 +589,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
             tokenizer = AutoTokenizer.from_pretrained('gpt2')   # Initialize tokenizer
             model = TFAutoModelWithLMHead.from_pretrained('gpt2')    # Download model and configuration from S3 and cache.
             input_context = 'My cute dog'  # "Legal" is one of the control codes for ctrl
-            bad_words = [tokenizer.encode(bard_word, add_prefix_space=True) for bad_word in ['idiot', 'stupid', 'shut up']]
+            bad_words_ids = [tokenizer.encode(bad_word, add_prefix_space=True) for bad_word in ['idiot', 'stupid', 'shut up']]
             input_ids = tokenizer.encode(input_context, return_tensors='tf')  # encode input context
-            outputs = model.generate(input_ids=input_ids, max_length=100, do_sample=True, bad_words_tokens=bad_words_tokens)  # generate sequences without allowing bad_words to be generated
+            outputs = model.generate(input_ids=input_ids, max_length=100, do_sample=True, bad_words_ids=bad_words_ids)  # generate sequences without allowing bad_words to be generated
         """
 
         # We cannot generate if the model does not have a LM head
@@ -617,7 +617,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
         no_repeat_ngram_size = (
             no_repeat_ngram_size if no_repeat_ngram_size is not None else self.config.no_repeat_ngram_size
         )
-        bad_words_tokens = bad_words_tokens if bad_words_tokens is not None else self.config.bad_words_tokens
+        bad_words_ids = bad_words_ids if bad_words_ids is not None else self.config.bad_words_ids
         num_return_sequences = (
             num_return_sequences if num_return_sequences is not None else self.config.num_return_sequences
         )
@@ -653,8 +653,8 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
             isinstance(num_return_sequences, int) and num_return_sequences > 0
         ), "`num_return_sequences` should be a strictely positive integer."
         assert (
-            bad_words_tokens is None or isinstance(bad_words_tokens, list) and isinstance(bad_words_tokens[0], list)
-        ), "`bad_words_tokens` is either `None` or a list of lists of tokens that should not be generated"
+            bad_words_ids is None or isinstance(bad_words_ids, list) and isinstance(bad_words_ids[0], list)
+        ), "`bad_words_ids` is either `None` or a list of lists of tokens that should not be generated"
 
         if input_ids is None:
             assert isinstance(bos_token_id, int) and bos_token_id >= 0, (
@@ -756,7 +756,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
                 top_p=top_p,
                 repetition_penalty=repetition_penalty,
                 no_repeat_ngram_size=no_repeat_ngram_size,
-                bad_words_tokens=bad_words_tokens,
+                bad_words_ids=bad_words_ids,
                 bos_token_id=bos_token_id,
                 pad_token_id=pad_token_id,
                 eos_token_id=eos_token_id,
@@ -781,7 +781,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
                 top_p=top_p,
                 repetition_penalty=repetition_penalty,
                 no_repeat_ngram_size=no_repeat_ngram_size,
-                bad_words_tokens=bad_words_tokens,
+                bad_words_ids=bad_words_ids,
                 bos_token_id=bos_token_id,
                 pad_token_id=pad_token_id,
                 eos_token_id=eos_token_id,
@@ -806,7 +806,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
         top_p,
         repetition_penalty,
         no_repeat_ngram_size,
-        bad_words_tokens,
+        bad_words_ids,
         bos_token_id,
         pad_token_id,
         eos_token_id,
@@ -857,9 +857,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
                     next_token_logits, tf.convert_to_tensor(banned_tokens_indices_mask, dtype=tf.bool), -float("inf")
                 )
 
-            if bad_words_tokens is not None:
+            if bad_words_ids is not None:
                 # calculate a list of banned tokens according to bad words
-                banned_tokens = calc_banned_bad_words_tokens(input_ids, bad_words_tokens)
+                banned_tokens = calc_banned_bad_words_ids(input_ids, bad_words_ids)
 
                 banned_tokens_indices_mask = []
                 for banned_tokens_slice in banned_tokens:
@@ -967,7 +967,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
         top_p,
         repetition_penalty,
         no_repeat_ngram_size,
-        bad_words_tokens,
+        bad_words_ids,
         bos_token_id,
         pad_token_id,
         decoder_start_token_id,
@@ -1058,9 +1058,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
                     scores, tf.convert_to_tensor(banned_tokens_indices_mask, dtype=tf.bool), -float("inf")
                 )
 
-            if bad_words_tokens is not None:
+            if bad_words_ids is not None:
                 # calculate a list of banned tokens according to bad words
-                banned_tokens = calc_banned_bad_words_tokens(input_ids, bad_words_tokens)
+                banned_tokens = calc_banned_bad_words_ids(input_ids, bad_words_ids)
 
                 banned_tokens_indices_mask = []
                 for banned_tokens_slice in banned_tokens:
@@ -1314,7 +1314,7 @@ def calc_banned_ngram_tokens(prev_input_ids, num_hypos, no_repeat_ngram_size, cu
     return banned_tokens
 
 
-def calc_banned_bad_words_tokens(prev_input_ids, bad_words_tokens):
+def calc_banned_bad_words_ids(prev_input_ids, bad_words_ids):
     banned_tokens = []
 
     def _tokens_match(prev_tokens, tokens):
@@ -1334,9 +1334,9 @@ def calc_banned_bad_words_tokens(prev_input_ids, bad_words_tokens):
     for prev_input_ids_slice in prev_input_ids:
         banned_tokens_slice = []
 
-        for banned_token_seq in bad_words_tokens:
+        for banned_token_seq in bad_words_ids:
             assert len(banned_token_seq) > 0, "Banned words token sequences {} cannot have an empty list".format(
-                bad_words_tokens
+                bad_words_ids
             )
 
             if _tokens_match(prev_input_ids_slice.numpy().tolist(), banned_token_seq[:-1]) is False:

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -467,6 +467,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
         top_k=None,
         top_p=None,
         repetition_penalty=None,
+        bad_words_tokens=None,
         bos_token_id=None,
         pad_token_id=None,
         eos_token_id=None,
@@ -532,6 +533,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
             no_repeat_ngram_size: (`optional`) int
                 If set to int > 0, all ngrams of size `no_repeat_ngram_size` can only occur once.
 
+            bad_words_tokens: (`optional`) list of lists of int
+                `bad_words_tokens` contains tokens that are not allowed to be generated. In order to get the tokens of the words that should not appear in the generated text, use `tokenizer.encode(bad_word, add_prefix_space=True)`.
+
             num_return_sequences: (`optional`) int
                 The number of independently computed returned sequences for each element in the batch. Default to 1.
 
@@ -582,6 +586,12 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
             outputs = model.generate(input_ids=input_ids, max_length=50, temperature=0.7, repetition_penalty=1.2)  # generate sequences
             print('Generated: {}'.format(tokenizer.decode(outputs[0], skip_special_tokens=True)))
 
+            tokenizer = AutoTokenizer.from_pretrained('gpt2')   # Initialize tokenizer
+            model = TFAutoModelWithLMHead.from_pretrained('gpt2')    # Download model and configuration from S3 and cache.
+            input_context = 'My cute dog'  # "Legal" is one of the control codes for ctrl
+            bad_words = [tokenizer.encode(bard_word, add_prefix_space=True) for bad_word in ['idiot', 'stupid', 'shut up']]
+            input_ids = tokenizer.encode(input_context, return_tensors='tf')  # encode input context
+            outputs = model.generate(input_ids=input_ids, max_length=100, do_sample=True, bad_words_tokens=bad_words_tokens)  # generate sequences without allowing bad_words to be generated
         """
 
         # We cannot generate if the model does not have a LM head
@@ -607,6 +617,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
         no_repeat_ngram_size = (
             no_repeat_ngram_size if no_repeat_ngram_size is not None else self.config.no_repeat_ngram_size
         )
+        bad_words_tokens = bad_words_tokens if bad_words_tokens is not None else self.config.bad_words_tokens
         num_return_sequences = (
             num_return_sequences if num_return_sequences is not None else self.config.num_return_sequences
         )
@@ -641,6 +652,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
         assert (
             isinstance(num_return_sequences, int) and num_return_sequences > 0
         ), "`num_return_sequences` should be a strictely positive integer."
+        assert (
+            bad_words_tokens is None or isinstance(bad_words_tokens, list) and isinstance(bad_words_tokens[0], list)
+        ), "`bad_words_tokens` is either `None` or a list of lists of tokens that should not be generated"
 
         if input_ids is None:
             assert isinstance(bos_token_id, int) and bos_token_id >= 0, (
@@ -742,6 +756,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
                 top_p=top_p,
                 repetition_penalty=repetition_penalty,
                 no_repeat_ngram_size=no_repeat_ngram_size,
+                bad_words_tokens=bad_words_tokens,
                 bos_token_id=bos_token_id,
                 pad_token_id=pad_token_id,
                 eos_token_id=eos_token_id,
@@ -766,6 +781,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
                 top_p=top_p,
                 repetition_penalty=repetition_penalty,
                 no_repeat_ngram_size=no_repeat_ngram_size,
+                bad_words_tokens=bad_words_tokens,
                 bos_token_id=bos_token_id,
                 pad_token_id=pad_token_id,
                 eos_token_id=eos_token_id,
@@ -790,6 +806,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
         top_p,
         repetition_penalty,
         no_repeat_ngram_size,
+        bad_words_tokens,
         bos_token_id,
         pad_token_id,
         eos_token_id,
@@ -828,8 +845,22 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
             if no_repeat_ngram_size > 0:
                 # calculate a list of banned tokens to prevent repetitively generating the same ngrams
                 # from fairseq: https://github.com/pytorch/fairseq/blob/a07cb6f40480928c9e0548b737aadd36ee66ac76/fairseq/sequence_generator.py#L345
-                banned_tokens = calc_banned_tokens(input_ids, batch_size, no_repeat_ngram_size, cur_len)
+                banned_tokens = calc_banned_ngram_tokens(input_ids, batch_size, no_repeat_ngram_size, cur_len)
                 # create banned_tokens boolean mask
+                banned_tokens_indices_mask = []
+                for banned_tokens_slice in banned_tokens:
+                    banned_tokens_indices_mask.append(
+                        [True if token in banned_tokens_slice else False for token in range(vocab_size)]
+                    )
+
+                next_token_logits = set_tensor_by_indices_to_value(
+                    next_token_logits, tf.convert_to_tensor(banned_tokens_indices_mask, dtype=tf.bool), -float("inf")
+                )
+
+            if bad_words_tokens is not None:
+                # calculate a list of banned tokens according to bad words
+                banned_tokens = calc_banned_bad_words_tokens(input_ids, bad_words_tokens)
+
                 banned_tokens_indices_mask = []
                 for banned_tokens_slice in banned_tokens:
                     banned_tokens_indices_mask.append(
@@ -936,6 +967,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
         top_p,
         repetition_penalty,
         no_repeat_ngram_size,
+        bad_words_tokens,
         bos_token_id,
         pad_token_id,
         decoder_start_token_id,
@@ -1012,8 +1044,22 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
                 # calculate a list of banned tokens to prevent repetitively generating the same ngrams
                 # from fairseq: https://github.com/pytorch/fairseq/blob/a07cb6f40480928c9e0548b737aadd36ee66ac76/fairseq/sequence_generator.py#L345
                 num_batch_hypotheses = batch_size * num_beams
-                banned_tokens = calc_banned_tokens(input_ids, num_batch_hypotheses, no_repeat_ngram_size, cur_len)
+                banned_tokens = calc_banned_ngram_tokens(input_ids, num_batch_hypotheses, no_repeat_ngram_size, cur_len)
                 # create banned_tokens boolean mask
+                banned_tokens_indices_mask = []
+                for banned_tokens_slice in banned_tokens:
+                    banned_tokens_indices_mask.append(
+                        [True if token in banned_tokens_slice else False for token in range(vocab_size)]
+                    )
+
+                scores = set_tensor_by_indices_to_value(
+                    scores, tf.convert_to_tensor(banned_tokens_indices_mask, dtype=tf.bool), -float("inf")
+                )
+
+            if bad_words_tokens is not None:
+                # calculate a list of banned tokens according to bad words
+                banned_tokens = calc_banned_bad_words_tokens(input_ids, bad_words_tokens)
+
                 banned_tokens_indices_mask = []
                 for banned_tokens_slice in banned_tokens:
                     banned_tokens_indices_mask.append(
@@ -1243,7 +1289,7 @@ def _create_next_token_logits_penalties(input_ids, logits, repetition_penalty):
     return tf.convert_to_tensor(token_penalties, dtype=tf.float32)
 
 
-def calc_banned_tokens(prev_input_ids, num_hypos, no_repeat_ngram_size, cur_len):
+def calc_banned_ngram_tokens(prev_input_ids, num_hypos, no_repeat_ngram_size, cur_len):
     # Copied from fairseq for no_repeat_ngram in beam_search"""
     if cur_len + 1 < no_repeat_ngram_size:
         # return no banned tokens if we haven't generated no_repeat_ngram_size tokens yet
@@ -1263,6 +1309,42 @@ def calc_banned_tokens(prev_input_ids, num_hypos, no_repeat_ngram_size, cur_len)
         return generated_ngrams[hypo_idx].get(ngram_idx, [])
 
     banned_tokens = [_get_generated_ngrams(hypo_idx) for hypo_idx in range(num_hypos)]
+    return banned_tokens
+
+
+def calc_banned_bad_words_tokens(prev_input_ids, bad_words_tokens):
+    banned_tokens = []
+
+    def _tokens_match(prev_tokens, tokens):
+        if len(tokens) == 0:
+            # if bad word tokens is just one token always ban it
+            return True
+        if len(tokens) > len(prev_input_ids):
+            # if bad word tokens are longer then prev input_ids they can't be equal
+            return False
+
+        if prev_tokens[-len(tokens) :] == tokens:
+            # if tokens match
+            return True
+        else:
+            return False
+
+    for prev_input_ids_slice in prev_input_ids:
+        banned_tokens_slice = []
+
+        for banned_token_seq in bad_words_tokens:
+            assert len(banned_token_seq) > 0, "Banned words token sequences {} cannot have an empty list".format(
+                bad_words_tokens
+            )
+
+            if _tokens_match(prev_input_ids_slice.numpy().tolist(), banned_token_seq[:-1]) is False:
+                # if tokens do not match continue
+                continue
+
+            banned_tokens_slice.append(banned_token_seq[-1])
+
+        banned_tokens.append(banned_tokens_slice)
+
     return banned_tokens
 
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1044,7 +1044,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
                 # calculate a list of banned tokens to prevent repetitively generating the same ngrams
                 # from fairseq: https://github.com/pytorch/fairseq/blob/a07cb6f40480928c9e0548b737aadd36ee66ac76/fairseq/sequence_generator.py#L345
                 num_batch_hypotheses = batch_size * num_beams
-                banned_tokens = calc_banned_ngram_tokens(input_ids, num_batch_hypotheses, no_repeat_ngram_size, cur_len)
+                banned_tokens = calc_banned_ngram_tokens(
+                    input_ids, num_batch_hypotheses, no_repeat_ngram_size, cur_len
+                )
                 # create banned_tokens boolean mask
                 banned_tokens_indices_mask = []
                 for banned_tokens_slice in banned_tokens:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1463,7 +1463,7 @@ def calc_banned_bad_words_tokens(prev_input_ids, bad_words_tokens):
             # if bad word tokens are longer then prev input_ids they can't be equal
             return False
 
-        if prev_tokens[-len(tokens):] == tokens:
+        if prev_tokens[-len(tokens) :] == tokens:
             # if tokens match
             return True
         else:
@@ -1473,7 +1473,9 @@ def calc_banned_bad_words_tokens(prev_input_ids, bad_words_tokens):
         banned_tokens_slice = []
 
         for banned_token_seq in bad_words_tokens:
-            assert len(banned_token_seq) > 0, 'Banned words token sequences {} cannot have an empty list'.format(bad_words_tokens)
+            assert len(banned_token_seq) > 0, "Banned words token sequences {} cannot have an empty list".format(
+                bad_words_tokens
+            )
 
             if _tokens_match(prev_input_ids_slice.tolist(), banned_token_seq[:-1]) is False:
                 # if tokens do not match continue

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1452,7 +1452,6 @@ def calc_banned_ngram_tokens(prev_input_ids, num_hypos, no_repeat_ngram_size, cu
 
 
 def calc_banned_bad_words_tokens(prev_input_ids, bad_words_tokens):
-
     banned_tokens = []
 
     def _tokens_match(prev_tokens, tokens):

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -641,14 +641,14 @@ class ModelTesterMixin:
                 with self.assertRaises(AssertionError):
                     model.generate(do_sample=True, max_length=5)
                 # batch_size = 1
-                self._check_generated_tokens(model.generate(input_ids, do_sample=True))
+                self._check_generated_ids(model.generate(input_ids, do_sample=True))
                 # batch_size = 1, num_beams > 1
-                self._check_generated_tokens(model.generate(input_ids, do_sample=True, num_beams=3))
+                self._check_generated_ids(model.generate(input_ids, do_sample=True, num_beams=3))
             else:
                 # batch_size = 1
-                self._check_generated_tokens(model.generate(do_sample=True, max_length=5))
+                self._check_generated_ids(model.generate(do_sample=True, max_length=5))
                 # batch_size = 1, num_beams > 1
-                self._check_generated_tokens(model.generate(do_sample=True, max_length=5, num_beams=3))
+                self._check_generated_ids(model.generate(do_sample=True, max_length=5, num_beams=3))
 
             with self.assertRaises(AssertionError):
                 # generating multiple sequences when greedy no beam generation
@@ -660,53 +660,53 @@ class ModelTesterMixin:
                 model.generate(input_ids, do_sample=False, num_return_sequences=3, num_beams=2)
 
             # batch_size > 1, sample
-            self._check_generated_tokens(model.generate(input_ids, do_sample=True, num_return_sequences=3))
+            self._check_generated_ids(model.generate(input_ids, do_sample=True, num_return_sequences=3))
             # batch_size > 1, greedy
-            self._check_generated_tokens(model.generate(input_ids, do_sample=False))
+            self._check_generated_ids(model.generate(input_ids, do_sample=False))
 
             # batch_size > 1, num_beams > 1, sample
-            self._check_generated_tokens(
+            self._check_generated_ids(
                 model.generate(input_ids, do_sample=True, num_beams=3, num_return_sequences=3,)
             )
             # batch_size > 1, num_beams > 1, greedy
-            self._check_generated_tokens(
+            self._check_generated_ids(
                 model.generate(input_ids, do_sample=False, num_beams=3, num_return_sequences=3)
             )
 
             # check bad words tokens language generation
-            bad_words_tokens = [
+            bad_words_ids = [
                 ids_tensor((1, 1), self.model_tester.vocab_size).squeeze(-1).tolist(),
                 ids_tensor((2, 1), self.model_tester.vocab_size).squeeze(-1).tolist(),
             ]
 
             # sampling
             output_tokens = model.generate(
-                input_ids, do_sample=True, bad_words_tokens=bad_words_tokens, num_return_sequences=3
+                input_ids, do_sample=True, bad_words_ids=bad_words_ids, num_return_sequences=3
             )
-            generated_tokens = output_tokens[:, input_ids.shape[-1] :]
-            self.assertFalse(self._check_match_tokens(generated_tokens.tolist(), bad_words_tokens))
+            generated_ids = output_tokens[:, input_ids.shape[-1] :]
+            self.assertFalse(self._check_match_tokens(generated_ids.tolist(), bad_words_ids))
 
             # beam search
             output_tokens = model.generate(
-                input_ids, do_sample=False, bad_words_tokens=bad_words_tokens, num_beams=3, num_return_sequences=3
+                input_ids, do_sample=False, bad_words_ids=bad_words_ids, num_beams=3, num_return_sequences=3
             )
-            generated_tokens = output_tokens[:, input_ids.shape[-1] :]
-            self.assertFalse(self._check_match_tokens(generated_tokens.tolist(), bad_words_tokens))
+            generated_ids = output_tokens[:, input_ids.shape[-1] :]
+            self.assertFalse(self._check_match_tokens(generated_ids.tolist(), bad_words_ids))
 
-    def _check_generated_tokens(self, output_ids):
+    def _check_generated_ids(self, output_ids):
         for token_id in output_ids[0].tolist():
             self.assertGreaterEqual(token_id, 0)
             self.assertLess(token_id, self.model_tester.vocab_size)
 
-    def _check_match_tokens(self, generated_tokens, bad_words_tokens):
+    def _check_match_tokens(self, generated_ids, bad_words_ids):
         # for all bad word tokens
-        for bad_word_tokens in bad_words_tokens:
+        for bad_word_ids in bad_words_ids:
             # for all slices in batch
-            for generated_tokens_slice in generated_tokens:
+            for generated_ids_slice in generated_ids:
                 # for all word idx
-                for i in range(len(bad_word_tokens), len(generated_tokens_slice)):
+                for i in range(len(bad_word_ids), len(generated_ids_slice)):
                     # if tokens match
-                    if generated_tokens_slice[i - len(bad_word_tokens) : i] == bad_word_tokens:
+                    if generated_ids_slice[i - len(bad_word_ids) : i] == bad_word_ids:
                         return True
         return False
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -673,10 +673,35 @@ class ModelTesterMixin:
                 model.generate(input_ids, do_sample=False, num_beams=3, num_return_sequences=3)
             )
 
+            # check bad words tokens language generation
+            bad_words_tokens = [ids_tensor((1, 1), self.model_tester.vocab_size).squeeze(-1).tolist(), ids_tensor((2, 1), self.model_tester.vocab_size).squeeze(-1).tolist()]
+
+            # sampling
+            output_tokens = model.generate(input_ids, do_sample=True, bad_words_tokens=bad_words_tokens, num_return_sequences=3)
+            generated_tokens = output_tokens[:, input_ids.shape[-1]:]
+            self.assertFalse(self._check_match_tokens(generated_tokens.tolist(), bad_words_tokens))
+
+            # beam search
+            output_tokens = model.generate(input_ids, do_sample=False, bad_words_tokens=bad_words_tokens, num_beams=3, num_return_sequences=3)
+            generated_tokens = output_tokens[:, input_ids.shape[-1]:]
+            self.assertFalse(self._check_match_tokens(generated_tokens.tolist(), bad_words_tokens))
+
     def _check_generated_tokens(self, output_ids):
         for token_id in output_ids[0].tolist():
             self.assertGreaterEqual(token_id, 0)
             self.assertLess(token_id, self.model_tester.vocab_size)
+
+    def _check_match_tokens(self, generated_tokens, bad_words_tokens):
+        # for all bad word tokens
+        for bad_word_tokens in bad_words_tokens:
+            # for all slices in batch
+            for generated_tokens_slice in generated_tokens:
+                # for all word idx
+                for i in range(len(bad_word_tokens), len(generated_tokens_slice)):
+                    # if tokens match
+                    if generated_tokens_slice[i - len(bad_word_tokens): i] == bad_word_tokens:
+                        return True
+        return False
 
 
 global_rng = random.Random()

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -674,16 +674,23 @@ class ModelTesterMixin:
             )
 
             # check bad words tokens language generation
-            bad_words_tokens = [ids_tensor((1, 1), self.model_tester.vocab_size).squeeze(-1).tolist(), ids_tensor((2, 1), self.model_tester.vocab_size).squeeze(-1).tolist()]
+            bad_words_tokens = [
+                ids_tensor((1, 1), self.model_tester.vocab_size).squeeze(-1).tolist(),
+                ids_tensor((2, 1), self.model_tester.vocab_size).squeeze(-1).tolist(),
+            ]
 
             # sampling
-            output_tokens = model.generate(input_ids, do_sample=True, bad_words_tokens=bad_words_tokens, num_return_sequences=3)
-            generated_tokens = output_tokens[:, input_ids.shape[-1]:]
+            output_tokens = model.generate(
+                input_ids, do_sample=True, bad_words_tokens=bad_words_tokens, num_return_sequences=3
+            )
+            generated_tokens = output_tokens[:, input_ids.shape[-1] :]
             self.assertFalse(self._check_match_tokens(generated_tokens.tolist(), bad_words_tokens))
 
             # beam search
-            output_tokens = model.generate(input_ids, do_sample=False, bad_words_tokens=bad_words_tokens, num_beams=3, num_return_sequences=3)
-            generated_tokens = output_tokens[:, input_ids.shape[-1]:]
+            output_tokens = model.generate(
+                input_ids, do_sample=False, bad_words_tokens=bad_words_tokens, num_beams=3, num_return_sequences=3
+            )
+            generated_tokens = output_tokens[:, input_ids.shape[-1] :]
             self.assertFalse(self._check_match_tokens(generated_tokens.tolist(), bad_words_tokens))
 
     def _check_generated_tokens(self, output_ids):
@@ -699,7 +706,7 @@ class ModelTesterMixin:
                 # for all word idx
                 for i in range(len(bad_word_tokens), len(generated_tokens_slice)):
                     # if tokens match
-                    if generated_tokens_slice[i - len(bad_word_tokens): i] == bad_word_tokens:
+                    if generated_tokens_slice[i - len(bad_word_tokens) : i] == bad_word_tokens:
                         return True
         return False
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -665,13 +665,9 @@ class ModelTesterMixin:
             self._check_generated_ids(model.generate(input_ids, do_sample=False))
 
             # batch_size > 1, num_beams > 1, sample
-            self._check_generated_ids(
-                model.generate(input_ids, do_sample=True, num_beams=3, num_return_sequences=3,)
-            )
+            self._check_generated_ids(model.generate(input_ids, do_sample=True, num_beams=3, num_return_sequences=3,))
             # batch_size > 1, num_beams > 1, greedy
-            self._check_generated_ids(
-                model.generate(input_ids, do_sample=False, num_beams=3, num_return_sequences=3)
-            )
+            self._check_generated_ids(model.generate(input_ids, do_sample=False, num_beams=3, num_return_sequences=3))
 
             # check bad words tokens language generation
             bad_words_ids = [

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -451,13 +451,9 @@ class TFModelTesterMixin:
             self._check_generated_ids(model.generate(input_ids, do_sample=False))
 
             # batch_size > 1, num_beams > 1, sample
-            self._check_generated_ids(
-                model.generate(input_ids, do_sample=True, num_beams=3, num_return_sequences=3,)
-            )
+            self._check_generated_ids(model.generate(input_ids, do_sample=True, num_beams=3, num_return_sequences=3,))
             # batch_size > 1, num_beams > 1, greedy
-            self._check_generated_ids(
-                model.generate(input_ids, do_sample=False, num_beams=3, num_return_sequences=3)
-            )
+            self._check_generated_ids(model.generate(input_ids, do_sample=False, num_beams=3, num_return_sequences=3))
 
             # check bad words tokens language generation
             bad_words_ids = [

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -427,14 +427,14 @@ class TFModelTesterMixin:
                 with self.assertRaises(AssertionError):
                     model.generate(do_sample=True, max_length=5)
                 # batch_size = 1
-                self._check_generated_tokens(model.generate(input_ids, do_sample=True))
+                self._check_generated_ids(model.generate(input_ids, do_sample=True))
                 # batch_size = 1, num_beams > 1
-                self._check_generated_tokens(model.generate(input_ids, do_sample=True, num_beams=3))
+                self._check_generated_ids(model.generate(input_ids, do_sample=True, num_beams=3))
             else:
                 # batch_size = 1
-                self._check_generated_tokens(model.generate(do_sample=True, max_length=5))
+                self._check_generated_ids(model.generate(do_sample=True, max_length=5))
                 # batch_size = 1, num_beams > 1
-                self._check_generated_tokens(model.generate(do_sample=True, max_length=5, num_beams=3))
+                self._check_generated_ids(model.generate(do_sample=True, max_length=5, num_beams=3))
 
             with self.assertRaises(AssertionError):
                 # generating multiple sequences when greedy no beam generation
@@ -446,53 +446,53 @@ class TFModelTesterMixin:
                 model.generate(input_ids, do_sample=False, num_return_sequences=3, num_beams=2)
 
             # batch_size > 1, sample
-            self._check_generated_tokens(model.generate(input_ids, do_sample=True, num_return_sequences=3))
+            self._check_generated_ids(model.generate(input_ids, do_sample=True, num_return_sequences=3))
             # batch_size > 1, greedy
-            self._check_generated_tokens(model.generate(input_ids, do_sample=False))
+            self._check_generated_ids(model.generate(input_ids, do_sample=False))
 
             # batch_size > 1, num_beams > 1, sample
-            self._check_generated_tokens(
+            self._check_generated_ids(
                 model.generate(input_ids, do_sample=True, num_beams=3, num_return_sequences=3,)
             )
             # batch_size > 1, num_beams > 1, greedy
-            self._check_generated_tokens(
+            self._check_generated_ids(
                 model.generate(input_ids, do_sample=False, num_beams=3, num_return_sequences=3)
             )
 
             # check bad words tokens language generation
-            bad_words_tokens = [
+            bad_words_ids = [
                 tf.squeeze(ids_tensor((1, 1), self.model_tester.vocab_size), -1).numpy().tolist(),
                 tf.squeeze(ids_tensor((2, 1), self.model_tester.vocab_size), -1).numpy().tolist(),
             ]
 
             # sampling
             output_tokens = model.generate(
-                input_ids, do_sample=True, bad_words_tokens=bad_words_tokens, num_return_sequences=3
+                input_ids, do_sample=True, bad_words_ids=bad_words_ids, num_return_sequences=3
             )
-            generated_tokens = output_tokens[:, input_ids.shape[-1] :]
-            self.assertFalse(self._check_match_tokens(generated_tokens.numpy().tolist(), bad_words_tokens))
+            generated_ids = output_tokens[:, input_ids.shape[-1] :]
+            self.assertFalse(self._check_match_tokens(generated_ids.numpy().tolist(), bad_words_ids))
 
             # beam search
             output_tokens = model.generate(
-                input_ids, do_sample=False, bad_words_tokens=bad_words_tokens, num_beams=3, num_return_sequences=3
+                input_ids, do_sample=False, bad_words_ids=bad_words_ids, num_beams=3, num_return_sequences=3
             )
-            generated_tokens = output_tokens[:, input_ids.shape[-1] :]
-            self.assertFalse(self._check_match_tokens(generated_tokens.numpy().tolist(), bad_words_tokens))
+            generated_ids = output_tokens[:, input_ids.shape[-1] :]
+            self.assertFalse(self._check_match_tokens(generated_ids.numpy().tolist(), bad_words_ids))
 
-    def _check_generated_tokens(self, output_ids):
+    def _check_generated_ids(self, output_ids):
         for token_id in output_ids[0].numpy().tolist():
             self.assertGreaterEqual(token_id, 0)
             self.assertLess(token_id, self.model_tester.vocab_size)
 
-    def _check_match_tokens(self, generated_tokens, bad_words_tokens):
+    def _check_match_tokens(self, generated_ids, bad_words_ids):
         # for all bad word tokens
-        for bad_word_tokens in bad_words_tokens:
+        for bad_word_ids in bad_words_ids:
             # for all slices in batch
-            for generated_tokens_slice in generated_tokens:
+            for generated_ids_slice in generated_ids:
                 # for all word idx
-                for i in range(len(bad_word_tokens), len(generated_tokens_slice)):
+                for i in range(len(bad_word_ids), len(generated_ids_slice)):
                     # if tokens match
-                    if generated_tokens_slice[i - len(bad_word_tokens) : i] == bad_word_tokens:
+                    if generated_ids_slice[i - len(bad_word_ids) : i] == bad_word_ids:
                         return True
         return False
 

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -459,10 +459,42 @@ class TFModelTesterMixin:
                 model.generate(input_ids, do_sample=False, num_beams=3, num_return_sequences=3)
             )
 
+            # check bad words tokens language generation
+            bad_words_tokens = [
+                tf.squeeze(ids_tensor((1, 1), self.model_tester.vocab_size), -1).numpy().tolist(),
+                tf.squeeze(ids_tensor((2, 1), self.model_tester.vocab_size), -1).numpy().tolist(),
+            ]
+
+            # sampling
+            output_tokens = model.generate(
+                input_ids, do_sample=True, bad_words_tokens=bad_words_tokens, num_return_sequences=3
+            )
+            generated_tokens = output_tokens[:, input_ids.shape[-1] :]
+            self.assertFalse(self._check_match_tokens(generated_tokens.numpy().tolist(), bad_words_tokens))
+
+            # beam search
+            output_tokens = model.generate(
+                input_ids, do_sample=False, bad_words_tokens=bad_words_tokens, num_beams=3, num_return_sequences=3
+            )
+            generated_tokens = output_tokens[:, input_ids.shape[-1] :]
+            self.assertFalse(self._check_match_tokens(generated_tokens.numpy().tolist(), bad_words_tokens))
+
     def _check_generated_tokens(self, output_ids):
         for token_id in output_ids[0].numpy().tolist():
             self.assertGreaterEqual(token_id, 0)
             self.assertLess(token_id, self.model_tester.vocab_size)
+
+    def _check_match_tokens(self, generated_tokens, bad_words_tokens):
+        # for all bad word tokens
+        for bad_word_tokens in bad_words_tokens:
+            # for all slices in batch
+            for generated_tokens_slice in generated_tokens:
+                # for all word idx
+                for i in range(len(bad_word_tokens), len(generated_tokens_slice)):
+                    # if tokens match
+                    if generated_tokens_slice[i - len(bad_word_tokens) : i] == bad_word_tokens:
+                        return True
+        return False
 
 
 def ids_tensor(shape, vocab_size, rng=None, name=None, dtype=None):


### PR DESCRIPTION
The `bad_words_ids` argument allows to insert a list of lists of `input_ids` that cannot be generated, *e.g.* bad words. 

That's a proposed feature request (I think there were actually multiple ones):
#3061

Also adds tests for all language models to verify behavior. 