### PR TITLE
Fix XLNet batch generation bug

### DIFF
--- a/src/transformers/modeling_xlnet.py
+++ b/src/transformers/modeling_xlnet.py
@@ -953,7 +953,7 @@ class XLNetLMHeadModel(XLNetPreTrainedModel):
         target_mapping = torch.zeros(
             (effective_batch_size, 1, sequence_length), dtype=torch.float, device=input_ids.device
         )
-        target_mapping[0, 0, -1] = 1.0
+        target_mapping[:, 0, -1] = 1.0
 
         inputs = {"input_ids": input_ids, "perm_mask": perm_mask, "target_mapping": target_mapping}
 


### PR DESCRIPTION
When doing batch generation with XLNet, only the first element in the batch contains any predictions. This seems to be caused by the target_mapping being improperly initialized in prepare_inputs_for_generation.