### PR TITLE
Optimize tokenization (85-92% time reduction)

### DIFF
--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -794,9 +794,11 @@ class PreTrainedTokenizer(object):
             tokenized_text = []
             text_list = [text]
             for tok in tok_list:
+                if tok not in text:
+                    continue
                 tokenized_text = []
                 for sub_text in text_list:
-                    if sub_text not in self.unique_added_tokens_encoder:
+                    if tok in sub_text:
                         tokenized_text += split_on_token(tok, sub_text)
                     else:
                         tokenized_text += [sub_text]


### PR DESCRIPTION
This optimization in tokenization reduces the tokenization time by ~ 85-92 %

Stats:

Before fix: 
 8%|████████▉                                                                                                      | 119574/1486030 [01:03<12:09, 1874.22it/s]

After fix: 
 98%|████████████████████████████████████  | 1459590/1486030 [01:59<00:02, 12244.82it/s]


Another stats: 
When huge number of new tokens (~58K) are added, tokenization time bumps up to ~27-28 hours 
With this fix the time drops to ~2.15 hours !