### PR TITLE
Add `qas_id` to SquadResult and SquadExample

### DIFF
--- a/examples/run_squad.py
+++ b/examples/run_squad.py
@@ -307,7 +307,7 @@ def evaluate(args, model, tokenizer, prefix=""):
             if args.model_type in ["xlm", "roberta", "distilbert", "camembert"]:
                 del inputs["token_type_ids"]
 
-            example_indices = batch[3]
+            feature_indices = batch[3]
 
             # XLNet and XLM use more arguments for their predictions
             if args.model_type in ["xlnet", "xlm"]:
@@ -320,8 +320,9 @@ def evaluate(args, model, tokenizer, prefix=""):
 
             outputs = model(**inputs)
 
-        for i, example_index in enumerate(example_indices):
-            eval_feature = features[example_index.item()]
+        for i, feature_index in enumerate(feature_indices):
+            # TODO: i and feature_index are the same number! Simplify by removing enumerate?
+            eval_feature = features[feature_index.item()]
             unique_id = int(eval_feature.unique_id)
 
             output = [to_list(output[i]) for output in outputs]

--- a/src/transformers/data/metrics/squad_metrics.py
+++ b/src/transformers/data/metrics/squad_metrics.py
@@ -384,8 +384,12 @@ def compute_predictions_logits(
     tokenizer,
 ):
     """Write final predictions to the json file and log-odds of null if needed."""
-    logger.info("Writing predictions to: %s" % (output_prediction_file))
-    logger.info("Writing nbest to: %s" % (output_nbest_file))
+    if output_prediction_file:
+        logger.info(f"Writing predictions to: {output_prediction_file}")
+    if output_nbest_file:
+        logger.info(f"Writing nbest to: {output_nbest_file}")
+    if output_null_log_odds_file and version_2_with_negative:
+        logger.info(f"Writing null_log_odds to: {output_null_log_odds_file}")
 
     example_index_to_features = collections.defaultdict(list)
     for feature in all_features:
@@ -554,13 +558,15 @@ def compute_predictions_logits(
                 all_predictions[example.qas_id] = best_non_null_entry.text
         all_nbest_json[example.qas_id] = nbest_json
 
-    with open(output_prediction_file, "w") as writer:
-        writer.write(json.dumps(all_predictions, indent=4) + "\n")
+    if output_prediction_file:
+        with open(output_prediction_file, "w") as writer:
+            writer.write(json.dumps(all_predictions, indent=4) + "\n")
 
-    with open(output_nbest_file, "w") as writer:
-        writer.write(json.dumps(all_nbest_json, indent=4) + "\n")
+    if output_nbest_file:
+        with open(output_nbest_file, "w") as writer:
+            writer.write(json.dumps(all_nbest_json, indent=4) + "\n")
 
-    if version_2_with_negative:
+    if output_null_log_odds_file and version_2_with_negative:
         with open(output_null_log_odds_file, "w") as writer:
             writer.write(json.dumps(scores_diff_json, indent=4) + "\n")
 

--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -251,6 +251,7 @@ def squad_convert_example_to_features(example, max_seq_length, doc_stride, max_q
                 start_position=start_position,
                 end_position=end_position,
                 is_impossible=span_is_impossible,
+                qas_id=example.qas_id,
             )
         )
     return features
@@ -374,6 +375,8 @@ def squad_convert_examples_to_features(
                         "input_ids": ex.input_ids,
                         "attention_mask": ex.attention_mask,
                         "token_type_ids": ex.token_type_ids,
+                        "example_index": ex.example_index,
+                        "qas_id": ex.qas_id,
                     },
                     {
                         "start_position": ex.start_position,
@@ -387,7 +390,13 @@ def squad_convert_examples_to_features(
         return tf.data.Dataset.from_generator(
             gen,
             (
-                {"input_ids": tf.int32, "attention_mask": tf.int32, "token_type_ids": tf.int32},
+                {
+                    "input_ids": tf.int32,
+                    "attention_mask": tf.int32,
+                    "token_type_ids": tf.int32,
+                    "example_index": tf.int64,
+                    "qas_id": tf.string,
+                },
                 {
                     "start_position": tf.int64,
                     "end_position": tf.int64,
@@ -401,6 +410,8 @@ def squad_convert_examples_to_features(
                     "input_ids": tf.TensorShape([None]),
                     "attention_mask": tf.TensorShape([None]),
                     "token_type_ids": tf.TensorShape([None]),
+                    "example_index": tf.TensorShape([]),
+                    "qas_id": tf.TensorShape([]),
                 },
                 {
                     "start_position": tf.TensorShape([]),
@@ -678,6 +689,7 @@ class SquadFeatures(object):
         start_position,
         end_position,
         is_impossible,
+        qas_id: str = None,
     ):
         self.input_ids = input_ids
         self.attention_mask = attention_mask
@@ -695,6 +707,7 @@ class SquadFeatures(object):
         self.start_position = start_position
         self.end_position = end_position
         self.is_impossible = is_impossible
+        self.qas_id = qas_id
 
 
 class SquadResult(object):


### PR DESCRIPTION
I'm in the process of adding a `run_tf_squad.py` script, per https://github.com/huggingface/transformers/issues/3685.

This PR:

- Fixes a buggy variable name: `all_example_indices` actually refers to feature indices, so I've renamed it to `all_feature_indices`. This can be verified by adding a breakpoint at https://github.com/huggingface/transformers/blob/master/src/transformers/data/processors/squad.py#L347 and running
```python
print(len(set(all_example_index))) # 12272
print(len(features)) # 12272
print(len(set([f.example_index for f in features]))) # 11873
```
This is because an `Example` refers to a Question + possibly several Answers.
A `Feature` refers to a Question + one Answer. There are 12272 features, but only 11873 examples in the SQuADv2 dataset.

- Adds two attributes to the TensorFlow SQuAD dataset: `feature_index` and `qas_id`. `feature_index` has the same function as it does in PyTorch, but it is now possible to retrieve through the tf.data API. `qas_id` is the ID of an example, and matches [the JSON here](https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v2.0.json).

These two features enable a TensorFlow SQuAD validation script. I have it up and running and will include it in a later PR, as support for a native `TFAlbertForQuestionAnswering` is required first.

