### PR TITLE
Add version control menu

### DIFF
--- a/docs/source/_static/css/huggingface.css
+++ b/docs/source/_static/css/huggingface.css
@@ -1,5 +1,45 @@
 /* Our DOM objects */
 
+/* Version control */
+
+.version-button {
+    background-color: #6670FF;
+    color: white;
+    border: none;
+    padding: 5px;
+    font-size: 15px;
+    cursor: pointer;
+}
+
+.version-button:hover, .version-button:focus {
+    background-color: #A6B0FF;
+}
+ 
+.version-dropdown {
+    display: none;
+    background-color: #6670FF;
+    min-width: 160px;
+    overflow: auto;
+    font-size: 15px;
+}
+  
+.version-dropdown a {
+    color: white;
+    padding: 3px 4px;
+    text-decoration: none;
+    display: block;
+}
+  
+.version-dropdown a:hover {
+    background-color: #A6B0FF;
+}
+  
+.version-show {
+    display: block;
+}
+
+/* Framework selector */
+
 .framework-selector {
     display: flex;
     flex-direction: row;
@@ -38,6 +78,7 @@
 
 /* The research field on top of the toc tree */
 .wy-side-nav-search{
+    padding-top: 0;
     background-color: #6670FF;
 }
 

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -95,8 +95,7 @@ function addVersionControl() {
     const versionMenu = document.createElement("div");
 
     const htmlLines = [];
-    for (const key in versionMapping) {
-        var value = versionMapping[key];
+    for (const [key, value] of Object.entries(versionMapping)) {
         var urlParts = (key == "") ? [] : [key];
         urlParts = urlParts.concat(parts.slice(versionIndex));
         htmlLines.push(`<a href="${urlParts.join('/')}">${value}</a>`);
@@ -119,9 +118,7 @@ function addVersionControl() {
     // Hide the menu when we click elsewhere
     window.addEventListener("click", (event) => {
         if (event.target != versionButton){
-            if (versionMenu.classList.contains('version-show')) {
-                versionMenu.classList.remove('version-show');
-            }
+            versionMenu.classList.remove('version-show');
         }
     });
 

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -1,8 +1,8 @@
 // These two things need to be updated at each release for the version selector.
 // Last stable version
-let stableVersion = "v2.11.0"
+const stableVersion = "v2.11.0"
 // Dictionary doc folder to label
-let versionMapping = {
+const versionMapping = {
     "master": "master",
     "": "v2.11.0 (stable)",
     "v2.10.0": "v2.10.0",
@@ -83,19 +83,19 @@ function addGithubButton() {
 
 function addVersionControl() {
     // To grab the version currently in view, we parse the url
-    let parts = location.toString().split('/');
-    var versionIndex = parts.length - 2
+    const parts = location.toString().split('/');
+    let versionIndex = parts.length - 2
     // Main classes and models are nested so we need to go deeper
     if (parts[versionIndex] == "main_classes" || parts[versionIndex] == "model_doc") {
         versionIndex = parts.length - 3
     } 
-    let version = parts[versionIndex];
+    const version = parts[versionIndex];
 
     // Menu with all the links,
     const versionMenu = document.createElement("div");
 
-    var htmlLines = [];
-    for (var key in versionMapping) {
+    const htmlLines = [];
+    for (const key in versionMapping) {
         var value = versionMapping[key];
         var urlParts = (key == "") ? [] : [key];
         urlParts = urlParts.concat(parts.slice(versionIndex));

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -1,3 +1,26 @@
+// These two things need to be updated at each release for the version selector.
+// Last stable version
+let stableVersion = "v2.11.0"
+// Dictionary doc folder to label
+let versionMapping = {
+    "master": "master",
+    "": "v2.11.0 (stable)",
+    "v2.10.0": "v2.10.0",
+    "v2.9.1": "v2.9.0/v2.9.1",
+    "v2.8.0": "v2.8.0",
+    "v2.7.0": "v2.7.0",
+    "v2.6.0": "v2.6.0",
+    "v2.5.1": "v2.5.0/v2.5.1",
+    "v2.4.0": "v2.4.0/v2.4.1",
+    "v2.3.0": "v2.3.0",
+    "v2.2.0": "v2.2.0/v2.2.1/v2.2.2",
+    "v2.1.1": "v2.1.1",
+    "v2.0.0": "v2.0.0",
+    "v1.2.0": "v1.2.0",
+    "v1.1.0": "v1.1.0",
+    "v1.0.0": "v1.0.0"
+}
+
 function addIcon() {
     const huggingFaceLogo = "https://huggingface.co/landing/assets/transformers-docs/huggingface_logo.svg";
     const image = document.createElement("img");
@@ -56,6 +79,63 @@ function addGithubButton() {
         </div>
     `;
     document.querySelector(".wy-side-nav-search .icon-home").insertAdjacentHTML('afterend', div);
+}
+
+function addVersionControl() {
+    // To grab the version currently in view, we parse the url
+    let parts = location.toString().split('/');
+    var versionIndex = parts.length - 2
+    // Main classes and models are nested so we need to go deeper
+    if (parts[versionIndex] == "main_classes" || parts[versionIndex] == "model_doc") {
+        versionIndex = parts.length - 3
+    } 
+    let version = parts[versionIndex];
+
+    // Menu with all the links,
+    const versionMenu = document.createElement("div");
+
+    var htmlLines = [];
+    for (var key in versionMapping) {
+        var value = versionMapping[key];
+        var urlParts = (key == "") ? [] : [key];
+        urlParts = urlParts.concat(parts.slice(versionIndex));
+        htmlLines.push(`<a href="${urlParts.join('/')}">${value}</a>`);
+    }
+
+    versionMenu.classList.add("version-dropdown");
+    versionMenu.innerHTML = htmlLines.join('\n');
+    
+    // Button for version selection
+    const versionButton = document.createElement("div");
+    versionButton.classList.add("version-button");
+    let label = (version == "transformers") ? stableVersion : version
+    versionButton.innerText = label.concat(" ▼");
+
+    // Toggle the menu when we click on the button
+    versionButton.addEventListener("click", () => {
+        versionMenu.classList.toggle("version-show");
+    });
+
+    // Hide the menu when we click elsewhere
+    window.addEventListener("click", (event) => {
+        if (event.target != versionButton){
+            if (versionMenu.classList.contains('version-show')) {
+                versionMenu.classList.remove('version-show');
+            }
+        }
+    });
+
+    // Container
+    const div = document.createElement("div");
+    div.appendChild(versionButton);
+    div.appendChild(versionMenu);
+    div.style.paddingTop = '25px';
+    div.style.backgroundColor = '#6670FF';
+    div.style.display = 'block';
+    div.style.textAlign = 'center';
+
+    const scrollDiv = document.querySelector(".wy-side-scroll");
+    scrollDiv.insertBefore(div, scrollDiv.children[1]);
 }
 
 function addHfMenu() {
@@ -149,6 +229,7 @@ function parseGithubButtons (){"use strict";var e=window.document,t=e.location,o
 
 function onLoad() {
     addIcon();
+    addVersionControl();
     addCustomFooter();
     addGithubButton();
     parseGithubButtons();

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -187,8 +187,8 @@ epub_title = project
 epub_exclude_files = ['search.html']
 
 def setup(app):
-    app.add_stylesheet('css/huggingface.css')
-    app.add_stylesheet('css/code-snippets.css')
+    app.add_css_file('css/huggingface.css')
+    app.add_css_file('css/code-snippets.css')
     app.add_js_file('js/custom.js')
 
 # -- Extension configuration -------------------------------------------------


### PR DESCRIPTION
This PR adds at the top of the navigation bar a menu to pick a version of the docs.

A few comments:

When switching version, the reader is sent on the same page of the docs in the older version (so it gives an error if the same page did not exist in this version of the docs). I don't know if this is preferable to the alternative (sending back to the index of the other version in the docs). Let me know what you think.

The menu will disappear once the reader goes to an older version of the docs (since it did not exist back then) unless we find a way to cherry pick in each release (but I doubt it's worth it).

Preview is [here](https://51918-155220641-gh.circle-artifacts.com/0/docs/_build/html/index.html). Side note, on a local build (like this one), the version appears as 'html', but it will be the right one once merged. Also, the preview/local build only has one version, so the links don't work there.