### PR TITLE
typo: fine-grained token-leven

### DIFF
--- a/notebooks/02-transformers.ipynb
+++ b/notebooks/02-transformers.ipynb
@@ -280,7 +280,7 @@
     "want to operate at a token-level. This is particularly useful for Named Entity Recognition and Question-Answering.\n",
     "\n",
     "The second, aggregated, representation is especially useful if you need to extract the overall context of the sequence and don't\n",
-    "require a fine-grained token-leven. This is the case for Sentiment-Analysis of the sequence or Information Retrieval."
+    "require a fine-grained token-level. This is the case for Sentiment-Analysis of the sequence or Information Retrieval."
    ]
   },
   {


### PR DESCRIPTION
Changing from "fine-grained token-leven" to "fine-grained token-level"