### PR TITLE
Fixing TPU training by disabling wandb.watch gradients logging

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -341,8 +341,8 @@ class Trainer:
                 'Automatic Weights & Biases logging enabled, to disable set os.environ["WANDB_DISABLED"] = "true"'
             )
             wandb.init(project=os.getenv("WANDB_PROJECT", "huggingface"), config=vars(self.args))
-            # keep track of model topology and gradients
-            if os.getenv("WANDB_WATCH") != "false":
+            # keep track of model topology and gradients, unsupported on TPU
+            if not is_torch_tpu_available() and os.getenv("WANDB_WATCH") != "false":
                 wandb.watch(
                     self.model, log=os.getenv("WANDB_WATCH", "gradients"), log_freq=max(100, self.args.logging_steps)
                 )


### PR DESCRIPTION
Fixes issue https://github.com/huggingface/transformers/issues/4814
PyTorch TPU trainer.py had a bug where the training would freeze up during the logging step. On investigation, the culprit was found to be a wandb.watch call which was trying to log gradients. This operation is suspected to be unsupported by Wandb for TPUs. Waiting for a confirmation of TPU gradient logging support by the Wandb team.