### PR TITLE
feat: add logging through Weights & Biases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ proc_data
 # examples
 runs
 /runs_old
+/wandb
 examples/runs
 
 # data

--- a/examples/run_glue.py
+++ b/examples/run_glue.py
@@ -163,7 +163,7 @@ def main():
 
     # Training
     if training_args.do_train:
-        global_step, _ = trainer.train(
+        trainer.train(
             model_path=model_args.model_name_or_path if os.path.isdir(model_args.model_name_or_path) else None
         )
         trainer.save_model()
@@ -187,9 +187,6 @@ def main():
 
         for eval_dataset in eval_datasets:
             result = trainer.evaluate(eval_dataset=eval_dataset)
-
-            # Log final results
-            trainer.log({**{"eval_{}".format(k):v for k, v in result.items()}, "epoch":training_args.num_train_epochs}, global_step)
 
             output_eval_file = os.path.join(
                 training_args.output_dir, f"eval_results_{eval_dataset.args.task_name}.txt"

--- a/examples/run_glue.py
+++ b/examples/run_glue.py
@@ -163,7 +163,7 @@ def main():
 
     # Training
     if training_args.do_train:
-        trainer.train(
+        global_step, _ = trainer.train(
             model_path=model_args.model_name_or_path if os.path.isdir(model_args.model_name_or_path) else None
         )
         trainer.save_model()
@@ -187,6 +187,9 @@ def main():
 
         for eval_dataset in eval_datasets:
             result = trainer.evaluate(eval_dataset=eval_dataset)
+
+            # Log final results
+            trainer.log({**{"eval_{}".format(k):v for k, v in result.items()}, "epoch":training_args.num_train_epochs}, global_step)
 
             output_eval_file = os.path.join(
                 training_args.output_dir, f"eval_results_{eval_dataset.args.task_name}.txt"

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -49,9 +49,11 @@ except ImportError:
 
 try:
     import wandb
+
     _has_wandb = True
 except ImportError:
     _has_wandb = False
+
 
 def is_tensorboard_available():
     return _has_tensorboard
@@ -275,7 +277,7 @@ class Trainer:
 
         # Start a wandb run and log config parameters
         if _has_wandb:
-            wandb.init(config={**vars(self.args), 'config':self.model.config.to_dict()})
+            wandb.init(config={**vars(self.args), "config": self.model.config.to_dict()})
             # keep track of model topology and gradients
             wandb.watch(self.model)
 
@@ -367,7 +369,13 @@ class Trainer:
                                 for k, v in logs.items():
                                     self.tb_writer.add_scalar(k, v, global_step)
                             if _has_wandb:
-                                wandb.log({**logs, "epoch": global_step / (len(train_dataloader) // self.args.gradient_accumulation_steps)})
+                                wandb.log(
+                                    {
+                                        **logs,
+                                        "epoch": global_step
+                                        / (len(train_dataloader) // self.args.gradient_accumulation_steps),
+                                    }
+                                )
 
                             epoch_iterator.write(json.dumps({**logs, **{"step": global_step}}))
 
@@ -485,7 +493,10 @@ class Trainer:
             shutil.rmtree(checkpoint)
 
     def evaluate(
-        self, eval_dataset: Optional[Dataset] = None, prediction_loss_only: Optional[bool] = None, no_log: Optional[bool] = False
+        self,
+        eval_dataset: Optional[Dataset] = None,
+        prediction_loss_only: Optional[bool] = None,
+        no_log: Optional[bool] = False,
     ) -> Dict[str, float]:
         """
         Run evaluation and return metrics.
@@ -506,7 +517,9 @@ class Trainer:
         output = self._prediction_loop(eval_dataloader, description="Evaluation")
         if _has_wandb and not no_log and wandb.run:
             # Log final metrics
-            wandb.log({**{"eval_{}".format(k):v for k, v in output.metrics.items()}, "epoch":self.args.num_train_epochs})
+            wandb.log(
+                {**{"eval_{}".format(k): v for k, v in output.metrics.items()}, "epoch": self.args.num_train_epochs}
+            )
         return output.metrics
 
     def predict(self, test_dataset: Dataset) -> PredictionOutput:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -2,7 +2,7 @@ import dataclasses
 import json
 import logging
 from dataclasses import dataclass, field
-from typing import Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from .file_utils import cached_property, is_torch_available, torch_required
 
@@ -138,3 +138,13 @@ class TrainingArguments:
         Serializes this instance to a JSON string.
         """
         return json.dumps(dataclasses.asdict(self), indent=2)
+
+    def to_sanitized_dict(self) -> Dict[str, Any]:
+        """
+        Sanitized serialization to use with TensorBoard’s hparams
+        """
+        d = dataclasses.asdict(self)
+        valid_types = [bool, int, float, str]
+        if is_torch_available():
+            valid_types.append(torch.Tensor)
+        return {k: v if type(v) in valid_types else str(v) for k, v in d.items()}


### PR DESCRIPTION
Hi,

I've been using hugging-face for a while and I've been loving it. I think it could become a central reference for NLP problems and the new `Trainer` class made it so much easier to add new functionality.

I would like to contribute in solving a few limitations I observed:
* some models don't have clear details on how they have been trained (hyper-parameters) and for which task, making it hard to reproduce their results (and even ensure those results were actually reached) -> ideally we would track & log their training process as well as config parameters used
* some new models keep on being requested/proposed without seeing their actual efficiency -> ideally we would be able to compare them to baselines
* I've seen issues where "better" models are offered to replace previous ones but there is no way to prove they are actually better -> maybe we can add a metrics table (linked to actual runs) to the model card
* it is hard to keep track of models and datasets
* overall I'd like to bring more traceability and transparency between users

This is why I propose to use [Weights & Biases](https://docs.wandb.com/) which is free for open source and will help solve those issues. Also it is already part of Pytorch-Lightning so it will be easy to integrate it with those scripts, if extra setup is required.

This PR brings :

* logging through Weights & Biases when `wandb` is installed
* logging of evaluation metrics at the end of training

See example run on distilbert-base-cased  -> [W&B run](https://app.wandb.ai/borisd13/transformers-examples/runs/3iuvnwam?workspace=user-borisd13)

![image](https://user-images.githubusercontent.com/715491/80064053-d3e75680-84fc-11ea-954a-9590185c65df.png)

If you navigate around, you will see that config parameters, metrics, gradients, computer resources, actual code (including git repo & command line used) and stdout have all been uploaded for full traceability and reproducibility. I can also easily upload trained model but maybe we could add an arg to make it optional in case users have limited connection (as you prefer)?

I can also easily compare bert-base-uncased and distilbert-base-uncased from my [project page](https://app.wandb.ai/borisd13/transformers-examples).
*Note: I didn't try any fine-tuning and just used same parameters on both in this example.*

![image](https://user-images.githubusercontent.com/715491/80064311-62f46e80-84fd-11ea-8e9a-d4a61af437b3.png)

This makes it easy to quickly see if a new model is actually interesting.

Finally, this integration let us create [cool reports](https://app.wandb.ai/stacey/keras_finetune/reports/Curriculum-Learning-in-Nature--Vmlldzo1MjcxNw) where graphs directly pool data and are interactive.

If you like it, then I'd love to add other features in later PR's:

* log trained model -> I'll just need to have access to path of relevant files so that I don't upload entire output directory
* add [W&B init args](https://docs.wandb.com/library/init) as parameters based on what can be useful for hugging-face
* log all command line args -> I need to access the parser so that I can also log parameters such as `model_path_or_name` and `max_seq_length` (for run_glue script) which will be convenient to create custom summary tables and compare models (or finetune)
* maybe log called script (unless `finetuning_taks` is enough?)
* in addition to metrics, track model size & inference speed which can help users choose the model they want
* use artifacts (W&B version control system) to track models, tokenizers & datasets -> central repository that will let us see easily that runs are based on same dataset or same pre-trained model + see all trained tasks associated to one pre-trained model
* log prediction samples (based on the task)
* create a central repo on W&B (entity: hugging-face) to have access to other's people runs
* integrate model card issue template so that we always add a link to a run as well as performance metrics
* add [sweeps](https://docs.wandb.com/sweeps) -> make it easy to optimize hyper-parameters
* we could add a hook to run automatically on all tasks any new model added (and link the run to the model cards)

Please let me know your thoughts and feel free to contact me or Weights & Biases directly to discuss this integration.