### PR TITLE
Fix for #3846

### DIFF
--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -2195,7 +2195,6 @@ class PreTrainedTokenizer(SpecialTokensMixin):
             .replace(" ' ", "'")
             .replace(" n't", "n't")
             .replace(" 'm", "'m")
-            .replace(" do not", " don't")
             .replace(" 's", "'s")
             .replace(" 've", "'ve")
             .replace(" 're", "'re")


### PR DESCRIPTION
Fix for #3846 . PretrainedTokenizer mapped " do not" to " don't" when .decode(...) is called. Removed the " do not" --> " don't" mapping from clean_up_tokenization(...).