### PR TITLE
Allow BatchEncoding to be pickled

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     packages=find_packages("src"),
     install_requires=[
         "numpy",
-        "tokenizers == 0.7.0",
+        "tokenizers == 0.8.0.dev1",
         # dataclasses for Python versions that don't have it
         "dataclasses;python_version<'3.7'",
         # filesystem locks e.g. to prevent parallel downloads

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -184,6 +184,16 @@ class BatchEncoding(UserDict):
             encoding = [encoding]
 
         self._encodings = encoding
+        self._is_fast = self._encodings is not None
+
+    @property
+    def is_fast(self):
+        """
+        Indicate if this BatchEncoding was generated from the result of a PreTrainedTokenizerFast
+        Returns: True if generated from subclasses of PreTrainedTokenizerFast, else otherwise
+
+        """
+        return self._is_fast
 
     def __getitem__(self, item: Union[int, str]) -> EncodingFast:
         """ If the key is a string, get the value of the dict associated to `key` ('input_ids', 'attention_mask'...)

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -212,6 +212,19 @@ class BatchEncoding(UserDict):
     def __getattr__(self, item: str):
         return self.data[item]
 
+    def __getstate__(self):
+        return {
+            "data": self.data,
+            "encodings": self._encodings
+        }
+
+    def __setstate__(self, state):
+        if "data" in state:
+            self.data = state["data"]
+
+        if "encodings" in state:
+            self._encodings = state["encodings"]
+
     def keys(self):
         return self.data.keys()
 

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -184,7 +184,6 @@ class BatchEncoding(UserDict):
             encoding = [encoding]
 
         self._encodings = encoding
-        self._fast = encoding is not None
 
     @property
     def is_fast(self):

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -234,7 +234,7 @@ class BatchEncoding(UserDict):
         """
         return self._encodings
 
-    def tokens(self, batch_index: int = 0) -> List[int]:
+    def tokens(self, batch_index: int = 0) -> List[str]:
         if not self._encodings:
             raise ValueError("tokens() is not available when using Python based tokenizers")
         return self._encodings[batch_index].tokens

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -212,10 +212,7 @@ class BatchEncoding(UserDict):
         return self.data[item]
 
     def __getstate__(self):
-        return {
-            "data": self.data,
-            "encodings": self._encodings
-        }
+        return {"data": self.data, "encodings": self._encodings}
 
     def __setstate__(self, state):
         if "data" in state:

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -184,7 +184,7 @@ class BatchEncoding(UserDict):
             encoding = [encoding]
 
         self._encodings = encoding
-        self._is_fast = self._encodings is not None
+        self._fast = encoding is not None
 
     @property
     def is_fast(self):
@@ -193,7 +193,7 @@ class BatchEncoding(UserDict):
         Returns: True if generated from subclasses of PreTrainedTokenizerFast, else otherwise
 
         """
-        return self._is_fast
+        return self._encodings is not None
 
     def __getitem__(self, item: Union[int, str]) -> EncodingFast:
         """ If the key is a string, get the value of the dict associated to `key` ('input_ids', 'attention_mask'...)

--- a/tests/test_tokenization_utils.py
+++ b/tests/test_tokenization_utils.py
@@ -16,7 +16,7 @@
 
 import unittest
 
-from transformers import PreTrainedTokenizer, BertTokenizer, BertTokenizerFast
+from transformers import BertTokenizer, BertTokenizerFast, PreTrainedTokenizer
 from transformers.tokenization_gpt2 import GPT2Tokenizer
 
 from .utils import slow


### PR DESCRIPTION
Overrides the methods ___get_state()___ & ___set_state()___ to (respectively) export the content of the underlying `data` dictionnary and - if defined - the content of `encodings`.

Unittests added to covert the serialization & deserialization of all the exported properties.
 
Block until new release of **tokenizers**