### PR TITLE
[T5, generation] Add decoder caching for T5

### DIFF
--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -855,6 +855,7 @@ T5_INPUTS_DOCSTRING = r"""
             Default behavior: generate a tensor that ignores pad tokens in decoder_input_ids. Causal mask will also be used by default.
         decoder_past_key_value_states (:obj:`tuple(tuple(torch.FloatTensor))` of length :obj:`config.n_layers` with each tuple having 4 tensors of shape :obj:`(batch_size, num_heads, sequence_length, embed_size_per_head)`):
             Contains pre-computed hidden-states (key and values in the attention blocks).
+            Can be used to speed up decoding.
         inputs_embeds (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, hidden_size)`, `optional`, defaults to :obj:`None`):
             Optionally, instead of passing :obj:`input_ids` you can choose to directly pass an embedded representation.
             This is useful if you want more control over how to convert `input_ids` indices into associated vectors
@@ -933,7 +934,7 @@ class T5Model(T5PreTrainedModel):
         :obj:`tuple(torch.FloatTensor)` comprising various elements depending on the configuration (:class:`~transformers.T5Config`) and inputs.
         last_hidden_state (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, hidden_size)`):
             Sequence of hidden-states at the output of the last layer of the model.
-        past_key_value_states (:obj:`tuple(tuple(torch.FloatTensor))` of length :obj:`config.n_layers` with each tuple having 4 tensors of shape :obj:`(batch_size, num_heads, sequence_length, embed_size_per_head)`):
+        past_key_value_states (:obj:`tuple(tuple(torch.FloatTensor))` of length :obj:`config.n_layers` with each tuple having 4 tensors of shape :obj:`(batch_size, num_heads, sequence_length, embed_size_per_head)`, `optional`, returned when ``config.output_past=True``):
             Contains pre-computed hidden-states (key and values in the attention blocks).
             Can be used (see `decoder_past_key_value_states` input) to speed up sequential decoding. The token ids which have their past given to this model
         hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``config.output_hidden_states=True``):
@@ -1067,7 +1068,7 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
             of shape :obj:`(batch_size, sequence_length, hidden_size)`.
 
             Hidden-states of the model at the output of each layer plus the initial embedding outputs.
-        past_key_value_states (:obj:`tuple(tuple(torch.FloatTensor))` of length :obj:`config.n_layers` with each tuple having 4 tensors of shape :obj:`(batch_size, num_heads, sequence_length, embed_size_per_head)`):
+        past_key_value_states (:obj:`tuple(tuple(torch.FloatTensor))` of length :obj:`config.n_layers` with each tuple having 4 tensors of shape :obj:`(batch_size, num_heads, sequence_length, embed_size_per_head)`, `optional`, returned when ``config.output_past=True``):
             Contains pre-computed hidden-states (key and values in the attention blocks).
             Can be used (see `decoder_past_key_value_states` input) to speed up sequential decoding. The token ids which have their past given to this model
         attentions (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``config.output_attentions=True``):

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -506,7 +506,11 @@ class T5Block(nn.Module):
         if self.is_decoder:
             # the actual query length is unknown for cross attention
             # if using past key value states. Need to inject it here
-            query_length = present_key_value_state[0].shape[2]
+            if present_key_value_state is not None:
+                query_length = present_key_value_state[0].shape[2]
+            else:
+                query_length = None
+
             cross_attention_outputs = self.layer[1](
                 hidden_states,
                 kv=encoder_hidden_states,
@@ -517,7 +521,10 @@ class T5Block(nn.Module):
                 query_length=query_length,
             )
             hidden_states = cross_attention_outputs[0]
-            present_key_value_state = present_key_value_state + cross_attention_outputs[1]
+            # Combine self attn and cross attn key value states
+            if present_key_value_state is not None:
+                present_key_value_state = present_key_value_state + cross_attention_outputs[1]
+
             # Keep cross-attention outputs and relative position weights
             attention_outputs = attention_outputs + cross_attention_outputs[2:]
 

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -936,7 +936,7 @@ class T5Model(T5PreTrainedModel):
             Sequence of hidden-states at the output of the last layer of the model.
         past_key_value_states (:obj:`tuple(tuple(torch.FloatTensor))` of length :obj:`config.n_layers` with each tuple having 4 tensors of shape :obj:`(batch_size, num_heads, sequence_length, embed_size_per_head)`, `optional`, returned when ``config.output_past=True``):
             Contains pre-computed hidden-states (key and values in the attention blocks).
-            Can be used (see `decoder_past_key_value_states` input) to speed up sequential decoding. The token ids which have their past given to this model
+            Can be used (see `decoder_past_key_value_states` input) to speed up sequential decoding.
         hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``config.output_hidden_states=True``):
             Tuple of :obj:`torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer)
             of shape :obj:`(batch_size, sequence_length, hidden_size)`.
@@ -1070,7 +1070,7 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
             Hidden-states of the model at the output of each layer plus the initial embedding outputs.
         past_key_value_states (:obj:`tuple(tuple(torch.FloatTensor))` of length :obj:`config.n_layers` with each tuple having 4 tensors of shape :obj:`(batch_size, num_heads, sequence_length, embed_size_per_head)`, `optional`, returned when ``config.output_past=True``):
             Contains pre-computed hidden-states (key and values in the attention blocks).
-            Can be used (see `decoder_past_key_value_states` input) to speed up sequential decoding. The token ids which have their past given to this model
+            Can be used (see `decoder_past_key_value_states` input) to speed up sequential decoding.
         attentions (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``config.output_attentions=True``):
             Tuple of :obj:`torch.FloatTensor` (one for each layer) of shape
             :obj:`(batch_size, num_heads, sequence_length, sequence_length)`.

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -853,9 +853,9 @@ T5_INPUTS_DOCSTRING = r"""
             `T5 Training <./t5.html#training>`_ .
         decoder_attention_mask (:obj:`torch.BoolTensor` of shape :obj:`(batch_size, tgt_seq_len)`, `optional`, defaults to :obj:`None`):
             Default behavior: generate a tensor that ignores pad tokens in decoder_input_ids. Causal mask will also be used by default.
