### PR TITLE
Fix version controller links (for realsies)

### DIFF
--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -84,14 +84,14 @@ function addGithubButton() {
 function addVersionControl() {
     // To grab the version currently in view, we parse the url
     const parts = location.toString().split('/');
-    let versionIndex = parts.length - 2
+    let versionIndex = parts.length - 2;
     // Index page may not have a last part with filename.html so we need to go up
-    if (! parts[versionIndex].match(/\.html$/)) {
-        versionIndex = parts.length - 1
+    if (parts[parts.length - 1] != "" && ! parts[parts.length - 1].match(/\.html$/)) {
+        versionIndex = parts.length - 1;
     }
     // Main classes and models are nested so we need to go deeper
     else if (parts[versionIndex] == "main_classes" || parts[versionIndex] == "model_doc") {
-        versionIndex = parts.length - 3
+        versionIndex = versionIndex - 1;
     } 
     const version = parts[versionIndex];
 
@@ -100,11 +100,12 @@ function addVersionControl() {
 
     const htmlLines = [];
     for (const [key, value] of Object.entries(versionMapping)) {
-        var urlParts = parts.slice(0, versionIndex-1);
+        let baseUrlIndex = (version == "transformers") ? versionIndex + 1: versionIndex;
+        var urlParts = parts.slice(0, baseUrlIndex);
         if (key != "") {
             urlParts = urlParts.concat([key]);
         }
-        urlParts = urlParts.concat(parts.slice(versionIndex));
+        urlParts = urlParts.concat(parts.slice(versionIndex+1));
         htmlLines.push(`<a href="${urlParts.join('/')}">${value}</a>`);
     }
 


### PR DESCRIPTION
This time tested on pretty much all situations and add proper links as a result. 

In particular: 
- not sure that `location.toString()` will end with a '/' or not when on the index, this works with both
- when nested, use the previous value and not an absolute one
- the base url needs to be slice up to the version, including it for stable