### PR TITLE
Fix bug in max_seq_length for preprocessing in ner example

### DIFF
--- a/examples/ner/preprocess.py
+++ b/examples/ner/preprocess.py
@@ -1,0 +1,41 @@
+import sys
+
+from transformers import AutoTokenizer
+
+
+dataset = sys.argv[1]
+model_name_or_path = sys.argv[2]
+max_len = int(sys.argv[3])
+
+subword_len_counter = 0
+
+tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
+
+with open(dataset, "rt") as f_p:
+    for line in f_p:
+        line = line.rstrip()
+
+        if not line:
+            print(line)
+            subword_len_counter = 0
+            continue
+
+        token = line.split()[0]
+
+        current_subwords_len = len(tokenizer.tokenize(token))
+
+        # Token contains strange control characters like \x96 or \x95
+        # Just filter out the complete line
+        if current_subwords_len == 0:
+            continue
+
+        # Account for added tokens for BERT and RoBERTa
+        if (subword_len_counter + current_subwords_len) > max_len - tokenizer.num_added_tokens():
+            print("")
+            print(line)
+            subword_len_counter = current_subwords_len
+            continue
+
+        subword_len_counter += current_subwords_len
+
+        print(line)

--- a/examples/ner/run.sh
+++ b/examples/ner/run.sh
@@ -4,7 +4,6 @@ curl -L 'https://sites.google.com/site/germeval2014ner/data/NER-de-dev.tsv?attre
 | grep -v "^#" | cut -f 2,3 | tr '\t' ' ' > dev.txt.tmp
 curl -L 'https://sites.google.com/site/germeval2014ner/data/NER-de-test.tsv?attredirects=0&d=1' \
 | grep -v "^#" | cut -f 2,3 | tr '\t' ' ' > test.txt.tmp
- wget "https://raw.githubusercontent.com/stefan-it/fine-tuned-berts-seq/master/scripts/preprocess.py"
 export MAX_LENGTH=128
 export BERT_MODEL=bert-base-multilingual-cased
 python3 preprocess.py train.txt.tmp $BERT_MODEL $MAX_LENGTH > train.txt


### PR DESCRIPTION
**Summary**

If you try to use a value for `max_seq_length` that is less than 128 in the NER example, the maximum sequence length is exceeded when the predictions are made. There is a warning logged for this "Maximum sequence length exceeded: No prediction for.." and predictions cannot be made for these tokens.

**Changes**

Two changes are made:

- In `preprocess.py`, `subword_len_counter` is set to `current_subwords_len` when a blank line is inserted to split up sequences that exceed the maximum sequence length.
- `tokenizer.num_added_tokens()` is subtracted from `max_len` to account for the additional tokens inserted by the BERT tokenizer.

