### PR TITLE
Fix Inconsistent NER Grouping (Pipeline)

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1069,7 +1069,7 @@ class TokenClassificationPipeline(Pipeline):
         Returns grouped entities
         """
         # Get the last entity in the entity group
-        entity = entities[-1]["entity"]
+        entity = entities[0]["entity"]
         scores = np.mean([entity["score"] for entity in entities])
         tokens = [entity["word"] for entity in entities]
 

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1011,7 +1011,8 @@ class TokenClassificationPipeline(Pipeline):
                 for idx, label_idx in enumerate(labels_idx)
                 if self.model.config.id2label[label_idx] not in self.ignore_labels
             ]
-            last_idx, _ = filtered_labels_idx[-1]
+            if filtered_labels_idx:
+                last_idx, _ = filtered_labels_idx[-1]
 
             for idx, label_idx in filtered_labels_idx:
 

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1021,21 +1021,24 @@ class TokenClassificationPipeline(Pipeline):
                     "index": idx,
                 }
                 last_idx, _ = filtered_labels_idx[-1]
+                is_last_idx = idx == last_idx
+
                 if self.grouped_entities:
                     if not entity_group_disagg:
                         entity_group_disagg += [entity]
-                        if idx == last_idx:
+                        if is_last_idx:
                             entity_groups += [self.group_entities(entity_group_disagg)]
                         continue
 
                     # If the current entity is similar and adjacent to the previous entity, append it to the disaggregated entity group
+                    # The split is meant to account for the "B" and "I" suffixes
                     if (
-                        entity["entity"] == entity_group_disagg[-1]["entity"]
+                        entity["entity"].split("-")[-1] == entity_group_disagg[-1]["entity"].split("-")[-1]
                         and entity["index"] == entity_group_disagg[-1]["index"] + 1
                     ):
                         entity_group_disagg += [entity]
                         # Group the entities at the last entity
-                        if idx == last_idx:
+                        if is_last_idx:
                             entity_groups += [self.group_entities(entity_group_disagg)]
                     # If the current entity is different from the previous entity, aggregate the disaggregated entity group
                     else:

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1032,7 +1032,7 @@ class TokenClassificationPipeline(Pipeline):
             return answers[0]
         return answers
 
-    def group_sub_entities(self, entities):
+    def group_sub_entities(self, entities: List[dict]) -> dict:
         """
         Returns grouped sub entities
         """
@@ -1048,7 +1048,7 @@ class TokenClassificationPipeline(Pipeline):
         }
         return entity_group
 
-    def group_entities(self, entities):
+    def group_entities(self, entities: List[dict]) -> List[dict]:
         """
         Returns grouped entities
         """

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1081,10 +1081,9 @@ class TokenClassificationPipeline(Pipeline):
             else:
                 entity_groups += [self.group_sub_entities(entity_group_disagg)]
                 entity_group_disagg = [entity]
-
-        # Ensure if an entity is the latest one in the sequence it gets appended to the output
-        if len(entity_group_disagg) > 0:
-            entity_groups.append(self.group_sub_entities(entity_group_disagg))
+                # If it's the last entity, add it to the entity groups
+                if is_last_idx:
+                    entity_groups += [self.group_entities(entity_group_disagg)]
 
         return entity_groups
 

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1009,8 +1009,6 @@ class TokenClassificationPipeline(Pipeline):
                 for idx, label_idx in enumerate(labels_idx)
                 if self.model.config.id2label[label_idx] not in self.ignore_labels
             ]
-            if filtered_labels_idx:
-                last_idx, _ = filtered_labels_idx[-1]
 
             for idx, label_idx in filtered_labels_idx:
 

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1044,9 +1044,6 @@ class TokenClassificationPipeline(Pipeline):
                     else:
                         entity_groups += [self.group_entities(entity_group_disagg)]
                         entity_group_disagg = [entity]
-                        # If it's the last entity,
-                        if is_last_idx:
-                            entity_groups += [self.group_entities(entity_group_disagg)]
 
                 entities += [entity]
 

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1011,6 +1011,7 @@ class TokenClassificationPipeline(Pipeline):
                 for idx, label_idx in enumerate(labels_idx)
                 if self.model.config.id2label[label_idx] not in self.ignore_labels
             ]
+            last_idx, _ = filtered_labels_idx[-1]
 
             for idx, label_idx in filtered_labels_idx:
 
@@ -1020,7 +1021,6 @@ class TokenClassificationPipeline(Pipeline):
                     "entity": self.model.config.id2label[label_idx],
                     "index": idx,
                 }
-                last_idx, _ = filtered_labels_idx[-1]
                 is_last_idx = idx == last_idx
 
                 if self.grouped_entities:

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1066,7 +1066,7 @@ class TokenClassificationPipeline(Pipeline):
         """
         Returns grouped entities
         """
-        # Get the last entity in the entity group
+        # Get the first entity in the entity group
         entity = entities[0]["entity"]
         scores = np.mean([entity["score"] for entity in entities])
         tokens = [entity["word"] for entity in entities]

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1083,7 +1083,7 @@ class TokenClassificationPipeline(Pipeline):
                 entity_group_disagg = [entity]
                 # If it's the last entity, add it to the entity groups
                 if is_last_idx:
-                    entity_groups += [self.group_entities(entity_group_disagg)]
+                    entity_groups += [self.group_sub_entities(entity_group_disagg)]
 
         return entity_groups
 

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1044,6 +1044,9 @@ class TokenClassificationPipeline(Pipeline):
                     else:
                         entity_groups += [self.group_entities(entity_group_disagg)]
                         entity_group_disagg = [entity]
+                        # If it's the last entity,
+                        if is_last_idx:
+                            entity_groups += [self.group_entities(entity_group_disagg)]
 
                 entities += [entity]
 

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1003,8 +1003,6 @@ class TokenClassificationPipeline(Pipeline):
             labels_idx = score.argmax(axis=-1)
 
             entities = []
-            entity_groups = []
-            entity_group_disagg = []
             # Filter to labels not in `self.ignore_labels`
             filtered_labels_idx = [
                 (idx, label_idx)
@@ -1022,39 +1020,13 @@ class TokenClassificationPipeline(Pipeline):
                     "entity": self.model.config.id2label[label_idx],
                     "index": idx,
                 }
-                is_last_idx = idx == last_idx
-
-                if self.grouped_entities:
-                    if not entity_group_disagg:
-                        entity_group_disagg += [entity]
-                        if is_last_idx:
-                            entity_groups += [self.group_entities(entity_group_disagg)]
-                        continue
-
-                    # If the current entity is similar and adjacent to the previous entity, append it to the disaggregated entity group
-                    # The split is meant to account for the "B" and "I" suffixes
-                    if (
-                        entity["entity"].split("-")[-1] == entity_group_disagg[-1]["entity"].split("-")[-1]
-                        and entity["index"] == entity_group_disagg[-1]["index"] + 1
-                    ):
-                        entity_group_disagg += [entity]
-                        # Group the entities at the last entity
-                        if is_last_idx:
-                            entity_groups += [self.group_entities(entity_group_disagg)]
-                    # If the current entity is different from the previous entity, aggregate the disaggregated entity group
-                    else:
-                        entity_groups += [self.group_entities(entity_group_disagg)]
-                        entity_group_disagg = [entity]
 
                 entities += [entity]
 
-            # Ensure if an entity is the latest one in the sequence it gets appended to the output
-            if len(entity_group_disagg) > 0:
-                entity_groups.append(self.group_entities(entity_group_disagg))
-
-            # Append
+            # Append grouped entities
             if self.grouped_entities:
-                answers += [entity_groups]
+                answers += [self.group_entities(entities)]
+            # Append ungrouped entities
             else:
                 answers += [entities]
 
@@ -1062,9 +1034,9 @@ class TokenClassificationPipeline(Pipeline):
             return answers[0]
         return answers
 
-    def group_entities(self, entities):
+    def group_sub_entities(self, entities):
         """
