### PR TITLE
bugfix: pass on tokenizer to pipeline in load_graph_from_args

### DIFF
--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -103,7 +103,7 @@ def load_graph_from_args(framework: str, model: str, tokenizer: Optional[str] = 
     print("Loading pipeline (model: {}, tokenizer: {})".format(model, tokenizer))
 
     # Allocate tokenizer and model
-    return pipeline("feature-extraction", model=model, framework=framework)
+    return pipeline("feature-extraction", model=model, tokenizer=tokenizer, framework=framework)
 
 
 def convert_pytorch(nlp: Pipeline, opset: int, output: str, use_external_format: bool):


### PR DESCRIPTION
I think I found a small bug in the `load_graph_from_args` function in `convert_graph_to_onnx.py` as it accepts a tokenizer as input but doesn't pass it on to the pipeline inside the function.

Love the library 🤗