### PR TITLE
[Pipelines] Encode to max length of input not max length of tokenizer for batch input

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -428,7 +428,6 @@ class Pipeline(_ScikitCompat):
             inputs,
             add_special_tokens=True,
             return_tensors=self.framework,
-            max_length=self.tokenizer.max_len,
             pad_to_max_length=pad_to_max_length,
         )
 

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -425,10 +425,7 @@ class Pipeline(_ScikitCompat):
         # Parse arguments
         inputs = self._args_parser(*texts, **kwargs)
         inputs = self.tokenizer.batch_encode_plus(
-            inputs,
-            add_special_tokens=True,
-            return_tensors=self.framework,
-            pad_to_max_length=pad_to_max_length,
+            inputs, add_special_tokens=True, return_tensors=self.framework, pad_to_max_length=pad_to_max_length,
         )
 
         return inputs


### PR DESCRIPTION
I don't see a reason why we have to pad to `tokenizer.max_length` when encoding. Tokenizers automatically encode until the longest `input_ids` which is much more efficient IMO.