-        decoder_past_key_value_states (:obj:`tuple(tuple(torch.FloatTensor))` of length :obj:`config.n_layers` with each tuple having 4 tensors of shape :obj:`(batch_size, num_heads, sequence_length, embed_size_per_head)`):
-            Contains pre-computed hidden-states (key and values in the attention blocks).
-            Can be used to speed up decoding. If `decoder_past_key_value_states` are used, the user can optionally input only the last `input_ids` of shape :obj:`(batch_size, 1)` instead of all `input_ids` of shape :obj:`(batch_size, sequence_length)`
+        decoder_past_key_value_states (:obj:`tuple(tuple(torch.FloatTensor))` of length :obj:`config.n_layers` with each tuple having 4 tensors of shape :obj:`(batch_size, num_heads, sequence_length - 1, embed_size_per_head)`):
+            Contains pre-computed key and value hidden-states of the attention blocks.
+            Can be used to speed up decoding. If `decoder_past_key_value_states` are used, the user can optionally input only the last `decoder_input_ids` of shape :obj:`(batch_size, 1)` instead of all `decoder_input_ids` of shape :obj:`(batch_size, sequence_length)`.
         inputs_embeds (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, hidden_size)`, `optional`, defaults to :obj:`None`):
             Optionally, instead of passing :obj:`input_ids` you can choose to directly pass an embedded representation.
             This is useful if you want more control over how to convert `input_ids` indices into associated vectors
@@ -939,9 +939,9 @@ class T5Model(T5PreTrainedModel):
             Sequence of hidden-states at the output of the last layer of the model.
             If `decoder_past_key_value_states` is used only the last hidden-state of the sequences of shape :obj:`(batch_size, 1, hidden_size)` is output.
         decoder_past_key_value_states (:obj:`tuple(tuple(torch.FloatTensor))` of length :obj:`config.n_layers` with each tuple having 4 tensors of shape :obj:`(batch_size, num_heads, sequence_length, embed_size_per_head)`, `optional`, returned when ``config.output_past=True``):
-            Contains pre-computed hidden-states (key and values in the attention blocks).
-            Can be used (see `decoder_past_key_value_states` input) to speed up sequential decoding.
-            Note that when using `decoder_past_key_value_states`, the model only outputs the last hidden state of the sequence.
+            Contains pre-computed key and value hidden-states of the attention blocks.
+            Can be used to speed up sequential decoding (see `decoder_past_key_value_states` input).
+            Note that when using `decoder_past_key_value_states`, the model only outputs the last `hidden-state` of the sequence of shape :obj:`(batch_size, 1, config.vocab_size)`.
         hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``config.output_hidden_states=True``):
             Tuple of :obj:`torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer)
             of shape :obj:`(batch_size, sequence_length, hidden_size)`.
