### PR TITLE
Fix TF WarmUp class

### DIFF
--- a/src/transformers/optimization_tf.py
+++ b/src/transformers/optimization_tf.py
@@ -44,7 +44,7 @@ class WarmUp(tf.keras.optimizers.schedules.LearningRateSchedule):
             return tf.cond(
                 global_step_float < warmup_steps_float,
                 lambda: warmup_learning_rate,
-                lambda: self.decay_schedule_fn(step),
+                lambda: self.decay_schedule_fn(step - self.warmup_steps),
                 name=name,
             )
 


### PR DESCRIPTION
This commit fixes the TF WarmUp learning rate scheduler.

The LR shape was wrong due to warmup steps. See linked issue for more details.

Fix #5098