### PR TITLE
change scheduler.get_last_lr to get_lr to avoid bug

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -340,7 +340,7 @@ class Trainer:
                                     logs[eval_key] = value
 
                             loss_scalar = (tr_loss - logging_loss) / self.args.logging_steps
-                            learning_rate_scalar = scheduler.get_last_lr()[0]
+                            learning_rate_scalar = scheduler.get_lr()[0]
                             logs["learning_rate"] = learning_rate_scalar
                             logs["loss"] = loss_scalar
                             logging_loss = tr_loss


### PR DESCRIPTION
Learning rate scheduler function for getting last lr is `get_lr` instead of `get_last_lr`.