### PR TITLE
Integrate Bert-like model on Flax runtime.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,8 @@ jobs:
         parallelism: 1
         steps:
             - checkout
+            - run: pip install --upgrade pip
+            - run: pip install git+https://github.com/huggingface/nlp
             - run: sudo pip install .[flax,sklearn,torch,testing]
             - run: sudo pip install codecov pytest-cov
             - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/ --cov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,10 +124,6 @@ jobs:
         parallelism: 1
         steps:
             - checkout
-            - run: sudo pip install .[sklearn,tf-cpu,testing]
-            - run: sudo pip install codecov pytest-cov
-            - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/ --cov
-            - run: codecov
             - restore_cache:
                   keys:
                       - v0.3-tf-{{ checksum "setup.py" }}
@@ -153,12 +149,18 @@ jobs:
         parallelism: 1
         steps:
             - checkout
-            - run: pip install --upgrade pip
-            - run: pip install git+https://github.com/huggingface/datasets
-            - run: sudo pip install .[flax,sklearn,torch,testing]
-            - run: sudo pip install codecov pytest-cov
-            - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/ --cov
-            - run: codecov
+            - restore_cache:
+                keys:
+                    - v0.3-flax-{{ checksum "setup.py" }}
+                    - v0.3-{{ checksum "setup.py" }}
+                    - run: pip install --upgrade pip
+                    - run: pip install git+https://github.com/huggingface/datasets
+                    - run: sudo pip install .[flax,sklearn,torch,testing]
+                    - save_cache:
+                        key: v0.3-flax-{{ checksum "setup.py" }}
+                        paths:
+                            - '~/.cache/pip'
+              - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/ --cov
     run_tests_custom_tokenizers:
         working_directory: ~/transformers
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,14 +153,14 @@ jobs:
                 keys:
                     - v0.3-flax-{{ checksum "setup.py" }}
                     - v0.3-{{ checksum "setup.py" }}
-                    - run: pip install --upgrade pip
-                    - run: pip install git+https://github.com/huggingface/datasets
-                    - run: sudo pip install .[flax,sklearn,torch,testing]
-                    - save_cache:
-                        key: v0.3-flax-{{ checksum "setup.py" }}
-                        paths:
-                            - '~/.cache/pip'
-              - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/ --cov
+                - run: pip install --upgrade pip
+                - run: pip install git+https://github.com/huggingface/datasets
+                - run: sudo pip install .[flax,sklearn,torch,testing]
+                - save_cache:
+                    key: v0.3-flax-{{ checksum "setup.py" }}
+                    paths:
+                        - '~/.cache/pip'
+                - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/ --cov
     run_tests_custom_tokenizers:
         working_directory: ~/transformers
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
                   key: v0.3-flax-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/ --cov
+            - run: python -m pytest -n 8 --dist=loadfile -rA -s ./tests/
     run_tests_custom_tokenizers:
         working_directory: ~/transformers
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,10 @@ jobs:
         parallelism: 1
         steps:
             - checkout
+            - run: sudo pip install .[sklearn,tf-cpu,testing]
+            - run: sudo pip install codecov pytest-cov
+            - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/ --cov
+            - run: codecov
             - restore_cache:
                   keys:
                       - v0.3-tf-{{ checksum "setup.py" }}
@@ -150,7 +154,7 @@ jobs:
         steps:
             - checkout
             - run: pip install --upgrade pip
-            - run: pip install git+https://github.com/huggingface/nlp
+            - run: pip install git+https://github.com/huggingface/datasets
             - run: sudo pip install .[flax,sklearn,torch,testing]
             - run: sudo pip install codecov pytest-cov
             - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/ --cov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,10 +124,6 @@ jobs:
         parallelism: 1
         steps:
             - checkout
-            - run: sudo pip install .[sklearn,tf-cpu,testing]
-            - run: sudo pip install codecov pytest-cov
-            - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/ --cov
-            - run: codecov
             - restore_cache:
                   keys:
                       - v0.3-tf-{{ checksum "setup.py" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,10 @@ jobs:
                   key: v0.3-flax-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: python -m pytest -n 8 --dist=loadfile -rA -s ./tests/
+            - run: python -m pytest -n 8 --dist=loadfile -rA -s ./tests/ | tee output.txt
+            - store_artifacts:
+                  path: ~/transformers/output.txt
+                  destination: test_output.txt
     run_tests_custom_tokenizers:
         working_directory: ~/transformers
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,10 @@ jobs:
         parallelism: 1
         steps:
             - checkout
+            - run: sudo pip install .[sklearn,tf-cpu,testing]
+            - run: sudo pip install codecov pytest-cov
+            - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/ --cov
+            - run: codecov
             - restore_cache:
                   keys:
                       - v0.3-tf-{{ checksum "setup.py" }}
@@ -139,6 +143,20 @@ jobs:
             - store_artifacts:
                path: ~/transformers/output.txt
                destination: test_output.txt
+    run_tests_flax:
+        working_directory: ~/transformers
+        docker:
+            - image: circleci/python:3.7
+        environment:
+            OMP_NUM_THREADS: 1
+        resource_class: xlarge
+        parallelism: 1
+        steps:
+            - checkout
+            - run: sudo pip install .[flax,sklearn,torch,testing]
+            - run: sudo pip install codecov pytest-cov
+            - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/ --cov
+            - run: codecov
     run_tests_custom_tokenizers:
         working_directory: ~/transformers
         docker:
@@ -305,6 +323,7 @@ workflows:
             - run_tests_torch_and_tf
             - run_tests_torch
             - run_tests_tf
+            - run_tests_flax
             - build_doc
             - deploy_doc: *workflow_filters
     tpu_testing_jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,14 +153,14 @@ jobs:
                 keys:
                     - v0.3-flax-{{ checksum "setup.py" }}
                     - v0.3-{{ checksum "setup.py" }}
-                - run: pip install --upgrade pip
-                - run: pip install git+https://github.com/huggingface/datasets
-                - run: sudo pip install .[flax,sklearn,torch,testing]
-                - save_cache:
-                    key: v0.3-flax-{{ checksum "setup.py" }}
-                    paths:
-                        - '~/.cache/pip'
-                - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/ --cov
+            - run: pip install --upgrade pip
+            - run: pip install git+https://github.com/huggingface/datasets
+            - run: sudo pip install .[flax,sklearn,torch,testing]
+            - save_cache:
+                  key: v0.3-flax-{{ checksum "setup.py" }}
+                  paths:
+                      - '~/.cache/pip'
+            - run: python -m pytest -n 8 --dist=loadfile -s -v ./tests/ --cov
     run_tests_custom_tokenizers:
         working_directory: ~/transformers
         docker:

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ extras["tf-cpu"] = [
     # "keras2onnx @ git+git://github.com/onnx/keras-onnx.git@cbdc75cb950b16db7f0a67be96a278f8d2953b48#egg=keras2onnx",
 ]
 extras["torch"] = ["torch>=1.0"]
+extras["flax"] = ["flax"]
 extras["onnxruntime"] = ["onnxruntime>=1.4.0", "onnxruntime-tools>=1.4.2"]
 
 extras["serving"] = ["pydantic", "uvicorn", "fastapi", "starlette"]

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ extras["tf-cpu"] = [
     # "keras2onnx @ git+git://github.com/onnx/keras-onnx.git@cbdc75cb950b16db7f0a67be96a278f8d2953b48#egg=keras2onnx",
 ]
 extras["torch"] = ["torch>=1.0"]
-extras["flax"] = ["jaxlib==0.1.55", "jax==0.1.76", "flax==0.2.1"]
+extras["flax"] = ["jaxlib==0.1.55", "jax==0.1.76", "flax==0.2.2"]
 extras["onnxruntime"] = ["onnxruntime>=1.4.0", "onnxruntime-tools>=1.4.2"]
 
 extras["serving"] = ["pydantic", "uvicorn", "fastapi", "starlette"]

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ extras["tf-cpu"] = [
     # "keras2onnx @ git+git://github.com/onnx/keras-onnx.git@cbdc75cb950b16db7f0a67be96a278f8d2953b48#egg=keras2onnx",
 ]
 extras["torch"] = ["torch>=1.0"]
-extras["flax"] = ["jaxlib==0.1.55", "jax==0.1.76", "flax==0.2.2"]
+extras["flax"] = ["jaxlib==0.1.55", "jax>=0.2.0", "flax==0.2.2"]
 extras["onnxruntime"] = ["onnxruntime>=1.4.0", "onnxruntime-tools>=1.4.2"]
 
 extras["serving"] = ["pydantic", "uvicorn", "fastapi", "starlette"]

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ extras["tf-cpu"] = [
     # "keras2onnx @ git+git://github.com/onnx/keras-onnx.git@cbdc75cb950b16db7f0a67be96a278f8d2953b48#egg=keras2onnx",
 ]
 extras["torch"] = ["torch>=1.0"]
-extras["flax"] = ["jaxlib", "jax", "flax"]
+extras["flax"] = ["jaxlib", "jax", "flax==0.1.0"]
 extras["onnxruntime"] = ["onnxruntime>=1.4.0", "onnxruntime-tools>=1.4.2"]
 
 extras["serving"] = ["pydantic", "uvicorn", "fastapi", "starlette"]

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ extras["tf-cpu"] = [
     # "keras2onnx @ git+git://github.com/onnx/keras-onnx.git@cbdc75cb950b16db7f0a67be96a278f8d2953b48#egg=keras2onnx",
 ]
 extras["torch"] = ["torch>=1.0"]
-extras["flax"] = ["jaxlib", "jax", "flax==0.1.0"]
+extras["flax"] = ["jaxlib==0.1.55", "jax==0.1.76", "flax==0.2.1"]
 extras["onnxruntime"] = ["onnxruntime>=1.4.0", "onnxruntime-tools>=1.4.2"]
 
 extras["serving"] = ["pydantic", "uvicorn", "fastapi", "starlette"]

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ extras["tf-cpu"] = [
     # "keras2onnx @ git+git://github.com/onnx/keras-onnx.git@cbdc75cb950b16db7f0a67be96a278f8d2953b48#egg=keras2onnx",
 ]
 extras["torch"] = ["torch>=1.0"]
-extras["flax"] = ["flax"]
+extras["flax"] = ["jaxlib", "jax", "flax"]
 extras["onnxruntime"] = ["onnxruntime>=1.4.0", "onnxruntime-tools>=1.4.2"]
 
 extras["serving"] = ["pydantic", "uvicorn", "fastapi", "starlette"]

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -111,6 +111,7 @@ from .file_utils import (
     is_tokenizers_available,
     is_torch_available,
     is_torch_tpu_available,
+    is_flax_available
 )
 from .hf_argparser import HfArgumentParser
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -111,7 +111,7 @@ from .file_utils import (
     is_tokenizers_available,
     is_torch_available,
     is_torch_tpu_available,
-    is_flax_available
+    is_flax_available,
 )
 from .hf_argparser import HfArgumentParser
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -112,6 +112,7 @@ from .file_utils import (
     is_tokenizers_available,
     is_torch_available,
     is_torch_tpu_available,
+    is_flax_available
 )
 from .hf_argparser import HfArgumentParser
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -818,6 +818,10 @@ else:
     from .utils.dummy_tf_objects import *
 
 
+if is_flax_available():
+    from .modeling_flax_bert import FlaxBertModel
+    from .modeling_flax_roberta import FlaxRobertaModel
+
 if not is_tf_available() and not is_torch_available():
     logger.warning(
         "Neither PyTorch nor TensorFlow >= 2.0 have been found."

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -112,7 +112,6 @@ from .file_utils import (
     is_tokenizers_available,
     is_torch_available,
     is_torch_tpu_available,
-    is_flax_available
 )
 from .hf_argparser import HfArgumentParser
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -103,6 +103,7 @@ from .file_utils import (
     is_apex_available,
     is_datasets_available,
     is_faiss_available,
+    is_flax_available,
     is_psutil_available,
     is_py3nvml_available,
     is_sentencepiece_available,
@@ -111,7 +112,6 @@ from .file_utils import (
     is_tokenizers_available,
     is_torch_available,
     is_torch_tpu_available,
-    is_flax_available,
 )
 from .hf_argparser import HfArgumentParser
 

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -73,6 +73,10 @@ try:
     if USE_JAX in ENV_VARS_TRUE_VALUES:
         import flax
         import jax
+        from jax.config import config
+        # TODO(marcvanzee): Flax Linen requires JAX omnistaging. Remove this 
+        # once JAX enables it by default.
+        config.enable_omnistaging()
 
         logger.info("JAX version {}, Flax: available".format(jax.__version__))
         logger.info("Flax available: {}".format(flax))

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -71,8 +71,8 @@ try:
     USE_JAX = os.environ.get("USE_FLAX", "AUTO").upper()
 
     if USE_JAX in ENV_VARS_TRUE_VALUES:
-        import jax
         import flax
+        import jax
 
         logger.info("JAX version {}, Flax: available".format(jax.__version__))
         logger.info("Flax available: {}".format(flax))

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -75,7 +75,7 @@ try:
         import flax
 
         logger.info("JAX version {}, Flax: available".format(jax.__version__))
-
+        logger.info("Flax available: {}".format(flax))
         _flax_available = True
     else:
         _flax_available = False

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -76,9 +76,6 @@ try:
         import jax
         from jax.config import config
 
-        # TODO(marcvanzee): Flax Linen requires JAX omnistaging. Remove this
-        # once JAX enables it by default.
-        config.enable_omnistaging()
 
         logger.info("JAX version {}, Flax: available".format(jax.__version__))
         logger.info("Flax available: {}".format(flax))

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -34,12 +34,13 @@ from .utils import logging
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
-ENV_VARS_TRUE_VALUES = ("1", "ON", "YES", "AUTO")
+ENV_VARS_TRUE_VALUES = {"1", "ON", "YES"}
+ENV_VARS_TRUE_AND_AUTO_VALUES = ENV_VARS_TRUE_VALUES.union({"AUTO"})
 
 try:
     USE_TF = os.environ.get("USE_TF", "AUTO").upper()
     USE_TORCH = os.environ.get("USE_TORCH", "AUTO").upper()
-    if USE_TORCH in ENV_VARS_TRUE_VALUES and USE_TF not in ("1", "ON", "YES"):
+    if USE_TORCH in ENV_VARS_TRUE_AND_AUTO_VALUES and USE_TF not in ENV_VARS_TRUE_VALUES:
         import torch
 
         _torch_available = True  # pylint: disable=invalid-name
@@ -54,7 +55,7 @@ try:
     USE_TF = os.environ.get("USE_TF", "AUTO").upper()
     USE_TORCH = os.environ.get("USE_TORCH", "AUTO").upper()
 
-    if USE_TF in ENV_VARS_TRUE_VALUES and USE_TORCH not in ("1", "ON", "YES"):
+    if USE_TF in ENV_VARS_TRUE_AND_AUTO_VALUES and USE_TORCH not in ENV_VARS_TRUE_VALUES:
         import tensorflow as tf
 
         assert hasattr(tf, "__version__") and int(tf.__version__[0]) >= 2
@@ -70,7 +71,7 @@ except (ImportError, AssertionError):
 try:
     USE_JAX = os.environ.get("USE_FLAX", "AUTO").upper()
 
-    if USE_JAX in ENV_VARS_TRUE_VALUES:
+    if USE_JAX in ENV_VARS_TRUE_AND_AUTO_VALUES:
         import flax
         import jax
         from jax.config import config

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -71,6 +71,22 @@ try:
     USE_JAX = os.environ.get("USE_FLAX", "AUTO").upper()
 
     if USE_JAX in ENV_VARS_TRUE_VALUES:
+        import jax
+        import flax
+
+        logger.info("JAX version {}, Flax: available".format(jax.__version__))
+
+        _flax_available = True
+    else:
+        _flax_available = False
+except ImportError:
+    _flax_available = False  # pylint: disable=invalid-name
+
+
+try:
+    USE_JAX = os.environ.get("USE_FLAX", "AUTO").upper()
+
+    if USE_JAX in ENV_VARS_TRUE_VALUES:
         import flax
         import jax
         from jax.config import config

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -74,7 +74,7 @@ try:
         import flax
         import jax
         from jax.config import config
-        # TODO(marcvanzee): Flax Linen requires JAX omnistaging. Remove this 
+        # TODO(marcvanzee): Flax Linen requires JAX omnistaging. Remove this
         # once JAX enables it by default.
         config.enable_omnistaging()
 

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -74,6 +74,7 @@ try:
         import flax
         import jax
         from jax.config import config
+
         # TODO(marcvanzee): Flax Linen requires JAX omnistaging. Remove this
         # once JAX enables it by default.
         config.enable_omnistaging()

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -71,8 +71,8 @@ try:
     USE_JAX = os.environ.get("USE_FLAX", "AUTO").upper()
 
     if USE_JAX in ENV_VARS_TRUE_VALUES:
-        import jax
         import flax
+        import jax
 
         logger.info("JAX version {}, Flax: available".format(jax.__version__))
 

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -73,22 +73,6 @@ try:
     if USE_JAX in ENV_VARS_TRUE_VALUES:
         import flax
         import jax
-
-        logger.info("JAX version {}, Flax: available".format(jax.__version__))
-
-        _flax_available = True
-    else:
-        _flax_available = False
-except ImportError:
-    _flax_available = False  # pylint: disable=invalid-name
-
-
-try:
-    USE_JAX = os.environ.get("USE_FLAX", "AUTO").upper()
-
-    if USE_JAX in ENV_VARS_TRUE_VALUES:
-        import flax
-        import jax
         from jax.config import config
         # TODO(marcvanzee): Flax Linen requires JAX omnistaging. Remove this
         # once JAX enables it by default.

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -76,7 +76,6 @@ try:
         import jax
         from jax.config import config
 
-
         logger.info("JAX version {}, Flax: available".format(jax.__version__))
         logger.info("Flax available: {}".format(flax))
         _flax_available = True

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -74,7 +74,6 @@ try:
     if USE_JAX in ENV_VARS_TRUE_AND_AUTO_VALUES:
         import flax
         import jax
-        from jax.config import config
 
         logger.info("JAX version {}, Flax: available".format(jax.__version__))
         logger.info("Flax available: {}".format(flax))

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -34,10 +34,12 @@ from .utils import logging
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
+ENV_VARS_TRUE_VALUES = ("1", "ON", "YES", "AUTO")
+
 try:
     USE_TF = os.environ.get("USE_TF", "AUTO").upper()
     USE_TORCH = os.environ.get("USE_TORCH", "AUTO").upper()
-    if USE_TORCH in ("1", "ON", "YES", "AUTO") and USE_TF not in ("1", "ON", "YES"):
+    if USE_TORCH in ENV_VARS_TRUE_VALUES and USE_TF not in ("1", "ON", "YES"):
         import torch
 
         _torch_available = True  # pylint: disable=invalid-name
@@ -52,7 +54,7 @@ try:
     USE_TF = os.environ.get("USE_TF", "AUTO").upper()
     USE_TORCH = os.environ.get("USE_TORCH", "AUTO").upper()
 
-    if USE_TF in ("1", "ON", "YES", "AUTO") and USE_TORCH not in ("1", "ON", "YES"):
+    if USE_TF in ENV_VARS_TRUE_VALUES and USE_TORCH not in ("1", "ON", "YES"):
         import tensorflow as tf
 
         assert hasattr(tf, "__version__") and int(tf.__version__[0]) >= 2
@@ -63,6 +65,22 @@ try:
         _tf_available = False
 except (ImportError, AssertionError):
     _tf_available = False  # pylint: disable=invalid-name
+
+
+try:
+    USE_JAX = os.environ.get("USE_FLAX", "AUTO").upper()
+
+    if USE_JAX in ENV_VARS_TRUE_VALUES:
+        import jax
+        import flax
+
+        logger.info("JAX version {}, Flax: available".format(jax.__version__))
+
+        _flax_available = True
+    else:
+        _flax_available = False
+except ImportError:
+    _flax_available = False  # pylint: disable=invalid-name
 
 
 try:
@@ -211,6 +229,10 @@ def is_torch_available():
 
 def is_tf_available():
     return _tf_available
+
+
+def is_flax_available():
+    return _flax_available
 
 
 def is_torch_tpu_available():

--- a/src/transformers/modeling_flax_auto.py
+++ b/src/transformers/modeling_flax_auto.py
@@ -1,0 +1,170 @@
+# coding=utf-8
+# Copyright 2018 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Auto Model class. """
+
+
+import logging
+from collections import OrderedDict
+
+from .configuration_auto import AutoConfig, BertConfig, RobertaConfig
+from .configuration_utils import PretrainedConfig
+from .modeling_flax_bert import FlaxBertModel
+from .modeling_flax_roberta import FlaxRobertaModel
+
+logger = logging.getLogger(__name__)
+
+
+ALL_PRETRAINED_MODEL_ARCHIVE_MAP = dict(
+    (key, value)
+    for pretrained_map in [
+        FlaxBertModel.pretrained_model_archive_map,
+        FlaxRobertaModel.pretrained_model_archive_map,
+    ]
+    for key, value, in pretrained_map.items()
+)
+
+MODEL_MAPPING = OrderedDict(
+    [
+        (RobertaConfig, FlaxRobertaModel),
+        (BertConfig, FlaxBertModel),
+    ]
+)
+
+
+class FlaxAutoModel(object):
+    r"""
+        :class:`~transformers.AutoModel` is a generic model class
+        that will be instantiated as one of the base model classes of the library
+        when created with the `AutoModel.from_pretrained(pretrained_model_name_or_path)`
+        or the `AutoModel.from_config(config)` class methods.
+
+        This class cannot be instantiated using `__init__()` (throws an error).
+    """
+
+    def __init__(self):
+        raise EnvironmentError(
+            "FlaxAutoModel is designed to be instantiated "
+            "using the `FlaxAutoModel.from_pretrained(pretrained_model_name_or_path)` or "
+            "`FlaxAutoModel.from_config(config)` methods."
+        )
+
+    @classmethod
+    def from_config(cls, config):
+        r""" Instantiates one of the base model classes of the library
+        from a configuration.
+
+        Args:
+            config (:class:`~transformers.PretrainedConfig`):
+                The model class to instantiate is selected based on the configuration class:
+
+                - isInstance of `roberta` configuration class: :class:`~transformers.RobertaModel` (RoBERTa model)
+                - isInstance of `bert` configuration class: :class:`~transformers.BertModel` (Bert model)
+        Examples:
+
+            config = BertConfig.from_pretrained('bert-base-uncased')    # Download configuration from S3 and cache.
+            model = AutoModel.from_config(config)  # E.g. model was saved using `save_pretrained('./test/saved_model/')`
+        """
+        for config_class, model_class in MODEL_MAPPING.items():
+            if isinstance(config, config_class):
+                return model_class(config)
+        raise ValueError(
+            "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
+            "Model type should be one of {}.".format(
+                config.__class__, cls.__name__, ", ".join(c.__name__ for c in MODEL_MAPPING.keys())
+            )
+        )
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
+        r""" Instantiates one of the base model classes of the library
+        from a pre-trained model configuration.
+
+        The `from_pretrained()` method takes care of returning the correct model class instance
+        based on the `model_type` property of the config object, or when it's missing,
+        falling back to using pattern matching on the `pretrained_model_name_or_path` string.
+
+        The base model class to instantiate is selected as the first pattern matching
+        in the `pretrained_model_name_or_path` string (in the following order):
+            - contains `roberta`: :class:`~transformers.RobertaModel` (RoBERTa model)
+            - contains `bert`: :class:`~transformers.BertModel` (Bert model)
+
+            The model is set in evaluation mode by default using `model.eval()` (Dropout modules are deactivated)
+            To train the model, you should first set it back in training mode with `model.train()`
+
+        Args:
+            pretrained_model_name_or_path: either:
+
+                - a string with the `shortcut name` of a pre-trained model to load from cache or download, e.g.: ``bert-base-uncased``.
+                - a string with the `identifier name` of a pre-trained model that was user-uploaded to our S3, e.g.: ``dbmdz/bert-base-german-cased``.
+                - a path to a `directory` containing model weights saved using :func:`~transformers.PreTrainedModel.save_pretrained`, e.g.: ``./my_model_directory/``.
+                - a path or url to a `tensorflow index checkpoint file` (e.g. `./tf_model/model.ckpt.index`). In this case, ``from_tf`` should be set to True and a configuration object should be provided as ``config`` argument. This loading path is slower than converting the TensorFlow checkpoint in a PyTorch model using the provided conversion scripts and loading the PyTorch model afterwards.
+
+            model_args: (`optional`) Sequence of positional arguments:
+                All remaning positional arguments will be passed to the underlying model's ``__init__`` method
+
+            config: (`optional`) instance of a class derived from :class:`~transformers.PretrainedConfig`:
+                Configuration for the model to use instead of an automatically loaded configuation. Configuration can be automatically loaded when:
+
+                - the model is a model provided by the library (loaded with the ``shortcut-name`` string of a pretrained model), or
+                - the model was saved using :func:`~transformers.PreTrainedModel.save_pretrained` and is reloaded by suppling the save directory.
+                - the model is loaded by suppling a local directory as ``pretrained_model_name_or_path`` and a configuration JSON file named `config.json` is found in the directory.
+
+            state_dict: (`optional`) dict:
+                an optional state dictionnary for the model to use instead of a state dictionary loaded from saved weights file.
+                This option can be used if you want to create a model from a pretrained configuration but load your own weights.
+                In this case though, you should check if using :func:`~transformers.PreTrainedModel.save_pretrained` and :func:`~transformers.PreTrainedModel.from_pretrained` is not a simpler option.
+
+            cache_dir: (`optional`) string:
+                Path to a directory in which a downloaded pre-trained model
+                configuration should be cached if the standard cache should not be used.
+
+            force_download: (`optional`) boolean, default False:
+                Force to (re-)download the model weights and configuration files and override the cached versions if they exists.
+
+            resume_download: (`optional`) boolean, default False:
+                Do not delete incompletely recieved file. Attempt to resume the download if such a file exists.
+
+            proxies: (`optional`) dict, default None:
+                A dictionary of proxy servers to use by protocol or endpoint, e.g.: {'http': 'foo.bar:3128', 'http://hostname': 'foo.bar:4012'}.
+                The proxies are used on each request.
+
+            output_loading_info: (`optional`) boolean:
+                Set to ``True`` to also return a dictionnary containing missing keys, unexpected keys and error messages.
+
+            kwargs: (`optional`) Remaining dictionary of keyword arguments:
+                These arguments will be passed to the configuration and the model.
+
+        Examples::
+
+            model = FlaxAutoModel.from_pretrained('bert-base-uncased')    # Download model and configuration from S3 and cache.
+            model = FlaxAutoModel.from_pretrained('./test/bert_model/')  # E.g. model was saved using `save_pretrained('./test/saved_model/')`
+            assert model.config.output_attention == True
+
+        """
+        config = kwargs.pop("config", None)
+        if not isinstance(config, PretrainedConfig):
+            config = AutoConfig.from_pretrained(pretrained_model_name_or_path, **kwargs)
+
+        for config_class, model_class in MODEL_MAPPING.items():
+            if isinstance(config, config_class):
+                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        raise ValueError(
+            "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
+            "Model type should be one of {}.".format(
+                config.__class__, cls.__name__, ", ".join(c.__name__ for c in MODEL_MAPPING.keys())
+            )
+        )
+
+

--- a/src/transformers/modeling_flax_auto.py
+++ b/src/transformers/modeling_flax_auto.py
@@ -29,11 +29,11 @@ logger = logging.getLogger(__name__)
 
 ALL_PRETRAINED_MODEL_ARCHIVE_MAP = dict(
     (key, value)
-    for pretrained_map in [FlaxBertModel.pretrained_model_archive_map, FlaxRobertaModel.pretrained_model_archive_map,]
+    for pretrained_map in [FlaxBertModel.pretrained_model_archive_map, FlaxRobertaModel.pretrained_model_archive_map, ]
     for key, value, in pretrained_map.items()
 )
 
-MODEL_MAPPING = OrderedDict([(RobertaConfig, FlaxRobertaModel), (BertConfig, FlaxBertModel),])
+MODEL_MAPPING = OrderedDict([(RobertaConfig, FlaxRobertaModel), (BertConfig, FlaxBertModel), ])
 
 
 class FlaxAutoModel(object):

--- a/src/transformers/modeling_flax_auto.py
+++ b/src/transformers/modeling_flax_auto.py
@@ -29,11 +29,11 @@ logger = logging.getLogger(__name__)
 
 ALL_PRETRAINED_MODEL_ARCHIVE_MAP = dict(
     (key, value)
-    for pretrained_map in [FlaxBertModel.pretrained_model_archive_map, FlaxRobertaModel.pretrained_model_archive_map, ]
+    for pretrained_map in [FlaxBertModel.pretrained_model_archive_map, FlaxRobertaModel.pretrained_model_archive_map,]
     for key, value, in pretrained_map.items()
 )
 
-MODEL_MAPPING = OrderedDict([(RobertaConfig, FlaxRobertaModel), (BertConfig, FlaxBertModel), ])
+MODEL_MAPPING = OrderedDict([(RobertaConfig, FlaxRobertaModel), (BertConfig, FlaxBertModel),])
 
 
 class FlaxAutoModel(object):

--- a/src/transformers/modeling_flax_auto.py
+++ b/src/transformers/modeling_flax_auto.py
@@ -23,24 +23,17 @@ from .configuration_utils import PretrainedConfig
 from .modeling_flax_bert import FlaxBertModel
 from .modeling_flax_roberta import FlaxRobertaModel
 
+
 logger = logging.getLogger(__name__)
 
 
 ALL_PRETRAINED_MODEL_ARCHIVE_MAP = dict(
     (key, value)
-    for pretrained_map in [
-        FlaxBertModel.pretrained_model_archive_map,
-        FlaxRobertaModel.pretrained_model_archive_map,
-    ]
+    for pretrained_map in [FlaxBertModel.pretrained_model_archive_map, FlaxRobertaModel.pretrained_model_archive_map,]
     for key, value, in pretrained_map.items()
 )
 
-MODEL_MAPPING = OrderedDict(
-    [
-        (RobertaConfig, FlaxRobertaModel),
-        (BertConfig, FlaxBertModel),
-    ]
-)
+MODEL_MAPPING = OrderedDict([(RobertaConfig, FlaxRobertaModel), (BertConfig, FlaxBertModel),])
 
 
 class FlaxAutoModel(object):
@@ -166,4 +159,3 @@ class FlaxAutoModel(object):
                 config.__class__, cls.__name__, ", ".join(c.__name__ for c in MODEL_MAPPING.keys())
             )
         )
-

--- a/src/transformers/modeling_flax_auto.py
+++ b/src/transformers/modeling_flax_auto.py
@@ -112,7 +112,7 @@ class FlaxAutoModel(object):
                 - a path or url to a `tensorflow index checkpoint file` (e.g. `./tf_model/model.ckpt.index`). In this case, ``from_tf`` should be set to True and a configuration object should be provided as ``config`` argument. This loading path is slower than converting the TensorFlow checkpoint in a PyTorch model using the provided conversion scripts and loading the PyTorch model afterwards.
 
             model_args: (`optional`) Sequence of positional arguments:
-                All remaning positional arguments will be passed to the underlying model's ``__init__`` method
+                All remaining positional arguments will be passed to the underlying model's ``__init__`` method
 
             config: (`optional`) instance of a class derived from :class:`~transformers.PretrainedConfig`:
                 Configuration for the model to use instead of an automatically loaded configuation. Configuration can be automatically loaded when:
@@ -166,5 +166,4 @@ class FlaxAutoModel(object):
                 config.__class__, cls.__name__, ", ".join(c.__name__ for c in MODEL_MAPPING.keys())
             )
         )
