### PR TITLE
Allow the creation of "entity groups" for NerPipeline #3548

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -925,14 +925,12 @@ class NerPipeline(Pipeline):
 
             for idx, label_idx in filtered_labels_idx:
 
-                entity = [
-                    {
-                        "word": self.tokenizer.convert_ids_to_tokens(int(input_ids[idx])),
-                        "score": score[idx][label_idx].item(),
-                        "entity": self.model.config.id2label[label_idx],
-                        "index": idx,
-                    }
-                ]
+                entity = {
+                    "word": self.tokenizer.convert_ids_to_tokens(int(input_ids[idx])),
+                    "score": score[idx][label_idx].item(),
+                    "entity": self.model.config.id2label[label_idx],
+                    "index": idx,
+                }
                 last_idx, _ = filtered_labels_idx[-1]
                 if self.group:
                     if not entity_group_disagg:

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -868,6 +868,7 @@ class NerPipeline(Pipeline):
         binary_output: bool = False,
         ignore_labels=["O"],
         task: str = "",
+        group: bool = False,
     ):
         super().__init__(
             model=model,
@@ -882,6 +883,7 @@ class NerPipeline(Pipeline):
 
         self._basic_tokenizer = BasicTokenizer(do_lower_case=False)
         self.ignore_labels = ignore_labels
+        self.group = group
 
     def __call__(self, *args, **kwargs):
         inputs = self._args_parser(*args, **kwargs)
@@ -911,23 +913,75 @@ class NerPipeline(Pipeline):
             score = np.exp(entities) / np.exp(entities).sum(-1, keepdims=True)
             labels_idx = score.argmax(axis=-1)
 
-            answer = []
-            for idx, label_idx in enumerate(labels_idx):
-                if self.model.config.id2label[label_idx] not in self.ignore_labels:
-                    answer += [
-                        {
-                            "word": self.tokenizer.convert_ids_to_tokens(int(input_ids[idx])),
-                            "score": score[idx][label_idx].item(),
-                            "entity": self.model.config.id2label[label_idx],
-                            "index": idx,
-                        }
-                    ]
+            entities = []
+            entity_groups = []
+            entity_group_disagg = []
+            # Filter to labels not in `self.ignore_labels`
+            filtered_labels_idx = [
+                (idx, label_idx)
+                for idx, label_idx in enumerate(labels_idx)
+                if self.model.config.id2label[label_idx] not in self.ignore_labels
+            ]
+
+            for idx, label_idx in filtered_labels_idx:
+
+                entity = [
+                    {
+                        "word": self.tokenizer.convert_ids_to_tokens(int(input_ids[idx])),
+                        "score": score[idx][label_idx].item(),
+                        "entity": self.model.config.id2label[label_idx],
+                        "index": idx,
+                    }
+                ]
+                last_idx, _ = filtered_labels_idx[-1]
+                if self.group:
+                    if not entity_group_disagg:
+                        entity_group_disagg += [entity]
+                        if idx == last_idx:
+                            entity_groups += [self.group_entities(entity_group_disagg)]
+                        continue
+
+                    # If the current entity is similar and adjacent to the previous entity, append it to the disaggregated entity group
+                    if (
+                        entity["entity"] == entity_group_disagg[-1]["entity"]
+                        and entity["index"] == entity_group_disagg[-1]["index"] + 1
+                    ):
+                        entity_group_disagg += [entity]
+                        # Group the entities at the last entity
+                        if idx == last_idx:
+                            entity_groups += [self.group_entities(entity_group_disagg)]
+                    # If the current entity is different from the previous entity, aggregate the disaggregated entity group
+                    else:
+                        entity_groups += [self.group_entities(entity_group_disagg)]
+                        entity_group_disagg = []
+
+                entities += [entity]
 
             # Append
-            answers += [answer]
+            if self.group:
+                answers += [entity_groups]
+            else:
+                answers += [entities]
+
         if len(answers) == 1:
             return answers[0]
         return answers
+
+    def group_entities(self, entities):
+        """
+        Returns grouped entities
+        """
+        # Get the last entity in the entity group
+        entity = entities[-1]["entity"]
+        scores = np.mean([entity["score"] for entity in entities])
+        tokens = [entity["word"] for entity in entities]
+
+        entity_group = {
+            "entity_group": entity,
+            "score": np.mean(scores),
+            "word": self.tokenizer.convert_tokens_to_string(tokens),
+        }
+        return entity_group
 
 
 TokenClassificationPipeline = NerPipeline

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -919,6 +919,7 @@ class NerPipeline(Pipeline):
                             "word": self.tokenizer.convert_ids_to_tokens(int(input_ids[idx])),
                             "score": score[idx][label_idx].item(),
                             "entity": self.model.config.id2label[label_idx],
+                            "index": idx,
                         }
                     ]
 

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -868,7 +868,7 @@ class NerPipeline(Pipeline):
         binary_output: bool = False,
         ignore_labels=["O"],
         task: str = "",
