### PR TITLE
Add pad_to_multiple_of on tokenizers (reimport)

### DIFF
--- a/src/transformers/tokenization_roberta.py
+++ b/src/transformers/tokenization_roberta.py
@@ -241,7 +241,7 @@ class RobertaTokenizer(GPT2Tokenizer):
 
     def prepare_for_tokenization(self, text, is_pretokenized=False, **kwargs):
         add_prefix_space = kwargs.pop("add_prefix_space", self.add_prefix_space)
-        if (is_pretokenized or add_prefix_space) and text:
+        if (is_pretokenized or add_prefix_space) and (len(text) > 0 and not text[0].isspace()):
             text = " " + text
         return (text, kwargs)
 

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -681,8 +681,8 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
             if padding_strategy is not PaddingStrategy.MAX_LENGTH:
                 logger.info(
                     "Overriding padding_strategy from {} to {} as required by pad_to_multiple_of={}",
-                    padding_strategy,
-                    PaddingStrategy.MAX_LENGTH,
+                    padding_strategy.name,
+                    PaddingStrategy.MAX_LENGTH.name,
                     pad_to_multiple_of,
                 )
             # max_length becomes multiple of provided integer

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -668,7 +668,8 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
         if pad_to_multiple_of is not None:
             if self.pad_token is None:
                 logger.warning(
-                    "No padding token set, pad_to_multiple_of={} will not be used".format(pad_to_multiple_of)
+                    "No padding token set, pad_to_multiple_of=%d will not be used",
+                    pad_to_multiple_of
                 )
 
             target_length = ((total_len // pad_to_multiple_of) + 1) * pad_to_multiple_of
@@ -676,7 +677,7 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
             # Warn the user about new max_length value
             if max_length is not None:
                 logger.info(
-                    "Overriding max_length {} to {} parameter to satisfy constraint pad_to_multiple_of {}",
+                    "Overriding max_length %s to %s parameter to satisfy constraint pad_to_multiple_of %d",
                     max_length,
                     target_length,
                     pad_to_multiple_of,
@@ -685,7 +686,7 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
             # Warn the user about new padding_strategy
             if padding_strategy is not PaddingStrategy.MAX_LENGTH:
                 logger.info(
-                    "Overriding padding_strategy from {} to {} as required by pad_to_multiple_of={}",
+                    "Overriding padding_strategy from %s to %s as required by pad_to_multiple_of=%d",
                     padding_strategy.name,
                     PaddingStrategy.MAX_LENGTH.name,
                     pad_to_multiple_of,

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -671,29 +671,29 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
                     "No padding token set, pad_to_multiple_of=%d will not be used",
                     pad_to_multiple_of
                 )
+            else:
+                target_length = ((total_len // pad_to_multiple_of) + 1) * pad_to_multiple_of
 
-            target_length = ((total_len // pad_to_multiple_of) + 1) * pad_to_multiple_of
+                # Warn the user about new max_length value
+                if max_length is not None:
+                    logger.info(
+                        "Overriding max_length %s to %s parameter to satisfy constraint pad_to_multiple_of %d",
+                        max_length,
+                        target_length,
+                        pad_to_multiple_of,
+                    )
 
-            # Warn the user about new max_length value
-            if max_length is not None:
-                logger.info(
-                    "Overriding max_length %s to %s parameter to satisfy constraint pad_to_multiple_of %d",
-                    max_length,
-                    target_length,
-                    pad_to_multiple_of,
-                )
-
-            # Warn the user about new padding_strategy
-            if padding_strategy is not PaddingStrategy.MAX_LENGTH:
-                logger.info(
-                    "Overriding padding_strategy from %s to %s as required by pad_to_multiple_of=%d",
-                    padding_strategy.name,
-                    PaddingStrategy.MAX_LENGTH.name,
-                    pad_to_multiple_of,
-                )
-            # max_length becomes multiple of provided integer
-            max_length = target_length
-            padding_strategy = PaddingStrategy.MAX_LENGTH
+                # Warn the user about new padding_strategy
+                if padding_strategy is not PaddingStrategy.MAX_LENGTH:
+                    logger.info(
+                        "Overriding padding_strategy from %s to %s as required by pad_to_multiple_of=%d",
+                        padding_strategy.name,
+                        PaddingStrategy.MAX_LENGTH.name,
+                        pad_to_multiple_of,
+                    )
+                # max_length becomes multiple of provided integer
+                max_length = target_length
+                padding_strategy = PaddingStrategy.MAX_LENGTH
 
         # Truncation: Handle max sequence length
         if truncation_strategy != TruncationStrategy.DO_NOT_TRUNCATE and max_length and total_len > max_length:

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -667,10 +667,7 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
         # Manage padding as multiple of provided integer
         if pad_to_multiple_of is not None:
             if self.pad_token is None:
-                logger.warning(
-                    "No padding token set, pad_to_multiple_of=%d will not be used",
-                    pad_to_multiple_of
-                )
+                logger.warning("No padding token set, pad_to_multiple_of=%d will not be used", pad_to_multiple_of)
             else:
                 target_length = ((total_len // pad_to_multiple_of) + 1) * pad_to_multiple_of
 

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -666,6 +666,11 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
 
         # Manage padding as multiple of provided integer
         if pad_to_multiple_of is not None:
+            if self.pad_token is None:
+                logger.warning(
+                    "No padding token set, pad_to_multiple_of={} will not be used".format(pad_to_multiple_of)
+                )
+
             target_length = ((total_len // pad_to_multiple_of) + 1) * pad_to_multiple_of
 
             # Warn the user about new max_length value

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -942,6 +942,9 @@ ENCODE_KWARGS_DOCSTRING = r"""
                 The value of this argument defines the number of overlapping tokens.
             is_pretokenized (:obj:`bool`, defaults to :obj:`False`):
                 Set to True to indicate the input is already tokenized
+            pad_to_multiple_of: (optional) Integer if set will pad the sequence to a multiple of the provided value.
+                This is especially useful to enable the use of Tensor Core on NVIDIA hardware with compute capability
+                >= 7.5 (Volta).
             return_tensors (:obj:`str`, `optional`, defaults to :obj:`None`):
                 Can be set to 'tf', 'pt' or 'np' to return respectively TensorFlow :obj:`tf.constant`,
                 PyTorch :obj:`torch.Tensor` or Numpy :oj: `np.ndarray` instead of a list of python integers.
@@ -1522,6 +1525,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
         max_length: Optional[int] = None,
         stride: int = 0,
         is_pretokenized: bool = False,
+        pad_to_multiple_of: Optional[int] = None,
         return_tensors: Optional[Union[str, TensorType]] = None,
         return_token_type_ids: Optional[bool] = None,
         return_attention_mask: Optional[bool] = None,
@@ -1563,6 +1567,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
                 max_length=max_length,
                 stride=stride,
                 is_pretokenized=is_pretokenized,
+                pad_to_multiple_of=pad_to_multiple_of,
                 return_tensors=return_tensors,
                 return_token_type_ids=return_token_type_ids,
                 return_attention_mask=return_attention_mask,
@@ -1583,6 +1588,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
                 max_length=max_length,
                 stride=stride,
                 is_pretokenized=is_pretokenized,
+                pad_to_multiple_of=pad_to_multiple_of,
                 return_tensors=return_tensors,
                 return_token_type_ids=return_token_type_ids,
                 return_attention_mask=return_attention_mask,
@@ -1605,6 +1611,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
         max_length: Optional[int] = None,
         stride: int = 0,
         is_pretokenized: bool = False,
+        pad_to_multiple_of: Optional[int] = None,
         return_tensors: Optional[Union[str, TensorType]] = None,
         return_token_type_ids: Optional[bool] = None,
         return_attention_mask: Optional[bool] = None,
@@ -1644,6 +1651,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
             max_length=max_length,
             stride=stride,
             is_pretokenized=is_pretokenized,
+            pad_to_multiple_of=pad_to_multiple_of,
             return_tensors=return_tensors,
             return_token_type_ids=return_token_type_ids,
             return_attention_mask=return_attention_mask,
@@ -1665,6 +1673,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
         max_length: Optional[int] = None,
         stride: int = 0,
         is_pretokenized: bool = False,
+        pad_to_multiple_of: Optional[int] = None,
         return_tensors: Optional[Union[str, TensorType]] = None,
         return_token_type_ids: Optional[bool] = None,
         return_attention_mask: Optional[bool] = None,
@@ -1694,6 +1703,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
         max_length: Optional[int] = None,
         stride: int = 0,
         is_pretokenized: bool = False,
+        pad_to_multiple_of: Optional[int] = None,
         return_tensors: Optional[Union[str, TensorType]] = None,
         return_token_type_ids: Optional[bool] = None,
         return_attention_mask: Optional[bool] = None,
@@ -1731,6 +1741,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
             max_length=max_length,
             stride=stride,
             is_pretokenized=is_pretokenized,
+            pad_to_multiple_of=pad_to_multiple_of,
             return_tensors=return_tensors,
             return_token_type_ids=return_token_type_ids,
             return_attention_mask=return_attention_mask,
@@ -1758,6 +1769,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
         max_length: Optional[int] = None,
         stride: int = 0,
         is_pretokenized: bool = False,
+        pad_to_multiple_of: Optional[int] = None,
         return_tensors: Optional[Union[str, TensorType]] = None,
         return_token_type_ids: Optional[bool] = None,
         return_attention_mask: Optional[bool] = None,

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -319,7 +319,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
 
         if pad_to_multiple_of is not None and padding_strategy != PaddingStrategy.MAX_LENGTH:
             logger.info(
-                "Overriding padding_strategy from {} to {} as required by pad_to_multiple_of={}",
+                "Overriding padding_strategy from %s to %s as required by pad_to_multiple_of=%d",
                 padding_strategy.name,
                 PaddingStrategy.MAX_LENGTH.name,
                 pad_to_multiple_of

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -322,7 +322,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
                 "Overriding padding_strategy from %s to %s as required by pad_to_multiple_of=%d",
                 padding_strategy.name,
                 PaddingStrategy.MAX_LENGTH.name,
-                pad_to_multiple_of
+                pad_to_multiple_of,
             )
 
             padding_strategy = PaddingStrategy.MAX_LENGTH
@@ -333,7 +333,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
             truncation_strategy=truncation_strategy,
             max_length=max_length,
             stride=stride,
-            pad_to_multiple_of=pad_to_multiple_of
+            pad_to_multiple_of=pad_to_multiple_of,
         )
 
         # Avoid thread overhead if only one example.

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -320,8 +320,8 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         if pad_to_multiple_of is not None and padding_strategy != PaddingStrategy.MAX_LENGTH:
             logger.info(
                 "Overriding padding_strategy from {} to {} as required by pad_to_multiple_of={}",
-                padding_strategy,
-                PaddingStrategy.MAX_LENGTH,
+                padding_strategy.name,
+                PaddingStrategy.MAX_LENGTH.name,
                 pad_to_multiple_of
             )
 

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -317,16 +317,6 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         if kwargs:
             raise ValueError(f"Keyword arguments {kwargs} not recognized.")
 
-        if pad_to_multiple_of is not None and padding_strategy != PaddingStrategy.MAX_LENGTH:
-            logger.info(
-                "Overriding padding_strategy from %s to %s as required by pad_to_multiple_of=%d",
-                padding_strategy.name,
-                PaddingStrategy.MAX_LENGTH.name,
-                pad_to_multiple_of,
-            )
-
-            padding_strategy = PaddingStrategy.MAX_LENGTH
-
         # Set the truncation and padding strategy and restore the initial configuration
         self.set_truncation_and_padding(
             padding_strategy=padding_strategy,

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -246,25 +246,26 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         return self._tokenizer.encode(text, pair, add_special_tokens=add_special_tokens).tokens
 
     def set_truncation_and_padding(
-        self, padding_strategy: PaddingStrategy, truncation_strategy: TruncationStrategy, max_length: int, stride: int,
+        self,
+        padding_strategy: PaddingStrategy,
+        truncation_strategy: TruncationStrategy,
+        max_length: int,
+        stride: int,
+        pad_to_multiple_of: Optional[int],
     ):
-        """ This contextmanager is in charge of defining the truncation and the padding strategies for fast tokenizers
+        """ Define the truncation and the padding strategies for fast tokenizers
             (provided by HuggingFace tokenizers library) and restore the tokenizer settings afterwards.
 
-            This contextmanager assumes the provider tokenizer has no padding / truncation strategy
+            The provided tokenizer has no padding / truncation strategy
             before the managed section. If your tokenizer set a padding / truncation strategy before,
             then it will be reset to no padding/truncation when exiting the managed section.
 
             Args:
-                tokenizer (BaseTokenizerFast): The tokenizer which will be used
-                max_length (int): The maximum size of the sequence
-                stride (int): The stride to use when handling overflow
-                strategy (str): Overflowing logic to use
-                pad_to_max_length (bool): Boolean indicating if the output needs to be padded up to max_length
-                padding_side (str): "left" or "right" indicating the direction the output sequence will be padded
-                pad_token_id (int): The integer representation of the padding token to use
-                pad_token_type_id (int): The integer representation of the padding token type to use
-                pad_token (str): The string representation of the padding token to use
+                padding_strategy (:obj:`PaddingStrategy`): The kind of padding that will be applied to the input
+                truncation_strategy (:obj:`TruncationStrategy`): The kind of truncation that will be applied to the input
+                max_length (:obj:`int`): The maximum size of the sequence
+                stride (:obj:`int`): The stride to use when handling overflow
+                pad_to_multiple_of (:obj:`int`, `optional`, defaults to `None`)
 
         """
         # Set truncation and padding on the backend tokenizer
@@ -280,6 +281,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
                 pad_id=self.pad_token_id,
                 pad_type_id=self.pad_token_type_id,
                 pad_token=self.pad_token,
+                pad_to_multiple_of=pad_to_multiple_of,
             )
         else:
             self._tokenizer.no_padding()
@@ -295,6 +297,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         max_length: Optional[int] = None,
         stride: int = 0,
         is_pretokenized: bool = False,
+        pad_to_multiple_of: Optional[int] = None,
         return_tensors: Optional[str] = None,
         return_token_type_ids: Optional[bool] = None,
         return_attention_mask: Optional[bool] = None,
@@ -314,12 +317,23 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         if kwargs:
             raise ValueError(f"Keyword arguments {kwargs} not recognized.")
 
+        if pad_to_multiple_of is not None and padding_strategy != PaddingStrategy.MAX_LENGTH:
+            logger.info(
+                "Overriding padding_strategy from {} to {} as required by pad_to_multiple_of={}",
+                padding_strategy,
+                PaddingStrategy.MAX_LENGTH,
+                pad_to_multiple_of
+            )
+
+            padding_strategy = PaddingStrategy.MAX_LENGTH
+
         # Set the truncation and padding strategy and restore the initial configuration
         self.set_truncation_and_padding(
             padding_strategy=padding_strategy,
             truncation_strategy=truncation_strategy,
             max_length=max_length,
             stride=stride,
+            pad_to_multiple_of=pad_to_multiple_of
         )
 
         # Avoid thread overhead if only one example.
@@ -388,6 +402,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         max_length: Optional[int] = None,
         stride: int = 0,
         is_pretokenized: bool = False,
+        pad_to_multiple_of: Optional[int] = None,
         return_tensors: Optional[bool] = None,
         return_token_type_ids: Optional[bool] = None,
         return_attention_mask: Optional[bool] = None,
@@ -408,6 +423,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
             truncation_strategy=truncation_strategy,
             max_length=max_length,
             stride=stride,
+            pad_to_multiple_of=pad_to_multiple_of,
             return_tensors=return_tensors,
             return_token_type_ids=return_token_type_ids,
             return_attention_mask=return_attention_mask,

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -890,14 +890,32 @@ class TokenizerTesterMixin:
                 self.skipTest("No padding token.")
             else:
                 with self.subTest(f"{tokenizer.__class__.__name__}"):
-                    empty_tokens = tokenizer("", pad_to_multiple_of=8)
-                    normal_tokens = tokenizer("This is a sample input", pad_to_multiple_of=8)
-
+                    empty_tokens = tokenizer("", padding=True, pad_to_multiple_of=8)
+                    normal_tokens = tokenizer("This is a sample input", padding=True, pad_to_multiple_of=8)
                     for key, value in empty_tokens.items():
                         self.assertEqual(len(value) % 8, 0, "BatchEncoding.{} is not multiple of 8".format(key))
-
                     for key, value in normal_tokens.items():
                         self.assertEqual(len(value) % 8, 0, "BatchEncoding.{} is not multiple of 8".format(key))
+
+                    normal_tokens = tokenizer("This", pad_to_multiple_of=8)
+                    for key, value in normal_tokens.items():
+                        self.assertNotEqual(len(value) % 8, 0, "BatchEncoding.{} is not multiple of 8".format(key))
+
+                    # Should also work with truncation
+                    normal_tokens = tokenizer("This", padding=True, truncation=True, pad_to_multiple_of=8)
+                    for key, value in normal_tokens.items():
+                        self.assertEqual(len(value) % 8, 0, "BatchEncoding.{} is not multiple of 8".format(key))
+
+                    # truncation to something which is not a multiple of pad_to_multiple_of raises an error
+                    self.assertRaises(
+                        ValueError,
+                        tokenizer.__call__,
+                        "This",
+                        padding=True,
+                        truncation=True,
+                        max_length=12,
+                        pad_to_multiple_of=8,
+                    )
 
     def test_encode_plus_with_padding(self):
         tokenizers = self.get_tokenizers(do_lower_case=False)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -883,6 +883,19 @@ class TokenizerTesterMixin:
                 assert sequence_length == padded_sequence_right_length
                 assert encoded_sequence == padded_sequence_right
 
+    def test_padding_to_multiple_of(self):
+        tokenizers = self.get_tokenizers()
+        for tokenizer in tokenizers:
+            with self.subTest(f"{tokenizer.__class__.__name__}"):
+                empty_tokens = tokenizer("", pad_to_multiple_of=8)
+                normal_tokens = tokenizer("This is a sample input", pad_to_multiple_of=8)
+
+                for key, value in empty_tokens:
+                    self.assertEqual(len(value) % 8, 0, "BatchEncoding.{} is not multiple of 8".format(key))
+
+                for key, value in normal_tokens:
+                    self.assertEqual(len(value) % 8, 0, "BatchEncoding.{} is not multiple of 8".format(key))
+
     def test_encode_plus_with_padding(self):
         tokenizers = self.get_tokenizers(do_lower_case=False)
         for tokenizer in tokenizers:

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -886,15 +886,18 @@ class TokenizerTesterMixin:
     def test_padding_to_multiple_of(self):
         tokenizers = self.get_tokenizers()
         for tokenizer in tokenizers:
-            with self.subTest(f"{tokenizer.__class__.__name__}"):
-                empty_tokens = tokenizer("", pad_to_multiple_of=8)
-                normal_tokens = tokenizer("This is a sample input", pad_to_multiple_of=8)
+            if tokenizer.pad_token is None:
+                self.skipTest("No padding token.")
+            else:
+                with self.subTest(f"{tokenizer.__class__.__name__}"):
+                    empty_tokens = tokenizer("", pad_to_multiple_of=8)
+                    normal_tokens = tokenizer("This is a sample input", pad_to_multiple_of=8)
 
-                for key, value in empty_tokens.items():
-                    self.assertEqual(len(value) % 8, 0, "BatchEncoding.{} is not multiple of 8".format(key))
+                    for key, value in empty_tokens.items():
+                        self.assertEqual(len(value) % 8, 0, "BatchEncoding.{} is not multiple of 8".format(key))
 
-                for key, value in normal_tokens.items():
-                    self.assertEqual(len(value) % 8, 0, "BatchEncoding.{} is not multiple of 8".format(key))
+                    for key, value in normal_tokens.items():
+                        self.assertEqual(len(value) % 8, 0, "BatchEncoding.{} is not multiple of 8".format(key))
 
     def test_encode_plus_with_padding(self):
         tokenizers = self.get_tokenizers(do_lower_case=False)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -890,10 +890,10 @@ class TokenizerTesterMixin:
                 empty_tokens = tokenizer("", pad_to_multiple_of=8)
                 normal_tokens = tokenizer("This is a sample input", pad_to_multiple_of=8)
 
-                for key, value in empty_tokens:
+                for key, value in empty_tokens.items():
                     self.assertEqual(len(value) % 8, 0, "BatchEncoding.{} is not multiple of 8".format(key))
 
-                for key, value in normal_tokens:
+                for key, value in normal_tokens.items():
                     self.assertEqual(len(value) % 8, 0, "BatchEncoding.{} is not multiple of 8".format(key))
 
     def test_encode_plus_with_padding(self):


### PR DESCRIPTION
Reimported from #4731.

Introduce `pad_to_multiple_of` on both slow and fast tokenizers. This parameter introduces the "bucketizaton behaviour" also refered as Shape Polymorphism. 

This is especially usefull when targetting NN dedicated accelerators such as: 
- NVidia Tensor Core (on >= Volta Architecture)
- XLA (PyTorch TPU)
- XLA (Jax / Flax)

Bonus:
- Fix RobertaTokenizer when input is empty `text[0].is_space()` would crash (#3608).

Edit (@thomwolf): 
- updated to the new API
- raise a `ValueError` if you want to truncation to a length which is not a multiple of `pad_to_multiple_of`