-
 

--- a/src/transformers/modeling_flax_auto.py
+++ b/src/transformers/modeling_flax_auto.py
@@ -45,10 +45,10 @@ MODEL_MAPPING = OrderedDict(
 
 class FlaxAutoModel(object):
     r"""
-        :class:`~transformers.AutoModel` is a generic model class
+        :class:`~transformers.FlaxAutoModel` is a generic model class
         that will be instantiated as one of the base model classes of the library
-        when created with the `AutoModel.from_pretrained(pretrained_model_name_or_path)`
-        or the `AutoModel.from_config(config)` class methods.
+        when created with the `FlaxAutoModel.from_pretrained(pretrained_model_name_or_path)`
+        or the `FlaxAutoModel.from_config(config)` class methods.
 
         This class cannot be instantiated using `__init__()` (throws an error).
     """
@@ -69,18 +69,18 @@ class FlaxAutoModel(object):
             config (:class:`~transformers.PretrainedConfig`):
                 The model class to instantiate is selected based on the configuration class:
 
-                - isInstance of `roberta` configuration class: :class:`~transformers.RobertaModel` (RoBERTa model)
-                - isInstance of `bert` configuration class: :class:`~transformers.BertModel` (Bert model)
+                - isInstance of `roberta` configuration class: :class:`~transformers.FlaxRobertaModel` (RoBERTa model)
+                - isInstance of `bert` configuration class: :class:`~transformers.FlaxBertModel` (Bert model)
         Examples:
 
             config = BertConfig.from_pretrained('bert-base-uncased')    # Download configuration from S3 and cache.
-            model = AutoModel.from_config(config)  # E.g. model was saved using `save_pretrained('./test/saved_model/')`
+            model = FlaxAutoModel.from_config(config)  # E.g. model was saved using `save_pretrained('./test/saved_model/')`
         """
         for config_class, model_class in MODEL_MAPPING.items():
             if isinstance(config, config_class):
                 return model_class(config)
         raise ValueError(
-            "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
+            "Unrecognized configuration class {} for this kind of FlaxAutoModel: {}.\n"
             "Model type should be one of {}.".format(
                 config.__class__, cls.__name__, ", ".join(c.__name__ for c in MODEL_MAPPING.keys())
             )
@@ -97,8 +97,8 @@ class FlaxAutoModel(object):
 
         The base model class to instantiate is selected as the first pattern matching
         in the `pretrained_model_name_or_path` string (in the following order):
-            - contains `roberta`: :class:`~transformers.RobertaModel` (RoBERTa model)
-            - contains `bert`: :class:`~transformers.BertModel` (Bert model)
+            - contains `roberta`: :class:`~transformers.FlaxRobertaModel` (RoBERTa model)
+            - contains `bert`: :class:`~transformers.FlaxBertModel` (Bert model)
 
             The model is set in evaluation mode by default using `model.eval()` (Dropout modules are deactivated)
             To train the model, you should first set it back in training mode with `model.train()`
@@ -161,7 +161,7 @@ class FlaxAutoModel(object):
             if isinstance(config, config_class):
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
-            "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
+            "Unrecognized configuration class {} for this kind of FlaxAutoModel: {}.\n"
             "Model type should be one of {}.".format(
                 config.__class__, cls.__name__, ", ".join(c.__name__ for c in MODEL_MAPPING.keys())
             )

--- a/src/transformers/modeling_flax_auto.py
+++ b/src/transformers/modeling_flax_auto.py
@@ -29,11 +29,11 @@ logger = logging.getLogger(__name__)
 
 ALL_PRETRAINED_MODEL_ARCHIVE_MAP = dict(
     (key, value)
-    for pretrained_map in [FlaxBertModel.pretrained_model_archive_map, FlaxRobertaModel.pretrained_model_archive_map, ]
+    for pretrained_map in [FlaxBertModel.pretrained_model_archive_map, FlaxRobertaModel.pretrained_model_archive_map]
     for key, value, in pretrained_map.items()
 )
 
-MODEL_MAPPING = OrderedDict([(RobertaConfig, FlaxRobertaModel), (BertConfig, FlaxBertModel), ])
+MODEL_MAPPING = OrderedDict([(RobertaConfig, FlaxRobertaModel), (BertConfig, FlaxBertModel)])
 
 
 class FlaxAutoModel(object):

--- a/src/transformers/modeling_flax_auto.py
+++ b/src/transformers/modeling_flax_auto.py
@@ -38,12 +38,12 @@ MODEL_MAPPING = OrderedDict([(RobertaConfig, FlaxRobertaModel), (BertConfig, Fla
 
 class FlaxAutoModel(object):
     r"""
-        :class:`~transformers.FlaxAutoModel` is a generic model class
-        that will be instantiated as one of the base model classes of the library
-        when created with the `FlaxAutoModel.from_pretrained(pretrained_model_name_or_path)`
-        or the `FlaxAutoModel.from_config(config)` class methods.
+    :class:`~transformers.FlaxAutoModel` is a generic model class
+    that will be instantiated as one of the base model classes of the library
+    when created with the `FlaxAutoModel.from_pretrained(pretrained_model_name_or_path)`
+    or the `FlaxAutoModel.from_config(config)` class methods.
 
-        This class cannot be instantiated using `__init__()` (throws an error).
+    This class cannot be instantiated using `__init__()` (throws an error).
     """
 
     def __init__(self):
@@ -55,7 +55,7 @@ class FlaxAutoModel(object):
 
     @classmethod
     def from_config(cls, config):
-        r""" Instantiates one of the base model classes of the library
+        r"""Instantiates one of the base model classes of the library
         from a configuration.
 
         Args:
@@ -81,7 +81,7 @@ class FlaxAutoModel(object):
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
-        r""" Instantiates one of the base model classes of the library
+        r"""Instantiates one of the base model classes of the library
         from a pre-trained model configuration.
 
         The `from_pretrained()` method takes care of returning the correct model class instance

--- a/src/transformers/modeling_flax_auto.py
+++ b/src/transformers/modeling_flax_auto.py
@@ -23,16 +23,25 @@ from .configuration_utils import PretrainedConfig
 from .modeling_flax_bert import FlaxBertModel
 from .modeling_flax_roberta import FlaxRobertaModel
 
+
 logger = logging.getLogger(__name__)
 
 
 ALL_PRETRAINED_MODEL_ARCHIVE_MAP = dict(
     (key, value)
-    for pretrained_map in [FlaxBertModel.pretrained_model_archive_map, FlaxRobertaModel.pretrained_model_archive_map,]
+    for pretrained_map in [
+        FlaxBertModel.pretrained_model_archive_map,
+        FlaxRobertaModel.pretrained_model_archive_map,
+    ]
     for key, value, in pretrained_map.items()
 )
 
-MODEL_MAPPING = OrderedDict([(RobertaConfig, FlaxRobertaModel), (BertConfig, FlaxBertModel),])
+MODEL_MAPPING = OrderedDict(
+    [
+        (RobertaConfig, FlaxRobertaModel),
+        (BertConfig, FlaxBertModel),
+    ]
+)
 
 
 class FlaxAutoModel(object):

--- a/src/transformers/modeling_flax_auto.py
+++ b/src/transformers/modeling_flax_auto.py
@@ -23,17 +23,16 @@ from .configuration_utils import PretrainedConfig
 from .modeling_flax_bert import FlaxBertModel
 from .modeling_flax_roberta import FlaxRobertaModel
 
-
 logger = logging.getLogger(__name__)
 
 
 ALL_PRETRAINED_MODEL_ARCHIVE_MAP = dict(
     (key, value)
-    for pretrained_map in [FlaxBertModel.pretrained_model_archive_map, FlaxRobertaModel.pretrained_model_archive_map]
+    for pretrained_map in [FlaxBertModel.pretrained_model_archive_map, FlaxRobertaModel.pretrained_model_archive_map,]
     for key, value, in pretrained_map.items()
 )
 
-MODEL_MAPPING = OrderedDict([(RobertaConfig, FlaxRobertaModel), (BertConfig, FlaxBertModel)])
+MODEL_MAPPING = OrderedDict([(RobertaConfig, FlaxRobertaModel), (BertConfig, FlaxBertModel),])
 
 
 class FlaxAutoModel(object):

--- a/src/transformers/modeling_flax_auto.py
+++ b/src/transformers/modeling_flax_auto.py
@@ -23,6 +23,7 @@ from .modeling_flax_bert import FlaxBertModel
 from .modeling_flax_roberta import FlaxRobertaModel
 from .utils import logging
 
+
 logger = logging.get_logger(__name__)
 
 

--- a/src/transformers/modeling_flax_auto.py
+++ b/src/transformers/modeling_flax_auto.py
@@ -15,16 +15,15 @@
 """ Auto Model class. """
 
 
-import logging
 from collections import OrderedDict
 
 from .configuration_auto import AutoConfig, BertConfig, RobertaConfig
 from .configuration_utils import PretrainedConfig
 from .modeling_flax_bert import FlaxBertModel
 from .modeling_flax_roberta import FlaxRobertaModel
+from .utils import logging
 
-
-logger = logging.getLogger(__name__)
+logger = logging.get_logger(__name__)
 
 
 ALL_PRETRAINED_MODEL_ARCHIVE_MAP = dict(

--- a/src/transformers/modeling_flax_auto.py
+++ b/src/transformers/modeling_flax_auto.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2018 The HuggingFace Inc. team.
+# Copyright 2018 The Google Flax Team Authors and The HuggingFace Inc. team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/transformers/modeling_flax_auto.py
+++ b/src/transformers/modeling_flax_auto.py
@@ -107,7 +107,7 @@ class FlaxAutoModel(object):
 
                 - a string with the `shortcut name` of a pre-trained model to load from cache or download, e.g.: ``bert-base-uncased``.
                 - a string with the `identifier name` of a pre-trained model that was user-uploaded to our S3, e.g.: ``dbmdz/bert-base-german-cased``.
-                - a path to a `directory` containing model weights saved using :func:`~transformers.PreTrainedModel.save_pretrained`, e.g.: ``./my_model_directory/``.
+                - a path to a `directory` containing model weights saved using :func:`~transformers.FlaxPreTrainedModel.save_pretrained`, e.g.: ``./my_model_directory/``.
                 - a path or url to a `tensorflow index checkpoint file` (e.g. `./tf_model/model.ckpt.index`). In this case, ``from_tf`` should be set to True and a configuration object should be provided as ``config`` argument. This loading path is slower than converting the TensorFlow checkpoint in a PyTorch model using the provided conversion scripts and loading the PyTorch model afterwards.
 
             model_args: (`optional`) Sequence of positional arguments:
@@ -117,13 +117,13 @@ class FlaxAutoModel(object):
                 Configuration for the model to use instead of an automatically loaded configuation. Configuration can be automatically loaded when:
 
                 - the model is a model provided by the library (loaded with the ``shortcut-name`` string of a pretrained model), or
-                - the model was saved using :func:`~transformers.PreTrainedModel.save_pretrained` and is reloaded by suppling the save directory.
+                - the model was saved using :func:`~transformers.FlaxPreTrainedModel.save_pretrained` and is reloaded by suppling the save directory.
                 - the model is loaded by suppling a local directory as ``pretrained_model_name_or_path`` and a configuration JSON file named `config.json` is found in the directory.
 
             state_dict: (`optional`) dict:
                 an optional state dictionnary for the model to use instead of a state dictionary loaded from saved weights file.
                 This option can be used if you want to create a model from a pretrained configuration but load your own weights.
-                In this case though, you should check if using :func:`~transformers.PreTrainedModel.save_pretrained` and :func:`~transformers.PreTrainedModel.from_pretrained` is not a simpler option.
+                In this case though, you should check if using :func:`~transformers.FlaxPreTrainedModel.save_pretrained` and :func:`~transformers.FlaxPreTrainedModel.from_pretrained` is not a simpler option.
 
             cache_dir: (`optional`) string:
                 Path to a directory in which a downloaded pre-trained model

--- a/src/transformers/modeling_flax_auto.py
+++ b/src/transformers/modeling_flax_auto.py
@@ -80,10 +80,9 @@ class FlaxAutoModel(object):
             if isinstance(config, config_class):
                 return model_class(config)
         raise ValueError(
-            "Unrecognized configuration class {} for this kind of FlaxAutoModel: {}.\n"
-            "Model type should be one of {}.".format(
-                config.__class__, cls.__name__, ", ".join(c.__name__ for c in MODEL_MAPPING.keys())
-            )
+            f"Unrecognized configuration class {config.__class__} "
+            f"for this kind of FlaxAutoModel: {cls.__name__}.\n"
+            f"Model type should be one of {', '.join(c.__name__ for c in MODEL_MAPPING.keys())}."
         )
 
     @classmethod
@@ -161,8 +160,7 @@ class FlaxAutoModel(object):
             if isinstance(config, config_class):
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
-            "Unrecognized configuration class {} for this kind of FlaxAutoModel: {}.\n"
-            "Model type should be one of {}.".format(
-                config.__class__, cls.__name__, ", ".join(c.__name__ for c in MODEL_MAPPING.keys())
-            )
+            f"Unrecognized configuration class {config.__class__} "
+            f"for this kind of FlaxAutoModel: {cls.__name__}.\n"
+            f"Model type should be one of {', '.join(c.__name__ for c in MODEL_MAPPING.keys())}"
         )

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -11,7 +11,35 @@ from flax.serialization import to_bytes
 from jax.random import PRNGKey
 
 from transformers import BertTokenizerFast, BertConfig, AutoModel
-from transformers.modeling_jax_utils import JaxPreTrainedModel
+from transformers.modeling_jax_utils import JaxPreTrainedModel, load_pytorch_weights_in_jax_model
+
+
+# Models are loaded from Pytorch checkpoints
+BERT_PRETRAINED_MODEL_ARCHIVE_MAP = {
+    "bert-base-uncased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-uncased-pytorch_model.bin",
+    "bert-large-uncased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-uncased-pytorch_model.bin",
+    "bert-base-cased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-cased-pytorch_model.bin",
+    "bert-large-cased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-cased-pytorch_model.bin",
+    "bert-base-multilingual-uncased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-multilingual-uncased-pytorch_model.bin",
+    "bert-base-multilingual-cased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-multilingual-cased-pytorch_model.bin",
+    "bert-base-chinese": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-chinese-pytorch_model.bin",
+    "bert-base-german-cased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-german-cased-pytorch_model.bin",
+    "bert-large-uncased-whole-word-masking": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-uncased-whole-word-masking-pytorch_model.bin",
+    "bert-large-cased-whole-word-masking": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-cased-whole-word-masking-pytorch_model.bin",
+    "bert-large-uncased-whole-word-masking-finetuned-squad": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-uncased-whole-word-masking-finetuned-squad-pytorch_model.bin",
+    "bert-large-cased-whole-word-masking-finetuned-squad": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-cased-whole-word-masking-finetuned-squad-pytorch_model.bin",
+    "bert-base-cased-finetuned-mrpc": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-cased-finetuned-mrpc-pytorch_model.bin",
+    "bert-base-german-dbmdz-cased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-german-dbmdz-cased-pytorch_model.bin",
+    "bert-base-german-dbmdz-uncased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-german-dbmdz-uncased-pytorch_model.bin",
+    "bert-base-japanese": "https://s3.amazonaws.com/models.huggingface.co/bert/cl-tohoku/bert-base-japanese-pytorch_model.bin",
+    "bert-base-japanese-whole-word-masking": "https://s3.amazonaws.com/models.huggingface.co/bert/cl-tohoku/bert-base-japanese-whole-word-masking-pytorch_model.bin",
+    "bert-base-japanese-char": "https://s3.amazonaws.com/models.huggingface.co/bert/cl-tohoku/bert-base-japanese-char-pytorch_model.bin",
+    "bert-base-japanese-char-whole-word-masking": "https://s3.amazonaws.com/models.huggingface.co/bert/cl-tohoku/bert-base-japanese-char-whole-word-masking-pytorch_model.bin",
+    "bert-base-finnish-cased-v1": "https://s3.amazonaws.com/models.huggingface.co/bert/TurkuNLP/bert-base-finnish-cased-v1/pytorch_model.bin",
+    "bert-base-finnish-uncased-v1": "https://s3.amazonaws.com/models.huggingface.co/bert/TurkuNLP/bert-base-finnish-uncased-v1/pytorch_model.bin",
+    "bert-base-dutch-cased": "https://s3.amazonaws.com/models.huggingface.co/bert/wietsedv/bert-base-dutch-cased/pytorch_model.bin",
+}
+
 
 ACT2FN = {
     "gelu": nn.gelu,
@@ -21,6 +49,7 @@ ACT2FN = {
 }
 
 
+@jax.jit
 def gelu(x):
     r"""Gaussian error linear unit activation function.
 
@@ -217,6 +246,8 @@ class FlaxBertModel(JaxPreTrainedModel):
 
     MODEL_CLASS = BertModel
     config_class = BertConfig
+    pretrained_model_archive_map = BERT_PRETRAINED_MODEL_ARCHIVE_MAP
+    base_model_prefix = "bert"
 
     def __init__(self, config: BertConfig, state: dict, **kwargs):
         self.config = config
@@ -260,41 +291,12 @@ class FlaxBertModel(JaxPreTrainedModel):
 
 
 if __name__ == '__main__':
-    tokenizer = BertTokenizerFast.from_pretrained("bert-base-cased")
-    model_pt = AutoModel.from_pretrained('bert-base-cased')
+    MODEL = "bert-base-cased"
+    tokenizer = BertTokenizerFast.from_pretrained(MODEL)
+    model_pt = AutoModel.from_pretrained(MODEL)
     model_pt.eval()
 
-    # with open("/data/Downloads/bert-base-cased-pytorch_model.bin", 'rb') as model_f:
-    #     state = torch.load(model_f)
-    #     state = {k: v.numpy() for k, v in state.items()}
-    #
-    #     # Need to change some parameters name to match Flax names so that we don't have to fork any layer
-    #     state = {k.replace("weight", "kernel") if {"dense", "query", "key", "value"} & set(k.split('.')) else k: v
-    #              for k, v in state.items()}
-    #
-    #     # SelfAttention output is not a separate layer, remove one nesting
-    #     state = {k.replace("attention.output.dense", "attention.self.out"): v for k, v in state.items()}
-    #     state = {k.replace("attention.output.LayerNorm", "attention.layer_norm"): v for k, v in state.items()}
-    #
-    #     # SelfAttention.out
-    #     state = {k: v.T if v.shape == (3072, 768) or v.shape == (768, 3072) else v for k, v in state.items()}
-    #     state = {k: v.reshape((12, 64, 768)).transpose((2, 0, 1)) if v.shape == (768, 768) and "out" not in k and "pooler" not in k else v for k, v in state.items()}
-    #
-    #     # Bias
-    #     state = {k: v.reshape((12, -1)) if v.shape == (768, ) and ("bias" in k) and ("out" not in k) and ("pooler" not in k) else v for k, v in state.items()}
-    #
-    #     # Self Attention output projection
-    #     state = {k: v.reshape((768, 12, 64)).transpose(1, 2, 0) if "out.kernel" in k else v for k, v in state.items()}
-    #
-    #     # Pooler
-    #     state = {k: v.T if "pooler.dense.kernel" in k else v for k, v in state.items()}
-    #     state = unflatten_dict({tuple(k.split('.')[1:]): v for k, v in state.items()})
-    #     model = FlaxBertModel.from_pretrained(model_pt.config, state)
-
-    model = FlaxBertModel.from_pretrained(
-        '/data/Workspace/transformers/src/transformers/bert-base-cased/bert-base-cased.bin',
-        config=model_pt.config,
-    )
+    model = FlaxBertModel.from_pretrained(MODEL)
 
     # Inputs
     flax_input = tokenizer.encode_plus("My name is Morgan")

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -6,33 +6,8 @@ import jax.numpy as jnp
 import numpy as np
 
 from transformers import BertConfig
+from transformers.modeling_bert import BERT_PRETRAINED_MODEL_ARCHIVE_MAP
 from transformers.modeling_jax_utils import JaxPreTrainedModel
-
-# Models are loaded from Pytorch checkpoints
-BERT_PRETRAINED_MODEL_ARCHIVE_MAP = {
-    "bert-base-uncased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-uncased-pytorch_model.bin",
-    "bert-large-uncased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-uncased-pytorch_model.bin",
-    "bert-base-cased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-cased-pytorch_model.bin",
-    "bert-large-cased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-cased-pytorch_model.bin",
-    "bert-base-multilingual-uncased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-multilingual-uncased-pytorch_model.bin",
-    "bert-base-multilingual-cased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-multilingual-cased-pytorch_model.bin",
-    "bert-base-chinese": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-chinese-pytorch_model.bin",
-    "bert-base-german-cased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-german-cased-pytorch_model.bin",
-    "bert-large-uncased-whole-word-masking": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-uncased-whole-word-masking-pytorch_model.bin",
-    "bert-large-cased-whole-word-masking": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-cased-whole-word-masking-pytorch_model.bin",
-    "bert-large-uncased-whole-word-masking-finetuned-squad": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-uncased-whole-word-masking-finetuned-squad-pytorch_model.bin",
-    "bert-large-cased-whole-word-masking-finetuned-squad": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-cased-whole-word-masking-finetuned-squad-pytorch_model.bin",
-    "bert-base-cased-finetuned-mrpc": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-cased-finetuned-mrpc-pytorch_model.bin",
-    "bert-base-german-dbmdz-cased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-german-dbmdz-cased-pytorch_model.bin",
-    "bert-base-german-dbmdz-uncased": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-german-dbmdz-uncased-pytorch_model.bin",
-    "bert-base-japanese": "https://s3.amazonaws.com/models.huggingface.co/bert/cl-tohoku/bert-base-japanese-pytorch_model.bin",
-    "bert-base-japanese-whole-word-masking": "https://s3.amazonaws.com/models.huggingface.co/bert/cl-tohoku/bert-base-japanese-whole-word-masking-pytorch_model.bin",
-    "bert-base-japanese-char": "https://s3.amazonaws.com/models.huggingface.co/bert/cl-tohoku/bert-base-japanese-char-pytorch_model.bin",
-    "bert-base-japanese-char-whole-word-masking": "https://s3.amazonaws.com/models.huggingface.co/bert/cl-tohoku/bert-base-japanese-char-whole-word-masking-pytorch_model.bin",
-    "bert-base-finnish-cased-v1": "https://s3.amazonaws.com/models.huggingface.co/bert/TurkuNLP/bert-base-finnish-cased-v1/pytorch_model.bin",
-    "bert-base-finnish-uncased-v1": "https://s3.amazonaws.com/models.huggingface.co/bert/TurkuNLP/bert-base-finnish-uncased-v1/pytorch_model.bin",
-    "bert-base-dutch-cased": "https://s3.amazonaws.com/models.huggingface.co/bert/wietsedv/bert-base-dutch-cased/pytorch_model.bin",
-}
 
 
 ACT2FN = {

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -193,7 +193,8 @@ class BertEncoder(nn.Module):
 class BertPooler(nn.Module):
 
     def apply(self, hidden_state):
-        out = nn.Dense(hidden_state, hidden_state.shape[-1], name="dense")
+        first_token = hidden_state[:, 0]
+        out = nn.Dense(first_token, hidden_state.shape[-1], name="dense")
         return jax.lax.tanh(out)
 
 
@@ -219,7 +220,8 @@ class BertModel(nn.Module):
             name="encoder"
         )
 
-        return BertPooler(encoder, name="pooler")
+        pooled = BertPooler(encoder, name="pooler")
+        return encoder, pooled
 
 
 class FXBertModel:
@@ -246,7 +248,7 @@ class FXBertModel:
 
         bert = nn.Model(model_def, self.state)
 
-        @jax.jit
+        # @jax.jit
         def predict(input_ids, token_type_ids, attention_mask):
             return bert(
                 jnp.array(input_ids, dtype='i4'),

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 from typing import Tuple, Callable
 
 from flax.nn import Model
-from flax.nn.normalization import LayerNorm
 from flax.serialization import from_state_dict
+from flax.traverse_util import unflatten_dict
 from jax.random import PRNGKey
 
 from transformers import BertModel as PTBertModel, BertTokenizerFast
@@ -30,12 +30,80 @@ class BertConfig:
     initializer_range: Tuple[int, int] = (-1, 1)
 
 
-# class BertEmbeddings(nn.Module):
-#     def apply(self, inputs, vocab_size, embedding_dim, emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1)):
-#         word_embeddings = self.param('bert.embeddings.word_embeddings.weight', (vocab_size, embedding_dim), emb_init)
-#         return word_embeddings[inputs.astype(np.int32)]
-#
-#         # return nn.Embed(inputs, num_embeddings=vocab_size, features=embedding_dim, name='')
+class BertLayerNorm(nn.Module):
+    """Layer normalization (https://arxiv.org/abs/1607.06450).
+    Operates on the last axis of the input data.
+    """
+
+    def apply(self,
+              x,
+              epsilon=1e-6,
+              dtype=jnp.float32,
+              bias=True,
+              scale=True,
+              bias_init=nn.initializers.zeros,
+              scale_init=nn.initializers.ones):
+        """Applies layer normalization on the input.
+        It normalizes the activations of the layer for each given example in a
+        batch independently, rather than across a batch like Batch Normalization.
+        i.e. applies a transformation that maintains the mean activation within
+        each example close to 0 and the activation standard deviation close to 1.
+        Args:
+          x: the inputs
+          epsilon: A small float added to variance to avoid dividing by zero.
+          dtype: the dtype of the computation (default: float32).
+          bias:  If True, bias (beta) is added.
+          scale: If True, multiply by scale (gamma). When the next layer is linear
+            (also e.g. nn.relu), this can be disabled since the scaling will be done
+            by the next layer.
+          bias_init: Initializer for bias, by default, zero.
+          scale_init: Initializer for scale, by default, one.
+        Returns:
+          Normalized inputs (the same shape as inputs).
+        """
+        features = x.shape[-1]
+        mean = jnp.mean(x, axis=-1, keepdims=True)
+        mean2 = jnp.mean(jnp.lax.square(x), axis=-1, keepdims=True)
+        var = mean2 - jnp.lax.square(mean)
+        mul = jnp.lax.rsqrt(var + epsilon)
+        if scale:
+            mul = mul * jnp.asarray(self.param('gamma', (features,), scale_init), dtype)
+        y = (x - mean) * mul
+        if bias:
+            y = y + jnp.asarray(self.param('beta', (features,), bias_init), dtype)
+        return y
+
+
+class BertEmbedding(nn.Module):
+    """
+    Specify a new class for doing the embedding stuff
+    as Flax's one use 'embedding' for the parameter name
+    and PyTorch use 'weight'
+    """
+
+    def apply(self, input, vocab_size: int, hidden_size: int,
+              emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1)):
+
+        embedding = self.param('weight', (vocab_size, hidden_size), emb_init)
+        return jnp.take(embedding, input, axis=0)
+
+
+class BertEmbeddings(nn.Module):
+    def apply(self, input_ids, token_type_ids, attention_mask, vocab_size: int,
+              hidden_size: int, type_vocab_size: int, max_length: int):
+
+        # Embed
+        w_emb = BertEmbedding(jnp.atleast_2d(input_ids.astype('i4')), vocab_size, hidden_size, name="word_embeddings")
+        p_emb = BertEmbedding(jnp.atleast_2d(np.arange(input_ids.shape[-1])), max_length, hidden_size, name="position_embeddings")
+        t_emb = BertEmbedding(jnp.atleast_2d(token_type_ids.astype('i4')), 2, hidden_size, name="token_type_embeddings")
+
+        # Sum all embeddings
+        summed_emb = w_emb + jnp.broadcast_to(p_emb, w_emb.shape) + t_emb
+
+        # Layer Norm
+        norm = BertLayerNorm(summed_emb, name="LayerNorm")
+
+        return norm
 
 
 class BertModel(nn.Module):
@@ -44,24 +112,13 @@ class BertModel(nn.Module):
               vocab_size: int, hidden_size: int, type_vocab_size: int, max_length: int,
               emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1)):
 
