### PR TITLE
Tanh torch warnings

### DIFF
--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -35,7 +35,7 @@ ACT2FN = {
     "relu": F.relu,
     "swish": swish,
     "gelu": gelu,
-    "tanh": F.tanh,
+    "tanh": torch.tanh,
     "gelu_new": gelu_new,
 }
 


### PR DESCRIPTION
This pull request the warning generated by using torch.nn.functional.tanh (which is deprecated). This pull request changes it to torch.tanh to remove the warning.