### PR TITLE
Improvements to the wandb integration

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -67,7 +67,15 @@ except ImportError:
 
 
 def is_wandb_available():
-    return _has_wandb
+    global _has_wandb
+    if _has_wandb:
+        wandb.ensure_configured()
+        if wandb.api.api_key is None:
+            _has_wandb = False
+            wandb.termwarn(
+                "W&B installed but not logged in.  Run `wandb login` or set the WANDB_API_KEY env variable."
+            )
+    return False if os.getenv("WANDB_DISABLED") else _has_wandb
 
 
 logger = logging.getLogger(__name__)
@@ -156,7 +164,8 @@ class Trainer:
             )
         if not is_wandb_available():
             logger.info(
-                "You are instantiating a Trainer but wandb is not installed. Install it to use Weights & Biases logging."
+                "You are instantiating a Trainer but W&B is not installed. To use wandb logging, \
+                    run `pip install wandb; wandb login` see https://docs.wandb.com/huggingface."
             )
         set_seed(self.args.seed)
         # Create output directory if needed
@@ -261,11 +270,25 @@ class Trainer:
         """
         Setup the optional Weights & Biases (`wandb`) integration.
 
-        One can override this method to customize the setup if needed.
+        One can override this method to customize the setup if needed.  Find more information at https://docs.wandb.com/huggingface
+        You can also override the following environment variables:
+
+        Environment:
+            WANDB_WATCH:
+                (Optional, ["gradients", "all", "false"]) "gradients" by default, set to "false" to disable gradient logging
+                or "all" to log gradients and parameters
+            WANDB_PROJECT:
+                (Optional): str - "huggingface" by default, set this to a custom string to store results in a different project
+            WANDB_DISABLED:
+                (Optional): boolean - defaults to false, set to "true" to disable wandb entirely
         """
-        wandb.init(name=self.args.logging_dir, config=vars(self.args))
+        logger.info('Automatic Weights & Biases logging enabled, to disable set os.environ["WANDB_DISABLED"] = "true"')
+        wandb.init(project=os.getenv("WANDB_PROJECT", "huggingface"), config=vars(self.args))
         # keep track of model topology and gradients
-        wandb.watch(self.model)
+        if os.getenv("WANDB_WATCH") != "false":
+            wandb.watch(
+                self.model, log=os.getenv("WANDB_WATCH", "gradients"), log_freq=max(100, self.args.logging_steps)
+            )
 
     def train(self, model_path: Optional[str] = None):
         """


### PR DESCRIPTION
Hey guys,

I'm one of the founders of W&B and have been working with @borisdayma on the wandb integration. I made a few changes to address a few cases we thought through:

1. If wandb is installed but the user hasn't logged in we now print a warning instead of prompting for an api_key
2. Made messaging more clear on how to install wandb and linked to more documentation
3. Added an environment variable for disabling wandb. This is important for users using fastai or lightning with their own wandb callback.
4. Added an environment variable for disabling wandb.watch. Because we're pulling gradients and parameters during training there is a small performance impact on training. We wanted to make it easy for users to disable this feature.

Happy to iterate on any feedback you guys have. Really excited about this integration!