### PR TITLE
Don't init TPU device twice

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -71,9 +71,7 @@ except ImportError:
 
 
 try:
-    import torch_xla.core.xla_model as xm
-
-    tpu_device = xm.xla_device()
+    import torch_xla.core.xla_model as xm  # noqa: F401
 
     if _torch_available:
         _torch_tpu_available = True  # pylint: disable=


### PR DESCRIPTION
closes #4893

The TPU device was initialized twice when using a the `xla_spawn.py` script. Removing this initialization solves the issue.

@patrickvonplaten, is this necessary for the benchmarking script?