### PR TITLE
[bart-mnli] Fix class flipping bug

### DIFF
--- a/src/transformers/data/datasets/glue.py
+++ b/src/transformers/data/datasets/glue.py
@@ -9,6 +9,7 @@ import torch
 from filelock import FileLock
 from torch.utils.data.dataset import Dataset
 
+from ...tokenization_bart import BartTokenizer
 from ...tokenization_roberta import RobertaTokenizer, RobertaTokenizerFast
 from ...tokenization_utils import PreTrainedTokenizer
 from ...tokenization_xlm_roberta import XLMRobertaTokenizer
@@ -92,6 +93,7 @@ class GlueDataset(Dataset):
             RobertaTokenizer,
             RobertaTokenizerFast,
             XLMRobertaTokenizer,
+            BartTokenizer,
         ):
             # HACK(label indices are swapped in RoBERTa pretrained model)
             label_list[1], label_list[2] = label_list[2], label_list[1]

--- a/src/transformers/data/datasets/glue.py
+++ b/src/transformers/data/datasets/glue.py
@@ -9,7 +9,7 @@ import torch
 from filelock import FileLock
 from torch.utils.data.dataset import Dataset
 
-from ...tokenization_bart import BartTokenizer
+from ...tokenization_bart import BartTokenizer, BartTokenizerFast
 from ...tokenization_roberta import RobertaTokenizer, RobertaTokenizerFast
 from ...tokenization_utils import PreTrainedTokenizer
 from ...tokenization_xlm_roberta import XLMRobertaTokenizer
@@ -94,6 +94,7 @@ class GlueDataset(Dataset):
             RobertaTokenizerFast,
             XLMRobertaTokenizer,
             BartTokenizer,
+            BartTokenizerFast,
         ):
             # HACK(label indices are swapped in RoBERTa pretrained model)
             label_list[1], label_list[2] = label_list[2], label_list[1]


### PR DESCRIPTION
Previously, `eval_mnli/acc` was 0.35, now .9. Same issue as other models ported from fairseq.
New results of Victor's command.
```bash
wandb:   eval_mnli-mm/acc 0.9001220504475184
wandb:           _runtime 274.7172155380249
wandb:          eval_loss 0.3496225342093929
wandb:      eval_mnli/acc 0.9011716760061131
wandb:         _timestamp 1592585765.2334569
```