### PR TITLE
[T5 fp16] Fix fp16 in T5

### DIFF
--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -707,7 +707,7 @@ class T5Stack(T5PreTrainedModel):
         extended_attention_mask = self.get_extended_attention_mask(attention_mask, input_shape, self.device)
 
         if self.is_decoder and encoder_attention_mask is not None:
-            encoder_extended_attention_mask = self.invert_attention_mask(encoder_attention_mask, dtype=self.dtype)
+            encoder_extended_attention_mask = self.invert_attention_mask(encoder_attention_mask)
         else:
             encoder_extended_attention_mask = None
 

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -151,8 +151,8 @@ class T5LayerNorm(nn.Module):
     def forward(self, x):
         # layer norm should always be calculated in float32
         variance = x.to(torch.float32).pow(2).mean(-1, keepdim=True)
-        x = (x / torch.sqrt(variance + self.variance_epsilon))
-            
+        x = x / torch.sqrt(variance + self.variance_epsilon)
+
         if self.weight.dtype == torch.float16:
             x = x.to(torch.float16)
         return self.weight * x
@@ -695,7 +695,9 @@ class T5Stack(T5PreTrainedModel):
             attention_mask = torch.ones(batch_size, mask_seq_length).to(inputs_embeds.device)
         if self.is_decoder and encoder_attention_mask is None and encoder_hidden_states is not None:
             encoder_seq_length = encoder_hidden_states.shape[1]
-            encoder_attention_mask = torch.ones(batch_size, encoder_seq_length, device=inputs_embeds.device, dtype=torch.long)
+            encoder_attention_mask = torch.ones(
+                batch_size, encoder_seq_length, device=inputs_embeds.device, dtype=torch.long
+            )
 
         # initialize past_key_value_states with `None` if past does not exist
         if past_key_value_states is None:
@@ -708,7 +710,6 @@ class T5Stack(T5PreTrainedModel):
             encoder_extended_attention_mask = self.invert_attention_mask(encoder_attention_mask, dtype=self.dtype)
         else:
             encoder_extended_attention_mask = None
-
 
         # Prepare head mask if needed
         head_mask = self.get_head_mask(head_mask, self.config.num_layers)

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -149,8 +149,12 @@ class T5LayerNorm(nn.Module):
         self.variance_epsilon = eps
 
     def forward(self, x):
-        variance = x.pow(2).mean(-1, keepdim=True)
-        x = x / torch.sqrt(variance + self.variance_epsilon)
+        # layer norm should always be calculated in float32
+        variance = x.to(torch.float32).pow(2).mean(-1, keepdim=True)
+        x = (x / torch.sqrt(variance + self.variance_epsilon))
+            
+        if self.weight.dtype == torch.float16:
+            x = x.to(torch.float16)
         return self.weight * x
 
 
@@ -691,7 +695,7 @@ class T5Stack(T5PreTrainedModel):
             attention_mask = torch.ones(batch_size, mask_seq_length).to(inputs_embeds.device)
         if self.is_decoder and encoder_attention_mask is None and encoder_hidden_states is not None:
             encoder_seq_length = encoder_hidden_states.shape[1]
-            encoder_attention_mask = torch.ones(batch_size, encoder_seq_length).to(inputs_embeds.device)
+            encoder_attention_mask = torch.ones(batch_size, encoder_seq_length, device=inputs_embeds.device, dtype=torch.long)
 
         # initialize past_key_value_states with `None` if past does not exist
         if past_key_value_states is None:
@@ -701,9 +705,10 @@ class T5Stack(T5PreTrainedModel):
         extended_attention_mask = self.get_extended_attention_mask(attention_mask, input_shape, self.device)
 
         if self.is_decoder and encoder_attention_mask is not None:
-            encoder_extended_attention_mask = self.invert_attention_mask(encoder_attention_mask)
+            encoder_extended_attention_mask = self.invert_attention_mask(encoder_attention_mask, dtype=self.dtype)
         else:
             encoder_extended_attention_mask = None
+
 
         # Prepare head mask if needed
         head_mask = self.get_head_mask(head_mask, self.config.num_layers)
