### PR TITLE
question-answering pipeline error : too many values to unpack (expected 2)

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1007,7 +1007,7 @@ class QuestionAnsweringPipeline(Pipeline):
                     with torch.no_grad():
                         # Retrieve the score for the context tokens only (removing question tokens)
                         fw_args = {k: torch.tensor(v, device=self.device) for (k, v) in fw_args.items()}
-                        start, end = self.model(**fw_args)
+                        start, end = self.model(**fw_args)[:2]
                         start, end = start.cpu().numpy(), end.cpu().numpy()
 
             answers = []


### PR DESCRIPTION
For some `question-answering` models the pipleline encounters extra tuples from the `.model()` call, where we must have exactly 2.

> This stub results in the following error:
```python
from transformers.pipelines import pipeline

model_name = "mrm8488/bert-uncased-finetuned-qnli"

nlp = pipeline("question-answering", model=model_name, tokenizer=model_name)
QA_input = {
    "question": "Why is model conversion important?",
    "context": "The option to convert models between FARM and transformers gives freedom to the user and let people easily switch between frameworks.",
}
res = nlp(QA_input)
```

> error message
```bash
Traceback (most recent call last):
  File "test3.py", line 10, in <module>
    res = nlp(QA_input)
  File "/opt/conda/lib/python3.7/site-packages/transformers/pipelines.py", line 1010, in __call__
    start, end = self.model(**fw_args)
ValueError: too many values to unpack (expected 2)
```

> env
```text
- `transformers` version: 2.8.0
- Platform: Linux-4.9.184-linuxkit-x86_64-with-debian-buster-sid
- Python version: 3.7.4
- PyTorch version (GPU?): 1.4.0 (False)
- Tensorflow version (GPU?): not installed (NA)
- Using GPU in script?: nope
- Using distributed or parallel set-up in script?: nope
```