### PR TITLE
feat: config what's trainable in Bert layers

### DIFF
--- a/src/transformers/configuration_bert.py
+++ b/src/transformers/configuration_bert.py
@@ -93,7 +93,7 @@ class BertConfig(PretrainedConfig):
                 Whether or not to make embeddings trainable in fine-tuning
             train_pooler (:obj:`bool`, optional, defaults to True):
                 Whether or not to make pooler trainable in fine-tuning
-            train_layers (:obj:`int` or :obj:`slice`, optional, defaults to `None` meaning all hidden layers):
+            train_layers (:obj:`int` or :obj:`list` or :obj:`range`, optional, defaults to `None` = all hidden layers):
                 Which encoder layers to make trainable in fine-tuning; if :obj:`int` then the top N layers are trainable
 
         Example::

--- a/src/transformers/configuration_bert.py
+++ b/src/transformers/configuration_bert.py
@@ -89,6 +89,12 @@ class BertConfig(PretrainedConfig):
                 The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
             layer_norm_eps (:obj:`float`, optional, defaults to 1e-12):
                 The epsilon used by the layer normalization layers.
+            train_embeddings (:obj:`bool`, optional, defaults to True):
+                Whether or not to make embeddings trainable in fine-tuning
+            train_pooler (:obj:`bool`, optional, defaults to True):
+                Whether or not to make pooler trainable in fine-tuning
+            train_layers (:obj:`int` or :obj:`slice`, optional, defaults to `None` meaning all hidden layers):
+                Which encoder layers to make trainable in fine-tuning; if :obj:`int` then the top N layers are trainable
 
         Example::
 
@@ -125,6 +131,9 @@ class BertConfig(PretrainedConfig):
         initializer_range=0.02,
         layer_norm_eps=1e-12,
         pad_token_id=0,
+        train_embeddings=True,
+        train_layers=None,
+        train_pooler=True,
         **kwargs
     ):
         super().__init__(pad_token_id=pad_token_id, **kwargs)
@@ -141,3 +150,6 @@ class BertConfig(PretrainedConfig):
         self.type_vocab_size = type_vocab_size
         self.initializer_range = initializer_range
         self.layer_norm_eps = layer_norm_eps
+        self.train_embeddings = train_embeddings
+        self.train_layers = train_layers
+        self.train_pooler = train_pooler

--- a/src/transformers/modeling_tf_bert.py
+++ b/src/transformers/modeling_tf_bert.py
@@ -94,6 +94,8 @@ class TFBertEmbeddings(tf.keras.layers.Layer):
     """
 
     def __init__(self, config, **kwargs):
+        if "trainable" not in kwargs:
+            kwargs["trainable"] = config.train_embeddings
         super().__init__(**kwargs)
         self.vocab_size = config.vocab_size
         self.hidden_size = config.hidden_size
@@ -404,6 +406,8 @@ class TFBertEncoder(tf.keras.layers.Layer):
 
 class TFBertPooler(tf.keras.layers.Layer):
     def __init__(self, config, **kwargs):
+        if "trainable" not in kwargs:
+            kwargs["trainable"] = config.train_pooler
         super().__init__(**kwargs)
         self.dense = tf.keras.layers.Dense(
             config.hidden_size,
@@ -490,9 +494,9 @@ class TFBertMainLayer(tf.keras.layers.Layer):
         super().__init__(**kwargs)
         self.num_hidden_layers = config.num_hidden_layers
 
-        self.embeddings = TFBertEmbeddings(config, name="embeddings", trainable=config.train_embeddings)
+        self.embeddings = TFBertEmbeddings(config, name="embeddings")
         self.encoder = TFBertEncoder(config, name="encoder")
-        self.pooler = TFBertPooler(config, name="pooler", trainable=config.train_pooler)
+        self.pooler = TFBertPooler(config, name="pooler")
 
     def get_input_embeddings(self):
         return self.embeddings


### PR DESCRIPTION
Make it possible to configure trainability for specific subparts of a `TFBertMainLayer`.

This is minimal and Bert-only. Really should be added in more model types, not just Bert, but it probably necessarily differs quite a bit between model types, so probably can't be done in a very “DRY” way.

See https://github.com/tensorflow/tensorflow/issues/37541 which makes this necessary: if we set `l.trainable = False` on a layer _after_ initializing it, then training and serialization proceeds without apparent problems but then deserialization will fail, because:

* the `trainable` attribute doesn't get persisted
* parameter values are deserialized and batch-assigned to model parameters _in order_ — with the implicit assumption that the ordering of parameters is the same as in the model before serialization
* that assumption doesn't hold if some layers were not trainable before serialization, because the ordering of parameters depends on the `trainable` attribute, which is `True` by default because it wasn't persisted