### PR TITLE
DOC: Make `import torch` explicit for "Quick tour TF 2.0" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ for model_class in BERT_MODEL_CLASSES:
 Let's do a quick example of how a TensorFlow 2.0 model can be trained in 12 lines of code with 🤗 Transformers and then loaded in PyTorch for fast inspection/tests.
 
 ```python
+import torch
 import tensorflow as tf
 import tensorflow_datasets
 from transformers import *


### PR DESCRIPTION
I tried to run the Quick Tour example with only the `tensorflow` and the `transformers` imports (as shown literally in the code snippet), and _obviously_ (in hint sight) this fails with:

```
pytorch_model = BertForSequenceClassification.from_pretrained('./models/', from_tf=True)
NameError: name 'BertForSequenceClassification' is not defined
```

The trivial fix was to add `import torch` to the snippet.

When running all examples in sequence, this is not an issue, but I
was running the `tensorflow 2` example in a separate project.

Adding this line may avoid this confusion for the next newcomer :-)