-        # Embed
-        word_embeddings = self.param('bert.embeddings.word_embeddings.weight', (vocab_size, hidden_size), emb_init)
-        pos_embeddings  = self.param('bert.embeddings.position_embeddings.weight', (max_length, hidden_size), emb_init)
-        type_embeddings = self.param('bert.embeddings.token_type_embeddings.weight', (type_vocab_size, hidden_size), emb_init)
+        embeddings = BertEmbeddings(
+            input_ids, token_type_ids, attention_mask,
+            vocab_size, hidden_size, type_vocab_size, max_length,
+            name="embeddings"
+        )
 
-        w_emb = word_embeddings[jnp.atleast_2d(input_ids.astype('i4'))]
-        p_emb = pos_embeddings[jnp.atleast_2d(np.arange(input_ids.shape[-1]))]
-        t_emb = type_embeddings[jnp.atleast_2d(token_type_ids.astype('i4'))]
-
-        # Sum all embeddings
-        summed_emb = w_emb + jnp.broadcast_to(p_emb, w_emb.shape) + t_emb
-
-        # Layer Norm
-        norm_gamma = self.param('bert.embeddings.LayerNorm.gamma', (hidden_size, ), emb_init)
-        norm_beta  = self.param('bert.embeddings.LayerNorm.beta', (hidden_size, ), emb_init)
-        norm = LayerNorm.call({"scale": norm_gamma, "bias": norm_beta, "epsilon": 1e-12}, summed_emb)
-
-        return norm
+        return embeddings
 
 
 class FXBertModel:
@@ -75,17 +132,15 @@ class FXBertModel:
         self.state = None
 
     def __call__(self, input_ids, token_type_ids, attention_mask):
-        inputs_shape = [(1, len(input_ids))] * 3
-
         model_def = BertModel.partial(
-            name="bert",
             vocab_size=self.config.vocab_size,
             hidden_size=self.config.hidden_size,
             type_vocab_size=2,
-            max_length=self.config.max_length
+            max_length=self.config.max_length,
         )
 
-        _ = model_def.init_by_shape(self.key, inputs_shape)
+        # inputs_shape = [(1, len(input_ids))] * 3
+        # _ = model_def.init_by_shape(self.key, inputs_shape)
         bert = Model(model_def, self.state)
         return bert(
             jnp.array(input_ids, dtype='i4'),
@@ -103,9 +158,10 @@ if __name__ == '__main__':
     model = FXBertModel(BertConfig(512, 28996, 768))
     model_pt = PTBertModel.from_pretrained('bert-base-cased')
     model_pt.eval()
+
     with open("/data/Downloads/bert-base-cased-pytorch_model.bin", 'rb') as model_f:
         state = torch.load(model_f)
-        state = {k: v.numpy() for k, v in state.items()}
+        state = unflatten_dict({tuple(k.split('.')[1:]): v.numpy() for k, v in state.items()})
         model.from_pretrained(state)
 
     out = model(**tokenizer.encode_plus("My name is Morgan"))

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -1,0 +1,31 @@
+import jax.numpy as jnp
+import flax.nn as nn
+
+
+ACT2FN = {
+    "gelu": nn.gelu,
+    "relu": nn.relu,
+    "swish": nn.swish,
+    "gelu_new": nn.gelu,
+}
+
+
+class BertEmbeddings(nn.Module):
+    def apply(self, inputs, token_type_ids, attention_mask, vocab_size, embedding_dim):
+        x = nn.Embed(inputs, num_embeddings=vocab_size, features=embedding_dim, name='embed')
+
+
+class BertModel(nn.Module):
+
+
+class FXBertModel:
+    """
+    BERT implementation using JAX/Flax as backend
+    """
+
+    def __init__(self, config, **kwargs):
+        self.vocab_size = config.vocab_size
+        self.hidden_size = config.hidden_size
+        self.initializer_range = config.initializer_range
+
+

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -7,7 +7,6 @@ import torch
 from dataclasses import dataclass
 from typing import Tuple, Callable
 
-from flax.nn import Model
 from flax.serialization import from_state_dict
 from flax.traverse_util import unflatten_dict
 from jax.random import PRNGKey
@@ -23,11 +22,31 @@ ACT2FN = {
 }
 
 
+def gelu(x):
+    r"""Gaussian error linear unit activation function.
+
+    Computes the element-wise function:
+
+    .. math::
+      \mathrm{gelu}(x) = \frac{x}{2} \left(1 + \mathrm{tanh} \left(
+        \sqrt{\frac{2}{\pi}} \left(x + 0.044715 x^3 \right) \right) \right)
+
+    We explicitly use the approximation rather than the exact formulation for
+    speed. For more information, see `Gaussian Error Linear Units (GELUs)
+    <https://arxiv.org/abs/1606.08415>`_, section 2.
+    """
+    return x * 0.5 * (1. + jax.lax.erf(x / jnp.sqrt(2.)))
+
+
 @dataclass
 class BertConfig:
     max_length: int
     vocab_size: int
     hidden_size: int
+    num_layers: int
+    num_heads: int
+    head_size: int
+    intermediate_size: int
     initializer_range: Tuple[int, int] = (-1, 1)
 
 
@@ -107,19 +126,94 @@ class BertEmbeddings(nn.Module):
         return norm
 
 
+class BertAttention(nn.Module):
+
+    def apply(self, hidden_state, attention_mask, num_heads: int, head_size: int, output_size: int):
+        self_att = nn.attention.SelfAttention(
+            hidden_state,
+            num_heads=num_heads,
+            qkv_features=head_size,
+            name="self"
+        )
+
+        return BertLayerNorm(self_att + hidden_state, name="layer_norm")
+
+
+class BertIntermediate(nn.Module):
+
+    def apply(self, hidden_state, output_size: int):
+        # TODO: Had ACT2FN reference to change activation function
+        h = nn.Dense(hidden_state, features=output_size, name="dense")
+        return gelu(h)
+
+
+class BertOutput(nn.Module):
+    def apply(self, intermediate_output, attention_output):
+        h = nn.Dense(intermediate_output, attention_output.shape[-1], name="dense")
+        h = BertLayerNorm(h + attention_output, name="LayerNorm")
+
+        return h
+
+
+class BertLayer(nn.Module):
+
+    def apply(self, hidden_state, attention_mask, num_heads: int, head_size: int, intermediate_size: int):
+        attention = BertAttention(hidden_state, attention_mask, num_heads, head_size, intermediate_size, name="attention")
+        intermediate = BertIntermediate(attention, intermediate_size, name="intermediate")
+        output = BertOutput(intermediate, attention, name="output")
+
+        return output
+
+
+class BertLayerCollection(nn.Module):
+    """
+    Stores N BertLayer(s)
+    """
+    def apply(self, input, attention_mask, num_layers: int, num_heads: int, head_size: int, intermediate_size: int):
+        assert num_layers > 0, "num_layers should be >= 1, got ({})".format(num_layers)
+
+        # Initialize input / output
+        input_i = output_i = input
+
+        # Forward over all encoders
+        for i in range(num_layers):
+            output_i = BertLayer(input_i, attention_mask, num_heads, head_size, intermediate_size, name="{}".format(i))
+            input_i = output_i
+        # output_i = BertLayer(input_i, attention_mask, num_heads, head_size, intermediate_size, name="0")
+        return output_i
+
+
+class BertEncoder(nn.Module):
+
+    def apply(self, hidden_state, attention_mask, num_layers: int, num_heads: int, head_size: int, intermediate_size: int):
+        encodings = BertLayerCollection(hidden_state, attention_mask, num_layers, num_heads, head_size, intermediate_size, name="layer")
+        return encodings
+
+
 class BertModel(nn.Module):
 
     def apply(self, input_ids, token_type_ids, attention_mask,
-              vocab_size: int, hidden_size: int, type_vocab_size: int, max_length: int,
+              vocab_size: int, hidden_size: int, type_vocab_size: int,
+              max_length: int, num_encoder_layers: int, num_heads: int,
+              head_size: int, intermediate_size: int,
               emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1)):
 
+        # Embedding
         embeddings = BertEmbeddings(
             input_ids, token_type_ids, attention_mask,
             vocab_size, hidden_size, type_vocab_size, max_length,
             name="embeddings"
         )
 
-        return embeddings
+        # N stacked encoding layers
+        encoder = BertEncoder(
+            embeddings, attention_mask, num_encoder_layers,
+            num_heads, head_size, intermediate_size,
+            name="encoder"
+        )
+
+        # TODO: Pooling
+        return encoder
 
 
 class FXBertModel:
@@ -138,13 +232,15 @@ class FXBertModel:
             hidden_size=self.config.hidden_size,
             type_vocab_size=2,
             max_length=self.config.max_length,
+            num_encoder_layers=self.config.num_layers,
+            num_heads=self.config.num_heads,
+            head_size=self.config.head_size,
+            intermediate_size=self.config.intermediate_size
         )
 
-        # inputs_shape = [(1, len(input_ids))] * 3
-        # _ = model_def.init_by_shape(self.key, inputs_shape)
-        bert = Model(model_def, self.state)
+        bert = nn.Model(model_def, self.state)
 
