### PR TITLE
QA Pipelines fixes

### DIFF
--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -138,7 +138,7 @@ def squad_convert_example_to_features(example, max_seq_length, doc_stride, max_q
             truncated_query if tokenizer.padding_side == "right" else span_doc_tokens,
             span_doc_tokens if tokenizer.padding_side == "right" else truncated_query,
             truncation="only_second" if tokenizer.padding_side == "right" else "only_first",
-            padding=PaddingStrategy.DO_NOT_PAD,
+            padding=PaddingStrategy.LONGEST,
             max_length=max_seq_length,
             return_overflowing_tokens=True,
             stride=max_seq_length - doc_stride - len(truncated_query) - sequence_pair_added_tokens,

--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 from ...file_utils import is_tf_available, is_torch_available
 from ...tokenization_bert import whitespace_tokenize
 from .utils import DataProcessor
-
+from ...tokenization_utils_base import PaddingStrategy
 
 if is_torch_available():
     import torch
@@ -137,7 +137,7 @@ def squad_convert_example_to_features(example, max_seq_length, doc_stride, max_q
             truncated_query if tokenizer.padding_side == "right" else span_doc_tokens,
             span_doc_tokens if tokenizer.padding_side == "right" else truncated_query,
             truncation="only_second" if tokenizer.padding_side == "right" else "only_first",
-            padding="max_length",
+            padding=PaddingStrategy.DO_NOT_PAD,
             max_length=max_seq_length,
             return_overflowing_tokens=True,
             stride=max_seq_length - doc_stride - len(truncated_query) - sequence_pair_added_tokens,

--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -9,8 +9,9 @@ from tqdm import tqdm
 
 from ...file_utils import is_tf_available, is_torch_available
 from ...tokenization_bert import whitespace_tokenize
-from .utils import DataProcessor
 from ...tokenization_utils_base import PaddingStrategy
+from .utils import DataProcessor
+
 
 if is_torch_available():
     import torch

--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -9,7 +9,6 @@ from tqdm import tqdm
 
 from ...file_utils import is_tf_available, is_torch_available
 from ...tokenization_bert import whitespace_tokenize
-from ...tokenization_utils_base import PaddingStrategy
 from .utils import DataProcessor
 
 
@@ -138,7 +137,7 @@ def squad_convert_example_to_features(example, max_seq_length, doc_stride, max_q
             truncated_query if tokenizer.padding_side == "right" else span_doc_tokens,
             span_doc_tokens if tokenizer.padding_side == "right" else truncated_query,
             truncation="only_second" if tokenizer.padding_side == "right" else "only_first",
-            padding=PaddingStrategy.LONGEST,
+            padding="max_length",
             max_length=max_seq_length,
             return_overflowing_tokens=True,
             stride=max_seq_length - doc_stride - len(truncated_query) - sequence_pair_added_tokens,

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1211,13 +1211,13 @@ class QuestionAnsweringPipeline(Pipeline):
             with self.device_placement():
                 if self.framework == "tf":
                     fw_args = {k: tf.constant(v) for (k, v) in fw_args.items()}
-                    start, end = self.model(fw_args)
+                    start, end = self.model(fw_args)[:2]
                     start, end = start.numpy(), end.numpy()
                 else:
                     with torch.no_grad():
                         # Retrieve the score for the context tokens only (removing question tokens)
                         fw_args = {k: torch.tensor(v, device=self.device) for (k, v) in fw_args.items()}
-                        start, end = self.model(**fw_args)
+                        start, end = self.model(**fw_args)[:2]
                         start, end = start.cpu().numpy(), end.cpu().numpy()
 
             min_null_score = 1000000  # large and positive

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1223,20 +1223,21 @@ class QuestionAnsweringPipeline(Pipeline):
             min_null_score = 1000000  # large and positive
             answers = []
             for (feature, start_, end_) in zip(features, start, end):
-                # Normalize logits and spans to retrieve the answer
-                start_ = np.exp(start_) / np.sum(np.exp(start_))
-                end_ = np.exp(end_) / np.sum(np.exp(end_))
-
                 # Mask padding and question
                 start_, end_ = (
                     start_ * np.abs(np.array(feature.p_mask) - 1),
                     end_ * np.abs(np.array(feature.p_mask) - 1),
                 )
 
+                # Mask CLS
+                start_[0] = end_[0] = 0
+
+                # Normalize logits and spans to retrieve the answer
+                start_ = np.exp(start_ - np.log(np.sum(np.exp(start_), axis=-1, keepdims=True)))
+                end_ = np.exp(end_ - np.log(np.sum(np.exp(end_), axis=-1, keepdims=True)))
+
                 if kwargs["handle_impossible_answer"]:
                     min_null_score = min(min_null_score, (start_[0] * end_[0]).item())
-
-                start_[0] = end_[0] = 0
 
                 starts, ends, scores = self.decode(start_, end_, kwargs["topk"], kwargs["max_answer_len"])
                 char_to_word = np.array(example.char_to_word_offset)


### PR DESCRIPTION
**1. Some newly introduced models such as [bart-large-finetuned-squadv1](https://huggingface.co/valhalla/bart-large-finetuned-squadv1) have more than 2 outputs by default on the QA pipeline which is not supported.** 

- This PR makes it possible to support such outputs and assumes the 2 first elements are the actual `start`, `end `logits.

**2. Minor refactoring of the decoding strategy:**

- Actually mask the padding & question **before** applying the softmax to extract answer
- Use the stabilized version of the `softmax `in log-space
