### PR TITLE
Resizing embedding matrix before sending it to the optimizer.

### DIFF
--- a/examples/run_language_modeling.py
+++ b/examples/run_language_modeling.py
@@ -233,6 +233,10 @@ def train(args, train_dataset, model: PreTrainedModel, tokenizer: PreTrainedToke
     else:
         t_total = len(train_dataloader) // args.gradient_accumulation_steps * args.num_train_epochs
 
+
+    model = model.module if hasattr(model, "module") else model  # Take care of distributed/parallel training
+    model.resize_token_embeddings(len(tokenizer))
+
     # Prepare optimizer and schedule (linear warmup and decay)
     no_decay = ["bias", "LayerNorm.weight"]
     optimizer_grouped_parameters = [
@@ -308,9 +312,6 @@ def train(args, train_dataset, model: PreTrainedModel, tokenizer: PreTrainedToke
             logger.info("  Starting fine-tuning.")
 
     tr_loss, logging_loss = 0.0, 0.0
-
-    model_to_resize = model.module if hasattr(model, "module") else model  # Take care of distributed/parallel training
-    model_to_resize.resize_token_embeddings(len(tokenizer))
 
     model.zero_grad()
     train_iterator = trange(

--- a/examples/run_language_modeling.py
+++ b/examples/run_language_modeling.py
@@ -233,7 +233,6 @@ def train(args, train_dataset, model: PreTrainedModel, tokenizer: PreTrainedToke
     else:
         t_total = len(train_dataloader) // args.gradient_accumulation_steps * args.num_train_epochs
 
-
     model = model.module if hasattr(model, "module") else model  # Take care of distributed/parallel training
     model.resize_token_embeddings(len(tokenizer))
 


### PR DESCRIPTION
Hi there,

This is a minor bug when fine-tuning a pre-trained language model with a larger vocabulary using the run_lm_finetuning.py script.
Nothing major but I spent a couple of hours trying to figure out why my token embeddings were not being updated with their corresponding gradient :)

This bug will rise when you add new token types in the Tokenizer.
Since the resizing was done after passing the params to the optimizer, the wrong set of params for the embedding table were optimized.

Cheers