### PR TITLE
Add drop_last arg for data loader

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -240,6 +240,7 @@ class Trainer:
             batch_size=self.args.train_batch_size,
             sampler=train_sampler,
             collate_fn=self.data_collator.collate_batch,
+            drop_last=self.args.dataloader_drop_last,
         )
 
         return data_loader
@@ -264,6 +265,7 @@ class Trainer:
             sampler=sampler,
             batch_size=self.args.eval_batch_size,
             collate_fn=self.data_collator.collate_batch,
+            drop_last=self.args.dataloader_drop_last,
         )
 
         return data_loader

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -133,6 +133,10 @@ class TrainingArguments:
     )
     tpu_metrics_debug: bool = field(default=False, metadata={"help": "TPU: Whether to print debug metrics"})
 
+    dataloader_drop_last: bool = field(
+        default=False, metadata={"help": "Drop the last incomplete batch if it is not divisible by the batch size."}
+    )
+
     @property
     def train_batch_size(self) -> int:
         if self.per_gpu_train_batch_size:


### PR DESCRIPTION
Add an extra argument to `TrainingArguments` that would be passed on to `Trainer` for use in DataLoader.

I ran into a problem while using the `Trainer` this week and the GPU expecting the full batch size of vector inputs, and put a workaround in place in the dataset class I was using, but would be useful to have this as an optional argument.