-        @jax.jit
+        # @jax.jit
         def predict(input_ids, token_type_ids, attention_mask):
             return bert(
                 jnp.array(input_ids, dtype='i4'),
@@ -161,15 +257,41 @@ class FXBertModel:
 
 if __name__ == '__main__':
     tokenizer = BertTokenizerFast.from_pretrained("bert-base-cased")
-    model = FXBertModel(BertConfig(512, 28996, 768))
-    model_pt = PTBertModel.from_pretrained('bert-base-cased')
+    model = FXBertModel(BertConfig(512, 28996, 768, 12, 12, 768, 3072))
+    model_pt = PTBertModel.from_pretrained('bert-base-cased', output_attentions=True)
     model_pt.eval()
 
     with open("/data/Downloads/bert-base-cased-pytorch_model.bin", 'rb') as model_f:
         state = torch.load(model_f)
-        state = unflatten_dict({tuple(k.split('.')[1:]): v.numpy() for k, v in state.items()})
+        state = {k: v.numpy() for k, v in state.items()}
+
+        # Need to change some parameters name to match Flax names so that we don't have to fork any layer
+        state = {k.replace("weight", "kernel") if {"dense", "query", "key", "value"} & set(k.split('.')) else k: v
+                 for k, v in state.items()}
+
+        # SelfAttention output is not a separate layer, remove one nesting
+        state = {k.replace("attention.output.dense", "attention.self.out"): v for k, v in state.items()}
+        state = {k.replace("attention.output.LayerNorm", "attention.layer_norm"): v for k, v in state.items()}
+
+        # SelfAttention.out
+        state = {k: v.T if v.shape == (3072, 768) or v.shape == (768, 3072) else v for k, v in state.items()}
+        state = {k: v.reshape((12, 64, 768)).transpose((2, 0, 1)) if v.shape == (768, 768) and "out" not in k else v for k, v in state.items()}
+
+        # Bias
+        state = {k: v.reshape((12, -1)) if v.shape == (768, ) and ("bias" in k) and ("out" not in k) else v for k, v in state.items()}
+
+        # Self Attention output projection
+        state = {k: v.reshape((768, 12, 64)).transpose(1, 2, 0) if "out.kernel" in k else v for k, v in state.items()}
+        state = unflatten_dict({tuple(k.split('.')[1:]): v for k, v in state.items()})
         model.from_pretrained(state)
 
-    out = model(**tokenizer.encode_plus("My name is Morgan"))
-    out_pt = model_pt.embeddings(tokenizer.encode_plus("My name is Morgan", return_tensors="pt")['input_ids'])
+    # Inputs
+    flax_input = tokenizer.encode_plus("My name is Morgan")
+    pt_input = tokenizer.encode_plus("My name is Morgan", return_tensors="pt")
+
+    # Forward
+    model_pt.eval()
+    pt_emb = model_pt.embeddings(pt_input['input_ids'])
+    pt_enc = model_pt.encoder(pt_emb, pt_input['attention_mask'], [None] * 12)
+    flax_enc = model(**flax_input)
     input()

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -1,5 +1,17 @@
 import jax.numpy as jnp
 import flax.nn as nn
+import numpy as np
+import torch
+
+from dataclasses import dataclass
+from typing import Tuple, Callable
+
+from flax.nn import Model
+from flax.nn.normalization import LayerNorm
+from flax.serialization import from_state_dict
+from jax.random import PRNGKey
+
+from transformers import BertModel as PTBertModel, BertTokenizerFast
 
 
 ACT2FN = {
@@ -10,9 +22,20 @@ ACT2FN = {
 }
 
 
-class BertEmbeddings(nn.Module):
-    def apply(self, inputs, token_type_ids, attention_mask, vocab_size, embedding_dim):
-        x = nn.Embed(inputs, num_embeddings=vocab_size, features=embedding_dim, name='embed')
+@dataclass
+class BertConfig:
+    max_length: int
+    vocab_size: int
+    hidden_size: int
+    initializer_range: Tuple[int, int] = (-1, 1)
+
+
+# class BertEmbeddings(nn.Module):
+#     def apply(self, inputs, vocab_size, embedding_dim, emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1)):
+#         word_embeddings = self.param('bert.embeddings.word_embeddings.weight', (vocab_size, embedding_dim), emb_init)
+#         return word_embeddings[inputs.astype(np.int32)]
+#
+#         # return nn.Embed(inputs, num_embeddings=vocab_size, features=embedding_dim, name='')
 
 
 class BertModel(nn.Module):
@@ -28,4 +51,21 @@ class FXBertModel:
         self.hidden_size = config.hidden_size
         self.initializer_range = config.initializer_range
 
+    def from_pretrained(self, state):
+        self.state = from_state_dict(BertModel, state)
+        return self.state
 
+
+if __name__ == '__main__':
+    tokenizer = BertTokenizerFast.from_pretrained("bert-base-cased")
+    model = FXBertModel(BertConfig(512, 28996, 768))
+    model_pt = PTBertModel.from_pretrained('bert-base-cased')
+    model_pt.eval()
+    with open("/data/Downloads/bert-base-cased-pytorch_model.bin", 'rb') as model_f:
+        state = torch.load(model_f)
+        state = {k: v.numpy() for k, v in state.items()}
+        model.from_pretrained(state)
+
+    out = model(**tokenizer.encode_plus("My name is Morgan"))
+    out_pt = model_pt.embeddings(tokenizer.encode_plus("My name is Morgan", return_tensors="pt")['input_ids'])
+    input()

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -2,7 +2,8 @@ from typing import Callable, Dict
 
 import numpy as np
 
-import flax.nn as nn
+import flax.linen as nn
+from flax.linen import compact
 import jax
 import jax.numpy as jnp
 from transformers import BertConfig
@@ -38,17 +39,15 @@ class BertLayerNorm(nn.Module):
     """Layer normalization (https://arxiv.org/abs/1607.06450).
     Operates on the last axis of the input data.
     """
+    epsilon: float = 1e-6
+    dtype: jnp.dtype = jnp.float32
+    bias: bool = True
+    scale: bool = True
+    bias_init: jnp.ndarray = nn.initializers.zeros
+    scale_init: jnp.ndarray = nn.initializers.ones
 
-    def apply(
-        self,
-        x,
-        epsilon=1e-6,
-        dtype=jnp.float32,
-        bias=True,
-        scale=True,
-        bias_init=nn.initializers.zeros,
-        scale_init=nn.initializers.ones,
-    ):
+    @compact
+    def __call__(self, x):
         """Applies layer normalization on the input.
         It normalizes the activations of the layer for each given example in a
         batch independently, rather than across a batch like Batch Normalization.
@@ -69,14 +68,16 @@ class BertLayerNorm(nn.Module):
         """
         features = x.shape[-1]
         mean = jnp.mean(x, axis=-1, keepdims=True)
-        mean2 = jnp.mean(jnp.lax.square(x), axis=-1, keepdims=True)
-        var = mean2 - jnp.lax.square(mean)
-        mul = jnp.lax.rsqrt(var + epsilon)
-        if scale:
-            mul = mul * jnp.asarray(self.param("gamma", (features,), scale_init), dtype)
+        mean2 = jnp.mean(jax.lax.square(x), axis=-1, keepdims=True)
+        var = mean2 - jax.lax.square(mean)
+        mul = jax.lax.rsqrt(var + self.epsilon)
+        if self.scale:
+            mul = mul * jnp.asarray(self.param("gamma", self.scale_init, (features,)), 
+                                    self.dtype)
         y = (x - mean) * mul
-        if bias:
-            y = y + jnp.asarray(self.param("beta", (features,), bias_init), dtype)
+        if self.bias:
+            y = y + jnp.asarray(self.param("beta", self.bias_init, (features,)),
+                                self.dtype)
         return y
 
 
@@ -86,79 +87,80 @@ class BertEmbedding(nn.Module):
     as Flax's one use 'embedding' for the parameter name
     and PyTorch use 'weight'
     """
+    vocab_size: int
+    hidden_size: int
+    emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1)
 
-    def apply(
-        self,
-        input,
-        vocab_size: int,
-        hidden_size: int,
-        emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1),
-    ):
-
-        embedding = self.param("weight", (vocab_size, hidden_size), emb_init)
-        return jnp.take(embedding, input, axis=0)
+    @compact
+    def __call__(self, inputs):
+        embedding = self.param("weight", self.emb_init, (self.vocab_size, self.hidden_size))
+        return jnp.take(embedding, inputs, axis=0)
 
 
 class BertEmbeddings(nn.Module):
-    def apply(
-        self,
-        input_ids,
-        token_type_ids,
-        position_ids,
-        attention_mask,
-        vocab_size: int,
-        hidden_size: int,
-        type_vocab_size: int,
-        max_length: int,
-    ):
+    vocab_size: int
+    hidden_size: int
+    type_vocab_size: int
+    max_length: int
+
+    @compact
+    def __call__(self, input_ids, token_type_ids, position_ids, attention_mask):
 
         # Embed
-        w_emb = BertEmbedding(jnp.atleast_2d(input_ids.astype("i4")), vocab_size, hidden_size, name="word_embeddings")
-        p_emb = BertEmbedding(
-            jnp.atleast_2d(position_ids.astype("i4")), max_length, hidden_size, name="position_embeddings"
-        )
-        t_emb = BertEmbedding(
-            jnp.atleast_2d(token_type_ids.astype("i4")), type_vocab_size, hidden_size, name="token_type_embeddings"
-        )
+        w_emb = BertEmbedding(self.vocab_size, self.hidden_size, name="word_embeddings")(jnp.atleast_2d(input_ids.astype("i4")))
+        p_emb = BertEmbedding(self.max_length, self.hidden_size, name="position_embeddings")(jnp.atleast_2d(position_ids.astype("i4")))
+        t_emb = BertEmbedding(self.type_vocab_size, self.hidden_size, name="token_type_embeddings")(jnp.atleast_2d(token_type_ids.astype("i4")))
 
         # Sum all embeddings
         summed_emb = w_emb + jnp.broadcast_to(p_emb, w_emb.shape) + t_emb
 
         # Layer Norm
-        norm = BertLayerNorm(summed_emb, name="layer_norm")
+        layer_norm = BertLayerNorm(name="layer_norm")(summed_emb)
 
-        return norm
+        return layer_norm
 
 
 class BertAttention(nn.Module):
-    def apply(self, hidden_state, attention_mask, num_heads: int, head_size: int):
-        self_att = nn.attention.SelfAttention(
-            hidden_state, num_heads=num_heads, qkv_features=head_size, padding_mask=attention_mask, name="self"
-        )
+    num_heads: int
+    head_size: int
 
-        return BertLayerNorm(self_att + hidden_state, name="layer_norm")
+    @compact
+    def __call__(self, hidden_state, attention_mask):
+        self_att = nn.attention.SelfAttention(
+            num_heads=self.num_heads, qkv_features=self.head_size, name="self")(hidden_state, attention_mask)
+
+        layer_norm = BertLayerNorm(name="layer_norm")(self_att + hidden_state)
+        return layer_norm
 
 
 class BertIntermediate(nn.Module):
-    def apply(self, hidden_state, output_size: int):
+    output_size: int
+
+    @compact
+    def __call__(self, hidden_state):
         # TODO: Add ACT2FN reference to change activation function
-        h = nn.Dense(hidden_state, features=output_size, name="dense")
-        return gelu(h)
+        dense = nn.Dense(features=self.output_size, name="dense")(hidden_state)
+        return gelu(dense)
 
 
 class BertOutput(nn.Module):
-    def apply(self, intermediate_output, attention_output):
-        h = nn.Dense(intermediate_output, attention_output.shape[-1], name="dense")
-        h = BertLayerNorm(h + attention_output, name="layer_norm")
-
+    @compact
+    def __call__(self, intermediate_output, attention_output):
+        h = nn.Dense(attention_output.shape[-1], name="dense")(intermediate_output)
+        h = BertLayerNorm(name="layer_norm")(h + attention_output)
         return h
 
 
 class BertLayer(nn.Module):
-    def apply(self, hidden_state, attention_mask, num_heads: int, head_size: int, intermediate_size: int):
-        attention = BertAttention(hidden_state, attention_mask, num_heads, head_size, name="attention")
-        intermediate = BertIntermediate(attention, intermediate_size, name="intermediate")
-        output = BertOutput(intermediate, attention, name="output")
+    num_heads: int
+    head_size: int
+    intermediate_size: int
+
+    @compact
+    def __call__(self, hidden_state, attention_mask):
+        attention = BertAttention(self.num_heads, self.head_size, name="attention")(hidden_state, attention_mask)
+        intermediate = BertIntermediate(self.intermediate_size, name="intermediate")(attention)
+        output = BertOutput(name="output")(intermediate, attention)
 
         return output
 
@@ -167,75 +169,71 @@ class BertLayerCollection(nn.Module):
     """
     Stores N BertLayer(s)
     """
+    num_layers: int
+    num_heads: int
+    head_size: int
+    intermediate_size: int
 
-    def apply(self, input, attention_mask, num_layers: int, num_heads: int, head_size: int, intermediate_size: int):
-        assert num_layers > 0, "num_layers should be >= 1, got ({})".format(num_layers)
+    @compact
+    def __call__(self, inputs, attention_mask):
+        assert self.num_layers > 0, "num_layers should be >= 1, got ({})".format(self.num_layers)
 
         # Initialize input / output
-        input_i = output_i = input
+        input_i = output_i = inputs
 
         # Forward over all encoders
-        for i in range(num_layers):
-            output_i = BertLayer(input_i, attention_mask, num_heads, head_size, intermediate_size, name="{}".format(i))
+        for i in range(self.num_layers):
+            layer = BertLayer(self.num_heads, self.head_size, self.intermediate_size, name="{}".format(i))
+            output_i = layer(input_i, attention_mask)
             input_i = output_i
         return output_i
 
 
 class BertEncoder(nn.Module):
-    def apply(
-        self, hidden_state, attention_mask, num_layers: int, num_heads: int, head_size: int, intermediate_size: int
-    ):
-        encodings = BertLayerCollection(
-            hidden_state, attention_mask, num_layers, num_heads, head_size, intermediate_size, name="layer"
-        )
-        return encodings
+    num_layers: int
+    num_heads: int
+    head_size: int
+    intermediate_size: int
+
+    @compact
+    def __call__(self, hidden_state, attention_mask):
+        layer = BertLayerCollection(self.num_layers, self.num_heads, self.head_size, 
+            self.intermediate_size, name="layer")(hidden_state, attention_mask)
+        return layer
 
 
 class BertPooler(nn.Module):
-    def apply(self, hidden_state):
+    @compact
+    def __call__(self, hidden_state):
         first_token = hidden_state[:, 0]
-        out = nn.Dense(first_token, hidden_state.shape[-1], name="dense")
+        out = nn.Dense(hidden_state.shape[-1], name="dense")(first_token)
         return jax.lax.tanh(out)
 
 
 class BertModel(nn.Module):
-    def apply(
-        self,
-        input_ids,
-        token_type_ids,
-        position_ids,
-        attention_mask,
-        vocab_size: int,
-        hidden_size: int,
-        type_vocab_size: int,
-        max_length: int,
-        num_encoder_layers: int,
-        num_heads: int,
-        head_size: int,
-        intermediate_size: int,
-        padding_idx: int,
-        emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1),
-    ):
+    vocab_size: int
+    hidden_size: int
+    type_vocab_size: int
+    max_length: int
+    num_encoder_layers: int
+    num_heads: int
+    head_size: int
+    intermediate_size: int
+    padding_idx: int
+    emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1)
+
+    @compact
+    def __call__(self, input_ids, token_type_ids, position_ids, attention_mask):
 
         # Embedding
-        embeddings = BertEmbeddings(
-            input_ids,
-            token_type_ids,
-            position_ids,
-            attention_mask,
-            vocab_size,
-            hidden_size,
-            type_vocab_size,
-            max_length,
-            name="embeddings",
-        )
+        embeddings = BertEmbeddings(self.vocab_size, self.hidden_size, self.type_vocab_size,
+            self.max_length, name="embeddings")(input_ids, token_type_ids, position_ids, attention_mask)
 
         # N stacked encoding layers
-        encoder = BertEncoder(
-            embeddings, attention_mask, num_encoder_layers, num_heads, head_size, intermediate_size, name="encoder"
-        )
+        encoder = BertEncoder(self.num_encoder_layers, self.num_heads, self.head_size, 
+            self.intermediate_size, name="encoder")(embeddings, attention_mask)
 
-        pooled = BertPooler(encoder, name="pooler")
+        pooled = BertPooler(name="pooler")(encoder)
         return encoder, pooled
 
 
@@ -257,7 +255,7 @@ class FlaxBertModel(FlaxPreTrainedModel):
             # Key parts
             key_parts = set(key.split("."))
 
-            # Every dense layer have a "kernel" parameters instead of "weight"
+            # Every dense layer has "kernel" parameters instead of "weight"
             if "dense.weight" in key:
                 del jax_state[key]
                 key = key.replace("weight", "kernel")
@@ -318,7 +316,7 @@ class FlaxBertModel(FlaxPreTrainedModel):
         return jax_state
 
     def __init__(self, config: BertConfig, state: dict, seed: int = 0, **kwargs):
-        model_def = BertModel.partial(
+        model = BertModel(
             vocab_size=config.vocab_size,
             hidden_size=config.hidden_size,
             type_vocab_size=config.type_vocab_size,
@@ -330,7 +328,7 @@ class FlaxBertModel(FlaxPreTrainedModel):
             padding_idx=config.pad_token_id,
         )
 
-        super().__init__(config, model_def, state, seed)
+        super().__init__(config, model, state, seed)
 
     @property
     def module(self) -> BertModel:
@@ -343,11 +341,12 @@ class FlaxBertModel(FlaxPreTrainedModel):
     def __call__(self, input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
         @jax.jit
         def predict(input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
-            return self.model(
+            return self.model.apply(
+                {"param": self.params},
                 jnp.array(input_ids, dtype="i4"),
                 jnp.array(token_type_ids, dtype="i4"),
                 jnp.array(position_ids, dtype="i4"),
-                jnp.array(attention_mask, dtype="i4"),
+                jnp.array(attention_mask, dtype="i4")
             )
 
         if token_type_ids is None:

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -211,7 +211,7 @@ class BertModel(nn.Module):
         return encoder, pooled
 
 
-class FXBertModel:
+class FlaxBertModel:
     """
     BERT implementation using JAX/Flax as backend
     """
@@ -253,7 +253,7 @@ class FXBertModel:
 if __name__ == '__main__':
     tokenizer = BertTokenizerFast.from_pretrained("bert-base-cased")
     model_pt = PTBertModel.from_pretrained('bert-base-cased')
-    model = FXBertModel(model_pt.config)
+    model = FlaxBertModel(model_pt.config)
     model_pt.eval()
 
     with open("/data/Downloads/bert-base-cased-pytorch_model.bin", 'rb') as model_f:
@@ -290,5 +290,8 @@ if __name__ == '__main__':
     # Forward
     model_pt.eval()
     pt_enc = model_pt(pt_input['input_ids'], pt_input['attention_mask'])
+    flax_enc = model(**flax_input)
+
+    flax_input = tokenizer.encode_plus("My name is Morgan and this sentence is longer")
     flax_enc = model(**flax_input)
     input()

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -1,3 +1,4 @@
+import jax
 import jax.numpy as jnp
 import flax.nn as nn
 import numpy as np
@@ -142,11 +143,16 @@ class FXBertModel:
         # inputs_shape = [(1, len(input_ids))] * 3
         # _ = model_def.init_by_shape(self.key, inputs_shape)
         bert = Model(model_def, self.state)
-        return bert(
-            jnp.array(input_ids, dtype='i4'),
-            jnp.array(token_type_ids, dtype='i4'),
-            jnp.array(attention_mask, dtype='i4')
-        )
+
+        @jax.jit
+        def predict(input_ids, token_type_ids, attention_mask):
+            return bert(
+                jnp.array(input_ids, dtype='i4'),
+                jnp.array(token_type_ids, dtype='i4'),
+                jnp.array(attention_mask, dtype='i4')
+            )
+
+        return predict(input_ids, token_type_ids, attention_mask)
 
     def from_pretrained(self, state):
         self.state = from_state_dict(BertModel, state)

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -246,7 +246,7 @@ class FXBertModel:
 
         bert = nn.Model(model_def, self.state)
 
-        # @jax.jit
+        @jax.jit
         def predict(input_ids, token_type_ids, attention_mask):
             return bert(
                 jnp.array(input_ids, dtype='i4'),

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -286,7 +286,7 @@ class FlaxBertModel(FlaxPreTrainedModel):
 
         return jax_state
 
-    def __init__(self, config: BertConfig, state: dict, **kwargs):
+    def __init__(self, config: BertConfig, state: dict, seed: int, **kwargs):
         model_def = BertModel.partial(
             vocab_size=config.vocab_size,
             hidden_size=config.hidden_size,
@@ -296,10 +296,10 @@ class FlaxBertModel(FlaxPreTrainedModel):
             num_heads=config.num_attention_heads,
             head_size=config.hidden_size,
             intermediate_size=config.intermediate_size,
-            padding_idx=config.pad_token_id
+            padding_idx=config.pad_token_id,
         )
 
-        super().__init__(config, model_def, state)
+        super().__init__(config, model_def, state, seed)
 
     @property
     def module(self) -> BertModel:

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -277,7 +277,7 @@ class FlaxBertModel(JaxPreTrainedModel):
                 token_type_ids = np.ones_like(input_ids)
 
             if position_ids is None:
-                position_ids = np.arange(np.atleast_2d(input_ids.shape[-1]))
+                position_ids = np.arange(np.atleast_2d(input_ids).shape[-1])
 
             if attention_mask is None:
                 attention_mask = np.ones_like(input_ids)
@@ -289,7 +289,7 @@ class FlaxBertModel(JaxPreTrainedModel):
                 jnp.array(attention_mask, dtype='i4')
             )
 
-        return predict(input_ids, token_type_ids, attention_mask)
+        return predict(input_ids, token_type_ids, position_ids, attention_mask)
 
     def save_pretrained(self, folder):
         folder_abs = os.path.abspath(folder)

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -245,7 +245,7 @@ class FlaxBertModel(JaxPreTrainedModel):
     BERT implementation using JAX/Flax as backend
     """
 
-    MODEL_CLASS = BertModel
+    model_class = BertModel
     config_class = BertConfig
     pretrained_model_archive_map = BERT_PRETRAINED_MODEL_ARCHIVE_MAP
     base_model_prefix = "bert"
@@ -300,23 +300,3 @@ class FlaxBertModel(JaxPreTrainedModel):
         with open(os.path.join(folder_abs, 'model.flax'), 'wb') as f:
             model_bytes = to_bytes(self._bert)
             f.write(model_bytes)
-
-
-if __name__ == '__main__':
-    MODEL = "bert-base-cased"
-    tokenizer = BertTokenizerFast.from_pretrained(MODEL)
-    model_pt = AutoModel.from_pretrained(MODEL)
-    model_pt.eval()
-
-    model = FlaxBertModel.from_pretrained(MODEL)
-
-    # Inputs
-    pt_input = tokenizer.batch_encode_plus(["My name is Morgan", "Test"], return_tensors="pt")
-    flax_input = {k: t.numpy() for k, t in pt_input.items()}
-
-    # Forward
-    model_pt.eval()
-    pt_enc = model_pt(pt_input['input_ids'], pt_input['attention_mask'])
-    flax_enc = model(**flax_input)
-
-    input()

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -7,15 +7,7 @@ import numpy as np
 
 from transformers import BertConfig
 from transformers.modeling_bert import BERT_PRETRAINED_MODEL_ARCHIVE_MAP
-from transformers.modeling_jax_utils import JaxPreTrainedModel
-
-
-ACT2FN = {
-    "gelu": nn.gelu,
-    "relu": nn.relu,
-    "swish": nn.swish,
-    "gelu_new": nn.gelu,
-}
+from transformers.modeling_flax_utils import FlaxPreTrainedModel
 
 
 @jax.jit
@@ -33,6 +25,14 @@ def gelu(x):
     <https://arxiv.org/abs/1606.08415>`_, section 2.
     """
     return x * 0.5 * (1. + jax.lax.erf(x / jnp.sqrt(2.)))
+
+
+ACT2FN = {
+    "gelu": gelu,
+    "relu": nn.relu,
+    "swish": nn.swish,
+    "gelu_new": gelu,
+}
 
 
 class BertLayerNorm(nn.Module):
@@ -209,7 +209,7 @@ class BertModel(nn.Module):
         return encoder, pooled
 
 
-class FlaxBertModel(JaxPreTrainedModel):
+class FlaxBertModel(FlaxPreTrainedModel):
     """
     BERT implementation using JAX/Flax as backend
     """

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -321,7 +321,7 @@ class FlaxBertModel(FlaxPreTrainedModel):
 
         return jax_state
 
-    def __init__(self, config: BertConfig, state: dict, seed: int, **kwargs):
+    def __init__(self, config: BertConfig, state: dict, seed: int = 0, **kwargs):
         model_def = BertModel.partial(
             vocab_size=config.vocab_size,
             hidden_size=config.hidden_size,

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -340,8 +340,8 @@ class FlaxBertModel(FlaxPreTrainedModel):
     def config(self) -> BertConfig:
         return self._config
 
-    @jax.jit
     def __call__(self, input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
+        @jax.jit
         def predict(input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
             return self.model(
                 jnp.array(input_ids, dtype="i4"),

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -158,7 +158,7 @@ class BertOutput(nn.Module):
 class BertLayer(nn.Module):
     def apply(self, hidden_state, attention_mask, num_heads: int, head_size: int, intermediate_size: int):
         attention = BertAttention(
-            hidden_state, attention_mask, num_heads, head_size, intermediate_size, name="attention"
+            hidden_state, attention_mask, num_heads, head_size, name="attention"
         )
         intermediate = BertIntermediate(attention, intermediate_size, name="intermediate")
         output = BertOutput(intermediate, attention, name="output")

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -342,8 +342,8 @@ class FlaxBertModel(FlaxPreTrainedModel):
     def config(self) -> BertConfig:
         return self._config
 
+    @jax.jit
     def __call__(self, input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
-        @jax.jit
         def predict(input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
             return self.model(
                 jnp.array(input_ids, dtype="i4"),

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -157,9 +157,7 @@ class BertOutput(nn.Module):
 
 class BertLayer(nn.Module):
     def apply(self, hidden_state, attention_mask, num_heads: int, head_size: int, intermediate_size: int):
-        attention = BertAttention(
-            hidden_state, attention_mask, num_heads, head_size, name="attention"
-        )
+        attention = BertAttention(hidden_state, attention_mask, num_heads, head_size, name="attention")
         intermediate = BertIntermediate(attention, intermediate_size, name="intermediate")
         output = BertOutput(intermediate, attention, name="output")
 

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -6,7 +6,6 @@ import flax.nn as nn
 import jax
 import jax.numpy as jnp
 from transformers import BertConfig
-from transformers.modeling_bert import BERT_PRETRAINED_MODEL_ARCHIVE_MAP
 from transformers.modeling_flax_utils import FlaxPreTrainedModel
 
 
@@ -247,7 +246,6 @@ class FlaxBertModel(FlaxPreTrainedModel):
 
     model_class = BertModel
     config_class = BertConfig
-    pretrained_model_archive_map = BERT_PRETRAINED_MODEL_ARCHIVE_MAP
     base_model_prefix = "bert"
 
     @staticmethod
@@ -362,3 +360,8 @@ class FlaxBertModel(FlaxPreTrainedModel):
             attention_mask = np.ones_like(input_ids)
 
         return predict(input_ids, token_type_ids, position_ids, attention_mask)
+
+
+if __name__ == '__main__':
+    model = FlaxBertModel.from_pretrained("bert-base-cased")
+    input()

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -362,6 +362,6 @@ class FlaxBertModel(FlaxPreTrainedModel):
         return predict(input_ids, token_type_ids, position_ids, attention_mask)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     model = FlaxBertModel.from_pretrained("bert-base-cased")
     input()

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -6,7 +6,7 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 from flax.linen import compact
-from transformers import BertConfig, AutoTokenizer, TensorType
+from transformers import AutoTokenizer, BertConfig, TensorType
 from transformers.modeling_flax_utils import FlaxPreTrainedModel
 
 
@@ -334,7 +334,6 @@ class FlaxBertModel(FlaxPreTrainedModel):
             num_heads=config.num_attention_heads,
             head_size=config.hidden_size,
             intermediate_size=config.intermediate_size,
-            padding_idx=config.pad_token_id,
         )
 
         super().__init__(config, model, state, seed)

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -6,7 +6,7 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 from flax.linen import compact
-from transformers import AutoTokenizer, BertConfig, TensorType
+from transformers import BertConfig
 from transformers.modeling_flax_utils import FlaxPreTrainedModel
 
 

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -228,8 +228,6 @@ class BertModule(nn.Module):
     num_heads: int
     head_size: int
     intermediate_size: int
-    padding_idx: int
-    emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1)
 
     @compact
     def __call__(self, input_ids, token_type_ids, position_ids, attention_mask):

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -28,7 +28,7 @@ def gelu(x):
 
 
 ACT2FN = {
-    "gelu": gelu,
+    "gelu": nn.gelu,
     "relu": nn.relu,
     "swish": nn.swish,
     "gelu_new": gelu,

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -69,9 +69,9 @@ class BertLayerNorm(nn.Module):
         """
         features = x.shape[-1]
         mean = jnp.mean(x, axis=-1, keepdims=True)
-        mean2 = jnp.mean(jnp.lax.square(x), axis=-1, keepdims=True)
-        var = mean2 - jnp.lax.square(mean)
-        mul = jnp.lax.rsqrt(var + epsilon)
+        mean2 = jnp.mean(jax.lax.square(x), axis=-1, keepdims=True)
+        var = mean2 - jax.lax.square(mean)
+        mul = jax.lax.rsqrt(var + epsilon)
         if scale:
             mul = mul * jnp.asarray(self.param("gamma", (features,), scale_init), dtype)
         y = (x - mean) * mul

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -2,8 +2,7 @@ from typing import Callable, Dict
 
 import numpy as np
 
-import flax.linen as nn
-from flax.linen import compact
+import flax.nn as nn
 import jax
 import jax.numpy as jnp
 from transformers import BertConfig
@@ -39,15 +38,17 @@ class BertLayerNorm(nn.Module):
     """Layer normalization (https://arxiv.org/abs/1607.06450).
     Operates on the last axis of the input data.
     """
-    epsilon: float = 1e-6
-    dtype: jnp.dtype = jnp.float32
-    bias: bool = True
-    scale: bool = True
-    bias_init: jnp.ndarray = nn.initializers.zeros
-    scale_init: jnp.ndarray = nn.initializers.ones
 
-    @compact
-    def __call__(self, x):
+    def apply(
+        self,
+        x,
+        epsilon=1e-6,
+        dtype=jnp.float32,
+        bias=True,
+        scale=True,
+        bias_init=nn.initializers.zeros,
+        scale_init=nn.initializers.ones,
+    ):
         """Applies layer normalization on the input.
         It normalizes the activations of the layer for each given example in a
         batch independently, rather than across a batch like Batch Normalization.
@@ -68,16 +69,14 @@ class BertLayerNorm(nn.Module):
         """
         features = x.shape[-1]
         mean = jnp.mean(x, axis=-1, keepdims=True)
-        mean2 = jnp.mean(jax.lax.square(x), axis=-1, keepdims=True)
-        var = mean2 - jax.lax.square(mean)
-        mul = jax.lax.rsqrt(var + self.epsilon)
-        if self.scale:
-            mul = mul * jnp.asarray(self.param("gamma", self.scale_init, (features,)), 
-                                    self.dtype)
+        mean2 = jnp.mean(jnp.lax.square(x), axis=-1, keepdims=True)
+        var = mean2 - jnp.lax.square(mean)
+        mul = jnp.lax.rsqrt(var + epsilon)
+        if scale:
+            mul = mul * jnp.asarray(self.param("gamma", (features,), scale_init), dtype)
         y = (x - mean) * mul
-        if self.bias:
-            y = y + jnp.asarray(self.param("beta", self.bias_init, (features,)),
-                                self.dtype)
+        if bias:
+            y = y + jnp.asarray(self.param("beta", (features,), bias_init), dtype)
         return y
 
 
@@ -87,80 +86,79 @@ class BertEmbedding(nn.Module):
     as Flax's one use 'embedding' for the parameter name
     and PyTorch use 'weight'
     """
-    vocab_size: int
-    hidden_size: int
-    emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1)
 
-    @compact
-    def __call__(self, inputs):
-        embedding = self.param("weight", self.emb_init, (self.vocab_size, self.hidden_size))
-        return jnp.take(embedding, inputs, axis=0)
+    def apply(
+        self,
+        input,
+        vocab_size: int,
+        hidden_size: int,
+        emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1),
+    ):
+
+        embedding = self.param("weight", (vocab_size, hidden_size), emb_init)
+        return jnp.take(embedding, input, axis=0)
 
 
 class BertEmbeddings(nn.Module):
-    vocab_size: int
-    hidden_size: int
-    type_vocab_size: int
-    max_length: int
-
-    @compact
-    def __call__(self, input_ids, token_type_ids, position_ids, attention_mask):
+    def apply(
+        self,
+        input_ids,
+        token_type_ids,
+        position_ids,
+        attention_mask,
+        vocab_size: int,
+        hidden_size: int,
+        type_vocab_size: int,
+        max_length: int,
+    ):
 
         # Embed
-        w_emb = BertEmbedding(self.vocab_size, self.hidden_size, name="word_embeddings")(jnp.atleast_2d(input_ids.astype("i4")))
-        p_emb = BertEmbedding(self.max_length, self.hidden_size, name="position_embeddings")(jnp.atleast_2d(position_ids.astype("i4")))
-        t_emb = BertEmbedding(self.type_vocab_size, self.hidden_size, name="token_type_embeddings")(jnp.atleast_2d(token_type_ids.astype("i4")))
+        w_emb = BertEmbedding(jnp.atleast_2d(input_ids.astype("i4")), vocab_size, hidden_size, name="word_embeddings")
+        p_emb = BertEmbedding(
+            jnp.atleast_2d(position_ids.astype("i4")), max_length, hidden_size, name="position_embeddings"
+        )
+        t_emb = BertEmbedding(
+            jnp.atleast_2d(token_type_ids.astype("i4")), type_vocab_size, hidden_size, name="token_type_embeddings"
+        )
 
         # Sum all embeddings
         summed_emb = w_emb + jnp.broadcast_to(p_emb, w_emb.shape) + t_emb
 
         # Layer Norm
-        layer_norm = BertLayerNorm(name="layer_norm")(summed_emb)
+        norm = BertLayerNorm(summed_emb, name="layer_norm")
 
-        return layer_norm
+        return norm
 
 
 class BertAttention(nn.Module):
-    num_heads: int
-    head_size: int
-
-    @compact
-    def __call__(self, hidden_state, attention_mask):
+    def apply(self, hidden_state, attention_mask, num_heads: int, head_size: int):
         self_att = nn.attention.SelfAttention(
-            num_heads=self.num_heads, qkv_features=self.head_size, name="self")(hidden_state, attention_mask)
+            hidden_state, num_heads=num_heads, qkv_features=head_size, padding_mask=attention_mask, name="self"
+        )
 
-        layer_norm = BertLayerNorm(name="layer_norm")(self_att + hidden_state)
-        return layer_norm
+        return BertLayerNorm(self_att + hidden_state, name="layer_norm")
 
 
 class BertIntermediate(nn.Module):
-    output_size: int
-
-    @compact
-    def __call__(self, hidden_state):
+    def apply(self, hidden_state, output_size: int):
         # TODO: Add ACT2FN reference to change activation function
-        dense = nn.Dense(features=self.output_size, name="dense")(hidden_state)
-        return gelu(dense)
+        h = nn.Dense(hidden_state, features=output_size, name="dense")
+        return gelu(h)
 
 
 class BertOutput(nn.Module):
-    @compact
-    def __call__(self, intermediate_output, attention_output):
-        h = nn.Dense(attention_output.shape[-1], name="dense")(intermediate_output)
-        h = BertLayerNorm(name="layer_norm")(h + attention_output)
+    def apply(self, intermediate_output, attention_output):
+        h = nn.Dense(intermediate_output, attention_output.shape[-1], name="dense")
+        h = BertLayerNorm(h + attention_output, name="layer_norm")
+
         return h
 
 
 class BertLayer(nn.Module):
-    num_heads: int
-    head_size: int
-    intermediate_size: int
-
-    @compact
-    def __call__(self, hidden_state, attention_mask):
-        attention = BertAttention(self.num_heads, self.head_size, name="attention")(hidden_state, attention_mask)
-        intermediate = BertIntermediate(self.intermediate_size, name="intermediate")(attention)
-        output = BertOutput(name="output")(intermediate, attention)
+    def apply(self, hidden_state, attention_mask, num_heads: int, head_size: int, intermediate_size: int):
+        attention = BertAttention(hidden_state, attention_mask, num_heads, head_size, name="attention")
+        intermediate = BertIntermediate(attention, intermediate_size, name="intermediate")
+        output = BertOutput(intermediate, attention, name="output")
 
         return output
 
@@ -169,71 +167,75 @@ class BertLayerCollection(nn.Module):
     """
     Stores N BertLayer(s)
     """
-    num_layers: int
-    num_heads: int
-    head_size: int
-    intermediate_size: int
 
-    @compact
-    def __call__(self, inputs, attention_mask):
-        assert self.num_layers > 0, "num_layers should be >= 1, got ({})".format(self.num_layers)
+    def apply(self, input, attention_mask, num_layers: int, num_heads: int, head_size: int, intermediate_size: int):
+        assert num_layers > 0, "num_layers should be >= 1, got ({})".format(num_layers)
 
         # Initialize input / output
-        input_i = output_i = inputs
+        input_i = output_i = input
 
         # Forward over all encoders
-        for i in range(self.num_layers):
-            layer = BertLayer(self.num_heads, self.head_size, self.intermediate_size, name="{}".format(i))
-            output_i = layer(input_i, attention_mask)
+        for i in range(num_layers):
+            output_i = BertLayer(input_i, attention_mask, num_heads, head_size, intermediate_size, name="{}".format(i))
             input_i = output_i
         return output_i
 
 
 class BertEncoder(nn.Module):
-    num_layers: int
-    num_heads: int
-    head_size: int
-    intermediate_size: int
-
-    @compact
-    def __call__(self, hidden_state, attention_mask):
-        layer = BertLayerCollection(self.num_layers, self.num_heads, self.head_size, 
-            self.intermediate_size, name="layer")(hidden_state, attention_mask)
-        return layer
+    def apply(
+        self, hidden_state, attention_mask, num_layers: int, num_heads: int, head_size: int, intermediate_size: int
+    ):
+        encodings = BertLayerCollection(
+            hidden_state, attention_mask, num_layers, num_heads, head_size, intermediate_size, name="layer"
+        )
+        return encodings
 
 
 class BertPooler(nn.Module):
-    @compact
-    def __call__(self, hidden_state):
+    def apply(self, hidden_state):
         first_token = hidden_state[:, 0]
-        out = nn.Dense(hidden_state.shape[-1], name="dense")(first_token)
+        out = nn.Dense(first_token, hidden_state.shape[-1], name="dense")
         return jax.lax.tanh(out)
 
 
 class BertModel(nn.Module):
-    vocab_size: int
-    hidden_size: int
-    type_vocab_size: int
-    max_length: int
-    num_encoder_layers: int
-    num_heads: int
-    head_size: int
-    intermediate_size: int
-    padding_idx: int
-    emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1)
-
-    @compact
-    def __call__(self, input_ids, token_type_ids, position_ids, attention_mask):
+    def apply(
+        self,
+        input_ids,
+        token_type_ids,
+        position_ids,
+        attention_mask,
+        vocab_size: int,
+        hidden_size: int,
+        type_vocab_size: int,
+        max_length: int,
+        num_encoder_layers: int,
+        num_heads: int,
+        head_size: int,
+        intermediate_size: int,
+        padding_idx: int,
+        emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1),
+    ):
 
         # Embedding
-        embeddings = BertEmbeddings(self.vocab_size, self.hidden_size, self.type_vocab_size,
-            self.max_length, name="embeddings")(input_ids, token_type_ids, position_ids, attention_mask)
+        embeddings = BertEmbeddings(
+            input_ids,
+            token_type_ids,
+            position_ids,
+            attention_mask,
+            vocab_size,
+            hidden_size,
+            type_vocab_size,
+            max_length,
+            name="embeddings",
+        )
 
         # N stacked encoding layers
-        encoder = BertEncoder(self.num_encoder_layers, self.num_heads, self.head_size, 
-            self.intermediate_size, name="encoder")(embeddings, attention_mask)
+        encoder = BertEncoder(
+            embeddings, attention_mask, num_encoder_layers, num_heads, head_size, intermediate_size, name="encoder"
+        )
 
-        pooled = BertPooler(name="pooler")(encoder)
+        pooled = BertPooler(encoder, name="pooler")
         return encoder, pooled
 
 
@@ -255,7 +257,7 @@ class FlaxBertModel(FlaxPreTrainedModel):
             # Key parts
             key_parts = set(key.split("."))
 
-            # Every dense layer has "kernel" parameters instead of "weight"
+            # Every dense layer have a "kernel" parameters instead of "weight"
             if "dense.weight" in key:
                 del jax_state[key]
                 key = key.replace("weight", "kernel")
@@ -316,7 +318,7 @@ class FlaxBertModel(FlaxPreTrainedModel):
         return jax_state
 
     def __init__(self, config: BertConfig, state: dict, seed: int = 0, **kwargs):
-        model = BertModel(
+        model_def = BertModel.partial(
             vocab_size=config.vocab_size,
             hidden_size=config.hidden_size,
             type_vocab_size=config.type_vocab_size,
@@ -328,7 +330,7 @@ class FlaxBertModel(FlaxPreTrainedModel):
             padding_idx=config.pad_token_id,
         )
 
-        super().__init__(config, model, state, seed)
+        super().__init__(config, model_def, state, seed)
 
     @property
     def module(self) -> BertModel:
@@ -341,12 +343,11 @@ class FlaxBertModel(FlaxPreTrainedModel):
     def __call__(self, input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
         @jax.jit
         def predict(input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
-            return self.model.apply(
-                {"param": self.params},
+            return self.model(
                 jnp.array(input_ids, dtype="i4"),
                 jnp.array(token_type_ids, dtype="i4"),
                 jnp.array(position_ids, dtype="i4"),
-                jnp.array(attention_mask, dtype="i4")
+                jnp.array(attention_mask, dtype="i4"),
             )
 
         if token_type_ids is None:

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -2,7 +2,8 @@ from typing import Callable, Dict
 
 import numpy as np
 
-import flax.nn as nn
+import flax.linen as nn
+from flax.linen import compact
 import jax
 import jax.numpy as jnp
 from transformers import BertConfig
@@ -38,17 +39,15 @@ class BertLayerNorm(nn.Module):
     """Layer normalization (https://arxiv.org/abs/1607.06450).
     Operates on the last axis of the input data.
     """
+    epsilon: float = 1e-6
+    dtype: jnp.dtype = jnp.float32
+    bias: bool = True
+    scale: bool = True
+    bias_init: jnp.ndarray = nn.initializers.zeros
+    scale_init: jnp.ndarray = nn.initializers.ones
 
-    def apply(
-        self,
-        x,
-        epsilon=1e-6,
-        dtype=jnp.float32,
-        bias=True,
-        scale=True,
-        bias_init=nn.initializers.zeros,
-        scale_init=nn.initializers.ones,
-    ):
+    @compact
+    def __call__(self, x):
         """Applies layer normalization on the input.
         It normalizes the activations of the layer for each given example in a
         batch independently, rather than across a batch like Batch Normalization.
@@ -71,12 +70,14 @@ class BertLayerNorm(nn.Module):
         mean = jnp.mean(x, axis=-1, keepdims=True)
         mean2 = jnp.mean(jax.lax.square(x), axis=-1, keepdims=True)
         var = mean2 - jax.lax.square(mean)
-        mul = jax.lax.rsqrt(var + epsilon)
-        if scale:
-            mul = mul * jnp.asarray(self.param("gamma", (features,), scale_init), dtype)
+        mul = jax.lax.rsqrt(var + self.epsilon)
+        if self.scale:
+            mul = mul * jnp.asarray(self.param("gamma", self.scale_init, (features,)),
+                                    self.dtype)
         y = (x - mean) * mul
-        if bias:
-            y = y + jnp.asarray(self.param("beta", (features,), bias_init), dtype)
+        if self.bias:
+            y = y + jnp.asarray(self.param("beta", self.bias_init, (features,)),
+                                self.dtype)
         return y
 
 
@@ -86,79 +87,80 @@ class BertEmbedding(nn.Module):
     as Flax's one use 'embedding' for the parameter name
     and PyTorch use 'weight'
     """
+    vocab_size: int
+    hidden_size: int
+    emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1)
 
-    def apply(
-        self,
-        input,
-        vocab_size: int,
-        hidden_size: int,
-        emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1),
-    ):
-
-        embedding = self.param("weight", (vocab_size, hidden_size), emb_init)
-        return jnp.take(embedding, input, axis=0)
+    @compact
+    def __call__(self, inputs):
+        embedding = self.param("weight", self.emb_init, (self.vocab_size, self.hidden_size))
+        return jnp.take(embedding, inputs, axis=0)
 
 
 class BertEmbeddings(nn.Module):
-    def apply(
-        self,
-        input_ids,
-        token_type_ids,
-        position_ids,
-        attention_mask,
-        vocab_size: int,
-        hidden_size: int,
-        type_vocab_size: int,
-        max_length: int,
-    ):
+    vocab_size: int
+    hidden_size: int
+    type_vocab_size: int
+    max_length: int
+
+    @compact
+    def __call__(self, input_ids, token_type_ids, position_ids, attention_mask):
 
         # Embed
-        w_emb = BertEmbedding(jnp.atleast_2d(input_ids.astype("i4")), vocab_size, hidden_size, name="word_embeddings")
-        p_emb = BertEmbedding(
-            jnp.atleast_2d(position_ids.astype("i4")), max_length, hidden_size, name="position_embeddings"
-        )
-        t_emb = BertEmbedding(
-            jnp.atleast_2d(token_type_ids.astype("i4")), type_vocab_size, hidden_size, name="token_type_embeddings"
-        )
+        w_emb = BertEmbedding(self.vocab_size, self.hidden_size, name="word_embeddings")(jnp.atleast_2d(input_ids.astype("i4")))
+        p_emb = BertEmbedding(self.max_length, self.hidden_size, name="position_embeddings")(jnp.atleast_2d(position_ids.astype("i4")))
+        t_emb = BertEmbedding(self.type_vocab_size, self.hidden_size, name="token_type_embeddings")(jnp.atleast_2d(token_type_ids.astype("i4")))
 
         # Sum all embeddings
         summed_emb = w_emb + jnp.broadcast_to(p_emb, w_emb.shape) + t_emb
 
         # Layer Norm
-        norm = BertLayerNorm(summed_emb, name="layer_norm")
+        layer_norm = BertLayerNorm(name="layer_norm")(summed_emb)
 
-        return norm
+        return layer_norm
 
 
 class BertAttention(nn.Module):
-    def apply(self, hidden_state, attention_mask, num_heads: int, head_size: int):
-        self_att = nn.attention.SelfAttention(
-            hidden_state, num_heads=num_heads, qkv_features=head_size, padding_mask=attention_mask, name="self"
-        )
+    num_heads: int
+    head_size: int
 
-        return BertLayerNorm(self_att + hidden_state, name="layer_norm")
+    @compact
+    def __call__(self, hidden_state, attention_mask):
+        self_att = nn.attention.SelfAttention(
+            num_heads=self.num_heads, qkv_features=self.head_size, name="self")(hidden_state, attention_mask)
+
+        layer_norm = BertLayerNorm(name="layer_norm")(self_att + hidden_state)
+        return layer_norm
 
 
 class BertIntermediate(nn.Module):
-    def apply(self, hidden_state, output_size: int):
+    output_size: int
+
+    @compact
+    def __call__(self, hidden_state):
         # TODO: Add ACT2FN reference to change activation function
-        h = nn.Dense(hidden_state, features=output_size, name="dense")
-        return gelu(h)
+        dense = nn.Dense(features=self.output_size, name="dense")(hidden_state)
+        return gelu(dense)
 
 
 class BertOutput(nn.Module):
-    def apply(self, intermediate_output, attention_output):
-        h = nn.Dense(intermediate_output, attention_output.shape[-1], name="dense")
-        h = BertLayerNorm(h + attention_output, name="layer_norm")
-
+    @compact
+    def __call__(self, intermediate_output, attention_output):
+        h = nn.Dense(attention_output.shape[-1], name="dense")(intermediate_output)
+        h = BertLayerNorm(name="layer_norm")(h + attention_output)
         return h
 
 
 class BertLayer(nn.Module):
-    def apply(self, hidden_state, attention_mask, num_heads: int, head_size: int, intermediate_size: int):
-        attention = BertAttention(hidden_state, attention_mask, num_heads, head_size, name="attention")
-        intermediate = BertIntermediate(attention, intermediate_size, name="intermediate")
-        output = BertOutput(intermediate, attention, name="output")
+    num_heads: int
+    head_size: int
+    intermediate_size: int
+
+    @compact
+    def __call__(self, hidden_state, attention_mask):
+        attention = BertAttention(self.num_heads, self.head_size, name="attention")(hidden_state, attention_mask)
+        intermediate = BertIntermediate(self.intermediate_size, name="intermediate")(attention)
+        output = BertOutput(name="output")(intermediate, attention)
 
         return output
 
@@ -167,75 +169,71 @@ class BertLayerCollection(nn.Module):
     """
     Stores N BertLayer(s)
     """
+    num_layers: int
+    num_heads: int
+    head_size: int
+    intermediate_size: int
 
-    def apply(self, input, attention_mask, num_layers: int, num_heads: int, head_size: int, intermediate_size: int):
-        assert num_layers > 0, "num_layers should be >= 1, got ({})".format(num_layers)
+    @compact
+    def __call__(self, inputs, attention_mask):
+        assert self.num_layers > 0, "num_layers should be >= 1, got ({})".format(self.num_layers)
 
         # Initialize input / output
-        input_i = output_i = input
+        input_i = output_i = inputs
 
         # Forward over all encoders
-        for i in range(num_layers):
-            output_i = BertLayer(input_i, attention_mask, num_heads, head_size, intermediate_size, name="{}".format(i))
+        for i in range(self.num_layers):
+            layer = BertLayer(self.num_heads, self.head_size, self.intermediate_size, name="{}".format(i))
+            output_i = layer(input_i, attention_mask)
             input_i = output_i
         return output_i
 
 
 class BertEncoder(nn.Module):
-    def apply(
-        self, hidden_state, attention_mask, num_layers: int, num_heads: int, head_size: int, intermediate_size: int
-    ):
-        encodings = BertLayerCollection(
-            hidden_state, attention_mask, num_layers, num_heads, head_size, intermediate_size, name="layer"
-        )
-        return encodings
+    num_layers: int
+    num_heads: int
+    head_size: int
+    intermediate_size: int
+
+    @compact
+    def __call__(self, hidden_state, attention_mask):
+        layer = BertLayerCollection(self.num_layers, self.num_heads, self.head_size,
+            self.intermediate_size, name="layer")(hidden_state, attention_mask)
+        return layer
 
 
 class BertPooler(nn.Module):
-    def apply(self, hidden_state):
+    @compact
+    def __call__(self, hidden_state):
         first_token = hidden_state[:, 0]
-        out = nn.Dense(first_token, hidden_state.shape[-1], name="dense")
+        out = nn.Dense(hidden_state.shape[-1], name="dense")(first_token)
         return jax.lax.tanh(out)
 
 
 class BertModel(nn.Module):
-    def apply(
-        self,
-        input_ids,
-        token_type_ids,
-        position_ids,
-        attention_mask,
-        vocab_size: int,
-        hidden_size: int,
-        type_vocab_size: int,
-        max_length: int,
-        num_encoder_layers: int,
-        num_heads: int,
-        head_size: int,
-        intermediate_size: int,
-        padding_idx: int,
-        emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1),
-    ):
+    vocab_size: int
+    hidden_size: int
+    type_vocab_size: int
+    max_length: int
+    num_encoder_layers: int
+    num_heads: int
+    head_size: int
+    intermediate_size: int
+    padding_idx: int
+    emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1)
+
+    @compact
+    def __call__(self, input_ids, token_type_ids, position_ids, attention_mask):
 
         # Embedding
-        embeddings = BertEmbeddings(
-            input_ids,
-            token_type_ids,
-            position_ids,
-            attention_mask,
-            vocab_size,
-            hidden_size,
-            type_vocab_size,
-            max_length,
-            name="embeddings",
-        )
+        embeddings = BertEmbeddings(self.vocab_size, self.hidden_size, self.type_vocab_size,
+            self.max_length, name="embeddings")(input_ids, token_type_ids, position_ids, attention_mask)
 
         # N stacked encoding layers
-        encoder = BertEncoder(
-            embeddings, attention_mask, num_encoder_layers, num_heads, head_size, intermediate_size, name="encoder"
-        )
+        encoder = BertEncoder(self.num_encoder_layers, self.num_heads, self.head_size,
+            self.intermediate_size, name="encoder")(embeddings, attention_mask)
 
-        pooled = BertPooler(encoder, name="pooler")
+        pooled = BertPooler(name="pooler")(encoder)
         return encoder, pooled
 
 
@@ -257,7 +255,7 @@ class FlaxBertModel(FlaxPreTrainedModel):
             # Key parts
             key_parts = set(key.split("."))
 
-            # Every dense layer have a "kernel" parameters instead of "weight"
+            # Every dense layer has "kernel" parameters instead of "weight"
             if "dense.weight" in key:
                 del jax_state[key]
                 key = key.replace("weight", "kernel")
@@ -318,7 +316,7 @@ class FlaxBertModel(FlaxPreTrainedModel):
         return jax_state
 
     def __init__(self, config: BertConfig, state: dict, seed: int = 0, **kwargs):
-        model_def = BertModel.partial(
+        model = BertModel(
             vocab_size=config.vocab_size,
             hidden_size=config.hidden_size,
             type_vocab_size=config.type_vocab_size,
@@ -330,7 +328,7 @@ class FlaxBertModel(FlaxPreTrainedModel):
             padding_idx=config.pad_token_id,
         )
 
-        super().__init__(config, model_def, state, seed)
+        super().__init__(config, model, state, seed)
 
     @property
     def module(self) -> BertModel:
@@ -343,11 +341,12 @@ class FlaxBertModel(FlaxPreTrainedModel):
     def __call__(self, input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
         @jax.jit
         def predict(input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
-            return self.model(
+            return self.model.apply(
+                {"param": self.params},
                 jnp.array(input_ids, dtype="i4"),
                 jnp.array(token_type_ids, dtype="i4"),
                 jnp.array(position_ids, dtype="i4"),
-                jnp.array(attention_mask, dtype="i4"),
+                jnp.array(attention_mask, dtype="i4")
             )
 
         if token_type_ids is None:

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -357,7 +357,7 @@ class FlaxBertModel(FlaxPreTrainedModel):
             attention_mask = jnp.ones_like(input_ids)
 
         return self.model.apply(
-            {"param": self.params},
+            {"params": self.params},
             jnp.array(input_ids, dtype="i4"),
             jnp.array(token_type_ids, dtype="i4"),
             jnp.array(position_ids, dtype="i4"),

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -347,22 +347,20 @@ class FlaxBertModel(FlaxPreTrainedModel):
         return self._config
 
     def __call__(self, input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
-        def predict(input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
-            return self.model.apply(
-                {"param": self.params},
-                jnp.array(input_ids, dtype="i4"),
-                jnp.array(token_type_ids, dtype="i4"),
-                jnp.array(position_ids, dtype="i4"),
-                jnp.array(attention_mask, dtype="i4"),
-            )
-
         if token_type_ids is None:
-            token_type_ids = np.ones_like(input_ids)
+            token_type_ids = jnp.ones_like(input_ids)
 
         if position_ids is None:
-            position_ids = np.arange(np.atleast_2d(input_ids).shape[-1])
+            position_ids = jnp.arange(jnp.atleast_2d(input_ids).shape[-1])
 
         if attention_mask is None:
-            attention_mask = np.ones_like(input_ids)
+            attention_mask = jnp.ones_like(input_ids)
 
-        return predict(input_ids, token_type_ids, position_ids, attention_mask)
+        return self.model.apply(
+            {"param": self.params},
+            jnp.array(input_ids, dtype="i4"),
+            jnp.array(token_type_ids, dtype="i4"),
+            jnp.array(position_ids, dtype="i4"),
+            jnp.array(attention_mask, dtype="i4"),
+        )
+

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -363,4 +363,3 @@ class FlaxBertModel(FlaxPreTrainedModel):
             jnp.array(position_ids, dtype="i4"),
             jnp.array(attention_mask, dtype="i4"),
         )
-

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -221,8 +221,8 @@ class FlaxBertEncoder(nn.Module):
 class FlaxBertPooler(nn.Module):
     @compact
     def __call__(self, hidden_state):
-        first_token = hidden_state[:, 0]
-        out = nn.Dense(hidden_state.shape[-1], name="dense")(first_token)
+        cls_token = hidden_state[:, 0]
+        out = nn.Dense(hidden_state.shape[-1], name="dense")(cls_token)
         return jax.lax.tanh(out)
 
 

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -22,7 +22,7 @@ import jax
 import jax.numpy as jnp
 from flax.linen import compact
 from transformers import BertConfig
-from transformers.modeling_flax_utils import FlaxPreTrainedModel
+from transformers.modeling_flax_utils import FlaxPreTrainedModel, gelu
 from transformers.utils import logging
 
 

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -161,9 +161,9 @@ class FlaxBertIntermediate(nn.Module):
 class FlaxBertOutput(nn.Module):
     @compact
     def __call__(self, intermediate_output, attention_output):
-        h = nn.Dense(attention_output.shape[-1], name="dense")(intermediate_output)
-        h = FlaxBertLayerNorm(name="layer_norm")(h + attention_output)
-        return h
+        hidden_state = nn.Dense(attention_output.shape[-1], name="dense")(intermediate_output)
+        hidden_state = FlaxBertLayerNorm(name="layer_norm")(hidden_state + attention_output)
+        return hidden_state
 
 
 class FlaxBertLayer(nn.Module):

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -1,3 +1,18 @@
+# coding=utf-8
+# Copyright 2018 The Google Flax Team Authors and The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Callable, Dict
 
 import numpy as np

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -195,14 +195,13 @@ class FlaxBertLayerCollection(nn.Module):
         assert self.num_layers > 0, "num_layers should be >= 1, got ({})".format(self.num_layers)
 
         # Initialize input / output
-        input_i = output_i = inputs
+        input_i = inputs
 
         # Forward over all encoders
         for i in range(self.num_layers):
             layer = FlaxBertLayer(self.num_heads, self.head_size, self.intermediate_size, name="{}".format(i))
-            output_i = layer(input_i, attention_mask)
-            input_i = output_i
-        return output_i
+            input_i = layer(input_i, attention_mask)
+        return input_i
 
 
 class FlaxBertEncoder(nn.Module):

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -192,14 +192,14 @@ class FlaxBertLayerCollection(nn.Module):
 
     @compact
     def __call__(self, inputs, attention_mask):
-        assert self.num_layers > 0, "num_layers should be >= 1, got ({})".format(self.num_layers)
+        assert self.num_layers > 0, f"num_layers should be >= 1, got ({self.num_layers})"
 
         # Initialize input / output
         input_i = inputs
 
         # Forward over all encoders
         for i in range(self.num_layers):
-            layer = FlaxBertLayer(self.num_heads, self.head_size, self.intermediate_size, name="{}".format(i))
+            layer = FlaxBertLayer(self.num_heads, self.head_size, self.intermediate_size, name=f"{i}")
             input_i = layer(input_i, attention_mask)
         return input_i
 

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -26,30 +26,6 @@ from transformers.modeling_flax_utils import FlaxPreTrainedModel
 from transformers.utils import logging
 
 
-@jax.jit
-def gelu(x):
-    r"""Gaussian error linear unit activation function.
-
-    Computes the element-wise function:
-
-    .. math::
-      \mathrm{gelu}(x) = \frac{x}{2} \left(1 + \mathrm{tanh} \left(
-        \sqrt{\frac{2}{\pi}} \left(x + 0.044715 x^3 \right) \right) \right)
-
-    We explicitly use the approximation rather than the exact formulation for
-    speed. For more information, see `Gaussian Error Linear Units (GELUs)
-    <https://arxiv.org/abs/1606.08415>`_, section 2.
-    """
-    return x * 0.5 * (1.0 + jax.lax.erf(x / jnp.sqrt(2.0)))
-
-
-ACT2FN = {
-    "gelu": nn.gelu,
-    "relu": nn.relu,
-    "swish": nn.swish,
-    "gelu_new": gelu,
-}
-
 logger = logging.get_logger(__name__)
 
 _CONFIG_FOR_DOC = "BertConfig"

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -318,119 +318,119 @@ class FlaxBertModule(nn.Module):
     BERT_START_DOCSTRING,
 )
 class FlaxBertModel(FlaxPreTrainedModel):
-     """
-     The model can behave as an encoder (with only self-attention) as well
-     as a decoder, in which case a layer of cross-attention is added between
-     the self-attention layers, following the architecture described in `Attention is all you need
-     <https://arxiv.org/abs/1706.03762>`__ by Ashish Vaswani, Noam Shazeer, Niki Parmar, Jakob Uszkoreit, Llion Jones,
-     Aidan N. Gomez, Lukasz Kaiser and Illia Polosukhin.
-     """
+    """
+    The model can behave as an encoder (with only self-attention) as well
+    as a decoder, in which case a layer of cross-attention is added between
+    the self-attention layers, following the architecture described in `Attention is all you need
+    <https://arxiv.org/abs/1706.03762>`__ by Ashish Vaswani, Noam Shazeer, Niki Parmar, Jakob Uszkoreit, Llion Jones,
+    Aidan N. Gomez, Lukasz Kaiser and Illia Polosukhin.
+    """
 
-     model_class = FlaxBertModule
-     config_class = BertConfig
-     base_model_prefix = "bert"
+    model_class = FlaxBertModule
+    config_class = BertConfig
+    base_model_prefix = "bert"
 
-     @staticmethod
-     def convert_from_pytorch(pt_state: Dict, config: BertConfig) -> Dict:
-         jax_state = dict(pt_state)
+    @staticmethod
+    def convert_from_pytorch(pt_state: Dict, config: BertConfig) -> Dict:
+        jax_state = dict(pt_state)
 
-         # Need to change some parameters name to match Flax names so that we don't have to fork any layer
-         for key, tensor in pt_state.items():
-             # Key parts
-             key_parts = set(key.split("."))
+        # Need to change some parameters name to match Flax names so that we don't have to fork any layer
+        for key, tensor in pt_state.items():
+            # Key parts
+            key_parts = set(key.split("."))
 
-             # Every dense layer has "kernel" parameters instead of "weight"
-             if "dense.weight" in key:
-                 del jax_state[key]
-                 key = key.replace("weight", "kernel")
-                 jax_state[key] = tensor
+            # Every dense layer has "kernel" parameters instead of "weight"
+            if "dense.weight" in key:
+                del jax_state[key]
+                key = key.replace("weight", "kernel")
+                jax_state[key] = tensor
 
-             # SelfAttention needs also to replace "weight" by "kernel"
-             if {"query", "key", "value"} & key_parts:
+            # SelfAttention needs also to replace "weight" by "kernel"
+            if {"query", "key", "value"} & key_parts:
 
-                 # Flax SelfAttention decomposes the heads (num_head, size // num_heads)
-                 if "bias" in key:
-                     jax_state[key] = tensor.reshape((config.num_attention_heads, -1))
-                 elif "weight":
-                     del jax_state[key]
-                     key = key.replace("weight", "kernel")
-                     tensor = tensor.reshape((config.num_attention_heads, -1, config.hidden_size)).transpose((2, 0, 1))
-                     jax_state[key] = tensor
+                # Flax SelfAttention decomposes the heads (num_head, size // num_heads)
+                if "bias" in key:
+                    jax_state[key] = tensor.reshape((config.num_attention_heads, -1))
+                elif "weight":
+                    del jax_state[key]
+                    key = key.replace("weight", "kernel")
+                    tensor = tensor.reshape((config.num_attention_heads, -1, config.hidden_size)).transpose((2, 0, 1))
+                    jax_state[key] = tensor
 
-             # SelfAttention output is not a separate layer, remove one nesting
-             if "attention.output.dense" in key:
-                 del jax_state[key]
-                 key = key.replace("attention.output.dense", "attention.self.out")
-                 jax_state[key] = tensor
+            # SelfAttention output is not a separate layer, remove one nesting
+            if "attention.output.dense" in key:
+                del jax_state[key]
+                key = key.replace("attention.output.dense", "attention.self.out")
+                jax_state[key] = tensor
 
-             # SelfAttention output is not a separate layer, remove nesting on layer norm
-             if "attention.output.LayerNorm" in key:
-                 del jax_state[key]
-                 key = key.replace("attention.output.LayerNorm", "attention.LayerNorm")
-                 jax_state[key] = tensor
+            # SelfAttention output is not a separate layer, remove nesting on layer norm
+            if "attention.output.LayerNorm" in key:
+                del jax_state[key]
+                key = key.replace("attention.output.LayerNorm", "attention.LayerNorm")
+                jax_state[key] = tensor
 
-             # There are some transposed parameters w.r.t their PyTorch counterpart
-             if "intermediate.dense.kernel" in key or "output.dense.kernel" in key:
-                 jax_state[key] = tensor.T
+            # There are some transposed parameters w.r.t their PyTorch counterpart
+            if "intermediate.dense.kernel" in key or "output.dense.kernel" in key:
+                jax_state[key] = tensor.T
 
-             # Self Attention output projection needs to be transposed
-             if "out.kernel" in key:
-                 jax_state[key] = tensor.reshape((config.hidden_size, config.num_attention_heads, -1)).transpose(
-                     1, 2, 0
-                 )
+            # Self Attention output projection needs to be transposed
+            if "out.kernel" in key:
+                jax_state[key] = tensor.reshape((config.hidden_size, config.num_attention_heads, -1)).transpose(
+                    1, 2, 0
+                )
 
-             # Pooler needs to transpose its kernel
-             if "pooler.dense.kernel" in key:
-                 jax_state[key] = tensor.T
+            # Pooler needs to transpose its kernel
+            if "pooler.dense.kernel" in key:
+                jax_state[key] = tensor.T
 
-             # Handle LayerNorm conversion
-             if "LayerNorm" in key:
-                 del jax_state[key]
+            # Handle LayerNorm conversion
+            if "LayerNorm" in key:
+                del jax_state[key]
 
-                 # Replace LayerNorm by layer_norm
-                 new_key = key.replace("LayerNorm", "layer_norm")
+                # Replace LayerNorm by layer_norm
+                new_key = key.replace("LayerNorm", "layer_norm")
 
-                 if "weight" in key:
-                     new_key = new_key.replace("weight", "gamma")
-                 elif "bias" in key:
-                     new_key = new_key.replace("bias", "beta")
+                if "weight" in key:
+                    new_key = new_key.replace("weight", "gamma")
+                elif "bias" in key:
+                    new_key = new_key.replace("bias", "beta")
 
-                 jax_state[new_key] = tensor
+                jax_state[new_key] = tensor
 
-         return jax_state
+        return jax_state
 
-     def __init__(self, config: BertConfig, state: dict, seed: int = 0, **kwargs):
-         model = FlaxBertModule(
-             vocab_size=config.vocab_size,
-             hidden_size=config.hidden_size,
-             type_vocab_size=config.type_vocab_size,
-             max_length=config.max_position_embeddings,
-             num_encoder_layers=config.num_hidden_layers,
-             num_heads=config.num_attention_heads,
-             head_size=config.hidden_size,
-             intermediate_size=config.intermediate_size,
-         )
+    def __init__(self, config: BertConfig, state: dict, seed: int = 0, **kwargs):
+        model = FlaxBertModule(
+            vocab_size=config.vocab_size,
+            hidden_size=config.hidden_size,
+            type_vocab_size=config.type_vocab_size,
+            max_length=config.max_position_embeddings,
+            num_encoder_layers=config.num_hidden_layers,
+            num_heads=config.num_attention_heads,
+            head_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+        )
 
-         super().__init__(config, model, state, seed)
+        super().__init__(config, model, state, seed)
 
-     @property
-     def module(self) -> nn.Module:
-         return self._module
+    @property
+    def module(self) -> nn.Module:
+        return self._module
 
-     def __call__(self, input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
-         if token_type_ids is None:
-             token_type_ids = jnp.ones_like(input_ids)
+    def __call__(self, input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
+        if token_type_ids is None:
+            token_type_ids = jnp.ones_like(input_ids)
 
-         if position_ids is None:
-             position_ids = jnp.arange(jnp.atleast_2d(input_ids).shape[-1])
+        if position_ids is None:
+            position_ids = jnp.arange(jnp.atleast_2d(input_ids).shape[-1])
 
-         if attention_mask is None:
-             attention_mask = jnp.ones_like(input_ids)
+        if attention_mask is None:
+            attention_mask = jnp.ones_like(input_ids)
 
-         return self.model.apply(
-             {"params": self.params},
-             jnp.array(input_ids, dtype="i4"),
-             jnp.array(token_type_ids, dtype="i4"),
-             jnp.array(position_ids, dtype="i4"),
-             jnp.array(attention_mask, dtype="i4"),
-         )
+        return self.model.apply(
+            {"params": self.params},
+            jnp.array(input_ids, dtype="i4"),
+            jnp.array(token_type_ids, dtype="i4"),
+            jnp.array(position_ids, dtype="i4"),
+            jnp.array(attention_mask, dtype="i4"),
+        )

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -21,9 +21,11 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 from flax.linen import compact
-from transformers import BertConfig, add_start_docstrings
-from transformers.modeling_flax_utils import FlaxPreTrainedModel, gelu
-from transformers.utils import logging
+
+from .configuration_bert import BertConfig
+from .file_utils import add_start_docstrings
+from .modeling_flax_utils import FlaxPreTrainedModel, gelu
+from .utils import logging
 
 
 logger = logging.get_logger(__name__)

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -1,0 +1,55 @@
+from typing import Callable
+
+import jax
+import numpy as np
+import jax.numpy as jnp
+from transformers import BertConfig
+
+from transformers import RobertaConfig
+from transformers.modeling_flax_bert import FlaxBertModel
+
+
+class FlaxRobertaModel(FlaxBertModel):
+    ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP = {
+        "roberta-base": "https://s3.amazonaws.com/models.huggingface.co/bert/roberta-base-pytorch_model.bin",
+        "roberta-large": "https://s3.amazonaws.com/models.huggingface.co/bert/roberta-large-pytorch_model.bin",
+        "roberta-large-mnli": "https://s3.amazonaws.com/models.huggingface.co/bert/roberta-large-mnli-pytorch_model.bin",
+        "distilroberta-base": "https://s3.amazonaws.com/models.huggingface.co/bert/distilroberta-base-pytorch_model.bin",
+        "roberta-base-openai-detector": "https://s3.amazonaws.com/models.huggingface.co/bert/roberta-base-openai-detector-pytorch_model.bin",
+        "roberta-large-openai-detector": "https://s3.amazonaws.com/models.huggingface.co/bert/roberta-large-openai-detector-pytorch_model.bin",
+    }
+
+    config_class = RobertaConfig
+    pretrained_model_archive_map = ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP
+    base_model_prefix = "roberta"
+
+    def __init__(self, config: BertConfig, state: dict, **kwargs):
+
+        super().__init__(config, state, **kwargs)
+
+        if config.pad_token_id is None:
+            config.pad_token_id = 1
+
+    def __call__(self, input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
+        @jax.jit
+        def predict(input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
+            if token_type_ids is None:
+                token_type_ids = np.ones_like(input_ids)
+
+            if position_ids is None:
+                position_ids = np.arange(
+                    self.config.pad_token_id + 1,
+                    np.atleast_2d(input_ids).shape[-1] + self.config.pad_token_id + 1
+                )
+
+            if attention_mask is None:
+                attention_mask = np.ones_like(input_ids)
+
+            return self._bert(
+                jnp.array(input_ids, dtype='i4'),
+                jnp.array(token_type_ids, dtype='i4'),
+                jnp.array(position_ids, dtype='i4'),
+                jnp.array(attention_mask, dtype='i4')
+            )
+
+        return predict(input_ids, token_type_ids, position_ids, attention_mask)

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -1,5 +1,3 @@
-from typing import Callable
-
 import jax
 import numpy as np
 import jax.numpy as jnp
@@ -30,6 +28,10 @@ class FlaxRobertaModel(FlaxBertModel):
         if config.pad_token_id is None:
             config.pad_token_id = 1
 
+    @property
+    def config(self) -> RobertaConfig:
+        return self._config
+
     def __call__(self, input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
         @jax.jit
         def predict(input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
@@ -45,7 +47,7 @@ class FlaxRobertaModel(FlaxBertModel):
             if attention_mask is None:
                 attention_mask = np.ones_like(input_ids)
 
-            return self._bert(
+            return self.model(
                 jnp.array(input_ids, dtype='i4'),
                 jnp.array(token_type_ids, dtype='i4'),
                 jnp.array(position_ids, dtype='i4'),

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -4,19 +4,11 @@ import jax.numpy as jnp
 from transformers import BertConfig
 
 from transformers import RobertaConfig
+from transformers.modeling_roberta import ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP
 from transformers.modeling_flax_bert import FlaxBertModel
 
 
 class FlaxRobertaModel(FlaxBertModel):
-    ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP = {
-        "roberta-base": "https://s3.amazonaws.com/models.huggingface.co/bert/roberta-base-pytorch_model.bin",
-        "roberta-large": "https://s3.amazonaws.com/models.huggingface.co/bert/roberta-large-pytorch_model.bin",
-        "roberta-large-mnli": "https://s3.amazonaws.com/models.huggingface.co/bert/roberta-large-mnli-pytorch_model.bin",
-        "distilroberta-base": "https://s3.amazonaws.com/models.huggingface.co/bert/distilroberta-base-pytorch_model.bin",
-        "roberta-base-openai-detector": "https://s3.amazonaws.com/models.huggingface.co/bert/roberta-base-openai-detector-pytorch_model.bin",
-        "roberta-large-openai-detector": "https://s3.amazonaws.com/models.huggingface.co/bert/roberta-large-openai-detector-pytorch_model.bin",
-    }
-
     config_class = RobertaConfig
     pretrained_model_archive_map = ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP
     base_model_prefix = "roberta"

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -24,24 +24,9 @@ class FlaxRobertaModel(FlaxBertModel):
         return self._config
 
     def __call__(self, input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
-        @jax.jit
-        def predict(input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
-            if token_type_ids is None:
-                token_type_ids = np.ones_like(input_ids)
-
-            if position_ids is None:
-                position_ids = np.arange(
-                    self.config.pad_token_id + 1, np.atleast_2d(input_ids).shape[-1] + self.config.pad_token_id + 1
-                )
-
-            if attention_mask is None:
-                attention_mask = np.ones_like(input_ids)
-
-            return self.model(
-                jnp.array(input_ids, dtype="i4"),
-                jnp.array(token_type_ids, dtype="i4"),
-                jnp.array(position_ids, dtype="i4"),
-                jnp.array(attention_mask, dtype="i4"),
+        if position_ids is None:
+            position_ids = np.arange(
+                self.config.pad_token_id + 1, np.atleast_2d(input_ids).shape[-1] + self.config.pad_token_id + 1
             )
 
-        return predict(input_ids, token_type_ids, position_ids, attention_mask)
+        return super().__call__(input_ids, token_type_ids, position_ids, attention_mask)

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -1,11 +1,10 @@
-import jax
 import numpy as np
-import jax.numpy as jnp
-from transformers import BertConfig
 
-from transformers import RobertaConfig
-from transformers.modeling_roberta import ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP
+import jax
+import jax.numpy as jnp
+from transformers import BertConfig, RobertaConfig
 from transformers.modeling_flax_bert import FlaxBertModel
+from transformers.modeling_roberta import ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP
 
 
 class FlaxRobertaModel(FlaxBertModel):
@@ -32,18 +31,17 @@ class FlaxRobertaModel(FlaxBertModel):
 
             if position_ids is None:
                 position_ids = np.arange(
-                    self.config.pad_token_id + 1,
-                    np.atleast_2d(input_ids).shape[-1] + self.config.pad_token_id + 1
+                    self.config.pad_token_id + 1, np.atleast_2d(input_ids).shape[-1] + self.config.pad_token_id + 1
                 )
 
             if attention_mask is None:
                 attention_mask = np.ones_like(input_ids)
 
             return self.model(
-                jnp.array(input_ids, dtype='i4'),
-                jnp.array(token_type_ids, dtype='i4'),
-                jnp.array(position_ids, dtype='i4'),
-                jnp.array(attention_mask, dtype='i4')
+                jnp.array(input_ids, dtype="i4"),
+                jnp.array(token_type_ids, dtype="i4"),
+                jnp.array(position_ids, dtype="i4"),
+                jnp.array(attention_mask, dtype="i4"),
             )
 
         return predict(input_ids, token_type_ids, position_ids, attention_mask)

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -10,7 +10,7 @@ class FlaxRobertaModel(FlaxBertModel):
     pretrained_model_archive_map = ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP
     base_model_prefix = "roberta"
 
-    def __init__(self, config: BertConfig, state: dict, seed: int, **kwargs):
+    def __init__(self, config: BertConfig, state: dict, seed: int = 0, **kwargs):
 
         super().__init__(config, state, seed, **kwargs)
 

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -1,7 +1,5 @@
 import numpy as np
 
-import jax
-import jax.numpy as jnp
 from transformers import BertConfig, RobertaConfig
 from transformers.modeling_flax_bert import FlaxBertModel
 from transformers.modeling_roberta import ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -13,9 +13,9 @@ class FlaxRobertaModel(FlaxBertModel):
     pretrained_model_archive_map = ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP
     base_model_prefix = "roberta"
 
-    def __init__(self, config: BertConfig, state: dict, **kwargs):
+    def __init__(self, config: BertConfig, state: dict, seed: int, **kwargs):
 
-        super().__init__(config, state, **kwargs)
+        super().__init__(config, state, seed, **kwargs)
 
         if config.pad_token_id is None:
             config.pad_token_id = 1

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -2,12 +2,10 @@ import numpy as np
 
 from transformers import BertConfig, RobertaConfig
 from transformers.modeling_flax_bert import FlaxBertModel
-from transformers.modeling_roberta import ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP
 
 
 class FlaxRobertaModel(FlaxBertModel):
     config_class = RobertaConfig
-    pretrained_model_archive_map = ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP
     base_model_prefix = "roberta"
 
     def __init__(self, config: BertConfig, state: dict, seed: int = 0, **kwargs):

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -238,7 +238,9 @@ class FlaxRobertaLayer(nn.Module):
 
     @compact
     def __call__(self, hidden_state, attention_mask):
-        attention = FlaxRobertaAttention(self.num_heads, self.head_size, name="attention")(hidden_state, attention_mask)
+        attention = FlaxRobertaAttention(self.num_heads, self.head_size, name="attention")(
+            hidden_state, attention_mask
+        )
         intermediate = FlaxRobertaIntermediate(self.intermediate_size, name="intermediate")(attention)
         output = FlaxRobertaOutput(name="output")(intermediate, attention)
 

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -329,8 +329,10 @@ class FlaxRobertaModule(nn.Module):
 )
 class FlaxRobertaModel(FlaxPreTrainedModel):
     """
-    An abstract class to handle weights initialization and
-    a simple interface for downloading and loading pretrained models.
+    The model can behave as an encoder (with only self-attention) as well
+    as a decoder, in which case a layer of cross-attention is added between
+    the self-attention layers, following the architecture described in `Attention is all you need`_ by Ashish Vaswani,
+    Noam Shazeer, Niki Parmar, Jakob Uszkoreit, Llion Jones, Aidan N. Gomez, Lukasz Kaiser and Illia Polosukhin.
     """
 
     model_class = FlaxRobertaModule

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -12,8 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Callable, Dict
 
 import numpy as np
+import flax.linen as nn
+import jax
+import jax.numpy as jnp
+
+from flax.linen import compact
+from transformers.modeling_flax_utils import FlaxPreTrainedModel
 
 from transformers import BertConfig, RobertaConfig, add_start_docstrings
 from transformers.modeling_flax_bert import FlaxBertModel
@@ -23,16 +30,6 @@ logger = logging.get_logger(__name__)
 
 _CONFIG_FOR_DOC = "RobertaConfig"
 _TOKENIZER_FOR_DOC = "RobertaTokenizer"
-
-ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST = [
-    "roberta-base",
-    "roberta-large",
-    "roberta-large-mnli",
-    "distilroberta-base",
-    "roberta-base-openai-detector",
-    "roberta-large-openai-detector",
-    # See all RoBERTa models at https://huggingface.co/models?filter=roberta
-]
 
 
 ROBERTA_START_DOCSTRING = r"""
@@ -104,25 +101,346 @@ ROBERTA_INPUTS_DOCSTRING = r"""
 """
 
 
+# Copied from transformers.modeling_flax_bert.FlaxBertLayerNorm with Bert->Roberta
+class FlaxRobertaLayerNorm(nn.Module):
+    """Layer normalization (https://arxiv.org/abs/1607.06450).
+    Operates on the last axis of the input data.
+    """
+
+    epsilon: float = 1e-6
+    dtype: jnp.dtype = jnp.float32
+    bias: bool = True
+    scale: bool = True
+    bias_init: jnp.ndarray = nn.initializers.zeros
+    scale_init: jnp.ndarray = nn.initializers.ones
+
+    @compact
+    def __call__(self, x):
+        """Applies layer normalization on the input.
+        It normalizes the activations of the layer for each given example in a
+        batch independently, rather than across a batch like Batch Normalization.
+        i.e. applies a transformation that maintains the mean activation within
+        each example close to 0 and the activation standard deviation close to 1.
+        Args:
+          x: the inputs
+          epsilon: A small float added to variance to avoid dividing by zero.
+          dtype: the dtype of the computation (default: float32).
+          bias:  If True, bias (beta) is added.
+          scale: If True, multiply by scale (gamma). When the next layer is linear
+            (also e.g. nn.relu), this can be disabled since the scaling will be done
+            by the next layer.
+          bias_init: Initializer for bias, by default, zero.
+          scale_init: Initializer for scale, by default, one.
+        Returns:
+          Normalized inputs (the same shape as inputs).
+        """
+        features = x.shape[-1]
+        mean = jnp.mean(x, axis=-1, keepdims=True)
+        mean2 = jnp.mean(jax.lax.square(x), axis=-1, keepdims=True)
+        var = mean2 - jax.lax.square(mean)
+        mul = jax.lax.rsqrt(var + self.epsilon)
+        if self.scale:
+            mul = mul * jnp.asarray(self.param("gamma", self.scale_init, (features,)), self.dtype)
+        y = (x - mean) * mul
+        if self.bias:
+            y = y + jnp.asarray(self.param("beta", self.bias_init, (features,)), self.dtype)
+        return y
+
+
+# Copied from transformers.modeling_flax_bert.FlaxBertEmbedding with Bert->Roberta
+class FlaxRobertaEmbedding(nn.Module):
+    """
+    Specify a new class for doing the embedding stuff
+    as Flax's one use 'embedding' for the parameter name
+    and PyTorch use 'weight'
+    """
+
+    vocab_size: int
+    hidden_size: int
+    emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1)
+
+    @compact
+    def __call__(self, inputs):
+        embedding = self.param("weight", self.emb_init, (self.vocab_size, self.hidden_size))
+        return jnp.take(embedding, inputs, axis=0)
+
+
+# Copied from transformers.modeling_flax_bert.FlaxBertEmbeddings with Bert->Roberta
+class FlaxRobertaEmbeddings(nn.Module):
+    """Construct the embeddings from word, position and token_type embeddings."""
+
+    vocab_size: int
+    hidden_size: int
+    type_vocab_size: int
+    max_length: int
+
+    @compact
+    def __call__(self, input_ids, token_type_ids, position_ids, attention_mask):
+
+        # Embed
+        w_emb = FlaxRobertaEmbedding(self.vocab_size, self.hidden_size, name="word_embeddings")(
+            jnp.atleast_2d(input_ids.astype("i4"))
+        )
+        p_emb = FlaxRobertaEmbedding(self.max_length, self.hidden_size, name="position_embeddings")(
+            jnp.atleast_2d(position_ids.astype("i4"))
+        )
+        t_emb = FlaxRobertaEmbedding(self.type_vocab_size, self.hidden_size, name="token_type_embeddings")(
+            jnp.atleast_2d(token_type_ids.astype("i4"))
+        )
+
+        # Sum all embeddings
+        summed_emb = w_emb + jnp.broadcast_to(p_emb, w_emb.shape) + t_emb
+
+        # Layer Norm
+        layer_norm = FlaxRobertaLayerNorm(name="layer_norm")(summed_emb)
+
+        return layer_norm
+
+
+# Copied from transformers.modeling_flax_bert.FlaxBertAttention with Bert->Roberta
+class FlaxRobertaAttention(nn.Module):
+    num_heads: int
+    head_size: int
+
+    @compact
+    def __call__(self, hidden_state, attention_mask):
+        self_att = nn.attention.SelfAttention(num_heads=self.num_heads, qkv_features=self.head_size, name="self")(
+            hidden_state, attention_mask
+        )
+
+        layer_norm = FlaxRobertaLayerNorm(name="layer_norm")(self_att + hidden_state)
+        return layer_norm
+
+
+# Copied from transformers.modeling_flax_bert.FlaxBertIntermediate with Bert->Roberta
+class FlaxRobertaIntermediate(nn.Module):
+    output_size: int
+
+    @compact
+    def __call__(self, hidden_state):
+        # TODO: Add ACT2FN reference to change activation function
+        dense = nn.Dense(features=self.output_size, name="dense")(hidden_state)
+        return gelu(dense)
+
+
+# Copied from transformers.modeling_flax_bert.FlaxBertOutput with Bert->Roberta
+class FlaxRobertaOutput(nn.Module):
+    @compact
+    def __call__(self, intermediate_output, attention_output):
+        hidden_state = nn.Dense(attention_output.shape[-1], name="dense")(intermediate_output)
+        hidden_state = FlaxRobertaLayerNorm(name="layer_norm")(hidden_state + attention_output)
+        return hidden_state
+
+
+# Copied from transformers.modeling_flax_bert.FlaxBertLayer with Bert->Roberta
+class FlaxRobertaLayer(nn.Module):
+    num_heads: int
+    head_size: int
+    intermediate_size: int
+
+    @compact
+    def __call__(self, hidden_state, attention_mask):
+        attention = FlaxRobertaAttention(self.num_heads, self.head_size, name="attention")(hidden_state, attention_mask)
+        intermediate = FlaxRobertaIntermediate(self.intermediate_size, name="intermediate")(attention)
+        output = FlaxRobertaOutput(name="output")(intermediate, attention)
+
+        return output
+
+
+# Copied from transformers.modeling_flax_bert.FlaxBertLayerCollection with Bert->Roberta
+class FlaxRobertaLayerCollection(nn.Module):
+    """
+    Stores N BertLayer(s)
+    """
+
+    num_layers: int
+    num_heads: int
+    head_size: int
+    intermediate_size: int
+
+    @compact
+    def __call__(self, inputs, attention_mask):
+        assert self.num_layers > 0, f"num_layers should be >= 1, got ({self.num_layers})"
+
+        # Initialize input / output
+        input_i = inputs
+
+        # Forward over all encoders
+        for i in range(self.num_layers):
+            layer = FlaxRobertaLayer(self.num_heads, self.head_size, self.intermediate_size, name=f"{i}")
+            input_i = layer(input_i, attention_mask)
+        return input_i
+
+
+# Copied from transformers.modeling_flax_bert.FlaxBertEncoder with Bert->Roberta
+class FlaxRobertaEncoder(nn.Module):
+    num_layers: int
+    num_heads: int
+    head_size: int
+    intermediate_size: int
+
+    @compact
+    def __call__(self, hidden_state, attention_mask):
+        layer = FlaxRobertaLayerCollection(
+            self.num_layers, self.num_heads, self.head_size, self.intermediate_size, name="layer"
+        )(hidden_state, attention_mask)
+        return layer
+
+
+# Copied from transformers.modeling_flax_bert.FlaxBertPooler with Bert->Roberta
+class FlaxRobertaPooler(nn.Module):
+    @compact
+    def __call__(self, hidden_state):
+        cls_token = hidden_state[:, 0]
+        out = nn.Dense(hidden_state.shape[-1], name="dense")(cls_token)
+        return jax.lax.tanh(out)
+
+
+# Copied from transformers.modeling_flax_bert.FlaxBertModule with Bert->Roberta
+class FlaxRobertaModule(nn.Module):
+    vocab_size: int
+    hidden_size: int
+    type_vocab_size: int
+    max_length: int
+    num_encoder_layers: int
+    num_heads: int
+    head_size: int
+    intermediate_size: int
+
+    @compact
+    def __call__(self, input_ids, token_type_ids, position_ids, attention_mask):
+
+        # Embedding
+        embeddings = FlaxRobertaEmbeddings(
+            self.vocab_size, self.hidden_size, self.type_vocab_size, self.max_length, name="embeddings"
+        )(input_ids, token_type_ids, position_ids, attention_mask)
+
+        # N stacked encoding layers
+        encoder = FlaxRobertaEncoder(
+            self.num_encoder_layers, self.num_heads, self.head_size, self.intermediate_size, name="encoder"
+        )(embeddings, attention_mask)
+
+        pooled = FlaxRobertaPooler(name="pooler")(encoder)
+        return encoder, pooled
+
+
 @add_start_docstrings(
     "The bare RoBERTa Model transformer outputting raw hidden-states without any specific head on top.",
     ROBERTA_START_DOCSTRING,
 )
-class FlaxRobertaModel(FlaxBertModel):
-    config_class = RobertaConfig
-    base_model_prefix = "roberta"
+class FlaxRobertaModel(FlaxPreTrainedModel):
+    """
+    An abstract class to handle weights initialization and
+    a simple interface for downloading and loading pretrained models.
+    """
+
+    model_class = FlaxRobertaModule
+    config_class = BertConfig
+    base_model_prefix = "bert"
+
+    @staticmethod
+    def convert_from_pytorch(pt_state: Dict, config: BertConfig) -> Dict:
+        jax_state = dict(pt_state)
+
+        # Need to change some parameters name to match Flax names so that we don't have to fork any layer
+        for key, tensor in pt_state.items():
+            # Key parts
+            key_parts = set(key.split("."))
+
+            # Every dense layer has "kernel" parameters instead of "weight"
+            if "dense.weight" in key:
+                del jax_state[key]
+                key = key.replace("weight", "kernel")
+                jax_state[key] = tensor
+
+            # SelfAttention needs also to replace "weight" by "kernel"
+            if {"query", "key", "value"} & key_parts:
+
+                # Flax SelfAttention decomposes the heads (num_head, size // num_heads)
+                if "bias" in key:
+                    jax_state[key] = tensor.reshape((config.num_attention_heads, -1))
+                elif "weight":
+                    del jax_state[key]
+                    key = key.replace("weight", "kernel")
+                    tensor = tensor.reshape((config.num_attention_heads, -1, config.hidden_size)).transpose((2, 0, 1))
+                    jax_state[key] = tensor
+
+            # SelfAttention output is not a separate layer, remove one nesting
+            if "attention.output.dense" in key:
+                del jax_state[key]
+                key = key.replace("attention.output.dense", "attention.self.out")
+                jax_state[key] = tensor
+
+            # SelfAttention output is not a separate layer, remove nesting on layer norm
+            if "attention.output.LayerNorm" in key:
+                del jax_state[key]
+                key = key.replace("attention.output.LayerNorm", "attention.LayerNorm")
+                jax_state[key] = tensor
+
+            # There are some transposed parameters w.r.t their PyTorch counterpart
+            if "intermediate.dense.kernel" in key or "output.dense.kernel" in key:
+                jax_state[key] = tensor.T
+
+            # Self Attention output projection needs to be transposed
+            if "out.kernel" in key:
+                jax_state[key] = tensor.reshape((config.hidden_size, config.num_attention_heads, -1)).transpose(
+                    1, 2, 0
+                )
+
+            # Pooler needs to transpose its kernel
+            if "pooler.dense.kernel" in key:
+                jax_state[key] = tensor.T
+
+            # Handle LayerNorm conversion
+            if "LayerNorm" in key:
+                del jax_state[key]
+
+                # Replace LayerNorm by layer_norm
+                new_key = key.replace("LayerNorm", "layer_norm")
+
+                if "weight" in key:
+                    new_key = new_key.replace("weight", "gamma")
+                elif "bias" in key:
+                    new_key = new_key.replace("bias", "beta")
+
+                jax_state[new_key] = tensor
+
+        return jax_state
 
     def __init__(self, config: BertConfig, state: dict, seed: int = 0, **kwargs):
+        model = FlaxRobertaModule(
+            vocab_size=config.vocab_size,
+            hidden_size=config.hidden_size,
+            type_vocab_size=config.type_vocab_size,
+            max_length=config.max_position_embeddings,
+            num_encoder_layers=config.num_hidden_layers,
+            num_heads=config.num_attention_heads,
+            head_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+        )
 
-        super().__init__(config, state, seed, **kwargs)
+        super().__init__(config, model, state, seed)
 
-        if config.pad_token_id is None:
-            config.pad_token_id = 1
+    @property
+    def module(self) -> nn.Module:
+        return self._module
 
     def __call__(self, input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
+        if token_type_ids is None:
+            token_type_ids = jnp.ones_like(input_ids)
+
         if position_ids is None:
             position_ids = np.arange(
                 self.config.pad_token_id + 1, np.atleast_2d(input_ids).shape[-1] + self.config.pad_token_id + 1
             )
 
-        return super().__call__(input_ids, token_type_ids, position_ids, attention_mask)
+        if attention_mask is None:
+            attention_mask = jnp.ones_like(input_ids)
+
+        return self.model.apply(
+            {"params": self.params},
+            jnp.array(input_ids, dtype="i4"),
+            jnp.array(token_type_ids, dtype="i4"),
+            jnp.array(position_ids, dtype="i4"),
+            jnp.array(attention_mask, dtype="i4"),
+        )

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -1,3 +1,18 @@
+# coding=utf-8
+# Copyright 2018 The Google Flax Team Authors and The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 
 from transformers import BertConfig, RobertaConfig, add_start_docstrings

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -20,9 +20,11 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 from flax.linen import compact
-from transformers import BertConfig, RobertaConfig, add_start_docstrings
-from transformers.modeling_flax_utils import FlaxPreTrainedModel, gelu
-from transformers.utils import logging
+
+from .configuration_roberta import RobertaConfig
+from .file_utils import add_start_docstrings
+from .modeling_flax_utils import FlaxPreTrainedModel, gelu
+from .utils import logging
 
 
 logger = logging.get_logger(__name__)
@@ -341,7 +343,7 @@ class FlaxRobertaModel(FlaxPreTrainedModel):
     base_model_prefix = "roberta"
 
     @staticmethod
-    def convert_from_pytorch(pt_state: Dict, config: BertConfig) -> Dict:
+    def convert_from_pytorch(pt_state: Dict, config: RobertaConfig) -> Dict:
         jax_state = dict(pt_state)
 
         # Need to change some parameters name to match Flax names so that we don't have to fork any layer
@@ -409,7 +411,7 @@ class FlaxRobertaModel(FlaxPreTrainedModel):
 
         return jax_state
 
-    def __init__(self, config: BertConfig, state: dict, seed: int = 0, **kwargs):
+    def __init__(self, config: RobertaConfig, state: dict, seed: int = 0, **kwargs):
         model = FlaxRobertaModule(
             vocab_size=config.vocab_size,
             hidden_size=config.hidden_size,

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -104,10 +104,6 @@ class FlaxRobertaModel(FlaxBertModel):
         if config.pad_token_id is None:
             config.pad_token_id = 1
 
-    @property
-    def config(self) -> RobertaConfig:
-        return self._config
-
     def __call__(self, input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
         if position_ids is None:
             position_ids = np.arange(

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -15,15 +15,15 @@
 from typing import Callable, Dict
 
 import numpy as np
+
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
-
 from flax.linen import compact
-from transformers.modeling_flax_utils import FlaxPreTrainedModel, gelu
-
 from transformers import BertConfig, RobertaConfig, add_start_docstrings
+from transformers.modeling_flax_utils import FlaxPreTrainedModel, gelu
 from transformers.utils import logging
+
 
 logger = logging.get_logger(__name__)
 
@@ -239,7 +239,9 @@ class FlaxRobertaLayer(nn.Module):
 
     @compact
     def __call__(self, hidden_state, attention_mask):
-        attention = FlaxRobertaAttention(self.num_heads, self.head_size, name="attention")(hidden_state, attention_mask)
+        attention = FlaxRobertaAttention(self.num_heads, self.head_size, name="attention")(
+            hidden_state, attention_mask
+        )
         intermediate = FlaxRobertaIntermediate(self.intermediate_size, name="intermediate")(attention)
         output = FlaxRobertaOutput(name="output")(intermediate, attention)
 

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -1,9 +1,98 @@
 import numpy as np
 
-from transformers import BertConfig, RobertaConfig
+from transformers import BertConfig, RobertaConfig, add_start_docstrings
 from transformers.modeling_flax_bert import FlaxBertModel
+from transformers.utils import logging
+
+logger = logging.get_logger(__name__)
+
+_CONFIG_FOR_DOC = "RobertaConfig"
+_TOKENIZER_FOR_DOC = "RobertaTokenizer"
+
+ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST = [
+    "roberta-base",
+    "roberta-large",
+    "roberta-large-mnli",
+    "distilroberta-base",
+    "roberta-base-openai-detector",
+    "roberta-large-openai-detector",
+    # See all RoBERTa models at https://huggingface.co/models?filter=roberta
+]
 
 
+ROBERTA_START_DOCSTRING = r"""
+
+    This model inherits from :class:`~transformers.PreTrainedModel`. Check the superclass documentation for the generic
+    methods the library implements for all its model (such as downloading or saving, resizing the input embeddings,
+    pruning heads etc.)
+
+    This model is also a PyTorch `torch.nn.Module <https://pytorch.org/docs/stable/nn.html#torch.nn.Module>`__ subclass.
+    Use it as a regular PyTorch Module and refer to the PyTorch documentation for all matter related to general
+    usage and behavior.
+
+    Parameters:
+        config (:class:`~transformers.RobertaConfig`): Model configuration class with all the parameters of the
+            model. Initializing with a config file does not load the weights associated with the model, only the configuration.
+            Check out the :meth:`~transformers.PreTrainedModel.from_pretrained` method to load the model weights.
+"""
+
+ROBERTA_INPUTS_DOCSTRING = r"""
+    Args:
+        input_ids (:obj:`torch.LongTensor` of shape :obj:`({0})`):
+            Indices of input sequence tokens in the vocabulary.
+
+            Indices can be obtained using :class:`~transformers.RobertaTokenizer`.
+            See :meth:`transformers.PreTrainedTokenizer.encode` and
+            :meth:`transformers.PreTrainedTokenizer.__call__` for details.
+
+            `What are input IDs? <../glossary.html#input-ids>`__
+        attention_mask (:obj:`torch.FloatTensor` of shape :obj:`({0})`, `optional`):
+            Mask to avoid performing attention on padding token indices.
+            Mask values selected in ``[0, 1]``:
+
+            - 1 for tokens that are **not masked**,
+            - 0 for tokens that are **maked**.
+
+            `What are attention masks? <../glossary.html#attention-mask>`__
+        token_type_ids (:obj:`torch.LongTensor` of shape :obj:`({0})`, `optional`):
+            Segment token indices to indicate first and second portions of the inputs.
+            Indices are selected in ``[0, 1]``:
+
+            - 0 corresponds to a `sentence A` token,
+            - 1 corresponds to a `sentence B` token.
+
+            `What are token type IDs? <../glossary.html#token-type-ids>`_
+        position_ids (:obj:`torch.LongTensor` of shape :obj:`({0})`, `optional`):
+            Indices of positions of each input sequence tokens in the position embeddings.
+            Selected in the range ``[0, config.max_position_embeddings - 1]``.
+
+            `What are position IDs? <../glossary.html#position-ids>`_
+        head_mask (:obj:`torch.FloatTensor` of shape :obj:`(num_heads,)` or :obj:`(num_layers, num_heads)`, `optional`):
+            Mask to nullify selected heads of the self-attention modules.
+            Mask values selected in ``[0, 1]``:
+
+            - 1 indicates the head is **not masked**,
+            - 0 indicates the head is **masked**.
+
+        inputs_embeds (:obj:`torch.FloatTensor` of shape :obj:`({0}, hidden_size)`, `optional`):
+            Optionally, instead of passing :obj:`input_ids` you can choose to directly pass an embedded representation.
+            This is useful if you want more control over how to convert :obj:`input_ids` indices into associated
+            vectors than the model's internal embedding lookup matrix.
+        output_attentions (:obj:`bool`, `optional`):
+            Whether or not to return the attentions tensors of all attention layers. See ``attentions`` under returned
+            tensors for more detail.
+        output_hidden_states (:obj:`bool`, `optional`):
+            Whether or not to return the hidden states of all layers. See ``hidden_states`` under returned tensors for
+            more detail.
+        return_dict (:obj:`bool`, `optional`):
+            Whether or not to return a :class:`~transformers.file_utils.ModelOutput` instead of a plain tuple.
+"""
+
+
+@add_start_docstrings(
+    "The bare RoBERTa Model transformer outputting raw hidden-states without any specific head on top.",
+    ROBERTA_START_DOCSTRING,
+)
 class FlaxRobertaModel(FlaxBertModel):
     config_class = RobertaConfig
     base_model_prefix = "roberta"

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -233,25 +233,54 @@ class FlaxRobertaOutput(nn.Module):
 
 # Copied from transformers.modeling_flax_bert.FlaxBertLayer with Bert->Roberta
 class FlaxRobertaLayer(nn.Module):
-    num_heads: int
-    head_size: int
-    intermediate_size: int
+    """Layer normalization (https://arxiv.org/abs/1607.06450).
+    Operates on the last axis of the input data.
+    """
+
+    epsilon: float = 1e-6
+    dtype: jnp.dtype = jnp.float32
+    bias: bool = True
+    scale: bool = True
+    bias_init: jnp.ndarray = nn.initializers.zeros
+    scale_init: jnp.ndarray = nn.initializers.ones
 
     @compact
-    def __call__(self, hidden_state, attention_mask):
-        attention = FlaxRobertaAttention(self.num_heads, self.head_size, name="attention")(
-            hidden_state, attention_mask
-        )
-        intermediate = FlaxRobertaIntermediate(self.intermediate_size, name="intermediate")(attention)
-        output = FlaxRobertaOutput(name="output")(intermediate, attention)
-
-        return output
+    def __call__(self, x):
+        """Applies layer normalization on the input.
+        It normalizes the activations of the layer for each given example in a
+        batch independently, rather than across a batch like Batch Normalization.
+        i.e. applies a transformation that maintains the mean activation within
+        each example close to 0 and the activation standard deviation close to 1.
+        Args:
+          x: the inputs
+          epsilon: A small float added to variance to avoid dividing by zero.
+          dtype: the dtype of the computation (default: float32).
+          bias:  If True, bias (beta) is added.
+          scale: If True, multiply by scale (gamma). When the next layer is linear
+            (also e.g. nn.relu), this can be disabled since the scaling will be done
+            by the next layer.
+          bias_init: Initializer for bias, by default, zero.
+          scale_init: Initializer for scale, by default, one.
+        Returns:
+          Normalized inputs (the same shape as inputs).
+        """
+        features = x.shape[-1]
+        mean = jnp.mean(x, axis=-1, keepdims=True)
+        mean2 = jnp.mean(jax.lax.square(x), axis=-1, keepdims=True)
+        var = mean2 - jax.lax.square(mean)
+        mul = jax.lax.rsqrt(var + self.epsilon)
+        if self.scale:
+            mul = mul * jnp.asarray(self.param("gamma", self.scale_init, (features,)), self.dtype)
+        y = (x - mean) * mul
+        if self.bias:
+            y = y + jnp.asarray(self.param("beta", self.bias_init, (features,)), self.dtype)
+        return y
 
 
 # Copied from transformers.modeling_flax_bert.FlaxBertLayerCollection with Bert->Roberta
 class FlaxRobertaLayerCollection(nn.Module):
     """
-    Stores N BertLayer(s)
+    Stores N RobertaLayer(s)
     """
 
     num_layers: int

--- a/src/transformers/modeling_flax_roberta.py
+++ b/src/transformers/modeling_flax_roberta.py
@@ -20,10 +20,9 @@ import jax
 import jax.numpy as jnp
 
 from flax.linen import compact
-from transformers.modeling_flax_utils import FlaxPreTrainedModel
+from transformers.modeling_flax_utils import FlaxPreTrainedModel, gelu
 
 from transformers import BertConfig, RobertaConfig, add_start_docstrings
-from transformers.modeling_flax_bert import FlaxBertModel
 from transformers.utils import logging
 
 logger = logging.get_logger(__name__)
@@ -335,8 +334,8 @@ class FlaxRobertaModel(FlaxPreTrainedModel):
     """
 
     model_class = FlaxRobertaModule
-    config_class = BertConfig
-    base_model_prefix = "bert"
+    config_class = RobertaConfig
+    base_model_prefix = "roberta"
 
     @staticmethod
     def convert_from_pytorch(pt_state: Dict, config: BertConfig) -> Dict:

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -123,8 +123,6 @@ class FlaxPreTrainedModel(ABC):
 
         # Instantiate model.
         with open(resolved_archive_file, "rb") as state_f:
-            from msgpack.exceptions import UnpackException
-
             try:
                 from flax.serialization import from_bytes
 

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -124,6 +124,7 @@ class FlaxPreTrainedModel(ABC):
         # Instantiate model.
         with open(resolved_archive_file, "rb") as state_f:
             from msgpack.exceptions import UnpackException
+
             try:
                 from flax.serialization import from_bytes
 

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -12,13 +12,13 @@ from transformers.file_utils import hf_bucket_url, cached_path, WEIGHTS_NAME, TF
     is_remote_url
 
 
-class JaxPreTrainedModel(ABC):
+class FlaxPreTrainedModel(ABC):
     config_class = None
     pretrained_model_archive_map = {}
     base_model_prefix = ""
     model_class = None
 
-    def __init__(self, config: PretrainedConfig, module: Module, state: Dict):
+    def __init__(self, config: PretrainedConfig, module: Module, state: Dict, seed: int = 0):
         if config is None:
             raise ValueError("config cannot be None")
 
@@ -33,7 +33,7 @@ class JaxPreTrainedModel(ABC):
         self._module = module
 
         # Those are public as their type is generic to every derived classes.
-        self.key = PRNGKey(0)
+        self.key = PRNGKey(seed)
         self.state = state
         self.model = Model(module, state)
 

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -129,7 +129,7 @@ class FlaxPreTrainedModel(ABC):
                 from flax.serialization import from_bytes
 
                 state = from_bytes(cls.model_class, state_f)
-            except UnpackException:
+            except TypeError:
                 try:
                     import torch
 

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -109,7 +109,6 @@ class FlaxPreTrainedModel(ABC):
                             pretrained_model_name_or_path,
                             ", ".join(cls.pretrained_model_archive_map.keys()),
                             archive_file,
-                            [WEIGHTS_NAME, TF2_WEIGHTS_NAME, TF_WEIGHTS_NAME],
                         )
                     )
                 raise EnvironmentError(msg)

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -47,13 +47,13 @@ class FlaxPreTrainedModel(ABC):
         Instantiate a pretrained pytorch model from a pre-trained model configuration.
         """
         config = kwargs.pop("config", None)
-        state_dict = kwargs.pop("state_dict", None)
+        # state_dict = kwargs.pop("state_dict", None)
         cache_dir = kwargs.pop("cache_dir", None)
-        from_tf = kwargs.pop("from_tf", False)
+        # from_tf = kwargs.pop("from_tf", False)
         force_download = kwargs.pop("force_download", False)
         resume_download = kwargs.pop("resume_download", False)
         proxies = kwargs.pop("proxies", None)
-        output_loading_info = kwargs.pop("output_loading_info", False)
+        # output_loading_info = kwargs.pop("output_loading_info", False)
         local_files_only = kwargs.pop("local_files_only", False)
         use_cdn = kwargs.pop("use_cdn", True)
 

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -9,8 +9,6 @@ from flax.traverse_util import unflatten_dict
 from jax.random import PRNGKey
 from transformers import PretrainedConfig, logger
 from transformers.file_utils import (
-    TF2_WEIGHTS_NAME,
-    TF_WEIGHTS_NAME,
     WEIGHTS_NAME,
     cached_path,
     hf_bucket_url,

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -79,11 +79,7 @@ class FlaxPreTrainedModel(ABC):
             if os.path.isfile(pretrained_model_name_or_path) or is_remote_url(pretrained_model_name_or_path):
                 archive_file = pretrained_model_name_or_path
             else:
-                archive_file = hf_bucket_url(
-                    pretrained_model_name_or_path,
-                    filename=WEIGHTS_NAME,
-                    use_cdn=use_cdn
-                )
+                archive_file = hf_bucket_url(pretrained_model_name_or_path, filename=WEIGHTS_NAME, use_cdn=use_cdn)
 
             # redirect to the cache, if necessary
             try:

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -8,12 +8,7 @@ from flax.serialization import to_bytes
 from flax.traverse_util import unflatten_dict
 from jax.random import PRNGKey
 from transformers import PretrainedConfig, logger
-from transformers.file_utils import (
-    WEIGHTS_NAME,
-    cached_path,
-    hf_bucket_url,
-    is_remote_url,
-)
+from transformers.file_utils import WEIGHTS_NAME, cached_path, hf_bucket_url, is_remote_url
 
 
 class FlaxPreTrainedModel(ABC):

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -47,13 +47,15 @@ class FlaxPreTrainedModel(ABC):
         Instantiate a pretrained pytorch model from a pre-trained model configuration.
         """
         config = kwargs.pop("config", None)
-        # state_dict = kwargs.pop("state_dict", None)
+        state_dict = kwargs.pop("state_dict", None)
         cache_dir = kwargs.pop("cache_dir", None)
+        from_tf = kwargs.pop("from_tf", False)
         force_download = kwargs.pop("force_download", False)
         resume_download = kwargs.pop("resume_download", False)
         proxies = kwargs.pop("proxies", None)
-        # output_loading_info = kwargs.pop("output_loading_info", False)
+        output_loading_info = kwargs.pop("output_loading_info", False)
         local_files_only = kwargs.pop("local_files_only", False)
+        use_cdn = kwargs.pop("use_cdn", True)
 
         # Load config if we don't provide a configuration
         if not isinstance(config, PretrainedConfig):
@@ -74,12 +76,14 @@ class FlaxPreTrainedModel(ABC):
 
         # Load model
         if pretrained_model_name_or_path is not None:
-            if pretrained_model_name_or_path in cls.pretrained_model_archive_map:
-                archive_file = cls.pretrained_model_archive_map[pretrained_model_name_or_path]
-            elif os.path.isfile(pretrained_model_name_or_path) or is_remote_url(pretrained_model_name_or_path):
+            if os.path.isfile(pretrained_model_name_or_path) or is_remote_url(pretrained_model_name_or_path):
                 archive_file = pretrained_model_name_or_path
             else:
-                archive_file = hf_bucket_url(pretrained_model_name_or_path, postfix=WEIGHTS_NAME)
+                archive_file = hf_bucket_url(
+                    pretrained_model_name_or_path,
+                    filename=WEIGHTS_NAME,
+                    use_cdn=use_cdn
+                )
 
             # redirect to the cache, if necessary
             try:

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from pickle import UnpicklingError
 from typing import Dict
 
-from flax.linen import Module
+from flax.nn import Model, Module
 from flax.serialization import to_bytes
 from flax.traverse_util import unflatten_dict
 from jax.random import PRNGKey
@@ -17,14 +17,14 @@ class FlaxPreTrainedModel(ABC):
     base_model_prefix = ""
     model_class = None
 
-    def __init__(self, config: PretrainedConfig, module: Module, params: Dict, seed: int = 0):
+    def __init__(self, config: PretrainedConfig, module: Module, state: Dict, seed: int = 0):
         if config is None:
             raise ValueError("config cannot be None")
 
         if module is None:
             raise ValueError("module cannot be None")
 
-        if params is None:
+        if state is None:
             raise ValueError("state cannot be None")
 
         # Those are private to be exposed as typed property on derived classes.
@@ -33,8 +33,8 @@ class FlaxPreTrainedModel(ABC):
 
         # Those are public as their type is generic to every derived classes.
         self.key = PRNGKey(seed)
-        self.params = params
-        self.model = module
+        self.state = state
+        self.model = Model(module, state)
 
     @staticmethod
     @abstractmethod
@@ -44,7 +44,7 @@ class FlaxPreTrainedModel(ABC):
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
         r"""
-        Instantiate a pretrained Flax model from a pre-trained model configuration.
+        Instantiate a pretrained pytorch model from a pre-trained model configuration.
         """
         config = kwargs.pop("config", None)
         # state_dict = kwargs.pop("state_dict", None)
@@ -142,5 +142,5 @@ class FlaxPreTrainedModel(ABC):
             os.mkdir(folder_abs)
 
         with open(os.path.join(folder_abs, "{}.flax".format(self._config.model_type)), "wb") as f:
-            model_bytes = to_bytes(self.params)
+            model_bytes = to_bytes(self.model)
             f.write(model_bytes)

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -24,8 +24,13 @@ import jax.numpy as jnp
 from flax.serialization import to_bytes
 from flax.traverse_util import unflatten_dict
 from jax.random import PRNGKey
-from transformers import PretrainedConfig, logger
-from transformers.file_utils import WEIGHTS_NAME, cached_path, hf_bucket_url, is_remote_url
+
+from .configuration_utils import PretrainedConfig
+from .file_utils import WEIGHTS_NAME, cached_path, hf_bucket_url, is_remote_url
+from .utils import logging
+
+
+logger = logging.get_logger(__name__)
 
 
 @jax.jit

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -36,6 +36,10 @@ class FlaxPreTrainedModel(ABC):
         self.params = params
         self.model = module
 
+    @property
+    def config(self) -> PretrainedConfig:
+        return self._config
+
     @staticmethod
     @abstractmethod
     def convert_from_pytorch(pt_state: Dict, config: PretrainedConfig) -> Dict:

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -97,23 +97,20 @@ class FlaxPreTrainedModel(ABC):
                 )
             except EnvironmentError:
                 if pretrained_model_name_or_path in cls.pretrained_model_archive_map:
-                    msg = "Couldn't reach server at '{}' to download pretrained weights.".format(archive_file)
+                    msg = f"Couldn't reach server at '{archive_file}' to download pretrained weights."
                 else:
                     msg = (
-                        "Model name '{}' was not found in model name list ({}). "
-                        "We assumed '{}' was a path or url to model weight files but "
-                        "couldn't find any such file at this path or url.".format(
-                            pretrained_model_name_or_path,
-                            ", ".join(cls.pretrained_model_archive_map.keys()),
-                            archive_file,
-                        )
+                        f"Model name '{pretrained_model_name_or_path}' "
+                        f"was not found in model name list ({', '.join(cls.pretrained_model_archive_map.keys())}). "
+                        f"We assumed '{archive_file}' was a path or url to model weight files but "
+                        "couldn't find any such file at this path or url."
                     )
                 raise EnvironmentError(msg)
 
             if resolved_archive_file == archive_file:
-                logger.info("loading weights file {}".format(archive_file))
+                logger.info(f"loading weights file {archive_file}")
             else:
-                logger.info("loading weights file {} from cache at {}".format(archive_file, resolved_archive_file))
+                logger.info(f"loading weights file {archive_file} from cache at {resolved_archive_file}")
         else:
             resolved_archive_file = None
 
@@ -133,8 +130,8 @@ class FlaxPreTrainedModel(ABC):
                     state = unflatten_dict({tuple(k.split(".")[1:]): v for k, v in state.items()})
                 except UnpicklingError:
                     raise EnvironmentError(
-                        "Unable to convert model {} to Flax deserializable object. "
-                        "Supported format are PyTorch archive or Flax msgpack".format(archive_file)
+                        f"Unable to convert model {archive_file} to Flax deserializable object. "
+                        "Supported format are PyTorch archive or Flax msgpack"
                     )
 
         return cls(config, state, *model_args, **model_kwargs)
@@ -145,6 +142,6 @@ class FlaxPreTrainedModel(ABC):
         if not os.path.exists(folder_abs):
             os.mkdir(folder_abs)
 
-        with open(os.path.join(folder_abs, "{}.flax".format(self._config.model_type)), "wb") as f:
+        with open(os.path.join(folder_abs, f"{self._config.model_type}.flax", "wb")) as f:
             model_bytes = to_bytes(self.params)
             f.write(model_bytes)

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -18,8 +18,8 @@ from abc import ABC, abstractmethod
 from pickle import UnpicklingError
 from typing import Dict
 
-import jax
 import flax.linen as nn
+import jax
 import jax.numpy as jnp
 from flax.serialization import to_bytes
 from flax.traverse_util import unflatten_dict

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -1,3 +1,18 @@
+# coding=utf-8
+# Copyright 2018 The Google Flax Team Authors and The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 from abc import ABC, abstractmethod
 from pickle import UnpicklingError

--- a/src/transformers/modeling_jax_utils.py
+++ b/src/transformers/modeling_jax_utils.py
@@ -1,0 +1,119 @@
+import os
+
+from flax.serialization import from_bytes
+
+from transformers import PretrainedConfig, logger
+from transformers.file_utils import hf_bucket_url, cached_path, WEIGHTS_NAME, TF2_WEIGHTS_NAME, TF_WEIGHTS_NAME, \
+    is_remote_url
+
+
+class JaxPreTrainedModel:
+    config_class = None
+    pretrained_model_archive_map = {}
+    base_model_prefix = ""
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
+        r"""
+        Instantiate a pretrained pytorch model from a pre-trained model configuration.
+        """
+        config = kwargs.pop("config", None)
+        state_dict = kwargs.pop("state_dict", None)
+        cache_dir = kwargs.pop("cache_dir", None)
+        from_tf = kwargs.pop("from_tf", False)
+        force_download = kwargs.pop("force_download", False)
+        resume_download = kwargs.pop("resume_download", False)
+        proxies = kwargs.pop("proxies", None)
+        output_loading_info = kwargs.pop("output_loading_info", False)
+        local_files_only = kwargs.pop("local_files_only", False)
+
+        # Load config if we don't provide a configuration
+        if not isinstance(config, PretrainedConfig):
+            config_path = config if config is not None else pretrained_model_name_or_path
+            config, model_kwargs = cls.config_class.from_pretrained(
+                config_path,
+                *model_args,
+                cache_dir=cache_dir,
+                return_unused_kwargs=True,
+                force_download=force_download,
+                resume_download=resume_download,
+                proxies=proxies,
+                local_files_only=local_files_only,
+                **kwargs,
+            )
+        else:
+            model_kwargs = kwargs
+
+        # Load model
+        if pretrained_model_name_or_path is not None:
+            if pretrained_model_name_or_path in cls.pretrained_model_archive_map:
+                archive_file = cls.pretrained_model_archive_map[pretrained_model_name_or_path]
+            elif os.path.isdir(pretrained_model_name_or_path):
+                if from_tf and os.path.isfile(os.path.join(pretrained_model_name_or_path, TF_WEIGHTS_NAME + ".index")):
+                    # Load from a TF 1.0 checkpoint
+                    archive_file = os.path.join(pretrained_model_name_or_path, TF_WEIGHTS_NAME + ".index")
+                elif from_tf and os.path.isfile(os.path.join(pretrained_model_name_or_path, TF2_WEIGHTS_NAME)):
+                    # Load from a TF 2.0 checkpoint
+                    archive_file = os.path.join(pretrained_model_name_or_path, TF2_WEIGHTS_NAME)
+                elif os.path.isfile(os.path.join(pretrained_model_name_or_path, WEIGHTS_NAME)):
+                    # Load from a PyTorch checkpoint
+                    archive_file = os.path.join(pretrained_model_name_or_path, WEIGHTS_NAME)
+                else:
+                    raise EnvironmentError(
+                        "Error no file named {} found in directory {} or `from_tf` set to False".format(
+                            [WEIGHTS_NAME, TF2_WEIGHTS_NAME, TF_WEIGHTS_NAME + ".index"], pretrained_model_name_or_path
+                        )
+                    )
+            elif os.path.isfile(pretrained_model_name_or_path) or is_remote_url(pretrained_model_name_or_path):
+                archive_file = pretrained_model_name_or_path
+            elif os.path.isfile(pretrained_model_name_or_path + ".index"):
+                assert (
+                    from_tf
+                ), "We found a TensorFlow checkpoint at {}, please set from_tf to True to load from this checkpoint".format(
+                    pretrained_model_name_or_path + ".index"
+                )
+                archive_file = pretrained_model_name_or_path + ".index"
+            else:
+                archive_file = hf_bucket_url(
+                    pretrained_model_name_or_path, postfix=(TF2_WEIGHTS_NAME if from_tf else WEIGHTS_NAME)
+                )
+
+            # redirect to the cache, if necessary
+            try:
+                resolved_archive_file = cached_path(
+                    archive_file,
+                    cache_dir=cache_dir,
+                    force_download=force_download,
+                    proxies=proxies,
+                    resume_download=resume_download,
+                    local_files_only=local_files_only,
+                )
+            except EnvironmentError:
+                if pretrained_model_name_or_path in cls.pretrained_model_archive_map:
+                    msg = "Couldn't reach server at '{}' to download pretrained weights.".format(archive_file)
+                else:
+                    msg = (
+                        "Model name '{}' was not found in model name list ({}). "
+                        "We assumed '{}' was a path or url to model weight files but "
+                        "couldn't find any such file at this path or url.".format(
+                            pretrained_model_name_or_path,
+                            ", ".join(cls.pretrained_model_archive_map.keys()),
+                            archive_file,
+                            [WEIGHTS_NAME, TF2_WEIGHTS_NAME, TF_WEIGHTS_NAME],
+                        )
+                    )
+                raise EnvironmentError(msg)
+
+            if resolved_archive_file == archive_file:
+                logger.info("loading weights file {}".format(archive_file))
+            else:
+                logger.info("loading weights file {} from cache at {}".format(archive_file, resolved_archive_file))
+        else:
+            resolved_archive_file = None
+
+        # Instantiate model.
+        with open(resolved_archive_file, 'rb') as state_f:
+            state_data = state_f.read()
+            state = from_bytes(cls.MODEL_CLASS, state_data)
+        model = cls(config, state, *model_args, **model_kwargs)
+        return model

--- a/src/transformers/modeling_jax_utils.py
+++ b/src/transformers/modeling_jax_utils.py
@@ -140,7 +140,7 @@ def load_pytorch_weights_in_jax_model(pt_state_dict, config: BertConfig):
 
         # Self Attention output projection needs to be transposed
         if "out.kernel" in key:
-            jax_state[key] = tensor.reshape((768, 12, 64)).transpose(1, 2, 0)
+            jax_state[key] = tensor.reshape((config.hidden_size, config.num_attention_heads, -1)).transpose(1, 2, 0)
 
         # Pooler needs to transpose its kernel
         if "pooler.dense.kernel" in key:

--- a/src/transformers/modeling_jax_utils.py
+++ b/src/transformers/modeling_jax_utils.py
@@ -114,6 +114,6 @@ class JaxPreTrainedModel:
         # Instantiate model.
         with open(resolved_archive_file, 'rb') as state_f:
             state_data = state_f.read()
-            state = from_bytes(cls.MODEL_CLASS, state_data)
+            state = from_bytes(cls.MODEL_CLASS, state_data)["params"]
         model = cls(config, state, *model_args, **model_kwargs)
         return model

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from .file_utils import (
     _datasets_available,
     _faiss_available,
+    _flax_available,
     _sentencepiece_available,
     _tf_available,
     _tokenizers_available,
@@ -113,6 +114,18 @@ def require_tf(test_case):
         return unittest.skip("test requires TensorFlow")(test_case)
     else:
         return test_case
+
+
+def require_flax(test_case):
+    """
+    Decorator marking a test that requires JAX & Flax
+
+    These tests are skipped when one / both are not installed
+
+    """
+    if not _flax_available:
+        test_case = unittest.skip("test requires JAX & Flax")(test_case)
+    return test_case
 
 
 def require_sentencepiece(test_case):

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -565,7 +565,9 @@ class BatchEncoding(UserDict):
         # Get a function reference for the correct framework
         if tensor_type == TensorType.TENSORFLOW:
             if not is_tf_available():
-                raise ImportError("Unable to convert output to TensorFlow tensors format, TensorFlow is not installed.")
+                raise ImportError(
+                    "Unable to convert output to TensorFlow tensors format, TensorFlow is not installed."
+                )
             as_tensor = tf.constant
         elif tensor_type == TensorType.PYTORCH:
             if not is_torch_available():

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -33,6 +33,7 @@ from .file_utils import (
     add_end_docstrings,
     cached_path,
     hf_bucket_url,
+    is_flax_available,
     is_remote_url,
     is_tf_available,
     is_tokenizers_available,
@@ -47,6 +48,8 @@ if is_tf_available():
 
 if is_torch_available():
     import torch
+if is_flax_available():
+    import jax.numpy as jnp
 
 if is_tokenizers_available():
     from tokenizers import AddedToken
@@ -143,6 +146,7 @@ class TensorType(ExplicitEnum):
     PYTORCH = "pt"
     TENSORFLOW = "tf"
     NUMPY = "np"
+    JAX = "jax"
 
 
 class CharSpan(NamedTuple):
@@ -565,6 +569,8 @@ class BatchEncoding(UserDict):
             as_tensor = torch.tensor
         elif tensor_type == TensorType.NUMPY:
             as_tensor = np.asarray
+        elif tensor_type == TensorType.JAX and is_flax_available():
+            as_tensor = jnp.array
         else:
             raise ImportError(
                 "Unable to convert output to tensors format {}, PyTorch or TensorFlow is not available.".format(

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -563,20 +563,25 @@ class BatchEncoding(UserDict):
             tensor_type = TensorType(tensor_type)
 
         # Get a function reference for the correct framework
-        if tensor_type == TensorType.TENSORFLOW and is_tf_available():
+        if tensor_type == TensorType.TENSORFLOW:
+            if not is_tf_available():
+                raise ImportError("Unable to convert output to TensorFlow tensors format, TensorFlow is not installed.")
             as_tensor = tf.constant
-        elif tensor_type == TensorType.PYTORCH and is_torch_available():
+        elif tensor_type == TensorType.PYTORCH:
+            if not is_torch_available():
+                raise ImportError("Unable to convert output to PyTorch tensors format, PyTorch is not installed.")
             as_tensor = torch.tensor
-        elif tensor_type == TensorType.NUMPY:
-            as_tensor = np.asarray
-        elif tensor_type == TensorType.JAX and is_flax_available():
+        elif tensor_type == TensorType.JAX:
+            if not is_flax_available():
+                raise ImportError("Unable to convert output to JAX tensors format, JAX is not installed.")
             as_tensor = jnp.array
         else:
-            raise ImportError(
-                "Unable to convert output to tensors format {}, PyTorch or TensorFlow is not available.".format(
-                    tensor_type
-                )
-            )
+            as_tensor = np.asarray
+        # (mfuntowicz: This code is unreachable)
+        # else:
+        #     raise ImportError(
+        #         "Unable to convert output to tensors format {}".format(tensor_type)
+        #     )
 
         # Do the tensor conversion in batch
         for key, value in self.items():

--- a/tests/test_flax_auto.py
+++ b/tests/test_flax_auto.py
@@ -1,0 +1,25 @@
+import unittest
+
+from transformers import AutoConfig, is_flax_available
+
+from tests.utils import require_flax, slow
+
+if is_flax_available():
+    from transformers.modeling_flax_auto import FlaxAutoModel, MODEL_MAPPING
+
+
+@require_flax
+class FlaxAutoModelTest(unittest.TestCase):
+    @slow
+    def test_model_from_pretrained(self):
+        for model_config, model_class in MODEL_MAPPING.items():
+
+            for model_name in model_class.pretrained_model_archive_map.keys():
+                with self.subTest(model_name):
+                    config = AutoConfig.from_pretrained(model_name)
+                    self.assertIsNotNone(config)
+                    self.assertIsInstance(config, model_config)
+
+                    model = FlaxAutoModel.from_pretrained(model_name)
+                    self.assertIsNotNone(model)
+                    self.assertIsInstance(model, model_class)

--- a/tests/test_flax_auto.py
+++ b/tests/test_flax_auto.py
@@ -1,8 +1,8 @@
 import unittest
 
+from tests.utils import require_flax, slow
 from transformers import AutoConfig, is_flax_available
 
-from tests.utils import require_flax, slow
 
 if is_flax_available():
     from transformers.modeling_flax_auto import FlaxAutoModel, MODEL_MAPPING

--- a/tests/test_flax_auto.py
+++ b/tests/test_flax_auto.py
@@ -1,8 +1,7 @@
 import unittest
 
-from tests.utils import require_flax, slow
 from transformers import AutoConfig, is_flax_available
-
+from transformers.testing_utils import require_flax, slow
 
 if is_flax_available():
     from transformers.modeling_flax_auto import FlaxAutoModel, MODEL_MAPPING

--- a/tests/test_flax_auto.py
+++ b/tests/test_flax_auto.py
@@ -3,8 +3,9 @@ import unittest
 from transformers import AutoConfig, is_flax_available
 from transformers.testing_utils import require_flax, slow
 
+
 if is_flax_available():
-    from transformers.modeling_flax_auto import FlaxAutoModel, MODEL_MAPPING
+    from transformers.modeling_flax_auto import MODEL_MAPPING, FlaxAutoModel
 
 
 @require_flax

--- a/tests/test_flax_auto.py
+++ b/tests/test_flax_auto.py
@@ -1,6 +1,6 @@
 import unittest
 
-from transformers import AutoConfig, is_flax_available, BertConfig
+from transformers import AutoConfig, BertConfig, is_flax_available
 from transformers.modeling_flax_bert import FlaxBertModel
 from transformers.modeling_flax_roberta import FlaxRobertaModel
 from transformers.testing_utils import require_flax, slow

--- a/tests/test_flax_auto.py
+++ b/tests/test_flax_auto.py
@@ -1,6 +1,6 @@
 import unittest
 
-from transformers import AutoConfig, AutoTokenizer, BertConfig, is_flax_available
+from transformers import AutoConfig, AutoTokenizer, BertConfig, is_flax_available, TensorType
 from transformers.testing_utils import require_flax, slow
 
 

--- a/tests/test_flax_auto.py
+++ b/tests/test_flax_auto.py
@@ -1,15 +1,14 @@
 import unittest
 
-import jax
-
-from transformers import AutoConfig, BertConfig, is_flax_available, AutoTokenizer, TensorType
-from transformers.modeling_flax_bert import FlaxBertModel
-from transformers.modeling_flax_roberta import FlaxRobertaModel
+from transformers import AutoConfig, BertConfig, is_flax_available, AutoTokenizer
 from transformers.testing_utils import require_flax, slow
 
 
 if is_flax_available():
+    import jax
     from transformers.modeling_flax_auto import FlaxAutoModel
+    from transformers.modeling_flax_bert import FlaxBertModel
+    from transformers.modeling_flax_roberta import FlaxRobertaModel
 
 
 @require_flax

--- a/tests/test_flax_auto.py
+++ b/tests/test_flax_auto.py
@@ -1,6 +1,6 @@
 import unittest
 
-from transformers import AutoConfig, AutoTokenizer, BertConfig, is_flax_available, TensorType
+from transformers import AutoConfig, AutoTokenizer, BertConfig, TensorType, is_flax_available
 from transformers.testing_utils import require_flax, slow
 
 

--- a/tests/test_flax_auto.py
+++ b/tests/test_flax_auto.py
@@ -1,25 +1,37 @@
 import unittest
 
-from transformers import AutoConfig, is_flax_available
+from transformers import AutoConfig, is_flax_available, BertConfig
+from transformers.modeling_flax_bert import FlaxBertModel
+from transformers.modeling_flax_roberta import FlaxRobertaModel
 from transformers.testing_utils import require_flax, slow
 
 
 if is_flax_available():
-    from transformers.modeling_flax_auto import MODEL_MAPPING, FlaxAutoModel
+    from transformers.modeling_flax_auto import FlaxAutoModel
 
 
 @require_flax
 class FlaxAutoModelTest(unittest.TestCase):
     @slow
-    def test_model_from_pretrained(self):
-        for model_config, model_class in MODEL_MAPPING.items():
+    def test_bert_from_pretrained(self):
+        for model_name in ["bert-base-cased", "bert-large-uncased"]:
+            with self.subTest(model_name):
+                config = AutoConfig.from_pretrained(model_name)
+                self.assertIsNotNone(config)
+                self.assertIsInstance(config, BertConfig)
 
-            for model_name in model_class.pretrained_model_archive_map.keys():
-                with self.subTest(model_name):
-                    config = AutoConfig.from_pretrained(model_name)
-                    self.assertIsNotNone(config)
-                    self.assertIsInstance(config, model_config)
+                model = FlaxAutoModel.from_pretrained(model_name)
+                self.assertIsNotNone(model)
+                self.assertIsInstance(model, FlaxBertModel)
 
-                    model = FlaxAutoModel.from_pretrained(model_name)
-                    self.assertIsNotNone(model)
-                    self.assertIsInstance(model, model_class)
+    @slow
+    def test_roberta_from_pretrained(self):
+        for model_name in ["roberta-base-cased", "roberta-large-uncased"]:
+            with self.subTest(model_name):
+                config = AutoConfig.from_pretrained(model_name)
+                self.assertIsNotNone(config)
+                self.assertIsInstance(config, BertConfig)
+
+                model = FlaxAutoModel.from_pretrained(model_name)
+                self.assertIsNotNone(model)
+                self.assertIsInstance(model, FlaxRobertaModel)

--- a/tests/test_flax_auto.py
+++ b/tests/test_flax_auto.py
@@ -1,6 +1,6 @@
 import unittest
 
-from transformers import AutoConfig, BertConfig, is_flax_available, AutoTokenizer
+from transformers import AutoConfig, AutoTokenizer, BertConfig, is_flax_available
 from transformers.testing_utils import require_flax, slow
 
 

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -1,0 +1,41 @@
+import unittest
+
+from numpy import ndarray
+from tests.utils import require_flax, require_torch
+from transformers import is_flax_available, is_torch_available
+from transformers.tokenization_bert import BertTokenizerFast
+
+if is_flax_available:
+    from transformers.modeling_flax_bert import FlaxBertModel
+
+if is_torch_available:
+    import torch
+    from transformers.modeling_bert import BertModel
+
+
+@require_flax
+@require_torch
+class FlaxBertModelTest(unittest.TestCase):
+
+    def test_from_pytorch(self):
+        torch.set_grad_enabled(False)
+
+        for model_id in FlaxBertModel.pretrained_model_archive_map.keys():
+            with self.subTest(model_id):
+                tokenizer = BertTokenizerFast.from_pretrained(model_id)
+                fx_model = FlaxBertModel.from_pretrained(model_id)
+                pt_model = BertModel.from_pretrained(model_id)
+
+                # Check for simple input
+                pt_inputs = tokenizer.encode_plus("This is a simple input", return_tensors="pt")
+                pt_outputs = pt_model(**pt_inputs)
+                fx_outputs = fx_model(**{k: v.numpy() for k, v in pt_inputs.items()})
+
+                self.assertEqual(len(fx_outputs), len(pt_outputs), "Output lengths differ between Flax and PyTorch")
+
+                for fx_output, pt_output in zip(fx_outputs, pt_outputs):
+                    self.assert_almost_equals(fx_output, pt_output.numpy(), 5e-4)
+
+    def assert_almost_equals(self, a: ndarray, b: ndarray, tol: float):
+        diff = (a - b).sum()
+        self.assertLessEqual(diff, tol, "Difference between torch and flax is {} (>= {})".format(diff, tol))

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -7,10 +7,10 @@ from transformers import is_flax_available, is_torch_available
 from transformers.tokenization_bert import BertTokenizerFast
 
 
-if is_flax_available:
+if is_flax_available():
     from transformers.modeling_flax_bert import FlaxBertModel
 
-if is_torch_available:
+if is_torch_available():
     import torch
     from transformers.modeling_bert import BertModel
 

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -1,9 +1,11 @@
 import unittest
 
 from numpy import ndarray
+
 from tests.utils import require_flax, require_torch
 from transformers import is_flax_available, is_torch_available
 from transformers.tokenization_bert import BertTokenizerFast
+
 
 if is_flax_available:
     from transformers.modeling_flax_bert import FlaxBertModel
@@ -16,7 +18,6 @@ if is_torch_available:
 @require_flax
 @require_torch
 class FlaxBertModelTest(unittest.TestCase):
-
     def test_from_pytorch(self):
         torch.set_grad_enabled(False)
 

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -12,6 +12,7 @@ if is_flax_available():
 
 if is_torch_available():
     import torch
+
     from transformers.modeling_bert import BertModel
 
 

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -2,8 +2,8 @@ import unittest
 
 from numpy import ndarray
 
-from tests.utils import require_flax, require_torch
 from transformers import is_flax_available, is_torch_available
+from transformers.testing_utils import require_flax, require_torch
 from transformers.tokenization_bert import BertTokenizerFast
 
 

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -21,21 +21,20 @@ class FlaxBertModelTest(unittest.TestCase):
     def test_from_pytorch(self):
         torch.set_grad_enabled(False)
 
-        for model_id in FlaxBertModel.pretrained_model_archive_map.keys():
-            with self.subTest(model_id):
-                tokenizer = BertTokenizerFast.from_pretrained(model_id)
-                fx_model = FlaxBertModel.from_pretrained(model_id)
-                pt_model = BertModel.from_pretrained(model_id)
+        with self.subTest("bert-base-cased"):
+            tokenizer = BertTokenizerFast.from_pretrained("bert-base-cased")
+            fx_model = FlaxBertModel.from_pretrained("bert-base-cased")
+            pt_model = BertModel.from_pretrained("bert-base-cased")
 
-                # Check for simple input
-                pt_inputs = tokenizer.encode_plus("This is a simple input", return_tensors="pt")
-                pt_outputs = pt_model(**pt_inputs)
-                fx_outputs = fx_model(**{k: v.numpy() for k, v in pt_inputs.items()})
+            # Check for simple input
+            pt_inputs = tokenizer.encode_plus("This is a simple input", return_tensors="pt")
+            pt_outputs = pt_model(**pt_inputs)
+            fx_outputs = fx_model(**{k: v.numpy() for k, v in pt_inputs.items()})
 
-                self.assertEqual(len(fx_outputs), len(pt_outputs), "Output lengths differ between Flax and PyTorch")
+            self.assertEqual(len(fx_outputs), len(pt_outputs), "Output lengths differ between Flax and PyTorch")
 
-                for fx_output, pt_output in zip(fx_outputs, pt_outputs):
-                    self.assert_almost_equals(fx_output, pt_output.numpy(), 5e-4)
+            for fx_output, pt_output in zip(fx_outputs, pt_outputs):
+                self.assert_almost_equals(fx_output, pt_output.numpy(), 5e-4)
 
     def assert_almost_equals(self, a: ndarray, b: ndarray, tol: float):
         diff = (a - b).sum()

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -2,7 +2,7 @@ import unittest
 
 from numpy import ndarray
 
-from transformers import is_flax_available, is_torch_available
+from transformers import is_flax_available, is_torch_available, TensorType
 from transformers.testing_utils import require_flax, require_torch
 from transformers.tokenization_bert import BertTokenizerFast
 
@@ -28,9 +28,10 @@ class FlaxBertModelTest(unittest.TestCase):
             pt_model = BertModel.from_pretrained("bert-base-cased")
 
             # Check for simple input
-            pt_inputs = tokenizer.encode_plus("This is a simple input", return_tensors="pt")
+            pt_inputs = tokenizer.encode_plus("This is a simple input", return_tensors=TensorType.PYTORCH)
+            fx_inputs = tokenizer.encode_plus("This is a simple input", return_tensors=TensorType.JAX)
             pt_outputs = pt_model(**pt_inputs)
-            fx_outputs = fx_model(**{k: v.numpy() for k, v in pt_inputs.items()})
+            fx_outputs = fx_model(**fx_inputs)
 
             self.assertEqual(len(fx_outputs), len(pt_outputs), "Output lengths differ between Flax and PyTorch")
 

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -2,7 +2,7 @@ import unittest
 
 from numpy import ndarray
 
-from transformers import is_flax_available, is_torch_available, TensorType
+from transformers import TensorType, is_flax_available, is_torch_available
 from transformers.testing_utils import require_flax, require_torch
 from transformers.tokenization_bert import BertTokenizerFast
 

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -4,7 +4,7 @@ from numpy import ndarray
 
 from transformers import TensorType, is_flax_available, is_torch_available
 from transformers.testing_utils import require_flax, require_torch
-from transformers.tokenization_bert import BertTokenizerFast
+from transformers.tokenization_bert_fast import BertTokenizerFast
 
 
 if is_flax_available():

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -1,0 +1,41 @@
+import unittest
+
+from numpy import ndarray
+from tests.utils import require_flax, require_torch
+from transformers import is_flax_available, is_torch_available
+from transformers.tokenization_roberta import RobertaTokenizerFast
+
+if is_flax_available:
+    from transformers.modeling_flax_roberta import FlaxRobertaModel
+
+if is_torch_available:
+    import torch
+    from transformers.modeling_bert import RobertaModel
+
+
+@require_flax
+@require_torch
+class FlaxBertModelTest(unittest.TestCase):
+
+    def test_from_pytorch(self):
+        torch.set_grad_enabled(False)
+
+        for model_id in FlaxRobertaModel.pretrained_model_archive_map.keys():
+            with self.subTest(model_id):
+                tokenizer = RobertaTokenizerFast.from_pretrained(model_id)
+                fx_model = FlaxRobertaModel.from_pretrained(model_id)
+                pt_model = RobertaModel.from_pretrained(model_id)
+
+                # Check for simple input
+                pt_inputs = tokenizer.encode_plus("This is a simple input", return_tensors="pt")
+                pt_outputs = pt_model(**pt_inputs)
+                fx_outputs = fx_model(**{k: v.numpy() for k, v in pt_inputs.items()})
+
+                self.assertEqual(len(fx_outputs), len(pt_outputs), "Output lengths differ between Flax and PyTorch")
+
+                for fx_output, pt_output in zip(fx_outputs, pt_outputs):
+                    self.assert_almost_equals(fx_output, pt_output.numpy(), 5e-4)
+
+    def assert_almost_equals(self, a: ndarray, b: ndarray, tol: float):
+        diff = (a - b).sum()
+        self.assertLessEqual(diff, tol, "Difference between torch and flax is {} (>= {})".format(diff, tol))

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -1,9 +1,11 @@
 import unittest
 
 from numpy import ndarray
+
 from tests.utils import require_flax, require_torch
 from transformers import is_flax_available, is_torch_available
 from transformers.tokenization_roberta import RobertaTokenizerFast
+
 
 if is_flax_available:
     from transformers.modeling_flax_roberta import FlaxRobertaModel
@@ -16,7 +18,6 @@ if is_torch_available:
 @require_flax
 @require_torch
 class FlaxBertModelTest(unittest.TestCase):
-
     def test_from_pytorch(self):
         torch.set_grad_enabled(False)
 

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -12,7 +12,7 @@ if is_flax_available():
 
 if is_torch_available():
     import torch
-    from transformers.modeling_bert import RobertaModel
+    from transformers.modeling_roberta import RobertaModel
 
 
 @require_flax

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -7,10 +7,10 @@ from transformers import is_flax_available, is_torch_available
 from transformers.tokenization_roberta import RobertaTokenizerFast
 
 
-if is_flax_available:
+if is_flax_available():
     from transformers.modeling_flax_roberta import FlaxRobertaModel
 
-if is_torch_available:
+if is_torch_available():
     import torch
     from transformers.modeling_bert import RobertaModel
 

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -2,8 +2,8 @@ import unittest
 
 from numpy import ndarray
 
-from tests.utils import require_flax, require_torch
 from transformers import is_flax_available, is_torch_available
+from transformers.testing_utils import require_flax, require_torch
 from transformers.tokenization_roberta import RobertaTokenizerFast
 
 

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -12,6 +12,7 @@ if is_flax_available():
 
 if is_torch_available():
     import torch
+
     from transformers.modeling_roberta import RobertaModel
 
 

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -21,21 +21,20 @@ class FlaxBertModelTest(unittest.TestCase):
     def test_from_pytorch(self):
         torch.set_grad_enabled(False)
 
-        for model_id in FlaxRobertaModel.pretrained_model_archive_map.keys():
-            with self.subTest(model_id):
-                tokenizer = RobertaTokenizerFast.from_pretrained(model_id)
-                fx_model = FlaxRobertaModel.from_pretrained(model_id)
-                pt_model = RobertaModel.from_pretrained(model_id)
+        with self.subTest("roberta-base"):
+            tokenizer = RobertaTokenizerFast.from_pretrained("roberta-base")
+            fx_model = FlaxRobertaModel.from_pretrained("roberta-base")
+            pt_model = RobertaModel.from_pretrained("roberta-base")
 
-                # Check for simple input
-                pt_inputs = tokenizer.encode_plus("This is a simple input", return_tensors="pt")
-                pt_outputs = pt_model(**pt_inputs)
-                fx_outputs = fx_model(**{k: v.numpy() for k, v in pt_inputs.items()})
+            # Check for simple input
+            pt_inputs = tokenizer.encode_plus("This is a simple input", return_tensors="pt")
+            pt_outputs = pt_model(**pt_inputs)
+            fx_outputs = fx_model(**{k: v.numpy() for k, v in pt_inputs.items()})
 
-                self.assertEqual(len(fx_outputs), len(pt_outputs), "Output lengths differ between Flax and PyTorch")
+            self.assertEqual(len(fx_outputs), len(pt_outputs), "Output lengths differ between Flax and PyTorch")
 
-                for fx_output, pt_output in zip(fx_outputs, pt_outputs):
-                    self.assert_almost_equals(fx_output, pt_output.numpy(), 5e-4)
+            for fx_output, pt_output in zip(fx_outputs, pt_outputs):
+                self.assert_almost_equals(fx_output, pt_output.numpy(), 5e-4)
 
     def assert_almost_equals(self, a: ndarray, b: ndarray, tol: float):
         diff = (a - b).sum()

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -2,7 +2,7 @@ import unittest
 
 from numpy import ndarray
 
-from transformers import is_flax_available, is_torch_available, TensorType
+from transformers import TensorType, is_flax_available, is_torch_available
 from transformers.testing_utils import require_flax, require_torch
 from transformers.tokenization_roberta import RobertaTokenizerFast
 

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -2,7 +2,7 @@ import unittest
 
 from numpy import ndarray
 
-from transformers import is_flax_available, is_torch_available
+from transformers import is_flax_available, is_torch_available, TensorType
 from transformers.testing_utils import require_flax, require_torch
 from transformers.tokenization_roberta import RobertaTokenizerFast
 
@@ -18,7 +18,7 @@ if is_torch_available():
 
 @require_flax
 @require_torch
-class FlaxBertModelTest(unittest.TestCase):
+class FlaxRobertaModelTest(unittest.TestCase):
     def test_from_pytorch(self):
         torch.set_grad_enabled(False)
 
@@ -28,9 +28,10 @@ class FlaxBertModelTest(unittest.TestCase):
             pt_model = RobertaModel.from_pretrained("roberta-base")
 
             # Check for simple input
-            pt_inputs = tokenizer.encode_plus("This is a simple input", return_tensors="pt")
+            pt_inputs = tokenizer.encode_plus("This is a simple input", return_tensors=TensorType.PYTORCH)
+            fx_inputs = tokenizer.encode_plus("This is a simple input", return_tensors=TensorType.JAX)
             pt_outputs = pt_model(**pt_inputs)
-            fx_outputs = fx_model(**{k: v.numpy() for k, v in pt_inputs.items()})
+            fx_outputs = fx_model(**fx_inputs)
 
             self.assertEqual(len(fx_outputs), len(pt_outputs), "Output lengths differ between Flax and PyTorch")
 

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -4,7 +4,7 @@ from numpy import ndarray
 
 from transformers import TensorType, is_flax_available, is_torch_available
 from transformers.testing_utils import require_flax, require_torch
-from transformers.tokenization_roberta import RobertaTokenizerFast
+from transformers.tokenization_roberta_fast import RobertaTokenizerFast
 
 
 if is_flax_available():

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -20,23 +20,22 @@ if is_torch_available():
 @require_torch
 class FlaxRobertaModelTest(unittest.TestCase):
     def test_from_pytorch(self):
-        torch.set_grad_enabled(False)
+        with torch.no_grad():
+            with self.subTest("roberta-base"):
+                tokenizer = RobertaTokenizerFast.from_pretrained("roberta-base")
+                fx_model = FlaxRobertaModel.from_pretrained("roberta-base")
+                pt_model = RobertaModel.from_pretrained("roberta-base")
 
-        with self.subTest("roberta-base"):
-            tokenizer = RobertaTokenizerFast.from_pretrained("roberta-base")
-            fx_model = FlaxRobertaModel.from_pretrained("roberta-base")
-            pt_model = RobertaModel.from_pretrained("roberta-base")
+                # Check for simple input
+                pt_inputs = tokenizer.encode_plus("This is a simple input", return_tensors=TensorType.PYTORCH)
+                fx_inputs = tokenizer.encode_plus("This is a simple input", return_tensors=TensorType.JAX)
+                pt_outputs = pt_model(**pt_inputs)
+                fx_outputs = fx_model(**fx_inputs)
 
-            # Check for simple input
-            pt_inputs = tokenizer.encode_plus("This is a simple input", return_tensors=TensorType.PYTORCH)
-            fx_inputs = tokenizer.encode_plus("This is a simple input", return_tensors=TensorType.JAX)
-            pt_outputs = pt_model(**pt_inputs)
-            fx_outputs = fx_model(**fx_inputs)
+                self.assertEqual(len(fx_outputs), len(pt_outputs), "Output lengths differ between Flax and PyTorch")
 
-            self.assertEqual(len(fx_outputs), len(pt_outputs), "Output lengths differ between Flax and PyTorch")
-
-            for fx_output, pt_output in zip(fx_outputs, pt_outputs):
-                self.assert_almost_equals(fx_output, pt_output.numpy(), 5e-4)
+                for fx_output, pt_output in zip(fx_outputs, pt_outputs):
+                    self.assert_almost_equals(fx_output, pt_output.numpy(), 5e-4)
 
     def assert_almost_equals(self, a: ndarray, b: ndarray, tol: float):
         diff = (a - b).sum()


### PR DESCRIPTION
This Pull Request attempts to bring support for [Flax](https://github.com/google/flax) framework as part of transformers. 

Main focus as been put on providing BERT-like models, principally by making it possible to load PyTorch checkpoints and doing the necessary conversions (few) directly on the fly. Supports also providing a **msgpack** formatted file from Flax.

`save_pretrained` will save the model through **msgpack** format to avoid dependency on torch inside Jax code. 

**Targeted models:** 
- [x] Bert
- [x] RoBERTa 
- [ ] DistilBERT
- [ ] DistilRoBERTa

**If not too hard**

- [ ] CamemBERT

