### PR TITLE
Created README.md for model card ChemBERTa

### DIFF
--- a/model_cards/seyonec/ChemBERTa-zinc-base-v1/README.md
+++ b/model_cards/seyonec/ChemBERTa-zinc-base-v1/README.md
@@ -1,6 +1,11 @@
-# RoBERTA: Training a BERT-like transformer model for masked language modelling of chemical SMILES strings.
+---
+tags: 
+- chemistry
+---
 
-Deep learning for chemistry and materials science remains a novel field with lots of potiential. However, the popularity of transfer learning based methods in areas such as NLP and computer vision have not yet been effectively developed in computational chemistry + machine learning. Using HuggingFace's suite of models and the ByteLeve tokenizer, we are able to train on a large corpus of 100k SMILES strings from a commonly known benchmark dataset, ZINC.
+# ChemBERTa: Training a BERT-like transformer model for masked language modelling of chemical SMILES strings.
+
+Deep learning for chemistry and materials science remains a novel field with lots of potiential. However, the popularity of transfer learning based methods in areas such as NLP and computer vision have not yet been effectively developed in computational chemistry + machine learning. Using HuggingFace's suite of models and the ByteLevel tokenizer, we are able to train on a large corpus of 100k SMILES strings from a commonly known benchmark dataset, ZINC.
 
 Training RoBERTa over 5 epochs, the model achieves a decent loss of 0.398, but may likely continue to decline if trained for a larger number of epochs. The model can predict tokens within a SMILES sequence/molecule, allowing for variants of a molecule within discoverable chemical space to be predicted.
 

--- a/model_cards/seyonec/ChemBERTa-zinc-base-v1/README.md
+++ b/model_cards/seyonec/ChemBERTa-zinc-base-v1/README.md
@@ -1,0 +1,14 @@
+# RoBERTA: Training a BERT-like transformer model for masked language modelling of chemical SMILES strings.
+
+Deep learning for chemistry and materials science remains a novel field with lots of potiential. However, the popularity of transfer learning based methods in areas such as NLP and computer vision have not yet been effectively developed in computational chemistry + machine learning. Using HuggingFace's suite of models and the ByteLeve tokenizer, we are able to train on a large corpus of 100k SMILES strings from a commonly known benchmark dataset, ZINC.
+
+Training RoBERTa over 5 epochs, the model achieves a decent loss of 0.398, but may likely continue to decline if trained for a larger number of epochs. The model can predict tokens within a SMILES sequence/molecule, allowing for variants of a molecule within discoverable chemical space to be predicted.
+
+By applying the representations of functional groups and atoms learned by the model, we can try to tackle problems of toxicity, solubility, drug-likeness, and synthesis accessibility on smaller datasets using the learned representations as features for graph convolution and attention models on the graph structure of molecules, as well as fine-tuning of BERT. Finally, we propose the use of attention visualization as a helpful tool for chemistry practitioners and students to quickly identify important substructures in various chemical properties.
+
+Additionally, visualization of the attention mechanism have been seen through previous research as incredibly valuable towards chemical reaction classification. The applications of open-sourcing large-scale transformer models such as RoBERTa with HuggingFace may allow for the acceleration of these individual research directions.
+
+A link to a repository which includes the training, uploading and evaluation notebook (with sample predictions on compounds such as Remdesivir) can be found [here](https://github.com/seyonechithrananda/bert-loves-chemistry). All of the notebooks can be copied into a new Colab runtime for easy execution.
+
+Thanks for checking this out!
+- Seyone


### PR DESCRIPTION
The README.md is added to explain an overview of SMILES, as this is the only model card trained on a non-language dataset. The documentation also explains potential use-cases for utilizing RoBERTa trained on masked language modelling for SMILES, and links to a repository with the original notebooks for evaluations, running predictions and some applications of the models for curiosity.