### PR TITLE
Fix `RobertaClassificationHead` style consistency.

### DIFF
--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -343,8 +343,9 @@ class RobertaForSequenceClassification(BertPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
         )
-        sequence_output = outputs[0]
-        logits = self.classifier(sequence_output)
+        sequence_output = outputs[0] # (bs, seq_len, dim)
+        pooled_output = sequence_output[:, 0] # (bs, dim); <s> token (equiv. to [CLS])
+        logits = self.classifier(pooled_output) # (bs, dim)
 
         outputs = (logits,) + outputs[2:]
         if labels is not None:
@@ -557,8 +558,7 @@ class RobertaClassificationHead(nn.Module):
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
         self.out_proj = nn.Linear(config.hidden_size, config.num_labels)
 
-    def forward(self, features, **kwargs):
-        x = features[:, 0, :]  # take <s> token (equiv. to [CLS])
+    def forward(self, x, **kwargs):
         x = self.dropout(x)
         x = self.dense(x)
         x = torch.tanh(x)

--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -24,18 +24,8 @@ import torch.nn as nn
 from torch.nn import CrossEntropyLoss, MSELoss
 
 from .configuration_roberta import RobertaConfig
-from .file_utils import (
-    add_code_sample_docstrings,
-    add_start_docstrings,
-    add_start_docstrings_to_callable,
-)
-from .modeling_bert import (
-    BertEmbeddings,
-    BertLayerNorm,
-    BertModel,
-    BertPreTrainedModel,
-    gelu,
-)
+from .file_utils import add_code_sample_docstrings, add_start_docstrings, add_start_docstrings_to_callable
+from .modeling_bert import BertEmbeddings, BertLayerNorm, BertModel, BertPreTrainedModel, gelu
 
 
 logger = logging.getLogger(__name__)

--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -24,8 +24,18 @@ import torch.nn as nn
 from torch.nn import CrossEntropyLoss, MSELoss
 
 from .configuration_roberta import RobertaConfig
-from .file_utils import add_code_sample_docstrings, add_start_docstrings, add_start_docstrings_to_callable
-from .modeling_bert import BertEmbeddings, BertLayerNorm, BertModel, BertPreTrainedModel, gelu
+from .file_utils import (
+    add_code_sample_docstrings,
+    add_start_docstrings,
+    add_start_docstrings_to_callable,
+)
+from .modeling_bert import (
+    BertEmbeddings,
+    BertLayerNorm,
+    BertModel,
+    BertPreTrainedModel,
+    gelu,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -53,7 +63,7 @@ class RobertaEmbeddings(BertEmbeddings):
         self.padding_idx = config.pad_token_id
         self.word_embeddings = nn.Embedding(config.vocab_size, config.hidden_size, padding_idx=self.padding_idx)
         self.position_embeddings = nn.Embedding(
-            config.max_position_embeddings, config.hidden_size, padding_idx=self.padding_idx
+            config.max_position_embeddings, config.hidden_size, padding_idx=self.padding_idx,
         )
 
     def forward(self, input_ids=None, token_type_ids=None, position_ids=None, inputs_embeds=None):
@@ -65,7 +75,7 @@ class RobertaEmbeddings(BertEmbeddings):
                 position_ids = self.create_position_ids_from_inputs_embeds(inputs_embeds)
 
         return super().forward(
-            input_ids, token_type_ids=token_type_ids, position_ids=position_ids, inputs_embeds=inputs_embeds
+            input_ids, token_type_ids=token_type_ids, position_ids=position_ids, inputs_embeds=inputs_embeds,
         )
 
     def create_position_ids_from_inputs_embeds(self, inputs_embeds):
@@ -79,7 +89,10 @@ class RobertaEmbeddings(BertEmbeddings):
         sequence_length = input_shape[1]
 
         position_ids = torch.arange(
-            self.padding_idx + 1, sequence_length + self.padding_idx + 1, dtype=torch.long, device=inputs_embeds.device
+            self.padding_idx + 1,
+            sequence_length + self.padding_idx + 1,
+            dtype=torch.long,
+            device=inputs_embeds.device,
         )
         return position_ids.unsqueeze(0).expand(input_shape)
 
@@ -162,7 +175,9 @@ class RobertaModel(BertModel):
         self.embeddings.word_embeddings = value
 
 
-@add_start_docstrings("""RoBERTa Model with a `language modeling` head on top. """, ROBERTA_START_DOCSTRING)
+@add_start_docstrings(
+    """RoBERTa Model with a `language modeling` head on top. """, ROBERTA_START_DOCSTRING,
+)
 class RobertaForMaskedLM(BertPreTrainedModel):
     config_class = RobertaConfig
     base_model_prefix = "roberta"
@@ -191,7 +206,7 @@ class RobertaForMaskedLM(BertPreTrainedModel):
         labels=None,
         output_attentions=None,
         output_hidden_states=None,
-        **kwargs
+        **kwargs,
     ):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
