### PR TITLE
Make T5 compatible with ONNX

### DIFF
--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -359,8 +359,8 @@ class T5Attention(nn.Module):
             present_key_value_state = (None,)
 
         # (bs, n_heads, qlen, klen)
-        scores = q @ k.transpose(
-            3, 2
+        scores = torch.matmul(
+            q, k.transpose(3, 2)
         )  # equivalent of torch.einsum("bnqd,bnkd->bnqk", q, k), compatible with onnx op>9
 
         if position_bias is None:

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -359,7 +359,9 @@ class T5Attention(nn.Module):
             present_key_value_state = (None,)
 
         # (bs, n_heads, qlen, klen)
-        scores = q @ k.transpose(3, 2) # equivalent of torch.einsum("bnqd,bnkd->bnqk", q, k), compatible with onnx op>9
+        scores = q @ k.transpose(
+            3, 2
+        )  # equivalent of torch.einsum("bnqd,bnkd->bnqk", q, k), compatible with onnx op>9
 
         if position_bias is None:
             if not self.has_relative_attention_bias:

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -821,7 +821,7 @@ T5_INPUTS_DOCSTRING = r"""
             Provide for sequence to sequence training. T5 uses the pad_token_id as the starting token for decoder_input_ids generation.
             If `decoder_past_key_value_states` is used, optionally only the last `decoder_input_ids` have to be input (see `decoder_past_key_value_states`).
             To know more on how to prepare :obj:`decoder_input_ids` for pre-training take a look at
-            `T5 Training <./t5.html#training>`__. If decoder_input_ids and decoder_inputs_embeds are both None, 
+            `T5 Training <./t5.html#training>`__. If decoder_input_ids and decoder_inputs_embeds are both None,
             decoder_input_ids takes the value of input_ids.
         decoder_attention_mask (:obj:`torch.BoolTensor` of shape :obj:`(batch_size, tgt_seq_len)`, `optional`, defaults to :obj:`None`):
             Default behavior: generate a tensor that ignores pad tokens in decoder_input_ids. Causal mask will also be used by default.
@@ -841,7 +841,7 @@ T5_INPUTS_DOCSTRING = r"""
             Optionally, instead of passing :obj:`decoder_input_ids` you can choose to directly pass an embedded representation.
             If `decoder_past_key_value_states` is used, optionally only the last `decoder_inputs_embeds` have to be input (see `decoder_past_key_value_states`).
             This is useful if you want more control over how to convert `decoder_input_ids` indices into associated vectors
-            than the model's internal embedding lookup matrix. If decoder_input_ids and decoder_inputs_embeds are both None, 
+            than the model's internal embedding lookup matrix. If decoder_input_ids and decoder_inputs_embeds are both None,
             decoder_inputs_embeds takes the value of inputs_embeds.
         head_mask: (:obj:`torch.FloatTensor` of shape :obj:`(num_heads,)` or :obj:`(num_layers, num_heads)`, `optional`, defaults to :obj:`None`):
             Mask to nullify selected heads of the self-attention modules.

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -358,7 +358,8 @@ class T5Attention(nn.Module):
         else:
             present_key_value_state = (None,)
 
-        scores = torch.einsum("bnqd,bnkd->bnqk", q, k)  # (bs, n_heads, qlen, klen)
+        # (bs, n_heads, qlen, klen)
+        scores = q @ k.transpose(3, 2) # equivalent of torch.einsum("bnqd,bnkd->bnqk", q, k), compatible with onnx op>9
 
         if position_bias is None:
             if not self.has_relative_attention_bias:

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -957,7 +957,7 @@ class T5Model(T5PreTrainedModel):
 
         # If the model is only provided with either input_ids or inputs_embeds,
         # use them as the inputs of the decoder. self.encoder checks for input_ids XOR inputs_embeds
-        if (decoder_input_ids is None) and (decoder_input_ids is None):
+        if (decoder_input_ids is None) and (decoder_inputs_embeds is None):
             decoder_input_ids = input_ids
             decoder_inputs_embeds = inputs_embeds
 

--- a/tests/test_modeling_t5.py
+++ b/tests/test_modeling_t5.py
@@ -350,19 +350,18 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
         for model_name in T5_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
             model = T5Model.from_pretrained(model_name)
             self.assertIsNotNone(model)
-    @slow
+
     def test_export_to_onnx(self):
         import tempfile
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
-        for model_name in T5_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
-            model = T5Model.from_pretrained(model_name)
-            with tempfile.TemporaryDirectory() as tmpdirname:
-                torch.onnx.export(model,
-                                  config_and_inputs[1],
-                                  f"{tmpdirname}/t5_test.onnx",
-                                  export_params=True,
-                                  opset_version=9,
-                                  )
+        model = T5Model(config_and_inputs[0])
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            torch.onnx.export(model,
+                              config_and_inputs[1],
+                              f"{tmpdirname}/t5_test.onnx",
+                              export_params=True,
+                              opset_version=9,
+                              )
 
 
 @require_torch

--- a/tests/test_modeling_t5.py
+++ b/tests/test_modeling_t5.py
@@ -353,15 +353,13 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
 
     def test_export_to_onnx(self):
         import tempfile
+
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         model = T5Model(config_and_inputs[0])
         with tempfile.TemporaryDirectory() as tmpdirname:
-            torch.onnx.export(model,
-                              config_and_inputs[1],
-                              f"{tmpdirname}/t5_test.onnx",
-                              export_params=True,
-                              opset_version=9,
-                              )
+            torch.onnx.export(
+                model, config_and_inputs[1], f"{tmpdirname}/t5_test.onnx", export_params=True, opset_version=9,
+            )
 
 
 @require_torch

--- a/tests/test_modeling_t5.py
+++ b/tests/test_modeling_t5.py
@@ -350,6 +350,19 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
         for model_name in T5_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
             model = T5Model.from_pretrained(model_name)
             self.assertIsNotNone(model)
+    @slow
+    def test_export_to_onnx(self):
+        import tempfile
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        for model_name in T5_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
+            model = T5Model.from_pretrained(model_name)
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                torch.onnx.export(model,
+                                  config_and_inputs[1],
+                                  f"{tmpdirname}/t5_test.onnx",
+                                  export_params=True,
+                                  opset_version=9,
+                                  )
 
 
 @require_torch


### PR DESCRIPTION
This is a small PR to make T5 exportable to ONNX with any op>9. It addresses an issue outlined in #5075 where T5 would not export to ONNX. In order to make it exportable, 2 changes are made:
- A torch.einsum is replaced with a tensor multiplication in 96d0ec7 since onnx does not currently support this notation
- Decoder inputs / embeddings are defaulted to the encoder's inputs / embeddings if they are not declared. I believe this is clearer as most of the examples right now include something along the lines of `model(input_ids=input_ids, decoder_input_ids=input_ids)`. It also allows t5 to be executed with the more common paradigm of calls like model(inputs)