### PR TITLE
revert unpin isort commit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ extras["testing"] = ["pytest", "pytest-xdist"]
 extras["docs"] = ["recommonmark", "sphinx", "sphinx-markdown-tables", "sphinx-rtd-theme"]
 extras["quality"] = [
     "black",
-    "isort",
+    "isort @ git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e528357650281a3d3ec22#egg=isort",
     "flake8",
 ]
 extras["dev"] = extras["testing"] + extras["quality"] + ["mecab-python3", "scikit-learn", "tensorflow", "torch"]


### PR DESCRIPTION
This PR reverts the change of 
https://github.com/huggingface/transformers/commit/fbc5bf10cfe4d4ca81f8daacc148b0abd51dda5a

Using the unpinned version of `isort` makes black and `isort` disagree in some cases. 
In this PR the unpinned version of `isort` leads to a falied code quality test:
https://github.com/huggingface/transformers/pull/3411 

