### PR TITLE
[Bart] Question Answering Model is added to tests

### DIFF
--- a/tests/test_modeling_bart.py
+++ b/tests/test_modeling_bart.py
@@ -113,7 +113,9 @@ def prepare_bart_inputs_dict(
 @require_torch
 class BARTModelTest(ModelTesterMixin, unittest.TestCase):
     all_model_classes = (
-        (BartModel, BartForConditionalGeneration, BartForSequenceClassification) if is_torch_available() else ()
+        (BartModel, BartForConditionalGeneration, BartForSequenceClassification, BartForQuestionAnswering)
+        if is_torch_available()
+        else ()
     )
     all_generative_model_classes = (BartForConditionalGeneration,) if is_torch_available() else ()
     is_encoder_decoder = True

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -38,6 +38,7 @@ if is_torch_available():
         BertConfig,
         BERT_PRETRAINED_MODEL_ARCHIVE_LIST,
         MODEL_FOR_MULTIPLE_CHOICE_MAPPING,
+        MODEL_FOR_QUESTION_ANSWERING_MAPPING,
         top_k_top_p_filtering,
     )
 
@@ -180,7 +181,12 @@ class ModelTesterMixin:
                 correct_outlen = 4
                 decoder_attention_idx = 1
 
-                if "lm_labels" in inputs_dict:  # loss will come first
+                # loss is at first position
+                if "labels" in inputs_dict:
+                    correct_outlen += 1  # compute loss
+                    decoder_attention_idx += 1
+                # Question Answering model returns start_logits and end_logits
+                if model_class in MODEL_FOR_QUESTION_ANSWERING_MAPPING.values():
                     correct_outlen += 1  # compute loss
                     decoder_attention_idx += 1
                 self.assertEqual(out_len, correct_outlen)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -183,7 +183,7 @@ class ModelTesterMixin:
 
                 # loss is at first position
                 if "labels" in inputs_dict:
-                    correct_outlen += 1  # compute loss
+                    correct_outlen += 1  # loss is added to beginning
                     decoder_attention_idx += 1
                 # Question Answering model returns start_logits and end_logits
                 if model_class in MODEL_FOR_QUESTION_ANSWERING_MAPPING.values():

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -187,7 +187,7 @@ class ModelTesterMixin:
                     decoder_attention_idx += 1
                 # Question Answering model returns start_logits and end_logits
                 if model_class in MODEL_FOR_QUESTION_ANSWERING_MAPPING.values():
-                    correct_outlen += 1  # compute loss
+                    correct_outlen += 1  # start_logits and end_logits instead of only 1 output
                     decoder_attention_idx += 1
                 self.assertEqual(out_len, correct_outlen)
 


### PR DESCRIPTION
As written in PR #4908, the Bart for QA was not added to the test suite. This PR fixes the output attentions test for encoder decoder QA models.

If we would have named tuples, such a test could be made much much cleaner.