### PR TITLE
[Encoder-Decoder] Force models outputs to always have batch_size as their first dim

### DIFF
--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -451,10 +451,9 @@ class BartDecoder(nn.Module):
         x = self.layernorm_embedding(x)
         x = F.dropout(x, p=self.dropout, training=self.training)
 
-        x = x.transpose(0, 1)  # (BS, seq_len, model_dim) -> (seq_len, BS, model_dim)
-        encoder_hidden_states = encoder_hidden_states.transpose(
-            0, 1
-        )  # (BS, seq_len, model_dim) -> (seq_len, BS, model_dim)
+        # Convert to Bart output format: (seq_len, BS, model_dim) -> (BS, seq_len, model_dim)
+        x = x.transpose(0, 1)
+        encoder_hidden_states = encoder_hidden_states.transpose(0, 1)
 
         # decoder layers
         all_hidden_states = ()

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -457,7 +457,6 @@ class T5PreTrainedModel(PreTrainedModel):
     pretrained_model_archive_map = T5_PRETRAINED_MODEL_ARCHIVE_MAP
     load_tf_weights = load_tf_weights_in_t5
     base_model_prefix = "transformer"
-    encoder_outputs_batch_dim_idx = 0  # outputs shaped (bs, ...)
 
     @property
     def dummy_inputs(self):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -948,18 +948,21 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 device=next(self.parameters()).device,
             )
             cur_len = 1
-            batch_idx = self.encoder_outputs_batch_dim_idx
+
             assert (
-                batch_size == encoder_outputs[0].shape[batch_idx]
-            ), f"expected encoder_outputs[0] to have 1st dimension bs={batch_size}, got {encoder_outputs[0].shape[1]} "
-            expanded_idx = (
+                batch_size == encoder_outputs[0].shape[0]
+            ), f"expected encoder_outputs[0] to have 1st dimension bs={batch_size}, got {encoder_outputs[0].shape[0]} "
+
+            # expand batch_idx to assign correct encoder output for expanded input_ids (due to num_beams > 1 and num_return_sequences > 1)
+            expanded_batch_idxs = (
                 torch.arange(batch_size)
                 .view(-1, 1)
                 .repeat(1, num_beams * effective_batch_mult)
                 .view(-1)
                 .to(input_ids.device)
             )
-            encoder_outputs = (encoder_outputs[0].index_select(batch_idx, expanded_idx), *encoder_outputs[1:])
+            # expand encoder_outputs
+            encoder_outputs = (encoder_outputs[0].index_select(0, expanded_batch_idxs), *encoder_outputs[1:])
 
         else:
             encoder_outputs = None


### PR DESCRIPTION
This PR remove the hard-coded variable `encoder_outputs_batch_dim_idx` from Bart and T5 by transposing BART's `encoder_outputs` dimensions before returning them.

**Reasons:**
- When adding more encoder-decoder models, we would always force the newly added model to have this variable
- When adding the modeling_encoder_decoder.py file, models that could be used in an encoder-decoder structure would also need to have this attribute, e.g. we would have to add it to Bert for example
- `encoder_outputs_batch_dim_idx` is a hard-coded variable that I don't think is very pretty

**Trade-off:**
- Now every encoder output in a encoder-decoder model has to have `batch_size` as their first dimension.

This PR is related to a question that already came up before (see #3120): 
*Should we force all model outputs to have `batch_size` as their first dimension* ?

I think it would be good to always have `batch_size` as the first dimension (to the user) exposed output @thomwolf @LysandreJik @sshleifer @julien-c 