### PR TITLE
[Reformer] automate axial_pos_shape

### DIFF
--- a/src/transformers/configuration_reformer.py
+++ b/src/transformers/configuration_reformer.py
@@ -149,7 +149,7 @@ class ReformerConfig(PretrainedConfig):
         attn_layers=["local", "lsh", "local", "lsh", "local", "lsh"],
         axial_norm_std=1.0,
         axial_pos_embds=True,
-        axial_pos_shape=[64, 64],
+        axial_pos_shape=None,
         axial_pos_embds_dim=[64, 192],
         chunk_size_lm_head=0,
         chunk_size_feed_forward=0,

--- a/src/transformers/modeling_reformer.py
+++ b/src/transformers/modeling_reformer.py
@@ -21,6 +21,7 @@ from collections import namedtuple
 from functools import reduce
 from operator import mul
 
+import math
 import numpy as np
 import torch
 from torch import nn
@@ -96,6 +97,7 @@ class AxialPositionEmbeddings(nn.Module):
 
         self.least_common_mult_chunk_length = _get_least_common_mult_chunk_len(config)
         self.weights = nn.ParameterList()
+        self.set_ax_pos_shape(self)
 
         assert (
             sum(self.axial_pos_embds_dim) == config.hidden_size
@@ -113,6 +115,17 @@ class AxialPositionEmbeddings(nn.Module):
             # create tensor and init
             self.weights.append(nn.Parameter(torch.ones(ax_shape, dtype=torch.float32)))
 
+            
+    def set_ax_pos_shape(self):
+        if(self.axial_pos_shape == None):
+            if(int(sqrt(self.max_position_embeddings)) * int(sqrt(self.max_position_embeddings)) == self.max_position_embeddings):
+                self.axial_pos_shape = [int(sqrt(self.max_position_embeddings)),int(sqrt(self.max_position_embeddings))]
+            elif(int(sqrt(self.max_position_embeddings/2)) * int(sqrt(self.max_position_embeddings)*2) == self.max_position_embeddings):
+                self.axial_pos_shape = [int(sqrt(self.max_position_embeddings/2)),int(sqrt(self.max_position_embeddings)*2)]
+            else:
+                #TODO replace with error message or bruteforce like method 
+                pass
+            
     def forward(self, position_ids):
         # broadcast weights to correct shape
         batch_size = position_ids.shape[0]


### PR DESCRIPTION
This PR automates the calculation of the axial_pos_shape.
checked that every combination of 2**n works using this sheet: https://docs.google.com/spreadsheets/d/19gnP1ve2fT2F59LNiky44SPpmtmOegfIlk5_3OFXjyU/edit?usp=sharing

@patrickvonplaten 
