### PR TITLE
Implemented lazy line-by-line text data set loading for LM example script

### DIFF
--- a/examples/run_language_modeling.py
+++ b/examples/run_language_modeling.py
@@ -102,7 +102,7 @@ class DataTrainingArguments:
         default=False,
         metadata={"help": "Whether distinct lines of text in the dataset are to be handled as distinct sequences."},
     )
-    lazy_loading: bool = field(
+    lazy_line_by_line: bool = field(
         default=False,
         metadata={"help": "Whether data file should be loaded lazily rather than loading all into memory up-front."},
     )

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -31,7 +31,6 @@ from .benchmark_utils import (
     start_memory_tracing,
     stop_memory_tracing,
 )
-
 # Configurations
 from .configuration_albert import ALBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, AlbertConfig
 from .configuration_auto import ALL_PRETRAINED_CONFIG_ARCHIVE_MAP, CONFIG_MAPPING, AutoConfig
@@ -71,7 +70,6 @@ from .data import (
     xnli_processors,
     xnli_tasks_num_labels,
 )
-
 # Files and general utilities
 from .file_utils import (
     CONFIG_NAME,
@@ -89,10 +87,8 @@ from .file_utils import (
     is_torch_available,
 )
 from .hf_argparser import HfArgumentParser
-
 # Model Cards
 from .modelcard import ModelCard
-
 # TF 2.0 <=> PyTorch conversion utilities
 from .modeling_tf_pytorch_utils import (
     convert_tf_weight_name_to_pt_weight_name,
@@ -103,7 +99,6 @@ from .modeling_tf_pytorch_utils import (
     load_tf2_model_in_pytorch_model,
     load_tf2_weights_in_pytorch_model,
 )
-
 # Pipelines
 from .pipelines import (
     CsvPipelineDataFormat,
@@ -122,7 +117,6 @@ from .pipelines import (
     TranslationPipeline,
     pipeline,
 )
-
 # Tokenizers
 from .tokenization_albert import AlbertTokenizer
 from .tokenization_auto import TOKENIZER_MAPPING, AutoTokenizer
@@ -325,8 +319,19 @@ if is_torch_available():
 
     # Trainer
     from .trainer import Trainer, set_seed, torch_distributed_zero_first, EvalPrediction
-    from .data.data_collator import DefaultDataCollator, DataCollator, DataCollatorForLanguageModeling
-    from .data.datasets import GlueDataset, TextDataset, LineByLineTextDataset, GlueDataTrainingArguments
+    from .data.data_collator import (
+        DefaultDataCollator,
+        DataCollator,
+        DataCollatorForLanguageModeling,
+        DataCollatorForLazyLanguageModeling,
+    )
+    from .data.datasets import (
+        GlueDataset,
+        TextDataset,
+        LineByLineTextDataset,
+        LazyLineByLineTextDataset,
+        GlueDataTrainingArguments,
+    )
 
 # TensorFlow
 if is_tf_available():

--- a/src/transformers/data/datasets/__init__.py
+++ b/src/transformers/data/datasets/__init__.py
@@ -3,4 +3,4 @@
 # module, but to preserve other warnings. So, don't check this module at all.
 
 from .glue import GlueDataset, GlueDataTrainingArguments
-from .language_modeling import LineByLineTextDataset, TextDataset
+from .language_modeling import LazyLineByLineTextDataset, LineByLineTextDataset, TextDataset

--- a/src/transformers/data/datasets/language_modeling.py
+++ b/src/transformers/data/datasets/language_modeling.py
@@ -1,3 +1,4 @@
+import linecache
 import logging
 import os
 import pickle
@@ -98,3 +99,40 @@ class LineByLineTextDataset(Dataset):
 
     def __getitem__(self, i) -> torch.Tensor:
         return torch.tensor(self.examples[i], dtype=torch.long)
+
+
+class LazyLineByLineTextDataset(Dataset):
+    """
+    Credit: @bramvanroy for this linecache implementation.
+    This will be superseded by a framework-agnostic approach
+    soon.
+    """
+
+    def __init__(self, file_path):
+        self.file_path = file_path
+        self.num_entries = self._get_n_lines(self.file_path)
+
+    @staticmethod
+    def _get_n_lines(fin, size=65536):
+        # borrowed from https://stackoverflow.com/a/9631635/1150683
+        def blocks(files):
+            while True:
+                b = files.read(size)
+                if not b:
+                    break
+                yield b
+
+        with open(fin, encoding="utf-8") as fhin:
+            n_lines = sum(bl.count("\n") for bl in blocks(fhin))
+        return n_lines
+
+    def __getitem__(self, idx):
+        """
+        :param idx (int): the index of the line to get
+        :return (str or None): The line as a string (newline removed) or None if there is an exception.
+        """
+        # linecache starts counting from one, not zero, +1 the given index
+        return linecache.getline(self.file_path, idx + 1).rstrip()
+
+    def __len__(self):
+        return self.num_entries


### PR DESCRIPTION
See PR #3388. Master changed substantially, requiring relocation of code into previously untouched files etc. Instead, here is a new PR using the same code but refactored to fit in to the new more modular structure of the scripts in `examples`.