### PR TITLE
Gradient checkpointing BERT & ALBERT poc

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -61,6 +61,7 @@ class PretrainedConfig(object):
         self.torchscript = kwargs.pop("torchscript", False)  # Only used by PyTorch models
         self.use_bfloat16 = kwargs.pop("use_bfloat16", False)
         self.pruned_heads = kwargs.pop("pruned_heads", {})
+        self.gradient_checkpointing = kwargs.pop("gradient_checkpointing", False)
 
         # Is decoder is used in encoder-decoder models to differentiate encoder from decoder
         self.is_encoder_decoder = kwargs.pop("is_encoder_decoder", False)

--- a/src/transformers/modeling_albert.py
+++ b/src/transformers/modeling_albert.py
@@ -327,6 +327,7 @@ class AlbertTransformer(nn.Module):
         hidden_states = self.embedding_hidden_mapping_in(hidden_states)
 
         all_attentions = ()
+        output_attentions = torch.tensor(output_attentions, dtype=torch.bool)
 
         if output_hidden_states:
             all_hidden_states = (hidden_states,)
@@ -461,6 +462,9 @@ class AlbertModel(AlbertPreTrainedModel):
 
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
+
+    def get_layers(self):
+        return [layer for layer_group in self.encoder.albert_layer_groups for layer in layer_group.albert_layers]
 
     def _resize_token_embeddings(self, new_num_tokens):
         old_embeddings = self.embeddings.word_embeddings

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import inspect
 import logging
 import os
@@ -23,7 +24,6 @@ import torch
 from torch import Tensor, device, dtype, nn
 from torch.nn import CrossEntropyLoss
 from torch.nn import functional as F
-import functools
 
 from .activations import get_activation
 from .configuration_utils import PretrainedConfig

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -351,8 +351,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
         Returns the model's transformer layers.
 
         Returns:
-            :obj:`nn.Module`:
-                A torch module mapping hidden states to vocabulary.
+            :obj:`List` or :obj:`nn.ModuleList`:
+                A list or :obj:`nn.ModuleList` containing all transformer layers.
         """
         base_model = getattr(self, self.base_model_prefix, self)
         if base_model is not self:

--- a/tests/test_modeling_albert.py
+++ b/tests/test_modeling_albert.py
@@ -260,6 +260,8 @@ class AlbertModelTester:
 @require_torch
 class AlbertModelTest(ModelTesterMixin, unittest.TestCase):
 
+    test_gradient_checkpointing = True
+
     all_model_classes = (
         (
             AlbertModel,

--- a/tests/test_modeling_bert.py
+++ b/tests/test_modeling_bert.py
@@ -431,6 +431,8 @@ class BertModelTester:
 @require_torch
 class BertModelTest(ModelTesterMixin, unittest.TestCase):
 
+    test_gradient_checkpointing = True
+
     all_model_classes = (
         (
             BertModel,


### PR DESCRIPTION
Proof of concept for gradient checkpointing in PyTorch, using a model-agnostic approach. The POC is done for BERT and ALBERT.

Pros:

- Model agnostic, only a few lines to add to models to be able to use this functionality
- Reinforces the model layer API, adding `get_layers()` (name to be discussed) alongside `get_input_embeddings()` and `get_output_embeddings()`

Cons:

- The checkpoint API can only handle positional arguments, pytorch tensors or None only. This means that:
    - The `output_hidden_states` must be cast to a tensor in the model
    - Models that pass keyword arguments to their layers need to pass positional arguments (see GPT-2 for example, which uses keyword arguments [here](https://github.com/huggingface/transformers/blob/b45e65efa0fbff2611ddd68e14fa75cacef3fe08/src/transformers/modeling_gpt2.py#L488-L493)).


If you think this is a cool API, I'll go ahead and implement this for the remaining models. @patrickvonplaten @thomwolf @julien-c @sgugger @ibeltagy

Here are the results using the benchmarking script:

```py
from transformers import PyTorchBenchmark, PyTorchBenchmarkArguments, BertConfig
args = PyTorchBenchmarkArguments(models=["bert-base-cased"], batch_sizes=[8], sequence_lengths=[8, 32, 128, 512], no_inference=True, training=True)
config_base = BertConfig.from_pretrained("bert-base-cased", gradient_checkpointing=False)
benchmark = PyTorchBenchmark(args, configs=[config_base])
benchmark.run()
```
Result (only relevant info):

```
====================        TRAIN - SPEED - RESULTS         ====================
--------------------------------------------------------------------------------
          Model Name             Batch Size     Seq Length     Time in s   
--------------------------------------------------------------------------------
       bert-base-cased               8               8             0.028     
       bert-base-cased               8               32            0.029     
       bert-base-cased               8              128            0.072     
       bert-base-cased               8              512            0.296     
--------------------------------------------------------------------------------

====================        TRAIN - MEMORY - RESULTS        ====================
--------------------------------------------------------------------------------
          Model Name             Batch Size     Seq Length    Memory in MB 
--------------------------------------------------------------------------------
       bert-base-cased               8               8              2419     
       bert-base-cased               8               32             2481     
       bert-base-cased               8              128             2985     
       bert-base-cased               8              512             8233     
--------------------------------------------------------------------------------
```

```py
from transformers import PyTorchBenchmark, PyTorchBenchmarkArguments, BertConfig
args = PyTorchBenchmarkArguments(models=["bert-base-cased"], batch_sizes=[8], sequence_lengths=[8, 32, 128, 512], no_inference=True, training=True)
config_base = BertConfig.from_pretrained("bert-base-cased", gradient_checkpointing=True)
benchmark = PyTorchBenchmark(args, configs=[config_base])
benchmark.run()
```

Result (only relevant info):

```
====================        TRAIN - SPEED - RESULTS         ====================
--------------------------------------------------------------------------------
          Model Name             Batch Size     Seq Length     Time in s   
--------------------------------------------------------------------------------
       bert-base-cased               8               8             0.049     
       bert-base-cased               8               32             0.05     
       bert-base-cased               8              128            0.109     
       bert-base-cased               8              512            0.473     
--------------------------------------------------------------------------------

====================        TRAIN - MEMORY - RESULTS        ====================
--------------------------------------------------------------------------------
          Model Name             Batch Size     Seq Length    Memory in MB 
--------------------------------------------------------------------------------
       bert-base-cased               8               8              2385     
       bert-base-cased               8               32             2403     
       bert-base-cased               8              128             2465     
       bert-base-cased               8              512             3969     
--------------------------------------------------------------------------------
```