### PR TITLE
enable invocation of run_ner.py and utils_ner.py in cython

### DIFF
--- a/examples/token-classification/run_ner.py
+++ b/examples/token-classification/run_ner.py
@@ -48,6 +48,14 @@ class ModelArguments:
     Arguments pertaining to which model/config/tokenizer we are going to fine-tune from.
     """
 
+    __annotations__ = {
+        "model_name_or_path": str,
+        "config_name": Optional[str],
+        "tokenizer_name": Optional[str],
+        "use_fast": bool,
+        "cache_dir": Optional[str],
+    }
+
     model_name_or_path: str = field(
         metadata={"help": "Path to pretrained model or model identifier from huggingface.co/models"}
     )
@@ -71,6 +79,12 @@ class DataTrainingArguments:
     Arguments pertaining to what data we are going to input our model for training and eval.
     """
 
+    __annotations__ = {
+        "data_dir": str,
+        "labels": Optional[str],
+        "max_seq_length": int,
+        "overwrite_cache": bool,
+    }
     data_dir: str = field(
         metadata={"help": "The input data dir. Should contain the .txt files for a CoNLL-2003-formatted task."}
     )

--- a/examples/token-classification/utils_ner.py
+++ b/examples/token-classification/utils_ner.py
@@ -42,6 +42,12 @@ class InputExample:
         specified for train and dev examples, but not for test examples.
     """
 
+    __annotations__ = {
+        "guid": str,
+        "words": List[str],
+        "labels": Optional[List[str]],
+    }
+
     guid: str
     words: List[str]
     labels: Optional[List[str]]
@@ -53,6 +59,13 @@ class InputFeatures:
     A single set of features of data.
     Property names are the same names as the corresponding inputs to a model.
     """
+
+    __annotations__ = {
+        "input_ids": List[int],
+        "attention_mask": List[int],
+        "token_type_ids": Optional[List[int]],
+        "label_ids": Optional[List[int]],
+    }
 
     input_ids: List[int]
     attention_mask: List[int]


### PR DESCRIPTION
Due to extant issue https://github.com/cython/cython/issues/2903, `run_ner.py` and `utils_ner.py` (among others, I imagine) cannot be invoked inside Cython. By manually adding in annotations, these changes work around the missing features in Cython 3.7 re: PEP557.
https://github.com/cython/cython/pull/3400 ought to eventually fix the underlying issue.

I'm offering code here that works around this behavior in case it would be helpful to others.