### PR TITLE
Added support for pathlib.Path objects instead of string paths in from_pretrained() (resolves #3962)

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -22,7 +22,7 @@ import logging
 import os
 from typing import Dict, Optional, Tuple
 
-from .file_utils import CONFIG_NAME, cached_path, hf_bucket_url, is_remote_url
+from .file_utils import CONFIG_NAME, cached_path, hf_bucket_url, is_remote_url, path_to_str
 
 
 logger = logging.getLogger(__name__)
@@ -229,6 +229,8 @@ class PretrainedConfig(object):
 
         if pretrained_config_archive_map is None:
             pretrained_config_archive_map = cls.pretrained_config_archive_map
+
+        pretrained_model_name_or_path = path_to_str(pretrained_model_name_or_path)
 
         if pretrained_model_name_or_path in pretrained_config_archive_map:
             config_file = pretrained_config_archive_map[pretrained_model_name_or_path]

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -8,6 +8,7 @@ import fnmatch
 import json
 import logging
 import os
+import pathlib
 import shutil
 import sys
 import tarfile
@@ -203,6 +204,20 @@ def filename_to_url(filename, cache_dir=None):
     etag = metadata["etag"]
 
     return url, etag
+
+
+def path_to_str(path_like_or_str):
+    """
+    Attempts to convert a path-like object to a string.
+    """
+    if hasattr(path_like_or_str, "__fspath__"):
+        return path_like_or_str.__fspath__()
+    elif isinstance(path_like_or_str, pathlib.Path):
+        return str(path_like_or_str)
+    elif isinstance(path_like_or_str, str):
+        return path_like_or_str
+    else:
+        raise ValueError("path_like_or_str is not a path-like object or string.")
 
 
 def cached_path(

--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -29,6 +29,7 @@ from .file_utils import (
     cached_path,
     hf_bucket_url,
     is_remote_url,
+    path_to_str,
 )
 
 
@@ -130,6 +131,8 @@ class ModelCard:
         proxies = kwargs.pop("proxies", None)
         find_from_standard_name = kwargs.pop("find_from_standard_name", True)
         return_unused_kwargs = kwargs.pop("return_unused_kwargs", False)
+
+        pretrained_model_name_or_path = path_to_str(pretrained_model_name_or_path)
 
         if pretrained_model_name_or_path in ALL_PRETRAINED_CONFIG_ARCHIVE_MAP:
             # For simplicity we use the same pretrained url than the configuration files

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -24,7 +24,15 @@ import tensorflow as tf
 from tensorflow.python.keras.saving import hdf5_format
 
 from .configuration_utils import PretrainedConfig
-from .file_utils import DUMMY_INPUTS, TF2_WEIGHTS_NAME, WEIGHTS_NAME, cached_path, hf_bucket_url, is_remote_url
+from .file_utils import (
+    DUMMY_INPUTS,
+    TF2_WEIGHTS_NAME,
+    WEIGHTS_NAME,
+    cached_path,
+    hf_bucket_url,
+    is_remote_url,
+    path_to_str,
+)
 from .modeling_tf_pytorch_utils import load_pytorch_checkpoint_in_tf2_model
 
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -320,6 +320,8 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
         proxies = kwargs.pop("proxies", None)
         output_loading_info = kwargs.pop("output_loading_info", False)
 
+        pretrained_model_name_or_path = path_to_str(pretrained_model_name_or_path)
+
         # Load config if we don't provide a configuration
         if not isinstance(config, PretrainedConfig):
             config_path = config if config is not None else pretrained_model_name_or_path

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -34,6 +34,7 @@ from .file_utils import (
     cached_path,
     hf_bucket_url,
     is_remote_url,
+    path_to_str,
 )
 
 
@@ -527,6 +528,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         proxies = kwargs.pop("proxies", None)
         output_loading_info = kwargs.pop("output_loading_info", False)
         local_files_only = kwargs.pop("local_files_only", False)
+
+        pretrained_model_name_or_path = path_to_str(pretrained_model_name_or_path)
 
         # Load config if we don't provide a configuration
         if not isinstance(config, PretrainedConfig):

--- a/src/transformers/tokenization_auto.py
+++ b/src/transformers/tokenization_auto.py
@@ -38,6 +38,7 @@ from .configuration_auto import (
     XLNetConfig,
 )
 from .configuration_utils import PretrainedConfig
+from .file_utils import path_to_str
 from .tokenization_albert import AlbertTokenizer
 from .tokenization_bart import BartTokenizer
 from .tokenization_bert import BertTokenizer, BertTokenizerFast
@@ -185,6 +186,7 @@ class AutoTokenizer:
         if not isinstance(config, PretrainedConfig):
             config = AutoConfig.from_pretrained(pretrained_model_name_or_path, **kwargs)
 
+        pretrained_model_name_or_path = path_to_str(pretrained_model_name_or_path)
         if "bert-base-japanese" in pretrained_model_name_or_path:
             return BertJapaneseTokenizer.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
 

--- a/src/transformers/tokenization_transfo_xl.py
+++ b/src/transformers/tokenization_transfo_xl.py
@@ -34,7 +34,7 @@ from tokenizers.normalizers import Lowercase, Sequence, Strip, unicode_normalize
 from tokenizers.pre_tokenizers import CharDelimiterSplit, WhitespaceSplit
 from tokenizers.processors import BertProcessing
 
-from .file_utils import cached_path, is_torch_available
+from .file_utils import cached_path, is_torch_available, path_to_str
 from .tokenization_utils import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 
@@ -638,6 +638,8 @@ class TransfoXLCorpus(object):
         """
         Instantiate a pre-processed corpus.
         """
+        pretrained_model_name_or_path = path_to_str(pretrained_model_name_or_path)
+
         vocab = TransfoXLTokenizer.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
         if pretrained_model_name_or_path in PRETRAINED_CORPUS_ARCHIVE_MAP:
             corpus_file = PRETRAINED_CORPUS_ARCHIVE_MAP[pretrained_model_name_or_path]

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -31,7 +31,7 @@ from tokenizers import Encoding as EncodingFast
 from tokenizers.decoders import Decoder as DecoderFast
 from tokenizers.implementations import BaseTokenizer as BaseTokenizerFast
 
-from .file_utils import cached_path, hf_bucket_url, is_remote_url, is_tf_available, is_torch_available
+from .file_utils import cached_path, hf_bucket_url, is_remote_url, is_tf_available, is_torch_available, path_to_str
 
 
 if is_tf_available():
@@ -874,6 +874,8 @@ class PreTrainedTokenizer(SpecialTokensMixin):
         resume_download = kwargs.pop("resume_download", False)
         proxies = kwargs.pop("proxies", None)
         local_files_only = kwargs.pop("local_files_only", False)
+
+        pretrained_model_name_or_path = path_to_str(pretrained_model_name_or_path)
 
         s3_models = list(cls.max_model_input_sizes.keys())
         vocab_files = {}


### PR DESCRIPTION
Resolves issue/feature request #3962 

This only covers string paths in `from_pretrained` (so vocab_file paths for` __init__` for tokenizers aren't covered). This may or may not be a feature that is desired (since it's fairly easy for the client to convert a path-like to a string). With the changes, you would be able to use `from_pretrained` with path-likes:

```
from pathlib import Path
from transformers import AutoModel, AutoTokenizer

my_path = Path("path/to/model_dir/")
AutoTokenizer.from_pretrained(my_path)
AutoModel.from_pretrained(my_path)
```