### PR TITLE
check type before logging in trainer to ensure values are scalars

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -554,7 +554,8 @@ class Trainer:
             logs["epoch"] = self.epoch
         if self.tb_writer:
             for k, v in logs.items():
-                self.tb_writer.add_scalar(k, v, self.global_step)
+                if isinstance(v, (int, float)):
+                    self.tb_writer.add_scalar(k, v, self.global_step)
             self.tb_writer.flush()
         if is_wandb_available():
             wandb.log(logs, step=self.global_step)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -557,10 +557,15 @@ class Trainer:
                 if isinstance(v, (int, float)):
                     self.tb_writer.add_scalar(k, v, self.global_step)
                 else:
-                    logger.warning("Trainer is attempting to log a value of "
-                                   "\"%s\" of type %s for key \"%s\" as a scalar. "
-                                   "This invocation may cause errors for TensorboardX's "
-                                   "writer.add_scalar() function.", v, type(v), k)
+                    logger.warning(
+                        "Trainer is attempting to log a value of "
+                        '"%s" of type %s for key "%s" as a scalar. '
+                        "This invocation may cause errors for TensorboardX's "
+                        "writer.add_scalar() function.",
+                        v,
+                        type(v),
+                        k,
+                    )
             self.tb_writer.flush()
         if is_wandb_available():
             wandb.log(logs, step=self.global_step)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -556,6 +556,11 @@ class Trainer:
             for k, v in logs.items():
                 if isinstance(v, (int, float)):
                     self.tb_writer.add_scalar(k, v, self.global_step)
+                else:
+                    logger.warning("Trainer is attempting to log a value of "
+                                   "\"%s\" of type %s for key \"%s\" as a scalar. "
+                                   "This invocation may cause errors for TensorboardX's "
+                                   "writer.add_scalar() function.", v, type(v), k)
             self.tb_writer.flush()
         if is_wandb_available():
             wandb.log(logs, step=self.global_step)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -560,8 +560,8 @@ class Trainer:
                     logger.warning(
                         "Trainer is attempting to log a value of "
                         '"%s" of type %s for key "%s" as a scalar. '
-                        "This invocation may cause errors for TensorboardX's "
-                        "writer.add_scalar() function.",
+                        "This invocation of Tensorboard's writer.add_scalar() "
+                        "is incorrect so we dropped this attribute.",
                         v,
                         type(v),
                         k,


### PR DESCRIPTION
This change was necessary to avoid https://github.com/lanpa/tensorboardX/issues/567 since a non-scalar value was being passed in.