### PR TITLE
[style] add pandas to setup.cfg

### DIFF
--- a/examples/longform-qa/eli5_utils.py
+++ b/examples/longform-qa/eli5_utils.py
@@ -5,6 +5,7 @@ from random import choice, randint
 from time import time
 
 import numpy as np
+import pandas as pd
 import torch
 import torch.utils.checkpoint as checkpoint
 from torch.utils.data import DataLoader, Dataset, RandomSampler, SequentialSampler
@@ -12,7 +13,6 @@ from tqdm import tqdm
 
 import faiss  # noqa: F401
 import nlp  # noqa: F401
-import pandas as pd
 from elasticsearch import Elasticsearch  # noqa: F401
 from elasticsearch.helpers import bulk, streaming_bulk  # noqa: F401
 from transformers import AdamW, AutoModel, AutoModelForSeq2SeqLM, AutoTokenizer, get_linear_schedule_with_warmup

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ known_third_party =
     nltk
     numpy
     packaging
+    pandas
     PIL
     psutil
     pytorch_lightning


### PR DESCRIPTION
Need to add pandas to setup.cfg. Otherwise, for people that have pandas installed locally isort tries to change `eli5_utils.py` everytime.
