### PR TITLE
Add t5 summarization example

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -3,3 +3,5 @@ tensorboard
 scikit-learn
 seqeval
 psutil
+rouge-score
+tensorflow_datasets

--- a/examples/summarization/t5/README.md
+++ b/examples/summarization/t5/README.md
@@ -1,4 +1,4 @@
-***This script evaluates the [T5 Model](https://arxiv.org/pdf/1910.10683.pdf) ``t5-large`` on the CNN/Daily Mail test dataset. Please note that the results in the paper were attained using a ``t5-large`` model fine-tuned on summarization, so that results will be slightly worse here***
+***This script evaluates the [T5 Model](https://arxiv.org/pdf/1910.10683.pdf) ``t5-large`` on the CNN/Daily Mail test dataset. Please note that the results in the paper were attained using a ``t5-large`` model fine-tuned on summarization, so that results will be worse here***
 
 ### Get the CNN Data
 First, you need to download the CNN data. It's about ~400 MB and can be downloaded by 

--- a/examples/summarization/t5/README.md
+++ b/examples/summarization/t5/README.md
@@ -1,4 +1,4 @@
-***This script evaluates the [T5 Model](https://arxiv.org/pdf/1910.10683.pdf) ``t5-large`` on the CNN/Daily Mail test dataset. Please note that the results in the paper were attained using a ``t5-large`` model fine-tuned on summarization, so that results will be worse here***
+***This script evaluates the [T5 Model](https://arxiv.org/pdf/1910.10683.pdf) ``t5-large`` on the CNN/Daily Mail test dataset. Please note that the results in the paper were attained using a ``t5-large`` model fine-tuned on summarization, so that results will be worse here (approx. 0.5 ROUGE points)***
 
 ### Get the CNN Data
 First, you need to download the CNN data. It's about ~400 MB and can be downloaded by 

--- a/examples/summarization/t5/README.md
+++ b/examples/summarization/t5/README.md
@@ -1,0 +1,25 @@
+***This script evaluates the [T5 Model](https://arxiv.org/pdf/1910.10683.pdf) ``t5-large`` on the CNN/Daily Mail test dataset. Please note that the results in the paper were attained using a ``t5-large`` model fine-tuned on summarization, so that results will be slightly worse here***
+
+### Get the CNN Data
+First, you need to download the CNN data. It's about ~400 MB and can be downloaded by 
+running 
+
+```bash
+python download_cnn_daily_mail.py cnn_articles_input_data.txt cnn_articles_reference_summaries.txt
+```
+
+You should confirm that each file has 11490 lines:
+
+```bash
+wc -l cnn_articles_input_data.txt # should print 11490
+wc -l cnn_articles_reference_summaries.txt # should print 11490
+```
+
+### Usage
+
+To create summaries for each article in dataset, run:
+```bash
+python evaluate_cnn.py cnn_articles_input_data.txt cnn_generated_articles_summaries.txt cnn_articles_reference_summaries.txt rouge_score.txt
+```
+The default batch size, 8, fits in 16GB GPU memory, but may need to be adjusted to fit your system.
+The rouge scores "rouge1, rouge2, rougeL" are automatically created and saved in ``rouge_score.txt``.

--- a/examples/summarization/t5/README.md
+++ b/examples/summarization/t5/README.md
@@ -1,4 +1,4 @@
-***This script evaluates the [T5 Model](https://arxiv.org/pdf/1910.10683.pdf) ``t5-large`` on the CNN/Daily Mail test dataset. Please note that the results in the paper were attained using a ``t5-large`` model fine-tuned on summarization, so that results will be worse here (approx. 0.5 ROUGE points)***
+***This script evaluates the the multitask pre-trained checkpoint for ``t5-large`` (see paper [here](https://arxiv.org/pdf/1910.10683.pdf)) on the CNN/Daily Mail test dataset. Please note that the results in the paper were attained using a model fine-tuned on summarization, so that results will be worse here (approx. 0.5 ROUGE points)***
 
 ### Get the CNN Data
 First, you need to download the CNN data. It's about ~400 MB and can be downloaded by 

--- a/examples/summarization/t5/README.md
+++ b/examples/summarization/t5/README.md
@@ -1,4 +1,4 @@
-***This script evaluates the the multitask pre-trained checkpoint for ``t5-large`` (see paper [here](https://arxiv.org/pdf/1910.10683.pdf)) on the CNN/Daily Mail test dataset. Please note that the results in the paper were attained using a model fine-tuned on summarization, so that results will be worse here (approx. 0.5 ROUGE points)***
+***This script evaluates the the multitask pre-trained checkpoint for ``t5-large`` (see paper [here](https://arxiv.org/pdf/1910.10683.pdf)) on the CNN/Daily Mail test dataset. Please note that the results in the paper were attained using a model fine-tuned on summarization, so that results will be worse here by approx. 0.5 ROUGE points***
 
 ### Get the CNN Data
 First, you need to download the CNN data. It's about ~400 MB and can be downloaded by 

--- a/examples/summarization/t5/download_cnn_daily_mail.py
+++ b/examples/summarization/t5/download_cnn_daily_mail.py
@@ -1,0 +1,31 @@
+import argparse
+from pathlib import Path
+
+import tensorflow_datasets as tfds
+
+
+def main(source_path, reference_path, data_dir):
+    cnn_ds = tfds.load("cnn_dailymail", split="test", shuffle_files=False, data_dir=data_dir)
+    cnn_ds_iter = tfds.as_numpy(cnn_ds)
+
+    test_articles_file = Path(source_path).open("w")
+    test_summaries_file = Path(reference_path).open("w")
+
+    for example in cnn_ds_iter:
+        test_articles_file.write(example["article"].decode("utf-8") + "\n")
+        test_articles_file.flush()
+        test_summaries_file.write(example["highlights"].decode("utf-8").replace("\n", " ") + "\n")
+        test_summaries_file.flush()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source_path", type=str, help="where to save the source data")
+    parser.add_argument(
+        "reference_path", type=str, help="where to save the reference summaries",
+    )
+    parser.add_argument(
+        "--data_dir", type=str, default="~/tensorflow_datasets", help="where to save the tensorflow datasets.",
+    )
+    args = parser.parse_args()
+    main(args.source_path, args.reference_path, args.data_dir)

--- a/examples/summarization/t5/download_cnn_daily_mail.py
+++ b/examples/summarization/t5/download_cnn_daily_mail.py
@@ -4,11 +4,11 @@ from pathlib import Path
 import tensorflow_datasets as tfds
 
 
-def main(source_path, reference_path, data_dir):
+def main(input_path, reference_path, data_dir):
     cnn_ds = tfds.load("cnn_dailymail", split="test", shuffle_files=False, data_dir=data_dir)
     cnn_ds_iter = tfds.as_numpy(cnn_ds)
 
-    test_articles_file = Path(source_path).open("w")
+    test_articles_file = Path(input_path).open("w")
     test_summaries_file = Path(reference_path).open("w")
 
     for example in cnn_ds_iter:
@@ -20,7 +20,7 @@ def main(source_path, reference_path, data_dir):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("source_path", type=str, help="where to save the source data")
+    parser.add_argument("input_path", type=str, help="where to save the articles input data")
     parser.add_argument(
         "reference_path", type=str, help="where to save the reference summaries",
     )
@@ -28,4 +28,4 @@ if __name__ == "__main__":
         "--data_dir", type=str, default="~/tensorflow_datasets", help="where to save the tensorflow datasets.",
     )
     args = parser.parse_args()
-    main(args.source_path, args.reference_path, args.data_dir)
+    main(args.input_path, args.reference_path, args.data_dir)

--- a/examples/summarization/t5/evaluate_cnn.py
+++ b/examples/summarization/t5/evaluate_cnn.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from rouge_score import rouge_scorer, scoring
 from tqdm import tqdm
 
-from transformers import T5Tokenizer, TFT5ForConditionalGeneration
+from transformers import T5Tokenizer, T5ForConditionalGeneration
 
 
 def chunks(lst, n):
@@ -16,7 +16,7 @@ def chunks(lst, n):
 def generate_summaries(lns, out_file, batch_size):
     fout = Path(out_file).open("w")
 
-    model = TFT5ForConditionalGeneration.from_pretrained("t5-large")
+    model = T5ForConditionalGeneration.from_pretrained("t5-large")
     tokenizer = T5Tokenizer.from_pretrained("t5-large")
 
     # update config with summarization specific params
@@ -69,9 +69,9 @@ def _run_generate():
         "--bs", type=int, default=8, required=False, help="batch size: how many to summarize at a time",
     )
     args = parser.parse_args()
-    source_lns = [x.rstrip() for x in open(args.source_path).readlines()]
-
-    generate_summaries(source_lns, args.output_path, args.bs)
+#    source_lns = [x.rstrip() for x in open(args.source_path).readlines()]
+#
+#    generate_summaries(source_lns, args.output_path, args.bs)
 
     output_lns = [x.rstrip() for x in open(args.output_path).readlines()]
     reference_lns = [x.rstrip() for x in open(args.reference_path).readlines()]

--- a/examples/summarization/t5/evaluate_cnn.py
+++ b/examples/summarization/t5/evaluate_cnn.py
@@ -1,11 +1,11 @@
 import argparse
 from pathlib import Path
 
+import torch
 from rouge_score import rouge_scorer, scoring
 from tqdm import tqdm
 
 from transformers import T5ForConditionalGeneration, T5Tokenizer
-import torch
 
 
 def chunks(lst, n):
@@ -14,8 +14,8 @@ def chunks(lst, n):
         yield lst[i : i + n]
 
 
-def generate_summaries(lns, out_file, batch_size, device):
-    fout = Path(out_file).open("w")
+def generate_summaries(lns, output_file_path, batch_size, device):
+    output_file = Path(output_file_path).open("w")
 
     model = T5ForConditionalGeneration.from_pretrained("t5-large")
     model.to(device)
@@ -38,8 +38,8 @@ def generate_summaries(lns, out_file, batch_size, device):
         dec = [tokenizer.decode(g, skip_special_tokens=True, clean_up_tokenization_spaces=False) for g in summaries]
 
         for hypothesis in dec:
-            fout.write(hypothesis + "\n")
-            fout.flush()
+            output_file.write(hypothesis + "\n")
+            output_file.flush()
 
 
 def calculate_rouge(output_lns, reference_lns, score_path):

--- a/examples/summarization/t5/evaluate_cnn.py
+++ b/examples/summarization/t5/evaluate_cnn.py
@@ -1,0 +1,83 @@
+import argparse
+from pathlib import Path
+
+from rouge_score import rouge_scorer, scoring
+from tqdm import tqdm
+
+from transformers import T5Tokenizer, TFT5ForConditionalGeneration
+
+
+def chunks(lst, n):
+    """Yield successive n-sized chunks from lst."""
+    for i in range(0, len(lst), n):
+        yield lst[i : i + n]
+
+
+def generate_summaries(lns, out_file, batch_size):
+    fout = Path(out_file).open("w")
+
+    model = TFT5ForConditionalGeneration.from_pretrained("t5-large")
+    tokenizer = T5Tokenizer.from_pretrained("t5-large")
+
+    # update config with summarization specific params
+    task_specific_params = model.config.task_specific_params
+    if task_specific_params is not None:
+        model.config.update(task_specific_params.get("summarization", {}))
+
+    for batch in tqdm(list(chunks(lns, batch_size))):
+        batch = [model.config.prefix + text for text in batch]
+
+        dct = tokenizer.batch_encode_plus(batch, max_length=512, return_tensors="tf", pad_to_max_length=True)
+        summaries = model.generate(input_ids=dct["input_ids"], attention_mask=dct["attention_mask"],)
+        dec = [tokenizer.decode(g, skip_special_tokens=True, clean_up_tokenization_spaces=False) for g in summaries]
+
+        for hypothesis in dec:
+            fout.write(hypothesis + "\n")
+            fout.flush()
+
+
+def calculate_rouge(output_lns, reference_lns, score_path):
+    score_file = Path(score_path).open("w")
+    scorer = rouge_scorer.RougeScorer(["rouge1", "rouge2", "rougeL"], use_stemmer=True)
+    aggregator = scoring.BootstrapAggregator()
+
+    for reference_ln, output_ln in zip(reference_lns, output_lns):
+        scores = scorer.score(reference_ln, output_ln)
+        aggregator.add_scores(scores)
+
+    result = aggregator.aggregate()
+    score_file.write(
+        "ROUGE_1: \n{} \n\n ROUGE_2: \n{} \n\n ROUGE_L: \n{} \n\n".format(
+            result["rouge1"], result["rouge2"], result["rougeL"]
+        )
+    )
+
+
+def _run_generate():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "source_path", type=str, help="like cnn_dm/test_articles_input.txt",
+    )
+    parser.add_argument(
+        "output_path", type=str, help="where to save summaries",
+    )
+    parser.add_argument("reference_path", type=str, help="like cnn_dm/test_reference_summaries.txt")
+    parser.add_argument(
+        "score_path", type=str, help="where to save the rouge score",
+    )
+    parser.add_argument(
+        "--bs", type=int, default=8, required=False, help="batch size: how many to summarize at a time",
+    )
+    args = parser.parse_args()
+    source_lns = [x.rstrip() for x in open(args.source_path).readlines()]
+
+    generate_summaries(source_lns, args.output_path, args.bs)
+
+    output_lns = [x.rstrip() for x in open(args.output_path).readlines()]
+    reference_lns = [x.rstrip() for x in open(args.reference_path).readlines()]
+
+    calculate_rouge(output_lns, reference_lns, args.score_path)
+
+
+if __name__ == "__main__":
+    _run_generate()

--- a/examples/summarization/t5/evaluate_cnn.py
+++ b/examples/summarization/t5/evaluate_cnn.py
@@ -2,9 +2,9 @@ import argparse
 from pathlib import Path
 
 import torch
-from rouge_score import rouge_scorer, scoring
 from tqdm import tqdm
 
+from rouge_score import rouge_scorer, scoring
 from transformers import T5ForConditionalGeneration, T5Tokenizer
 
 

--- a/examples/summarization/t5/evaluate_cnn.py
+++ b/examples/summarization/t5/evaluate_cnn.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from rouge_score import rouge_scorer, scoring
 from tqdm import tqdm
 
-from transformers import T5Tokenizer, T5ForConditionalGeneration
+from transformers import T5ForConditionalGeneration, T5Tokenizer
 
 
 def chunks(lst, n):
@@ -69,9 +69,9 @@ def _run_generate():
         "--bs", type=int, default=8, required=False, help="batch size: how many to summarize at a time",
     )
     args = parser.parse_args()
-#    source_lns = [x.rstrip() for x in open(args.source_path).readlines()]
-#
-#    generate_summaries(source_lns, args.output_path, args.bs)
+    #    source_lns = [x.rstrip() for x in open(args.source_path).readlines()]
+    #
+    #    generate_summaries(source_lns, args.output_path, args.bs)
 
     output_lns = [x.rstrip() for x in open(args.output_path).readlines()]
     reference_lns = [x.rstrip() for x in open(args.reference_path).readlines()]

--- a/examples/summarization/t5/evaluate_cnn.py
+++ b/examples/summarization/t5/evaluate_cnn.py
@@ -27,7 +27,7 @@ def generate_summaries(lns, out_file, batch_size):
     for batch in tqdm(list(chunks(lns, batch_size))):
         batch = [model.config.prefix + text for text in batch]
 
-        dct = tokenizer.batch_encode_plus(batch, max_length=512, return_tensors="tf", pad_to_max_length=True)
+        dct = tokenizer.batch_encode_plus(batch, max_length=512, return_tensors="pt", pad_to_max_length=True)
         summaries = model.generate(input_ids=dct["input_ids"], attention_mask=dct["attention_mask"],)
         dec = [tokenizer.decode(g, skip_special_tokens=True, clean_up_tokenization_spaces=False) for g in summaries]
 
@@ -53,10 +53,10 @@ def calculate_rouge(output_lns, reference_lns, score_path):
     )
 
 
-def _run_generate():
+def run_generate():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "source_path", type=str, help="like cnn_dm/test_articles_input.txt",
+        "input_path", type=str, help="like cnn_dm/test_articles_input.txt",
     )
     parser.add_argument(
         "output_path", type=str, help="where to save summaries",
@@ -69,9 +69,9 @@ def _run_generate():
         "--bs", type=int, default=8, required=False, help="batch size: how many to summarize at a time",
     )
     args = parser.parse_args()
-    #    source_lns = [x.rstrip() for x in open(args.source_path).readlines()]
-    #
-    #    generate_summaries(source_lns, args.output_path, args.bs)
+    source_lns = [x.rstrip() for x in open(args.input_path).readlines()]
+
+    generate_summaries(source_lns, args.output_path, args.bs)
 
     output_lns = [x.rstrip() for x in open(args.output_path).readlines()]
     reference_lns = [x.rstrip() for x in open(args.reference_path).readlines()]
@@ -80,4 +80,4 @@ def _run_generate():
 
 
 if __name__ == "__main__":
-    _run_generate()
+    run_generate()

--- a/examples/summarization/t5/test_t5_examples.py
+++ b/examples/summarization/t5/test_t5_examples.py
@@ -15,8 +15,8 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
 
 
-class TestTFT5Examples(unittest.TestCase):
-    def test_tf_t5_cli(self):
+class TestT5Examples(unittest.TestCase):
+    def test_t5_cli(self):
         stream_handler = logging.StreamHandler(sys.stdout)
         logger.addHandler(stream_handler)
         tmp = Path(tempfile.gettempdir()) / "utest_generations.hypo"

--- a/examples/summarization/t5/test_t5_examples.py
+++ b/examples/summarization/t5/test_t5_examples.py
@@ -5,7 +5,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from .evaluate_cnn import _run_generate
+from .evaluate_cnn import run_generate
 
 
 articles = ["New York (CNN)When Liana Barrientos was 23 years old, she got married in Westchester County."]
@@ -24,5 +24,6 @@ class TestT5Examples(unittest.TestCase):
             f.write("\n".join(articles))
         testargs = ["evaluate_cnn.py", str(tmp), "output.txt", str(tmp), "score.txt"]
         with patch.object(sys, "argv", testargs):
-            _run_generate()
+            run_generate()
             self.assertTrue(Path("output.txt").exists())
+            self.assertTrue(Path("score.txt").exists())

--- a/examples/summarization/t5/test_tf_t5_examples.py
+++ b/examples/summarization/t5/test_tf_t5_examples.py
@@ -1,0 +1,28 @@
+import logging
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from .evaluate_cnn import _run_generate
+
+
+articles = ["New York (CNN)When Liana Barrientos was 23 years old, she got married in Westchester County."]
+
+logging.basicConfig(level=logging.DEBUG)
+
+logger = logging.getLogger()
+
+
+class TestTFT5Examples(unittest.TestCase):
+    def test_tf_t5_cli(self):
+        stream_handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(stream_handler)
+        tmp = Path(tempfile.gettempdir()) / "utest_generations.hypo"
+        with tmp.open("w") as f:
+            f.write("\n".join(articles))
+        testargs = ["evaluate_cnn.py", str(tmp), "output.txt", str(tmp), "score.txt"]
+        with patch.object(sys, "argv", testargs):
+            _run_generate()
+            self.assertTrue(Path("output.txt").exists())


### PR DESCRIPTION
Adds TF 2.0 Example for T5 summarization. 

Adds dataset download file via `tensorflow_datasets` and a rouge scorer. 


Example is currently being tested on T5-large on GPU to see how rouge scorer performs in comparsion to `examples/summarization/bart` rouge scorer.