### PR TITLE
enable pickling for TF Bert models

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -486,6 +486,14 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin):
             return False
         return True
 
+    def __getstate__(self):
+        """Remove unpickable objects"""
+
+        state = super().__getstate__()
+        state.pop("_trackable_saver", None)
+        state.pop("_compiled_trainable_state", None)
+        return state
+
     def generate(
         self,
         input_ids=None,

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -101,7 +101,7 @@ class TFModelTesterMixin:
             outputs = model(inputs_dict)
             serialized = pickle.dumps(model)
 
-            model = pickle.loads(serialized) 
+            model = pickle.loads(serialized)
             after_outputs = model(inputs_dict)
 
             self.assert_outputs_same(after_outputs, outputs)

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -92,6 +92,20 @@ class TFModelTesterMixin:
 
                 self.assert_outputs_same(after_outputs, outputs)
 
+    def test_base_pickle(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        import pickle
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            outputs = model(inputs_dict)
+            serialized = pickle.dumps(model)
+
+            model = pickle.loads(serialized) 
+            after_outputs = model(inputs_dict)
+
+            self.assert_outputs_same(after_outputs, outputs)
+
     def test_keras_save_load(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
@@ -271,7 +285,7 @@ class TFModelTesterMixin:
             outputs_dict = model(input_ids)
             hidden_states = outputs_dict[0]
 
-            # Add a dense layer on top to test intetgration with other keras modules
+            ## Add a dense layer on top to test intetgration with other keras modules
             outputs = tf.keras.layers.Dense(2, activation="softmax", name="outputs")(hidden_states)
 
             # Compile extended model

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -285,7 +285,7 @@ class TFModelTesterMixin:
             outputs_dict = model(input_ids)
             hidden_states = outputs_dict[0]
 
-            ## Add a dense layer on top to test intetgration with other keras modules
+            # Add a dense layer on top to test intetgration with other keras modules
             outputs = tf.keras.layers.Dense(2, activation="softmax", name="outputs")(hidden_states)
 
             # Compile extended model

--- a/tests/test_modeling_tf_ctrl.py
+++ b/tests/test_modeling_tf_ctrl.py
@@ -187,6 +187,13 @@ class TFCTRLModelTest(TFModelTesterMixin, unittest.TestCase):
         self.model_tester = TFCTRLModelTest.TFCTRLModelTester(self)
         self.config_tester = ConfigTester(self, config_class=CTRLConfig, n_embd=37)
 
+    @unittest.skip("known to fail")
+    def test_base_pickle(self):
+        # the test from base class is known to fail for TFCTRLModel
+        # it need a fix in keras.Sequential implementation
+        # https://github.com/tensorflow/tensorflow/issues/34697
+        pass
+
     def test_config(self):
         self.config_tester.run_common_tests()
 


### PR DESCRIPTION
this implements `__getstate__` for BERT models to enable pickling (without this PR the pickle attempt due to `weakref` errors). It also adds a unit test.