### PR TITLE
p_mask in SQuAD pre-processing

### DIFF
--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -195,18 +195,23 @@ def squad_convert_example_to_features(example, max_seq_length, doc_stride, max_q
         cls_index = span["input_ids"].index(tokenizer.cls_token_id)
 
         # p_mask: mask with 1 for token than cannot be in the answer (0 for token which can be in an answer)
-        # Original TF implem also keep the classification token (set to 0) (not sure why...)
+        # Original TF implem also keep the classification token (set to 0)
         p_mask = np.array(span["token_type_ids"])
-
-        p_mask = np.minimum(p_mask, 1)
-
+        p_mask.fill(1)
         if tokenizer.padding_side == "right":
-            # Limit positive values to one
-            p_mask = 1 - p_mask
+            p_mask[len(truncated_query) + sequence_added_tokens :] = 0
+        else:
+            p_mask[-len(span["tokens"]) : -(len(truncated_query) + sequence_added_tokens)] = 0
 
-        p_mask[np.where(np.array(span["input_ids"]) == tokenizer.sep_token_id)[0]] = 1
+        pad_token_indices = np.where(span["input_ids"] == tokenizer.pad_token_id)
+        special_token_indices = np.where(
+            np.array(tokenizer.get_special_tokens_mask(span["input_ids"], already_has_special_tokens=True))
+        )
 
-        # Set the CLS index to '0'
+        p_mask[pad_token_indices] = 1
+        p_mask[special_token_indices] = 1
+
+        # Set the cls index to 0: the CLS index can be used for impossible answers
         p_mask[cls_index] = 0
 
         span_is_impossible = example.is_impossible

--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -196,17 +196,16 @@ def squad_convert_example_to_features(example, max_seq_length, doc_stride, max_q
 
         # p_mask: mask with 1 for token than cannot be in the answer (0 for token which can be in an answer)
         # Original TF implem also keep the classification token (set to 0)
-        p_mask = np.array(span["token_type_ids"])
-        p_mask.fill(1)
+        p_mask = np.ones_like(span["token_type_ids"])
         if tokenizer.padding_side == "right":
             p_mask[len(truncated_query) + sequence_added_tokens :] = 0
         else:
             p_mask[-len(span["tokens"]) : -(len(truncated_query) + sequence_added_tokens)] = 0
 
         pad_token_indices = np.where(span["input_ids"] == tokenizer.pad_token_id)
-        special_token_indices = np.where(
-            np.array(tokenizer.get_special_tokens_mask(span["input_ids"], already_has_special_tokens=True))
-        )
+        special_token_indices = np.asarray(
+            tokenizer.get_special_tokens_mask(span["input_ids"], already_has_special_tokens=True)
+        ).nonzero()
 
         p_mask[pad_token_indices] = 1
         p_mask[special_token_indices] = 1


### PR DESCRIPTION
In question answering, the `p_mask` is a mask with 1 for tokens than cannot be in the answer (0 for token which can be in an answer).

Currently the p_mask construction fails for RoBERTa, and is overall not very robust as it depends directly on the `token_type_ids`, while some models do not make use of them and therefore do not generate them (best example being RoBERTa).

This PR changes the way the p_mask is built, and slightly changes it as well. Up to now, here's what was done with the `p_mask`, I believe with the original implementation being google-research BERT's SQuAD script: 

- Consider every token that is not the question to be a possible answer. This includes special tokens, and padding tokens.

This PR changes this by removing those special tokens and padding tokens from the possible answer pool. It does still keep the classification token as a possible answer, given that it's sometimes used as the `impossible` token.

closes https://github.com/huggingface/transformers/issues/2788