### PR TITLE
[WIP - Don't merge yet][Pipeline] Make "task" a static class variable

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -379,7 +379,13 @@ class Pipeline(_ScikitCompat):
         args_parser: ArgumentHandler = None,
         device: int = -1,
         binary_output: bool = False,
+        **kwargs,
     ):
+        if "task" in kwargs:
+            warnings.warn(
+                "The `task` argument is deprecated and will be removed in a future version, there is no need to use it anymore",
+                DeprecationWarning,
+            )
 
         if framework is None:
             framework = get_framework()
@@ -549,6 +555,7 @@ class FeatureExtractionPipeline(Pipeline):
         framework: Optional[str] = None,
         args_parser: ArgumentHandler = None,
         device: int = -1,
+        **kwargs,
     ):
         super().__init__(
             model=model,
@@ -558,6 +565,7 @@ class FeatureExtractionPipeline(Pipeline):
             args_parser=args_parser,
             device=device,
             binary_output=True,
+            **kwargs,
         )
 
     def __call__(self, *args, **kwargs):
@@ -794,6 +802,7 @@ class FillMaskPipeline(Pipeline):
         args_parser: ArgumentHandler = None,
         device: int = -1,
         topk=5,
+        **kwargs,
     ):
         super().__init__(
             model=model,
@@ -803,6 +812,7 @@ class FillMaskPipeline(Pipeline):
             args_parser=args_parser,
             device=device,
             binary_output=True,
+            **kwargs,
         )
 
         self.topk = topk
@@ -903,6 +913,7 @@ class TokenClassificationPipeline(Pipeline):
         binary_output: bool = False,
         ignore_labels=["O"],
         grouped_entities: bool = False,
+        **kwargs,
     ):
         super().__init__(
             model=model,
@@ -912,6 +923,7 @@ class TokenClassificationPipeline(Pipeline):
             args_parser=args_parser,
             device=device,
             binary_output=binary_output,
+            **kwargs,
         )
 
         self._basic_tokenizer = BasicTokenizer(do_lower_case=False)
@@ -1759,7 +1771,7 @@ def pipeline(
             # Instead "translation" should be used with "src_lang" and "tgt_lang" kwargs
             if not ("src_lang" in kwargs and "tgt_lang" in kwargs):
                 warnings.warn(
-                    f"When using pipeline with 'translation', `src_lang` and `tgt_lang` should be provided in kwargs",
+                    "When using translation pipeline, `src_lang` and `tgt_lang` should be provided in kwargs",
                     FutureWarning,
                 )
                 assert "_to_" in task, "f{task} should be in the format 'translation_{src_lang}_to_{tgt_lang}"

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1776,7 +1776,7 @@ def pipeline(
                 )
                 assert "_to_" in task, "f{task} should be in the format 'translation_{src_lang}_to_{tgt_lang}"
 
-                langs = task.split("translation")[-1]
+                langs = task.split("translation_")[-1]
                 src_lang, tgt_lang = langs.split("_to_")
                 kwargs["src_lang"] = src_lang
                 kwargs["tgt_lang"] = tgt_lang

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -402,10 +402,11 @@ class Pipeline(_ScikitCompat):
         if self.framework == "pt" and self.device.type == "cuda":
             self.model = self.model.to(self.device)
 
-        # Update config with task specific parameters
-        if self.task not in SUPPORTED_TASKS and self.abstract_task not in SUPPORTED_TASKS:
-            raise KeyError("Unknown task {}, available tasks are {}".format(self.task, list(SUPPORTED_TASKS.keys())))
+        assert (
+            self.task is not None
+        ), "A task specific `Pipeline` class, such as `SummarizationPipeline` has to instantiated."
 
+        # Update config with task specific parameters
         task_specific_params = self.model.config.task_specific_params
         if task_specific_params is not None and self.task in task_specific_params:
             self.model.config.update(task_specific_params.get(self.task))
@@ -732,7 +733,7 @@ class TextClassificationPipeline(Pipeline):
             on the associated CUDA device id.
     """
 
-    task = "sentiment-analysis"
+    task = "text-classification"
 
     def __init__(self, return_all_scores: bool = False, **kwargs):
         super().__init__(**kwargs)
@@ -900,7 +901,7 @@ class TokenClassificationPipeline(Pipeline):
     """
 
     default_input_names = "sequences"
-    task = "ner"
+    task = "token-classification"
 
     def __init__(
         self,

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1768,6 +1768,8 @@ def pipeline(
             assert (
                 isinstance(kwargs["tgt_lang"], str) and len(kwargs["tgt_lang"]) > 0
             ), f"{kwargs['tgt_lang']} cannot be empty"
+
+            task = "translation"
         else:
             raise KeyError("Unknown task {}, available tasks are {}".format(task, list(SUPPORTED_TASKS.keys())))
 

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -901,7 +901,6 @@ class TokenClassificationPipeline(Pipeline):
         device: int = -1,
         binary_output: bool = False,
         ignore_labels=["O"],
-        task: str = "",
         grouped_entities: bool = False,
     ):
         super().__init__(
@@ -912,7 +911,6 @@ class TokenClassificationPipeline(Pipeline):
             args_parser=args_parser,
             device=device,
             binary_output=binary_output,
-            task=task,
         )
 
         self._basic_tokenizer = BasicTokenizer(do_lower_case=False)

--- a/tests/test_modeling_marian.py
+++ b/tests/test_modeling_marian.py
@@ -234,7 +234,9 @@ class TestMarian_en_ROMANCE(MarianIntegrationTest):
 
     def test_pipeline(self):
         device = 0 if torch_device == "cuda" else -1
-        pipeline = TranslationPipeline(self.model, self.tokenizer, framework="pt", device=device)
+        pipeline = TranslationPipeline(
+            self.model, self.tokenizer, framework="pt", device=device, src_lang=self.src, tgt_lang=self.tgt
+        )
         output = pipeline(self.src_text)
         self.assertEqual(self.expected_text, [x["translation_text"] for x in output])
 


### PR DESCRIPTION
This PR removes "task" from the "init" of the class and adds it as a static variable.
In my opinion, it is cleaner to have "task" as a static variable instead of an object attribute. This would also solve #5210 .

The problem we would run into then is that for the "Translation" pipeline we would need a class for each translation. I think this is still the better option though because it is less prone to errors (see #5210) and we could add a "get translation factory design" or something.

After some discussion with @mfuntowicz, I think the best option is to add two additional 
parameters `src_lang` and `tgt_lang` to the pipelines function and delete the task names 
`translation_en_to_fr` in favor of just `translation`. 

The new recommended way of instantiating a translation pipeline is 

```python 
translation_en_to_fr = pipeline("translation", src_lang="en", tgt_lang="fr")
```

The option:
```python 
translation_en_to_fr = pipeline("translation_en_to_fr")
```

is still supported with a future warning.

@mfuntowicz @julien-c @LysandreJik @sshleifer 
What do you think?

**Backward Compatibility**

It should be fully backward compatible, but I added some warning statements to let the user know of Future Depreciation

### TODO:
If this PR is ok for you, I will update the docs and add tests.