### PR TITLE
[Seq2Seq Generation] Call encoder before expanding input_ids

### DIFF
--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -894,7 +894,6 @@ class BartForConditionalGeneration(PretrainedBartModel):
             encoder_outputs, decoder_cached_states = past, None
         else:
             encoder_outputs, decoder_cached_states = past
-        print(encoder_outputs.shape)
         return {
             "input_ids": None,  # encoder_outputs is defined. input_ids not needed
             "encoder_outputs": encoder_outputs,

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -113,7 +113,7 @@ class PretrainedBartModel(PreTrainedModel):
     config_class = BartConfig
     base_model_prefix = "model"
     pretrained_model_archive_map = BART_PRETRAINED_MODEL_ARCHIVE_MAP
-    encoder_outputs_batch_idx = 1  # outputs shaped (bs, ...)
+    encoder_outputs_batch_dim_idx = 1  # outputs shaped (seq_len, bs, ...)
 
     def _init_weights(self, module):
         std = self.config.init_std

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -888,12 +888,13 @@ class BartForConditionalGeneration(PretrainedBartModel):
     def prepare_inputs_for_generation(self, decoder_input_ids, past, attention_mask, **kwargs):
         assert past is not None, "past has to be defined for encoder_outputs"
 
+
         # first step, decoder_cached_states are empty
         if not past[1]:
             encoder_outputs, decoder_cached_states = past, None
         else:
             encoder_outputs, decoder_cached_states = past
-
+        print(encoder_outputs.shape)
         return {
             "input_ids": None,  # encoder_outputs is defined. input_ids not needed
             "encoder_outputs": encoder_outputs,

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -113,6 +113,7 @@ class PretrainedBartModel(PreTrainedModel):
     config_class = BartConfig
     base_model_prefix = "model"
     pretrained_model_archive_map = BART_PRETRAINED_MODEL_ARCHIVE_MAP
+    encoder_outputs_batch_idx = 1  # outputs shaped (bs, ...)
 
     def _init_weights(self, module):
         std = self.config.init_std
@@ -887,7 +888,6 @@ class BartForConditionalGeneration(PretrainedBartModel):
 
     def prepare_inputs_for_generation(self, decoder_input_ids, past, attention_mask, **kwargs):
         assert past is not None, "past has to be defined for encoder_outputs"
-
 
         # first step, decoder_cached_states are empty
         if not past[1]:

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -457,6 +457,7 @@ class T5PreTrainedModel(PreTrainedModel):
     pretrained_model_archive_map = T5_PRETRAINED_MODEL_ARCHIVE_MAP
     load_tf_weights = load_tf_weights_in_t5
     base_model_prefix = "transformer"
+    encoder_outputs_batch_idx = 0  # outputs shaped (bs, ...)
 
     @property
     def dummy_inputs(self):

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -457,7 +457,7 @@ class T5PreTrainedModel(PreTrainedModel):
     pretrained_model_archive_map = T5_PRETRAINED_MODEL_ARCHIVE_MAP
     load_tf_weights = load_tf_weights_in_t5
     base_model_prefix = "transformer"
-    encoder_outputs_batch_idx = 0  # outputs shaped (bs, ...)
+    encoder_outputs_batch_dim_idx = 0  # outputs shaped (bs, ...)
 
     @property
     def dummy_inputs(self):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -934,18 +934,18 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 device=next(self.parameters()).device,
             )
             cur_len = 1
-            batch_idx = self.encoder_outputs_batch_idx
+            batch_idx = self.encoder_outputs_batch_dim_idx
             assert (
                 batch_size == encoder_outputs[0].shape[batch_idx]
             ), f"expected encoder_outputs[0] to have 1st dimension bs={batch_size}, got {encoder_outputs[0].shape[1]} "
-            expanded_index = (
+            expanded_idx = (
                 torch.arange(batch_size)
                 .view(-1, 1)
                 .repeat(1, num_beams * effective_batch_mult)
                 .view(-1)
                 .to(input_ids.device)
             )
-            encoder_outputs = (encoder_outputs[0].index_select(batch_idx, expanded_index), *encoder_outputs[1:])
+            encoder_outputs = (encoder_outputs[0].index_select(batch_idx, expanded_idx), *encoder_outputs[1:])
         else:
             encoder_outputs = None
             cur_len = input_ids.shape[-1]


### PR DESCRIPTION
Proposing to call model.encoder before expanding `input_ids` to `effective_batch_size*num_beams`.

For Bart, this saves 1.5 GB of GPU mem on batch_size=6. Savings probably similar for T5 (untested).

Requires knowing which index of the encoder_outputs is associated with the batch dim (we need to expand this dimension), which is different between `Bart` and `T5`. This difference is encoded in the `self.encoder_outputs_batch_idx` variable.


This PR is WIP because `encoder_outputs_batch_idx` could be avoided if we transposed Bart's encoder_outputs, which I haven't tried. 
