### PR TITLE
[Naming] lm_labels -> labels ; masked_lm_labels -> masked_labels

### DIFF
--- a/examples/contrib/run_transfo_xl.py
+++ b/examples/contrib/run_transfo_xl.py
@@ -105,7 +105,7 @@ def main():
         with torch.no_grad():
             mems = None
             for idx, (data, target, seq_len) in enumerate(eval_iter):
-                ret = model(data, lm_labels=target, mems=mems)
+                ret = model(data, labels=target, mems=mems)
                 loss, _, mems = ret
                 loss = loss.mean()
                 total_loss += seq_len * loss.item()

--- a/examples/summarization/bart/finetune.py
+++ b/examples/summarization/bart/finetune.py
@@ -31,18 +31,18 @@ class SummarizationTrainer(BaseTransformer):
             max_target_length=self.hparams.max_target_length,
         )
 
-    def forward(self, input_ids, attention_mask=None, decoder_input_ids=None, lm_labels=None):
+    def forward(self, input_ids, attention_mask=None, decoder_input_ids=None, labels=None):
         return self.model(
-            input_ids, attention_mask=attention_mask, decoder_input_ids=decoder_input_ids, lm_labels=lm_labels,
+            input_ids, attention_mask=attention_mask, decoder_input_ids=decoder_input_ids, labels=labels,
         )
 
     def _step(self, batch):
         pad_token_id = self.tokenizer.pad_token_id
         source_ids, source_mask, y = batch["source_ids"], batch["source_mask"], batch["target_ids"]
         y_ids = y[:, :-1].contiguous()
-        lm_labels = y[:, 1:].clone()
-        lm_labels[y[:, 1:] == pad_token_id] = -100
-        outputs = self(source_ids, attention_mask=source_mask, decoder_input_ids=y_ids, lm_labels=lm_labels,)
+        labels = y[:, 1:].clone()
+        labels[y[:, 1:] == pad_token_id] = -100
+        outputs = self(source_ids, attention_mask=source_mask, decoder_input_ids=y_ids, labels=labels,)
 
         loss = outputs[0]
 

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -91,7 +91,7 @@ class DataCollatorForLanguageModeling(DataCollator):
         batch = self._tensorize_batch(examples)
         if self.mlm:
             inputs, labels = self.mask_tokens(batch)
-            return {"input_ids": inputs, "masked_lm_labels": labels}
+            return {"input_ids": inputs, "masked_labels": labels}
         else:
             return {"input_ids": batch, "labels": batch}
 

--- a/src/transformers/modeling_albert.py
+++ b/src/transformers/modeling_albert.py
@@ -620,10 +620,10 @@ class AlbertForMaskedLM(AlbertPreTrainedModel):
         position_ids=None,
         head_mask=None,
         inputs_embeds=None,
-        masked_lm_labels=None,
+        masked_labels=None,
     ):
         r"""
-        masked_lm_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
+        masked_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
             Labels for computing the masked language modeling loss.
             Indices should be in ``[-100, 0, ..., config.vocab_size]`` (see ``input_ids`` docstring)
             Tokens with indices set to ``-100`` are ignored (masked), the loss is only computed for the tokens with
@@ -631,7 +631,7 @@ class AlbertForMaskedLM(AlbertPreTrainedModel):
 
     Returns:
         :obj:`tuple(torch.FloatTensor)` comprising various elements depending on the configuration (:class:`~transformers.AlbertConfig`) and inputs:
-        loss (`optional`, returned when ``masked_lm_labels`` is provided) ``torch.FloatTensor`` of shape ``(1,)``:
+        loss (`optional`, returned when ``masked_labels`` is provided) ``torch.FloatTensor`` of shape ``(1,)``:
             Masked language modeling loss.
         prediction_scores (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, config.vocab_size)`)
             Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
@@ -655,7 +655,7 @@ class AlbertForMaskedLM(AlbertPreTrainedModel):
         tokenizer = AlbertTokenizer.from_pretrained('albert-base-v2')
         model = AlbertForMaskedLM.from_pretrained('albert-base-v2')
         input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute", add_special_tokens=True)).unsqueeze(0)  # Batch size 1
-        outputs = model(input_ids, masked_lm_labels=input_ids)
+        outputs = model(input_ids, masked_labels=input_ids)
         loss, prediction_scores = outputs[:2]
 
         """
@@ -672,9 +672,9 @@ class AlbertForMaskedLM(AlbertPreTrainedModel):
         prediction_scores = self.predictions(sequence_outputs)
 
         outputs = (prediction_scores,) + outputs[2:]  # Add hidden states and attention if they are here
-        if masked_lm_labels is not None:
+        if masked_labels is not None:
             loss_fct = CrossEntropyLoss()
-            masked_lm_loss = loss_fct(prediction_scores.view(-1, self.config.vocab_size), masked_lm_labels.view(-1))
+            masked_lm_loss = loss_fct(prediction_scores.view(-1, self.config.vocab_size), masked_labels.view(-1))
             outputs = (masked_lm_loss,) + outputs
 
         return outputs

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -869,12 +869,12 @@ class BartForConditionalGeneration(PretrainedBartModel):
         decoder_input_ids=None,
         decoder_attention_mask=None,
         decoder_cached_states=None,
-        lm_labels=None,
+        labels=None,
         use_cache=False,
         **unused
     ):
         r"""
-        masked_lm_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
+        masked_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
             Labels for computing the masked language modeling loss.
             Indices should either be in ``[0, ..., config.vocab_size]`` or -100 (see ``input_ids`` docstring).
             Tokens with indices set to ``-100`` are ignored (masked), the loss is only computed for the tokens
@@ -883,7 +883,7 @@ class BartForConditionalGeneration(PretrainedBartModel):
 
     Returns:
         :obj:`tuple(torch.FloatTensor)` comprising various elements depending on the configuration (:class:`~transformers.RobertaConfig`) and inputs:
-        masked_lm_loss (`optional`, returned when ``masked_lm_labels`` is provided) ``torch.FloatTensor`` of shape ``(1,)``:
+        masked_lm_loss (`optional`, returned when ``masked_labels`` is provided) ``torch.FloatTensor`` of shape ``(1,)``:
             Masked language modeling loss.
         prediction_scores (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, config.vocab_size)`)
             Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
@@ -925,10 +925,10 @@ class BartForConditionalGeneration(PretrainedBartModel):
         )
         lm_logits = F.linear(outputs[0], self.model.shared.weight)
         outputs = (lm_logits,) + outputs[1:]  # Add hidden states and attention if they are here
-        if lm_labels is not None:
+        if labels is not None:
             loss_fct = nn.CrossEntropyLoss()
-            # TODO(SS): do we need to ignore pad tokens in lm_labels?
-            masked_lm_loss = loss_fct(lm_logits.view(-1, self.config.vocab_size), lm_labels.view(-1))
+            # TODO(SS): do we need to ignore pad tokens in labels?
+            masked_lm_loss = loss_fct(lm_logits.view(-1, self.config.vocab_size), labels.view(-1))
             outputs = (masked_lm_loss,) + outputs
 
         return outputs

--- a/src/transformers/modeling_ctrl.py
+++ b/src/transformers/modeling_ctrl.py
@@ -499,7 +499,7 @@ class CTRLLMHeadModel(CTRLPreTrainedModel):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
             Labels for language modeling.
-            Note that the labels **are shifted** inside the model, i.e. you can set ``lm_labels = input_ids``
+            Note that the labels **are shifted** inside the model, i.e. you can set ``labels = input_ids``
             Indices are selected in ``[-100, 0, ..., config.vocab_size]``
             All labels set to ``-100`` are ignored (masked), the loss is only
             computed for labels in ``[0, ..., config.vocab_size]``

--- a/src/transformers/modeling_distilbert.py
+++ b/src/transformers/modeling_distilbert.py
@@ -493,9 +493,9 @@ class DistilBertForMaskedLM(DistilBertPreTrainedModel):
         return self.vocab_projector
 
     @add_start_docstrings_to_callable(DISTILBERT_INPUTS_DOCSTRING)
-    def forward(self, input_ids=None, attention_mask=None, head_mask=None, inputs_embeds=None, masked_lm_labels=None):
+    def forward(self, input_ids=None, attention_mask=None, head_mask=None, inputs_embeds=None, masked_labels=None):
         r"""
