### PR TITLE
[pipeline] Tokenizer should not add special tokens for text generation

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -657,8 +657,6 @@ class TextGenerationPipeline(Pipeline):
                         clean_up_tokenization_spaces=clean_up_tokenization_spaces,
                     )
 
-                    print(text)
-
                     # Remove PADDING prompt of the sequence if XLNet or Transfo-XL model is used
                     if input_ids is None:
                         prompt_length = 0


### PR DESCRIPTION
This PR fixes generation in pipelines for all models whose tokenizer adds special tokens to the input, *e.g.* XLNet. 

I think this is good for now, but I think the `_parse_and_tokenize()` function needs a larger refactoring to allow more flexibility in the future, also see Issue: #4501 