### PR TITLE
[HANS] Fix label_list for RoBERTa/BART (class flipping)

### DIFF
--- a/examples/adversarial/run_hans.py
+++ b/examples/adversarial/run_hans.py
@@ -33,7 +33,7 @@ from transformers import (
     default_data_collator,
     set_seed,
 )
-from utils_hans import HansDataset, InputFeatures, hans_processors
+from utils_hans import HansDataset, InputFeatures, hans_processors, hans_tasks_num_labels
 
 
 logger = logging.getLogger(__name__)
@@ -130,9 +130,7 @@ def main():
     set_seed(training_args.seed)
 
     try:
-        processor = hans_processors[data_args.task_name]()
-        label_list = processor.get_labels()
-        num_labels = len(label_list)
+        num_labels = hans_tasks_num_labels[data_args.task_name]
     except KeyError:
         raise ValueError("Task not found: %s" % (data_args.task_name))
 
@@ -214,6 +212,7 @@ def main():
 
         pair_ids = [ex.pairID for ex in eval_dataset]
         output_eval_file = os.path.join(training_args.output_dir, "hans_predictions.txt")
+        label_list = eval_dataset.get_labels()
         if trainer.is_world_master():
             with open(output_eval_file, "w") as writer:
                 writer.write("pairID,gold_label\n")

--- a/examples/adversarial/utils_hans.py
+++ b/examples/adversarial/utils_hans.py
@@ -23,13 +23,7 @@ import tqdm
 from filelock import FileLock
 
 from transformers import DataProcessor, PreTrainedTokenizer, is_tf_available, is_torch_available
-from transformers import (
-    BartTokenizer,
-    BartTokenizerFast,
-    RobertaTokenizer,
-    RobertaTokenizerFast,
-    XLMRobertaTokenizer
-)
+from transformers import BartTokenizer, BartTokenizerFast, RobertaTokenizer, RobertaTokenizerFast, XLMRobertaTokenizer
 
 
 logger = logging.getLogger(__name__)
@@ -153,6 +147,7 @@ if is_torch_available():
         def get_labels(self):
             return self.label_list
 
+
 if is_tf_available():
     import tensorflow as tf
 
@@ -237,6 +232,7 @@ if is_tf_available():
 
         def get_labels(self):
             return self.label_list
+
 
 class HansProcessor(DataProcessor):
     """Processor for the HANS data set."""

--- a/examples/adversarial/utils_hans.py
+++ b/examples/adversarial/utils_hans.py
@@ -23,6 +23,13 @@ import tqdm
 from filelock import FileLock
 
 from transformers import DataProcessor, PreTrainedTokenizer, is_tf_available, is_torch_available
+from transformers import (
+    BartTokenizer,
+    BartTokenizerFast,
+    RobertaTokenizer,
+    RobertaTokenizerFast,
+    XLMRobertaTokenizer
+)
 
 
 logger = logging.getLogger(__name__)
@@ -105,6 +112,17 @@ if is_torch_available():
                     "dev" if evaluate else "train", tokenizer.__class__.__name__, str(max_seq_length), task,
                 ),
             )
+            label_list = processor.get_labels()
+            if tokenizer.__class__ in (
+                RobertaTokenizer,
+                RobertaTokenizerFast,
+                XLMRobertaTokenizer,
+                BartTokenizer,
+                BartTokenizerFast,
+            ):
+                # HACK(label indices are swapped in RoBERTa pretrained model)
+                label_list[1], label_list[2] = label_list[2], label_list[1]
+            self.label_list = label_list
 
             # Make sure only the first process in distributed training processes the dataset,
             # and the others will use the cache.
@@ -116,7 +134,6 @@ if is_torch_available():
                     self.features = torch.load(cached_features_file)
                 else:
                     logger.info(f"Creating features from dataset file at {data_dir}")
-                    label_list = processor.get_labels()
 
                     examples = (
                         processor.get_dev_examples(data_dir) if evaluate else processor.get_train_examples(data_dir)
@@ -133,6 +150,8 @@ if is_torch_available():
         def __getitem__(self, i) -> InputFeatures:
             return self.features[i]
 
+        def get_labels(self):
+            return self.label_list
 
 if is_tf_available():
     import tensorflow as tf
@@ -156,6 +175,16 @@ if is_tf_available():
         ):
             processor = hans_processors[task]()
             label_list = processor.get_labels()
+            if tokenizer.__class__ in (
+                RobertaTokenizer,
+                RobertaTokenizerFast,
+                XLMRobertaTokenizer,
+                BartTokenizer,
+                BartTokenizerFast,
+            ):
+                # HACK(label indices are swapped in RoBERTa pretrained model)
+                label_list[1], label_list[2] = label_list[2], label_list[1]
+            self.label_list = label_list
 
             examples = processor.get_dev_examples(data_dir) if evaluate else processor.get_train_examples(data_dir)
             self.features = hans_convert_examples_to_features(examples, label_list, max_seq_length, tokenizer)
@@ -206,6 +235,8 @@ if is_tf_available():
         def __getitem__(self, i) -> InputFeatures:
             return self.features[i]
 
+        def get_labels(self):
+            return self.label_list
 
 class HansProcessor(DataProcessor):
     """Processor for the HANS data set."""

--- a/examples/adversarial/utils_hans.py
+++ b/examples/adversarial/utils_hans.py
@@ -22,8 +22,17 @@ from typing import List, Optional, Union
 import tqdm
 from filelock import FileLock
 
-from transformers import DataProcessor, PreTrainedTokenizer, is_tf_available, is_torch_available
-from transformers import BartTokenizer, BartTokenizerFast, RobertaTokenizer, RobertaTokenizerFast, XLMRobertaTokenizer
+from transformers import (
+    BartTokenizer,
+    BartTokenizerFast,
+    DataProcessor,
+    PreTrainedTokenizer,
+    RobertaTokenizer,
+    RobertaTokenizerFast,
+    XLMRobertaTokenizer,
+    is_tf_available,
+    is_torch_available,
+)
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
the MNLI checkpoints ported from fairseq (more specifically RoBERTa and BART) has flipping classes. @sshleifer  fixed it for `run_glue.py` last week (see https://github.com/huggingface/transformers/pull/5141), this PR fixes the same problem for `run_hans.py`.

Now the HANS evaluation for [bart-large-mnli](https://huggingface.co/facebook/bart-large-mnli) gives:
```
Heuristic entailed results:
lexical_overlap: 0.9932
subsequence: 0.9996
constituent: 0.9982

Heuristic non-entailed results:
lexical_overlap: 0.8002
subsequence: 0.263
constituent: 0.2074
```
 
For [roberta-large-mnli](https://huggingface.co/roberta-large-mnli):
```
Heuristic entailed results:
lexical_overlap: 1.0
subsequence: 1.0
constituent: 1.0

Heuristic non-entailed results:
lexical_overlap: 0.8746
subsequence: 0.2804
constituent: 0.1056
```