### PR TITLE
Add packaging to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,8 @@ setup(
         "sentencepiece",
         # for XLM
         "sacremoses",
+        # for Trainer PyTorch version check
+        "packaging",
     ],
     extras_require=extras,
     scripts=["transformers-cli"],


### PR DESCRIPTION
Running `pip install -e transformers` and then `python -c "import transformers"` fails on a fresh Docker container with the error:

```bash
ModuleNotFoundError: No module named 'packaging'
Thu May 21 21:59:44 2020<stderr>:Traceback (most recent call last):
Thu May 21 21:59:44 2020<stderr>:  File "/.../", line 37, in <module>
Thu May 21 21:59:44 2020<stderr>:    from transformers import (
Thu May 21 21:59:44 2020<stderr>:  File "/fsx/transformers/src/transformers/__init__.py", line 350, in <module>
Thu May 21 21:59:44 2020<stderr>:    from .trainer import Trainer, set_seed, torch_distributed_zero_first, EvalPrediction
Thu May 21 21:59:44 2020<stderr>:  File "/fsx/transformers/src/transformers/trainer.py", line 14, in <module>
Thu May 21 21:59:44 2020<stderr>:    from packaging import version
```

Looks like this dependency was recently added, so adding it to setup.py requirements.