-        group: bool = False,
+        grouped_entities: bool = False,
     ):
         super().__init__(
             model=model,
@@ -883,7 +883,7 @@ class NerPipeline(Pipeline):
 
         self._basic_tokenizer = BasicTokenizer(do_lower_case=False)
         self.ignore_labels = ignore_labels
-        self.group = group
+        self.grouped_entities = grouped_entities
 
     def __call__(self, *args, **kwargs):
         inputs = self._args_parser(*args, **kwargs)
@@ -932,7 +932,7 @@ class NerPipeline(Pipeline):
                     "index": idx,
                 }
                 last_idx, _ = filtered_labels_idx[-1]
-                if self.group:
+                if self.grouped_entities:
                     if not entity_group_disagg:
                         entity_group_disagg += [entity]
                         if idx == last_idx:
@@ -956,7 +956,7 @@ class NerPipeline(Pipeline):
                 entities += [entity]
 
             # Append
-            if self.group:
+            if self.grouped_entities:
                 answers += [entity_groups]
             else:
                 answers += [entities]

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -951,7 +951,7 @@ class NerPipeline(Pipeline):
                     # If the current entity is different from the previous entity, aggregate the disaggregated entity group
                     else:
                         entity_groups += [self.group_entities(entity_group_disagg)]
-                        entity_group_disagg = []
+                        entity_group_disagg = [entity]
 
                 entities += [entity]
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -182,7 +182,7 @@ class MonoColumnInputTestCase(unittest.TestCase):
         mandatory_keys = {"entity_group", "word", "score"}
         valid_inputs = ["HuggingFace is solving NLP one commit at a time.", "HuggingFace is based in New-York & Paris"]
         invalid_inputs = [None]
-        for tokenizer, model, config in TF_NER_FINETUNED_MODELS:
+        for tokenizer, model, config in NER_FINETUNED_MODELS:
             nlp = pipeline(
                 task="ner", model=model, config=config, tokenizer=tokenizer, framework="tf", grouped_entities=True
             )

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -160,6 +160,15 @@ class MonoColumnInputTestCase(unittest.TestCase):
             nlp = pipeline(task="ner", model=model_name, tokenizer=model_name)
             self._test_mono_column_pipeline(nlp, valid_inputs, mandatory_keys)
 
+    @require_torch
+    def test_ner_grouped(self):
+        mandatory_keys = {"entity_group", "word", "score"}
+        valid_inputs = ["HuggingFace is solving NLP one commit at a time.", "HuggingFace is based in New-York & Paris"]
+        invalid_inputs = [None]
+        for tokenizer, model, config in NER_FINETUNED_MODELS:
+            nlp = pipeline(task="ner", model=model, config=config, tokenizer=tokenizer, grouped_entities=True)
+            self._test_mono_column_pipeline(nlp, valid_inputs, invalid_inputs, mandatory_keys)
+
     @require_tf
     def test_tf_ner(self):
         mandatory_keys = {"entity", "word", "score"}
@@ -167,6 +176,17 @@ class MonoColumnInputTestCase(unittest.TestCase):
         for model_name in NER_FINETUNED_MODELS:
             nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf")
             self._test_mono_column_pipeline(nlp, valid_inputs, mandatory_keys)
+
+    @require_tf
+    def test_tf_ner_grouped(self):
+        mandatory_keys = {"entity_group", "word", "score"}
+        valid_inputs = ["HuggingFace is solving NLP one commit at a time.", "HuggingFace is based in New-York & Paris"]
+        invalid_inputs = [None]
+        for tokenizer, model, config in TF_NER_FINETUNED_MODELS:
+            nlp = pipeline(
+                task="ner", model=model, config=config, tokenizer=tokenizer, framework="tf", grouped_entities=True
+            )
+            self._test_mono_column_pipeline(nlp, valid_inputs, invalid_inputs, mandatory_keys)
 
     @require_torch
     def test_torch_sentiment_analysis(self):

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -164,10 +164,9 @@ class MonoColumnInputTestCase(unittest.TestCase):
     def test_ner_grouped(self):
         mandatory_keys = {"entity_group", "word", "score"}
         valid_inputs = ["HuggingFace is solving NLP one commit at a time.", "HuggingFace is based in New-York & Paris"]
