### PR TITLE
[fix] Move _adjust_logits above postprocess to fix Marian.generate

### DIFF
--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -993,7 +993,7 @@ class BartForConditionalGeneration(PretrainedBartModel):
             "use_cache": use_cache,  # change this to avoid caching (presumably for debugging)
         }
 
-    def _adjust_logits(self, logits, cur_len, max_length):
+    def adjust_logits_during_generation(self, logits, cur_len, max_length):
         if cur_len == 1:
             self._force_token_ids_generation(logits, self.config.bos_token_id)
         if cur_len == max_length - 1 and self.config.eos_token_id is not None:

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -993,7 +993,7 @@ class BartForConditionalGeneration(PretrainedBartModel):
             "use_cache": use_cache,  # change this to avoid caching (presumably for debugging)
         }
 
-    def prepare_logits_for_generation(self, logits, cur_len, max_length):
+    def _adjust_logits(self, logits, cur_len, max_length):
         if cur_len == 1:
             self._force_token_ids_generation(logits, self.config.bos_token_id)
         if cur_len == max_length - 1 and self.config.eos_token_id is not None:

--- a/src/transformers/modeling_marian.py
+++ b/src/transformers/modeling_marian.py
@@ -46,7 +46,7 @@ class MarianMTModel(BartForConditionalGeneration):
 
     """
 
-    def prepare_logits_for_generation(self, logits, cur_len, max_length):
+    def _adjust_logits(self, logits, cur_len, max_length):
         logits[:, self.config.pad_token_id] = float("-inf")
         if cur_len == max_length - 1 and self.config.eos_token_id is not None:
             self._force_token_ids_generation(logits, self.config.eos_token_id)

--- a/src/transformers/modeling_marian.py
+++ b/src/transformers/modeling_marian.py
@@ -46,7 +46,7 @@ class MarianMTModel(BartForConditionalGeneration):
 
     """
 
-    def _adjust_logits(self, logits, cur_len, max_length):
+    def adjust_logits_during_generation(self, logits, cur_len, max_length):
         logits[:, self.config.pad_token_id] = float("-inf")
         if cur_len == max_length - 1 and self.config.eos_token_id is not None:
             self._force_token_ids_generation(logits, self.config.eos_token_id)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1416,8 +1416,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 num_beams=num_beams,
             )
 
-
-
             assert scores.shape == (batch_size * num_beams, vocab_size), "Shapes of scores: {} != {}".format(
                 scores.shape, (batch_size * num_beams, vocab_size)
             )

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -792,7 +792,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
     def prepare_inputs_for_generation(self, input_ids, **kwargs):
         return {"input_ids": input_ids}
 
-    def _adjust_logits(self, logits, **kwargs):
+    def adjust_logits_during_generation(self, logits, **kwargs):
         return logits
 
     def _use_cache(self, outputs, use_cache):
@@ -1398,7 +1398,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
                 past = outputs[1]
             if self.config.is_encoder_decoder and do_sample is False:
                 # TODO (PVP) still a bit hacky here - there might be a better solution
-                next_token_logits = self._adjust_logits(next_token_logits, cur_len=cur_len, max_length=max_length)
+                next_token_logits = self.adjust_logits_during_generation(
+                    next_token_logits, cur_len=cur_len, max_length=max_length
+                )
 
             scores = F.log_softmax(next_token_logits, dim=-1)  # (batch_size * num_beams, vocab_size)
 


### PR DESCRIPTION
Fixes slow gpu test failures caused by #5031 

This logic was already discussed in a previous PR, but, to summarize, the marian model loves to predict `pad_token_id` and if we allow pad_token_id's high score to enter the softmax we get very low probabilities for everything else.


I also rename `prepare_logits_for_generation` -> `_adjust_logits`