### PR TITLE
[cleanup] MarianTokenizer: delete unused constants

### DIFF
--- a/src/transformers/tokenization_marian.py
+++ b/src/transformers/tokenization_marian.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import warnings
 from pathlib import Path
@@ -7,7 +8,6 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import sentencepiece
 
-from .file_utils import S3_BUCKET_PREFIX
 from .tokenization_utils import BatchEncoding, PreTrainedTokenizer
 
 
@@ -16,11 +16,6 @@ vocab_files_names = {
     "target_spm": "target.spm",
     "vocab": "vocab.json",
     "tokenizer_config_file": "tokenizer_config.json",
-}
-MODEL_NAMES = ("opus-mt-en-de",)  # TODO(SS): delete this, the only required constant is vocab_files_names
-PRETRAINED_VOCAB_FILES_MAP = {
-    k: {m: f"{S3_BUCKET_PREFIX}/Helsinki-NLP/{m}/{fname}" for m in MODEL_NAMES}
-    for k, fname in vocab_files_names.items()
 }
 # Example URL https://s3.amazonaws.com/models.huggingface.co/bert/Helsinki-NLP/opus-mt-en-de/vocab.json
 
@@ -41,8 +36,6 @@ class MarianTokenizer(PreTrainedTokenizer):
     """
 
     vocab_files_names = vocab_files_names
-    pretrained_vocab_files_map = PRETRAINED_VOCAB_FILES_MAP
-    max_model_input_sizes = {m: 512 for m in MODEL_NAMES}
     model_input_names = ["attention_mask"]  # actually attention_mask, decoder_attention_mask
     language_code_re = re.compile(">>.+<<")  # type: re.Pattern
 

--- a/src/transformers/tokenization_marian.py
+++ b/src/transformers/tokenization_marian.py
@@ -1,5 +1,4 @@
 import json
-import os
 import re
 import warnings
 from pathlib import Path


### PR DESCRIPTION
slow tests pass.
The only needed constant is `vocab_files_names`