### PR TITLE
[WIP] Adding model parallelism for T5 (should work for other models as well)

### DIFF
--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -20,7 +20,7 @@ import itertools
 import logging
 import math
 import os
-from typing import Optional, List
+from typing import List, Optional
 
 import torch
 import torch.nn.functional as F
@@ -827,7 +827,6 @@ class T5Model(T5PreTrainedModel):
         # Move the remaining modules (embeddings) on the first device
         for module in list(modules_to_move):
             module.to(devices[0])
-
 
     def get_block_list(self):
         return list(self.encoder.get_block_list()) + list(self.decoder.get_block_list())


### PR DESCRIPTION
This PR adds:
- a `get_block_list()` utility method which returns a list of the blocks in a Transformers model (currently only added on T5). Block can be Modules or list/tuple of Modules (if a single transformer block is spread in several ModuleList like in XLM).
- a `spread_on_devices(devices: Optional[List] = None)` method to spread a model on several devices by spreading the transformers blocks (roughly) evenly on the provided device list or all visible CUDA devices if no device list is given. The first device will host the remaining non-block modules in addition (the embeddings usually).

Currently, the code is in the T5 model but should be generic enough to be applied to other models if needed.

To use:
``` python
model = T5ForConditionalGeneration.from_pretrained('...')
model.spread_on_devices()  # Will spread on all visible CUDA devices by default
input = torch.tensor([...]).to('cuda:0')  # Inputs and outputs are on the first device
model(input)  # you should probably use only positional arguments for the forward pass (see spread_on_devices's docstring)
```

TODO:
 - [ ] try it
 - [ ] add tests if possible (on a dummy device list like ['cpu', 'cpu']?)

cc @patrickvonplaten @craffel