### PR TITLE
Add back option --do_lower_case in SQuAD for uncased models

### DIFF
--- a/examples/question-answering/README.md
+++ b/examples/question-answering/README.md
@@ -28,6 +28,7 @@ python run_squad.py \
   --model_name_or_path bert-base-uncased \
   --do_train \
   --do_eval \
+  --do_lower_case \
   --train_file $SQUAD_DIR/train-v1.1.json \
   --predict_file $SQUAD_DIR/dev-v1.1.json \
   --per_gpu_train_batch_size 12 \
@@ -56,6 +57,7 @@ python -m torch.distributed.launch --nproc_per_node=8 ./examples/question-answer
     --model_name_or_path bert-large-uncased-whole-word-masking \
     --do_train \
     --do_eval \
+    --do_lower_case \
     --train_file $SQUAD_DIR/train-v1.1.json \
     --predict_file $SQUAD_DIR/dev-v1.1.json \
     --learning_rate 3e-5 \


### PR DESCRIPTION
The option `--do_lower_case` is currently needed by the uncased models (i.e., bert-base-uncased, bert-large-uncased). The results w/ and w/o this option are shown below. 

The option was deleted in the current v2.9.0 version so this PR tries to add it back. This would not affect the cased models (i.e., RoBERTa, XLNet).

Results of SQuAD v1.1:
bert-base-uncased **without** `--do_lower_case`:  'exact': 73.83, 'f1': 82.22
bert-base-uncased **with** `--do_lower_cas`e:  'exact': 81.02, 'f1': 88.34