### PR TITLE
Attempt to do some optimizations for BERT models

### DIFF
--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -201,8 +201,8 @@ class BertSelfAttention(nn.Module):
         self.value = nn.Linear(config.hidden_size, self.all_head_size)
 
         self.qkv_weight = nn.Parameter(torch.cat(
-            (self.query.weight, self.key.weight, self.value.weight), dim=0)
-        ).t().contiguous()
+            (self.query.weight, self.key.weight, self.value.weight), dim=0
+        ).t().contiguous())
 
         self.qkv_bias = nn.Parameter(
             torch.cat((self.query.bias, self.key.bias, self.value.bias), dim=0)
@@ -210,10 +210,10 @@ class BertSelfAttention(nn.Module):
 
         self.dropout = partial(nn.functional.dropout, p=config.attention_probs_dropout_prob)
 
-    def transpose_for_scores(self, x):
-        new_x_shape = x.size()[:-1] + (self.num_attention_heads, self.attention_head_size)
-        x = x.view(*new_x_shape)
-        return x.permute(0, 2, 1, 3)
+    # def transpose_for_scores(self, x):
+    #     new_x_shape = x.size()[:-1] + (self.num_attention_heads, self.attention_head_size)
+    #     x = x.view(*new_x_shape)
+    #     return x.permute(0, 2, 1, 3)
 
     def forward(
         self,

--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -194,6 +194,7 @@ class BertSelfAttention(nn.Module):
         self.num_attention_heads = config.num_attention_heads
         self.attention_head_size = int(config.hidden_size / config.num_attention_heads)
         self.all_head_size = self.num_attention_heads * self.attention_head_size
+        self.scale_factor = 1. / math.sqrt(self.attention_head_size)
 
         self.query = nn.Linear(config.hidden_size, self.all_head_size)
         self.key = nn.Linear(config.hidden_size, self.all_head_size)
@@ -233,7 +234,7 @@ class BertSelfAttention(nn.Module):
 
         # Take the dot product between "query" and "key" to get the raw attention scores.
         attention_scores = torch.matmul(query_layer, key_layer.transpose(-1, -2))
-        attention_scores = attention_scores / math.sqrt(self.attention_head_size)
+        attention_scores = attention_scores * self.scale_factor
         if attention_mask is not None:
             # Apply the attention mask is (precomputed for all layers in BertModel forward() function)
             attention_scores = attention_scores + attention_mask

--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -239,7 +239,7 @@ class BertSelfAttention(nn.Module):
             attention_scores = attention_scores + attention_mask
 
         # Normalize the attention scores to probabilities.
-        attention_probs = nn.Softmax(dim=-1)(attention_scores)
+        attention_probs = torch.softmax(attention_scores, dim=-1)
 
         # This is actually dropping out entire tokens to attend to, which might
         # seem a bit unusual, but is taken from the original Transformer paper.


### PR DESCRIPTION
- Use functional as much as possible instead of creating a class instance everytime
- Precompute and store the attention scaling factor to avoid `1/sqrt(...)` every forward
- Refactor Self-Attention to group QKV weights and and increase hardware density