### PR TITLE
Fix for IndexError when Roberta Tokenizer is called on empty text

### DIFF
--- a/src/transformers/tokenization_roberta.py
+++ b/src/transformers/tokenization_roberta.py
@@ -236,7 +236,7 @@ class RobertaTokenizer(GPT2Tokenizer):
             add_prefix_space = kwargs["add_prefix_space"]
         else:
             add_prefix_space = add_special_tokens
-        if add_prefix_space and not text[0].isspace():
+        if add_prefix_space and len(text) > 0 and not text[0].isspace():
             text = " " + text
         return text
 


### PR DESCRIPTION
Check if `text` is set to avoid IndexError

Fix for https://github.com/huggingface/transformers/issues/3809