### PR TITLE
[isort] add matplotlib to known 3rd party dependencies

### DIFF
--- a/examples/benchmarking/plot_csv_file.py
+++ b/examples/benchmarking/plot_csv_file.py
@@ -3,9 +3,9 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Optional
 
+import matplotlib.pyplot as plt
 import numpy as np
 
-import matplotlib.pyplot as plt
 from transformers import HfArgumentParser
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ known_third_party =
     fastprogress
     git
     h5py
+    matplotlib
     MeCab
     nltk
     numpy


### PR DESCRIPTION
Many people (like me) have it installed locally, so this will synchronize local isort and circleci.