### PR TITLE
Fix force_download of files on Windows

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -487,7 +487,7 @@ def get_from_cache(
                 http_get(url, temp_file, proxies=proxies, resume_size=resume_size, user_agent=user_agent)
 
         logger.info("storing %s in cache at %s", url, cache_path)
-        os.rename(temp_file.name, cache_path)
+        os.replace(temp_file.name, cache_path)
 
         logger.info("creating metadata file for %s", cache_path)
         meta = {"url": url, "etag": etag}


### PR DESCRIPTION
On Windows, `os.rename` gives the error
```
FileExistsError: [WinError 183] Cannot create a file when that file already exists:
```
when trying to re-download a model that already exists in cache using `force_download=True`.