### PR TITLE
Possible fix to make AMP work with DDP in the trainer

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -174,6 +174,9 @@ class TrainingArguments:
             torch.distributed.init_process_group(backend="nccl")
             device = torch.device("cuda", self.local_rank)
             n_gpu = 1
+
+        torch.cuda.set_device(device)
+
         return device, n_gpu
 
     @property

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -166,7 +166,11 @@ class TrainingArguments:
         elif self.local_rank == -1:
             # if n_gpu is > 1 we'll use nn.DataParallel.
             # If you only want to use a specific subset of GPUs use `CUDA_VISIBLE_DEVICES=0`
-            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            # Explicitly set CUDA to the first (index 0) CUDA device, otherwise `set_device` will
+            # trigger an error that a device index is missing. Index 0 takes into account the
+            # GPUs available in the environment, so `CUDA_VISIBLE_DEVICES=1,2` with `cuda:0`
+            # will use the first GPU in that env, i.e. GPU#1
+            device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
             n_gpu = torch.cuda.device_count()
         else:
             # Here, we'll use torch.distributed.

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -175,7 +175,8 @@ class TrainingArguments:
             device = torch.device("cuda", self.local_rank)
             n_gpu = 1
 
-        torch.cuda.set_device(device)
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
 
         return device, n_gpu
 


### PR DESCRIPTION
closes https://github.com/huggingface/transformers/issues/4657

Using multiple GPUs in PyTorch (with DistrubutedDataParallel) speeds up performance drastically. To get even more speed out of it, the example scripts often - if not always - allow the use of apex for automatic mixed precision. This is great. However, some issues can arise, particularly the infamous "illegal memory access" error which seems to have an easy, one-line solution. 

Currently, we assume that by using things like `.to(args.device)` we solve any and all issues of where our data or model should go. However, the author of AMP @mcarilli seems to [suggest](https://github.com/NVIDIA/apex/issues/319#issuecomment-503372924) that it is recommended to always set the current process' default device, too, to ensure no further issues. This suggestion also [helped](https://github.com/huggingface/transformers/issues/4657#issuecomment-637703146) the aforementioned issue. Therefore it seems a good idea to also implement this. In fact, some examples such as Hans already do this.

https://github.com/huggingface/transformers/blob/b231a413f5d58592bb4d98304c3d3b668c5d4a42/examples/adversarial/test_hans.py#L518

To avoid DRY issues, I would suspect that the trainer_args file is the best place to do this _only once_ but other suggestions are welcome (this is different from what I suggested in the linked issue, though I think `trainer_args` is the better place). I am not sure which examples do not use trainer_args, but those would need to be checked and updated as well. If anyone can give a quick rundown of which examples do NOT use the new trainer, I can have a look quickly. Otherwise I'll have to go over the examples another time.

**Side note**: I am not sure how and if this works with TPUs so to be sure that this only involves CUDA devices, I first check whether the device is a CUDA device.