-        masked_lm_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
+        masked_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
             Labels for computing the masked language modeling loss.
             Indices should be in ``[-100, 0, ..., config.vocab_size]`` (see ``input_ids`` docstring)
             Tokens with indices set to ``-100`` are ignored (masked), the loss is only computed for the tokens with labels
@@ -503,7 +503,7 @@ class DistilBertForMaskedLM(DistilBertPreTrainedModel):
 
     Returns:
         :obj:`tuple(torch.FloatTensor)` comprising various elements depending on the configuration (:class:`~transformers.DistilBertConfig`) and inputs:
-        loss (`optional`, returned when ``masked_lm_labels`` is provided) ``torch.FloatTensor`` of shape ``(1,)``:
+        loss (`optional`, returned when ``masked_labels`` is provided) ``torch.FloatTensor`` of shape ``(1,)``:
             Masked language modeling loss.
         prediction_scores (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, config.vocab_size)`)
             Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
@@ -527,7 +527,7 @@ class DistilBertForMaskedLM(DistilBertPreTrainedModel):
         tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-cased')
         model = DistilBertForMaskedLM.from_pretrained('distilbert-base-cased')
         input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute", add_special_tokens=True)).unsqueeze(0)  # Batch size 1
-        outputs = model(input_ids, masked_lm_labels=input_ids)
+        outputs = model(input_ids, masked_labels=input_ids)
         loss, prediction_scores = outputs[:2]
 
         """
@@ -541,9 +541,9 @@ class DistilBertForMaskedLM(DistilBertPreTrainedModel):
         prediction_logits = self.vocab_projector(prediction_logits)  # (bs, seq_length, vocab_size)
 
         outputs = (prediction_logits,) + dlbrt_output[1:]
-        if masked_lm_labels is not None:
+        if masked_labels is not None:
             mlm_loss = self.mlm_loss_fct(
-                prediction_logits.view(-1, prediction_logits.size(-1)), masked_lm_labels.view(-1)
+                prediction_logits.view(-1, prediction_logits.size(-1)), masked_labels.view(-1)
             )
             outputs = (mlm_loss,) + outputs
 

--- a/src/transformers/modeling_electra.py
+++ b/src/transformers/modeling_electra.py
@@ -454,10 +454,10 @@ class ElectraForMaskedLM(ElectraPreTrainedModel):
         position_ids=None,
         head_mask=None,
         inputs_embeds=None,
-        masked_lm_labels=None,
+        masked_labels=None,
     ):
         r"""
-        masked_lm_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
+        masked_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
             Labels for computing the masked language modeling loss.
             Indices should be in ``[-100, 0, ..., config.vocab_size]`` (see ``input_ids`` docstring)
             Tokens with indices set to ``-100`` are ignored (masked), the loss is only computed for the tokens with labels
@@ -465,7 +465,7 @@ class ElectraForMaskedLM(ElectraPreTrainedModel):
 
     Returns:
         :obj:`tuple(torch.FloatTensor)` comprising various elements depending on the configuration (:class:`~transformers.ElectraConfig`) and inputs:
-        masked_lm_loss (`optional`, returned when ``masked_lm_labels`` is provided) ``torch.FloatTensor`` of shape ``(1,)``:
+        masked_lm_loss (`optional`, returned when ``masked_labels`` is provided) ``torch.FloatTensor`` of shape ``(1,)``:
             Masked language modeling loss.
         prediction_scores (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, config.vocab_size)`)
             Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
@@ -490,7 +490,7 @@ class ElectraForMaskedLM(ElectraPreTrainedModel):
             model = ElectraForMaskedLM.from_pretrained('google/electra-small-generator')
 
             input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute", add_special_tokens=True)).unsqueeze(0)  # Batch size 1
-            outputs = model(input_ids, masked_lm_labels=input_ids)
+            outputs = model(input_ids, masked_labels=input_ids)
 
             loss, prediction_scores = outputs[:2]
 
@@ -507,9 +507,9 @@ class ElectraForMaskedLM(ElectraPreTrainedModel):
         output = (prediction_scores,)
 
         # Masked language modeling softmax layer
-        if masked_lm_labels is not None:
+        if masked_labels is not None:
             loss_fct = nn.CrossEntropyLoss()  # -100 index = padding token
-            loss = loss_fct(prediction_scores.view(-1, self.config.vocab_size), masked_lm_labels.view(-1))
+            loss = loss_fct(prediction_scores.view(-1, self.config.vocab_size), masked_labels.view(-1))
             output = (loss,) + output
 
         output += generator_hidden_states[1:]

--- a/src/transformers/modeling_encoder_decoder.py
+++ b/src/transformers/modeling_encoder_decoder.py
@@ -176,8 +176,8 @@ class EncoderDecoderModel(PreTrainedModel):
         decoder_attention_mask=None,
         decoder_head_mask=None,
         decoder_inputs_embeds=None,
-        masked_lm_labels=None,
-        lm_labels=None,
+        masked_labels=None,
+        labels=None,
         **kwargs,
     ):
 
@@ -219,12 +219,12 @@ class EncoderDecoderModel(PreTrainedModel):
                 Optionally, instead of passing :obj:`decoder_input_ids` you can choose to directly pass an embedded representation.
                 This is useful if you want more control over how to convert `decoder_input_ids` indices into associated vectors
                 than the model's internal embedding lookup matrix.
-            masked_lm_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
+            masked_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
                 Labels for computing the masked language modeling loss for the decoder.
                 Indices should be in ``[-100, 0, ..., config.vocab_size]`` (see ``input_ids`` docstring)
                 Tokens with indices set to ``-100`` are ignored (masked), the loss is only computed for the tokens with labels
                 in ``[0, ..., config.vocab_size]``
-            lm_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
+            labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
                 Labels for computing the left-to-right language modeling loss (next word prediction) for the decoder.
                 Indices should be in ``[-100, 0, ..., config.vocab_size]`` (see ``input_ids`` docstring)
                 Tokens with indices set to ``-100`` are ignored (masked), the loss is only computed for the tokens with labels
@@ -246,7 +246,7 @@ class EncoderDecoderModel(PreTrainedModel):
             outputs = model(input_ids=input_ids, decoder_input_ids=input_ids)
 
             # training
-            loss, outputs = model(input_ids=input_ids, decoder_input_ids=input_ids, lm_labels=input_ids)[:2]
+            loss, outputs = model(input_ids=input_ids, decoder_input_ids=input_ids, labels=input_ids)[:2]
 
             # generation
             generated = model.generate(input_ids, decoder_start_token_id=model.config.decoder.pad_token_id)
@@ -278,8 +278,8 @@ class EncoderDecoderModel(PreTrainedModel):
             encoder_hidden_states=hidden_states,
             encoder_attention_mask=attention_mask,
             head_mask=decoder_head_mask,
-            lm_labels=lm_labels,
-            masked_lm_labels=masked_lm_labels,
+            labels=labels,
+            masked_labels=masked_labels,
             **kwargs_decoder,
         )
 

--- a/src/transformers/modeling_gpt2.py
+++ b/src/transformers/modeling_gpt2.py
@@ -566,7 +566,7 @@ class GPT2LMHeadModel(GPT2PreTrainedModel):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
             Labels for language modeling.
-            Note that the labels **are shifted** inside the model, i.e. you can set ``lm_labels = input_ids``
+            Note that the labels **are shifted** inside the model, i.e. you can set ``labels = input_ids``
             Indices are selected in ``[-100, 0, ..., config.vocab_size]``
             All labels set to ``-100`` are ignored (masked), the loss is only
             computed for labels in ``[0, ..., config.vocab_size]``
@@ -664,7 +664,7 @@ class GPT2DoubleHeadsModel(GPT2PreTrainedModel):
         head_mask=None,
         inputs_embeds=None,
         mc_token_ids=None,
