### PR TITLE
Align sentiment-analysis' tokenizer (currently cased) to the model (uncased)

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1531,7 +1531,7 @@ SUPPORTED_TASKS = {
                 "tf": "distilbert-base-uncased-finetuned-sst-2-english",
             },
             "config": "distilbert-base-uncased-finetuned-sst-2-english",
-            "tokenizer": "distilbert-base-cased",
+            "tokenizer": "distilbert-base-uncased",
         },
     },
     "ner": {


### PR DESCRIPTION
`sentiment-analysis` pipeline has a tokenizer using a cased vocab while the model is uncased. 

This PR makes the tokenizer uncased to match the actual model's vocab.