### PR TITLE
Bans SentencePiece 0.1.92

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
         # for OpenAI GPT
         "regex != 2019.12.17",
         # for XLNet
-        "sentencepiece",
+        "sentencepiece != 0.1.92",
         # for XLM
         "sacremoses",
     ],


### PR DESCRIPTION
SentencePiece 0.1.92 seems to cause Segmentation Fault, as visible [here](https://github.com/huggingface/transformers/issues/4857).