-        lm_labels=None,
+        labels=None,
         mc_labels=None,
         use_cache=True,
     ):
@@ -672,9 +672,9 @@ class GPT2DoubleHeadsModel(GPT2PreTrainedModel):
         mc_token_ids (:obj:`torch.LongTensor` of shape :obj:`(batch_size, num_choices)`, `optional`, default to index of the last token of the input)
             Index of the classification token in each input sequence.
             Selected in the range ``[0, input_ids.size(-1) - 1[``.
-        lm_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`)
+        labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`)
             Labels for language modeling.
-            Note that the labels **are shifted** inside the model, i.e. you can set ``lm_labels = input_ids``
+            Note that the labels **are shifted** inside the model, i.e. you can set ``labels = input_ids``
             Indices are selected in ``[-1, 0, ..., config.vocab_size]``
             All labels set to ``-100`` are ignored (masked), the loss is only
             computed for labels in ``[0, ..., config.vocab_size]``
@@ -685,7 +685,7 @@ class GPT2DoubleHeadsModel(GPT2PreTrainedModel):
 
     Return:
         :obj:`tuple(torch.FloatTensor)` comprising various elements depending on the configuration (:class:`~transformers.GPT2Config`) and inputs:
-        lm_loss (:obj:`torch.FloatTensor` of shape :obj:`(1,)`, `optional`, returned when ``lm_labels`` is provided):
+        lm_loss (:obj:`torch.FloatTensor` of shape :obj:`(1,)`, `optional`, returned when ``labels`` is provided):
             Language modeling loss.
         mc_loss (:obj:`torch.FloatTensor` of shape :obj:`(1,)`, `optional`, returned when :obj:`multiple_choice_labels` is provided):
             Multiple choice classification loss.
@@ -753,9 +753,9 @@ class GPT2DoubleHeadsModel(GPT2PreTrainedModel):
             loss_fct = CrossEntropyLoss()
             loss = loss_fct(mc_logits.view(-1, mc_logits.size(-1)), mc_labels.view(-1))
             outputs = (loss,) + outputs
-        if lm_labels is not None:
+        if labels is not None:
             shift_logits = lm_logits[..., :-1, :].contiguous()
-            shift_labels = lm_labels[..., 1:].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
             loss_fct = CrossEntropyLoss()
             loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
             outputs = (loss,) + outputs

--- a/src/transformers/modeling_openai.py
+++ b/src/transformers/modeling_openai.py
@@ -493,7 +493,7 @@ class OpenAIGPTLMHeadModel(OpenAIGPTPreTrainedModel):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
             Labels for language modeling.
-            Note that the labels **are shifted** inside the model, i.e. you can set ``lm_labels = input_ids``
+            Note that the labels **are shifted** inside the model, i.e. you can set ``labels = input_ids``
             Indices are selected in ``[-100, 0, ..., config.vocab_size]``
             All labels set to ``-100`` are ignored (masked), the loss is only
             computed for labels in ``[0, ..., config.vocab_size]``
@@ -588,16 +588,16 @@ class OpenAIGPTDoubleHeadsModel(OpenAIGPTPreTrainedModel):
         head_mask=None,
         inputs_embeds=None,
         mc_token_ids=None,
-        lm_labels=None,
+        labels=None,
         mc_labels=None,
     ):
         r"""
         mc_token_ids (:obj:`torch.LongTensor` of shape :obj:`(batch_size, num_choices)`, `optional`, default to index of the last token of the input)
             Index of the classification token in each input sequence.
             Selected in the range ``[0, input_ids.size(-1) - 1[``.
-        lm_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`)
+        labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`)
             Labels for language modeling.
-            Note that the labels **are shifted** inside the model, i.e. you can set ``lm_labels = input_ids``
+            Note that the labels **are shifted** inside the model, i.e. you can set ``labels = input_ids``
             Indices are selected in ``[-1, 0, ..., config.vocab_size]``
             All labels set to ``-100`` are ignored (masked), the loss is only
             computed for labels in ``[0, ..., config.vocab_size]``
@@ -608,7 +608,7 @@ class OpenAIGPTDoubleHeadsModel(OpenAIGPTPreTrainedModel):
 
     Return:
         :obj:`tuple(torch.FloatTensor)` comprising various elements depending on the configuration (:class:`~transformers.OpenAIGPTConfig`) and inputs:
-        lm_loss (:obj:`torch.FloatTensor` of shape :obj:`(1,)`, `optional`, returned when ``lm_labels`` is provided):
+        lm_loss (:obj:`torch.FloatTensor` of shape :obj:`(1,)`, `optional`, returned when ``labels`` is provided):
             Language modeling loss.
         mc_loss (:obj:`torch.FloatTensor` of shape :obj:`(1,)`, `optional`, returned when :obj:`multiple_choice_labels` is provided):
             Multiple choice classification loss.
@@ -668,9 +668,9 @@ class OpenAIGPTDoubleHeadsModel(OpenAIGPTPreTrainedModel):
             loss_fct = CrossEntropyLoss()
             loss = loss_fct(mc_logits.view(-1, mc_logits.size(-1)), mc_labels.view(-1))
             outputs = (loss,) + outputs
-        if lm_labels is not None:
+        if labels is not None:
             shift_logits = lm_logits[..., :-1, :].contiguous()
-            shift_labels = lm_labels[..., 1:].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
             loss_fct = CrossEntropyLoss()
             loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
             outputs = (loss,) + outputs

--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -184,10 +184,10 @@ class RobertaForMaskedLM(BertPreTrainedModel):
         position_ids=None,
         head_mask=None,
         inputs_embeds=None,
-        masked_lm_labels=None,
+        masked_labels=None,
     ):
         r"""
-        masked_lm_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
+        masked_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
             Labels for computing the masked language modeling loss.
             Indices should be in ``[-100, 0, ..., config.vocab_size]`` (see ``input_ids`` docstring)
             Tokens with indices set to ``-100`` are ignored (masked), the loss is only computed for the tokens with labels
@@ -195,7 +195,7 @@ class RobertaForMaskedLM(BertPreTrainedModel):
 
     Returns:
         :obj:`tuple(torch.FloatTensor)` comprising various elements depending on the configuration (:class:`~transformers.RobertaConfig`) and inputs:
