### PR TITLE
Fixing docs for Encoder Decoder Config

### DIFF
--- a/src/transformers/configuration_encoder_decoder.py
+++ b/src/transformers/configuration_encoder_decoder.py
@@ -37,7 +37,7 @@ class EncoderDecoderConfig(PretrainedConfig):
                 Remaining dictionary of keyword arguments. Notably:
                     encoder (:class:`PretrainedConfig`, optional, defaults to `None`):
                         An instance of a configuration object that defines the encoder config.
-                    encoder (:class:`PretrainedConfig`, optional, defaults to `None`):
+                    decoder (:class:`PretrainedConfig`, optional, defaults to `None`):
                         An instance of a configuration object that defines the decoder config.
 
         Example::


### PR DESCRIPTION
This is a small contribution to the EncoderDecoderConfig documentation.
While trying to use this class, I noticed the documentation said that we could pass 2 "encoder" parameters to the class constructor. 
I am almost 99.99% certain it meant we could pass an encoder and a decoder parameter to the class constructor.