### PR TITLE
Introduce a new tensor type for return_tensors on tokenizer for NumPy

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -145,7 +145,7 @@ from .tokenization_reformer import ReformerTokenizer
 from .tokenization_roberta import RobertaTokenizer, RobertaTokenizerFast
 from .tokenization_t5 import T5Tokenizer
 from .tokenization_transfo_xl import TransfoXLCorpus, TransfoXLTokenizer, TransfoXLTokenizerFast
-from .tokenization_utils import PreTrainedTokenizer
+from .tokenization_utils import PreTrainedTokenizer, TensorType
 from .tokenization_xlm import XLMTokenizer
 from .tokenization_xlm_roberta import XLMRobertaTokenizer
 from .tokenization_xlnet import SPIECE_UNDERLINE, XLNetTokenizer

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -19,6 +19,7 @@ import functools
 import itertools
 import json
 import logging
+import numpy as np
 import operator
 import os
 import re
@@ -74,6 +75,7 @@ EncodedInputPair = Tuple[List[int], List[int]]
 class TensorType(Enum):
     PYTORCH = "pt"
     TENSORFLOW = "tf"
+    NUMPY = "np"
 
 
 class CharSpan(NamedTuple):
@@ -189,6 +191,8 @@ def convert_to_tensors(batch_outputs: MutableMapping, return_tensors: Union[str,
         as_tensor = tf.constant
     elif return_tensors == TensorType.PYTORCH and is_torch_available():
         as_tensor = torch.tensor
+    elif return_tensors == TensorType.NUMPY:
+        as_tensor = np.ndarray
     else:
        raise ImportError(
             "Unable to convert output to tensors format {}, PyTorch or TensorFlow is not available.".format(

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -194,7 +194,7 @@ def convert_to_tensors(batch_outputs: MutableMapping, return_tensors: Union[str,
     elif return_tensors == TensorType.NUMPY:
         as_tensor = np.ndarray
     else:
-       raise ImportError(
+        raise ImportError(
             "Unable to convert output to tensors format {}, PyTorch or TensorFlow is not available.".format(
                 return_tensors
             )

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -167,14 +167,19 @@ def truncate_and_pad(
         tokenizer.no_padding()
 
 
-def to_framework_tensor(encoded_inputs: MutableMapping, framework: TensorType) -> MutableMapping:
+def to_framework_tensor(encoded_inputs: MutableMapping, framework: Union[str, TensorType]) -> MutableMapping:
+    if isinstance(framework, str):
+        framework = TensorType(framework)
 
     if framework == TensorType.TENSORFLOW and is_tf_available():
         as_tensor = tf.constant
     elif framework == TensorType.PYTORCH and is_torch_available():
         as_tensor = torch.tensor
     else:
-        raise ValueError("Unknown tensor type {}. Please use any of {}".format(framework, TensorType.__members__))
+        raise ValueError(
+            "Unable to convert output to tensors format {}, " \
+            "PyTorch or TensorFlow is not available.".format(framework)
+        )
 
     # Encode everything
     encoded_inputs["input_ids"] = as_tensor([encoded_inputs["input_ids"]])
@@ -2352,31 +2357,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizer):
                 encoding_dict["offset_mapping"].append(e.offsets)
 
         if return_tensors is not None:
-            if isinstance(return_tensors, str):
-                return_tensors = TensorType(return_tensors)
-
             encoding_dict = to_framework_tensor(encoding_dict, return_tensors)
-            #     if return_tensors == TensorType.TENSORFLOW and is_tf_available():
-            #         encoding_dict[key] = tf.constant(value)
-            #     elif return_tensors == TensorType.PYTORCH and is_torch_available():
-            #         encoding_dict[key] = torch.tensor(value)
-            #     elif return_tensors is not None:
-            #         logger.warning(
-            #             "Unable to convert output to tensors format {}, "
-            #             "PyTorch or TensorFlow is not available.".format(return_tensors)
-            #         )
-
-
-            # for key, value in encoding_dict.items():
-            #     if return_tensors == TensorType.TENSORFLOW and is_tf_available():
-            #         encoding_dict[key] = tf.constant(value)
-            #     elif return_tensors == TensorType.PYTORCH and is_torch_available():
-            #         encoding_dict[key] = torch.tensor(value)
-            #     elif return_tensors is not None:
-            #         logger.warning(
-            #             "Unable to convert output to tensors format {}, "
-            #             "PyTorch or TensorFlow is not available.".format(return_tensors)
-            #         )
 
         return encoding_dict
 

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -19,7 +19,6 @@ import functools
 import itertools
 import json
 import logging
-import numpy as np
 import operator
 import os
 import re
@@ -27,8 +26,9 @@ import warnings
 from collections import UserDict, defaultdict
 from contextlib import contextmanager
 from enum import Enum
-from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Tuple, Union, MutableMapping
+from typing import Any, Dict, List, MutableMapping, NamedTuple, Optional, Sequence, Tuple, Union
 
+import numpy as np
 from tokenizers import AddedToken as AddedTokenFast
 from tokenizers import Encoding as EncodingFast
 from tokenizers.decoders import Decoder as DecoderFast

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -207,7 +207,7 @@ def convert_to_tensors(batch_outputs: MutableMapping, return_tensors: Union[str,
 
             # at-least2d
             if tensor.ndim > 2:
-                tensor.squeeze_(0)
+                tensor = tensor.squeeze(0)
             elif tensor.ndim < 2:
                 tensor = tensor[None, :]
 

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -181,7 +181,9 @@ def truncate_and_pad(
         tokenizer.no_padding()
 
 
-def convert_to_tensors(batch_outputs: MutableMapping, return_tensors: Union[str, TensorType], prepend_batch_axis: bool = False) -> MutableMapping:
+def convert_to_tensors(
+    batch_outputs: MutableMapping, return_tensors: Union[str, TensorType], prepend_batch_axis: bool = False
+) -> MutableMapping:
     # Convert to TensorType
     if not isinstance(return_tensors, TensorType):
         return_tensors = TensorType(return_tensors)
@@ -1642,7 +1644,7 @@ class PreTrainedTokenizer(SpecialTokensMixin):
             return_token_type_ids=return_token_type_ids,
             return_overflowing_tokens=return_overflowing_tokens,
             return_special_tokens_mask=return_special_tokens_mask,
-            prepend_batch_axis=return_tensors is not None
+            prepend_batch_axis=return_tensors is not None,
         )
 
     def batch_encode_plus(
@@ -1855,7 +1857,7 @@ class PreTrainedTokenizer(SpecialTokensMixin):
         return_overflowing_tokens: bool = False,
         return_special_tokens_mask: bool = False,
         return_lengths: bool = False,
-        prepend_batch_axis: bool = False
+        prepend_batch_axis: bool = False,
     ) -> BatchEncoding:
         """ Prepares a sequence of input id, or a pair of sequences of inputs ids so that it can be used by the model.
         It adds special tokens, truncates sequences if overflowing while taking into account the special tokens and

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -834,7 +834,19 @@ class TokenizerTesterMixin:
             model(batch_encoded_sequence_fast)
 
     def test_np_encode_plus_sent_to_model(self):
+        from transformers import MODEL_MAPPING, TOKENIZER_MAPPING
+
+        MODEL_TOKENIZER_MAPPING = merge_model_tokenizer_mappings(MODEL_MAPPING, TOKENIZER_MAPPING)
+
         tokenizer = self.get_tokenizer()
+        if tokenizer.__class__ not in MODEL_TOKENIZER_MAPPING:
+            return
+
+        config_class, model_class = MODEL_TOKENIZER_MAPPING[tokenizer.__class__]
+        config = config_class()
+
+        if config.is_encoder_decoder or config.pad_token_id is None:
+            return
 
         # Build sequence
         first_ten_tokens = list(tokenizer.get_vocab().keys())[:10]

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -857,6 +857,12 @@ class TokenizerTesterMixin:
         batch_encoded_sequence = tokenizer.batch_encode_plus([sequence, sequence], return_tensors="np")
 
         # TODO: add forward through JAX/Flax when PR is merged
+        # This is currently here to make flake8 happy !
+        if encoded_sequence is None:
+            raise ValueError("Cannot convert list to numpy tensor on  encode_plus()")
+
+        if batch_encoded_sequence is None:
+            raise ValueError("Cannot convert list to numpy tensor on  batch_encode_plus()")
 
         if self.test_rust_tokenizer:
             fast_tokenizer = self.get_rust_tokenizer()
@@ -864,3 +870,10 @@ class TokenizerTesterMixin:
             batch_encoded_sequence_fast = fast_tokenizer.batch_encode_plus([sequence, sequence], return_tensors="np")
 
             # TODO: add forward through JAX/Flax when PR is merged
+            # This is currently here to make flake8 happy !
+            if encoded_sequence_fast is None:
+                raise ValueError("Cannot convert list to numpy tensor on  encode_plus() (fast)")
+
+            if batch_encoded_sequence_fast is None:
+                raise ValueError("Cannot convert list to numpy tensor on  batch_encode_plus() (fast)")
+

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -833,6 +833,8 @@ class TokenizerTesterMixin:
             model(encoded_sequence_fast)
             model(batch_encoded_sequence_fast)
 
+    # TODO: Check if require_torch is the best to test for numpy here ... Maybe move to require_flax when available
+    @require_torch
     def test_np_encode_plus_sent_to_model(self):
         from transformers import MODEL_MAPPING, TOKENIZER_MAPPING
 

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -876,4 +876,3 @@ class TokenizerTesterMixin:
 
             if batch_encoded_sequence_fast is None:
                 raise ValueError("Cannot convert list to numpy tensor on  batch_encode_plus() (fast)")
-

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -832,3 +832,21 @@ class TokenizerTesterMixin:
             # This should not fail
             model(encoded_sequence_fast)
             model(batch_encoded_sequence_fast)
+
+    def test_np_encode_plus_sent_to_model(self):
+        tokenizer = self.get_tokenizer()
+
+        # Build sequence
+        first_ten_tokens = list(tokenizer.get_vocab().keys())[:10]
+        sequence = " ".join(first_ten_tokens)
+        encoded_sequence = tokenizer.encode_plus(sequence, return_tensors="np")
+        batch_encoded_sequence = tokenizer.batch_encode_plus([sequence, sequence], return_tensors="np")
+
+        # TODO: add forward through JAX/Flax when PR is merged
+
+        if self.test_rust_tokenizer:
+            fast_tokenizer = self.get_rust_tokenizer()
+            encoded_sequence_fast = fast_tokenizer.encode_plus(sequence, return_tensors="np")
+            batch_encoded_sequence_fast = fast_tokenizer.batch_encode_plus([sequence, sequence], return_tensors="np")
+
+            # TODO: add forward through JAX/Flax when PR is merged

--- a/tests/test_tokenization_utils.py
+++ b/tests/test_tokenization_utils.py
@@ -16,7 +16,7 @@
 
 import unittest
 
-from transformers import PreTrainedTokenizer
+from transformers import PreTrainedTokenizer, TensorType
 from transformers.tokenization_gpt2 import GPT2Tokenizer
 
 from .utils import slow
@@ -39,3 +39,8 @@ class TokenizerUtilsTest(unittest.TestCase):
     @slow
     def test_pretrained_tokenizers(self):
         self.check_tokenizer_from_pretrained(GPT2Tokenizer)
+
+    def check_tensor_type_from_str(self):
+        self.assertEqual(TensorType("tf"), TensorType.TENSORFLOW)
+        self.assertEqual(TensorType("pt"), TensorType.PYTORCH)
+        self.assertEqual(TensorType("np"), TensorType.NUMPY)


### PR DESCRIPTION
Two changes in this PR:

- As we're introducing more than two tensor backend alternatives I created an enum `TensorType` listing all the possible tensor we can create `TensorType.TENSORFLOW`, `TensorType.PYTORCH`, `TensorType.NUMPY`. This might help newcomers who don't know about `"tf"`, `"pt"`.

   _->Note: TensorType are compatible with previous  `"tf"`, `"pt"` and now `"np"` str to allow backward compatbility (+unittest)_

- Numpy is now a possible target when creating tensors. This is usefull for JAX :) 