### PR TITLE
[isort] add known 3rd party to setup.cfg

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ Follow these steps to start contributing:
    ```bash
    $ pip install -U git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e528357650281a3d3ec22#egg=isort
    ```
-
+    (Note: if your local isort command returns different results than CircleCI, you might need to add a third party package to setup.cfg)
 5. Develop the features on your branch.
 
    As you work on the features, you should make sure that the test suite

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,6 @@ Follow these steps to start contributing:
    ```bash
    $ pip install -U git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e528357650281a3d3ec22#egg=isort
    ```
-    (Note: if your local isort command returns different results than CircleCI, you might need to add a third party package to setup.cfg)
 5. Develop the features on your branch.
 
    As you work on the features, you should make sure that the test suite

--- a/examples/summarization/t5/evaluate_cnn.py
+++ b/examples/summarization/t5/evaluate_cnn.py
@@ -2,9 +2,9 @@ import argparse
 from pathlib import Path
 
 import torch
+from rouge_score import rouge_scorer, scoring
 from tqdm import tqdm
 
-from rouge_score import rouge_scorer, scoring
 from transformers import T5ForConditionalGeneration, T5Tokenizer
 
 

--- a/examples/translation/t5/evaluate_wmt.py
+++ b/examples/translation/t5/evaluate_wmt.py
@@ -2,9 +2,9 @@ import argparse
 from pathlib import Path
 
 import torch
+from sacrebleu import corpus_bleu
 from tqdm import tqdm
 
-from sacrebleu import corpus_bleu
 from transformers import T5ForConditionalGeneration, T5Tokenizer
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,8 @@ known_third_party =
     PIL
     psutil
     pytorch_lightning
+    rouge_score
+    sacrebleu
     seqeval
     sklearn
     tensorboardX


### PR DESCRIPTION
Resolve local/circleci isort discrepancy by adding sacrebleu, rouge_score to `known_third_party`.

Previously, if you had either package installed on your system, they would be `known_third_party`. Now they are `known_third_party` on everybody's system.
