### PR TITLE
[Generation] better error message

### DIFF
--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -347,6 +347,10 @@ class TFGenerationMixin:
             encoder_outputs = None
             cur_len = shape_list(input_ids)[-1]
 
+        assert (
+            cur_len < max_length
+        ), f"The context has {cur_len} number of tokens, but `max_length` is only {max_length}. Please make sure that `max_length` is bigger than the number of tokens, by setting either `generate(max_length=...,...)` or `config.max_length = ...`"
+
         if num_beams > 1:
             output = self._generate_beam_search(
                 input_ids,

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -428,6 +428,10 @@ class GenerationMixin:
             encoder_outputs = None
             cur_len = input_ids.shape[-1]
 
+        assert (
+            cur_len < max_length
+        ), f"The context has {cur_len} number of tokens, but `max_length` is only {max_length}. Please make sure that `max_length` is bigger than the number of tokens, by setting either `generate(max_length=...,...)` or `config.max_length = ...`"
+
         if num_beams > 1:
             output = self._generate_beam_search(
                 input_ids,


### PR DESCRIPTION
If `cur_len` of input context is as long or longer than `max_length` a nice error message should be shown.