### PR TITLE
Add .vs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ dmypy.json
 .pyre/
 
 # vscode
+.vs
 .vscode
 
 # Pycharm


### PR DESCRIPTION
My VS code writes stuff there so added it to the .gitignore.

I also have other untracked files:
- in tests/fixtures/ I have some cached_lm_\*Tokenizer_\*.txt and .txt.lock after running the tests
- in docs/ I have the simlink to examples.md as indicated in [here](https://github.com/huggingface/transformers/tree/master/docs#building-the-documentation)

Should I add stuff in .gitignore to ignore those as well?