### PR TITLE
Don't access pad_token_id if there is no pad_token

### DIFF
--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -2467,7 +2467,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizer):
             strategy=truncation_strategy,
             pad_to_max_length=pad_to_max_length,
             padding_side=self.padding_side,
-            pad_token_id=self.pad_token_id,
+            pad_token_id=self.pad_token_id if self._pad_token is not None else None,
             pad_token_type_id=self.pad_token_type_id,
             pad_token=self._pad_token,
         ):


### PR DESCRIPTION
When using the `encode`  method of a fast tokenizer, we end up here and accessing `pad_token_id` may log an error even when no padding is done. This PR corrects that.

This fixes #4764 .
