### PR TITLE
[pl examples] add using_native_amp flag to support pl 0.8.4

### DIFF
--- a/examples/lightning_base.py
+++ b/examples/lightning_base.py
@@ -116,8 +116,9 @@ class BaseTransformer(pl.LightningModule):
         self.opt = optimizer
         return [optimizer]
 
-    def optimizer_step(self, epoch, batch_idx, optimizer, optimizer_idx, second_order_closure=None,
-                       using_native_amp=None):
+    def optimizer_step(
+        self, epoch, batch_idx, optimizer, optimizer_idx, second_order_closure=None, using_native_amp=None
+    ):
         if self.trainer.use_tpu:
             xm.optimizer_step(optimizer)
         else:

--- a/examples/lightning_base.py
+++ b/examples/lightning_base.py
@@ -116,7 +116,8 @@ class BaseTransformer(pl.LightningModule):
         self.opt = optimizer
         return [optimizer]
 
-    def optimizer_step(self, epoch, batch_idx, optimizer, optimizer_idx, second_order_closure=None):
+    def optimizer_step(self, epoch, batch_idx, optimizer, optimizer_idx, second_order_closure=None,
+                       using_native_amp=None):
         if self.trainer.use_tpu:
             xm.optimizer_step(optimizer)
         else:


### PR DESCRIPTION
running the example `finetune_bart_tiny.sh` in `seq2seq` fails with:
```
Traceback (most recent call last):
  File "finetune.py", line 344, in <module>
    main(args)
  File "finetune.py", line 322, in main
    logger=logger,
  File "/root/notebooks/analysis/transformers/examples/lightning_base.py", line 330, in generic_train
    trainer.fit(model)
  File "/apps/python3/lib/python3.7/site-packages/pytorch_lightning/trainer/trainer.py", line 1020, in fit
    self.run_pretrain_routine(model)
  File "/apps/python3/lib/python3.7/site-packages/pytorch_lightning/trainer/trainer.py", line 1156, in run_pretrain_routine
    self.train()
  File "/apps/python3/lib/python3.7/site-packages/pytorch_lightning/trainer/training_loop.py", line 370, in train
    self.run_training_epoch()
  File "/apps/python3/lib/python3.7/site-packages/pytorch_lightning/trainer/training_loop.py", line 452, in run_training_epoch
    batch_output = self.run_training_batch(batch, batch_idx)
  File "/apps/python3/lib/python3.7/site-packages/pytorch_lightning/trainer/training_loop.py", line 659, in run_training_batch
    grad_norm_dic = self.run_batch_backward_pass(split_batch, batch_idx, opt_idx, optimizer)
  File "/apps/python3/lib/python3.7/site-packages/pytorch_lightning/trainer/training_loop.py", line 711, in run_batch_backward_pass
    self.call_optimizer_step(optimizer, opt_idx, batch_idx, split_batch)
  File "/apps/python3/lib/python3.7/site-packages/pytorch_lightning/trainer/training_loop.py", line 750, in call_optimizer_step
    using_native_amp=native_amp)
TypeError: optimizer_step() got an unexpected keyword argument 'using_native_amp'
```

seems like the issue is with the missing argument.