### PR TITLE
SummarizationPipeline: init required task name

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1392,7 +1392,7 @@ class SummarizationPipeline(Pipeline):
     """
 
     def __init__(self, task: str = "summarization", **kwargs):
-        kwargs.update(task=task)
+        kwargs.update(task='summarization')
         super().__init__(**kwargs)
 
     def __call__(

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1391,6 +1391,10 @@ class SummarizationPipeline(Pipeline):
             on the associated CUDA device id.
     """
 
+    def __init__(self, task: str = "summarization", **kwargs):
+        kwargs.update(task=task)
+        super().__init__(**kwargs)
+
     def __call__(
         self, *documents, return_tensors=False, return_text=True, clean_up_tokenization_spaces=False, **generate_kwargs
     ):

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1391,8 +1391,8 @@ class SummarizationPipeline(Pipeline):
             on the associated CUDA device id.
     """
 
-    def __init__(self, task: str = "summarization", **kwargs):
-        kwargs.update(task='summarization')
+    def __init__(self, **kwargs):
+        kwargs.update(task="summarization")
         super().__init__(**kwargs)
 
     def __call__(


### PR DESCRIPTION
Otherwise, can't do:


```python
tokenizer = AutoTokenizer.from_pretrained("facebook/bart-large-cnn")
model = AutoModelWithLMHead.from_pretrained("facebook/bart-large-cnn")
p = SummarizationPipeline(model=model, tokenizer=tokenizer)

p("Long boring text to summarize, etc. etc.")
```