### PR TITLE
Add mecab dependency on slow tests.

### DIFF
--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         source .env/bin/activate
-        pip install .[sklearn,tf,torch,testing]
+        pip install .[sklearn,mecab,tf,torch,testing]
 
     - name: Are GPUs recognized by our DL frameworks
       run: |


### PR DESCRIPTION
Solves the following error: 

```
2020-05-19T17:01:17.3352437Z [gw0] linux -- Python 3.7.6 /home/hf/actions-r
2020-05-19T17:01:17.3354221Z     @slow
2020-05-19T17:01:17.3354825Z     def test_sequence_builders(self):
2020-05-19T17:01:17.3356512Z >       tokenizer = self.tokenizer_class.from_pretrained("bert-base-japanese-char")
2020-05-19T17:01:17.3356685Z 
2020-05-19T17:01:17.3357374Z tests/test_tokenization_bert_japanese.py:192: 
2020-05-19T17:01:17.3359012Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2020-05-19T17:01:17.3360868Z .env/lib/python3.7/site-packages/transformers/tokenization_utils.py:902: in from_pretrained
2020-05-19T17:01:17.3361266Z     return cls._from_pretrained(*inputs, **kwargs)
2020-05-19T17:01:17.3363161Z .env/lib/python3.7/site-packages/transformers/tokenization_utils.py:1055: in _from_pretrained
2020-05-19T17:01:17.3363615Z     tokenizer = cls(*init_inputs, **init_kwargs)
2020-05-19T17:01:17.3365382Z .env/lib/python3.7/site-packages/transformers/tokenization_bert_japanese.py:139: in __init__
2020-05-19T17:01:17.3366229Z     do_lower_case=do_lower_case, never_split=never_split, **(mecab_kwargs or {})
2020-05-19T17:01:17.3367669Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2020-05-19T17:01:17.3367895Z 
2020-05-19T17:01:17.3369474Z self = <transformers.tokenization_bert_japanese.MecabTokenizer object at 0x7f433565b9d0>
2020-05-19T17:01:17.3371043Z do_lower_case = False, never_split = None, normalize_text = True
2020-05-19T17:01:17.3371414Z mecab_option = None
2020-05-19T17:01:17.3371564Z 
2020-05-19T17:01:17.3373681Z     def __init__(self, do_lower_case=False, never_split=None, normalize_text=True, mecab_option: Optional[str] = None):
2020-05-19T17:01:17.3373909Z         """Constructs a MecabTokenizer.
2020-05-19T17:01:17.3374082Z     
2020-05-19T17:01:17.3374357Z         Args:
2020-05-19T17:01:17.3375149Z             **do_lower_case**: (`optional`) boolean (default True)
2020-05-19T17:01:17.3375850Z                 Whether to lower case the input.
2020-05-19T17:01:17.3376666Z             **never_split**: (`optional`) list of str
2020-05-19T17:01:17.3377692Z                 Kept for backward compatibility purposes.
2020-05-19T17:01:17.3378953Z                 Now implemented directly at the base class level (see :func:`PreTrainedTokenizer.tokenize`)
2020-05-19T17:01:17.3379578Z                 List of token not to split.
2020-05-19T17:01:17.3380559Z             **normalize_text**: (`optional`) boolean (default True)
2020-05-19T17:01:17.3381677Z                 Whether to apply unicode normalization to text before tokenization.
2020-05-19T17:01:17.3382985Z             **mecab_option**: (`optional`) string passed to `MeCab.Tagger` constructor (default "")
2020-05-19T17:01:17.3383398Z         """
2020-05-19T17:01:17.3384034Z         self.do_lower_case = do_lower_case
2020-05-19T17:01:17.3385088Z         self.never_split = never_split if never_split is not None else []
2020-05-19T17:01:17.3385841Z         self.normalize_text = normalize_text
2020-05-19T17:01:17.3386284Z     
2020-05-19T17:01:17.3386881Z >       import MeCab
2020-05-19T17:01:17.3388516Z E       ModuleNotFoundError: No module named 'MeCab'
```