### PR TITLE
[Bart: example] drop columns that are exclusively pad_token_id from input_ids

### DIFF
--- a/examples/summarization/bart/evaluate_cnn.py
+++ b/examples/summarization/bart/evaluate_cnn.py
@@ -16,6 +16,17 @@ def chunks(lst, n):
         yield lst[i : i + n]
 
 
+def trim_batch(
+    input_ids, pad_token_id, attention_mask=None,
+):
+    """Remove columns that are populated exclusively by pad_token_id"""
+    keep_column_mask = input_ids.ne(pad_token_id).any(dim=0)
+    if attention_mask is None:
+        return input_ids[:, keep_column_mask]
+    else:
+        return (input_ids[:, keep_column_mask], attention_mask[:, keep_column_mask])
+
+
 def generate_summaries(lns, out_file, batch_size=8, device=DEFAULT_DEVICE):
     fout = Path(out_file).open("w")
     model = BartForConditionalGeneration.from_pretrained("bart-large-cnn", output_past=True,).to(device)
@@ -26,9 +37,12 @@ def generate_summaries(lns, out_file, batch_size=8, device=DEFAULT_DEVICE):
 
     for batch in tqdm(list(chunks(lns, batch_size))):
         dct = tokenizer.batch_encode_plus(batch, max_length=1024, return_tensors="pt", pad_to_max_length=True)
+        input_ids, attention_mask = trim_batch(
+            dct["input_ids"].to(device), model.config.pad_token_id, attention_mask=dct["attention_mask"].to(device)
+        )
         summaries = model.generate(
-            input_ids=dct["input_ids"].to(device),
-            attention_mask=dct["attention_mask"].to(device),
+            input_ids=input_ids,
+            attention_mask=input_ids,
             num_beams=4,
             length_penalty=2.0,
             max_length=max_length + 2,  # +2 from original because we start at step=1 and stop before max_length

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -1997,3 +1997,14 @@ class PreTrainedTokenizerFast(PreTrainedTokenizer):
             files = self._tokenizer.save(folder, name=file)
 
         return tuple(files)
+
+
+def trim_batch(
+    input_ids, pad_token_id, attention_mask=None,
+):
+    """Remove columns that are populated exclusively by pad_token_id"""
+    keep_column_mask = input_ids.ne(pad_token_id).any(dim=0)
+    if attention_mask is None:
+        return input_ids[:, keep_column_mask]
+    else:
+        return (input_ids[:, keep_column_mask], attention_mask[:, keep_column_mask])


### PR DESCRIPTION
reasoning: These columns slow down computation, but do not change output.
impact: this reduces the runtime to compute EVAL on the CNN examples from 2h to 1:37 before any other changes.

I'm open to putting this as a method on `PretrainedTokenizer` if others find it useful.

@joeddav you might find this useful.


### Code for easy copy paste
```python
def trim_batch(
    input_ids, pad_token_id, attention_mask=None,
):
    """Remove columns that are populated exclusively by pad_token_id"""
    keep_column_mask = input_ids.ne(pad_token_id).any(dim=0)
    if attention_mask is None:
        return input_ids[:, keep_column_mask]
    else:
        return (input_ids[:, keep_column_mask], attention_mask[:, keep_column_mask])
```