### PR TITLE
Fix bug in run_*.py scripts: double wrap into DataParallel during eval

### DIFF
--- a/examples/hans/test_hans.py
+++ b/examples/hans/test_hans.py
@@ -255,7 +255,7 @@ def evaluate(args, model, tokenizer, prefix=""):
         eval_dataloader = DataLoader(eval_dataset, sampler=eval_sampler, batch_size=args.eval_batch_size)
 
         # multi-gpu eval
-        if args.n_gpu > 1:
+        if args.n_gpu > 1 and not isinstance(model, torch.nn.DataParallel):
             model = torch.nn.DataParallel(model)
 
         # Eval!

--- a/examples/mm-imdb/run_mmimdb.py
+++ b/examples/mm-imdb/run_mmimdb.py
@@ -278,7 +278,7 @@ def evaluate(args, model, tokenizer, criterion, prefix=""):
     )
 
     # multi-gpu eval
-    if args.n_gpu > 1:
+    if args.n_gpu > 1 and not isinstance(model, torch.nn.DataParallel):
         model = torch.nn.DataParallel(model)
 
     # Eval!

--- a/examples/ner/run_ner.py
+++ b/examples/ner/run_ner.py
@@ -253,7 +253,7 @@ def evaluate(args, model, tokenizer, labels, pad_token_label_id, mode, prefix=""
     eval_dataloader = DataLoader(eval_dataset, sampler=eval_sampler, batch_size=args.eval_batch_size)
 
     # multi-gpu evaluate
-    if args.n_gpu > 1:
+    if args.n_gpu > 1 and not isinstance(model, torch.nn.DataParallel):
         model = torch.nn.DataParallel(model)
 
     # Eval!

--- a/examples/run_language_modeling.py
+++ b/examples/run_language_modeling.py
@@ -427,7 +427,7 @@ def evaluate(args, model: PreTrainedModel, tokenizer: PreTrainedTokenizer, prefi
     )
 
     # multi-gpu evaluate
-    if args.n_gpu > 1:
+    if args.n_gpu > 1 and not isinstance(model, torch.nn.DataParallel):
         model = torch.nn.DataParallel(model)
 
     # Eval!

--- a/examples/run_multiple_choice.py
+++ b/examples/run_multiple_choice.py
@@ -256,7 +256,7 @@ def evaluate(args, model, tokenizer, prefix="", test=False):
         eval_dataloader = DataLoader(eval_dataset, sampler=eval_sampler, batch_size=args.eval_batch_size)
 
         # multi-gpu evaluate
-        if args.n_gpu > 1:
+        if args.n_gpu > 1 and not isinstance(model, torch.nn.DataParallel):
             model = torch.nn.DataParallel(model)
 
         # Eval!

--- a/examples/run_xnli.py
+++ b/examples/run_xnli.py
@@ -266,7 +266,7 @@ def evaluate(args, model, tokenizer, prefix=""):
         eval_dataloader = DataLoader(eval_dataset, sampler=eval_sampler, batch_size=args.eval_batch_size)
 
         # multi-gpu eval
-        if args.n_gpu > 1:
+        if args.n_gpu > 1 and not isinstance(model, torch.nn.DataParallel):
             model = torch.nn.DataParallel(model)
 
         # Eval!


### PR DESCRIPTION
This bug is present in several scripts in `examples`:
* `examples/run_language_modeling.py`
* `examples/run_multiple_choice.py`
* `examples/run_xnli.py`
* `examples/ner/run_ner.py`
* `examples/mm-imdb/run_mmimdb.py`
* `examples/hans/test_hans.py`

The problem is exactly the same as it was in #1801 and in #1504:

During the evaluation, we are trying to wrap the `model` into `DataParallel` second time (we did it already during training). As a result we have: 
> "RuntimeError: module must have its parameters and buffers on device cuda:0 (device_ids[0]) but found one of them on device: cuda:1" (ids of devices may differ)

The fix is straightforward:
Before:
```python
# multi-gpu eval
if args.n_gpu > 1:
    model = torch.nn.DataParallel(model)
```

After:
```python
# multi-gpu eval
if args.n_gpu > 1 and not isinstance(model, torch.nn.DataParallel):
    model = torch.nn.DataParallel(model)
```
