### PR TITLE
Specify tensorboard logging in BART finetuning

### DIFF
--- a/examples/lightning_base.py
+++ b/examples/lightning_base.py
@@ -256,7 +256,7 @@ def generic_train(model: BaseTransformer, args: argparse.Namespace):
         gradient_clip_val=args.max_grad_norm,
         checkpoint_callback=checkpoint_callback,
         callbacks=[LoggingCallback()],
-        logging_dir=args.logging_dir
+        logging_dir=args.logging_dir,
     )
 
     if args.fp16:
@@ -274,11 +274,7 @@ def generic_train(model: BaseTransformer, args: argparse.Namespace):
         train_params["distributed_backend"] = "ddp"
 
     if args.logging_dir:
-        logger = pl.loggers.TensorBoardLogger(
-                    save_dir=args.logging_dir,
-                    version='',
-                    name=''
-                )
+        logger = pl.loggers.TensorBoardLogger(save_dir=args.logging_dir, version="", name="")
         train_params["logger"] = logger
 
     trainer = pl.Trainer(**train_params)

--- a/examples/lightning_base.py
+++ b/examples/lightning_base.py
@@ -256,6 +256,7 @@ def generic_train(model: BaseTransformer, args: argparse.Namespace):
         gradient_clip_val=args.max_grad_norm,
         checkpoint_callback=checkpoint_callback,
         callbacks=[LoggingCallback()],
+        logging_dir=args.logging_dir
     )
 
     if args.fp16:
@@ -271,6 +272,14 @@ def generic_train(model: BaseTransformer, args: argparse.Namespace):
 
     if args.n_gpu > 1:
         train_params["distributed_backend"] = "ddp"
+
+    if args.logging_dir:
+        logger = pl.loggers.TensorBoardLogger(
+                    save_dir=args.logging_dir,
+                    version='',
+                    name=''
+                )
+        train_params["logger"] = logger
 
     trainer = pl.Trainer(**train_params)
 

--- a/examples/summarization/bart/finetune.py
+++ b/examples/summarization/bart/finetune.py
@@ -152,6 +152,13 @@ class SummarizationTrainer(BaseTransformer):
             required=True,
             help="The input data dir. Should contain the dataset files for the CNN/DM summarization task.",
         )
+        parser.add_argument(
+            "--logging_dir",
+            default='tensorboard_logs',
+            type=str,
+            required=False,
+            help="The directory for tensorboard_logs",
+        )
         return parser
 
 

--- a/examples/summarization/bart/finetune.py
+++ b/examples/summarization/bart/finetune.py
@@ -154,7 +154,7 @@ class SummarizationTrainer(BaseTransformer):
         )
         parser.add_argument(
             "--logging_dir",
-            default='tensorboard_logs',
+            default="tensorboard_logs",
             type=str,
             required=False,
             help="The directory for tensorboard_logs",

--- a/examples/summarization/bart/finetune.py
+++ b/examples/summarization/bart/finetune.py
@@ -154,10 +154,8 @@ class SummarizationTrainer(BaseTransformer):
         )
         parser.add_argument(
             "--logging_dir",
-            default="tensorboard_logs",
             type=str,
-            required=False,
-            help="The directory for tensorboard_logs",
+            help="The directory for tensorboard logs",
         )
         return parser
 


### PR DESCRIPTION
Allows you to specify the directory in which to store tensorboard logs when running the BART finetuning script. 

Issue: #4349
