### PR TITLE
Add support for past states

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -504,8 +504,7 @@ class Trainer:
                     steps_trained_in_current_epoch -= 1
                     continue
 
-                loss = self._training_step(model, inputs, optimizer)
-                tr_loss += loss
+                tr_loss += self._training_step(model, inputs, optimizer)
 
                 if (step + 1) % self.args.gradient_accumulation_steps == 0 or (
                     # last step in epoch but step is always smaller than gradient_accumulation_steps

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -816,7 +816,7 @@ class Trainer:
         if is_torch_tpu_available():
             dataloader = pl.ParallelLoader(dataloader, [self.args.device]).per_device_loader(self.args.device)
 
-        if self.args.past_index:
+        if self.args.past_index >= 0:
             past = None
 
         for inputs in tqdm(dataloader, desc=description):
@@ -825,7 +825,7 @@ class Trainer:
             for k, v in inputs.items():
                 if isinstance(v, torch.Tensor):
                     inputs[k] = v.to(self.args.device)
-            if self.args.past_index:
+            if self.args.past_index >= 0:
                 inputs["mems"] = past
 
             with torch.no_grad():
@@ -835,7 +835,7 @@ class Trainer:
                     eval_losses += [step_eval_loss.mean().item()]
                 else:
                     logits = outputs[0]
-                if self.args.past_index:
+                if self.args.past_index >= 0:
                     past = outputs[self.args.past_index if has_labels else self.args.past_index - 1]
 
             if not prediction_loss_only:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -494,7 +494,7 @@ class Trainer:
                 epoch_iterator = tqdm(train_dataloader, desc="Iteration", disable=not self.is_local_master())
 
             # Reset the past mems state at the beginning of each epoch if necessary.
-            if args.past_index >= 0:
+            if self.args.past_index >= 0:
                 self._past = None
 
             for step, inputs in enumerate(epoch_iterator):
@@ -624,15 +624,15 @@ class Trainer:
         for k, v in inputs.items():
             if isinstance(v, torch.Tensor):
                 inputs[k] = v.to(self.args.device)
-        
-        if args.past_index >= 0 and self._past is not None:
+
+        if self.args.past_index >= 0 and self._past is not None:
             inputs["mems"] = self._past
 
         outputs = model(**inputs)
         loss = outputs[0]  # model outputs are always tuple in transformers (see doc)
 
-        if args.past_index >= 0:
-            self._past = outputs[args.past_index]
+        if self.args.past_index >= 0:
+            self._past = outputs[self.args.past_index]
 
         if self.args.n_gpu > 1:
             loss = loss.mean()  # mean() to average on multi-gpu parallel training
@@ -645,7 +645,7 @@ class Trainer:
         else:
             loss.backward()
 
-        return loss.item(), past
+        return loss.item()
 
     def is_local_master(self) -> bool:
         if is_torch_tpu_available():

--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -240,6 +240,10 @@ class TFTrainer:
 
         step: int = 1
 
+        # Reset the past mems state at the beginning of the evaluation if necessary.
+        if self.args.past_index >= 0:
+            self._past = None
+
         for features, labels in dataset:
             step = tf.convert_to_tensor(step, dtype=tf.int64)
             loss, logits = self._evaluate_steps(features, labels)
@@ -287,6 +291,10 @@ class TFTrainer:
         for key in list(metrics.keys()):
             if not key.startswith("eval_"):
                 metrics[f"eval_{key}"] = metrics.pop(key)
+
+        if self.args.past_index and hasattr(self, "_past"):
+            # Clean the state at the end of training
+            delattr(self, "_past")
 
         return PredictionOutput(predictions=preds, label_ids=label_ids, metrics=metrics)
 
@@ -405,6 +413,9 @@ class TFTrainer:
         logger.info("  Total optimization steps = %d", t_total)
 
         for epoch_iter in range(epochs_trained, int(epochs + 1)):
+            # Reset the past mems state at the beginning of each epoch if necessary.
+            if self.args.past_index >= 0:
+                self._past = None
             for step, training_loss in enumerate(self._training_steps(train_ds, optimizer)):
                 self.global_step = iterations.numpy()
                 self.epoch_logging = epoch_iter - 1 + (step + 1) / steps_per_epoch
@@ -443,6 +454,10 @@ class TFTrainer:
 
                 if self.args.max_steps > 0 and self.global_step % self.args.max_steps == 0:
                     break
+
+        if self.args.past_index and hasattr(self, "_past"):
+            # Clean the state at the end of training
+            delattr(self, "_past")
 
     def _training_steps(self, ds, optimizer):
         """
@@ -518,10 +533,15 @@ class TFTrainer:
           labels: the batched labels.
           training: run the model in training mode or not
         """
+        if self.args.past_index >= 0 and getattr(self, "_past", None) is not None:
+            features["mems"] = self._past
         if isinstance(labels, (dict)):
-            loss, logits = self.model(features, training=training, **labels)[:2]
+            outputs = self.model(features, training=training, **labels)[:2]
         else:
-            loss, logits = self.model(features, labels=labels, training=training)[:2]
+            outputs = self.model(features, labels=labels, training=training)[:2]
+        loss, logits = outputs[:2]
+        if self.args.past_index >= 0:
+            self._past = outputs[self.args.past_index]
         loss += sum(self.model.losses) * (1.0 / self.args.n_gpu)
 
         return loss, logits

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -208,6 +208,11 @@ class TrainingArguments:
         default=False, metadata={"help": "Drop the last incomplete batch if it is not divisible by the batch size."}
     )
 
