### PR TITLE
Fix a bug in the initialization and serialization of TFRobertaClassificationHead

### DIFF
--- a/src/transformers/modeling_tf_roberta.py
+++ b/src/transformers/modeling_tf_roberta.py
@@ -321,7 +321,7 @@ class TFRobertaClassificationHead(tf.keras.layers.Layer):
     """Head for sentence-level classification tasks."""
 
     def __init__(self, config, **kwargs):
-        super().__init__(config, **kwargs)
+        super().__init__(**kwargs)
         self.dense = tf.keras.layers.Dense(
             config.hidden_size,
             kernel_initializer=get_initializer(config.initializer_range),


### PR DESCRIPTION
For `TFRobertaClassificationHead`, `config` was being passed as the first parameter to the `__init__` of the parent class `tf.keras.layers.Layer`. The latter [expects](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer) trainable as the first parameter. 

This fixes #4709 and #3664, making the TFRoberta models serializable to `savedmodel` format too.