### PR TITLE
[Tokenization] fix edge case for bert tokenization

### DIFF
--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -1396,13 +1396,7 @@ class PreTrainedTokenizer(SpecialTokensMixin):
 
         input_ids = []
         for ids_or_pair_ids in batch_text_or_text_pairs:
-            is_list_of_untokenized_strings = (
-                isinstance(ids_or_pair_ids, (list, tuple))
-                and len(ids_or_pair_ids) == 2
-                and not all([isinstance(x, str) and x == self.tokenize(x)[0] for x in ids_or_pair_ids])
-            )
-
-            if is_list_of_untokenized_strings:
+            if isinstance(ids_or_pair_ids, (list, tuple)) and len(ids_or_pair_ids) == 2 and not is_pretokenized:
                 ids, pair_ids = ids_or_pair_ids
             else:
                 ids, pair_ids = ids_or_pair_ids, None

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -1396,7 +1396,13 @@ class PreTrainedTokenizer(SpecialTokensMixin):
 
         input_ids = []
         for ids_or_pair_ids in batch_text_or_text_pairs:
-            if isinstance(ids_or_pair_ids, (list, tuple)) and len(ids_or_pair_ids) == 2:
+            is_list_of_untokenized_strings = (
+                isinstance(ids_or_pair_ids, (list, tuple))
+                and len(ids_or_pair_ids) > 0
+                and not all([isinstance(x, str) and x == self.tokenize(x)[0] for x in ids_or_pair_ids])
+            )
+
+            if is_list_of_untokenized_strings and len(ids_or_pair_ids) == 2:
                 ids, pair_ids = ids_or_pair_ids
             else:
                 ids, pair_ids = ids_or_pair_ids, None

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -1398,11 +1398,11 @@ class PreTrainedTokenizer(SpecialTokensMixin):
         for ids_or_pair_ids in batch_text_or_text_pairs:
             is_list_of_untokenized_strings = (
                 isinstance(ids_or_pair_ids, (list, tuple))
-                and len(ids_or_pair_ids) > 0
+                and len(ids_or_pair_ids) == 2
                 and not all([isinstance(x, str) and x == self.tokenize(x)[0] for x in ids_or_pair_ids])
             )
 
-            if is_list_of_untokenized_strings and len(ids_or_pair_ids) == 2:
+            if is_list_of_untokenized_strings:
                 ids, pair_ids = ids_or_pair_ids
             else:
                 ids, pair_ids = ids_or_pair_ids, None


### PR DESCRIPTION
This PR fixes #3502 . 

The reason why the tests fail in #3502 is because of an edge case. 

If the input to `tokenizer.batch_encode_plus()` consists of a tokenized string that results in a list of exactly two strings (``[[16], [.]]`` in issue #3502) then it is treated as a pair of input sequences (=> [CLS] input_sequence_1 [SEP] input_sequence_2 [SEP]) but this behavior should only happen if the input list consists of two **untokenized** strings. 