### PR TITLE
[Generate] beam search should generate without replacement

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1736,7 +1736,7 @@ def shape_list(x):
     return [dynamic[i] if s is None else s for i, s in enumerate(static)]
 
 
-def sample_without_replacement(logits, dtype, num_samples):
+def sample_without_replacement(logits, num_samples):
     """
         categorical sampling witouth replacement is currently not implemented
         the gumbel-max trick will do for now


### PR DESCRIPTION
When doing beam search decoding and sampling instead of argmax (edge case, probably very rarely used), we need to sample **without** replacement. This is implemented by  default in torch, but not in TF, see https://pytorch.org/docs/master/generated/torch.multinomial.html#torch.multinomial (torch). An easy solution is to use the Gumbel max trick instead: https://github.com/tensorflow/tensorflow/issues/9260

This will fix the sometimes flaky TFBeamSearchGenerate Tests as well: #4447 