### PR TITLE
Feature/torchserve interface [WIP]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ extras["tf-cpu"] = ["tensorflow-cpu"]
 extras["torch"] = ["torch==1.4.0"]
 
 extras["serving"] = ["pydantic", "uvicorn", "fastapi", "starlette"]
+extras["torchserve"] = ["torchserve", "torch-model-archiver"]
 extras["all"] = extras["serving"] + ["tensorflow", "torch"]
 
 extras["testing"] = ["pytest", "pytest-xdist"]

--- a/src/transformers/commands/torchserve.py
+++ b/src/transformers/commands/torchserve.py
@@ -8,6 +8,10 @@ from transformers.pipelines import SUPPORTED_TASKS, pipeline
 
 
 try:
+    from model_archiver.model_packaging import package_model
+    from model_archiver.model_packaging import ModelExportUtils
+    from model_archiver.manifest_components.manifest import RuntimeType
+
     _torchserve_dependencies_installed = True
 except (ImportError, AttributeError):
     _torchserve_dependencies_installed = False
@@ -15,12 +19,13 @@ except (ImportError, AttributeError):
 
 logger = logging.getLogger("transformers-cli/torchserve")
 
+
 class TorchServeCommand(BaseTransformersCLICommand):
     @staticmethod
     def register_subcommand(parser: ArgumentParser):
         torchserve_parser = parser.add_parser(
             "torchserve",
-            help="CLI interface to package and version models for serving with pytorch/serve."
+            help="CLI interface to package and version models for serving with pytorch/serve.",
         )
         torchserve_parser.set_defaults(func=lambda args: TorchServeCommand(args))
 

--- a/src/transformers/commands/torchserve.py
+++ b/src/transformers/commands/torchserve.py
@@ -1,0 +1,37 @@
+import logging
+from argparse import ArgumentParser, Namespace
+from typing import Any, List, Optional
+
+from transformers import Pipeline
+from transformers.commands import BaseTransformersCLICommand
+from transformers.pipelines import SUPPORTED_TASKS, pipeline
+
+
+try:
+    _torchserve_dependencies_installed = True
+except (ImportError, AttributeError):
+    _torchserve_dependencies_installed = False
+
+
+logger = logging.getLogger("transformers-cli/torchserve")
+
+class TorchServeCommand(BaseTransformersCLICommand):
+    @staticmethod
+    def register_subcommand(parser: ArgumentParser):
+        torchserve_parser = parser.add_parser(
+            "torchserve",
+            help="CLI interface to package and version models for serving with pytorch/serve."
+        )
+        torchserve_parser.set_defaults(func=lambda args: TorchServeCommand(args))
+
+    def __init__(self, args: Namespace):
+        if not _torchserve_dependencies_installed:
+            raise RuntimeError(
+                "Using torchserve command requires torchserve and torch-model-archiver. "
+                'Please install transformers with [torchserve]: pip install "transformers[torchserve]".'
+                "Or install torchserve and torch-model-archiver separately."
+            )
+        self.args = args
+
+    def run(self):
+        raise NotImplementedError()

--- a/transformers-cli
+++ b/transformers-cli
@@ -6,6 +6,7 @@ from transformers.commands.download import DownloadCommand
 from transformers.commands.env import EnvironmentCommand
 from transformers.commands.run import RunCommand
 from transformers.commands.serving import ServeCommand
+from transformers.commands.torchserve import TorchServeCommand
 from transformers.commands.user import UserCommands
 
 if __name__ == '__main__':
@@ -18,6 +19,7 @@ if __name__ == '__main__':
     EnvironmentCommand.register_subcommand(commands_parser)
     RunCommand.register_subcommand(commands_parser)
     ServeCommand.register_subcommand(commands_parser)
+    TorchServeCommand.register_subcommand(commands_parser)
     UserCommands.register_subcommand(commands_parser)
 
     # Let's go


### PR DESCRIPTION
Work in progress PR to add a CLI interface for easy packaging of transformers models 
for serving in [pytorch/serve](https://github.com/pytorch/serve). 

Intended usage example:
`transformers-cli torchserve --checkpoint="distilbert-base-uncased-finetuned-sst-2-english" --tokenizer="distilbert-base-uncased" --model-name="distilbert" --task="sentiment-analysis"`

The call above produces a MAR (model archive) file that can be served directly by the `torchserve` binary. 