### PR TITLE
fixed ImportError: cannot import name 'hf_bucket_url' on convert_pytorch_checkpoint_to_tf2.py

### DIFF
--- a/src/transformers/convert_pytorch_checkpoint_to_tf2.py
+++ b/src/transformers/convert_pytorch_checkpoint_to_tf2.py
@@ -71,11 +71,11 @@ from transformers import (
     XLMRobertaConfig,
     XLNetConfig,
     cached_path,
-    hf_bucket_url,
     is_torch_available,
     load_pytorch_checkpoint_in_tf2_model,
 )
 
+from transformers.file_utils import hf_bucket_url
 
 if is_torch_available():
     import torch


### PR DESCRIPTION
So I installed the latest version of transformers on Google Colab 

    !pip install transformers 

When trying to invoke the conversion file using 

    !python /usr/local/lib/python3.6/dist-packages/transformers/convert_pytorch_checkpoint_to_tf2.py .py --help  

Or trying to use 

    from transformers.file_utils import hf_bucket_url.                                 // works 
    from transformers.convert_pytorch_checkpoint_to_tf2 import *.                      // fails

    convert_pytorch_checkpoint_to_tf("gpt2", pytorch_file, config_file, tf_file).      


I get this error

     ImportError                               Traceback (most recent call last)

    <ipython-input-3-dadaf83ecea0> in <module>()
          1 from transformers.file_utils import hf_bucket_url
    ----> 2 from transformers.convert_pytorch_checkpoint_to_tf2 import *
          3 
          4 convert_pytorch_checkpoint_to_tf("gpt2", pytorch_file, config_file, tf_file)
    /usr/local/lib/python3.6/dist-packages/transformers/convert_pytorch_checkpoint_to_tf2.py in <module>()
         20 import os
         21 
    ---> 22 from transformers import (
         23     ALBERT_PRETRAINED_CONFIG_ARCHIVE_MAP,
         24     BERT_PRETRAINED_CONFIG_ARCHIVE_MAP,
    
    ImportError: cannot import name 'hf_bucket_url'


Turns out, there's a problem in the import of `hf_bucket_url`. Once fixed, the code ran properly. 