### PR TITLE
fix resize_token_embeddings to accept padding_idx for xlm-roberta models

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -346,7 +346,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
 
         return model_embeds
 
-    def _resize_token_embeddings(self, new_num_tokens, padding_idx):
+    def _resize_token_embeddings(self, new_num_tokens, padding_idx=None):
         old_embeddings = self.get_input_embeddings()
         new_embeddings = self._get_resized_embeddings(old_embeddings, new_num_tokens, padding_idx)
         self.set_input_embeddings(new_embeddings)


### PR DESCRIPTION
When resize_token_embedding there is no option for padding_idx 
and it leads to the wrong embedding for xlm-roberta models 
which needs embedding to have padding_idx as 1 not 0.

I fixed issue by adding option for padding_idx and considered padding_idx as None (which is 0 as default) for compatibility for other types of transformers models.