### PR TITLE
TPU hangs when saving optimizer/scheduler

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -463,10 +463,9 @@ class Trainer:
                 train_dataloader.sampler.set_epoch(epoch)
 
             if is_tpu_available():
-                parallel_loader = pl.ParallelLoader(
-                    train_dataloader,
-                    [self.args.device]
-                ).per_device_loader(self.args.device)
+                parallel_loader = pl.ParallelLoader(train_dataloader, [self.args.device]).per_device_loader(
+                    self.args.device
+                )
                 epoch_iterator = tqdm(parallel_loader, desc="Iteration", disable=not self.is_local_master())
             else:
                 epoch_iterator = tqdm(train_dataloader, desc="Iteration", disable=not self.is_local_master())

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -514,24 +514,29 @@ class Trainer:
                         if self.args.evaluate_during_training:
                             self.evaluate()
 
-                    if self.is_world_master():
-                        if self.args.save_steps > 0 and self.global_step % self.args.save_steps == 0:
-                            # In all cases (even distributed/parallel), self.model is always a reference
-                            # to the model we want to save.
-                            if hasattr(model, "module"):
-                                assert model.module is self.model
-                            else:
-                                assert model is self.model
-                            # Save model checkpoint
-                            output_dir = os.path.join(
-                                self.args.output_dir, f"{PREFIX_CHECKPOINT_DIR}-{self.global_step}"
-                            )
+                    if self.args.save_steps > 0 and self.global_step % self.args.save_steps == 0:
+                        # In all cases (even distributed/parallel), self.model is always a reference
+                        # to the model we want to save.
+                        if hasattr(model, "module"):
+                            assert model.module is self.model
+                        else:
+                            assert model is self.model
+                        # Save model checkpoint
+                        output_dir = os.path.join(
+                            self.args.output_dir, f"{PREFIX_CHECKPOINT_DIR}-{self.global_step}"
+                        )
 
-                            self.save_model(output_dir)
+                        self.save_model(output_dir)
+
+                        if self.is_world_master():
                             self._rotate_checkpoints()
-                            torch.save(optimizer.state_dict(), os.path.join(output_dir, "optimizer.pt"))
-                            torch.save(scheduler.state_dict(), os.path.join(output_dir, "scheduler.pt"))
-                            logger.info("Saving optimizer and scheduler states to %s", output_dir)
+
+                        if self.is_world_master() or is_tpu_available():
+                            saving_method = torch.save if not is_tpu_available() else xm.save
+                            if is_tpu_available():
+                                xm.rendezvous("saving_optimizer_states")
+                            saving_method(optimizer.state_dict(), os.path.join(output_dir, "optimizer.pt"))
+                            saving_method(scheduler.state_dict(), os.path.join(output_dir, "scheduler.pt"))
 
                 if self.args.max_steps > 0 and self.global_step > self.args.max_steps:
                     epoch_iterator.close()

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -522,9 +522,7 @@ class Trainer:
                         else:
                             assert model is self.model
                         # Save model checkpoint
-                        output_dir = os.path.join(
-                            self.args.output_dir, f"{PREFIX_CHECKPOINT_DIR}-{self.global_step}"
-                        )
+                        output_dir = os.path.join(self.args.output_dir, f"{PREFIX_CHECKPOINT_DIR}-{self.global_step}")
 
                         self.save_model(output_dir)
 


### PR DESCRIPTION
Similarly to when saving a model state dict, the optimizer and scheduler should be saved using `xm.save` and behind an `xm.rendezvous`.

Additional fix: `pl.ParallelLoader` is not a `torch.utils.data.DataLoader`, and, therefore, must be reinitialized at each epoch.