### PR TITLE
[examples] fixes arguments for summarization finetune scripts

### DIFF
--- a/examples/summarization/finetune.sh
+++ b/examples/summarization/finetune.sh
@@ -1,4 +1,4 @@
-export OUTPUT_DIR=bart_cnn_finetune
+export OUTPUT_DIR=bart_finetune
 
 # Make output directory if it doesn't exist
 mkdir -p $OUTPUT_DIR
@@ -9,10 +9,9 @@ export PYTHONPATH="../":"${PYTHONPATH}"
 
 # --model_name_or_path=t5-base for t5
 
+# the proper usage is documented in the README
 python finetune.py \
     --model_name_or_path=facebook/bart-large \
-    --data_dir=./cnn-dailymail/cnn_dm \
-    --output_dir=$OUTPUT_DIR \
     --learning_rate=3e-5 \
     --fp16 \
     --gpus 1 \

--- a/examples/summarization/finetune.sh
+++ b/examples/summarization/finetune.sh
@@ -1,7 +1,3 @@
-export OUTPUT_DIR=bart_finetune
-
-# Make output directory if it doesn't exist
-mkdir -p $OUTPUT_DIR
 
 # Add parent directory to python path to access lightning_base.py
 export PYTHONPATH="../":"${PYTHONPATH}"

--- a/examples/summarization/finetune.sh
+++ b/examples/summarization/finetune.sh
@@ -11,6 +11,8 @@ export PYTHONPATH="../":"${PYTHONPATH}"
 
 python finetune.py \
     --model_name_or_path=facebook/bart-large \
+    --data_dir=./cnn-dailymail/cnn_dm \
+    --output_dir=$OUTPUT_DIR \
     --learning_rate=3e-5 \
     --fp16 \
     --gpus 1 \

--- a/examples/summarization/finetune_bart_tiny.sh
+++ b/examples/summarization/finetune_bart_tiny.sh
@@ -16,14 +16,13 @@ mkdir -p $OUTPUT_DIR
 export PYTHONPATH="../":"${PYTHONPATH}"
 python finetune.py \
 --data_dir=cnn_tiny/ \
---model_type=bart \
 --model_name_or_path=sshleifer/bart-tiny-random \
 --learning_rate=3e-5 \
 --train_batch_size=2 \
 --eval_batch_size=2 \
 --output_dir=$OUTPUT_DIR \
 --num_train_epochs=1  \
---n_gpu=0 \
+--gpus=0 \
 --do_train $@
 
 rm -rf cnn_tiny

--- a/examples/summarization/finetune_t5.sh
+++ b/examples/summarization/finetune_t5.sh
@@ -11,7 +11,6 @@ export PYTHONPATH="../":"${PYTHONPATH}"
 python finetune.py \
 --data_dir=./cnn-dailymail/cnn_dm \
 --model_name_or_path=t5-large \
---model_type=t5
 --learning_rate=3e-5 \
 --train_batch_size=4 \
 --eval_batch_size=4 \


### PR DESCRIPTION
This PR fixes arguments in bash scripts for finetuning bart/bart_tiny/t5 models in summarization examples.

After changes that were merged in #4951 i noticed some small problems. That includes:
* missing default arguments for `finetune.py` (--data_dir, output_dir)
* invalid argument name for number of gpu to use (`n_gpu` instead of `gpus`)
* argument `model_type` that is not present in list of arguments and crashes the script