### PR TITLE
Fix bug in GLUE example for models that do not require token_type_ids

### DIFF
--- a/examples/run_glue.py
+++ b/examples/run_glue.py
@@ -370,7 +370,8 @@ def load_and_cache_examples(args, task, tokenizer, evaluate=False):
     # Convert to Tensors and build dataset
     all_input_ids = torch.tensor([f.input_ids for f in features], dtype=torch.long)
     all_attention_mask = torch.tensor([f.attention_mask for f in features], dtype=torch.long)
-    all_token_type_ids = torch.tensor([f.token_type_ids for f in features], dtype=torch.long)
+    all_token_type_ids = torch.tensor([f.token_type_ids if args.model_type in \
+            ["bert", "xlnet", "albert"] else 0 for f in features], dtype=torch.long)
     if output_mode == "classification":
         all_labels = torch.tensor([f.label for f in features], dtype=torch.long)
     elif output_mode == "regression":


### PR DESCRIPTION
If you try to run the `run_glue.py` example with e.g. roberta from a fresh install of the library, it errors out with the following error:

```
Traceback (most recent call last):
  File "examples/run_glue.py", line 564, in <module>
    main()
  File "examples/run_glue.py", line 512, in main
    train_dataset = load_and_cache_examples(args, args.task_name, tokenizer, evaluate=False)
  File "examples/run_glue.py", line 373, in load_and_cache_examples
    all_token_type_ids = torch.tensor([f.token_type_ids for f in features], dtype=torch.long)
TypeError: an integer is required (got type NoneType)
```

To reproduce, run e.g.

`python examples/run_glue.py --model_name_or_path roberta-base --task_name SST-2 --per_gpu_eval_batch_size=8 --per_gpu_train_batch_size=8 --data_dir ./glue_data/SST-2/ --output_dir ./blah --model_type roberta --do_train --do_eval --max_seq_length 128 --learning_rate 2e-5 --num_train_epochs 3.0`

The reason is obviously that roberta does not have segment ids so `token_type_ids` is set to null in the data loader, causing `torch.tensor` to freak out. There's probably a more elegant long-term solution for this, but it's easy to fix by just setting it to 0 instead of null for those models.