-        masked_lm_loss (`optional`, returned when ``masked_lm_labels`` is provided) ``torch.FloatTensor`` of shape ``(1,)``:
+        masked_lm_loss (`optional`, returned when ``masked_labels`` is provided) ``torch.FloatTensor`` of shape ``(1,)``:
             Masked language modeling loss.
         prediction_scores (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, config.vocab_size)`)
             Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
@@ -219,7 +219,7 @@ class RobertaForMaskedLM(BertPreTrainedModel):
         tokenizer = RobertaTokenizer.from_pretrained('roberta-base')
         model = RobertaForMaskedLM.from_pretrained('roberta-base')
         input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute", add_special_tokens=True)).unsqueeze(0)  # Batch size 1
-        outputs = model(input_ids, masked_lm_labels=input_ids)
+        outputs = model(input_ids, masked_labels=input_ids)
         loss, prediction_scores = outputs[:2]
 
         """
@@ -236,9 +236,9 @@ class RobertaForMaskedLM(BertPreTrainedModel):
 
         outputs = (prediction_scores,) + outputs[2:]  # Add hidden states and attention if they are here
 
-        if masked_lm_labels is not None:
+        if masked_labels is not None:
             loss_fct = CrossEntropyLoss()
-            masked_lm_loss = loss_fct(prediction_scores.view(-1, self.config.vocab_size), masked_lm_labels.view(-1))
+            masked_lm_loss = loss_fct(prediction_scores.view(-1, self.config.vocab_size), masked_labels.view(-1))
             outputs = (masked_lm_loss,) + outputs
 
         return outputs  # (masked_lm_loss), prediction_scores, (hidden_states), (attentions)

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -612,10 +612,10 @@ class T5PreTrainedModel(PreTrainedModel):
         shifted_input_ids[..., 0] = decoder_start_token_id
 
         assert pad_token_id is not None, "self.model.config.pad_token_id has to be defined."
-        # replace possible -100 values in lm_labels by `pad_token_id`
+        # replace possible -100 values in labels by `pad_token_id`
         shifted_input_ids.masked_fill_(shifted_input_ids == -100, pad_token_id)
 
-        assert torch.all(shifted_input_ids >= 0).item(), "Verify that `lm_labels` has only positive values and -100"
+        assert torch.all(shifted_input_ids >= 0).item(), "Verify that `labels` has only positive values and -100"
 
         return shifted_input_ids
 
@@ -998,13 +998,13 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
         decoder_attention_mask=None,
         decoder_past_key_value_states=None,
         use_cache=True,
-        lm_labels=None,
+        labels=None,
         inputs_embeds=None,
         decoder_inputs_embeds=None,
         head_mask=None,
     ):
         r"""
-        lm_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`, defaults to :obj:`None`):
+        labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`, defaults to :obj:`None`):
                 Labels for computing the sequence classification/regression loss.
                 Indices should be in :obj:`[-100, 0, ..., config.vocab_size - 1]`.
                 All labels set to ``-100`` are ignored (masked), the loss is only
@@ -1037,7 +1037,7 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
         tokenizer = T5Tokenizer.from_pretrained('t5-small')
         model = T5ForConditionalGeneration.from_pretrained('t5-small')
         input_ids = tokenizer.encode("Hello, my dog is cute", return_tensors="pt")  # Batch size 1
-        outputs = model(input_ids=input_ids, decoder_input_ids=input_ids, lm_labels=input_ids)
+        outputs = model(input_ids=input_ids, decoder_input_ids=input_ids, labels=input_ids)
         loss, prediction_scores = outputs[:2]
 
         tokenizer = T5Tokenizer.from_pretrained('t5-small')
@@ -1055,14 +1055,14 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
 
         hidden_states = encoder_outputs[0]
 
-        if lm_labels is not None and decoder_input_ids is None and decoder_inputs_embeds is None:
+        if labels is not None and decoder_input_ids is None and decoder_inputs_embeds is None:
             # get decoder inputs from shifting lm labels to the right
-            decoder_input_ids = self._shift_right(lm_labels)
+            decoder_input_ids = self._shift_right(labels)
 
         # If decoding with past key value states, only the last tokens
         # should be given as an input
         if decoder_past_key_value_states is not None:
-            assert lm_labels is None, "Decoder should not use cached key value states when training."
+            assert labels is None, "Decoder should not use cached key value states when training."
             if decoder_input_ids is not None:
                 decoder_input_ids = decoder_input_ids[:, -1:]
             if decoder_inputs_embeds is not None:
@@ -1093,9 +1093,9 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
         lm_logits = self.lm_head(sequence_output)
 
         decoder_outputs = (lm_logits,) + decoder_outputs[1:]  # Add hidden states and attention if they are here
-        if lm_labels is not None:
+        if labels is not None:
             loss_fct = CrossEntropyLoss(ignore_index=-100)
-            loss = loss_fct(lm_logits.view(-1, lm_logits.size(-1)), lm_labels.view(-1))
+            loss = loss_fct(lm_logits.view(-1, lm_logits.size(-1)), labels.view(-1))
             # TODO(thom): Add z_loss https://github.com/tensorflow/mesh/blob/fa19d69eafc9a482aff0b59ddd96b025c0cb207d/mesh_tensorflow/layers.py#L666
             decoder_outputs = (loss,) + decoder_outputs
 

--- a/src/transformers/modeling_transfo_xl.py
+++ b/src/transformers/modeling_transfo_xl.py
@@ -852,7 +852,7 @@ class TransfoXLLMHeadModel(TransfoXLPreTrainedModel):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
             Labels for language modeling.
-            Note that the labels **are shifted** inside the model, i.e. you can set ``lm_labels = input_ids``
+            Note that the labels **are shifted** inside the model, i.e. you can set ``labels = input_ids``
             Indices are selected in ``[-100, 0, ..., config.vocab_size]``
             All labels set to ``-100`` are ignored (masked), the loss is only
             computed for labels in ``[0, ..., config.vocab_size]``

--- a/src/transformers/modeling_xlm.py
+++ b/src/transformers/modeling_xlm.py
@@ -640,7 +640,7 @@ class XLMWithLMHeadModel(XLMPreTrainedModel):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
             Labels for language modeling.
-            Note that the labels **are shifted** inside the model, i.e. you can set ``lm_labels = input_ids``
+            Note that the labels **are shifted** inside the model, i.e. you can set ``labels = input_ids``
             Indices are selected in ``[-100, 0, ..., config.vocab_size]``
             All labels set to ``-100`` are ignored (masked), the loss is only
             computed for labels in ``[0, ..., config.vocab_size]``

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -522,7 +522,7 @@ class Trainer:
         model.eval()
 
         for inputs in tqdm(dataloader, desc=description):
-            has_labels = any(inputs.get(k) is not None for k in ["labels", "masked_lm_labels"])
+            has_labels = any(inputs.get(k) is not None for k in ["labels", "masked_labels"])
 
             for k, v in inputs.items():
                 inputs[k] = v.to(self.args.device)

--- a/templates/adding_a_new_model/modeling_xxx.py
+++ b/templates/adding_a_new_model/modeling_xxx.py
@@ -389,14 +389,14 @@ class XxxModel(XxxPreTrainedModel):
 )
 class XxxForMaskedLM(XxxPreTrainedModel):
     r"""
-        **masked_lm_labels**: (`optional`) ``torch.LongTensor`` of shape ``(batch_size, sequence_length)``:
+        **masked_labels**: (`optional`) ``torch.LongTensor`` of shape ``(batch_size, sequence_length)``:
             Labels for computing the masked language modeling loss.
             Indices should be in ``[-1, 0, ..., config.vocab_size]`` (see ``input_ids`` docstring)
             Tokens with indices set to ``-100`` are ignored (masked), the loss is only computed for the tokens with labels
             in ``[0, ..., config.vocab_size]``
 
     Outputs: `Tuple` comprising various elements depending on the configuration (config) and inputs:
-        **loss**: (`optional`, returned when ``masked_lm_labels`` is provided) ``torch.FloatTensor`` of shape ``(1,)``:
+        **loss**: (`optional`, returned when ``masked_labels`` is provided) ``torch.FloatTensor`` of shape ``(1,)``:
             Masked language modeling loss.
         **prediction_scores**: ``torch.FloatTensor`` of shape ``(batch_size, sequence_length, config.vocab_size)``
             Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
@@ -413,7 +413,7 @@ class XxxForMaskedLM(XxxPreTrainedModel):
         tokenizer = XxxTokenizer.from_pretrained('xxx-base-uncased')
         model = XxxForMaskedLM.from_pretrained('xxx-base-uncased')
         input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute")).unsqueeze(0)  # Batch size 1
-        outputs = model(input_ids, masked_lm_labels=input_ids)
+        outputs = model(input_ids, masked_labels=input_ids)
         loss, prediction_scores = outputs[:2]
 
     """
@@ -437,7 +437,7 @@ class XxxForMaskedLM(XxxPreTrainedModel):
         position_ids=None,
         head_mask=None,
         inputs_embeds=None,
-        masked_lm_labels=None,
+        masked_labels=None,
     ):
 
         outputs = self.transformer(
@@ -453,9 +453,9 @@ class XxxForMaskedLM(XxxPreTrainedModel):
         prediction_scores = self.cls(sequence_output)
 
         outputs = (prediction_scores,) + outputs[2:]  # Add hidden states and attention if they are here
-        if masked_lm_labels is not None:
+        if masked_labels is not None:
             loss_fct = CrossEntropyLoss()
-            masked_lm_loss = loss_fct(prediction_scores.view(-1, self.config.vocab_size), masked_lm_labels.view(-1))
+            masked_lm_loss = loss_fct(prediction_scores.view(-1, self.config.vocab_size), masked_labels.view(-1))
             outputs = (masked_lm_loss,) + outputs
 
         return outputs  # (masked_lm_loss), prediction_scores, (hidden_states), (attentions)

--- a/templates/adding_a_new_model/tests/test_modeling_xxx.py
+++ b/templates/adding_a_new_model/tests/test_modeling_xxx.py
@@ -157,7 +157,7 @@ class XxxModelTest(ModelTesterMixin, unittest.TestCase):
             model.to(torch_device)
             model.eval()
             loss, prediction_scores = model(
-                input_ids, attention_mask=input_mask, token_type_ids=token_type_ids, masked_lm_labels=token_labels
+                input_ids, attention_mask=input_mask, token_type_ids=token_type_ids, masked_labels=token_labels
             )
             result = {
                 "loss": loss,

--- a/tests/test_modeling_albert.py
+++ b/tests/test_modeling_albert.py
@@ -158,7 +158,7 @@ class AlbertModelTest(ModelTesterMixin, unittest.TestCase):
             model.to(torch_device)
             model.eval()
             loss, prediction_scores = model(
-                input_ids, attention_mask=input_mask, token_type_ids=token_type_ids, masked_lm_labels=token_labels
+                input_ids, attention_mask=input_mask, token_type_ids=token_type_ids, masked_labels=token_labels
             )
             result = {
                 "loss": loss,

--- a/tests/test_modeling_bart.py
+++ b/tests/test_modeling_bart.py
@@ -297,7 +297,7 @@ class BartTranslationTests(unittest.TestCase):
         lm_model = BartForConditionalGeneration(config).to(torch_device)
         context = torch.Tensor([[71, 82, 18, 33, 46, 91, 2], [68, 34, 26, 58, 30, 2, 1]]).long().to(torch_device)
         summary = torch.Tensor([[82, 71, 82, 18, 2], [58, 68, 2, 1, 1]]).long().to(torch_device)
-        loss, logits, enc_features = lm_model(input_ids=context, decoder_input_ids=summary, lm_labels=summary)
+        loss, logits, enc_features = lm_model(input_ids=context, decoder_input_ids=summary, labels=summary)
         expected_shape = (*summary.shape, config.vocab_size)
         self.assertEqual(logits.shape, expected_shape)
 
@@ -358,10 +358,10 @@ class BartHeadTests(unittest.TestCase):
 
     def test_lm_forward(self):
         config, input_ids, batch_size = self._get_config_and_data()
-        lm_labels = ids_tensor([batch_size, input_ids.shape[1]], self.vocab_size).to(torch_device)
+        labels = ids_tensor([batch_size, input_ids.shape[1]], self.vocab_size).to(torch_device)
         lm_model = BartForConditionalGeneration(config)
         lm_model.to(torch_device)
-        loss, logits, enc_features = lm_model(input_ids=input_ids, lm_labels=lm_labels)
+        loss, logits, enc_features = lm_model(input_ids=input_ids, labels=labels)
         expected_shape = (batch_size, input_ids.shape[1], config.vocab_size)
         self.assertEqual(logits.shape, expected_shape)
         self.assertIsInstance(loss.item(), float)
@@ -381,7 +381,7 @@ class BartHeadTests(unittest.TestCase):
         lm_model = BartForConditionalGeneration(config).to(torch_device)
         context = torch.Tensor([[71, 82, 18, 33, 46, 91, 2], [68, 34, 26, 58, 30, 2, 1]]).long().to(torch_device)
         summary = torch.Tensor([[82, 71, 82, 18, 2], [58, 68, 2, 1, 1]]).long().to(torch_device)
-        loss, logits, enc_features = lm_model(input_ids=context, decoder_input_ids=summary, lm_labels=summary)
+        loss, logits, enc_features = lm_model(input_ids=context, decoder_input_ids=summary, labels=summary)
         expected_shape = (*summary.shape, config.vocab_size)
         self.assertEqual(logits.shape, expected_shape)
 

--- a/tests/test_modeling_bert.py
+++ b/tests/test_modeling_bert.py
@@ -235,7 +235,7 @@ class BertModelTest(ModelTesterMixin, unittest.TestCase):
             model.to(torch_device)
             model.eval()
             loss, prediction_scores = model(
-                input_ids, attention_mask=input_mask, token_type_ids=token_type_ids, masked_lm_labels=token_labels
+                input_ids, attention_mask=input_mask, token_type_ids=token_type_ids, masked_labels=token_labels
             )
             result = {
                 "loss": loss,
@@ -265,7 +265,7 @@ class BertModelTest(ModelTesterMixin, unittest.TestCase):
                 input_ids,
                 attention_mask=input_mask,
                 token_type_ids=token_type_ids,
-                masked_lm_labels=token_labels,
+                masked_labels=token_labels,
                 encoder_hidden_states=encoder_hidden_states,
                 encoder_attention_mask=encoder_attention_mask,
             )
@@ -273,7 +273,7 @@ class BertModelTest(ModelTesterMixin, unittest.TestCase):
                 input_ids,
                 attention_mask=input_mask,
                 token_type_ids=token_type_ids,
-                masked_lm_labels=token_labels,
+                masked_labels=token_labels,
                 encoder_hidden_states=encoder_hidden_states,
             )
             result = {
@@ -314,7 +314,7 @@ class BertModelTest(ModelTesterMixin, unittest.TestCase):
                 input_ids,
                 attention_mask=input_mask,
                 token_type_ids=token_type_ids,
-                masked_lm_labels=token_labels,
+                masked_labels=token_labels,
                 next_sentence_label=sequence_labels,
             )
             result = {

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -147,7 +147,7 @@ class ModelTesterMixin:
                 correct_outlen = 4
                 decoder_attention_idx = 1
 
-                if "lm_labels" in inputs_dict:  # loss will come first
+                if "labels" in inputs_dict:  # loss will come first
                     correct_outlen += 1  # compute loss
                     decoder_attention_idx += 1
                 self.assertEqual(out_len, correct_outlen)

--- a/tests/test_modeling_distilbert.py
+++ b/tests/test_modeling_distilbert.py
@@ -151,7 +151,7 @@ class DistilBertModelTest(ModelTesterMixin, unittest.TestCase):
             model = DistilBertForMaskedLM(config=config)
             model.to(torch_device)
             model.eval()
-            loss, prediction_scores = model(input_ids, attention_mask=input_mask, masked_lm_labels=token_labels)
+            loss, prediction_scores = model(input_ids, attention_mask=input_mask, masked_labels=token_labels)
             result = {
                 "loss": loss,
                 "prediction_scores": prediction_scores,

--- a/tests/test_modeling_electra.py
+++ b/tests/test_modeling_electra.py
@@ -179,7 +179,7 @@ class ElectraModelTest(ModelTesterMixin, unittest.TestCase):
             model.to(torch_device)
             model.eval()
             loss, prediction_scores = model(
-                input_ids, attention_mask=input_mask, token_type_ids=token_type_ids, masked_lm_labels=token_labels
+                input_ids, attention_mask=input_mask, token_type_ids=token_type_ids, masked_labels=token_labels
             )
             result = {
                 "loss": loss,

--- a/tests/test_modeling_encoder_decoder.py
+++ b/tests/test_modeling_encoder_decoder.py
@@ -69,8 +69,8 @@ class EncoderDecoderModelTest(unittest.TestCase):
             "decoder_token_labels": decoder_token_labels,
             "decoder_choice_labels": decoder_choice_labels,
             "encoder_hidden_states": encoder_hidden_states,
-            "lm_labels": decoder_token_labels,
-            "masked_lm_labels": decoder_token_labels,
+            "labels": decoder_token_labels,
+            "masked_labels": decoder_token_labels,
         }
 
     def create_and_check_bert_encoder_decoder_model(
@@ -223,7 +223,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
     def check_loss_output(self, loss):
         self.assertEqual(loss.size(), ())
 
-    def create_and_check_bert_encoder_decoder_model_mlm_labels(
+    def create_and_check_bert_encoder_decoder_model_mlabels(
         self,
         config,
         input_ids,
@@ -232,7 +232,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
         decoder_config,
         decoder_input_ids,
         decoder_attention_mask,
-        masked_lm_labels,
+        masked_labels,
         **kwargs
     ):
         encoder_model = BertModel(config)
@@ -244,7 +244,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
             decoder_input_ids=decoder_input_ids,
             attention_mask=attention_mask,
             decoder_attention_mask=decoder_attention_mask,
-            masked_lm_labels=masked_lm_labels,
+            masked_labels=masked_labels,
         )
 
         mlm_loss = outputs_encoder_decoder[0]
@@ -255,7 +255,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
         self.assertEqual(outputs_encoder_decoder[1].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)))
         self.assertEqual(outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,)))
 
-    def create_and_check_bert_encoder_decoder_model_lm_labels(
+    def create_and_check_bert_encoder_decoder_model_labels(
         self,
         config,
         input_ids,
@@ -264,7 +264,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
         decoder_config,
         decoder_input_ids,
         decoder_attention_mask,
-        lm_labels,
+        labels,
         **kwargs
     ):
         encoder_model = BertModel(config)
@@ -276,7 +276,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
             decoder_input_ids=decoder_input_ids,
             attention_mask=attention_mask,
             decoder_attention_mask=decoder_attention_mask,
-            lm_labels=lm_labels,
+            labels=labels,
         )
 
         lm_loss = outputs_encoder_decoder[0]
@@ -315,13 +315,13 @@ class EncoderDecoderModelTest(unittest.TestCase):
         input_ids_dict = self.prepare_config_and_inputs_bert()
         self.create_and_check_save_and_load_encoder_decoder_model(**input_ids_dict)
 
-    def test_bert_encoder_decoder_model_mlm_labels(self):
+    def test_bert_encoder_decoder_model_mlabels(self):
         input_ids_dict = self.prepare_config_and_inputs_bert()
-        self.create_and_check_bert_encoder_decoder_model_mlm_labels(**input_ids_dict)
+        self.create_and_check_bert_encoder_decoder_model_mlabels(**input_ids_dict)
 
-    def test_bert_encoder_decoder_model_lm_labels(self):
+    def test_bert_encoder_decoder_model_labels(self):
         input_ids_dict = self.prepare_config_and_inputs_bert()
-        self.create_and_check_bert_encoder_decoder_model_lm_labels(**input_ids_dict)
+        self.create_and_check_bert_encoder_decoder_model_labels(**input_ids_dict)
 
     def test_bert_encoder_decoder_model_generate(self):
         input_ids_dict = self.prepare_config_and_inputs_bert()

--- a/tests/test_modeling_gpt2.py
+++ b/tests/test_modeling_gpt2.py
@@ -268,7 +268,7 @@ class GPT2ModelTest(ModelTesterMixin, unittest.TestCase):
                 "mc_token_ids": mc_token_ids,
                 "attention_mask": multiple_choice_input_mask,
                 "token_type_ids": multiple_choice_token_type_ids,
-                "lm_labels": multiple_choice_inputs_ids,
+                "labels": multiple_choice_inputs_ids,
             }
 
             loss, lm_logits, mc_logits, _ = model(**inputs)

--- a/tests/test_modeling_openai.py
+++ b/tests/test_modeling_openai.py
@@ -169,7 +169,7 @@ class OpenAIGPTModelTest(ModelTesterMixin, unittest.TestCase):
             model.to(torch_device)
             model.eval()
 
-            loss, lm_logits, mc_logits = model(input_ids, token_type_ids=token_type_ids, lm_labels=input_ids)
+            loss, lm_logits, mc_logits = model(input_ids, token_type_ids=token_type_ids, labels=input_ids)
 
             result = {"loss": loss, "lm_logits": lm_logits}
 

--- a/tests/test_modeling_roberta.py
+++ b/tests/test_modeling_roberta.py
@@ -155,7 +155,7 @@ class RobertaModelTest(ModelTesterMixin, unittest.TestCase):
             model.to(torch_device)
             model.eval()
             loss, prediction_scores = model(
-                input_ids, attention_mask=input_mask, token_type_ids=token_type_ids, masked_lm_labels=token_labels
+                input_ids, attention_mask=input_mask, token_type_ids=token_type_ids, masked_labels=token_labels
             )
             result = {
                 "loss": loss,

--- a/tests/test_modeling_t5.py
+++ b/tests/test_modeling_t5.py
@@ -95,9 +95,9 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
                 attention_mask = ids_tensor([self.batch_size, self.encoder_seq_length], vocab_size=2)
                 decoder_attention_mask = ids_tensor([self.batch_size, self.decoder_seq_length], vocab_size=2)
 
-            lm_labels = None
+            labels = None
             if self.use_labels:
-                lm_labels = ids_tensor([self.batch_size, self.decoder_seq_length], self.vocab_size)
+                labels = ids_tensor([self.batch_size, self.decoder_seq_length], self.vocab_size)
 
             config = T5Config(
                 vocab_size=self.vocab_size,
@@ -122,47 +122,47 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
                 decoder_input_ids,
                 attention_mask,
                 decoder_attention_mask,
-                lm_labels,
+                labels,
             )
 
         def check_loss_output(self, result):
             self.parent.assertListEqual(list(result["loss"].size()), [])
 
-        def check_prepare_lm_labels_via_shift_left(
-            self, config, input_ids, decoder_input_ids, attention_mask, decoder_attention_mask, lm_labels,
+        def check_prepare_labels_via_shift_left(
+            self, config, input_ids, decoder_input_ids, attention_mask, decoder_attention_mask, labels,
         ):
             model = T5Model(config=config)
             model.to(torch_device)
             model.eval()
 
-            # make sure that lm_labels are correctly padded from the right
-            lm_labels.masked_fill_((lm_labels == self.decoder_start_token_id), self.eos_token_id)
+            # make sure that labels are correctly padded from the right
+            labels.masked_fill_((labels == self.decoder_start_token_id), self.eos_token_id)
 
             # add casaul pad token mask
-            triangular_mask = torch.tril(lm_labels.new_ones(lm_labels.shape)).logical_not()
-            lm_labels.masked_fill_(triangular_mask, self.pad_token_id)
-            decoder_input_ids = model._shift_right(lm_labels)
+            triangular_mask = torch.tril(labels.new_ones(labels.shape)).logical_not()
+            labels.masked_fill_(triangular_mask, self.pad_token_id)
+            decoder_input_ids = model._shift_right(labels)
 
-            for i, (decoder_input_ids_slice, lm_labels_slice) in enumerate(zip(decoder_input_ids, lm_labels)):
+            for i, (decoder_input_ids_slice, labels_slice) in enumerate(zip(decoder_input_ids, labels)):
                 # first item
                 self.parent.assertEqual(decoder_input_ids_slice[0].item(), self.decoder_start_token_id)
                 if i < decoder_input_ids_slice.shape[-1]:
                     if i < decoder_input_ids.shape[-1] - 1:
                         # items before diagonal
                         self.parent.assertListEqual(
-                            decoder_input_ids_slice[1 : i + 1].tolist(), lm_labels_slice[:i].tolist()
+                            decoder_input_ids_slice[1 : i + 1].tolist(), labels_slice[:i].tolist()
                         )
                     # pad items after diagonal
                     if i < decoder_input_ids.shape[-1] - 2:
                         self.parent.assertListEqual(
-                            decoder_input_ids_slice[i + 2 :].tolist(), lm_labels_slice[i + 1 : -1].tolist()
+                            decoder_input_ids_slice[i + 2 :].tolist(), labels_slice[i + 1 : -1].tolist()
                         )
                 else:
                     # all items after square
-                    self.parent.assertListEqual(decoder_input_ids_slice[1:].tolist(), lm_labels_slice[:-1].tolist())
+                    self.parent.assertListEqual(decoder_input_ids_slice[1:].tolist(), labels_slice[:-1].tolist())
 
         def create_and_check_t5_model(
-            self, config, input_ids, decoder_input_ids, attention_mask, decoder_attention_mask, lm_labels,
+            self, config, input_ids, decoder_input_ids, attention_mask, decoder_attention_mask, labels,
         ):
             model = T5Model(config=config)
             model.to(torch_device)
@@ -197,7 +197,7 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
             self.parent.assertEqual(len(decoder_past[1][0]), 4)
 
         def create_and_check_t5_with_lm_head(
-            self, config, input_ids, decoder_input_ids, attention_mask, decoder_attention_mask, lm_labels,
+            self, config, input_ids, decoder_input_ids, attention_mask, decoder_attention_mask, labels,
         ):
             model = T5ForConditionalGeneration(config=config)
             model.to(torch_device)
@@ -206,7 +206,7 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
                 input_ids=input_ids,
                 decoder_input_ids=decoder_input_ids,
                 decoder_attention_mask=decoder_attention_mask,
-                lm_labels=lm_labels,
+                labels=labels,
             )
             loss, prediction_scores, _, _ = outputs
             self.parent.assertEqual(len(outputs), 4)
@@ -220,7 +220,7 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
             self.check_loss_output(result)
 
         def create_and_check_t5_decoder_model_past(
-            self, config, input_ids, decoder_input_ids, attention_mask, decoder_attention_mask, lm_labels,
+            self, config, input_ids, decoder_input_ids, attention_mask, decoder_attention_mask, labels,
         ):
             model = T5Model(config=config).get_decoder()
             model.to(torch_device)
@@ -247,7 +247,7 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
             self.parent.assertTrue(torch.allclose(output_from_past_slice, output_from_no_past_slice, atol=1e-3))
 
         def create_and_check_t5_decoder_model_attention_mask_past(
-            self, config, input_ids, decoder_input_ids, attention_mask, decoder_attention_mask, lm_labels,
+            self, config, input_ids, decoder_input_ids, attention_mask, decoder_attention_mask, labels,
         ):
             model = T5Model(config=config).get_decoder()
             model.to(torch_device)
@@ -291,7 +291,7 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
             self.parent.assertTrue(torch.allclose(output_from_past_slice, output_from_no_past_slice, atol=1e-3))
 
         def create_t5_and_check_t5_generate_with_past_key_value_states(
-            self, config, input_ids, decoder_input_ids, attention_mask, decoder_attention_mask, lm_labels,
+            self, config, input_ids, decoder_input_ids, attention_mask, decoder_attention_mask, labels,
         ):
             model = T5ForConditionalGeneration(config=config)
             model.to(torch_device)
@@ -312,7 +312,7 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
                 decoder_input_ids,
                 attention_mask,
                 decoder_attention_mask,
-                lm_labels,
+                labels,
             ) = config_and_inputs
 
             inputs_dict = {
@@ -333,7 +333,7 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
 
     def test_shift_right(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
-        self.model_tester.check_prepare_lm_labels_via_shift_left(*config_and_inputs)
+        self.model_tester.check_prepare_labels_via_shift_left(*config_and_inputs)
 
     def test_t5_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/test_modeling_tf_transfo_xl.py
+++ b/tests/test_modeling_tf_transfo_xl.py
@@ -91,9 +91,9 @@ class TFTransfoXLModelTest(TFModelTesterMixin, unittest.TestCase):
             input_ids_1 = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
             input_ids_2 = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
 
-            lm_labels = None
+            labels = None
             if self.use_labels:
-                lm_labels = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
+                labels = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
 
             config = TransfoXLConfig(
                 vocab_size=self.vocab_size,
@@ -110,13 +110,13 @@ class TFTransfoXLModelTest(TFModelTesterMixin, unittest.TestCase):
                 eos_token_id=self.eos_token_id,
             )
 
-            return (config, input_ids_1, input_ids_2, lm_labels)
+            return (config, input_ids_1, input_ids_2, labels)
 
         def set_seed(self):
             random.seed(self.seed)
             tf.random.set_seed(self.seed)
 
-        def create_and_check_transfo_xl_model(self, config, input_ids_1, input_ids_2, lm_labels):
+        def create_and_check_transfo_xl_model(self, config, input_ids_1, input_ids_2, labels):
             model = TFTransfoXLModel(config)
 
             hidden_states_1, mems_1 = model(input_ids_1)
@@ -147,17 +147,17 @@ class TFTransfoXLModelTest(TFModelTesterMixin, unittest.TestCase):
                 [[self.mem_len, self.batch_size, self.hidden_size]] * self.num_hidden_layers,
             )
 
-        def create_and_check_transfo_xl_lm_head(self, config, input_ids_1, input_ids_2, lm_labels):
+        def create_and_check_transfo_xl_lm_head(self, config, input_ids_1, input_ids_2, labels):
             model = TFTransfoXLLMHeadModel(config)
 
             lm_logits_1, mems_1 = model(input_ids_1)
 
-            inputs = {"input_ids": input_ids_1, "labels": lm_labels}
+            inputs = {"input_ids": input_ids_1, "labels": labels}
             _, mems_1 = model(inputs)
 
             lm_logits_2, mems_2 = model([input_ids_2, mems_1])
 
-            inputs = {"input_ids": input_ids_1, "mems": mems_1, "labels": lm_labels}
+            inputs = {"input_ids": input_ids_1, "mems": mems_1, "labels": labels}
 
             _, mems_2 = model(inputs)
 
@@ -186,7 +186,7 @@ class TFTransfoXLModelTest(TFModelTesterMixin, unittest.TestCase):
 
         def prepare_config_and_inputs_for_common(self):
             config_and_inputs = self.prepare_config_and_inputs()
-            (config, input_ids_1, input_ids_2, lm_labels) = config_and_inputs
+            (config, input_ids_1, input_ids_2, labels) = config_and_inputs
             inputs_dict = {"input_ids": input_ids_1}
             return config, inputs_dict
 

--- a/tests/test_modeling_tf_xlnet.py
+++ b/tests/test_modeling_tf_xlnet.py
@@ -127,10 +127,10 @@ class TFXLNetModelTest(TFModelTesterMixin, unittest.TestCase):
             # target_mapping[:, 0, -1] = 1.0  # predict last token
 
             sequence_labels = None
-            lm_labels = None
+            labels = None
             is_impossible_labels = None
             if self.use_labels:
-                lm_labels = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
+                labels = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
                 sequence_labels = ids_tensor([self.batch_size], self.type_sequence_label_size)
                 is_impossible_labels = ids_tensor([self.batch_size], 2, dtype=tf.float32)
 
@@ -162,7 +162,7 @@ class TFXLNetModelTest(TFModelTesterMixin, unittest.TestCase):
                 input_mask,
                 target_mapping,
                 segment_ids,
-                lm_labels,
+                labels,
                 sequence_labels,
                 is_impossible_labels,
             )
@@ -181,7 +181,7 @@ class TFXLNetModelTest(TFModelTesterMixin, unittest.TestCase):
             input_mask,
             target_mapping,
             segment_ids,
-            lm_labels,
+            labels,
             sequence_labels,
             is_impossible_labels,
         ):
@@ -223,7 +223,7 @@ class TFXLNetModelTest(TFModelTesterMixin, unittest.TestCase):
             input_mask,
             target_mapping,
             segment_ids,
-            lm_labels,
+            labels,
             sequence_labels,
             is_impossible_labels,
         ):
@@ -274,7 +274,7 @@ class TFXLNetModelTest(TFModelTesterMixin, unittest.TestCase):
             input_mask,
             target_mapping,
             segment_ids,
-            lm_labels,
+            labels,
             sequence_labels,
             is_impossible_labels,
         ):
@@ -306,7 +306,7 @@ class TFXLNetModelTest(TFModelTesterMixin, unittest.TestCase):
             input_mask,
             target_mapping,
             segment_ids,
-            lm_labels,
+            labels,
             sequence_labels,
             is_impossible_labels,
         ):
@@ -335,7 +335,7 @@ class TFXLNetModelTest(TFModelTesterMixin, unittest.TestCase):
             input_mask,
             target_mapping,
             segment_ids,
-            lm_labels,
+            labels,
             sequence_labels,
             is_impossible_labels,
         ):
@@ -370,7 +370,7 @@ class TFXLNetModelTest(TFModelTesterMixin, unittest.TestCase):
                 input_mask,
                 target_mapping,
                 segment_ids,
-                lm_labels,
+                labels,
                 sequence_labels,
                 is_impossible_labels,
             ) = config_and_inputs

--- a/tests/test_modeling_transfo_xl.py
+++ b/tests/test_modeling_transfo_xl.py
@@ -87,9 +87,9 @@ class TransfoXLModelTest(ModelTesterMixin, unittest.TestCase):
             input_ids_1 = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
             input_ids_2 = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
 
-            lm_labels = None
+            labels = None
             if self.use_labels:
-                lm_labels = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
+                labels = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
 
             config = TransfoXLConfig(
                 vocab_size=self.vocab_size,
@@ -106,13 +106,13 @@ class TransfoXLModelTest(ModelTesterMixin, unittest.TestCase):
                 eos_token_id=self.eos_token_id,
             )
 
-            return (config, input_ids_1, input_ids_2, lm_labels)
+            return (config, input_ids_1, input_ids_2, labels)
 
         def set_seed(self):
             random.seed(self.seed)
             torch.manual_seed(self.seed)
 
-        def create_transfo_xl_model(self, config, input_ids_1, input_ids_2, lm_labels):
+        def create_transfo_xl_model(self, config, input_ids_1, input_ids_2, labels):
             model = TransfoXLModel(config)
             model.to(torch_device)
             model.eval()
@@ -143,15 +143,15 @@ class TransfoXLModelTest(ModelTesterMixin, unittest.TestCase):
                 [[self.mem_len, self.batch_size, self.hidden_size]] * self.num_hidden_layers,
             )
 
-        def create_transfo_xl_lm_head(self, config, input_ids_1, input_ids_2, lm_labels):
+        def create_transfo_xl_lm_head(self, config, input_ids_1, input_ids_2, labels):
             model = TransfoXLLMHeadModel(config)
             model.to(torch_device)
             model.eval()
 
             lm_logits_1, mems_1 = model(input_ids_1)
-            loss_1, _, mems_1 = model(input_ids_1, labels=lm_labels)
+            loss_1, _, mems_1 = model(input_ids_1, labels=labels)
             lm_logits_2, mems_2 = model(input_ids_2, mems=mems_1)
-            loss_2, _, mems_2 = model(input_ids_2, labels=lm_labels, mems=mems_1)
+            loss_2, _, mems_2 = model(input_ids_2, labels=labels, mems=mems_1)
 
             outputs = {
                 "loss_1": loss_1,
@@ -184,7 +184,7 @@ class TransfoXLModelTest(ModelTesterMixin, unittest.TestCase):
 
         def prepare_config_and_inputs_for_common(self):
             config_and_inputs = self.prepare_config_and_inputs()
-            (config, input_ids_1, input_ids_2, lm_labels) = config_and_inputs
+            (config, input_ids_1, input_ids_2, labels) = config_and_inputs
             inputs_dict = {"input_ids": input_ids_1}
             return config, inputs_dict
 

--- a/tests/test_modeling_xlnet.py
+++ b/tests/test_modeling_xlnet.py
@@ -128,11 +128,11 @@ class XLNetModelTest(ModelTesterMixin, unittest.TestCase):
             target_mapping[:, 0, -1] = 1.0  # predict last token
 
             sequence_labels = None
-            lm_labels = None
+            labels = None
             is_impossible_labels = None
             token_labels = None
             if self.use_labels:
-                lm_labels = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
+                labels = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
                 sequence_labels = ids_tensor([self.batch_size], self.type_sequence_label_size)
                 is_impossible_labels = ids_tensor([self.batch_size], 2).float()
                 token_labels = ids_tensor([self.batch_size, self.seq_length], self.type_vocab_size)
@@ -165,7 +165,7 @@ class XLNetModelTest(ModelTesterMixin, unittest.TestCase):
                 input_mask,
                 target_mapping,
                 segment_ids,
-                lm_labels,
+                labels,
                 sequence_labels,
                 is_impossible_labels,
                 token_labels,
@@ -185,7 +185,7 @@ class XLNetModelTest(ModelTesterMixin, unittest.TestCase):
             input_mask,
             target_mapping,
             segment_ids,
-            lm_labels,
+            labels,
             sequence_labels,
             is_impossible_labels,
             token_labels,
@@ -229,7 +229,7 @@ class XLNetModelTest(ModelTesterMixin, unittest.TestCase):
             input_mask,
             target_mapping,
             segment_ids,
-            lm_labels,
+            labels,
             sequence_labels,
             is_impossible_labels,
             token_labels,
@@ -255,7 +255,7 @@ class XLNetModelTest(ModelTesterMixin, unittest.TestCase):
             input_mask,
             target_mapping,
             segment_ids,
-            lm_labels,
+            labels,
             sequence_labels,
             is_impossible_labels,
             token_labels,
@@ -264,10 +264,10 @@ class XLNetModelTest(ModelTesterMixin, unittest.TestCase):
             model.to(torch_device)
             model.eval()
 
-            loss_1, all_logits_1, mems_1 = model(input_ids_1, token_type_ids=segment_ids, labels=lm_labels)
+            loss_1, all_logits_1, mems_1 = model(input_ids_1, token_type_ids=segment_ids, labels=labels)
 
             loss_2, all_logits_2, mems_2 = model(
-                input_ids_2, token_type_ids=segment_ids, labels=lm_labels, mems=mems_1
+                input_ids_2, token_type_ids=segment_ids, labels=labels, mems=mems_1
             )
 
             logits, _ = model(input_ids_q, perm_mask=perm_mask, target_mapping=target_mapping)
@@ -309,7 +309,7 @@ class XLNetModelTest(ModelTesterMixin, unittest.TestCase):
             input_mask,
             target_mapping,
             segment_ids,
-            lm_labels,
+            labels,
             sequence_labels,
             is_impossible_labels,
             token_labels,
@@ -385,7 +385,7 @@ class XLNetModelTest(ModelTesterMixin, unittest.TestCase):
             input_mask,
             target_mapping,
             segment_ids,
-            lm_labels,
+            labels,
             sequence_labels,
             is_impossible_labels,
             token_labels,
@@ -422,7 +422,7 @@ class XLNetModelTest(ModelTesterMixin, unittest.TestCase):
             input_mask,
             target_mapping,
             segment_ids,
-            lm_labels,
+            labels,
             sequence_labels,
             is_impossible_labels,
             token_labels,
@@ -460,7 +460,7 @@ class XLNetModelTest(ModelTesterMixin, unittest.TestCase):
                 input_mask,
                 target_mapping,
                 segment_ids,
-                lm_labels,
+                labels,
                 sequence_labels,
                 is_impossible_labels,
                 token_labels,

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -74,14 +74,14 @@ class DataCollatorIntegrationTest(unittest.TestCase):
         batch = data_collator.collate_batch(examples)
         self.assertIsInstance(batch, dict)
         self.assertEqual(batch["input_ids"].shape, torch.Size((31, 107)))
-        self.assertEqual(batch["masked_lm_labels"].shape, torch.Size((31, 107)))
+        self.assertEqual(batch["masked_labels"].shape, torch.Size((31, 107)))
 
         dataset = TextDataset(tokenizer, file_path=PATH_SAMPLE_TEXT, block_size=512, overwrite_cache=True)
         examples = [dataset[i] for i in range(len(dataset))]
         batch = data_collator.collate_batch(examples)
         self.assertIsInstance(batch, dict)
         self.assertEqual(batch["input_ids"].shape, torch.Size((2, 512)))
-        self.assertEqual(batch["masked_lm_labels"].shape, torch.Size((2, 512)))
+        self.assertEqual(batch["masked_labels"].shape, torch.Size((2, 512)))
 
 
 @require_torch


### PR DESCRIPTION
This PR is a simple find and replace of the regex "lm_labels" into "labels" over all files.
This way we can use the Trainer class for all models. 

It does break backward compatibility a bit though, since some people will have to rename the `lm_labels` argument in their code. 

