### PR TITLE
Remove wandb warning as it is unnecessary

### DIFF
--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -10,7 +10,6 @@ try:
     wandb.ensure_configured()
     if wandb.api.api_key is None:
         _has_wandb = False
-        wandb.termwarn("W&B installed but not logged in.  Run `wandb login` or set the WANDB_API_KEY env variable.")
     else:
         _has_wandb = False if os.getenv("WANDB_DISABLED") else True
 except (ImportError, AttributeError):


### PR DESCRIPTION
Remove wandb warning as it is unnecessary. If wandb is installed, this throws a warning which just makes noise.
Some images might have wandb installed but the user doesn't want to use it. If the user knows what wandb is they will have the API key set anyways.