### PR TITLE
Fix two bugs on MNLI dataset and SST-2 respectively.

### DIFF
--- a/src/transformers/data/processors/glue.py
+++ b/src/transformers/data/processors/glue.py
@@ -332,11 +332,12 @@ class Sst2Processor(DataProcessor):
     def _create_examples(self, lines, set_type):
         """Creates examples for the training, dev and test sets."""
         examples = []
+        text_index = 1 if set_type == "test" else 0
         for (i, line) in enumerate(lines):
             if i == 0:
                 continue
             guid = "%s-%s" % (set_type, i)
-            text_a = line[0]
+            text_a = line[text_index]
             label = None if set_type == "test" else line[1]
             examples.append(InputExample(guid=guid, text_a=text_a, text_b=None, label=label))
         return examples


### PR DESCRIPTION
The text index of test data of SST-2 are 1 rather than 0.

The label of MNLI task has a tricky swap on MNLI dataset, which should also be involved in get_labels() of dataset for correctness. 