### PR TITLE
Adding --do_lower_case option

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -414,6 +414,7 @@ python run_squad.py \
   --model_name_or_path bert-base-uncased \
   --do_train \
   --do_eval \
+  --do_lower_case \
   --train_file $SQUAD_DIR/train-v1.1.json \
   --predict_file $SQUAD_DIR/dev-v1.1.json \
   --per_gpu_train_batch_size 12 \
@@ -442,6 +443,7 @@ python -m torch.distributed.launch --nproc_per_node=8 ./examples/run_squad.py \
     --model_name_or_path bert-large-uncased-whole-word-masking \
     --do_train \
     --do_eval \
+    --do_lower_case \
     --train_file $SQUAD_DIR/train-v1.1.json \
     --predict_file $SQUAD_DIR/dev-v1.1.json \
     --learning_rate 3e-5 \


### PR DESCRIPTION
In SQuAD 1.1 using the uncased BERT model, **--do_lower_case** option must be used for initialization of a tokenizer.
Omitting this optional argument, the performance in development set would be lower around 8-9pt in both EM and F1 (In the official setting described in readme, the actual metrics were 72.09 (EM)/81.84 (F1) we confirmed).