### PR TITLE
Correct TF formatting to exclude LayerNorms from weight decay

### DIFF
--- a/src/transformers/optimization_tf.py
+++ b/src/transformers/optimization_tf.py
@@ -75,7 +75,7 @@ def create_optimizer(init_lr, num_train_steps, num_warmup_steps, end_lr=0.0, opt
         beta_1=0.9,
         beta_2=0.999,
         epsilon=1e-6,
-        exclude_from_weight_decay=["LayerNorm", "bias"],
+        exclude_from_weight_decay=["LayerNorm", "layer_norm", "bias"],
     )
 
     return optimizer

--- a/src/transformers/optimization_tf.py
+++ b/src/transformers/optimization_tf.py
@@ -75,7 +75,7 @@ def create_optimizer(init_lr, num_train_steps, num_warmup_steps, end_lr=0.0, opt
         beta_1=0.9,
         beta_2=0.999,
         epsilon=1e-6,
-        exclude_from_weight_decay=["layer_norm", "bias"],
+        exclude_from_weight_decay=["LayerNorm", "bias"],
     )
 
     return optimizer


### PR DESCRIPTION
Fixes #4360 

Layer Norm is formated in the wrong way for TensorFlow. This causes it not to be excluded from weight decay in the [run_tf_glue.py](https://github.com/huggingface/transformers/blob/master/examples/text-classification/run_tf_glue.py) script. 

This pr simply formats the string to fit the TensorFlow naming. 

Not sure if you want a test for this? One option would be to check that all elements in `_exclude_from_weight_decay` trigger a regexp match. But seems a bit overkill. 