### PR TITLE
Fix use of mems in Transformer-XL text generation

### DIFF
--- a/src/transformers/modeling_transfo_xl.py
+++ b/src/transformers/modeling_transfo_xl.py
@@ -923,10 +923,13 @@ class TransfoXLLMHeadModel(TransfoXLPreTrainedModel):
             return self.crit.out_layers[-1]
 
     def prepare_inputs_for_generation(self, input_ids, past, **model_kwargs):
-        inputs = {"input_ids": input_ids}
+        inputs = {}
 
         # if past is defined in model kwargs then use it for faster decoding
         if past:
             inputs["mems"] = past
+            inputs["input_ids"] = input_ids[:, -1].unsqueeze(-1)
+        else:
+            inputs["input_ids"] = input_ids
 
         return inputs


### PR DESCRIPTION
In Transformer-XL, when ```mems``` is being used to save computation with the ```generate``` function, the inputs are not properly truncated, so that ```mems``` does not actually speed things up, and also seems to create inaccuracies in the output. I have attempted to fix this by changing Transformer-XL's ```prepare_inputs_for_generation``` function to make it more like that function as used in GPT-2.

See the issue at https://github.com/huggingface/transformers/issues/4752 for more details.
