### PR TITLE
Fix for continuing training

### DIFF
--- a/examples/run_language_modeling.py
+++ b/examples/run_language_modeling.py
@@ -624,6 +624,7 @@ def main():
         and os.listdir(args.output_dir)
         and args.do_train
         and not args.overwrite_output_dir
+        and not args.should_continue
     ):
         raise ValueError(
             "Output directory ({}) already exists and is not empty. Use --overwrite_output_dir to overcome.".format(


### PR DESCRIPTION
If `args.should_continue` is true, then there is no way in the current example to reload a checkpoint since it is assumed it exists within the output_dir. Checking here fixes everything as expected.