-        invalid_inputs = [None]
-        for tokenizer, model, config in NER_FINETUNED_MODELS:
-            nlp = pipeline(task="ner", model=model, config=config, tokenizer=tokenizer, grouped_entities=True)
-            self._test_mono_column_pipeline(nlp, valid_inputs, invalid_inputs, mandatory_keys)
+        for model_name in NER_FINETUNED_MODELS:
+            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, grouped_entities=True)
+            self._test_mono_column_pipeline(nlp, valid_inputs, mandatory_keys)
 
     @require_tf
     def test_tf_ner(self):
@@ -181,12 +180,9 @@ class MonoColumnInputTestCase(unittest.TestCase):
     def test_tf_ner_grouped(self):
         mandatory_keys = {"entity_group", "word", "score"}
         valid_inputs = ["HuggingFace is solving NLP one commit at a time.", "HuggingFace is based in New-York & Paris"]
-        invalid_inputs = [None]
-        for tokenizer, model, config in NER_FINETUNED_MODELS:
-            nlp = pipeline(
-                task="ner", model=model, config=config, tokenizer=tokenizer, framework="tf", grouped_entities=True
-            )
-            self._test_mono_column_pipeline(nlp, valid_inputs, invalid_inputs, mandatory_keys)
+        for model_name in NER_FINETUNED_MODELS:
+            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf", grouped_entities=True)
+            self._test_mono_column_pipeline(nlp, valid_inputs, mandatory_keys)
 
     @require_torch
     def test_torch_sentiment_analysis(self):


### PR DESCRIPTION
### This pull request applies the entity group transformation by setting the parameter: group=True.

This was done by reflecting the transformation inside NerPipeline. This is similar to a previously closed [PR](https://github.com/huggingface/transformers/pull/3607), which I closed because I accidentlly deleted my fork (apologies for my clumsiness).

Details of what I want to be able to do can be found in issue #3548.

cc @julien-c @mfuntowicz @petulla

Sample code:
```
# Install branch
# Make sure to restart runtime after installing if using Google Colab
!pip install -e git+git://github.com/enzoampil/transformers.git@add_index_to_ner_pipeline#egg=transformers

# Grouped NER
from transformers import pipeline
nlp = pipeline('ner', grouped_entities=True)
nlp("Enzo works at the Australian National University (AUN)")

# [{'entity_group': 'I-PER', 'score': 0.9968132972717285, 'word': 'Enzo'},
# {'entity_group': 'I-ORG', 'score': 0.9970400333404541, 'word': 'Australian National University'},
# {'entity_group': 'I-ORG', 'score': 0.9831967651844025, 'word': 'AUN'}]

# Ungrouped NER
nlp = pipeline('ner', grouped_entities=False)
nlp("Enzo works at the Australian National University (AUN)")

# [{'entity': 'I-PER', 'index': 1, 'score': 0.9983270168304443, 'word': 'En'},
# {'entity': 'I-PER', 'index': 2, 'score': 0.9952995777130127, 'word': '##zo'},
# {'entity': 'I-ORG', 'index': 6, 'score': 0.9984350204467773, 'word': 'Australian'},
# {'entity': 'I-ORG','index': 7, 'score': 0.9967807531356812, 'word': 'National'},
# {'entity': 'I-ORG', 'index': 8  'score': 0.9959043264389038, 'word': 'University'},
# {'entity': 'I-ORG', 'index': 10, 'score': 0.9900023937225342, 'word': 'AU'},
# {'entity': 'I-ORG', 'index': 11, 'score': 0.9763911366462708, 'word': '##N'}]
```

Tutorial on how to do Entity Grouping w/ NerPipeline [here](https://colab.research.google.com/drive/1CVLP0n3Q5t5qiWpode7jyhUNZpmLg0mS)

I'm very keen to get feedback for the above, so please let me know if I should change anything, or perform additional steps to bring its quality to an acceptable level.