### PR TITLE
Expose classes used in documentation

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -132,7 +132,13 @@ from .tokenization_reformer import ReformerTokenizer
 from .tokenization_roberta import RobertaTokenizer, RobertaTokenizerFast
 from .tokenization_t5 import T5Tokenizer
 from .tokenization_transfo_xl import TransfoXLCorpus, TransfoXLTokenizer, TransfoXLTokenizerFast
-from .tokenization_utils import BatchEncoding, PreTrainedTokenizer, PreTrainedTokenizerFast, SpecialTokensMixin, TensorType
+from .tokenization_utils import (
+    BatchEncoding,
+    PreTrainedTokenizer,
+    PreTrainedTokenizerFast,
+    SpecialTokensMixin,
+    TensorType,
+)
 from .tokenization_xlm import XLMTokenizer
 from .tokenization_xlm_roberta import XLMRobertaTokenizer
 from .tokenization_xlnet import SPIECE_UNDERLINE, XLNetTokenizer

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -132,10 +132,12 @@ from .tokenization_reformer import ReformerTokenizer
 from .tokenization_roberta import RobertaTokenizer, RobertaTokenizerFast
 from .tokenization_t5 import T5Tokenizer
 from .tokenization_transfo_xl import TransfoXLCorpus, TransfoXLTokenizer, TransfoXLTokenizerFast
-from .tokenization_utils import PreTrainedTokenizer, TensorType
+from .tokenization_utils import BatchEncoding, PreTrainedTokenizer, PreTrainedTokenizerFast, SpecialTokensMixin, TensorType
 from .tokenization_xlm import XLMTokenizer
 from .tokenization_xlm_roberta import XLMRobertaTokenizer
 from .tokenization_xlnet import SPIECE_UNDERLINE, XLNetTokenizer
+
+# Trainer
 from .trainer_utils import EvalPrediction
 from .training_args import TrainingArguments
 from .training_args_tf import TFTrainingArguments


### PR DESCRIPTION
Currently, the documentation page of the tokenizers has three methods lacking documentation (see [here](https://huggingface.co/transformers/main_classes/tokenizer.html#pretrainedtokenizerfast)). This PR adds them to the `__init__` so sphynx can see them.

If there is one that should not be public, we should remove it from the documentation.