### PR TITLE
Added the option to seed generation in encoder-decoder models

### DIFF
--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -450,8 +450,8 @@ class BartDecoder(nn.Module):
         input_ids,
         encoder_hidden_states,
         encoder_padding_mask,
-        decoder_padding_mask,
-        decoder_causal_mask,
+        decoder_padding_mask=None,
+        decoder_causal_mask=None,
         decoder_cached_states=None,
         use_cache=False,
         **unused

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -981,7 +981,7 @@ class BartForConditionalGeneration(PretrainedBartModel):
         }
 
     def prepare_scores_for_generation(self, scores, cur_len, max_length):
-        if cur_len == 0:
+        if cur_len == 1:
             self._force_token_ids_generation(scores, self.config.bos_token_id)
         if cur_len == max_length - 1 and self.config.eos_token_id is not None:
             self._force_token_ids_generation(scores, self.config.eos_token_id)

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -981,7 +981,7 @@ class BartForConditionalGeneration(PretrainedBartModel):
         }
 
     def prepare_scores_for_generation(self, scores, cur_len, max_length):
-        if cur_len == 1:
+        if cur_len == 0:
             self._force_token_ids_generation(scores, self.config.bos_token_id)
         if cur_len == max_length - 1 and self.config.eos_token_id is not None:
             self._force_token_ids_generation(scores, self.config.eos_token_id)


### PR DESCRIPTION
Added the `decoder_input_ids` argument to `.generate()`, which acts as `input_ids` for the decoder instead of fixed BOS tokens used now.