### PR TITLE
[fix] mobilebert had wrong path, causing slow test failure

### DIFF
--- a/src/transformers/modeling_mobilebert.py
+++ b/src/transformers/modeling_mobilebert.py
@@ -39,7 +39,7 @@ from .modeling_utils import PreTrainedModel, find_pruneable_heads_and_indices, p
 
 
 logger = logging.getLogger(__name__)
-MOBILEBERT_PRETRAINED_MODEL_ARCHIVE_LIST = ["mobilebert-uncased"]
+MOBILEBERT_PRETRAINED_MODEL_ARCHIVE_LIST = ["google/mobilebert-uncased"]
 
 
 def load_tf_weights_in_mobilebert(model, config, tf_checkpoint_path):

--- a/tests/test_modeling_mobilebert.py
+++ b/tests/test_modeling_mobilebert.py
@@ -454,12 +454,6 @@ class MobileBertModelTest(ModelTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_mobilebert_for_token_classification(*config_and_inputs)
 
-    @slow
-    def test_model_from_pretrained(self):
-        for model_name in MOBILEBERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
-            model = MobileBertModel.from_pretrained(model_name)
-            self.assertIsNotNone(model)
-
 
 def _long_tensor(tok_lst):
     return torch.tensor(tok_lst, dtype=torch.long, device=torch_device,)


### PR DESCRIPTION
Also deleted redundant slow test. `test_inference_no_head` covers this completely.