### PR TITLE
Adds option to keep tb_writer open after training finishes

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -348,7 +348,6 @@ class Trainer:
             model_path:
                 (Optional) Local path to model if model to train has been instantiated from a local path
                 If present, we will try reloading the optimizer/scheduler states from there.
-            
             close_tb_writer:
                 (Optional) Whether or not to close tb_writer after training is done.
         """

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -340,7 +340,7 @@ class Trainer:
         """
         return len(dataloader.dataset)
 
-    def train(self, model_path: Optional[str] = None):
+    def train(self, model_path: Optional[str] = None, close_tb_writer: Optional[bool] = True):
         """
         Main training entry point.
 
@@ -348,6 +348,9 @@ class Trainer:
             model_path:
                 (Optional) Local path to model if model to train has been instantiated from a local path
                 If present, we will try reloading the optimizer/scheduler states from there.
+            
+            close_tb_writer:
+                (Optional) Whether or not to close tb_writer after training is done.
         """
         train_dataloader = self.get_train_dataloader()
         if self.args.max_steps > 0:
@@ -533,7 +536,7 @@ class Trainer:
                 # tpu-comment: Logging debug metrics for PyTorch/XLA (compile, execute times, ops, etc.)
                 xm.master_print(met.metrics_report())
 
-        if self.tb_writer:
+        if self.tb_writer and close_tb_writer:
             self.tb_writer.close()
 
         logger.info("\n\nTraining completed. Do not forget to share your model on huggingface.co/models =)\n\n")

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -170,9 +170,9 @@ class Trainer:
             prediction_loss_only:
                 (Optional) in evaluation and prediction, only return the loss
             keep_tb_writer_open:
-                (Optional) Whether or not to keep tb_writer open after training 
-                is done. If kept open, this allows you to write additional 
-                data/metrics to tensorboard after the model is done training 
+                (Optional) Whether or not to keep tb_writer open after training
+                is done. If kept open, this allows you to write additional
+                data/metrics to tensorboard after the model is done training
                 by accessing the `tb_writer` class attribute.
         """
         self.model = model.to(args.device)


### PR DESCRIPTION
Set the `close_tb_writer` parameter to `False` in `Trainer.train()` to keep the tensorboard writer open.

```
tb_writer = SummaryWriter(log_dir="some_dir")

# do some stuff with tb_writer before training

trainer = Trainer(
    model=model,
    args=training_args,
    train_dataset=train_dataset,
    eval_dataset=test_dataset,
    compute_metrics=compute_metrics,
    tb_writer=tb_writer,
)
trainer.train(close_tb_writer=False)

# you can now use tb_writer even after training!
```

Closes #5329 