### PR TITLE
Make transformers-cli cross-platform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,9 @@ setup(
         "sacremoses",
     ],
     extras_require=extras,
-    scripts=["transformers-cli"],
+    entry_points={
+        "console_scripts": ["transformers-cli=transformers.commands.transformers_cli:main"]
+    },
     python_requires=">=3.6.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/src/transformers/commands/transformers_cli.py
+++ b/src/transformers/commands/transformers_cli.py
@@ -8,7 +8,8 @@ from transformers.commands.run import RunCommand
 from transformers.commands.serving import ServeCommand
 from transformers.commands.user import UserCommands
 
-if __name__ == '__main__':
+
+def main():
     parser = ArgumentParser('Transformers CLI tool', usage='transformers-cli <command> [<args>]')
     commands_parser = parser.add_subparsers(help='transformers-cli command helpers')
 
@@ -30,3 +31,7 @@ if __name__ == '__main__':
     # Run
     service = args.func(args)
     service.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/transformers/commands/transformers_cli.py
+++ b/src/transformers/commands/transformers_cli.py
@@ -10,8 +10,8 @@ from transformers.commands.user import UserCommands
 
 
 def main():
-    parser = ArgumentParser('Transformers CLI tool', usage='transformers-cli <command> [<args>]')
-    commands_parser = parser.add_subparsers(help='transformers-cli command helpers')
+    parser = ArgumentParser("Transformers CLI tool", usage="transformers-cli <command> [<args>]")
+    commands_parser = parser.add_subparsers(help="transformers-cli command helpers")
 
     # Register commands
     ConvertCommand.register_subcommand(commands_parser)
@@ -24,7 +24,7 @@ def main():
     # Let's go
     args = parser.parse_args()
 
-    if not hasattr(args, 'func'):
+    if not hasattr(args, "func"):
         parser.print_help()
         exit(1)
 
@@ -33,5 +33,5 @@ def main():
     service.run()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Using `scripts` is a useful option in `setup.py` particularly when you want to get access to non-python scripts. However, in this case we want to have an entry point into some of our own Python scripts. To do this in a concise, cross-platfom way, we can use `entry_points.console_scripts`. This change is necessary to provide the CLI on different platforms (particularly also including Windows), which "scripts" does not ensure.

Usage remains the same, but the "transformers-cli" script has to be moved (be part of the library) and renamed (underscore + extension). So even though the script itself has been renamed to `transformers_cli.py` and moved to `src/commands`, its usage is still the same: `transformers-cli <args>`.

Tested on Ubuntu and Windows.