@@ -1073,9 +1073,9 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
             Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
             If `past_key_value_states` is used only the last prediction_scores of the sequences of shape :obj:`(batch_size, 1, hidden_size)` is output.
         decoder_past_key_value_states (:obj:`tuple(tuple(torch.FloatTensor))` of length :obj:`config.n_layers` with each tuple having 4 tensors of shape :obj:`(batch_size, num_heads, sequence_length, embed_size_per_head)`, `optional`, returned when ``config.output_past=True``):
-            Contains pre-computed hidden-states (key and values in the attention blocks).
-            Can be used (see `decoder_past_key_value_states` input) to speed up sequential decoding.
-            Note that when using `decoder_past_key_value_states`, the model only outputs the last hidden state of the sequence.
+            Contains pre-computed key and value hidden-states of the attention blocks.
+            Can be used to speed up sequential decoding (see `decoder_past_key_value_states` input).
+            Note that when using `decoder_past_key_value_states`, the model only outputs the last `prediction_score` of the sequence of shape :obj:`(batch_size, 1, config.vocab_size)`.
         hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``config.output_hidden_states=True``):
             Tuple of :obj:`torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer)
             of shape :obj:`(batch_size, sequence_length, hidden_size)`.

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -900,6 +900,10 @@ class T5Model(T5PreTrainedModel):
     def set_output_past(self, do_output_past: bool):
         self.config.output_past = do_output_past
         self.decoder.output_past = do_output_past
+        for block in self.decoder.block:
+            block.output_past = do_output_past
+            block.layer[0].SelfAttention.output_past = do_output_past
+            block.layer[1].EncDecAttention.output_past = do_output_past
         self.encoder.output_past = do_output_past
 
     def get_encoder(self):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1419,6 +1419,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
     def _reorder_cache(past, beam_idx):
         return tuple(layer_past.index_select(1, beam_idx) for layer_past in past)
 
+
 def calc_banned_ngram_tokens(prev_input_ids, num_hypos, no_repeat_ngram_size, cur_len):
     # Copied from fairseq for no_repeat_ngram in beam_search"""
     if cur_len + 1 < no_repeat_ngram_size:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1417,18 +1417,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
 
     @staticmethod
     def _reorder_cache(past, beam_idx):
-        reordered_past = []
-        for layer_past in past:
-            # get the correct batch idx from layer past batch dim
-            # batch dim of `past` and `mems` is at 2nd position
-            reordered_layer_past = [layer_past[:, i].unsqueeze(1).clone().detach() for i in beam_idx]
-            reordered_layer_past = torch.cat(reordered_layer_past, dim=1)
-            # check that shape matches
-            assert reordered_layer_past.shape == layer_past.shape
-            reordered_past.append(reordered_layer_past)
-        past = tuple(reordered_past)
-        return past
-
+        return tuple(layer_past.index_select(1, beam_idx) for layer_past in past)
 
 def calc_banned_ngram_tokens(prev_input_ids, num_hypos, no_repeat_ngram_size, cur_len):
     # Copied from fairseq for no_repeat_ngram in beam_search"""

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -128,6 +128,7 @@ class ModelTesterMixin:
         for model_class in self.all_model_classes:
             config.output_attentions = True
             config.output_hidden_states = False
+            config.output_past = False
             model = model_class(config)
             model.to(torch_device)
             model.eval()
@@ -144,13 +145,8 @@ class ModelTesterMixin:
             out_len = len(outputs)
 
             if self.is_encoder_decoder:
-                if model.config.output_past:
-                    # decoder_features_or_logits, decoder_past_key_value_states, decoder_attentions, encoder_features, encoder_attentions
-                    correct_outlen = 5
-                    decoder_attention_idx = 2
-                else:
-                    correct_outlen = 4
-                    decoder_attention_idx = 1
+                correct_outlen = 4
+                decoder_attention_idx = 1
 
                 if "lm_labels" in inputs_dict:  # loss will come first
                     correct_outlen += 1  # compute loss

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -144,10 +144,14 @@ class ModelTesterMixin:
             out_len = len(outputs)
 
             if self.is_encoder_decoder:
-                correct_outlen = (
-                    4  # decoder_features_or_logits, decoder_attentions, encoder_features, encoder_attentions
-                )
-                decoder_attention_idx = 1
+                if model.config.output_past:
+                    # decoder_features_or_logits, decoder_attentions, encoder_features, encoder_attentions
+                    correct_outlen = 5
+                    decoder_attention_idx = 2
+                else:
+                    correct_outlen = 4
+                    decoder_attention_idx = 1
+
                 if "lm_labels" in inputs_dict:  # loss will come first
                     correct_outlen += 1  # compute loss
                     decoder_attention_idx += 1

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -145,7 +145,7 @@ class ModelTesterMixin:
 
             if self.is_encoder_decoder:
                 if model.config.output_past:
-                    # decoder_features_or_logits, decoder_attentions, encoder_features, encoder_attentions
+                    # decoder_features_or_logits, decoder_past_key_value_states, decoder_attentions, encoder_features, encoder_attentions
                     correct_outlen = 5
                     decoder_attention_idx = 2
                 else:

--- a/tests/test_modeling_t5.py
+++ b/tests/test_modeling_t5.py
@@ -193,8 +193,8 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
             self.parent.assertTrue(torch.all(decoder_past[0][0] == encoder_output))
             # There should be `num_layers` key value embeddings stored in decoder_past[1]
             self.parent.assertEqual(len(decoder_past[1]), config.num_layers)
-            # There should be a key and a value embeddings stored in each decoder_past[1] tuple
-            self.parent.assertEqual(len(decoder_past[1][0]), 2)
+            # There should be a self attn key, a self attn value, a cross attn key and a cross attn value stored in each decoder_past[1] tuple
+            self.parent.assertEqual(len(decoder_past[1][0]), 4)
 
         def create_and_check_t5_with_lm_head(
             self, config, input_ids, decoder_input_ids, attention_mask, decoder_attention_mask, lm_labels,


### PR DESCRIPTION
This PR greatly speeds up the autoregressive decoding for T5 by storing past key / value states.
The summarization test: https://github.com/huggingface/transformers/blob/500aa12318ce5acd289d5edb6cb8266b3c3b162e/tests/test_modeling_t5.py#L260 now takes only 44s whereas before it took 311s -> 7.5x Speed up

This will also significantly speed up the translation and summarization pipelines when using T5.

- [x] Add key value state caching
- [x] Test for equal output on hard-coded tests
- [x] Add simple past tests including using an attention mask
- [x] update the docstring
- [x] clean up code

The caching design was already somewhat outcommented in place. It was cleaned, made functional and implemented very similar to GPT2's one.

### IMPORTANT: 
This PR has a breaking change, in that it increases the default output length of T5Model and T5ForConditionalGeneration from 4 to 5 (including the `past_key_value_states`).

### Future PR:
- [ ] Do the same for TF if this PR is accepted.

Would be nice if you could take a look @craffel @thomwolf @LysandreJik @sshleifer 