### PR TITLE
Add decoder specific error message for T5Stack.forward

### DIFF
--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -666,7 +666,10 @@ class T5Stack(T5PreTrainedModel):
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:
-            raise ValueError("You have to specify either input_ids or inputs_embeds")
+            if self.is_decoder:
+                raise ValueError("You have to specify either decoder_input_ids or decoder_inputs_embeds")
+            else:
+                raise ValueError("You have to specify either input_ids or inputs_embeds")
 
         if inputs_embeds is None:
             assert self.embed_tokens is not None, "You have to intialize the model with valid token embeddings"


### PR DESCRIPTION
#### This PR adds a decoder specific error message in `T5Stack.forward` in the case that `self.is_decoder == True`

This was requested in #4126 and suggested by @patrickvonplaten in #3626 .

Confirmed that this works as expected in this colab [notebook](https://colab.research.google.com/drive/1j1mdtOylXZClH-ikZthDiOxXg4DOis_4?usp=sharing).

Missing `decoder_input_ids` example:

```
## Setup t5-small and tokenized inputs
from transformers import T5Tokenizer, T5Model
tokenizer = T5Tokenizer.from_pretrained('t5-small')
model = T5Model.from_pretrained('t5-small')
input_ids = tokenizer.encode("Hello, my dog is cute", return_tensors="pt")  # Batch size 1

# Test missing `decoder_input_ids`
model(input_ids=input_ids)[0]
# ValueError: You have to specify either decoder_input_ids or decoder_inputs_embeds
```

Missing `input_ids` example:

```
model(decoder_input_ids=input_ids)[0]
# ValueError: You have to specify either input_ids or inputs_embeds
```