### PR TITLE
Update Bertabs example to work again

### DIFF
--- a/examples/seq2seq/bertabs/run_summarization.py
+++ b/examples/seq2seq/bertabs/run_summarization.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 from modeling_bertabs import BertAbs, build_predictor
 from transformers import BertTokenizer
 
-from utils_summarization import (
+from .utils_summarization import (
     CNNDMDataset,
     build_mask,
     compute_token_type_ids,

--- a/examples/seq2seq/bertabs/run_summarization.py
+++ b/examples/seq2seq/bertabs/run_summarization.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 from modeling_bertabs import BertAbs, build_predictor
 from transformers import BertTokenizer
 
-from .utils_summarization import (
+from utils_summarization import (
     CNNDMDataset,
     build_mask,
     compute_token_type_ids,
@@ -30,7 +30,7 @@ Batch = namedtuple("Batch", ["document_names", "batch_size", "src", "segs", "mas
 
 def evaluate(args):
     tokenizer = BertTokenizer.from_pretrained("bert-base-uncased", do_lower_case=True)
-    model = BertAbs.from_pretrained("bertabs-finetuned-cnndm")
+    model = BertAbs.from_pretrained("remi/bertabs-finetuned-extractive-abstractive-summarization")
     model.to(args.device)
     model.eval()
 


### PR DESCRIPTION
Fix the bug 'Attempted relative import with no known parent package' when using the bertabs example. Also change the used model from bertabs-finetuned-cnndm, since it seems not be accessible anymore