@@ -343,9 +358,9 @@ class RobertaForSequenceClassification(BertPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
         )
-        sequence_output = outputs[0] # (bs, seq_len, dim)
-        pooled_output = sequence_output[:, 0] # (bs, dim); <s> token (equiv. to [CLS])
-        logits = self.classifier(pooled_output) # (bs, dim)
+        sequence_output = outputs[0]  # (bs, seq_len, dim)
+        pooled_output = sequence_output[:, 0]  # (bs, dim); <s> token (equiv. to [CLS])
+        logits = self.classifier(pooled_output)  # (bs, dim)
 
         outputs = (logits,) + outputs[2:]
         if labels is not None:
@@ -539,7 +554,7 @@ class RobertaForTokenClassification(BertPreTrainedModel):
                 active_loss = attention_mask.view(-1) == 1
                 active_logits = logits.view(-1, self.num_labels)
                 active_labels = torch.where(
-                    active_loss, labels.view(-1), torch.tensor(loss_fct.ignore_index).type_as(labels)
+                    active_loss, labels.view(-1), torch.tensor(loss_fct.ignore_index).type_as(labels),
                 )
                 loss = loss_fct(active_logits, active_labels)
             else:

--- a/src/transformers/modeling_tf_roberta.py
+++ b/src/transformers/modeling_tf_roberta.py
@@ -320,8 +320,7 @@ class TFRobertaClassificationHead(tf.keras.layers.Layer):
             config.num_labels, kernel_initializer=get_initializer(config.initializer_range), name="out_proj"
         )
 
-    def call(self, features, training=False):
-        x = features[:, 0, :]  # take <s> token (equiv. to [CLS])
+    def call(self, x, training=False):
         x = self.dropout(x, training=training)
         x = self.dense(x)
         x = self.dropout(x, training=training)
@@ -393,8 +392,9 @@ class TFRobertaForSequenceClassification(TFRobertaPreTrainedModel, TFSequenceCla
             training=training,
         )
 
-        sequence_output = outputs[0]
-        logits = self.classifier(sequence_output, training=training)
+        sequence_output = outputs[0] # (bs, seq_len, dim)
+        pooled_output = sequence_output[:, 0] # (bs, dim); <s> token (equiv. to [CLS])
+        logits = self.classifier(pooled_output, training=training)
 
         outputs = (logits,) + outputs[2:]
 

--- a/src/transformers/modeling_tf_roberta.py
+++ b/src/transformers/modeling_tf_roberta.py
@@ -239,7 +239,7 @@ class TFRobertaLMHead(tf.keras.layers.Layer):
         super().__init__(**kwargs)
         self.vocab_size = config.vocab_size
         self.dense = tf.keras.layers.Dense(
-            config.hidden_size, kernel_initializer=get_initializer(config.initializer_range), name="dense"
+            config.hidden_size, kernel_initializer=get_initializer(config.initializer_range), name="dense",
         )
         self.layer_norm = tf.keras.layers.LayerNormalization(epsilon=config.layer_norm_eps, name="layer_norm")
         self.act = tf.keras.layers.Activation(gelu)
@@ -263,7 +263,9 @@ class TFRobertaLMHead(tf.keras.layers.Layer):
         return x
 
 
-@add_start_docstrings("""RoBERTa Model with a `language modeling` head on top. """, ROBERTA_START_DOCSTRING)
+@add_start_docstrings(
+    """RoBERTa Model with a `language modeling` head on top. """, ROBERTA_START_DOCSTRING,
+)
 class TFRobertaForMaskedLM(TFRobertaPreTrainedModel):
     def __init__(self, config, *inputs, **kwargs):
         super().__init__(config, *inputs, **kwargs)
