### PR TITLE
Use the script in utils

### DIFF
--- a/examples/text-classification/README.md
+++ b/examples/text-classification/README.md
@@ -52,9 +52,12 @@ Some of these results are significantly different from the ones reported on the 
 of GLUE benchmark on the website. For QQP and WNLI, please refer to [FAQ #12](https://gluebenchmark.com/faq) on the webite.
 
 Before running any one of these GLUE tasks you should download the
-[GLUE data](https://gluebenchmark.com/tasks) by running
-[this script](https://gist.github.com/W4ngatang/60c2bdb54d156a41194446737ce03e2e)
-and unpack it to some directory `$GLUE_DIR`.
+[GLUE data](https://gluebenchmark.com/tasks) by running the following lines at the root of the repo
+```
+python utils/download_glue_data.py --data_dir /path/to/glue --tasks all
+```
+
+after replacing *path/to/glue* with a value that you like. Then you can run
 
 ```bash
 export GLUE_DIR=/path/to/glue


### PR DESCRIPTION
Since we have the script `download_glue_data` in the utils folder, changing the instructions in the README for the GLUE example to use it for now (of course nlp will ultimately make this even easier) since it's easier than copying the gist in a local file.