### PR TITLE
Reformer self attention mask value not converted in apex half precision

### DIFF
--- a/src/transformers/modeling_reformer.py
+++ b/src/transformers/modeling_reformer.py
@@ -561,8 +561,8 @@ class LSHSelfAttention(nn.Module, EfficientAttentionMixin):
 
         # get correct mask values depending on precision
         if query_key_dots.dtype == torch.float16:
-            self_mask_value = self.self_mask_value_float16
-            mask_value = self.mask_value_float16
+            self_mask_value = self.self_mask_value_float16.half()
+            mask_value = self.mask_value_float16.half()
         else:
             self_mask_value = self.self_mask_value_float32
             mask_value = self.mask_value_float32
@@ -833,7 +833,7 @@ class LocalSelfAttention(nn.Module, EfficientAttentionMixin):
         if mask is not None:
             # get mask tensor depending on half precision or not
             if query_key_dots.dtype == torch.float16:
-                mask_value = self.mask_value_float16
+                mask_value = self.mask_value_float16.half()
             else:
                 mask_value = self.mask_value_float32
 


### PR DESCRIPTION
# 🐛 Bug

## Information

Model I am using Reformer:

Language I am using the model on English:

The problem arises when using:
* [ x] my own modified scripts: (give details below)

The tasks I am working on is:
* [x ] my own task or dataset: (give details below)

## To reproduce

Steps to reproduce the behavior:

Install the latest transformers 2.9.0 and apex

```
from transformers import ReformerModel, ReformerTokenizer
import torch
from apex import amp

tokenizer = ReformerTokenizer.from_pretrained('google/reformer-crime-and-punishment')
model =  ReformerModel.from_pretrained('google/reformer-crime-and-punishment').cuda()

optimizer = torch.optim.Adam(model.parameters(), lr=0.0001)

model, optimizer = amp.initialize(model, optimizer, opt_level='O1')

input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute", add_special_tokens=True)).unsqueeze(0).cuda()  # Batch size 1
outputs = model(input_ids)

last_hidden_states = outputs[0]  # The last hidden-state is the first element of the output tuple

```

## Expected behavior

```
File "/home/model/env/lib/python3.7/site-packages/transformers/modeling_reformer.py", line 840, in forward
    query_key_dots = torch.where(mask, query_key_dots, mask_value)
RuntimeError: expected scalar type Half but found Float
```


- `transformers` version:
- Platform: Ubuntu 18.04
- Python version: 3.7
- PyTorch version (GPU?): 1.5.0 cuda
- Tensorflow version (GPU?): No tensorflow
- Using GPU in script?: Yes
- Using distributed or parallel set-up in script?: No
