### PR TITLE
Ignore simlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/examples.md
 
 # PyBuilder
 target/

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,6 +76,18 @@ It should build the static app that will be available under `/docs/_build/html`
 Accepted files are reStructuredText (.rst) and Markdown (.md). Create a file with its extension and put it
 in the source directory. You can then link it to the toc-tree by putting the filename without the extension.
 
+## Preview the documentation in a pull request
+
+Once you have made your pull request, you can check what the documentation will look like after it's merged by
+following these steps:
+
+- Look at the checks at the bottom of the conversation page of your PR (you may need to click on "show all checks" to
+  expand them).
+- Click on "details" next to the `ci/circleci: build_doc` check.
+- In the new window, click on the "Artifacts" tab.
+- Locate the file "docs/_build/html/index.html" (or any specific page you want to check) and click on it to get a 
+  preview.
+
 ## Writing Documentation - Specification
 
 The `huggingface/transformers` documentation follows the


### PR DESCRIPTION
Didn't get an answer to my question on #4774 so asking again in the form of a PR ;-)

Currently, building the docs require making a simlink to the examples README (as per the [instructions](https://github.com/huggingface/transformers/tree/master/docs#building-the-documentation)) and that file then becomes untracked bit git. We should either ignore it (as proposed in this PR) or add it once for all (might be OS-dependent though). 

Happy to amend this PR to the second solution, I just don't like untracked files. :-)