### PR TITLE
Remove hard-coded pad token id in distilbert and albert

### DIFF
--- a/src/transformers/modeling_albert.py
+++ b/src/transformers/modeling_albert.py
@@ -174,7 +174,7 @@ class AlbertEmbeddings(BertEmbeddings):
     def __init__(self, config):
         super().__init__(config)
 
-        self.word_embeddings = nn.Embedding(config.vocab_size, config.embedding_size, padding_idx=0)
+        self.word_embeddings = nn.Embedding(config.vocab_size, config.embedding_size, padding_idx=config.pad_token_id)
         self.position_embeddings = nn.Embedding(config.max_position_embeddings, config.embedding_size)
         self.token_type_embeddings = nn.Embedding(config.type_vocab_size, config.embedding_size)
         self.LayerNorm = torch.nn.LayerNorm(config.embedding_size, eps=config.layer_norm_eps)

--- a/src/transformers/modeling_distilbert.py
+++ b/src/transformers/modeling_distilbert.py
@@ -61,7 +61,7 @@ def create_sinusoidal_embeddings(n_pos, dim, out):
 class Embeddings(nn.Module):
     def __init__(self, config):
         super().__init__()
-        self.word_embeddings = nn.Embedding(config.vocab_size, config.dim, padding_idx=0)
+        self.word_embeddings = nn.Embedding(config.vocab_size, config.dim, padding_idx=config.pad_token_id)
         self.position_embeddings = nn.Embedding(config.max_position_embeddings, config.dim)
         if config.sinusoidal_pos_embds:
             create_sinusoidal_embeddings(


### PR DESCRIPTION
As the config adds `pad_token_id` attribute, `padding_idx` set the value of `config.pad_token_id` in BertEmbedding. ( PR #3793 )

But it seems that not only the config of `Bert`, but also that of `DistilBert` and `Albert` has `pad_token_id`. ([Distilbert config](https://s3.amazonaws.com/models.huggingface.co/bert/distilbert-base-uncased-config.json), [Albert config](https://s3.amazonaws.com/models.huggingface.co/bert/albert-base-v1-config.json))

But in Embedding class of Distilbert and Albert, it seems that `padding_idx` is still hard-coded. So I've fixed those parts.