### PR TITLE
[Wait to merge] [Bart] Rename lm_labels argument to masked_lm_labels

### DIFF
--- a/examples/summarization/bart/run_bart_sum.py
+++ b/examples/summarization/bart/run_bart_sum.py
@@ -22,7 +22,12 @@ class BartSystem(BaseTransformer):
         super(BartSystem, self).__init__(hparams, num_labels=None, mode=self.mode)
 
     def forward(
-        self, input_ids, attention_mask=None, decoder_input_ids=None, decoder_attention_mask=None, masked_lm_labels=None
+        self,
+        input_ids,
+        attention_mask=None,
+        decoder_input_ids=None,
+        decoder_attention_mask=None,
+        masked_lm_labels=None,
     ):
         return self.model(
             input_ids,

--- a/examples/summarization/bart/run_bart_sum.py
+++ b/examples/summarization/bart/run_bart_sum.py
@@ -22,26 +22,26 @@ class BartSystem(BaseTransformer):
         super(BartSystem, self).__init__(hparams, num_labels=None, mode=self.mode)
 
     def forward(
-        self, input_ids, attention_mask=None, decoder_input_ids=None, decoder_attention_mask=None, lm_labels=None
+        self, input_ids, attention_mask=None, decoder_input_ids=None, decoder_attention_mask=None, masked_lm_labels=None
     ):
         return self.model(
             input_ids,
             attention_mask=attention_mask,
             decoder_input_ids=decoder_input_ids,
             decoder_attention_mask=decoder_attention_mask,
-            masked_lm_labels=lm_labels,
+            masked_lm_labels=masked_lm_labels,
         )
 
     def _step(self, batch):
         y = batch["target_ids"]
         y_ids = y[:, :-1].contiguous()
-        lm_labels = y[:, 1:].clone()
-        lm_labels[y[:, 1:] == self.tokenizer.pad_token_id] = -100
+        masked_lm_labels = y[:, 1:].clone()
+        masked_lm_labels[y[:, 1:] == self.tokenizer.pad_token_id] = -100
         outputs = self(
             input_ids=batch["source_ids"],
             attention_mask=batch["source_mask"],
             decoder_input_ids=y_ids,
-            lm_labels=lm_labels,
+            masked_lm_labels=masked_lm_labels,
         )
 
         loss = outputs[0]

--- a/examples/summarization/bart/run_bart_sum.py
+++ b/examples/summarization/bart/run_bart_sum.py
@@ -29,7 +29,7 @@ class BartSystem(BaseTransformer):
             attention_mask=attention_mask,
             decoder_input_ids=decoder_input_ids,
             decoder_attention_mask=decoder_attention_mask,
-            lm_labels=lm_labels,
+            masked_lm_labels=lm_labels,
         )
 
     def _step(self, batch):

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -830,7 +830,7 @@ class BartForConditionalGeneration(PretrainedBartModel):
         decoder_input_ids=None,
         decoder_attention_mask=None,
         decoder_cached_states=None,
-        lm_labels=None,
+        masked_lm_labels=None,
         generation_mode=False,
         **unused
     ):
@@ -886,10 +886,10 @@ class BartForConditionalGeneration(PretrainedBartModel):
         )
         lm_logits = F.linear(outputs[0], self.model.shared.weight)
         outputs = (lm_logits,) + outputs[1:]  # Add hidden states and attention if they are here
-        if lm_labels is not None:
+        if masked_lm_labels is not None:
             loss_fct = nn.CrossEntropyLoss()
             # TODO(SS): do we need to ignore pad tokens in lm_labels?
-            masked_lm_loss = loss_fct(lm_logits.view(-1, self.config.vocab_size), lm_labels.view(-1))
+            masked_lm_loss = loss_fct(lm_logits.view(-1, self.config.vocab_size), masked_lm_labels.view(-1))
             outputs = (masked_lm_loss,) + outputs
 
         return outputs

--- a/tests/test_modeling_bart.py
+++ b/tests/test_modeling_bart.py
@@ -242,10 +242,10 @@ class BartHeadTests(unittest.TestCase):
 
     def test_lm_forward(self):
         config, input_ids, batch_size = self._get_config_and_data(output_past=False)
-        lm_labels = ids_tensor([batch_size, input_ids.shape[1]], self.vocab_size).to(torch_device)
+        masked_lm_labels = ids_tensor([batch_size, input_ids.shape[1]], self.vocab_size).to(torch_device)
         lm_model = BartForConditionalGeneration(config)
         lm_model.to(torch_device)
-        loss, logits, enc_features = lm_model(input_ids=input_ids, lm_labels=lm_labels)
+        loss, logits, enc_features = lm_model(input_ids=input_ids, masked_lm_labels=masked_lm_labels)
         expected_shape = (batch_size, input_ids.shape[1], config.vocab_size)
         self.assertEqual(logits.shape, expected_shape)
         self.assertIsInstance(loss.item(), float)
@@ -265,7 +265,7 @@ class BartHeadTests(unittest.TestCase):
         lm_model = BartForConditionalGeneration(config).to(torch_device)
         context = torch.Tensor([[71, 82, 18, 33, 46, 91, 2], [68, 34, 26, 58, 30, 2, 1]]).long().to(torch_device)
         summary = torch.Tensor([[82, 71, 82, 18, 2], [58, 68, 2, 1, 1]]).long().to(torch_device)
-        loss, logits, enc_features = lm_model(input_ids=context, decoder_input_ids=summary, lm_labels=summary)
+        loss, logits, enc_features = lm_model(input_ids=context, decoder_input_ids=summary, masked_lm_labels=summary)
         expected_shape = (*summary.shape, config.vocab_size)
         self.assertEqual(logits.shape, expected_shape)
 


### PR DESCRIPTION
While the docstring correctly lists masked_lm_labels, forward
was expecting lm_labels. Renaming to match BERT and the rest of
the MLM-based models