+    past_index: int = field(
+        default=-1,
+        metadata={"help": "If >=0, uses the corresponding part of the output as the past state for next step."},
+    )
+
     @property
     def train_batch_size(self) -> int:
         """

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -106,7 +106,7 @@ class TrainingArguments:
             Some models like :doc:`TransformerXL <../model_doc/transformerxl>` or :doc`XLNet <../model_doc/xlnet>` can
             make use of the past hidden states for their predictions. If this argument is set to a positive int, the
             ``Trainer`` will use the corresponding output (usually index 2) as the past state and feed it to the model
-            at the next training step under the keyword argument ``mems``. 
+            at the next training step under the keyword argument ``mems``.
     """
 
     output_dir: str = field(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -102,6 +102,11 @@ class TrainingArguments:
         dataloader_drop_last (:obj:`bool`, `optional`, defaults to :obj:`False`):
             Whether to drop the last incomplete batch (if the length of the dataset is not divisible by the batch size)
             or not.
+        past_index (:obj:`int`, `optional`, defaults to -1):
+            Some models like :doc:`TransformerXL <../model_doc/transformerxl>` or :doc`XLNet <../model_doc/xlnet>` can
+            make use of the past hidden states for their predictions. If this argument is set to a positive int, the
+            ``Trainer`` will use the corresponding output (usually index 2) as the past state and feed it to the model
+            at the next training step under the keyword argument ``mems``. 
     """
 
     output_dir: str = field(

--- a/src/transformers/training_args_tf.py
+++ b/src/transformers/training_args_tf.py
@@ -85,6 +85,11 @@ class TFTrainingArguments(TrainingArguments):
         dataloader_drop_last (:obj:`bool`, `optional`, defaults to :obj:`False`):
             Whether to drop the last incomplete batch (if the length of the dataset is not divisible by the batch size)
             or not.
+        past_index (:obj:`int`, `optional`, defaults to -1):
+            Some models like :doc:`TransformerXL <../model_doc/transformerxl>` or :doc`XLNet <../model_doc/xlnet>` can
+            make use of the past hidden states for their predictions. If this argument is set to a positive int, the
+            ``Trainer`` will use the corresponding output (usually index 2) as the past state and feed it to the model
+            at the next training step under the keyword argument ``mems``.
         tpu_name (:obj:`str`, `optional`):
             The name of the TPU the process is running on.
         eval_steps (:obj:`int`, `optional`, defaults to 1000):


### PR DESCRIPTION
This adds support in the `Trainer` for models that can use past states. Since there is no way to know in advance where the output will be in the model (we can guess it's going to be the second, but that may not always be the case for all models or user-defined models), I added an argument to the `TrainingArguments` for the index of where to look at mems in the outputs.

If it's left to -1, nothing happens, and if it's set, the `Trainer` will save the past mems in its state at each training step and add them to the inputs on the next step.

If this looks good to you, I'll add the same thing on the TF side before merging.