### PR TITLE
isort ignores examples directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,14 @@
 
 quality:
 	black --check --line-length 119 --target-version py35 examples templates tests src utils
-	isort --check-only --recursive examples templates tests src utils
+	isort --check-only --recursive templates tests src utils
 	flake8 examples templates tests src utils
 
 # Format source code automatically
 
 style:
 	black --line-length 119 --target-version py35 examples templates tests src utils
-	isort --recursive examples templates tests src utils
+	isort --recursive templates tests src utils
 
 # Run tests for the library
 


### PR DESCRIPTION
Temporary solution while we wait for an isort release.
I have my local alias hacked in this way, but I figure new contributors might get confused by the circleci/local isort discrepancy.