### PR TITLE
Fix the example command for SQuAD

### DIFF
--- a/examples/question-answering/README.md
+++ b/examples/question-answering/README.md
@@ -28,6 +28,7 @@ python run_squad.py \
   --model_name_or_path bert-base-uncased \
   --do_train \
   --do_eval \
+  --do_lower_case \
   --train_file $SQUAD_DIR/train-v1.1.json \
   --predict_file $SQUAD_DIR/dev-v1.1.json \
   --per_gpu_train_batch_size 12 \

--- a/examples/question-answering/README.md
+++ b/examples/question-answering/README.md
@@ -57,6 +57,7 @@ python -m torch.distributed.launch --nproc_per_node=8 ./examples/question-answer
     --model_name_or_path bert-large-uncased-whole-word-masking \
     --do_train \
     --do_eval \
+    --do_lower_case \
     --train_file $SQUAD_DIR/train-v1.1.json \
     --predict_file $SQUAD_DIR/dev-v1.1.json \
     --learning_rate 3e-5 \


### PR DESCRIPTION
Issue #4549: added the missing argument `--do_lower_case` for reproducing the intended results.