### PR TITLE
Export PretrainedBartModel from __init__

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -230,6 +230,7 @@ if is_torch_available():
         XLM_PRETRAINED_MODEL_ARCHIVE_LIST,
     )
     from .modeling_bart import (
+        PretrainedBartModel,
         BartForSequenceClassification,
         BartModel,
         BartForConditionalGeneration,


### PR DESCRIPTION
`PretrainedBartModel ` is currently not being exported so one has to manually do

```python
from transformers.modeling_bart import PretrainedBartModel
```

This required behaviour is different from other models which do expose their PretrainedModel in `__init__`. 