@@ -733,6 +738,7 @@ class T5Stack(T5PreTrainedModel):
             # layer_outputs is a tuple with:
             # hidden-states, key-value-states, (self-attention weights), (self-attention position bias), (cross-attention weights), (cross-attention position bias)
             hidden_states, present_key_value_state = layer_outputs[:2]
+
             if i == 0:
                 # We share the position biases between the layers - the first layer store them
                 # layer_outputs = hidden-states, key-value-states (self-attention weights), (self-attention position bias), (cross-attention weights), (cross-attention position bias)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -134,7 +134,9 @@ class ModuleUtilsMixin:
         elif dtype == torch.float32:
             encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * -1e9
         else:
-            raise ValueError("{} not recognized. `dtype` should be set to either `torch.float32` or `torch.float16`".format(dtype))
+            raise ValueError(
+                "{} not recognized. `dtype` should be set to either `torch.float32` or `torch.float16`".format(dtype)
+            )
 
         return encoder_extended_attention_mask
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -116,7 +116,7 @@ class ModuleUtilsMixin:
     def dtype(self) -> dtype:
         return next(self.parameters()).dtype
 
-    def invert_attention_mask(self, encoder_attention_mask: Tensor, dtype: dtype = torch.float32) -> Tensor:
+    def invert_attention_mask(self, encoder_attention_mask: Tensor) -> Tensor:
         """type: torch.Tensor -> torch.Tensor"""
         if encoder_attention_mask.dim() == 3:
             encoder_extended_attention_mask = encoder_attention_mask[:, None, :, :]
@@ -129,13 +129,15 @@ class ModuleUtilsMixin:
         # encoder_extended_attention_mask.transpose(-1, -2))
         encoder_extended_attention_mask = encoder_extended_attention_mask.to(dtype=self.dtype)  # fp16 compatibility
 
-        if dtype == torch.float16:
+        if self.dtype == torch.float16:
             encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * -1e4
-        elif dtype == torch.float32:
+        elif self.dtype == torch.float32:
             encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * -1e9
         else:
             raise ValueError(
-                "{} not recognized. `dtype` should be set to either `torch.float32` or `torch.float16`".format(dtype)
+                "{} not recognized. `dtype` should be set to either `torch.float31` or `torch.float16`".format(
+                    self.dtype
+                )
             )
 
         return encoder_extended_attention_mask

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -135,7 +135,7 @@ class ModuleUtilsMixin:
             encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * -1e9
         else:
             raise ValueError(
-                "{} not recognized. `dtype` should be set to either `torch.float31` or `torch.float16`".format(
+                "{} not recognized. `dtype` should be set to either `torch.float32` or `torch.float16`".format(
                     self.dtype
                 )
             )

--- a/tests/test_modeling_t5.py
+++ b/tests/test_modeling_t5.py
@@ -304,6 +304,16 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
             output_with_past_cache = model.generate(input_ids[:1], num_beams=2, max_length=5, do_sample=True)
             self.parent.assertTrue(torch.all(output_with_past_cache == output_without_past_cache))
 
+        def create_and_check_t5_model_fp16_forward(
+            self, config, input_ids, decoder_input_ids, attention_mask, decoder_attention_mask, lm_labels,
+        ):
+            model = T5Model(config=config)
+            model.to(torch_device)
+            model.half()
+            model.eval()
+            output = model(input_ids, decoder_input_ids=input_ids, attention_mask=attention_mask)[0]
+            self.parent.assertFalse(torch.isnan(output).any().item())
+
         def prepare_config_and_inputs_for_common(self):
             config_and_inputs = self.prepare_config_and_inputs()
             (
@@ -354,6 +364,11 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
     def test_t5_generate_with_past_key_value_states(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_t5_and_check_t5_generate_with_past_key_value_states(*config_and_inputs)
+
+    @unittest.skipIf(torch_device == "cpu", "Cant do half precision")
+    def test_t5_model_fp16_forward(self):
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_t5_model_fp16_forward(*config_and_inputs)
 
     @slow
     def test_model_from_pretrained(self):


### PR DESCRIPTION
This PR fixes the issue: #4287. 

- A test for T5 is added.
- The function self.invert_attention_mask included a if statement now so that no errors will occur when using the function in `fp16` mode.