### PR TITLE
example code missing `encode`

### DIFF
--- a/docs/source/training.rst
+++ b/docs/source/training.rst
@@ -86,7 +86,7 @@ prepares everything we might need to pass to the model.
     from transformers import BertTokenizer
     tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
     text_batch = ["I love Pixar.", "I don't care for Pixar."]
-    encoding = tokenizer(text_batch, return_tensors='pt', padding=True, truncation=True)
+    encoding = tokenizer.encode(text_batch, return_tensors='pt', padding=True, truncation=True)
     input_ids = encoding['input_ids']
     attention_mask = encoding['attention_mask']
 


### PR DESCRIPTION
following example, and realized by running 
```
In [27]:     encoding = tokenizer(text_batch, return_tensors='pt', padding=True, truncation=True)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-27-c8731cd264f2> in <module>
----> 1 encoding = tokenizer(text_batch, return_tensors='pt', padding=True, truncation=True)

TypeError: 'BertTokenizer' object is not callable
```