### PR TITLE
Allow a more backward compatible behavior of max_len_single_sentence and max_len_sentences_pair

### DIFF
--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -779,6 +779,26 @@ class PreTrainedTokenizer(SpecialTokensMixin):
     def max_len_sentences_pair(self):
         return self.model_max_length - self.num_special_tokens_to_add(pair=True)
 
+    @max_len_single_sentence.setter
+    def max_len_single_sentence(self, value):
+        """ For backward compatibility, allow to try to setup 'max_len_single_sentence' """
+        if value == self.model_max_length - self.num_special_tokens_to_add(pair=False):
+            logger.warning("Setting 'max_len_single_sentence' is now deprecated. "
+                           "This value is automatically set up.")
+        else:
+            raise ValueError("Setting 'max_len_single_sentence' is now deprecated. "
+                             "This value is automatically set up.")
+
+    @max_len_sentences_pair.setter
+    def max_len_sentences_pair(self, value):
+        """ For backward compatibility, allow to try to setup 'max_len_sentences_pair' """
+        if value == self.model_max_length - self.num_special_tokens_to_add(pair=True):
+            logger.warning("Setting 'max_len_sentences_pair' is now deprecated. "
+                           "This value is automatically set up.")
+        else:
+            raise ValueError("Setting 'max_len_sentences_pair' is now deprecated. "
+                             "This value is automatically set up.")
+
     def get_vocab(self):
         """ Returns the vocabulary as a dict of {token: index} pairs. `tokenizer.get_vocab()[token]` is equivalent to `tokenizer.convert_tokens_to_ids(token)` when `token` is in the vocab. """
         raise NotImplementedError()

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -783,21 +783,25 @@ class PreTrainedTokenizer(SpecialTokensMixin):
     def max_len_single_sentence(self, value):
         """ For backward compatibility, allow to try to setup 'max_len_single_sentence' """
         if value == self.model_max_length - self.num_special_tokens_to_add(pair=False):
-            logger.warning("Setting 'max_len_single_sentence' is now deprecated. "
-                           "This value is automatically set up.")
+            logger.warning(
+                "Setting 'max_len_single_sentence' is now deprecated. " "This value is automatically set up."
+            )
         else:
-            raise ValueError("Setting 'max_len_single_sentence' is now deprecated. "
-                             "This value is automatically set up.")
+            raise ValueError(
+                "Setting 'max_len_single_sentence' is now deprecated. " "This value is automatically set up."
+            )
 
     @max_len_sentences_pair.setter
     def max_len_sentences_pair(self, value):
         """ For backward compatibility, allow to try to setup 'max_len_sentences_pair' """
         if value == self.model_max_length - self.num_special_tokens_to_add(pair=True):
-            logger.warning("Setting 'max_len_sentences_pair' is now deprecated. "
-                           "This value is automatically set up.")
+            logger.warning(
+                "Setting 'max_len_sentences_pair' is now deprecated. " "This value is automatically set up."
+            )
         else:
-            raise ValueError("Setting 'max_len_sentences_pair' is now deprecated. "
-                             "This value is automatically set up.")
+            raise ValueError(
+                "Setting 'max_len_sentences_pair' is now deprecated. " "This value is automatically set up."
+            )
 
     def get_vocab(self):
         """ Returns the vocabulary as a dict of {token: index} pairs. `tokenizer.get_vocab()[token]` is equivalent to `tokenizer.convert_tokens_to_ids(token)` when `token` is in the vocab. """


### PR DESCRIPTION
Since #3706, `max_len_single_sentence` and `max_len_sentences_pair` are now automatically setup in the base class.

This PR allows the user to try to setup `max_len_single_sentence` and `max_len_sentences_pair`. If the value if the same as the pre-computed, we display a deprecation warning (avoid breaking old code in this case). If the value is different we raise an explicit error message.

cc @HendrikStrobelt