### PR TITLE
Update BERT-of-Theseus model card to avoid confusion

### DIFF
--- a/model_cards/canwenxu/BERT-of-Theseus-MNLI/README.md
+++ b/model_cards/canwenxu/BERT-of-Theseus-MNLI/README.md
@@ -20,3 +20,5 @@ We provide a 6-layer pretrained model on MNLI as a general-purpose model, which 
 | BERT-base       | 83.5 | 89.5 | 91.2 | 89.8 | 71.1 | 91.5  | 88.9  |
 | DistillBERT     | 79.0 | 87.5 | 85.3 | 84.9 | 59.9 | 90.7  | 81.2  |
 | BERT-of-Theseus | 82.1 | 87.5 | 88.8 | 88.8 | 70.1 | 91.8  | 87.8  |
+
+Please Note: this checkpoint is for [Intermediate-Task Transfer Learning](https://arxiv.org/abs/2005.00628) so it does not include the classification head for MNLI! Please fine-tune it before use (like DistilBERT).


### PR DESCRIPTION
@VictorSanh said this checkpoint cannot be evaluated directly on MNLI. Indeed this model is for intermediate task transfer (in BERT-of-Theseus [arxiv version](https://arxiv.org/abs/2002.02925), it's called a "general-purpose" model) so it doesn't (and shouldn't) contain a classification head. This note helps prevent confusion.