### PR TITLE
Fix in Reformer Config documentation

### DIFF
--- a/src/transformers/configuration_reformer.py
+++ b/src/transformers/configuration_reformer.py
@@ -97,7 +97,7 @@ class ReformerConfig(PretrainedConfig):
                 Number of following neighbouring chunks to attend to in LocalSelfAttention layer in addition to itself.
             local_attention_probs_dropout_prob (:obj:`float`, optional, defaults to 0.1):
                 The dropout ratio for the attention probabilities in LocalSelfAttention.
-            lsh_chunk_length (:obj:`int`, optional, defaults to 64):
+            lsh_attn_chunk_length (:obj:`int`, optional, defaults to 64):
                 Length of chunk which attends to itself in LSHSelfAttention. Chunking reduces memory complexity from sequence length x sequence length (self attention) to chunk length x chunk length x sequence length / chunk length (chunked self attention).
             lsh_num_chunks_before (:obj:`int`, optional, defaults to 1):
                 Number of previous neighbouring chunks to attend to in LSHSelfAttention layer to itself.


### PR DESCRIPTION
Fixed a variable name in the Reformer Config docstring (`lsh_chunk_length` -> `lsh_attn_chunk_length`)