### PR TITLE
Fix object is not subscriptable error in BertEncoder (#1188)

### DIFF
--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -399,6 +399,10 @@ class BertEncoder(nn.Module):
     ):
         all_hidden_states = ()
         all_attentions = ()
+
+        if head_mask is None:
+            head_mask = [None] * len(self.layer)
+
         for i, layer_module in enumerate(self.layer):
             if self.output_hidden_states:
                 all_hidden_states = all_hidden_states + (hidden_states,)


### PR DESCRIPTION
Fix object is not subscriptable error in BertEncoder when head mask is None.

Issue #1188 describes problem.

BertLayer accepts head_mask as None, however if BertEncoder gets head_mask as None - it tries to index None.