### PR TITLE
Update dependency mecab to at least version 1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ if stale_egg_info.exists():
 
 extras = {}
 
-extras["mecab"] = ["mecab-python3<1"]
+extras["mecab"] = ["mecab-python3>=1.0"]
 extras["sklearn"] = ["scikit-learn"]
 
 # keras2onnx and onnxconverter-common version is specific through a commit until 1.7.0 lands on pypi
@@ -92,7 +92,7 @@ extras["quality"] = [
     "isort",
     "flake8",
 ]
-extras["dev"] = extras["testing"] + extras["quality"] + ["mecab-python3<1", "scikit-learn", "tensorflow", "torch"]
+extras["dev"] = extras["testing"] + extras["quality"] + ["mecab-python3>=1.0", "scikit-learn", "tensorflow", "torch"]
 
 setup(
     name="transformers",


### PR DESCRIPTION
Require at least version 1.0 of mecab, which comes with prebuilt wheels for all major platforms (OS X, Linux, Windows). This should do away with some reported incompatibility issues for non-linux systems.

See https://github.com/SamuraiT/mecab-python3/issues/31#issuecomment-651053281

Note: code untested but nothing much to test. [Version 1.0.0 is on PyPi](https://pypi.org/project/mecab-python3/1.0.0/) so it should work as written.