### PR TITLE
Fix quickstart

### DIFF
--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -207,13 +207,11 @@ context = torch.tensor([generated])
 past = None
 
 for i in range(100):
-    print(i)
-    output, past = model(context, past=past)
-    token = torch.argmax(output[..., -1, :])
+    output, past = model(context, past=past, use_cache=True)
+    token = torch.argmax(output[..., -1, :]).view(1, 1)
+    context = torch.cat((context, token), -1)
 
-    generated += [token.tolist()]
-    context = token.unsqueeze(0)
-
+generated = context.tolist()[0]
 sequence = tokenizer.decode(generated)
 
 print(sequence)

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -207,7 +207,7 @@ context = torch.tensor([generated])
 past = None
 
 for i in range(100):
-    output, past = model(context, past=past, use_cache=True)
+    output, past = model(context, past=past)
     token = torch.argmax(output[..., -1, :]).view(1, 1)
     context = torch.cat((context, token), -1)
 


### PR DESCRIPTION
GPT-2 now requires the entire context to be passed, even when specifying the past since #3734 

closes #4259