### PR TITLE
Adds train_batch_size, eval_batch_size, and n_gpu to to_sanitized_dict output for logging.

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -327,7 +327,7 @@ class Trainer:
             logger.info(
                 'Automatic Weights & Biases logging enabled, to disable set os.environ["WANDB_DISABLED"] = "true"'
             )
-            wandb.init(project=os.getenv("WANDB_PROJECT", "huggingface"), config=vars(self.args))
+            wandb.init(project=os.getenv("WANDB_PROJECT", "huggingface"), config=self.args.to_sanitized_dict())
             # keep track of model topology and gradients, unsupported on TPU
             if not is_torch_tpu_available() and os.getenv("WANDB_WATCH") != "false":
                 wandb.watch(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -211,7 +211,17 @@ class TrainingArguments:
         Sanitized serialization to use with TensorBoard’s hparams
         """
         d = dataclasses.asdict(self)
+        d = {
+            **d,
+            **{
+                "train_batch_size": self.train_batch_size,
+                "eval_batch_size": self.eval_batch_size,
+                "n_gpu": self.n_gpu,
+            },
+        }
+
         valid_types = [bool, int, float, str]
         if is_torch_available():
             valid_types.append(torch.Tensor)
+
         return {k: v if type(v) in valid_types else str(v) for k, v in d.items()}

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -213,11 +213,7 @@ class TrainingArguments:
         d = dataclasses.asdict(self)
         d = {
             **d,
-            **{
-                "train_batch_size": self.train_batch_size,
-                "eval_batch_size": self.eval_batch_size,
-                "n_gpu": self.n_gpu,
-            },
+            **{"train_batch_size": self.train_batch_size, "eval_batch_size": self.eval_batch_size,},
         }
 
         valid_types = [bool, int, float, str]

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -211,10 +211,7 @@ class TrainingArguments:
         Sanitized serialization to use with TensorBoard’s hparams
         """
         d = dataclasses.asdict(self)
-        d = {
-            **d,
-            **{"train_batch_size": self.train_batch_size, "eval_batch_size": self.eval_batch_size,},
-        }
+        d = {**d, **{"train_batch_size": self.train_batch_size, "eval_batch_size": self.eval_batch_size}}
 
         valid_types = [bool, int, float, str]
         if is_torch_available():


### PR DESCRIPTION
Closes #5330 

``` 
>>> from transformers import TrainingArguments
>>> args = TrainingArguments("dir")
>>> args.to_sanitized_dict()
{
    "output_dir": "dir",
    "overwrite_output_dir": False,
    "do_train": False,
    ...
    "train_batch_size": 8,
    "eval_batch_size": 8,
    "n_gpu": 0,
}
```