### PR TITLE
Allow for None gradients in GradientAccumulator.

### DIFF
--- a/src/transformers/optimization_tf.py
+++ b/src/transformers/optimization_tf.py
@@ -217,7 +217,7 @@ class GradientAccumulator(object):
         """The accumulated gradients on the current replica."""
         if not self._gradients:
             raise ValueError("The accumulator should be called first to initialize the gradients")
-        return list(gradient.value() for gradient in self._gradients)
+        return list(gradient.value() if gradient is not None else gradient for gradient in self._gradients)
 
     def __call__(self, gradients):
         """Accumulates :obj:`gradients` on the current replica."""
@@ -231,6 +231,8 @@ class GradientAccumulator(object):
                         synchronization=tf.VariableSynchronization.ON_READ,
                         aggregation=tf.VariableAggregation.ONLY_FIRST_REPLICA,
                     )
+                    if gradient is not None
+                    else gradient
                     for gradient in gradients
                 ]
             )
@@ -238,7 +240,8 @@ class GradientAccumulator(object):
             raise ValueError("Expected %s gradients, but got %d" % (len(self._gradients), len(gradients)))
 
         for accum_gradient, gradient in zip(self._gradients, gradients):
-            accum_gradient.assign_add(gradient)
+            if accum_gradient is not None and gradient is not None:
+                accum_gradient.assign_add(gradient)
 
         self._accum_steps.assign_add(1)
 
@@ -248,4 +251,5 @@ class GradientAccumulator(object):
             return
         self._accum_steps.assign(0)
         for gradient in self._gradients:
-            gradient.assign(tf.zeros_like(gradient))
+            if gradient is not None:
+                gradient.assign(tf.zeros_like(gradient))


### PR DESCRIPTION
The [TFTrainer commit](https://github.com/huggingface/transformers/commit/aad50151f35b934039c455242c433a24f011cc93#diff-2a765415189cf1edda4414e1758b0e79) seems to have reverted the ability for gradients to be None in GradientAccumulator. This behavior is necessary when pretraining a model, such as AlbertForPreTraining, and using only one loss (only SOP or only MLM).

The [OpenNMT repository](https://github.com/OpenNMT/OpenNMT-tf/blob/master/opennmt/optimizers/utils.py) the code was taken from lacks this ability, but it's important. This commit restores the ability for gradients to be None.