### PR TITLE
Fix PABEE division by zero error

### DIFF
--- a/examples/bert-loses-patience/run_glue_with_pabee.py
+++ b/examples/bert-loses-patience/run_glue_with_pabee.py
@@ -254,7 +254,7 @@ def train(args, train_dataset, model, tokenizer):
     return global_step, tr_loss / global_step
 
 
-def evaluate(args, model, tokenizer, prefix="", patience=None):
+def evaluate(args, model, tokenizer, prefix="", patience=0):
 
     if args.model_type == "albert":
         model.albert.set_regression_threshold(args.regression_threshold)


### PR DESCRIPTION
Fix the `division_by_zero` error when `patience` is set to `0` during inference.

https://github.com/JetRunner/PABEE/issues/2