### PR TITLE
[ElectraForQuestionAnswering] fix qa example in doc

### DIFF
--- a/src/transformers/modeling_electra.py
+++ b/src/transformers/modeling_electra.py
@@ -814,10 +814,11 @@ class ElectraForQuestionAnswering(ElectraPreTrainedModel):
         model = ElectraForQuestionAnswering.from_pretrained('google/electra-base-discriminator')
 
         question, text = "Who was Jim Henson?", "Jim Henson was a nice puppet"
-        input_ids = tokenizer.encode(question, text)
-        start_scores, end_scores = model(torch.tensor([input_ids]))
+        encoding = tokenizer.encode_plus(question, text, return_tensors='pt')
+        input_ids, token_type_ids = encoding['input_ids'], encoding['token_type_ids']
+        start_scores, end_scores = model(input_ids, token_type_ids=token_type_ids)
 
-        all_tokens = tokenizer.convert_ids_to_tokens(input_ids)
+        all_tokens = tokenizer.convert_ids_to_tokens(input_ids.squeeze(0))
         answer = ' '.join(all_tokens[torch.argmax(start_scores) : torch.argmax(end_scores)+1])
 
         """


### PR DESCRIPTION
This PR fixes the QA example in the doc for `ElectraForQuestionAnswering`. In the last example `token_type_ids` were not used, this PR fixes that

@sgugger 