### PR TITLE
Allow the creation of "entity groups" for NerPipeline #3548

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -829,7 +829,7 @@ class NerPipeline(Pipeline):
                     # If the current entity is different from the previous entity, aggregate the disaggregated entity group
                     else:
                         entity_groups += [self.group_entities(entity_group_disagg)]
-                        entity_group_disagg = []
+                        entity_group_disagg = [entity]
 
                 entities += [entity]
 

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -797,6 +797,7 @@ class NerPipeline(Pipeline):
                             "word": self.tokenizer.convert_ids_to_tokens(int(input_ids[idx])),
                             "score": score[idx][label_idx].item(),
                             "entity": self.model.config.id2label[label_idx],
+                            "index": idx,
                         }
                     ]
 

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -746,6 +746,7 @@ class NerPipeline(Pipeline):
         binary_output: bool = False,
         ignore_labels=["O"],
         task: str = "",
+        group: bool = False,
     ):
         super().__init__(
             model=model,
@@ -760,6 +761,7 @@ class NerPipeline(Pipeline):
 
         self._basic_tokenizer = BasicTokenizer(do_lower_case=False)
         self.ignore_labels = ignore_labels
+        self.group = group
 
     def __call__(self, *texts, **kwargs):
         inputs = self._args_parser(*texts, **kwargs)
@@ -789,23 +791,75 @@ class NerPipeline(Pipeline):
             score = np.exp(entities) / np.exp(entities).sum(-1, keepdims=True)
             labels_idx = score.argmax(axis=-1)
 
-            answer = []
-            for idx, label_idx in enumerate(labels_idx):
-                if self.model.config.id2label[label_idx] not in self.ignore_labels:
-                    answer += [
-                        {
-                            "word": self.tokenizer.convert_ids_to_tokens(int(input_ids[idx])),
-                            "score": score[idx][label_idx].item(),
-                            "entity": self.model.config.id2label[label_idx],
-                            "index": idx,
-                        }
-                    ]
+            entities = []
+            entity_groups = []
+            entity_group_disagg = []
+            # Filter to labels not in `self.ignore_labels`
+            filtered_labels_idx = [
+                (idx, label_idx)
+                for idx, label_idx in enumerate(labels_idx)
+                if self.model.config.id2label[label_idx] not in self.ignore_labels
+            ]
+
+            for idx, label_idx in filtered_labels_idx:
+
+                entity = [
+                    {
+                        "word": self.tokenizer.convert_ids_to_tokens(int(input_ids[idx])),
+                        "score": score[idx][label_idx].item(),
+                        "entity": self.model.config.id2label[label_idx],
+                        "index": idx,
+                    }
+                ]
+                last_idx, _ = filtered_labels_idx[-1]
+                if self.group:
+                    if not entity_group_disagg:
+                        entity_group_disagg += [entity]
+                        if idx == last_idx:
+                            entity_groups += [self.group_entities(entity_group_disagg)]
+                        continue
+
+                    # If the current entity is similar and adjacent to the previous entity, append it to the disaggregated entity group
+                    if (
+                        entity["entity"] == entity_group_disagg[-1]["entity"]
+                        and entity["index"] == entity_group_disagg[-1]["index"] + 1
+                    ):
+                        entity_group_disagg += [entity]
+                        # Group the entities at the last entity
+                        if idx == last_idx:
+                            entity_groups += [self.group_entities(entity_group_disagg)]
+                    # If the current entity is different from the previous entity, aggregate the disaggregated entity group
+                    else:
+                        entity_groups += [self.group_entities(entity_group_disagg)]
+                        entity_group_disagg = []
+
+                entities += [entity]
 
             # Append
-            answers += [answer]
+            if self.group:
+                answers += [entity_groups]
+            else:
+                answers += [entities]
+
         if len(answers) == 1:
             return answers[0]
         return answers
+
+    def group_entities(self, entities):
+        """
+        Returns grouped entities
+        """
+        # Get the last entity in the entity group
+        entity = entities[-1]["entity"]
+        scores = np.mean([entity["score"] for entity in entities])
+        tokens = [entity["word"] for entity in entities]
+
+        entity_group = {
+            "entity_group": entity,
+            "score": np.mean(scores),
+            "word": self.tokenizer.convert_tokens_to_string(tokens),
+        }
+        return entity_group
 
 
 TokenClassificationPipeline = NerPipeline

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -803,14 +803,12 @@ class NerPipeline(Pipeline):
 
             for idx, label_idx in filtered_labels_idx:
 
-                entity = [
-                    {
-                        "word": self.tokenizer.convert_ids_to_tokens(int(input_ids[idx])),
-                        "score": score[idx][label_idx].item(),
-                        "entity": self.model.config.id2label[label_idx],
-                        "index": idx,
-                    }
-                ]
+                entity = {
+                    "word": self.tokenizer.convert_ids_to_tokens(int(input_ids[idx])),
+                    "score": score[idx][label_idx].item(),
+                    "entity": self.model.config.id2label[label_idx],
+                    "index": idx,
+                }
                 last_idx, _ = filtered_labels_idx[-1]
                 if self.group:
                     if not entity_group_disagg:


### PR DESCRIPTION
This pull request adds an `index` key to the dictionary returned by `NerPipeline`. The index will be necessary in order to identify **entity groups**, where an entity group is a contiguous series of tokens, having the same **entity type**.

Details of what I want to be able to do can be found in issue #3548.

If this PR gets merged, I would also like to ask if you guys would recommend that I implement the **entity group** transformation in `NerPipeline` itself.

Possibly, I can set the parameter `group` at initialization, where if `True`, the *grouped* version of the output will be returned.


E.g.

Instead of the following *ungrouped* output:

```
[{'entity': 'I-PER', 'score': 0.9983270168304443, 'word': 'En'},
 {'entity': 'I-PER', 'score': 0.9952995777130127, 'word': '##zo'},
 {'entity': 'I-ORG', 'score': 0.9984350204467773, 'word': 'Australian'},
 {'entity': 'I-ORG', 'score': 0.9967807531356812, 'word': 'National'},
 {'entity': 'I-ORG', 'score': 0.9959043264389038, 'word': 'University'},
 {'entity': 'I-ORG', 'score': 0.9900023937225342, 'word': 'AU'},
 {'entity': 'I-ORG', 'score': 0.9763911366462708, 'word': '##N'}]
```

We get something like the following *grouped* output:

```
[{'entity_group': 'I-PER', 'score': 0.9983270168304443, 'word': 'Enzo'},
 {'entity_group': 'I-ORG', 'score': 0.9984350204467773, 'word': 'Australian National University'},
 {'entity_group': 'I-ORG', 'score': 0.9900023937225342, 'word': 'AUN'}]
```