### PR TITLE
Allow gpt2 to be exported to valid ONNX

### DIFF
--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -26,7 +26,7 @@ def gelu_new(x):
     """ Implementation of the gelu activation function currently in Google Bert repo (identical to OpenAI GPT).
         Also see https://arxiv.org/abs/1606.08415
     """
-    return 0.5 * x * (1 + torch.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * torch.pow(x, 3.0))))
+    return 0.5 * x * (1.0 + torch.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * torch.pow(x, 3.0))))
 
 
 if torch.__version__ < "1.4.0":
@@ -36,7 +36,7 @@ else:
 
 
 def gelu_fast(x):
-    return 0.5 * x * (1 + torch.tanh(x * 0.7978845608 * (1 + 0.044715 * x * x)))
+    return 0.5 * x * (1.0 + torch.tanh(x * 0.7978845608 * (1.0 + 0.044715 * x * x)))
 
 
 ACT2FN = {

--- a/src/transformers/modeling_gpt2.py
+++ b/src/transformers/modeling_gpt2.py
@@ -142,7 +142,7 @@ class Attention(nn.Module):
     def _attn(self, q, k, v, attention_mask=None, head_mask=None):
         w = torch.matmul(q, k)
         if self.scale:
-            w = w / float(v.size(-1) ** 0.5)
+            w = w / (float(v.size(-1)) ** 0.5)
         nd, ns = w.size(-2), w.size(-1)
         mask = self.bias[:, :, ns - nd : ns, :ns]
         w = torch.where(mask.bool(), w, self.masked_bias.to(w.dtype))

--- a/src/transformers/modeling_gpt2.py
+++ b/src/transformers/modeling_gpt2.py
@@ -142,10 +142,10 @@ class Attention(nn.Module):
     def _attn(self, q, k, v, attention_mask=None, head_mask=None):
         w = torch.matmul(q, k)
         if self.scale:
-            w = w / (v.size(-1) ** 0.5)
+            w = w / float(v.size(-1) ** 0.5)
         nd, ns = w.size(-2), w.size(-1)
         mask = self.bias[:, :, ns - nd : ns, :ns]
-        w = torch.where(mask, w, self.masked_bias.to(w.dtype))
+        w = torch.where(mask.bool(), w, self.masked_bias.to(w.dtype))
 
         if attention_mask is not None:
             # Apply the attention mask


### PR DESCRIPTION
Problem: gpt2 model and other models using gelu_new or gelu_fast cannot be exported to valid ONNX model.

Causes:
PyTorch will export some constants like 1 or 2 as int64, while ONNX operators like [Add](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Add) and [Pow](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Pow) requires data type matches between two inputs. It is invalid to have one input as float and another as int64.

For GPT2 model, another issue is the ONNX operator [Where](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Where). It requires the first input to be bool tensor but currently it is uint8 tensor.

Add explicit data type cast could solve these problems. It is verified in exporting 3 pretrained models to ONNX model and loading by ONNX Runtime: albert-base-v2, distilgpt2, gpt2.