### PR TITLE
[WIP] Support label_smoothed_cross_entropy

### DIFF
--- a/examples/summarization/utils.py
+++ b/examples/summarization/utils.py
@@ -246,3 +246,24 @@ def assert_not_all_frozen(model):
     model_grads: List[bool] = list(grad_status(model))
     npars = len(model_grads)
     assert any(model_grads), f"none of {npars} weights require grad"
+
+
+class LabelSmoothedCrossEntropyLoss(nn.Module):
+    """this loss performs label smoothing to compute cross-entropy with soft labels, when smoothing=0.0, this
+    is the same as torch.nn.CrossEntropyLoss"""
+
+    def __init__(self, n_classes, smoothing=0.0, dim=-1):
+        super().__init__()
+        self.confidence = 1.0 - smoothing
+        self.smoothing = smoothing
+        self.n_classes = n_classes
+        self.dim = dim
+
+    def forward(self, pred, target):
+        pred = pred.log_softmax(dim=self.dim)
+        with torch.no_grad():
+            true_dist = torch.zeros_like(pred)
+            true_dist.fill_(self.smoothing / (self.n_classes - 1))
+            true_dist.scatter_(1, target.data.unsqueeze(1), self.confidence)
+
+        return torch.mean(torch.sum(-true_dist * pred, dim=self.dim))


### PR DESCRIPTION
By default there is no implementation of cross entropy with soft labels in Pytorch as discussed in #5168

I found a feature request in pytorch for it but it is still not done. 

https://github.com/pytorch/pytorch/issues/7455

There is also discussion where i found an implemented version of this loss. I checked that it performs the same as nn.CrossEntropyLoss given smoothing=0.0 and accurately smoothes labels given nonzero smoothing. I ported it with small refactoring.

Key improvements that are planned in this PR:

1) Add label smoothing cross entropy loss
2) support and parametrise loss choice in `finetune.py`