-        Returns grouped entities
+        Returns grouped sub entities
         """
         # Get the first entity in the entity group
         entity = entities[0]["entity"]
@@ -1077,6 +1049,46 @@ class TokenClassificationPipeline(Pipeline):
             "word": self.tokenizer.convert_tokens_to_string(tokens),
         }
         return entity_group
+
+    def group_entities(self, entities):
+        """
+        Returns grouped entities
+        """
+
+        entity_groups = []
+        entity_group_disagg = []
+
+        if entities:
+            last_idx = entities[-1]["index"]
+
+        for entity in entities:
+            is_last_idx = entity["index"] == last_idx
+            if not entity_group_disagg:
+                entity_group_disagg += [entity]
+                if is_last_idx:
+                    entity_groups += [self.group_sub_entities(entity_group_disagg)]
+                continue
+
+            # If the current entity is similar and adjacent to the previous entity, append it to the disaggregated entity group
+            # The split is meant to account for the "B" and "I" suffixes
+            if (
+                entity["entity"].split("-")[-1] == entity_group_disagg[-1]["entity"].split("-")[-1]
+                and entity["index"] == entity_group_disagg[-1]["index"] + 1
+            ):
+                entity_group_disagg += [entity]
+                # Group the entities at the last entity
+                if is_last_idx:
+                    entity_groups += [self.group_sub_entities(entity_group_disagg)]
+            # If the current entity is different from the previous entity, aggregate the disaggregated entity group
+            else:
+                entity_groups += [self.group_sub_entities(entity_group_disagg)]
+                entity_group_disagg = [entity]
+
+        # Ensure if an entity is the latest one in the sequence it gets appended to the output
+        if len(entity_group_disagg) > 0:
+            entity_groups.append(self.group_sub_entities(entity_group_disagg))
+
+        return entity_groups
 
 
 NerPipeline = TokenClassificationPipeline

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -382,7 +382,7 @@ class NerPipelineTests(unittest.TestCase):
 
         self.assertIsNotNone(nlp)
 
-        mono_result = nlp(VALID_INPUTS[0], **kwargs)
+        mono_result = nlp(VALID_INPUTS[0])
         self.assertIsInstance(mono_result, list)
         self.assertIsInstance(mono_result[0], (dict, list))
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -166,34 +166,6 @@ class MonoColumnInputTestCase(unittest.TestCase):
         self.assertRaises(Exception, nlp, invalid_inputs)
 
     @require_torch
-    def test_torch_ner(self):
-        mandatory_keys = {"entity", "word", "score"}
-        for model_name in NER_FINETUNED_MODELS:
-            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name)
-            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
-
-    @require_torch
-    def test_ner_grouped(self):
-        mandatory_keys = {"entity_group", "word", "score"}
-        for model_name in NER_FINETUNED_MODELS:
-            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, grouped_entities=True)
-            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
-
-    @require_tf
-    def test_tf_ner(self):
-        mandatory_keys = {"entity", "word", "score"}
-        for model_name in NER_FINETUNED_MODELS:
-            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf")
-            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
-
-    @require_tf
-    def test_tf_ner_grouped(self):
-        mandatory_keys = {"entity_group", "word", "score"}
-        for model_name in NER_FINETUNED_MODELS:
-            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf", grouped_entities=True)
-            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
-
-    @require_torch
     def test_torch_sentiment_analysis(self):
         mandatory_keys = {"label", "score"}
         for model_name in TEXT_CLASSIF_FINETUNED_MODELS:
@@ -400,6 +372,36 @@ class QAPipelineTests(unittest.TestCase):
         for model_name in QA_FINETUNED_MODELS:
             nlp = pipeline(task="question-answering", model=model_name, tokenizer=model_name, framework="tf")
             self._test_qa_pipeline(nlp)
+
+
+class TokenClassificationPipelineTests(unittest.TestCase):
+    @require_torch
+    def test_torch_ner(self):
+        mandatory_keys = {"entity", "word", "score"}
+        for model_name in NER_FINETUNED_MODELS:
+            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name)
+            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
+
+    @require_torch
+    def test_ner_grouped(self):
+        mandatory_keys = {"entity_group", "word", "score"}
+        for model_name in NER_FINETUNED_MODELS:
+            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, grouped_entities=True)
+            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
+
+    @require_tf
+    def test_tf_ner(self):
+        mandatory_keys = {"entity", "word", "score"}
+        for model_name in NER_FINETUNED_MODELS:
+            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf")
+            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
+
+    @require_tf
+    def test_tf_ner_grouped(self):
+        mandatory_keys = {"entity_group", "word", "score"}
+        for model_name in NER_FINETUNED_MODELS:
+            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf", grouped_entities=True)
+            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
 
 
 class PipelineCommonTests(unittest.TestCase):

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -377,9 +377,8 @@ class QAPipelineTests(unittest.TestCase):
 class NerPipelineTests(unittest.TestCase):
     def _test_ner_pipeline(
         self, nlp: Pipeline,
+        output_keys: Iterable[str],
     ):
-        output_keys = {"entity", "word", "score"}
-
         self.assertIsNotNone(nlp)
 
         mono_result = nlp(VALID_INPUTS[0])
@@ -405,27 +404,31 @@ class NerPipelineTests(unittest.TestCase):
 
     @require_torch
     def test_torch_ner(self):
+        mandatory_keys = {"entity", "word", "score"}
         for model_name in NER_FINETUNED_MODELS:
             nlp = pipeline(task="ner", model=model_name, tokenizer=model_name)
-            self._test_ner_pipeline(nlp)
+            self._test_ner_pipeline(nlp, mandatory_keys)
 
     @require_torch
     def test_ner_grouped(self):
+        mandatory_keys = {"entity_group", "word", "score"}
         for model_name in NER_FINETUNED_MODELS:
             nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, grouped_entities=True)
-            self._test_ner_pipeline(nlp)
+            self._test_ner_pipeline(nlp, mandatory_keys)
 
     @require_tf
     def test_tf_ner(self):
+        mandatory_keys = {"entity", "word", "score"}
         for model_name in NER_FINETUNED_MODELS:
             nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf")
-            self._test_ner_pipeline(nlp)
+            self._test_ner_pipeline(nlp, mandatory_keys)
 
     @require_tf
     def test_tf_ner_grouped(self):
+        mandatory_keys = {"entity_group", "word", "score"}
         for model_name in NER_FINETUNED_MODELS:
             nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf", grouped_entities=True)
-            self._test_ner_pipeline(nlp)
+            self._test_ner_pipeline(nlp, mandatory_keys)
 
 
 class PipelineCommonTests(unittest.TestCase):

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -423,54 +423,6 @@ class QAPipelineTests(unittest.TestCase):
             self._test_qa_pipeline(nlp)
 
 
-class QAPipelineTests(unittest.TestCase):
-    def _test_qa_pipeline(self, nlp):
-        output_keys = {"score", "answer", "start", "end"}
-        valid_inputs = [
-            {"question": "Where was HuggingFace founded ?", "context": "HuggingFace was founded in Paris."},
-            {
-                "question": "In what field is HuggingFace working ?",
-                "context": "HuggingFace is a startup based in New-York founded in Paris which is trying to solve NLP.",
-            },
-        ]
-        invalid_inputs = [
-            {"question": "", "context": "This is a test to try empty question edge case"},
-            {"question": None, "context": "This is a test to try empty question edge case"},
-            {"question": "What is does with empty context ?", "context": ""},
-            {"question": "What is does with empty context ?", "context": None},
-        ]
-        self.assertIsNotNone(nlp)
-
-        mono_result = nlp(valid_inputs[0])
-        self.assertIsInstance(mono_result, dict)
-
-        for key in output_keys:
-            self.assertIn(key, mono_result)
-
-        multi_result = nlp(valid_inputs)
-        self.assertIsInstance(multi_result, list)
-        self.assertIsInstance(multi_result[0], dict)
-
-        for result in multi_result:
-            for key in output_keys:
-                self.assertIn(key, result)
-        for bad_input in invalid_inputs:
-            self.assertRaises(Exception, nlp, bad_input)
-        self.assertRaises(Exception, nlp, invalid_inputs)
-
-    @require_torch
-    def test_torch_question_answering(self):
-        for model_name in QA_FINETUNED_MODELS:
-            nlp = pipeline(task="question-answering", model=model_name, tokenizer=model_name)
-            self._test_qa_pipeline(nlp)
-
-    @require_tf
-    def test_tf_question_answering(self):
-        for model_name in QA_FINETUNED_MODELS:
-            nlp = pipeline(task="question-answering", model=model_name, tokenizer=model_name, framework="tf")
-            self._test_qa_pipeline(nlp)
-
-
 class PipelineCommonTests(unittest.TestCase):
 
     pipelines = SUPPORTED_TASKS.keys()

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -166,34 +166,6 @@ class MonoColumnInputTestCase(unittest.TestCase):
         self.assertRaises(Exception, nlp, invalid_inputs)
 
     @require_torch
-    def test_torch_ner(self):
-        mandatory_keys = {"entity", "word", "score"}
-        for model_name in NER_FINETUNED_MODELS:
-            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name)
-            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
-
-    @require_torch
-    def test_ner_grouped(self):
-        mandatory_keys = {"entity_group", "word", "score"}
-        for model_name in NER_FINETUNED_MODELS:
-            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, grouped_entities=True)
-            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
-
-    @require_tf
-    def test_tf_ner(self):
-        mandatory_keys = {"entity", "word", "score"}
-        for model_name in NER_FINETUNED_MODELS:
-            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf")
-            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
-
-    @require_tf
-    def test_tf_ner_grouped(self):
-        mandatory_keys = {"entity_group", "word", "score"}
-        for model_name in NER_FINETUNED_MODELS:
-            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf", grouped_entities=True)
-            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
-
-    @require_torch
     def test_torch_sentiment_analysis(self):
         mandatory_keys = {"label", "score"}
         for model_name in TEXT_CLASSIF_FINETUNED_MODELS:
@@ -400,6 +372,60 @@ class QAPipelineTests(unittest.TestCase):
         for model_name in QA_FINETUNED_MODELS:
             nlp = pipeline(task="question-answering", model=model_name, tokenizer=model_name, framework="tf")
             self._test_qa_pipeline(nlp)
+
+
+class NerPipelineTests(unittest.TestCase):
+    def _test_ner_pipeline(
+        self, nlp: Pipeline,
+    ):
+        output_keys = {"entity", "word", "score"}
+
+        self.assertIsNotNone(nlp)
+
+        mono_result = nlp(VALID_INPUTS[0], **kwargs)
+        self.assertIsInstance(mono_result, list)
+        self.assertIsInstance(mono_result[0], (dict, list))
+
+        if isinstance(mono_result[0], list):
+            mono_result = mono_result[0]
+
+        for key in output_keys:
+            self.assertIn(key, mono_result[0])
+
+        multi_result = [nlp(input) for input in VALID_INPUTS]
+        self.assertIsInstance(multi_result, list)
+        self.assertIsInstance(multi_result[0], (dict, list))
+
+        if isinstance(multi_result[0], list):
+            multi_result = multi_result[0]
+
+        for result in multi_result:
+            for key in output_keys:
+                self.assertIn(key, result)
+
+    @require_torch
+    def test_torch_ner(self):
+        for model_name in NER_FINETUNED_MODELS:
+            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name)
+            self._test_ner_pipeline(nlp)
+
+    @require_torch
+    def test_ner_grouped(self):
+        for model_name in NER_FINETUNED_MODELS:
+            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, grouped_entities=True)
+            self._test_ner_pipeline(nlp)
+
+    @require_tf
+    def test_tf_ner(self):
+        for model_name in NER_FINETUNED_MODELS:
+            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf")
+            self._test_ner_pipeline(nlp)
+
+    @require_tf
+    def test_tf_ner_grouped(self):
+        for model_name in NER_FINETUNED_MODELS:
+            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf", grouped_entities=True)
+            self._test_ner_pipeline(nlp)
 
 
 class PipelineCommonTests(unittest.TestCase):

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -39,14 +39,6 @@ expected_fill_mask_result = [
     ],
 ]
 
-expected_grouped_ner_result = [
-    [
-        {"entity_group": "B-PER", "score": 0.9710702640669686, "word": "Consuelo Araújo Noguera"},
-        {"entity_group": "B-PER", "score": 0.9997273534536362, "word": "Andrés Pastrana"},
-        {"entity_group": "B-ORG", "score": 0.8589080572128296, "word": "Farc"},
-    ]
-]
-
 SUMMARIZATION_KWARGS = dict(num_beams=2, min_length=2, max_length=5)
 
 
@@ -376,9 +368,43 @@ class QAPipelineTests(unittest.TestCase):
 
 class NerPipelineTests(unittest.TestCase):
     def _test_ner_pipeline(
-        self, nlp: Pipeline,
-        output_keys: Iterable[str],
+        self, nlp: Pipeline, output_keys: Iterable[str],
     ):
+
+        ungrouped_ner_inputs = [
+            [
+                {"entity": "B-PER", "index": 1, "score": 0.9994944930076599, "word": "Cons"},
+                {"entity": "B-PER", "index": 2, "score": 0.8025449514389038, "word": "##uelo"},
+                {"entity": "I-PER", "index": 3, "score": 0.9993102550506592, "word": "Ara"},
+                {"entity": "I-PER", "index": 4, "score": 0.9993743896484375, "word": "##új"},
+                {"entity": "I-PER", "index": 5, "score": 0.9992871880531311, "word": "##o"},
+                {"entity": "I-PER", "index": 6, "score": 0.9993029236793518, "word": "No"},
+                {"entity": "I-PER", "index": 7, "score": 0.9981776475906372, "word": "##guera"},
+                {"entity": "B-PER", "index": 15, "score": 0.9998136162757874, "word": "Andrés"},
+                {"entity": "I-PER", "index": 16, "score": 0.999740719795227, "word": "Pas"},
+                {"entity": "I-PER", "index": 17, "score": 0.9997414350509644, "word": "##tran"},
+                {"entity": "I-PER", "index": 18, "score": 0.9996136426925659, "word": "##a"},
+                {"entity": "B-ORG", "index": 28, "score": 0.9989739060401917, "word": "Far"},
+                {"entity": "I-ORG", "index": 29, "score": 0.7188422083854675, "word": "##c"},
+            ],
+            [
+                {"entity": "I-PER", "index": 1, "score": 0.9968166351318359, "word": "En"},
+                {"entity": "I-PER", "index": 2, "score": 0.9957635998725891, "word": "##zo"},
+                {"entity": "I-ORG", "index": 7, "score": 0.9986497163772583, "word": "UN"},
+            ],
+        ]
+        expected_grouped_ner_results = [
+            [
+                {"entity_group": "B-PER", "score": 0.9710702640669686, "word": "Consuelo Araújo Noguera"},
+                {"entity_group": "B-PER", "score": 0.9997273534536362, "word": "Andrés Pastrana"},
+                {"entity_group": "B-ORG", "score": 0.8589080572128296, "word": "Farc"},
+            ],
+            [
+                {"entity_group": "I-PER", "score": 0.9962901175022125, "word": "Enzo"},
+                {"entity_group": "I-ORG", "score": 0.9986497163772583, "word": "UN"},
+            ],
+        ]
+
         self.assertIsNotNone(nlp)
 
         mono_result = nlp(VALID_INPUTS[0])
@@ -401,6 +427,9 @@ class NerPipelineTests(unittest.TestCase):
         for result in multi_result:
             for key in output_keys:
                 self.assertIn(key, result)
+
+        for ungrouped_input, grouped_result in zip(ungrouped_ner_inputs, expected_grouped_ner_results):
+            self.assertEqual(nlp.group_entities(ungrouped_input), grouped_result)
 
     @require_torch
     def test_torch_ner(self):

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -200,19 +200,9 @@ class MonoColumnInputTestCase(unittest.TestCase):
     @require_tf
     def test_tf_ner_grouped(self):
         mandatory_keys = {"entity_group", "word", "score"}
-        valid_inputs = [
-            "Consuelo Araújo Noguera, ministra de cultura del presidente Andrés Pastrana (1998.2002) fue asesinada por las Farc luego de haber permanecido secuestrada por algunos meses."
-        ]
-        expected_check_keys = ["entity_group", "word"]
-        for model_name in GROUPED_NER_FINETUNED_MODELS:
+        for model_name in NER_FINETUNED_MODELS:
             nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf", grouped_entities=True)
-            self._test_mono_column_pipeline(
-                nlp,
-                valid_inputs,
-                mandatory_keys,
-                expected_multi_result=expected_grouped_ner_result,
-                expected_check_keys=expected_check_keys,
-            )
+            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
 
     @require_torch
     def test_torch_sentiment_analysis(self):

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -166,6 +166,34 @@ class MonoColumnInputTestCase(unittest.TestCase):
         self.assertRaises(Exception, nlp, invalid_inputs)
 
     @require_torch
+    def test_torch_ner(self):
+        mandatory_keys = {"entity", "word", "score"}
+        for model_name in NER_FINETUNED_MODELS:
+            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name)
+            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
+
+    @require_torch
+    def test_ner_grouped(self):
+        mandatory_keys = {"entity_group", "word", "score"}
+        for model_name in NER_FINETUNED_MODELS:
+            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, grouped_entities=True)
+            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
+
+    @require_tf
+    def test_tf_ner(self):
+        mandatory_keys = {"entity", "word", "score"}
+        for model_name in NER_FINETUNED_MODELS:
+            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf")
+            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
+
+    @require_tf
+    def test_tf_ner_grouped(self):
+        mandatory_keys = {"entity_group", "word", "score"}
+        for model_name in NER_FINETUNED_MODELS:
+            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf", grouped_entities=True)
+            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
+
+    @require_torch
     def test_torch_sentiment_analysis(self):
         mandatory_keys = {"label", "score"}
         for model_name in TEXT_CLASSIF_FINETUNED_MODELS:
@@ -372,36 +400,6 @@ class QAPipelineTests(unittest.TestCase):
         for model_name in QA_FINETUNED_MODELS:
             nlp = pipeline(task="question-answering", model=model_name, tokenizer=model_name, framework="tf")
             self._test_qa_pipeline(nlp)
-
-
-class TokenClassificationPipelineTests(unittest.TestCase):
-    @require_torch
-    def test_torch_ner(self):
-        mandatory_keys = {"entity", "word", "score"}
-        for model_name in NER_FINETUNED_MODELS:
-            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name)
-            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
-
-    @require_torch
-    def test_ner_grouped(self):
-        mandatory_keys = {"entity_group", "word", "score"}
-        for model_name in NER_FINETUNED_MODELS:
-            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, grouped_entities=True)
-            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
-
-    @require_tf
-    def test_tf_ner(self):
-        mandatory_keys = {"entity", "word", "score"}
-        for model_name in NER_FINETUNED_MODELS:
-            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf")
-            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
-
-    @require_tf
-    def test_tf_ner_grouped(self):
-        mandatory_keys = {"entity_group", "word", "score"}
-        for model_name in NER_FINETUNED_MODELS:
-            nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, framework="tf", grouped_entities=True)
-            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
 
 
 class PipelineCommonTests(unittest.TestCase):

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -10,7 +10,6 @@ DEFAULT_DEVICE_NUM = -1 if torch_device == "cpu" else 0
 VALID_INPUTS = ["A simple string", ["list of strings"]]
 
 NER_FINETUNED_MODELS = ["sshleifer/tiny-dbmdz-bert-large-cased-finetuned-conll03-english"]
-GROUPED_NER_FINETUNED_MODELS = ["mrm8488/bert-spanish-cased-finetuned-ner"]
 
 # xlnet-base-cased disabled for now, since it crashes TF2
 FEATURE_EXTRACT_FINETUNED_MODELS = ["sshleifer/tiny-distilbert-base-cased"]
@@ -176,19 +175,9 @@ class MonoColumnInputTestCase(unittest.TestCase):
     @require_torch
     def test_ner_grouped(self):
         mandatory_keys = {"entity_group", "word", "score"}
-        valid_inputs = [
-            "Consuelo Araújo Noguera, ministra de cultura del presidente Andrés Pastrana (1998.2002) fue asesinada por las Farc luego de haber permanecido secuestrada por algunos meses."
-        ]
-        expected_check_keys = ["entity_group", "word"]
-        for model_name in GROUPED_NER_FINETUNED_MODELS:
+        for model_name in NER_FINETUNED_MODELS:
             nlp = pipeline(task="ner", model=model_name, tokenizer=model_name, grouped_entities=True)
-            self._test_mono_column_pipeline(
-                nlp,
-                valid_inputs,
-                mandatory_keys,
-                expected_multi_result=expected_grouped_ner_result,
-                expected_check_keys=expected_check_keys,
-            )
+            self._test_mono_column_pipeline(nlp, VALID_INPUTS, mandatory_keys)
 
     @require_tf
     def test_tf_ner(self):


### PR DESCRIPTION
### This PR solves issue #4816 by:

1. Applying entity grouping to similar entity types with different prefixes (i.e. `B` and `I`)
2. Ensuring that separate entities at the last filtered index are no longer excluded from grouping.


Running the sample script below (based on reference issue #4816) returns the expected results. Do note that the `entity_group` is based on the `entity_type` of the first entity in the group.

```
from transformers import pipeline
NER_MODEL = "mrm8488/bert-spanish-cased-finetuned-ner"
nlp_ner = pipeline("ner", model=NER_MODEL,
                   grouped_entities=True,
                   tokenizer=(NER_MODEL, {"use_fast": False}))

t = """Consuelo Araújo Noguera, ministra de cultura del presidente Andrés Pastrana (1998.2002) fue asesinada por las Farc luego de haber permanecido secuestrada por algunos meses."""
nlp_ner(t)

[{'entity_group': 'B-PER', 'score': 0.9710702640669686, 'word': 'Consuelo Araújo Noguera'},
 {'entity_group': 'B-PER', 'score': 0.9997273534536362, 'word': 'Andrés Pastrana'},
 {'entity_group': 'B-ORG', 'score': 0.8589080572128296, 'word': 'Farc'}]
```

I also ran another test to ensure that number 2 (separate entity at the last index) is working properly. I confirmed that it is working properly now.

```
nlp = pipeline('ner', grouped_entities=False)
nlp("Enzo works at the the UN")
[{'entity': 'I-PER', 'index': 1, 'score': 0.9968166351318359, 'word': 'En'},
 {'entity': 'I-PER', 'index': 2, 'score': 0.9957635998725891, 'word': '##zo'},
 {'entity': 'I-ORG', 'index': 7, 'score': 0.9986497163772583, 'word': 'UN'}]

nlp2 = pipeline('ner', grouped_entities=True)
nlp2("Enzo works at the the UN")
[{'entity_group': 'I-PER', 'score': 0.9962901175022125, 'word': 'Enzo'},
 {'entity_group': 'I-ORG', 'score': 0.9986497163772583, 'word': 'UN'}]

```

You can test these out yourself in this colab [notebook](https://colab.research.google.com/drive/1D0xK7MSOQcxOCAe8hpnpFVqdoKrmejSS?usp=sharing).

cc @dav009 @mfuntowicz