### PR TITLE
Trace log probs on generation

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1074,7 +1074,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
 
         past = encoder_outputs  # defined for encoder-decoder models, None for decoder-only models
 
-        log_probs = [] # if we want to trace log probabilities of the generation
+        log_probs = []  # if we want to trace log probabilities of the generation
 
         while cur_len < max_length:
             model_inputs = self.prepare_inputs_for_generation(input_ids, past=past, attention_mask=attention_mask)


### PR DESCRIPTION
This PR makes a **few code-line changes** to accomplish the following:

- We want to trace the log probabilities of tokens generated during generation, so that we can do policy gradient methods (e.g we want to improve ROUGE scores for summarization by using RL).

- This requires keeping track of the computation graph as well as the log probs.

- We remove the @torch.no_grad() decorator on the `generate` method in `modeling_utils.py`. We replace this with `torch.set_grad_enabled(False)` by default. At the end of the function, we do `torch.set_grad_enabled(True), to restore the original state.

- We use `torch.distributions.Categorical` to sample from the softmax. We can call `dist.sample()` and Torch will keep the gradients.

- We modify `top_k_top_p_filtering` slightly by adding `with torch.no_grad()` for parts of the code which unnecessarily trace the gradient.

## Tests

I have run the tests not including the slow ones and they all passed.

## Example:

```
tokenizer = AutoTokenizer.from_pretrained('distilgpt2')
model = AutoModelWithLMHead.from_pretrained('distilgpt2')   

outputs = model.generate(max_length=40, 
do_sample=True, 
trace_log_probs=True, 
eos_token_id=99999, 
num_beams=1, 
num_return_sequences=3
) 

tokens, log_probs = outputs
print(log_probs)
print(log_probs.shape)
print(tokens.shape)
```

We add error handling to disallow for configurations not supported:

- beam search not supported
```
outputs = model.generate(max_length=40, 
do_sample=True, 
trace_log_probs=True, 
eos_token_id=99999, 
num_beams=5, 
num_return_sequences=3
)  # throws an error
```

- trying to trace while not doing do_sample
```
outputs = model.generate(max_length=40, 
do_sample=False, 
trace_log_probs=True, 
eos_token_id=99999, 
num_beams=1, 
num_return_sequences=3
)  # throws an error
```

