### PR TITLE
Use args.per_gpu_train_batch_size instead of args.train_batch_size in…

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -237,7 +237,7 @@ class Trainer:
 
         data_loader = DataLoader(
             self.train_dataset,
-            batch_size=self.args.train_batch_size,
+            batch_size=self.args.per_gpu_train_batch_size,
             sampler=train_sampler,
             collate_fn=self.data_collator.collate_batch,
         )
@@ -419,10 +419,10 @@ class Trainer:
 
         # Train!
         if is_tpu_available():
-            total_train_batch_size = self.args.train_batch_size * xm.xrt_world_size()
+            total_train_batch_size = self.args.per_gpu_train_batch_size * xm.xrt_world_size()
         else:
             total_train_batch_size = (
-                self.args.train_batch_size
+                self.args.per_gpu_train_batch_size
                 * self.args.gradient_accumulation_steps
                 * (torch.distributed.get_world_size() if self.args.local_rank != -1 else 1)
             )


### PR DESCRIPTION
… Trainer.

It appears that this is preferred, per https://github.com/huggingface/transformers/blob/master/src/transformers/training_args.py. This also matches the calculation which is printed referring to batch size at https://github.com/huggingface/transformers/blob/master/src/transformers/trainer.py#L432.

As a side note, the GPT-2 example in https://github.com/huggingface/transformers/blob/master/examples/language-modeling/README.md no longer works. There is a default `per_gpu_train_batch_size=8`, which throws OOM on a Tesla V100 with 32GB RAM. I ran it successfully with `--per_gpu_train_batch_size=1`, and it used 7GB of RAM. So we probably want to add that hyperparameter to the example command.