### PR TITLE
[Bart] Fix: put dummy_inputs on correct device

### DIFF
--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -138,10 +138,6 @@ class PretrainedBartModel(PreTrainedModel):
         }
         return dummy_inputs
 
-    @property
-    def device(self):
-        return next(self.parameters()).device
-
 
 def _make_linear_from_emb(emb):
     vocab_size, emb_size = emb.weight.shape

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -128,8 +128,8 @@ class PretrainedBartModel(PreTrainedModel):
     @property
     def dummy_inputs(self):
         pad_token = self.config.pad_token_id
-        input_ids = torch.tensor([[0, 6, 10, 4, 2], [0, 8, 12, 2, pad_token]])
-        decoder_input_ids, decoder_attn_mask = _prepare_bart_decoder_inputs(self.config, input_ids,)
+        input_ids = torch.tensor([[0, 6, 10, 4, 2], [0, 8, 12, 2, pad_token]], device=self.device)
+        decoder_input_ids, decoder_attn_mask = _prepare_bart_decoder_inputs(self.config, input_ids)
         dummy_inputs = {
             "decoder_input_ids": decoder_input_ids,
             "attention_mask": input_ids.ne(pad_token),
@@ -137,6 +137,10 @@ class PretrainedBartModel(PreTrainedModel):
             "decoder_attention_mask": decoder_attn_mask,
         }
         return dummy_inputs
+
+    @property
+    def device(self):
+        return next(self.parameters()).device
 
 
 def _make_linear_from_emb(emb):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -108,6 +108,10 @@ class ModuleUtilsMixin:
             module.mem_rss_post_forward = 0
             module.mem_rss_pre_forward = 0
 
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
 
 class PreTrainedModel(nn.Module, ModuleUtilsMixin):
     r""" Base class for all models.


### PR DESCRIPTION
This fixes `test_dummy_inputs`, which was failing on GPU because dummy inputs were put on CPU even if model was on GPU.