### PR TITLE
[EncoderDecoder] Add RoBERTa as a decoder

### DIFF
--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -185,10 +185,18 @@ class RobertaForMaskedLM(BertPreTrainedModel):
         head_mask=None,
         inputs_embeds=None,
         masked_lm_labels=None,
+        encoder_hidden_states=None,
+        encoder_attention_mask=None,
+        lm_labels=None,
     ):
         r"""
         masked_lm_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
             Labels for computing the masked language modeling loss.
+            Indices should be in ``[-100, 0, ..., config.vocab_size]`` (see ``input_ids`` docstring)
+            Tokens with indices set to ``-100`` are ignored (masked), the loss is only computed for the tokens with labels
+            in ``[0, ..., config.vocab_size]``
+        lm_labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
+            Labels for computing the left-to-right language modeling loss (next word prediction).
             Indices should be in ``[-100, 0, ..., config.vocab_size]`` (see ``input_ids`` docstring)
             Tokens with indices set to ``-100`` are ignored (masked), the loss is only computed for the tokens with labels
             in ``[0, ..., config.vocab_size]``
@@ -230,6 +238,8 @@ class RobertaForMaskedLM(BertPreTrainedModel):
             position_ids=position_ids,
             head_mask=head_mask,
             inputs_embeds=inputs_embeds,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=encoder_attention_mask,
         )
         sequence_output = outputs[0]
         prediction_scores = self.lm_head(sequence_output)
@@ -241,7 +251,37 @@ class RobertaForMaskedLM(BertPreTrainedModel):
             masked_lm_loss = loss_fct(prediction_scores.view(-1, self.config.vocab_size), masked_lm_labels.view(-1))
             outputs = (masked_lm_loss,) + outputs
 
-        return outputs  # (masked_lm_loss), prediction_scores, (hidden_states), (attentions)
+        if lm_labels is not None:
+            # we are doing next-token prediction; shift prediction scores and input ids by one
+            prediction_scores = prediction_scores[:, :-1, :].contiguous()
+            lm_labels = lm_labels[:, 1:].contiguous()
+            loss_fct = CrossEntropyLoss()
+            ltr_lm_loss = loss_fct(prediction_scores.view(-1, self.config.vocab_size), lm_labels.view(-1))
+            outputs = (ltr_lm_loss,) + outputs
+
+        return outputs  # (ltr_lm_loss),  (masked_lm_loss), prediction_scores, (hidden_states), (attentions)
+
+    def prepare_inputs_for_generation(self, input_ids, attention_mask=None, **model_kwargs):
+        input_shape = input_ids.shape
+        effective_batch_size = input_shape[0]
+
+        # if model is used as a decoder in encoder-decoder model, the decoder attention mask is created on the fly
+        if attention_mask is None:
+            attention_mask = input_ids.new_ones(input_shape)
+
+        # if model is does not use a causal mask then add a dummy token
+        if self.config.is_decoder is False:
+            assert self.config.pad_token_id is not None, "The PAD token should be defined for generation"
+            attention_mask = torch.cat(
+                [attention_mask, attention_mask.new_zeros((attention_mask.shape[0], 1))], dim=-1
+            )
+
+            dummy_token = torch.full(
+                (effective_batch_size, 1), self.config.pad_token_id, dtype=torch.long, device=input_ids.device
+            )
+            input_ids = torch.cat([input_ids, dummy_token], dim=1)
+
+        return {"input_ids": input_ids, "attention_mask": attention_mask}
 
 
 class RobertaLMHead(nn.Module):

--- a/tests/test_modeling_encoder_decoder.py
+++ b/tests/test_modeling_encoder_decoder.py
@@ -265,7 +265,8 @@ class EncoderDecoderModelTest(unittest.TestCase):
             out_2 = outputs[0].cpu().numpy()
             out_2[np.isnan(out_2)] = 0
 
-            with tempfile.TemporaryDirectory() as encoder_tmp_dirname, tempfile.TemporaryDirectory() as decoder_tmp_dirname:
+            with tempfile.TemporaryDirectory() as encoder_tmp_dirname, \
+                 tempfile.TemporaryDirectory() as decoder_tmp_dirname:
                 enc_dec_model.encoder.save_pretrained(encoder_tmp_dirname)
                 enc_dec_model.decoder.save_pretrained(decoder_tmp_dirname)
                 EncoderDecoderModel.from_encoder_decoder_pretrained(

--- a/tests/test_modeling_encoder_decoder.py
+++ b/tests/test_modeling_encoder_decoder.py
@@ -27,7 +27,13 @@ from .utils import require_torch, slow, torch_device
 
 
 if is_torch_available():
-    from transformers import BertModel, BertForMaskedLM, RobertaModel, RobertaForMaskedLM, EncoderDecoderModel
+    from transformers import (
+        BertModel,
+        BertForMaskedLM,
+        RobertaModel,
+        RobertaForMaskedLM,
+        EncoderDecoderModel,
+    )
     import numpy as np
     import torch
 
@@ -37,7 +43,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
     def prepare_config_and_inputs_bert(self):
         bert_model_tester = BertModelTester(self)
         encoder_config_and_inputs = bert_model_tester.prepare_config_and_inputs()
-        decoder_config_and_inputs = bert_model_tester.prepare_config_and_inputs_for_decoder()
+        decoder_config_and_inputs = (
+            bert_model_tester.prepare_config_and_inputs_for_decoder()
+        )
         (
             config,
             input_ids,
@@ -87,7 +95,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
     ):
         encoder_model = BertModel(config)
         decoder_model = BertForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
+        enc_dec_model = EncoderDecoderModel(
+            encoder=encoder_model, decoder=decoder_model
+        )
         enc_dec_model.to(torch_device)
         outputs_encoder_decoder = enc_dec_model(
             input_ids=input_ids,
@@ -96,8 +106,13 @@ class EncoderDecoderModelTest(unittest.TestCase):
             decoder_attention_mask=decoder_attention_mask,
         )
 
-        self.assertEqual(outputs_encoder_decoder[0].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)))
-        self.assertEqual(outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,)))
+        self.assertEqual(
+            outputs_encoder_decoder[0].shape,
+            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+        )
+        self.assertEqual(
+            outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,))
+        )
         encoder_outputs = (encoder_hidden_states,)
         outputs_encoder_decoder = enc_dec_model(
             encoder_outputs=encoder_outputs,
@@ -106,9 +121,13 @@ class EncoderDecoderModelTest(unittest.TestCase):
             decoder_attention_mask=decoder_attention_mask,
         )
 
-        self.assertEqual(outputs_encoder_decoder[0].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)))
-        self.assertEqual(outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,)))
-
+        self.assertEqual(
+            outputs_encoder_decoder[0].shape,
+            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+        )
+        self.assertEqual(
+            outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,))
+        )
 
     def create_and_check_roberta_encoder_decoder_model(
         self,
@@ -123,7 +142,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
     ):
         encoder_model = RobertaModel(config)
         decoder_model = RobertaForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
+        enc_dec_model = EncoderDecoderModel(
+            encoder=encoder_model, decoder=decoder_model
+        )
         enc_dec_model.to(torch_device)
         outputs_encoder_decoder = enc_dec_model(
             input_ids=input_ids,
@@ -132,8 +153,13 @@ class EncoderDecoderModelTest(unittest.TestCase):
             decoder_attention_mask=decoder_attention_mask,
         )
 
-        self.assertEqual(outputs_encoder_decoder[0].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)))
-        self.assertEqual(outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,)))
+        self.assertEqual(
+            outputs_encoder_decoder[0].shape,
+            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+        )
+        self.assertEqual(
+            outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,))
+        )
         encoder_outputs = (encoder_hidden_states,)
         outputs_encoder_decoder = enc_dec_model(
             encoder_outputs=encoder_outputs,
@@ -142,9 +168,13 @@ class EncoderDecoderModelTest(unittest.TestCase):
             decoder_attention_mask=decoder_attention_mask,
         )
 
-        self.assertEqual(outputs_encoder_decoder[0].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)))
-        self.assertEqual(outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,)))
-
+        self.assertEqual(
+            outputs_encoder_decoder[0].shape,
+            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+        )
+        self.assertEqual(
+            outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,))
+        )
 
     def create_and_check_bert_encoder_decoder_model_from_pretrained(
         self,
@@ -169,8 +199,13 @@ class EncoderDecoderModelTest(unittest.TestCase):
             decoder_attention_mask=decoder_attention_mask,
         )
 
-        self.assertEqual(outputs_encoder_decoder[0].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)))
-        self.assertEqual(outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,)))
+        self.assertEqual(
+            outputs_encoder_decoder[0].shape,
+            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+        )
+        self.assertEqual(
+            outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,))
+        )
 
     def create_and_check_roberta_encoder_decoder_model_from_pretrained(
         self,
@@ -195,8 +230,13 @@ class EncoderDecoderModelTest(unittest.TestCase):
             decoder_attention_mask=decoder_attention_mask,
         )
 
-        self.assertEqual(outputs_encoder_decoder[0].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)))
-        self.assertEqual(outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,)))
+        self.assertEqual(
+            outputs_encoder_decoder[0].shape,
+            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+        )
+        self.assertEqual(
+            outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,))
+        )
 
     def create_and_check_save_and_load(
         self,
@@ -211,7 +251,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
     ):
         encoder_model = BertModel(config)
         decoder_model = BertForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
+        enc_dec_model = EncoderDecoderModel(
+            encoder=encoder_model, decoder=decoder_model
+        )
         enc_dec_model.to(torch_device)
         enc_dec_model.eval()
         with torch.no_grad():
@@ -252,7 +294,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
     ):
         encoder_model = BertModel(config)
         decoder_model = BertForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
+        enc_dec_model = EncoderDecoderModel(
+            encoder=encoder_model, decoder=decoder_model
+        )
         enc_dec_model.to(torch_device)
         enc_dec_model.eval()
         with torch.no_grad():
@@ -265,8 +309,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
             out_2 = outputs[0].cpu().numpy()
             out_2[np.isnan(out_2)] = 0
 
-            with tempfile.TemporaryDirectory() as encoder_tmp_dirname, \
-                 tempfile.TemporaryDirectory() as decoder_tmp_dirname:
+            with tempfile.TemporaryDirectory() as encoder_tmp_dirname, tempfile.TemporaryDirectory() as decoder_tmp_dirname:
                 enc_dec_model.encoder.save_pretrained(encoder_tmp_dirname)
                 enc_dec_model.decoder.save_pretrained(decoder_tmp_dirname)
                 EncoderDecoderModel.from_encoder_decoder_pretrained(
@@ -302,7 +345,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
     ):
         encoder_model = BertModel(config)
         decoder_model = BertForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
+        enc_dec_model = EncoderDecoderModel(
+            encoder=encoder_model, decoder=decoder_model
+        )
         enc_dec_model.to(torch_device)
         outputs_encoder_decoder = enc_dec_model(
             input_ids=input_ids,
@@ -317,8 +362,13 @@ class EncoderDecoderModelTest(unittest.TestCase):
         # check that backprop works
         mlm_loss.backward()
 
-        self.assertEqual(outputs_encoder_decoder[1].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)))
-        self.assertEqual(outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,)))
+        self.assertEqual(
+            outputs_encoder_decoder[1].shape,
+            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+        )
+        self.assertEqual(
+            outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,))
+        )
 
     def create_and_check_roberta_encoder_decoder_model_mlm_labels(
         self,
@@ -334,7 +384,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
     ):
         encoder_model = RobertaModel(config)
         decoder_model = RobertaForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
+        enc_dec_model = EncoderDecoderModel(
+            encoder=encoder_model, decoder=decoder_model
+        )
         enc_dec_model.to(torch_device)
         outputs_encoder_decoder = enc_dec_model(
             input_ids=input_ids,
@@ -349,8 +401,13 @@ class EncoderDecoderModelTest(unittest.TestCase):
         # check that backprop works
         mlm_loss.backward()
 
-        self.assertEqual(outputs_encoder_decoder[1].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)))
-        self.assertEqual(outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,)))
+        self.assertEqual(
+            outputs_encoder_decoder[1].shape,
+            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+        )
+        self.assertEqual(
+            outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,))
+        )
 
     def create_and_check_bert_encoder_decoder_model_lm_labels(
         self,
@@ -366,7 +423,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
     ):
         encoder_model = BertModel(config)
         decoder_model = BertForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
+        enc_dec_model = EncoderDecoderModel(
+            encoder=encoder_model, decoder=decoder_model
+        )
         enc_dec_model.to(torch_device)
         outputs_encoder_decoder = enc_dec_model(
             input_ids=input_ids,
@@ -381,8 +440,13 @@ class EncoderDecoderModelTest(unittest.TestCase):
         # check that backprop works
         lm_loss.backward()
 
-        self.assertEqual(outputs_encoder_decoder[1].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)))
-        self.assertEqual(outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,)))
+        self.assertEqual(
+            outputs_encoder_decoder[1].shape,
+            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+        )
+        self.assertEqual(
+            outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,))
+        )
 
     def create_and_check_roberta_encoder_decoder_model_lm_labels(
         self,
@@ -398,7 +462,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
     ):
         encoder_model = RobertaModel(config)
         decoder_model = RobertaForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
+        enc_dec_model = EncoderDecoderModel(
+            encoder=encoder_model, decoder=decoder_model
+        )
         enc_dec_model.to(torch_device)
         outputs_encoder_decoder = enc_dec_model(
             input_ids=input_ids,
@@ -413,32 +479,49 @@ class EncoderDecoderModelTest(unittest.TestCase):
         # check that backprop works
         lm_loss.backward()
 
-        self.assertEqual(outputs_encoder_decoder[1].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)))
-        self.assertEqual(outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,)))
+        self.assertEqual(
+            outputs_encoder_decoder[1].shape,
+            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+        )
+        self.assertEqual(
+            outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,))
+        )
 
-    def create_and_check_bert_encoder_decoder_model_generate(self, input_ids, config, decoder_config, **kwargs):
+    def create_and_check_bert_encoder_decoder_model_generate(
+        self, input_ids, config, decoder_config, **kwargs
+    ):
         encoder_model = BertModel(config)
         decoder_model = BertForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
+        enc_dec_model = EncoderDecoderModel(
+            encoder=encoder_model, decoder=decoder_model
+        )
         enc_dec_model.to(torch_device)
 
         # Bert does not have a bos token id, so use pad_token_id instead
         generated_output = enc_dec_model.generate(
             input_ids, decoder_start_token_id=enc_dec_model.config.decoder.pad_token_id
         )
-        self.assertEqual(generated_output.shape, (input_ids.shape[0],) + (decoder_config.max_length,))
+        self.assertEqual(
+            generated_output.shape, (input_ids.shape[0],) + (decoder_config.max_length,)
+        )
 
-    def create_and_check_roberta_encoder_decoder_model_generate(self, input_ids, config, decoder_config, **kwargs):
+    def create_and_check_roberta_encoder_decoder_model_generate(
+        self, input_ids, config, decoder_config, **kwargs
+    ):
         encoder_model = RobertaModel(config)
         decoder_model = RobertaForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
+        enc_dec_model = EncoderDecoderModel(
+            encoder=encoder_model, decoder=decoder_model
+        )
         enc_dec_model.to(torch_device)
 
         # Bert does not have a bos token id, so use pad_token_id instead
         generated_output = enc_dec_model.generate(
             input_ids, decoder_start_token_id=enc_dec_model.config.decoder.pad_token_id
         )
-        self.assertEqual(generated_output.shape, (input_ids.shape[0],) + (decoder_config.max_length,))
+        self.assertEqual(
+            generated_output.shape, (input_ids.shape[0],) + (decoder_config.max_length,)
+        )
 
     def test_bert_encoder_decoder_model(self):
         input_ids_dict = self.prepare_config_and_inputs_bert()
@@ -450,11 +533,15 @@ class EncoderDecoderModelTest(unittest.TestCase):
 
     def test_bert_encoder_decoder_model_from_pretrained(self):
         input_ids_dict = self.prepare_config_and_inputs_bert()
-        self.create_and_check_bert_encoder_decoder_model_from_pretrained(**input_ids_dict)
+        self.create_and_check_bert_encoder_decoder_model_from_pretrained(
+            **input_ids_dict
+        )
 
     def test_roberta_encoder_decoder_model_from_pretrained(self):
         input_ids_dict = self.prepare_config_and_inputs_bert()
-        self.create_and_check_roberta_encoder_decoder_model_from_pretrained(**input_ids_dict)
+        self.create_and_check_roberta_encoder_decoder_model_from_pretrained(
+            **input_ids_dict
+        )
 
     def test_save_and_load_from_pretrained(self):
         input_ids_dict = self.prepare_config_and_inputs_bert()
@@ -490,33 +577,47 @@ class EncoderDecoderModelTest(unittest.TestCase):
 
     @slow
     def test_real_bert_model_from_pretrained(self):
-        model = EncoderDecoderModel.from_encoder_decoder_pretrained("bert-base-uncased", "bert-base-uncased")
+        model = EncoderDecoderModel.from_encoder_decoder_pretrained(
+            "bert-base-uncased", "bert-base-uncased"
+        )
         self.assertIsNotNone(model)
 
     @slow
     def test_real_roberta_model_from_pretrained(self):
-        model = EncoderDecoderModel.from_encoder_decoder_pretrained("roberta-base", "roberta-base")
+        model = EncoderDecoderModel.from_encoder_decoder_pretrained(
+            "roberta-base", "roberta-base"
+        )
         self.assertIsNotNone(model)
 
     @slow
     def test_real_bert_model_from_pretrained_has_cross_attention(self):
-        model = EncoderDecoderModel.from_encoder_decoder_pretrained("bert-base-uncased", "bert-base-uncased")
+        model = EncoderDecoderModel.from_encoder_decoder_pretrained(
+            "bert-base-uncased", "bert-base-uncased"
+        )
         self.assertTrue(hasattr(model.decoder.bert.encoder.layer[0], "crossattention"))
 
     @slow
     def test_real_roberta_model_from_pretrained_has_cross_attention(self):
-        model = EncoderDecoderModel.from_encoder_decoder_pretrained("roberta-base", "roberta-base")
+        model = EncoderDecoderModel.from_encoder_decoder_pretrained(
+            "roberta-base", "roberta-base"
+        )
         self.assertTrue(hasattr(model.decoder.bert.encoder.layer[0], "crossattention"))
 
     @slow
     def test_real_bert_model_save_load_from_pretrained(self):
-        model_2 = EncoderDecoderModel.from_encoder_decoder_pretrained("bert-base-uncased", "bert-base-uncased")
+        model_2 = EncoderDecoderModel.from_encoder_decoder_pretrained(
+            "bert-base-uncased", "bert-base-uncased"
+        )
         model_2.to(torch_device)
         input_ids = ids_tensor([13, 5], model_2.config.encoder.vocab_size)
         decoder_input_ids = ids_tensor([13, 1], model_2.config.encoder.vocab_size)
         attention_mask = ids_tensor([13, 5], vocab_size=2)
         with torch.no_grad():
-            outputs = model_2(input_ids=input_ids, decoder_input_ids=decoder_input_ids, attention_mask=attention_mask,)
+            outputs = model_2(
+                input_ids=input_ids,
+                decoder_input_ids=decoder_input_ids,
+                attention_mask=attention_mask,
+            )
             out_2 = outputs[0].cpu().numpy()
             out_2[np.isnan(out_2)] = 0
 
@@ -526,7 +627,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
                 model_1.to(torch_device)
 
                 after_outputs = model_1(
-                    input_ids=input_ids, decoder_input_ids=decoder_input_ids, attention_mask=attention_mask,
+                    input_ids=input_ids,
+                    decoder_input_ids=decoder_input_ids,
+                    attention_mask=attention_mask,
                 )
                 out_1 = after_outputs[0].cpu().numpy()
                 out_1[np.isnan(out_1)] = 0
@@ -535,13 +638,19 @@ class EncoderDecoderModelTest(unittest.TestCase):
 
     @slow
     def test_real_roberta_model_save_load_from_pretrained(self):
-        model_2 = EncoderDecoderModel.from_encoder_decoder_pretrained("roberta-base", "roberta-base")
+        model_2 = EncoderDecoderModel.from_encoder_decoder_pretrained(
+            "roberta-base", "roberta-base"
+        )
         model_2.to(torch_device)
         input_ids = ids_tensor([13, 5], model_2.config.encoder.vocab_size)
         decoder_input_ids = ids_tensor([13, 1], model_2.config.encoder.vocab_size)
         attention_mask = ids_tensor([13, 5], vocab_size=2)
         with torch.no_grad():
-            outputs = model_2(input_ids=input_ids, decoder_input_ids=decoder_input_ids, attention_mask=attention_mask,)
+            outputs = model_2(
+                input_ids=input_ids,
+                decoder_input_ids=decoder_input_ids,
+                attention_mask=attention_mask,
+            )
             out_2 = outputs[0].cpu().numpy()
             out_2[np.isnan(out_2)] = 0
 
@@ -551,7 +660,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
                 model_1.to(torch_device)
 
                 after_outputs = model_1(
-                    input_ids=input_ids, decoder_input_ids=decoder_input_ids, attention_mask=attention_mask,
+                    input_ids=input_ids,
+                    decoder_input_ids=decoder_input_ids,
+                    attention_mask=attention_mask,
                 )
                 out_1 = after_outputs[0].cpu().numpy()
                 out_1[np.isnan(out_1)] = 0

--- a/tests/test_modeling_encoder_decoder.py
+++ b/tests/test_modeling_encoder_decoder.py
@@ -43,9 +43,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
     def prepare_config_and_inputs_bert(self):
         bert_model_tester = BertModelTester(self)
         encoder_config_and_inputs = bert_model_tester.prepare_config_and_inputs()
-        decoder_config_and_inputs = (
-            bert_model_tester.prepare_config_and_inputs_for_decoder()
-        )
+        decoder_config_and_inputs = bert_model_tester.prepare_config_and_inputs_for_decoder()
         (
             config,
             input_ids,
@@ -95,9 +93,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
     ):
         encoder_model = BertModel(config)
         decoder_model = BertForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(
-            encoder=encoder_model, decoder=decoder_model
-        )
+        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
         enc_dec_model.to(torch_device)
         outputs_encoder_decoder = enc_dec_model(
             input_ids=input_ids,
@@ -107,12 +103,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            outputs_encoder_decoder[0].shape,
-            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+            outputs_encoder_decoder[0].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)),
         )
-        self.assertEqual(
-            outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,))
-        )
+        self.assertEqual(outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,)))
         encoder_outputs = (encoder_hidden_states,)
         outputs_encoder_decoder = enc_dec_model(
             encoder_outputs=encoder_outputs,
@@ -122,12 +115,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            outputs_encoder_decoder[0].shape,
-            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+            outputs_encoder_decoder[0].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)),
         )
-        self.assertEqual(
-            outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,))
-        )
+        self.assertEqual(outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,)))
 
     def create_and_check_roberta_encoder_decoder_model(
         self,
@@ -142,9 +132,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
     ):
         encoder_model = RobertaModel(config)
         decoder_model = RobertaForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(
-            encoder=encoder_model, decoder=decoder_model
-        )
+        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
         enc_dec_model.to(torch_device)
         outputs_encoder_decoder = enc_dec_model(
             input_ids=input_ids,
@@ -154,12 +142,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            outputs_encoder_decoder[0].shape,
-            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+            outputs_encoder_decoder[0].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)),
         )
-        self.assertEqual(
-            outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,))
-        )
+        self.assertEqual(outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,)))
         encoder_outputs = (encoder_hidden_states,)
         outputs_encoder_decoder = enc_dec_model(
             encoder_outputs=encoder_outputs,
@@ -169,12 +154,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            outputs_encoder_decoder[0].shape,
-            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+            outputs_encoder_decoder[0].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)),
         )
-        self.assertEqual(
-            outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,))
-        )
+        self.assertEqual(outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,)))
 
     def create_and_check_bert_encoder_decoder_model_from_pretrained(
         self,
@@ -200,12 +182,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            outputs_encoder_decoder[0].shape,
-            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+            outputs_encoder_decoder[0].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)),
         )
-        self.assertEqual(
-            outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,))
-        )
+        self.assertEqual(outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,)))
 
     def create_and_check_roberta_encoder_decoder_model_from_pretrained(
         self,
@@ -231,12 +210,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            outputs_encoder_decoder[0].shape,
-            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+            outputs_encoder_decoder[0].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)),
         )
-        self.assertEqual(
-            outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,))
-        )
+        self.assertEqual(outputs_encoder_decoder[1].shape, (input_ids.shape + (config.hidden_size,)))
 
     def create_and_check_save_and_load(
         self,
@@ -251,9 +227,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
     ):
         encoder_model = BertModel(config)
         decoder_model = BertForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(
-            encoder=encoder_model, decoder=decoder_model
-        )
+        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
         enc_dec_model.to(torch_device)
         enc_dec_model.eval()
         with torch.no_grad():
@@ -294,9 +268,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
     ):
         encoder_model = BertModel(config)
         decoder_model = BertForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(
-            encoder=encoder_model, decoder=decoder_model
-        )
+        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
         enc_dec_model.to(torch_device)
         enc_dec_model.eval()
         with torch.no_grad():
@@ -345,9 +317,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
     ):
         encoder_model = BertModel(config)
         decoder_model = BertForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(
-            encoder=encoder_model, decoder=decoder_model
-        )
+        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
         enc_dec_model.to(torch_device)
         outputs_encoder_decoder = enc_dec_model(
             input_ids=input_ids,
@@ -363,12 +333,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
         mlm_loss.backward()
 
         self.assertEqual(
-            outputs_encoder_decoder[1].shape,
-            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+            outputs_encoder_decoder[1].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)),
         )
-        self.assertEqual(
-            outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,))
-        )
+        self.assertEqual(outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,)))
 
     def create_and_check_roberta_encoder_decoder_model_mlm_labels(
         self,
@@ -384,9 +351,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
     ):
         encoder_model = RobertaModel(config)
         decoder_model = RobertaForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(
-            encoder=encoder_model, decoder=decoder_model
-        )
+        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
         enc_dec_model.to(torch_device)
         outputs_encoder_decoder = enc_dec_model(
             input_ids=input_ids,
@@ -402,12 +367,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
         mlm_loss.backward()
 
         self.assertEqual(
-            outputs_encoder_decoder[1].shape,
-            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+            outputs_encoder_decoder[1].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)),
         )
-        self.assertEqual(
-            outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,))
-        )
+        self.assertEqual(outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,)))
 
     def create_and_check_bert_encoder_decoder_model_lm_labels(
         self,
@@ -423,9 +385,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
     ):
         encoder_model = BertModel(config)
         decoder_model = BertForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(
-            encoder=encoder_model, decoder=decoder_model
-        )
+        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
         enc_dec_model.to(torch_device)
         outputs_encoder_decoder = enc_dec_model(
             input_ids=input_ids,
@@ -441,12 +401,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
         lm_loss.backward()
 
         self.assertEqual(
-            outputs_encoder_decoder[1].shape,
-            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+            outputs_encoder_decoder[1].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)),
         )
-        self.assertEqual(
-            outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,))
-        )
+        self.assertEqual(outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,)))
 
     def create_and_check_roberta_encoder_decoder_model_lm_labels(
         self,
@@ -462,9 +419,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
     ):
         encoder_model = RobertaModel(config)
         decoder_model = RobertaForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(
-            encoder=encoder_model, decoder=decoder_model
-        )
+        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
         enc_dec_model.to(torch_device)
         outputs_encoder_decoder = enc_dec_model(
             input_ids=input_ids,
@@ -480,48 +435,33 @@ class EncoderDecoderModelTest(unittest.TestCase):
         lm_loss.backward()
 
         self.assertEqual(
-            outputs_encoder_decoder[1].shape,
-            (decoder_input_ids.shape + (decoder_config.vocab_size,)),
+            outputs_encoder_decoder[1].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,)),
         )
-        self.assertEqual(
-            outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,))
-        )
+        self.assertEqual(outputs_encoder_decoder[2].shape, (input_ids.shape + (config.hidden_size,)))
 
-    def create_and_check_bert_encoder_decoder_model_generate(
-        self, input_ids, config, decoder_config, **kwargs
-    ):
+    def create_and_check_bert_encoder_decoder_model_generate(self, input_ids, config, decoder_config, **kwargs):
         encoder_model = BertModel(config)
         decoder_model = BertForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(
-            encoder=encoder_model, decoder=decoder_model
-        )
+        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
         enc_dec_model.to(torch_device)
 
         # Bert does not have a bos token id, so use pad_token_id instead
         generated_output = enc_dec_model.generate(
             input_ids, decoder_start_token_id=enc_dec_model.config.decoder.pad_token_id
         )
-        self.assertEqual(
-            generated_output.shape, (input_ids.shape[0],) + (decoder_config.max_length,)
-        )
+        self.assertEqual(generated_output.shape, (input_ids.shape[0],) + (decoder_config.max_length,))
 
-    def create_and_check_roberta_encoder_decoder_model_generate(
-        self, input_ids, config, decoder_config, **kwargs
-    ):
+    def create_and_check_roberta_encoder_decoder_model_generate(self, input_ids, config, decoder_config, **kwargs):
         encoder_model = RobertaModel(config)
         decoder_model = RobertaForMaskedLM(decoder_config)
-        enc_dec_model = EncoderDecoderModel(
-            encoder=encoder_model, decoder=decoder_model
-        )
+        enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
         enc_dec_model.to(torch_device)
 
         # Bert does not have a bos token id, so use pad_token_id instead
         generated_output = enc_dec_model.generate(
             input_ids, decoder_start_token_id=enc_dec_model.config.decoder.pad_token_id
         )
-        self.assertEqual(
-            generated_output.shape, (input_ids.shape[0],) + (decoder_config.max_length,)
-        )
+        self.assertEqual(generated_output.shape, (input_ids.shape[0],) + (decoder_config.max_length,))
 
     def test_bert_encoder_decoder_model(self):
         input_ids_dict = self.prepare_config_and_inputs_bert()
@@ -533,15 +473,11 @@ class EncoderDecoderModelTest(unittest.TestCase):
 
     def test_bert_encoder_decoder_model_from_pretrained(self):
         input_ids_dict = self.prepare_config_and_inputs_bert()
-        self.create_and_check_bert_encoder_decoder_model_from_pretrained(
-            **input_ids_dict
-        )
+        self.create_and_check_bert_encoder_decoder_model_from_pretrained(**input_ids_dict)
 
     def test_roberta_encoder_decoder_model_from_pretrained(self):
         input_ids_dict = self.prepare_config_and_inputs_bert()
-        self.create_and_check_roberta_encoder_decoder_model_from_pretrained(
-            **input_ids_dict
-        )
+        self.create_and_check_roberta_encoder_decoder_model_from_pretrained(**input_ids_dict)
 
     def test_save_and_load_from_pretrained(self):
         input_ids_dict = self.prepare_config_and_inputs_bert()
@@ -577,47 +513,33 @@ class EncoderDecoderModelTest(unittest.TestCase):
 
     @slow
     def test_real_bert_model_from_pretrained(self):
-        model = EncoderDecoderModel.from_encoder_decoder_pretrained(
-            "bert-base-uncased", "bert-base-uncased"
-        )
+        model = EncoderDecoderModel.from_encoder_decoder_pretrained("bert-base-uncased", "bert-base-uncased")
         self.assertIsNotNone(model)
 
     @slow
     def test_real_roberta_model_from_pretrained(self):
-        model = EncoderDecoderModel.from_encoder_decoder_pretrained(
-            "roberta-base", "roberta-base"
-        )
+        model = EncoderDecoderModel.from_encoder_decoder_pretrained("roberta-base", "roberta-base")
         self.assertIsNotNone(model)
 
     @slow
     def test_real_bert_model_from_pretrained_has_cross_attention(self):
-        model = EncoderDecoderModel.from_encoder_decoder_pretrained(
-            "bert-base-uncased", "bert-base-uncased"
-        )
+        model = EncoderDecoderModel.from_encoder_decoder_pretrained("bert-base-uncased", "bert-base-uncased")
         self.assertTrue(hasattr(model.decoder.bert.encoder.layer[0], "crossattention"))
 
     @slow
     def test_real_roberta_model_from_pretrained_has_cross_attention(self):
-        model = EncoderDecoderModel.from_encoder_decoder_pretrained(
-            "roberta-base", "roberta-base"
-        )
+        model = EncoderDecoderModel.from_encoder_decoder_pretrained("roberta-base", "roberta-base")
         self.assertTrue(hasattr(model.decoder.bert.encoder.layer[0], "crossattention"))
 
     @slow
     def test_real_bert_model_save_load_from_pretrained(self):
-        model_2 = EncoderDecoderModel.from_encoder_decoder_pretrained(
-            "bert-base-uncased", "bert-base-uncased"
-        )
+        model_2 = EncoderDecoderModel.from_encoder_decoder_pretrained("bert-base-uncased", "bert-base-uncased")
         model_2.to(torch_device)
         input_ids = ids_tensor([13, 5], model_2.config.encoder.vocab_size)
         decoder_input_ids = ids_tensor([13, 1], model_2.config.encoder.vocab_size)
         attention_mask = ids_tensor([13, 5], vocab_size=2)
         with torch.no_grad():
-            outputs = model_2(
-                input_ids=input_ids,
-                decoder_input_ids=decoder_input_ids,
-                attention_mask=attention_mask,
-            )
+            outputs = model_2(input_ids=input_ids, decoder_input_ids=decoder_input_ids, attention_mask=attention_mask,)
             out_2 = outputs[0].cpu().numpy()
             out_2[np.isnan(out_2)] = 0
 
@@ -627,9 +549,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
                 model_1.to(torch_device)
 
                 after_outputs = model_1(
-                    input_ids=input_ids,
-                    decoder_input_ids=decoder_input_ids,
-                    attention_mask=attention_mask,
+                    input_ids=input_ids, decoder_input_ids=decoder_input_ids, attention_mask=attention_mask,
                 )
                 out_1 = after_outputs[0].cpu().numpy()
                 out_1[np.isnan(out_1)] = 0
@@ -638,19 +558,13 @@ class EncoderDecoderModelTest(unittest.TestCase):
 
     @slow
     def test_real_roberta_model_save_load_from_pretrained(self):
-        model_2 = EncoderDecoderModel.from_encoder_decoder_pretrained(
-            "roberta-base", "roberta-base"
-        )
+        model_2 = EncoderDecoderModel.from_encoder_decoder_pretrained("roberta-base", "roberta-base")
         model_2.to(torch_device)
         input_ids = ids_tensor([13, 5], model_2.config.encoder.vocab_size)
         decoder_input_ids = ids_tensor([13, 1], model_2.config.encoder.vocab_size)
         attention_mask = ids_tensor([13, 5], vocab_size=2)
         with torch.no_grad():
-            outputs = model_2(
-                input_ids=input_ids,
-                decoder_input_ids=decoder_input_ids,
-                attention_mask=attention_mask,
-            )
+            outputs = model_2(input_ids=input_ids, decoder_input_ids=decoder_input_ids, attention_mask=attention_mask,)
             out_2 = outputs[0].cpu().numpy()
             out_2[np.isnan(out_2)] = 0
 
@@ -660,9 +574,7 @@ class EncoderDecoderModelTest(unittest.TestCase):
                 model_1.to(torch_device)
 
                 after_outputs = model_1(
-                    input_ids=input_ids,
-                    decoder_input_ids=decoder_input_ids,
-                    attention_mask=attention_mask,
+                    input_ids=input_ids, decoder_input_ids=decoder_input_ids, attention_mask=attention_mask,
                 )
                 out_1 = after_outputs[0].cpu().numpy()
                 out_1[np.isnan(out_1)] = 0


### PR DESCRIPTION
* Add crossattention input
* Add EncoderDecoder tests for RoBERTa

Since RoBERTa is a subclass of BERT, it inherits all the crossattention mechanics in the model itself. This change allows RobertaForMaskedLM to take in encoder hidden states and language model labels to work with the EncoderDecoder framework.