### PR TITLE
Replace pad_token with -100 for LM loss calculation

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -93,7 +93,9 @@ class DataCollatorForLanguageModeling(DataCollator):
             inputs, labels = self.mask_tokens(batch)
             return {"input_ids": inputs, "labels": labels}
         else:
-            return {"input_ids": batch, "labels": batch}
+            labels = batch.clone().detach()
+            labels[labels == self.tokenizer.pad_token_id] = -100
+            return {"input_ids": batch, "labels": labels}
 
     def _tensorize_batch(self, examples: List[torch.Tensor]) -> torch.Tensor:
         length_of_first = examples[0].size(0)


### PR DESCRIPTION
The docs for both GPT and [GPT2](https://huggingface.co/transformers/model_doc/gpt2.html#gpt2lmheadmodel) specify that labels that are not -100 will be used for the calculation of the loss. So, the padding for the labels should be `-100`, not `tokenizer.pad_token_id`.