### PR TITLE
[cleanup] examples test_run_squad uses tiny model

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -55,7 +55,7 @@ class ExamplesTests(unittest.TestCase):
 
         testargs = """
             run_glue.py
-            --model_name_or_path bert-base-uncased
+            --model_name_or_path distilbert-base-uncased
             --data_dir ./tests/fixtures/tests_samples/MRPC/
             --task_name mrpc
             --do_train
@@ -79,6 +79,7 @@ class ExamplesTests(unittest.TestCase):
     def test_run_language_modeling(self):
         stream_handler = logging.StreamHandler(sys.stdout)
         logger.addHandler(stream_handler)
+        # TODO: switch to smaller model like sshleifer/tiny-distilroberta-base
 
         testargs = """
             run_language_modeling.py
@@ -105,10 +106,9 @@ class ExamplesTests(unittest.TestCase):
 
         testargs = """
             run_squad.py
-            --model_type=bert
-            --model_name_or_path=bert-base-uncased
+            --model_type=distilbert
+            --model_name_or_path=sshleifer/tiny-distilbert-base-cased-distilled-squad
             --data_dir=./tests/fixtures/tests_samples/SQUAD
-            --model_name=bert-base-uncased
             --output_dir=./tests/fixtures/tests_samples/temp_dir
             --max_steps=10
             --warmup_steps=2
@@ -123,15 +123,15 @@ class ExamplesTests(unittest.TestCase):
         """.split()
         with patch.object(sys, "argv", testargs):
             result = run_squad.main()
-            self.assertGreaterEqual(result["f1"], 30)
-            self.assertGreaterEqual(result["exact"], 30)
+            self.assertGreaterEqual(result["f1"], 25)
+            self.assertGreaterEqual(result["exact"], 21)
 
     def test_generation(self):
         stream_handler = logging.StreamHandler(sys.stdout)
         logger.addHandler(stream_handler)
 
         testargs = ["run_generation.py", "--prompt=Hello", "--length=10", "--seed=42"]
-        model_type, model_name = ("--model_type=openai-gpt", "--model_name_or_path=openai-gpt")
+        model_type, model_name = ("--model_type=gpt2", "--model_name_or_path=sshleifer/tiny-gpt2")
         with patch.object(sys, "argv", testargs + [model_type, model_name]):
             result = run_generation.main()
             self.assertGreaterEqual(len(result[0]), 10)


### PR DESCRIPTION
This speeds up the examples tests from 120s to 70s.
Note that this probably understates the difference, since all the relevant models are cached on my local machine.
We can also improve `test_run_glue` in a future PR.
I made an issue discussing improvements this PR does not fix: #5059 


### More detail:

Before (master):  119.36s


```bash
============================ slowest test durations ============================
42.69s call     examples/test_examples.py::ExamplesTests::test_run_squad
21.20s call     examples/test_examples.py::ExamplesTests::test_run_glue
19.02s call     examples/token-classification/test_ner_examples.py::ExamplesTests::test_run_ner
13.65s call     examples/test_examples.py::ExamplesTests::test_run_language_modeling
3.80s call     examples/test_examples.py::ExamplesTests::test_generation

```
After: 69.3 Seconds
```bash
============================ slowest test durations ============================
19.12s call     examples/token-classification/test_ner_examples.py::ExamplesTests::test_run_ner
14.60s call     examples/test_examples.py::ExamplesTests::test_run_language_modeling
13.49s call     examples/test_examples.py::ExamplesTests::test_run_glue
3.87s call     examples/summarization/test_summarization_examples.py::TestBartExamples::test_bart_run_sum_cli
3.08s call     examples/translation/t5/test_t5_examples.py::TestT5Examples::test_t5_cli
2.64s call     examples/summarization/test_summarization_examples.py::TestT5Examples::test_t5_cli
2.20s call     examples/summarization/test_summarization_examples.py::TestBartExamples::test_t5_run_sum_cli
1.81s call     examples/test_examples.py::ExamplesTests::test_run_squad
1.67s call     examples/test_examples.py::ExamplesTests::test_generation

```
