### PR TITLE
Update setup.py for sentencepiece.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
         # for OpenAI GPT
         "regex != 2019.12.17",
         # for XLNet
-        "sentencepiece",
+        "sentencepiece==0.1.91",
         # for XLM
         "sacremoses",
     ],


### PR DESCRIPTION
Now the `sentencepiece` library has upgraded to `0.1.92` version which is incompatible with ` transformers==2.8.0`.

sentencepiece==0.1.92 gives segmentation fault (core dumped).