### PR TITLE
Specify device in DataCollator 

### DIFF
--- a/examples/bertology/run_bertology.py
+++ b/examples/bertology/run_bertology.py
@@ -424,7 +424,10 @@ def main():
         eval_dataset = Subset(eval_dataset, list(range(min(args.data_subset, len(eval_dataset)))))
     eval_sampler = SequentialSampler(eval_dataset) if args.local_rank == -1 else DistributedSampler(eval_dataset)
     eval_dataloader = DataLoader(
-        eval_dataset, sampler=eval_sampler, batch_size=args.batch_size, collate_fn=DefaultDataCollator().collate_batch
+        eval_dataset,
+        sampler=eval_sampler,
+        batch_size=args.batch_size,
+        collate_fn=DefaultDataCollator(args.device).collate_batch,
     )
 
     # Compute head entropy and importance score

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -222,7 +222,7 @@ def main():
     train_dataset = get_dataset(data_args, tokenizer=tokenizer) if training_args.do_train else None
     eval_dataset = get_dataset(data_args, tokenizer=tokenizer, evaluate=True) if training_args.do_eval else None
     data_collator = DataCollatorForLanguageModeling(
-        tokenizer=tokenizer, mlm=data_args.mlm, mlm_probability=data_args.mlm_probability
+        tokenizer=tokenizer, mlm=data_args.mlm, mlm_probability=data_args.mlm_probability, device=training_args.device
     )
 
     # Initialize our Trainer

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -20,7 +20,7 @@ class DataCollator(ABC):
     - "cpu": Tensors are allocated on the CPU
     - "cuda:X": Tensors are allocated on the GPU "X"
     """
-    device: Union[torch.device, str] = "cpu"
+    device: Union[torch.device, str]
 
     @abstractmethod
     def collate_batch(self) -> Dict[str, torch.Tensor]:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -193,7 +193,7 @@ class Trainer:
         if data_collator is not None:
             self.data_collator = data_collator
         else:
-            self.data_collator = DefaultDataCollator()
+            self.data_collator = DefaultDataCollator(args.device)
         self.train_dataset = train_dataset
         self.eval_dataset = eval_dataset
         self.compute_metrics = compute_metrics
@@ -565,9 +565,6 @@ class Trainer:
         self, model: nn.Module, inputs: Dict[str, torch.Tensor], optimizer: torch.optim.Optimizer
     ) -> float:
         model.train()
-        for k, v in inputs.items():
-            inputs[k] = v.to(self.args.device)
-
         outputs = model(**inputs)
         loss = outputs[0]  # model outputs are always tuple in transformers (see doc)
 
@@ -748,9 +745,6 @@ class Trainer:
 
         for inputs in tqdm(dataloader, desc=description):
             has_labels = any(inputs.get(k) is not None for k in ["labels", "lm_labels", "masked_lm_labels"])
-
-            for k, v in inputs.items():
-                inputs[k] = v.to(self.args.device)
 
             with torch.no_grad():
                 outputs = model(**inputs)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -31,7 +31,7 @@ class DataCollatorIntegrationTest(unittest.TestCase):
             task_name="mrpc", data_dir="./tests/fixtures/tests_samples/MRPC", overwrite_cache=True
         )
         dataset = GlueDataset(data_args, tokenizer=tokenizer, mode="dev")
-        data_collator = DefaultDataCollator()
+        data_collator = DefaultDataCollator(device="cpu")
         batch = data_collator.collate_batch(dataset.features)
         self.assertEqual(batch["labels"].dtype, torch.long)
 
@@ -42,13 +42,13 @@ class DataCollatorIntegrationTest(unittest.TestCase):
             task_name="sts-b", data_dir="./tests/fixtures/tests_samples/STS-B", overwrite_cache=True
         )
         dataset = GlueDataset(data_args, tokenizer=tokenizer, mode="dev")
-        data_collator = DefaultDataCollator()
+        data_collator = DefaultDataCollator(device="cpu")
         batch = data_collator.collate_batch(dataset.features)
         self.assertEqual(batch["labels"].dtype, torch.float)
 
     def test_lm_tokenizer_without_padding(self):
         tokenizer = AutoTokenizer.from_pretrained("gpt2")
-        data_collator = DataCollatorForLanguageModeling(tokenizer, mlm=False)
+        data_collator = DataCollatorForLanguageModeling(device="cpu", tokenizer=tokenizer, mlm=False)
         # ^ causal lm
 
         dataset = LineByLineTextDataset(tokenizer, file_path=PATH_SAMPLE_TEXT, block_size=512)
@@ -66,7 +66,7 @@ class DataCollatorIntegrationTest(unittest.TestCase):
 
     def test_lm_tokenizer_with_padding(self):
         tokenizer = AutoTokenizer.from_pretrained("distilroberta-base")
-        data_collator = DataCollatorForLanguageModeling(tokenizer)
+        data_collator = DataCollatorForLanguageModeling(device="cpu", tokenizer=tokenizer)
         # ^ masked lm
 
         dataset = LineByLineTextDataset(tokenizer, file_path=PATH_SAMPLE_TEXT, block_size=512)


### PR DESCRIPTION
By setting `device` parameter in `DataCollator` we're able to allocate tensors directly on the right device at tensor creation and avoid moving data around afterwards.

This effectively avoid some snippet like this in the Trainer: 

```python

for k, v in some_dict.items():
     v.to(device)
```