### PR TITLE
Added support for XLNet language modelling training in examples

### DIFF
--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -101,6 +101,9 @@ class DataTrainingArguments:
     mlm_probability: float = field(
         default=0.15, metadata={"help": "Ratio of tokens to mask for masked language modeling loss"}
     )
+    max_gram: int = field(
+        default=5, metadata={"help": "Maximum individual mask span length for XLNet training"}
+    )
 
     block_size: int = field(
         default=-1,
@@ -207,8 +210,8 @@ def main():
 
     if config.model_type in ["bert", "roberta", "distilbert", "camembert"] and not data_args.mlm:
         raise ValueError(
-            "BERT and RoBERTa-like models do not have LM heads but masked LM heads. They must be run using the --mlm "
-            "flag (masked language modeling)."
+            "BERT, RoBERTa and XLNet-like models do not have LM heads but masked LM heads. They must be run using the"
+            "--mlm flag (masked language modeling)."
         )
 
     if data_args.block_size <= 0:
@@ -221,9 +224,15 @@ def main():
 
     train_dataset = get_dataset(data_args, tokenizer=tokenizer) if training_args.do_train else None
     eval_dataset = get_dataset(data_args, tokenizer=tokenizer, evaluate=True) if training_args.do_eval else None
-    data_collator = DataCollatorForLanguageModeling(
-        tokenizer=tokenizer, mlm=data_args.mlm, mlm_probability=data_args.mlm_probability
-    )
+    if config.model_type == "xlnet":
+        data_collator = DataCollatorForXLNetLanguageModeling(
+            tokenizer=tokenizer, mlm=data_args.mlm, mlm_probability=data_args.mlm_probability,
+            max_gram=data_args.max_gram
+        )
+    else:
+        data_collator = DataCollatorForLanguageModeling(
+            tokenizer=tokenizer, mlm=data_args.mlm, mlm_probability=data_args.mlm_probability
+        )
 
     # Initialize our Trainer
     trainer = Trainer(

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -101,9 +101,7 @@ class DataTrainingArguments:
     mlm_probability: float = field(
         default=0.15, metadata={"help": "Ratio of tokens to mask for masked language modeling loss"}
     )
-    max_gram: int = field(
-        default=5, metadata={"help": "Maximum individual mask span length for XLNet training"}
-    )
+    max_gram: int = field(default=5, metadata={"help": "Maximum individual mask span length for XLNet training"})
 
     block_size: int = field(
         default=-1,
@@ -226,8 +224,10 @@ def main():
     eval_dataset = get_dataset(data_args, tokenizer=tokenizer, evaluate=True) if training_args.do_eval else None
     if config.model_type == "xlnet":
         data_collator = DataCollatorForXLNetLanguageModeling(
-            tokenizer=tokenizer, mlm=data_args.mlm, mlm_probability=data_args.mlm_probability,
-            max_gram=data_args.max_gram
+            tokenizer=tokenizer,
+            mlm=data_args.mlm,
+            mlm_probability=data_args.mlm_probability,
+            max_gram=data_args.max_gram,
         )
     else:
         data_collator = DataCollatorForLanguageModeling(

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -33,6 +33,7 @@ from transformers import (
     AutoModelWithLMHead,
     AutoTokenizer,
     DataCollatorForLanguageModeling,
+    DataCollatorForXLNetLanguageModeling,
     HfArgumentParser,
     LineByLineTextDataset,
     PreTrainedTokenizer,

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -148,7 +148,7 @@ class DataCollatorForXLNetLanguageModeling:
     mlm_probability: float = 0.15
     max_gram: int = 5  # maximum individual mask span length L
 
-    def collate_batch(self, examples: List[torch.Tensor]) -> Dict[str, torch.Tensor]:
+    def __call__(self, examples: List[torch.Tensor]) -> Dict[str, torch.Tensor]:
         batch = self._tensorize_batch(examples)
         if self.mlm:
             inputs, perm_mask, target_mapping, labels = self.mask_tokens(batch)

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -133,3 +133,108 @@ class DataCollatorForLanguageModeling:
 
         # The rest of the time (10% of the time) we keep the masked input tokens unchanged
         return inputs, labels
+
+@dataclass
+class DataCollatorForXLNetLanguageModeling:
+    """
+    Data collator used for language modeling with XLNet.
+    - collates batches of tensors, honoring their tokenizer's pad_token
+    - preprocesses batches for masked language modeling with procedures specific to XLNet
+    """
+
+    tokenizer: PreTrainedTokenizer
+    mlm: bool = True
+    mlm_probability: float = 0.15
+    max_gram: int = 5 # maximum individual mask span length L
+    
+    def collate_batch(self, examples: List[torch.Tensor]) -> Dict[str, torch.Tensor]:
+        batch = self._tensorize_batch(examples)
+        if self.mlm:
+            inputs, perm_mask, target_mapping, labels = self.mask_tokens(batch)
+            return {"input_ids": inputs, "perm_mask": perm_mask, "target_mapping": target_mapping, "labels": labels}
+        else:
+            return {"input_ids": batch, "labels": batch}
+
+    def _tensorize_batch(self, examples: List[torch.Tensor]) -> torch.Tensor:
+        length_of_first = examples[0].size(0)
+        are_tensors_same_length = all(x.size(0) == length_of_first for x in examples)
+        if are_tensors_same_length:
+            return torch.stack(examples, dim=0)
+        else:
+            if self.tokenizer._pad_token is None:
+                raise ValueError(
+                    "You are attempting to pad samples but the tokenizer you are using"
+                    f" ({self.tokenizer.__class__.__name__}) does not have one."
+                )
+            return pad_sequence(examples, batch_first=True, padding_value=self.tokenizer.pad_token_id)
+
+
+    def mask_tokens(self, inputs: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        The mask is determined by iteratively performing the following steps until the end of the sequence:
+            1. Sample an n-gram length (n) from [1, ..., max_ngram] (L in the paper)
+            2. Reserve a context of length of n-gram length / mlm_probability (In the paper, context size is K*n, where K is close to the inverse of mlm_probability)
+            3. Sample a starting point and mask n tokens continuously from then
+        """
+
+        if self.tokenizer.mask_token is None:
+            raise ValueError(
+                "This tokenizer does not have a mask token which is necessary for masked language modeling. Remove the --mlm flag if you want to use this tokenizer."
+            )
+        
+        labels = inputs.clone()
+        # Creating the mask and target mapping tensors
+        masked_indices = torch.full(labels.shape, 0, dtype=torch.bool)
+        target_mapping = torch.zeros((labels.size(0), labels.size(1), labels.size(1)), dtype=torch.FloatTensor)
+
+        for i in range(labels.size(0)):
+            cur_len = 0
+            max_len = labels.size(1)
+            # Since we're replacing non-masked (non-functional) tokens with -100 in the labels tensor,
+            # the i-th label corresponds to the i-th token. 
+            target_mapping[i] = torch.eye(labels.size(1))
+            while cur_len < max_len:
+                n = torch.randint(1, self.max_gram + 1, 1).item()
+                ctx_size = int(n / self.mlm_probability)
+                start = cur_len + torch.randint(ctx_size - n + 1, 1).item()
+                end = start + 1
+                while end < max_len and end < start + n:
+                    end += 1
+                masked_indices[i, start:end] = 1
+                cur_len += ctx_size
+        
+        special_tokens_mask = torch.tensor([
+            self.tokenizer.get_special_tokens_mask(val, already_has_special_tokens=True) for val in labels.tolist()
+        ], dtype=torch.bool)
+        masked_indices.masked_fill_(special_tokens_mask, value=0.0)
+        if self.tokenizer._pad_token is not None:
+            padding_mask = labels.eq(self.tokenizer.pad_token_id)
+            masked_indices.masked_fill_(padding_mask, value=0.0)
+
+        # Mask indicating non-functional tokens, where functional tokens are [SEP], [CLS], padding, etc.
+        non_func_mask = ~(padding_mask & special_tokens_mask)
+ 
+        inputs[masked_indices] = self.tokenizer.convert_tokens_to_ids(self.tokenizer.mask_token)
+        labels[~masked_indices] = -100  # We only compute loss on masked tokens
+
+        perm_mask = torch.zeros((labels.size(0), labels.size(1), labels.size(1)), dtype=torch.FloatTensor)
+
+        for i in range(labels.size(0)):
+            # Generate permutation indices
+            # Maximum permutation length has to be less than or equal reused sequence length, 
+            # otherwise leakage will occur. We assume that reused length is half of sequence length
+            # and equality is enforced. This requires that sequence length be even.
+            perm_idx = torch.arange(labels.size(1))
+            perm_idx = perm_idx.reshape((-1, labels.size(1) // 2)).transpose(0, 1)
+            perm_idx = perm_idx[torch.randperm(labels.size(1) // 2)]
+            perm_idx = torch.flatten(perm_idx.transpose(0, 1))
+            # Set the permutation indices of non-masked (non-functional) tokens to the
+            # smallest index (-1): 
+            # (1) they can be seen by all other positions
+            # (2) they cannot see masked positions, so there won't be information leak            
+            perm_idx.masked_fill_(~masked_indices & non_func_mask, -1)
+            # 1: cannot attend if i <= j and j is not non-masked (masked_or_func_tokens)
+            # 0: can attend if i > j or j is non-masked
+            perm_mask[i] = (perm_idx.reshape((labels.size(1), 1)) <= perm_idx.reshape((1, labels.size(1)))) & masked_indices[i] 
+
+        return inputs, perm_mask, target_mapping, labels


### PR DESCRIPTION
Updated src/transformers/data/data_collator.py with a new XLNet-specific collator that applies masking and generates revelant tensors (input_ids, perm_mask, target_mask, labels) as per https://github.com/zihangdai/xlnet/blob/master/data_utils.py. Also added relevant calls and imports in examples/language-modeling/run_language_modeling.py. Relevant issues #4739 #2008 