### PR TITLE
[Config, Serialization] more readable config serialization

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -125,7 +125,7 @@ class PretrainedConfig(object):
         self.label2id = dict(zip(self.id2label.values(), self.id2label.keys()))
         self.label2id = dict((key, int(value)) for key, value in self.label2id.items())
 
-    def save_pretrained(self, save_directory, use_diff=True):
+    def save_pretrained(self, save_directory):
         """
         Save a configuration object to the directory `save_directory`, so that it
         can be re-loaded using the :func:`~transformers.PretrainedConfig.from_pretrained` class method.
@@ -141,7 +141,7 @@ class PretrainedConfig(object):
         # If we save using the predefined names, we can load using `from_pretrained`
         output_config_file = os.path.join(save_directory, CONFIG_NAME)
 
-        self.to_json_file(output_config_file, use_diff=use_diff)
+        self.to_json_file(output_config_file, use_diff=True)
         logger.info("Configuration saved in {}".format(output_config_file))
 
     @classmethod
@@ -364,12 +364,7 @@ class PretrainedConfig(object):
         """
         config_dict = self.to_dict()
 
-        # This way only the diff to the correct model class config would be serialized
-        # v1 in PR
-        default_config_dict = self.__class__().to_dict()
-
-        # This way the diff to the pretrained generic class config would be serialized
-        # v2 in PR
+        # get the default config dict
         default_config_dict = PretrainedConfig().to_dict()
 
         serializable_config_dict = {}
@@ -393,9 +388,13 @@ class PretrainedConfig(object):
             output["model_type"] = self.__class__.model_type
         return output
 
-    def to_json_string(self, use_diff=False):
+    def to_json_string(self, use_diff=True):
         """
         Serializes this instance to a JSON string.
+
+        Args:
+            use_diff (:obj:`bool`):
+                If set to True, only the difference between the config instance and the default PretrainedConfig() is serialized to JSON string.
 
         Returns:
             :obj:`string`: String containing all the attributes that make up this configuration instance in JSON format.
@@ -406,13 +405,15 @@ class PretrainedConfig(object):
             config_dict = self.to_dict()
         return json.dumps(config_dict, indent=2, sort_keys=True) + "\n"
 
-    def to_json_file(self, json_file_path, use_diff=False):
+    def to_json_file(self, json_file_path, use_diff=True):
         """
         Save this instance to a json file.
 
         Args:
             json_file_path (:obj:`string`):
                 Path to the JSON file in which this configuration instance's parameters will be saved.
+            use_diff (:obj:`bool`):
+                If set to True, only the difference between the config instance and the default PretrainedConfig() is serialized to JSON file.
         """
         with open(json_file_path, "w", encoding="utf-8") as writer:
             writer.write(self.to_json_string(use_diff=use_diff))


### PR DESCRIPTION
Given the discussion in PR: #3433, we want to make the serialized model conf more readable. 

### Problem:

E.g. `bert-base-cased` has the following config on S3:
```
{
  "architectures": [
    "BertForMaskedLM"
  ],
  "attention_probs_dropout_prob": 0.1,
  "hidden_act": "gelu",
  "hidden_dropout_prob": 0.1,
  "hidden_size": 768,
  "initializer_range": 0.02,
  "intermediate_size": 3072,
  "max_position_embeddings": 512,
  "num_attention_heads": 12,
  "num_hidden_layers": 12,
  "type_vocab_size": 2,
  "vocab_size": 28996
}
```

But when saved all default params are saved as well (which is unnecessary):

```
{
  "architectures": [
    "BertForMaskedLM"
  ],
  "attention_probs_dropout_prob": 0.1,
  "hidden_act": "gelu",
  "hidden_dropout_prob": 0.1,
  "hidden_size": 768,
  "initializer_range": 0.02,
  "intermediate_size": 3072,
  "max_position_embeddings": 512,
  "num_attention_heads": 12,
  "num_hidden_layers": 12,
  "type_vocab_size": 2,
  "vocab_size": 28996
}
(which is readable imo) and once it's saved it now looks like this:

{
  "_num_labels": 2,
  "architectures": [
    "BertForMaskedLM"
  ],
  "attention_probs_dropout_prob": 0.1,
  "bos_token_id": null,
  "do_sample": false,
  "early_stopping": false,
  "eos_token_id": null,
  "finetuning_task": null,
  "hidden_act": "gelu",
  "hidden_dropout_prob": 0.1,
  "hidden_size": 768,
  "id2label": {
    "0": "LABEL_0",
    "1": "LABEL_1"
  },
  "initializer_range": 0.02,
  "intermediate_size": 3072,
  "is_decoder": false,
  "is_encoder_decoder": false,
  "label2id": {
    "LABEL_0": 0,
    "LABEL_1": 1
  },
  "layer_norm_eps": 1e-12,
  "length_penalty": 1.0,
  "max_length": 20,
  "max_position_embeddings": 512,
  "min_length": 0,
  "model_type": "bert",
  "no_repeat_ngram_size": 0,
  "num_attention_heads": 12,
  "num_beams": 1,
  "num_hidden_layers": 12,
  "num_return_sequences": 1,
  "output_attentions": false,
  "output_hidden_states": false,
  "output_past": true,
  "pad_token_id": 0,
  "pruned_heads": {},
  "repetition_penalty": 1.0,
  "temperature": 1.0,
  "top_k": 50,
  "top_p": 1.0,
  "torchscript": false,
  "type_vocab_size": 2,
  "use_bfloat16": false,
  "vocab_size": 28996
} 
```

### Solution: 

We should only save the difference of the actual config to either **v1**) to the model class' config or **v2**) to the PretrainedConfig() (which contains most of the unnecessary default params). 

This PR implements either **v1**) or **v2**) - up for discussion! 

**v1**) for `bert-base-cased` would look like this:

```
{
  "architectures": [
    "BertForMaskedLM"
  ],
  "vocab_size": 28996
}
```

**v2**) for `bert-base-cased` would look like this:

```
{
  "architectures": [
    "BertForMaskedLM"
  ],
  "attention_probs_dropout_prob": 0.1,
  "hidden_act": "gelu",
  "hidden_dropout_prob": 0.1,
  "hidden_size": 768,
  "initializer_range": 0.02,
  "intermediate_size": 3072,
  "layer_norm_eps": 1e-12,
  "max_position_embeddings": 512,
  "model_type": "bert",
  "num_attention_heads": 12,
  "num_hidden_layers": 12,
  "pad_token_id": 0,
  "type_vocab_size": 2,
  "vocab_size": 28996
}
```
