### PR TITLE
[Discussion] fix zero divison error (Reformer batch size bug)

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -385,7 +385,7 @@ class Trainer:
         if self.args.max_steps > 0:
             t_total = self.args.max_steps
             num_train_epochs = (
-                self.args.max_steps // (len(train_dataloader) // self.args.gradient_accumulation_steps) + 1
+                int((self.args.max_steps / len(train_dataloader)) / self.args.gradient_accumulation_steps) + 1
             )
         else:
             t_total = int(len(train_dataloader) // self.args.gradient_accumulation_steps * self.args.num_train_epochs)


### PR DESCRIPTION
This PR is for discussion
During the training of the reformer model, I noticed that when you increase the batch size, a zero divison error often occurs
With these changes the error no longer occurs