### PR TITLE
Fix the __getattr__ method in BatchEncoding

### DIFF
--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -200,7 +200,10 @@ class BatchEncoding(UserDict):
             )
 
     def __getattr__(self, item: str):
-        return self.data[item]
+        try:
+            return self.data[item]
+        except KeyError:
+            raise AttributeError
 
     def keys(self):
         return self.data.keys()


### PR DESCRIPTION
Fix the issue where the `__getattr__` method in `BatchEncoding` was raising a `KeyError` instead of an `AttributeError` when the attribute was accessed with `getattr()`.

Example:
```
from transformers import BertTokenizer
tokenizer = BertTokenizer.from_pretrained("bert-base-cased")
features = tokenizer.encode_plus("Hello here")
getattr(features, "attr", False)
```

Previous output:
```
/home/jplu/transformers/src/transformers/tokenization_utils.py:204 __getattr__
        return self.data[item]
    KeyError: 'attr'
```

New output:
```
False
```