### PR TITLE
Delay decay schedule until the end of warmup

### DIFF
--- a/src/transformers/optimization_tf.py
+++ b/src/transformers/optimization_tf.py
@@ -44,7 +44,7 @@ class WarmUp(tf.keras.optimizers.schedules.LearningRateSchedule):
             return tf.cond(
                 global_step_float < warmup_steps_float,
                 lambda: warmup_learning_rate,
-                lambda: self.decay_schedule_fn(step),
+                lambda: self.decay_schedule_fn(step - self.warmup_steps),
                 name=name,
             )
 


### PR DESCRIPTION
The decay schedule should start at the end of the warmup steps. Without this simple edit, learning rate will drop at the end of the warmup steps, like the figure shown below:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/15783079/84426617-c5820500-ac38-11ea-9579-2c0d5f374e33.png">
