### PR TITLE
update run_language_modeling.py for high efficiency in Multi GPUs

### DIFF
--- a/examples/run_language_modeling.py
+++ b/examples/run_language_modeling.py
@@ -64,7 +64,7 @@ MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
 
 class Model(nn.Module):   
     def __init__(self, encoder):
-        super(Roberta, self).__init__()
+        super(Model, self).__init__()
         self.encoder = encoder
         
     def forward(self, input_ids,masked_lm_labels=None): 

--- a/examples/run_language_modeling.py
+++ b/examples/run_language_modeling.py
@@ -68,7 +68,7 @@ class Model(nn.Module):
         self.encoder = encoder
         
     def forward(self, input_ids,masked_lm_labels=None): 
-        return self.encoder.roberta(input_ids,masked_lm_labels)[0]
+        return self.encoder(input_ids,masked_lm_labels)[0]
     
     
 class TextDataset(Dataset):


### PR DESCRIPTION
The code "model(inputs, masked_lm_labels=labels)" will return all outputs which causes out of GPU memory in train() function. After modifying the code, batch size per GPU increases from 4 to 32 in Multi GPUs. 