### PR TITLE
Pass existing tensorboard SummaryWriter to Trainer PR (#4019)

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -123,6 +123,7 @@ class Trainer:
         eval_dataset: Optional[Dataset] = None,
         compute_metrics: Optional[Callable[[EvalPrediction], Dict]] = None,
         prediction_loss_only=False,
+        tb_writer: Optional["SummaryWriter"] = None,
     ):
         """
         Trainer is a simple but feature-complete training and eval loop for PyTorch,
@@ -142,7 +143,9 @@ class Trainer:
         self.eval_dataset = eval_dataset
         self.compute_metrics = compute_metrics
         self.prediction_loss_only = prediction_loss_only
-        if is_tensorboard_available() and self.args.local_rank in [-1, 0]:
+        if tb_writer is not None:
+            self.tb_writer = tb_writer
+        elif is_tensorboard_available() and self.args.local_rank in [-1, 0]:
             self.tb_writer = SummaryWriter(log_dir=self.args.logging_dir)
         if not is_tensorboard_available():
             logger.warning(


### PR DESCRIPTION
Implements feature request for issue #4019.

You should be able to pass in you're own `SummaryWriter`s to `Trainer` via the `tb_writer` parameter to the `__init__` function:

```
tb_writer = SummaryWriter(log_dir="my_log_dir")
tb_writer.add_hparams(my_hparams_dict, my_metrics_dict)

trainer = Trainer(
    model = model,
    args = training_args,
    train_dataset = train_dataset,
    tb_writer = tb_writer
)

trainer.train()
```