### PR TITLE
Truncation in GLUE should be longest first

### DIFF
--- a/src/transformers/data/processors/glue.py
+++ b/src/transformers/data/processors/glue.py
@@ -132,7 +132,7 @@ def _glue_convert_examples_to_features(
         [(example.text_a, example.text_b) for example in examples],
         max_length=max_length,
         padding="max_length",
-        truncation=True,
+        truncation="longest_first",
     )
 
     features = []


### PR DESCRIPTION
The GLUE example currently crashes with the QQP task because of the truncation.

It outputs the following warnings:

```
ERROR:transformers.tokenization_utils:We need to remove 186 to truncate the inputbut the first sequence has a length 25. Please select another truncation strategy than TruncationStrategy.ONLY_FIRST, for instance 'longest_first' or 'only_second'.
ERROR:transformers.tokenization_utils:We need to remove 49 to truncate the inputbut the first sequence has a length 34. Please select another truncation strategy than TruncationStrategy.ONLY_FIRST, for instance 'longest_first' or 'only_second'.
ERROR:transformers.tokenization_utils:We need to remove 203 to truncate the inputbut the first sequence has a length 42. Please select another truncation strategy than TruncationStrategy.ONLY_FIRST, for instance 'longest_first' or 'only_second'.
ERROR:transformers.tokenization_utils:We need to remove 39 to truncate the inputbut the first sequence has a length 28. Please select another truncation strategy than TruncationStrategy.ONLY_FIRST, for instance 'longest_first' or 'only_second'.
ERROR:transformers.tokenization_utils:We need to remove 23 to truncate the inputbut the first sequence has a length 20. Please select another truncation strategy than TruncationStrategy.ONLY_FIRST, for instance 'longest_first' or 'only_second'.
ERROR:transformers.tokenization_utils:We need to remove 91 to truncate the inputbut the first sequence has a length 63. Please select another truncation strategy than TruncationStrategy.ONLY_FIRST, for instance 'longest_first' or 'only_second'.
```

before crashing with the following:

```
ValueError: expected sequence of length 128 at dim 1 (got 202)
```

closes https://github.com/huggingface/transformers/issues/5460