### PR TITLE
layer name change to match compatibility with pytorch layer name in BertForQuestionAnswering

### DIFF
--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -106,7 +106,7 @@ def load_tf_weights_in_bert(model, config, tf_checkpoint_path):
             elif scope_names[0] == "output_weights":
                 pointer = getattr(pointer, "weight")
             elif scope_names[0] == "squad":
-                pointer = getattr(pointer, "classifier")
+                pointer = getattr(pointer, "qa_outputs")
             else:
                 try:
                     pointer = getattr(pointer, scope_names[0])


### PR DESCRIPTION
As pointed out in #438 When using BertForQuestionAnswering to load a tensorflow model using from_pretrained, one runs into an error 
`AttributeError: 'BertForQuestionAnswering' object has no attribute 'classifier'`

As pointed out in the thread it should be "qa_outputs" and not "classifier" for this functionality to work as expected. 
