### PR TITLE
Continue training args and tqdm in notebooks

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -15,7 +15,7 @@ from torch.utils.data.dataloader import DataLoader
 from torch.utils.data.dataset import Dataset
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data.sampler import RandomSampler
-from tqdm import tqdm, trange
+from tqdm.auto import tqdm, trange
 
 from .data.data_collator import DataCollator, DefaultDataCollator
 from .modeling_utils import PreTrainedModel

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -73,7 +73,7 @@ class TrainingArguments:
         metadata={
             "help": (
                 "Limit the total amount of checkpoints."
-                "Delete the older checkpoints in the output_dir, does not delete by default"
+                "Deletes the older checkpoints in the output_dir. Default is unlimited checkpoints"
             )
         },
     )

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -29,10 +29,12 @@ class TrainingArguments:
         metadata={"help": "The output directory where the model predictions and checkpoints will be written."}
     )
     overwrite_output_dir: bool = field(
-        default=False, 
+        default=False,
         metadata={
-        	"help": "Overwrite the content of the output directory." 
-        	"continue training if output_dir points to a checkpoint directory."
+            "help": (
+                "Overwrite the content of the output directory."
+                "continue training if output_dir points to a checkpoint directory."
+            )
         },
     )
 
@@ -40,14 +42,14 @@ class TrainingArguments:
     do_eval: bool = field(default=False, metadata={"help": "Whether to run eval on the dev set."})
     do_predict: bool = field(default=False, metadata={"help": "Whether to run predictions on the test set."})
     evaluate_during_training: bool = field(
-        default=False, metadata={"help": "Run evaluation during training at each logging step."}
+        default=False, metadata={"help": "Run evaluation during training at each logging step."},
     )
 
     per_gpu_train_batch_size: int = field(default=8, metadata={"help": "Batch size per GPU/CPU for training."})
     per_gpu_eval_batch_size: int = field(default=8, metadata={"help": "Batch size per GPU/CPU for evaluation."})
     gradient_accumulation_steps: int = field(
-        default=1, 
-        metadata={"help": "Number of updates steps to accumulate before performing a backward/update pass."}
+        default=1,
+        metadata={"help": "Number of updates steps to accumulate before performing a backward/update pass."},
     )
 
     learning_rate: float = field(default=5e-5, metadata={"help": "The initial learning rate for Adam."})
@@ -69,8 +71,10 @@ class TrainingArguments:
     save_total_limit: Optional[int] = field(
         default=None,
         metadata={
-            "help": "Limit the total amount of checkpoints" 
-            "delete the older checkpoints in the output_dir, does not delete by default"
+            "help": (
+                "Limit the total amount of checkpoints"
+                "delete the older checkpoints in the output_dir, does not delete by default"
+            )
         },
     )
     no_cuda: bool = field(default=False, metadata={"help": "Avoid using CUDA even if it is available"})
@@ -83,8 +87,10 @@ class TrainingArguments:
     fp16_opt_level: str = field(
         default="O1",
         metadata={
-            "help": "For fp16: Apex AMP optimization level selected in ['O0', 'O1', 'O2', and 'O3']."
-            "See details at https://nvidia.github.io/apex/amp.html"
+            "help": (
+                "For fp16: Apex AMP optimization level selected in ['O0', 'O1', 'O2', and 'O3']."
+                "See details at https://nvidia.github.io/apex/amp.html"
+            )
         },
     )
     local_rank: int = field(default=-1, metadata={"help": "For distributed training: local_rank"})

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -29,7 +29,11 @@ class TrainingArguments:
         metadata={"help": "The output directory where the model predictions and checkpoints will be written."}
     )
     overwrite_output_dir: bool = field(
-        default=False, metadata={"help": "Overwrite the content of the output directory, continue training if output_dir points to a checkpoint directory."}
+        default=False, 
+        metadata={
+        	"help": "Overwrite the content of the output directory." 
+        	"continue training if output_dir points to a checkpoint directory."
+        },
     )
 
     do_train: bool = field(default=False, metadata={"help": "Whether to run training."})

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -72,8 +72,8 @@ class TrainingArguments:
         default=None,
         metadata={
             "help": (
-                "Limit the total amount of checkpoints"
-                "delete the older checkpoints in the output_dir, does not delete by default"
+                "Limit the total amount of checkpoints."
+                "Delete the older checkpoints in the output_dir, does not delete by default"
             )
         },
     )

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -29,7 +29,7 @@ class TrainingArguments:
         metadata={"help": "The output directory where the model predictions and checkpoints will be written."}
     )
     overwrite_output_dir: bool = field(
-        default=False, metadata={"help": "Overwrite the content of the output directory, continue training if points to a checkpoint directory."}
+        default=False, metadata={"help": "Overwrite the content of the output directory, continue training if output_dir points to a checkpoint directory."}
     )
 
     do_train: bool = field(default=False, metadata={"help": "Whether to run training."})

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -33,7 +33,7 @@ class TrainingArguments:
         metadata={
             "help": (
                 "Overwrite the content of the output directory."
-                "continue training if output_dir points to a checkpoint directory."
+                "Use this to continue training if output_dir points to a checkpoint directory."
             )
         },
     )

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -29,7 +29,7 @@ class TrainingArguments:
         metadata={"help": "The output directory where the model predictions and checkpoints will be written."}
     )
     overwrite_output_dir: bool = field(
-        default=False, metadata={"help": "Overwrite the content of the output directory"}
+        default=False, metadata={"help": "Overwrite the content of the output directory, continue training if points to a checkpoint directory."}
     )
 
     do_train: bool = field(default=False, metadata={"help": "Whether to run training."})

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -46,7 +46,8 @@ class TrainingArguments:
     per_gpu_train_batch_size: int = field(default=8, metadata={"help": "Batch size per GPU/CPU for training."})
     per_gpu_eval_batch_size: int = field(default=8, metadata={"help": "Batch size per GPU/CPU for evaluation."})
     gradient_accumulation_steps: int = field(
-        default=1, metadata={"help": "Number of updates steps to accumulate before performing a backward/update pass."}
+        default=1, 
+        metadata={"help": "Number of updates steps to accumulate before performing a backward/update pass."}
     )
 
     learning_rate: float = field(default=5e-5, metadata={"help": "The initial learning rate for Adam."})
@@ -68,7 +69,8 @@ class TrainingArguments:
     save_total_limit: Optional[int] = field(
         default=None,
         metadata={
-            "help": "Limit the total amount of checkpoints, delete the older checkpoints in the output_dir, does not delete by default"
+            "help": "Limit the total amount of checkpoints" 
+            "delete the older checkpoints in the output_dir, does not delete by default"
         },
     )
     no_cuda: bool = field(default=False, metadata={"help": "Avoid using CUDA even if it is available"})


### PR DESCRIPTION
Added a little more description to the metadata of training args for new scripts. 
`--overwrite_output_dir` can be used to continue training from checkpoint if `--output_dir` points to a directory already having checkpoints.

This can help reduce the confusion when migrating from older script.


tqdm in colab prints every step in new line.
so updated to 
`from tqdm.auto import tqdm`