### PR TITLE
considering empty input text to avoid string index out of range error

### DIFF
--- a/src/transformers/tokenization_roberta.py
+++ b/src/transformers/tokenization_roberta.py
@@ -236,7 +236,7 @@ class RobertaTokenizer(GPT2Tokenizer):
             add_prefix_space = kwargs["add_prefix_space"]
         else:
             add_prefix_space = add_special_tokens
-        if add_prefix_space and not text[0].isspace():
+        if add_prefix_space and (len(text) == 0 or not text[0].isspace()):
             text = " " + text
         return text
 


### PR DESCRIPTION
When the input string is empty, the above condition in the tokenization_roberta will encounter string index out of range error. For example, a pair input string exists in the QQP dataset that has an empty string:

{'idx': 362246,
 'label': 0,
 'question1': b'How can I develop android app?',
 'question2': b''}