### PR TITLE
[PL examples]: fix progress bar bug

### DIFF
--- a/examples/transformer_base.py
+++ b/examples/transformer_base.py
@@ -104,7 +104,8 @@ class BaseTransformer(pl.LightningModule):
         self.lr_scheduler.step()
 
     def get_tqdm_dict(self):
-        tqdm_dict = {"loss": "{:.3f}".format(self.trainer.avg_loss), "lr": self.lr_scheduler.get_last_lr()[-1]}
+        avg_loss = getattr(self.trainer, "avg_loss", 0.0)
+        tqdm_dict = {"loss": "{:.3f}".format(avg_loss), "lr": self.lr_scheduler.get_last_lr()[-1]}
 
         return tqdm_dict
 


### PR DESCRIPTION
As shown by @prabalbansal in #3576, the fine tuning script for seq2seq models is failing with the following error:

![](https://user-images.githubusercontent.com/30004110/78461843-b2006e00-76cc-11ea-9be8-06171cad86e5.png)

This PR includes the fix suggested by @sshleifer in [this comment](https://github.com/huggingface/transformers/issues/3576#issuecomment-611755174), which made it work, but it seems to be suboptimal since the loss is not shown in the progress.