### PR TITLE
[pl_examples] revert deletion of optimizer_step

### DIFF
--- a/examples/summarization/finetune.py
+++ b/examples/summarization/finetune.py
@@ -149,7 +149,7 @@ class SummarizationModule(BaseTransformer):
         source_ids, source_mask, y = SummarizationDataset.trim_seq2seq_batch(batch, pad_token_id)
         t0 = time.time()
         generated_ids = self.model.generate(input_ids=source_ids, attention_mask=source_mask, use_cache=True,)
-        gen_time = time.time() - t0 / source_ids.shape[0]
+        gen_time = (time.time() - t0) / source_ids.shape[0]
         preds = self.ids_to_clean_text(generated_ids)
         target = self.ids_to_clean_text(y)
         loss_tensors = self._step(batch)

--- a/examples/summarization/run_distiller.sh
+++ b/examples/summarization/run_distiller.sh
@@ -7,5 +7,6 @@ python distillation.py \
 --learning_rate=3e-4 \
 --do_train \
 --do_predict \
+--fp16 \
 --val_check_interval 0.1 \
 $@


### PR DESCRIPTION
using default `optimizer_step` has at least 2 issues:
The default version...
1) doesn't call `lr_scheduler.step()`
2) does call `self.trainer.scaler.step(optimizer)`

I haven't diagnosed which of these is the main culprit of the issue I was seeing (very high loss, not going down). This fixes that issue. 

I suspect it is mostly the latter: @williamFalcon 
