### PR TITLE
[Tokenization] Fix #5181 - make #5155 more explicit - move back the default logging level in tests to WARNING

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1837,7 +1837,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
         if return_attention_mask is None:
             return_attention_mask = "attention_mask" in self.model_input_names
 
-        if padding_strategy == PaddingStrategy.LONGEST and max_length is None:
+        if padding_strategy == PaddingStrategy.LONGEST:
             max_length = len(encoded_inputs["input_ids"])
 
         needs_to_be_padded = (

--- a/tests/test_modeling_auto.py
+++ b/tests/test_modeling_auto.py
@@ -67,7 +67,6 @@ if is_torch_available():
 class AutoModelTest(unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
-        logging.basicConfig(level=logging.INFO)
         for model_name in BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
             config = AutoConfig.from_pretrained(model_name)
             self.assertIsNotNone(config)
@@ -82,7 +81,6 @@ class AutoModelTest(unittest.TestCase):
 
     @slow
     def test_model_for_pretraining_from_pretrained(self):
-        logging.basicConfig(level=logging.INFO)
         for model_name in BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
             config = AutoConfig.from_pretrained(model_name)
             self.assertIsNotNone(config)
@@ -98,7 +96,6 @@ class AutoModelTest(unittest.TestCase):
 
     @slow
     def test_lmhead_model_from_pretrained(self):
-        logging.basicConfig(level=logging.INFO)
         for model_name in BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
             config = AutoConfig.from_pretrained(model_name)
             self.assertIsNotNone(config)
@@ -111,7 +108,6 @@ class AutoModelTest(unittest.TestCase):
 
     @slow
     def test_model_for_causal_lm(self):
-        logging.basicConfig(level=logging.INFO)
         for model_name in GPT2_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
             config = AutoConfig.from_pretrained(model_name)
             self.assertIsNotNone(config)
@@ -124,7 +120,6 @@ class AutoModelTest(unittest.TestCase):
 
     @slow
     def test_model_for_masked_lm(self):
-        logging.basicConfig(level=logging.INFO)
         for model_name in BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
             config = AutoConfig.from_pretrained(model_name)
             self.assertIsNotNone(config)
@@ -137,7 +132,6 @@ class AutoModelTest(unittest.TestCase):
 
     @slow
     def test_model_for_encoder_decoder_lm(self):
-        logging.basicConfig(level=logging.INFO)
         for model_name in T5_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
             config = AutoConfig.from_pretrained(model_name)
             self.assertIsNotNone(config)
@@ -150,7 +144,6 @@ class AutoModelTest(unittest.TestCase):
 
     @slow
     def test_sequence_classification_model_from_pretrained(self):
-        logging.basicConfig(level=logging.INFO)
         for model_name in BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
             config = AutoConfig.from_pretrained(model_name)
             self.assertIsNotNone(config)
@@ -165,7 +158,6 @@ class AutoModelTest(unittest.TestCase):
 
     @slow
     def test_question_answering_model_from_pretrained(self):
-        logging.basicConfig(level=logging.INFO)
         for model_name in BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
             config = AutoConfig.from_pretrained(model_name)
             self.assertIsNotNone(config)
@@ -178,7 +170,6 @@ class AutoModelTest(unittest.TestCase):
 
     @slow
     def test_token_classification_model_from_pretrained(self):
-        logging.basicConfig(level=logging.INFO)
         for model_name in BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
             config = AutoConfig.from_pretrained(model_name)
             self.assertIsNotNone(config)
@@ -190,14 +181,12 @@ class AutoModelTest(unittest.TestCase):
             self.assertIsInstance(model, BertForTokenClassification)
 
     def test_from_pretrained_identifier(self):
-        logging.basicConfig(level=logging.INFO)
         model = AutoModelWithLMHead.from_pretrained(SMALL_MODEL_IDENTIFIER)
         self.assertIsInstance(model, BertForMaskedLM)
         self.assertEqual(model.num_parameters(), 14830)
         self.assertEqual(model.num_parameters(only_trainable=True), 14830)
 
     def test_from_identifier_from_model_type(self):
-        logging.basicConfig(level=logging.INFO)
         model = AutoModelWithLMHead.from_pretrained(DUMMY_UNKWOWN_IDENTIFIER)
         self.assertIsInstance(model, RobertaForMaskedLM)
         self.assertEqual(model.num_parameters(), 14830)

--- a/tests/test_modeling_auto.py
+++ b/tests/test_modeling_auto.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-import logging
 import unittest
 
 from transformers import is_torch_available

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -855,7 +855,6 @@ def floats_tensor(shape, scale=1.0, rng=None, name=None):
 class ModelUtilsTest(unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
-        logging.basicConfig(level=logging.INFO)
         for model_name in BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
             config = BertConfig.from_pretrained(model_name)
             self.assertIsNotNone(config)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import copy
-import logging
 import os.path
 import random
 import tempfile

--- a/tests/test_modeling_tf_auto.py
+++ b/tests/test_modeling_tf_auto.py
@@ -48,7 +48,6 @@ class TFAutoModelTest(unittest.TestCase):
 
         self.assertTrue(h5py.version.hdf5_version.startswith("1.10"))
 
-        logging.basicConfig(level=logging.INFO)
         # for model_name in TF_BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
         for model_name in ["bert-base-uncased"]:
             config = AutoConfig.from_pretrained(model_name)
@@ -65,7 +64,6 @@ class TFAutoModelTest(unittest.TestCase):
 
         self.assertTrue(h5py.version.hdf5_version.startswith("1.10"))
 
-        logging.basicConfig(level=logging.INFO)
         # for model_name in TF_BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
         for model_name in ["bert-base-uncased"]:
             config = AutoConfig.from_pretrained(model_name)
@@ -78,7 +76,6 @@ class TFAutoModelTest(unittest.TestCase):
 
     @slow
     def test_lmhead_model_from_pretrained(self):
-        logging.basicConfig(level=logging.INFO)
         # for model_name in TF_BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
         for model_name in ["bert-base-uncased"]:
             config = AutoConfig.from_pretrained(model_name)
@@ -91,7 +88,6 @@ class TFAutoModelTest(unittest.TestCase):
 
     @slow
     def test_sequence_classification_model_from_pretrained(self):
-        logging.basicConfig(level=logging.INFO)
         # for model_name in TF_BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
         for model_name in ["bert-base-uncased"]:
             config = AutoConfig.from_pretrained(model_name)
@@ -104,7 +100,6 @@ class TFAutoModelTest(unittest.TestCase):
 
     @slow
     def test_question_answering_model_from_pretrained(self):
-        logging.basicConfig(level=logging.INFO)
         # for model_name in TF_BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
         for model_name in ["bert-base-uncased"]:
             config = AutoConfig.from_pretrained(model_name)
@@ -116,14 +111,12 @@ class TFAutoModelTest(unittest.TestCase):
             self.assertIsInstance(model, TFBertForQuestionAnswering)
 
     def test_from_pretrained_identifier(self):
-        logging.basicConfig(level=logging.INFO)
         model = TFAutoModelWithLMHead.from_pretrained(SMALL_MODEL_IDENTIFIER)
         self.assertIsInstance(model, TFBertForMaskedLM)
         self.assertEqual(model.num_parameters(), 14830)
         self.assertEqual(model.num_parameters(only_trainable=True), 14830)
 
     def test_from_identifier_from_model_type(self):
-        logging.basicConfig(level=logging.INFO)
         model = TFAutoModelWithLMHead.from_pretrained(DUMMY_UNKWOWN_IDENTIFIER)
         self.assertIsInstance(model, TFRobertaForMaskedLM)
         self.assertEqual(model.num_parameters(), 14830)

--- a/tests/test_modeling_tf_auto.py
+++ b/tests/test_modeling_tf_auto.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-import logging
 import unittest
 
 from transformers import is_tf_available

--- a/tests/test_tokenization_auto.py
+++ b/tests/test_tokenization_auto.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-import logging
 import unittest
 
 from transformers import (

--- a/tests/test_tokenization_auto.py
+++ b/tests/test_tokenization_auto.py
@@ -36,7 +36,6 @@ from .utils import DUMMY_UNKWOWN_IDENTIFIER, SMALL_MODEL_IDENTIFIER, slow  # noq
 class AutoTokenizerTest(unittest.TestCase):
     # @slow
     def test_tokenizer_from_pretrained(self):
-        logging.basicConfig(level=logging.INFO)
         for model_name in (x for x in BERT_PRETRAINED_CONFIG_ARCHIVE_MAP.keys() if "japanese" not in x):
             tokenizer = AutoTokenizer.from_pretrained(model_name)
             self.assertIsNotNone(tokenizer)
@@ -50,19 +49,16 @@ class AutoTokenizerTest(unittest.TestCase):
             self.assertGreater(len(tokenizer), 0)
 
     def test_tokenizer_from_pretrained_identifier(self):
-        logging.basicConfig(level=logging.INFO)
         tokenizer = AutoTokenizer.from_pretrained(SMALL_MODEL_IDENTIFIER)
         self.assertIsInstance(tokenizer, (BertTokenizer, BertTokenizerFast))
         self.assertEqual(tokenizer.vocab_size, 12)
 
     def test_tokenizer_from_model_type(self):
-        logging.basicConfig(level=logging.INFO)
         tokenizer = AutoTokenizer.from_pretrained(DUMMY_UNKWOWN_IDENTIFIER)
         self.assertIsInstance(tokenizer, (RobertaTokenizer, RobertaTokenizerFast))
         self.assertEqual(tokenizer.vocab_size, 20)
 
     def test_tokenizer_identifier_with_correct_config(self):
-        logging.basicConfig(level=logging.INFO)
         for tokenizer_class in [BertTokenizer, BertTokenizerFast, AutoTokenizer]:
             tokenizer = tokenizer_class.from_pretrained("wietsedv/bert-base-dutch-cased")
             self.assertIsInstance(tokenizer, (BertTokenizer, BertTokenizerFast))
@@ -75,7 +71,6 @@ class AutoTokenizerTest(unittest.TestCase):
             self.assertEqual(tokenizer.max_len, 512)
 
     def test_tokenizer_identifier_non_existent(self):
-        logging.basicConfig(level=logging.INFO)
         for tokenizer_class in [BertTokenizer, BertTokenizerFast, AutoTokenizer]:
             with self.assertRaises(EnvironmentError):
                 _ = tokenizer_class.from_pretrained("julien-c/herlolip-not-exists")

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -493,7 +493,7 @@ class TokenizerTesterMixin:
 
                 seq_1 = "This is another sentence to be encoded."
                 seq1_tokens = tokenizer.encode(seq_1, add_special_tokens=False)
-                if len(seq0_tokens) == len(seq1_tokens):
+                if abs(len(seq0_tokens) - len(seq1_tokens)) <= 2:
                     seq1_tokens = seq1_tokens + seq1_tokens
                     seq_1 = tokenizer.decode(seq1_tokens, clean_up_tokenization_spaces=False)
                 seq1_tokens = tokenizer.encode(seq_1, add_special_tokens=False)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -22,7 +22,7 @@ import tempfile
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Dict, Tuple, Union
 
-from tests.utils import require_tf, require_torch
+from tests.utils import require_tf, require_torch, slow
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 
@@ -1274,6 +1274,7 @@ class TokenizerTesterMixin:
             # add pad_token_id to pass subsequent tests
             tokenizer.add_special_tokens({"pad_token": "<PAD>"})
 
+    @slow
     @require_torch
     def test_torch_encode_plus_sent_to_model(self):
         import torch
@@ -1323,6 +1324,7 @@ class TokenizerTesterMixin:
         #     model(**encoded_sequence_fast)
         #     model(**batch_encoded_sequence_fast)
 
+    @slow
     @require_tf
     def test_tf_encode_plus_sent_to_model(self):
         from transformers import TF_MODEL_MAPPING, TOKENIZER_MAPPING
@@ -1357,6 +1359,7 @@ class TokenizerTesterMixin:
                 model(batch_encoded_sequence)
 
     # TODO: Check if require_torch is the best to test for numpy here ... Maybe move to require_flax when available
+    @slow
     @require_torch
     def test_np_encode_plus_sent_to_model(self):
         from transformers import MODEL_MAPPING, TOKENIZER_MAPPING

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -482,8 +482,8 @@ class TokenizerTesterMixin:
                 stride = 2
                 seq_0, ids = self.get_clean_sequence(tokenizer)
                 if len(ids) <= 2 + stride:
-                    seq_0 = [s for s in seq_0 for _ in range(2 + stride)]
-                    ids = [i for i in ids for _ in range(2 + stride)]
+                    seq_0 = (seq_0 + " ") * (2 + stride)
+                    ids = None
 
                 seq0_tokens = tokenizer.encode(seq_0, add_special_tokens=False)
                 assert len(seq0_tokens) > 2 + stride

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -421,8 +421,11 @@ class TokenizerTesterMixin:
                 ), "Issue with the testing sequence, please update it it's too short"
 
                 # Simple
+                padding_strategies = (
+                    [False, True, "longest"] if tokenizer.pad_token and tokenizer.pad_token_id >= 0 else [False]
+                )
                 for truncation_state in [True, "longest_first", "only_first"]:
-                    for padding_state in [False, True, "longest"]:
+                    for padding_state in padding_strategies:
                         with self.subTest(f"Padding: {padding_state} - Truncation: {truncation_state}"):
                             output = tokenizer(seq_1, padding=padding_state, truncation=truncation_state)
                             self.assertEqual(len(output["input_ids"]), model_max_length)
@@ -432,7 +435,7 @@ class TokenizerTesterMixin:
 
                 # Simple with no truncation
                 for truncation_state in [False]:
-                    for padding_state in [False, True, "longest"]:
+                    for padding_state in padding_strategies:
                         with self.subTest(f"Padding: {padding_state} - Truncation: {truncation_state}"):
                             output = tokenizer(seq_1, padding=padding_state, truncation=truncation_state)
                             self.assertNotEqual(len(output["input_ids"]), model_max_length)
@@ -516,8 +519,11 @@ class TokenizerTesterMixin:
                 assert total_length2 > model_max_length, "Issue with the testing sequence, please update it."
 
                 # Simple
+                padding_strategies = (
+                    [False, True, "longest"] if tokenizer.pad_token and tokenizer.pad_token_id >= 0 else [False]
+                )
                 for truncation_state in [True, "longest_first", "only_first"]:
-                    for padding_state in [False, True, "longest"]:
+                    for padding_state in padding_strategies:
                         with self.subTest(f"Padding: {padding_state} - Truncation: {truncation_state}"):
                             output = tokenizer(seq_2, seq_1, padding=padding_state, truncation=truncation_state)
                             self.assertEqual(len(output["input_ids"]), model_max_length)
@@ -527,7 +533,7 @@ class TokenizerTesterMixin:
 
                 # Simple
                 for truncation_state in ["only_second"]:
-                    for padding_state in [False, True, "longest"]:
+                    for padding_state in padding_strategies:
                         with self.subTest(f"Padding: {padding_state} - Truncation: {truncation_state}"):
                             output = tokenizer(seq_1, seq_2, padding=padding_state, truncation=truncation_state)
                             self.assertEqual(len(output["input_ids"]), model_max_length)
@@ -537,7 +543,7 @@ class TokenizerTesterMixin:
 
                 # Simple with no truncation
                 for truncation_state in [False]:
-                    for padding_state in [False, True, "longest"]:
+                    for padding_state in padding_strategies:
                         with self.subTest(f"Padding: {padding_state} - Truncation: {truncation_state}"):
                             output = tokenizer(seq_1, seq_2, padding=padding_state, truncation=truncation_state)
                             self.assertNotEqual(len(output["input_ids"]), model_max_length)

--- a/tests/test_tokenization_fast.py
+++ b/tests/test_tokenization_fast.py
@@ -22,8 +22,6 @@ from transformers.tokenization_roberta import RobertaTokenizerFast
 from transformers.tokenization_transfo_xl import TransfoXLTokenizerFast
 
 
-logging.basicConfig(level=logging.INFO)
-
 logger = logging.getLogger(__name__)
 
 NON_ENGLISH_TAGS = ["chinese", "dutch", "french", "finnish", "german", "multilingual"]

--- a/tests/test_trainer_distributed.py
+++ b/tests/test_trainer_distributed.py
@@ -62,7 +62,6 @@ if __name__ == "__main__":
     parser = HfArgumentParser((TrainingArguments,))
     training_args = parser.parse_args_into_dataclasses(sys.argv + ["--output_dir", "./examples"])[0]
 
-    logging.basicConfig(level=logging.INFO)
     logger.warning(
         "Process rank: %s, device: %s, n_gpu: %s, distributed training: %s",
         training_args.local_rank,


### PR DESCRIPTION
Padding to max sequence length while truncating to another length did not behave as expected on slow tokenizers as raised in #5181 by @sshleifer (it was truncating and then padding back to original length...)

This PR adds more tests to cover various combinations of padding + truncation strategies.

Fix #5181 

This PR also:
- make #5155 clearer by changing the assertion in a cleaner error message (until the data processors are refactored)
- move back the default level of logging in tests to `logging.WARNING`
- switch some really slow tokenizations tests on CPU (when the inputs go in the full models) to `@slow` and speed-up testing by limiting the max sequence length used for testing