### PR TITLE
Add missing arg in 02-transformers notebook

### DIFF
--- a/notebooks/02-transformers.ipynb
+++ b/notebooks/02-transformers.ipynb
@@ -221,7 +221,7 @@
    },
    "source": [
     "The code you saw in the previous section introduced all the steps required to do simple model invocation.\n",
-    "For more day-to-day usage, transformers provides you higher-level methods which will makes your NLP journey easier\n",
+    "For more day-to-day usage, transformers provides you higher-level methods which will makes your NLP journey easier.\n",
     "Let's improve our previous example"
    ]
   },
@@ -268,7 +268,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see above, the methode `encode_plus` provides a convenient way to generate all the required parameters\n",
+    "As you can see above, the method `encode_plus` provides a convenient way to generate all the required parameters\n",
     "that will go through the model. \n",
     "\n",
     "Moreover, you might have noticed it generated some additional tensors: \n",

--- a/notebooks/02-transformers.ipynb
+++ b/notebooks/02-transformers.ipynb
@@ -133,7 +133,7 @@
     "MODEL_NAME = \"bert-base-cased\"\n",
     "\n",
     "# We need to create the model and tokenizer\n",
-    "model = AutoModel.from_pretrained(MODEL_NAME, from_tf=True)\n",
+    "model = AutoModel.from_pretrained(MODEL_NAME)\n",
     "tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)"
    ]
   },

--- a/notebooks/02-transformers.ipynb
+++ b/notebooks/02-transformers.ipynb
@@ -133,7 +133,7 @@
     "MODEL_NAME = \"bert-base-cased\"\n",
     "\n",
     "# We need to create the model and tokenizer\n",
-    "model = AutoModel.from_pretrained(MODEL_NAME)\n",
+    "model = AutoModel.from_pretrained(MODEL_NAME, from_tf=True)\n",
     "tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)"
    ]
   },


### PR DESCRIPTION
Add missing `from_tf=True` arg when creating the model `AutoModel.from_pretrained()` to avoid an OSError from loading a PyTorch model from a TF 2.0 checkpoint.

Also fixed two small typos in markdown text.