### PR TITLE
append keyword arguments to the output

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -789,7 +789,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         return model
 
     def prepare_inputs_for_generation(self, input_ids, **kwargs):
-        return {"input_ids": input_ids}
+        return {"input_ids": input_ids, **kwargs}
 
     def prepare_logits_for_generation(self, logits, **kwargs):
         return logits


### PR DESCRIPTION
prepare_inputs_for_generation function receives keyword arguments (model_specific_kwargs)
However, these arguments are not ignored.
I fix this codes to return arguments including these keyword arguments.

Actually, I don't have an idea about the purpose of prepare_logits_for_generation function, which only returns the logit values.