### PR TITLE
Added the feature to provide a generation prompt for encoder-decoder models.

### DIFF
--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -450,8 +450,8 @@ class BartDecoder(nn.Module):
         input_ids,
         encoder_hidden_states,
         encoder_padding_mask,
-        decoder_padding_mask,
-        decoder_causal_mask,
+        decoder_padding_mask=None,
+        decoder_causal_mask=None,
         decoder_cached_states=None,
         use_cache=False,
         **unused


### PR DESCRIPTION
Added the `decoder_input_ids` argument to `.generate(...)`, which should be used (only) with encoder-decoder models to start generation from some sequence.