@@ -317,7 +319,7 @@ class TFRobertaClassificationHead(tf.keras.layers.Layer):
         )
         self.dropout = tf.keras.layers.Dropout(config.hidden_dropout_prob)
         self.out_proj = tf.keras.layers.Dense(
-            config.num_labels, kernel_initializer=get_initializer(config.initializer_range), name="out_proj"
+            config.num_labels, kernel_initializer=get_initializer(config.initializer_range), name="out_proj",
         )
 
     def call(self, x, training=False):
@@ -392,8 +394,8 @@ class TFRobertaForSequenceClassification(TFRobertaPreTrainedModel, TFSequenceCla
             training=training,
         )
 
-        sequence_output = outputs[0] # (bs, seq_len, dim)
-        pooled_output = sequence_output[:, 0] # (bs, dim); <s> token (equiv. to [CLS])
+        sequence_output = outputs[0]  # (bs, seq_len, dim)
+        pooled_output = sequence_output[:, 0]  # (bs, dim); <s> token (equiv. to [CLS])
         logits = self.classifier(pooled_output, training=training)
 
         outputs = (logits,) + outputs[2:]
@@ -417,7 +419,7 @@ class TFRobertaForMultipleChoice(TFRobertaPreTrainedModel, TFMultipleChoiceLoss)
         self.roberta = TFRobertaMainLayer(config, name="roberta")
         self.dropout = tf.keras.layers.Dropout(config.hidden_dropout_prob)
         self.classifier = tf.keras.layers.Dense(
-            1, kernel_initializer=get_initializer(config.initializer_range), name="classifier"
+            1, kernel_initializer=get_initializer(config.initializer_range), name="classifier",
         )
 
     @property
@@ -546,7 +548,7 @@ class TFRobertaForTokenClassification(TFRobertaPreTrainedModel, TFTokenClassific
         self.roberta = TFRobertaMainLayer(config, name="roberta")
         self.dropout = tf.keras.layers.Dropout(config.hidden_dropout_prob)
         self.classifier = tf.keras.layers.Dense(
-            config.num_labels, kernel_initializer=get_initializer(config.initializer_range), name="classifier"
+            config.num_labels, kernel_initializer=get_initializer(config.initializer_range), name="classifier",
         )
 
     @add_start_docstrings_to_callable(ROBERTA_INPUTS_DOCSTRING)
@@ -629,7 +631,7 @@ class TFRobertaForQuestionAnswering(TFRobertaPreTrainedModel, TFQuestionAnswerin
 
         self.roberta = TFRobertaMainLayer(config, name="roberta")
         self.qa_outputs = tf.keras.layers.Dense(
-            config.num_labels, kernel_initializer=get_initializer(config.initializer_range), name="qa_outputs"
+            config.num_labels, kernel_initializer=get_initializer(config.initializer_range), name="qa_outputs",
         )
 
     @add_start_docstrings_to_callable(ROBERTA_INPUTS_DOCSTRING)


### PR DESCRIPTION
There's a slight inconsistency in `RobertaClassificationHead` in that it takes in the whole sequence output from the `RobertaModel`, and extracts the pooled output inside its own forward method, seen [here](https://github.com/huggingface/transformers/blob/58cca47c16149e43d1b516623d59e3c5d97f695e/src/transformers/modeling_roberta.py#L561).


This is different from other models, where the pooled output is computed beforehand and directly expected as input in the classifier. E.g. in [`BertForSequenceClassification`](https://github.com/huggingface/transformers/blob/58cca47c16149e43d1b516623d59e3c5d97f695e/src/transformers/modeling_bert.py#L1270), [`DistilBertForSequenceClassification`](https://github.com/huggingface/transformers/blob/58cca47c16149e43d1b516623d59e3c5d97f695e/src/transformers/modeling_distilbert.py#L631), [`BartForSequenceClassification`](https://github.com/huggingface/transformers/blob/58cca47c16149e43d1b516623d59e3c5d97f695e/src/transformers/modeling_bart.py#L1138), etc.

This mainly addresses this issue in `modeling_roberta.py` and `modeling_tf_roberta.py`. Additionally, some minor aesthetic changes are made to these files in order to pass the black / sort code quality checks.

Note: This PR is a duplicate of #4107 with minor changes made to pass code quality checks. Closed that one since it was outdated.