### PR TITLE
[ci] Load pretrained models into the default (long-lived) cache

### DIFF
--- a/tests/test_modeling_albert.py
+++ b/tests/test_modeling_albert.py
@@ -20,7 +20,7 @@ from transformers import is_torch_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_common import ModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_torch, slow, torch_device
+from .utils import require_torch, slow, torch_device
 
 
 if is_torch_available():
@@ -267,5 +267,5 @@ class AlbertModelTest(ModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(ALBERT_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = AlbertModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = AlbertModel.from_pretrained(model_name)
             self.assertIsNotNone(model)

--- a/tests/test_modeling_bart.py
+++ b/tests/test_modeling_bart.py
@@ -21,7 +21,7 @@ from transformers import is_torch_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_common import ModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_torch, slow, torch_device
+from .utils import require_torch, slow, torch_device
 
 
 if is_torch_available():
@@ -562,7 +562,7 @@ class BartModelIntegrationTests(unittest.TestCase):
     def test_model_from_pretrained(self):
         # Forces 1.6GB download from S3 for each model
         for model_name in list(BART_PRETRAINED_MODEL_ARCHIVE_MAP.keys()):
-            model = BartModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = BartModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
     @slow

--- a/tests/test_modeling_bert.py
+++ b/tests/test_modeling_bert.py
@@ -20,7 +20,7 @@ from transformers import is_torch_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_common import ModelTesterMixin, floats_tensor, ids_tensor
-from .utils import CACHE_DIR, require_torch, slow, torch_device
+from .utils import require_torch, slow, torch_device
 
 
 if is_torch_available():
@@ -501,5 +501,5 @@ class BertModelTest(ModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(BERT_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = BertModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = BertModel.from_pretrained(model_name)
             self.assertIsNotNone(model)

--- a/tests/test_modeling_ctrl.py
+++ b/tests/test_modeling_ctrl.py
@@ -19,7 +19,7 @@ from transformers import is_torch_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_common import ModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_torch, slow, torch_device
+from .utils import require_torch, slow, torch_device
 
 
 if is_torch_available():
@@ -211,7 +211,7 @@ class CTRLModelTest(ModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(CTRL_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = CTRLModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = CTRLModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 

--- a/tests/test_modeling_distilbert.py
+++ b/tests/test_modeling_distilbert.py
@@ -248,5 +248,5 @@ class DistilBertModelTest(ModelTesterMixin, unittest.TestCase):
     # @slow
     # def test_model_from_pretrained(self):
     #     for model_name in list(DISTILBERT_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-    #         model = DistilBertModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+    #         model = DistilBertModel.from_pretrained(model_name)
     #         self.assertIsNotNone(model)

--- a/tests/test_modeling_electra.py
+++ b/tests/test_modeling_electra.py
@@ -20,7 +20,7 @@ from transformers import is_torch_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_common import ModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_torch, slow, torch_device
+from .utils import require_torch, slow, torch_device
 
 
 if is_torch_available():
@@ -283,5 +283,5 @@ class ElectraModelTest(ModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(ELECTRA_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = ElectraModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = ElectraModel.from_pretrained(model_name)
             self.assertIsNotNone(model)

--- a/tests/test_modeling_flaubert.py
+++ b/tests/test_modeling_flaubert.py
@@ -20,7 +20,7 @@ from transformers import is_torch_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_common import ModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_torch, slow, torch_device
+from .utils import require_torch, slow, torch_device
 
 
 if is_torch_available():
@@ -388,5 +388,5 @@ class FlaubertModelTest(ModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(FLAUBERT_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = FlaubertModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = FlaubertModel.from_pretrained(model_name)
             self.assertIsNotNone(model)

--- a/tests/test_modeling_gpt2.py
+++ b/tests/test_modeling_gpt2.py
@@ -20,7 +20,7 @@ from transformers import is_torch_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_common import ModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_torch, slow, torch_device
+from .utils import require_torch, slow, torch_device
 
 
 if is_torch_available():
@@ -335,7 +335,7 @@ class GPT2ModelTest(ModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(GPT2_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = GPT2Model.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = GPT2Model.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 

--- a/tests/test_modeling_openai.py
+++ b/tests/test_modeling_openai.py
@@ -20,7 +20,7 @@ from transformers import is_torch_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_common import ModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_torch, slow, torch_device
+from .utils import require_torch, slow, torch_device
 
 
 if is_torch_available():
@@ -219,7 +219,7 @@ class OpenAIGPTModelTest(ModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(OPENAI_GPT_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = OpenAIGPTModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = OpenAIGPTModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 

--- a/tests/test_modeling_roberta.py
+++ b/tests/test_modeling_roberta.py
@@ -20,7 +20,7 @@ from transformers import is_torch_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_common import ModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_torch, slow, torch_device
+from .utils import require_torch, slow, torch_device
 
 
 if is_torch_available():
@@ -274,7 +274,7 @@ class RobertaModelTest(ModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = RobertaModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = RobertaModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
     def test_create_position_ids_respects_padding_index(self):

--- a/tests/test_modeling_t5.py
+++ b/tests/test_modeling_t5.py
@@ -20,7 +20,7 @@ from transformers import is_torch_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_common import ModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_torch, slow, torch_device
+from .utils import require_torch, slow, torch_device
 
 
 if is_torch_available():
@@ -358,7 +358,7 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(T5_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = T5Model.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = T5Model.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 

--- a/tests/test_modeling_tf_albert.py
+++ b/tests/test_modeling_tf_albert.py
@@ -20,7 +20,7 @@ from transformers import AlbertConfig, is_tf_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_tf_common import TFModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_tf, slow
+from .utils import require_tf, slow
 
 
 if is_tf_available():
@@ -231,5 +231,5 @@ class TFAlbertModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(TF_ALBERT_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = TFAlbertModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = TFAlbertModel.from_pretrained(model_name)
             self.assertIsNotNone(model)

--- a/tests/test_modeling_tf_bert.py
+++ b/tests/test_modeling_tf_bert.py
@@ -20,7 +20,7 @@ from transformers import BertConfig, is_tf_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_tf_common import TFModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_tf, slow
+from .utils import require_tf, slow
 
 
 if is_tf_available():
@@ -313,5 +313,5 @@ class TFBertModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_model_from_pretrained(self):
         # for model_name in list(TF_BERT_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
         for model_name in ["bert-base-uncased"]:
-            model = TFBertModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = TFBertModel.from_pretrained(model_name)
             self.assertIsNotNone(model)

--- a/tests/test_modeling_tf_ctrl.py
+++ b/tests/test_modeling_tf_ctrl.py
@@ -20,7 +20,7 @@ from transformers import CTRLConfig, is_tf_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_tf_common import TFModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_tf, slow
+from .utils import require_tf, slow
 
 
 if is_tf_available():
@@ -201,7 +201,7 @@ class TFCTRLModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(TF_CTRL_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = TFCTRLModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = TFCTRLModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 

--- a/tests/test_modeling_tf_distilbert.py
+++ b/tests/test_modeling_tf_distilbert.py
@@ -219,5 +219,5 @@ class TFDistilBertModelTest(TFModelTesterMixin, unittest.TestCase):
     # @slow
     # def test_model_from_pretrained(self):
     #     for model_name in list(DISTILBERT_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-    #         model = DistilBertModesss.from_pretrained(model_name, cache_dir=CACHE_DIR)
+    #         model = DistilBertModesss.from_pretrained(model_name)
     #         self.assertIsNotNone(model)

--- a/tests/test_modeling_tf_electra.py
+++ b/tests/test_modeling_tf_electra.py
@@ -20,7 +20,7 @@ from transformers import ElectraConfig, is_tf_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_tf_common import TFModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_tf, slow
+from .utils import require_tf, slow
 
 
 if is_tf_available():
@@ -223,5 +223,5 @@ class TFElectraModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_model_from_pretrained(self):
         # for model_name in list(TF_ELECTRA_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
         for model_name in ["electra-small-discriminator"]:
-            model = TFElectraModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = TFElectraModel.from_pretrained(model_name)
             self.assertIsNotNone(model)

--- a/tests/test_modeling_tf_gpt2.py
+++ b/tests/test_modeling_tf_gpt2.py
@@ -20,7 +20,7 @@ from transformers import GPT2Config, is_tf_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_tf_common import TFModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_tf, slow
+from .utils import require_tf, slow
 
 
 if is_tf_available():
@@ -324,7 +324,7 @@ class TFGPT2ModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(TF_GPT2_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = TFGPT2Model.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = TFGPT2Model.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 

--- a/tests/test_modeling_tf_openai_gpt.py
+++ b/tests/test_modeling_tf_openai_gpt.py
@@ -20,7 +20,7 @@ from transformers import OpenAIGPTConfig, is_tf_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_tf_common import TFModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_tf, slow
+from .utils import require_tf, slow
 
 
 if is_tf_available():
@@ -236,7 +236,7 @@ class TFOpenAIGPTModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(TF_OPENAI_GPT_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = TFOpenAIGPTModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = TFOpenAIGPTModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 

--- a/tests/test_modeling_tf_roberta.py
+++ b/tests/test_modeling_tf_roberta.py
@@ -20,7 +20,7 @@ from transformers import RobertaConfig, is_tf_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_tf_common import TFModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_tf, slow
+from .utils import require_tf, slow
 
 
 if is_tf_available():
@@ -233,7 +233,7 @@ class TFRobertaModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(TF_ROBERTA_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = TFRobertaModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = TFRobertaModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 

--- a/tests/test_modeling_tf_t5.py
+++ b/tests/test_modeling_tf_t5.py
@@ -20,7 +20,7 @@ from transformers import T5Config, is_tf_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_tf_common import TFModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_tf, slow
+from .utils import require_tf, slow
 
 
 if is_tf_available():
@@ -260,7 +260,7 @@ class TFT5ModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in ["t5-small"]:
-            model = TFT5Model.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = TFT5Model.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 

--- a/tests/test_modeling_tf_transfo_xl.py
+++ b/tests/test_modeling_tf_transfo_xl.py
@@ -21,7 +21,7 @@ from transformers import TransfoXLConfig, is_tf_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_tf_common import TFModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_tf, slow
+from .utils import require_tf, slow
 
 
 if is_tf_available():
@@ -210,7 +210,7 @@ class TFTransfoXLModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(TF_TRANSFO_XL_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = TFTransfoXLModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = TFTransfoXLModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 

--- a/tests/test_modeling_tf_xlm.py
+++ b/tests/test_modeling_tf_xlm.py
@@ -20,7 +20,7 @@ from transformers import is_tf_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_tf_common import TFModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_tf, slow
+from .utils import require_tf, slow
 
 
 if is_tf_available():
@@ -309,7 +309,7 @@ class TFXLMModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(TF_XLM_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = TFXLMModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = TFXLMModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 

--- a/tests/test_modeling_tf_xlnet.py
+++ b/tests/test_modeling_tf_xlnet.py
@@ -21,7 +21,7 @@ from transformers import XLNetConfig, is_tf_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_tf_common import TFModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_tf, slow
+from .utils import require_tf, slow
 
 
 if is_tf_available():
@@ -411,7 +411,7 @@ class TFXLNetModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(TF_XLNET_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = TFXLNetModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = TFXLNetModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 

--- a/tests/test_modeling_transfo_xl.py
+++ b/tests/test_modeling_transfo_xl.py
@@ -21,7 +21,7 @@ from transformers import is_torch_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_common import ModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_torch, slow, torch_device
+from .utils import require_torch, slow, torch_device
 
 
 if is_torch_available():
@@ -210,7 +210,7 @@ class TransfoXLModelTest(ModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(TRANSFO_XL_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = TransfoXLModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = TransfoXLModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 

--- a/tests/test_modeling_xlm.py
+++ b/tests/test_modeling_xlm.py
@@ -20,7 +20,7 @@ from transformers import is_torch_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_common import ModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_torch, slow, torch_device
+from .utils import require_torch, slow, torch_device
 
 
 if is_torch_available():
@@ -426,7 +426,7 @@ class XLMModelTest(ModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(XLM_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = XLMModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = XLMModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 

--- a/tests/test_modeling_xlnet.py
+++ b/tests/test_modeling_xlnet.py
@@ -21,7 +21,7 @@ from transformers import is_torch_available
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_common import ModelTesterMixin, ids_tensor
-from .utils import CACHE_DIR, require_torch, slow, torch_device
+from .utils import require_torch, slow, torch_device
 
 
 if is_torch_available():
@@ -509,7 +509,7 @@ class XLNetModelTest(ModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in list(XLNET_PRETRAINED_MODEL_ARCHIVE_MAP.keys())[:1]:
-            model = XLNetModel.from_pretrained(model_name, cache_dir=CACHE_DIR)
+            model = XLNetModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -107,16 +107,15 @@ class TokenizerTesterMixin:
 
         before_tokens = tokenizer.encode("He is very happy, UNwant\u00E9d,running", add_special_tokens=False)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            tokenizer.save_pretrained(tmpdirname)
-            tokenizer = self.tokenizer_class.from_pretrained(tmpdirname)
+        tokenizer.save_pretrained(self.tmpdirname)
+        tokenizer = self.tokenizer_class.from_pretrained(self.tmpdirname)
 
-            after_tokens = tokenizer.encode("He is very happy, UNwant\u00E9d,running", add_special_tokens=False)
-            self.assertListEqual(before_tokens, after_tokens)
+        after_tokens = tokenizer.encode("He is very happy, UNwant\u00E9d,running", add_special_tokens=False)
+        self.assertListEqual(before_tokens, after_tokens)
 
-            self.assertEqual(tokenizer.max_len, 42)
-            tokenizer = self.tokenizer_class.from_pretrained(tmpdirname, max_len=43)
-            self.assertEqual(tokenizer.max_len, 43)
+        self.assertEqual(tokenizer.max_len, 42)
+        tokenizer = self.tokenizer_class.from_pretrained(self.tmpdirname, max_len=43)
+        self.assertEqual(tokenizer.max_len, 43)
 
     def test_pickle_tokenizer(self):
         tokenizer = self.get_tokenizer()
@@ -125,14 +124,12 @@ class TokenizerTesterMixin:
         text = "Munich and Berlin are nice cities"
         subwords = tokenizer.tokenize(text)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        filename = os.path.join(self.tmpdirname, "tokenizer.bin")
+        with open(filename, "wb") as handle:
+            pickle.dump(tokenizer, handle)
 
-            filename = os.path.join(tmpdirname, "tokenizer.bin")
-            with open(filename, "wb") as handle:
-                pickle.dump(tokenizer, handle)
-
-            with open(filename, "rb") as handle:
-                tokenizer_new = pickle.load(handle)
+        with open(filename, "rb") as handle:
+            tokenizer_new = pickle.load(handle)
 
         subwords_loaded = tokenizer_new.tokenize(text)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,12 +1,9 @@
 import os
-import tempfile
 import unittest
 from distutils.util import strtobool
 
 from transformers.file_utils import _tf_available, _torch_available
 
-
-CACHE_DIR = os.path.join(tempfile.gettempdir(), "transformers_test")
 
 SMALL_MODEL_IDENTIFIER = "julien-c/bert-xsmall-dummy"
 DUMMY_UNKWOWN_IDENTIFIER = "julien-c/dummy-unknown"


### PR DESCRIPTION
There's an inconsistency right now where:
- we load some models into CACHE_DIR
- and some models in the default cache
- and often, in both for the same models

When running the RUN_SLOW tests, this takes a lot of disk space, time, and bandwidth.

I'd rather always use the default cache
