### PR TITLE
JIT not compatible with PyTorch/XLA

### DIFF
--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -1,7 +1,11 @@
+import logging
 import math
 
 import torch
 import torch.nn.functional as F
+
+
+logger = logging.getLogger(__name__)
 
 
 def swish(x):
@@ -29,7 +33,15 @@ if torch.__version__ < "1.4.0":
     gelu = _gelu_python
 else:
     gelu = F.gelu
-    gelu_new = torch.jit.script(gelu_new)
+    try:
+        import torch_xla  # noqa F401
+
+        logger.warning(
+            "The torch_xla package was detected in the python environment. PyTorch/XLA and JIT is untested,"
+            " no activation function will be traced with JIT."
+        )
+    except ImportError:
+        gelu_new = torch.jit.script(gelu_new)
 
 ACT2FN = {
     "relu": F.relu,


### PR DESCRIPTION
Tracing with JIT is not supported by TPUs. If `torch_xla` is detected in the environment, the `gelu_new` method won't be traced.

If tracing is done, the line:

```py
model = xm.send_cpu_data_to_device(model, xm.xla_device())
```
in `modeling_utils.py`

will raise:

```py
TypeError: can't pickle torch._C.ScriptFunction objects
```


the `# noqa F401` is necessary, otherwise, flake8 gives the following error:
```
src/transformers/activations.py:37:9: F401 'torch_xla' imported but unused
```