### PR TITLE
[BART] Update encoder and decoder on set_input_embedding

### DIFF
--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -804,6 +804,8 @@ class BartModel(PretrainedBartModel):
 
     def set_input_embeddings(self, value):
         self.shared = value
+        self.encoder.embed_tokens = self.shared
+        self.decoder.embed_tokens = self.shared
 
     def get_output_embeddings(self):
         return _make_linear_from_emb(self.shared)  # make it on the fly


### PR DESCRIPTION
Since  _resize_token_embeddings will create a new embedding layer,
resizing the input embeddings for BART will currently break, as the
model.shared will refer to the new embedding created but the
model.encoder.embed_tokens and the model.decoder.embed_tokens will
still refer to the old embedding created.

We need to re-assign the encoder/decoder or just their weights, I opted for the second option.
Unfortunately can't see how to write a test in the test_resize_tokens_embeddings to capture this without putting a BART-specific if statement there, but this is also related to https://github.com/huggingface/transformers/issues/3378

Run tests:
 733 passed, 319 skipped, 80 warnings in 269.62s (0:04:29) 