### PR TITLE
Add data_collator with attention_mask feature

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, NewType, Tuple
+from typing import Any, Callable, Dict, List, NewType, Tuple, Union
 
 import torch
 from torch.nn.utils.rnn import pad_sequence
@@ -68,77 +68,6 @@ def default_data_collator(features: List[InputDataClass]) -> Dict[str, torch.Ten
 @dataclass
 class DataCollatorForLanguageModeling:
     """
-    Data collator used for language modeling.
-    - collates batches of tensors, honoring their tokenizer's pad_token
-    - preprocesses batches for masked language modeling
-    """
-
-    tokenizer: PreTrainedTokenizer
-    mlm: bool = True
-    mlm_probability: float = 0.15
-
-    def __call__(self, examples: List[torch.Tensor]) -> Dict[str, torch.Tensor]:
-        batch = self._tensorize_batch(examples)
-        if self.mlm:
-            inputs, labels = self.mask_tokens(batch)
-            return {"input_ids": inputs, "labels": labels}
-        else:
-            labels = batch.clone().detach()
-            labels[labels == self.tokenizer.pad_token_id] = -100
-            return {"input_ids": batch, "labels": labels}
-
-    def _tensorize_batch(self, examples: List[torch.Tensor]) -> torch.Tensor:
-        length_of_first = examples[0].size(0)
-        are_tensors_same_length = all(x.size(0) == length_of_first for x in examples)
-        if are_tensors_same_length:
-            return torch.stack(examples, dim=0)
-        else:
-            if self.tokenizer._pad_token is None:
-                raise ValueError(
-                    "You are attempting to pad samples but the tokenizer you are using"
-                    f" ({self.tokenizer.__class__.__name__}) does not have one."
-                )
-            return pad_sequence(examples, batch_first=True, padding_value=self.tokenizer.pad_token_id)
-
-    def mask_tokens(self, inputs: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        """
-        Prepare masked tokens inputs/labels for masked language modeling: 80% MASK, 10% random, 10% original.
-        """
-
-        if self.tokenizer.mask_token is None:
-            raise ValueError(
-                "This tokenizer does not have a mask token which is necessary for masked language modeling. Remove the --mlm flag if you want to use this tokenizer."
-            )
-
-        labels = inputs.clone()
-        # We sample a few tokens in each sequence for masked-LM training (with probability args.mlm_probability defaults to 0.15 in Bert/RoBERTa)
-        probability_matrix = torch.full(labels.shape, self.mlm_probability)
-        special_tokens_mask = [
-            self.tokenizer.get_special_tokens_mask(val, already_has_special_tokens=True) for val in labels.tolist()
-        ]
-        probability_matrix.masked_fill_(torch.tensor(special_tokens_mask, dtype=torch.bool), value=0.0)
-        if self.tokenizer._pad_token is not None:
-            padding_mask = labels.eq(self.tokenizer.pad_token_id)
-            probability_matrix.masked_fill_(padding_mask, value=0.0)
-        masked_indices = torch.bernoulli(probability_matrix).bool()
-        labels[~masked_indices] = -100  # We only compute loss on masked tokens
-
-        # 80% of the time, we replace masked input tokens with tokenizer.mask_token ([MASK])
-        indices_replaced = torch.bernoulli(torch.full(labels.shape, 0.8)).bool() & masked_indices
-        inputs[indices_replaced] = self.tokenizer.convert_tokens_to_ids(self.tokenizer.mask_token)
-
-        # 10% of the time, we replace masked input tokens with random word
-        indices_random = torch.bernoulli(torch.full(labels.shape, 0.5)).bool() & masked_indices & ~indices_replaced
-        random_words = torch.randint(len(self.tokenizer), labels.shape, dtype=torch.long)
-        inputs[indices_random] = random_words[indices_random]
-
-        # The rest of the time (10% of the time) we keep the masked input tokens unchanged
-        return inputs, labels
-
-
-@dataclass
-class DataCollatorForMaskedLanguageModeling:
-    """
     Data collator used for masked language modeling.
     - collates batches of tensors, honoring their tokenizer's pad_token
     - preprocesses batches for masked language modeling
@@ -148,18 +77,33 @@ class DataCollatorForMaskedLanguageModeling:
     mlm: bool = True
     mlm_probability: float = 0.15
 
-    def __call__(self, examples: List[List[torch.Tensor]]) -> Dict[str, torch.Tensor]:
-        input_ids = self._tensorize_batch([e[0] for e in examples], self.tokenizer.pad_token_id)
-        token_type_ids = self._tensorize_batch([e[1] for e in examples], 0)
-        attention_mask = self._tensorize_batch([e[2] for e in examples], 0)
+    def __call__(self, examples: Union[List[Dict[str, torch.Tensor]], List[torch.Tensor]]) -> Dict[str, torch.Tensor]:
+        batch = {}
+
+        if isinstance(examples[0], dict):
+            for k in examples[0].keys():
+                if k == "input_ids":
+                    pad_token = self.tokenizer.pad_token_id
+                else:
+                    pad_token = 0
+                v = self._tensorize_batch([e[k] for e in examples], pad_token)
+                batch[k] = v
+            input_ids = batch["input_ids"]
+
+        else:
+            input_ids = self._tensorize_batch(examples, self.tokenizer.pad_token_id)
+            batch["input_ids"] = input_ids
 
         if self.mlm:
             input_ids, labels = self.mask_tokens(input_ids)
+            batch["input_ids"] = input_ids
+            batch["labels"] = labels
         else:
             labels = input_ids.clone().detach()
             labels[labels == self.tokenizer.pad_token_id] = -100
+            batch["labels"] = labels
 
-        return {"input_ids": input_ids, "token_type_ids": token_type_ids, "attention_mask": attention_mask, "labels": labels}
+        return batch
 
     def _tensorize_batch(self, batch: List[torch.Tensor], pad_token: int) -> torch.Tensor:
         length_of_first = batch[0].size(0)
@@ -222,12 +166,28 @@ class DataCollatorForPermutationLanguageModeling:
     plm_probability: float = 1 / 6
     max_span_length: int = 5  # maximum length of a span of masked tokens
 
-    def __call__(self, examples: List[torch.Tensor]) -> Dict[str, torch.Tensor]:
-        batch = self._tensorize_batch(examples)
-        inputs, perm_mask, target_mapping, labels = self.mask_tokens(batch)
-        return {"input_ids": inputs, "perm_mask": perm_mask, "target_mapping": target_mapping, "labels": labels}
+    def __call__(self, examples: Union[List[Dict[str, torch.Tensor]], List[torch.Tensor]]) -> Dict[str, torch.Tensor]:
+        batch = {}
 
-    def _tensorize_batch(self, examples: List[torch.Tensor]) -> torch.Tensor:
+        if isinstance(examples[0], dict):
+            for k in examples[0].keys():
+                if k == "input_ids":
+                    pad_token = self.tokenizer.pad_token_id
+                else:
+                    pad_token = 0
+                v = self._tensorize_batch([e[k] for e in examples], pad_token)
+                batch[k] = v
+            input_ids = batch["input_ids"]
+
+        else:
+            input_ids = self._tensorize_batch(examples, self.tokenizer.pad_token_id)
+            batch["input_ids"] = input_ids
+
+        inputs, perm_mask, target_mapping, labels = self.mask_tokens(input_ids)
+        batch.update({"input_ids": inputs, "perm_mask": perm_mask, "target_mapping": target_mapping, "labels": labels})
+        return batch
+
+    def _tensorize_batch(self, examples: List[torch.Tensor], pad_token: int) -> torch.Tensor:
         length_of_first = examples[0].size(0)
         are_tensors_same_length = all(x.size(0) == length_of_first for x in examples)
         if are_tensors_same_length:
@@ -238,7 +198,7 @@ class DataCollatorForPermutationLanguageModeling:
                     "You are attempting to pad samples but the tokenizer you are using"
                     f" ({self.tokenizer.__class__.__name__}) does not have one."
                 )
-            return pad_sequence(examples, batch_first=True, padding_value=self.tokenizer.pad_token_id)
+            return pad_sequence(examples, batch_first=True, padding_value=pad_token)
 
     def mask_tokens(self, inputs: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -137,6 +137,80 @@ class DataCollatorForLanguageModeling:
 
 
 @dataclass
+class DataCollatorForMaskedLanguageModeling:
+    """
+    Data collator used for masked language modeling.
+    - collates batches of tensors, honoring their tokenizer's pad_token
+    - preprocesses batches for masked language modeling
+    """
+
+    tokenizer: PreTrainedTokenizer
+    mlm: bool = True
+    mlm_probability: float = 0.15
+
+    def __call__(self, examples: List[List[torch.Tensor]]) -> Dict[str, torch.Tensor]:
+        input_ids = self._tensorize_batch([e[0] for e in examples], self.tokenizer.pad_token_id)
+        token_type_ids = self._tensorize_batch([e[1] for e in examples], 0)
+        attention_mask = self._tensorize_batch([e[2] for e in examples], 0)
+
+        if self.mlm:
+            input_ids, labels = self.mask_tokens(input_ids)
+        else:
+            labels = input_ids.clone().detach()
+            labels[labels == self.tokenizer.pad_token_id] = -100
+
+        return {"input_ids": input_ids, "token_type_ids": token_type_ids, "attention_mask": attention_mask, "labels": labels}
+
+    def _tensorize_batch(self, batch: List[torch.Tensor], pad_token: int) -> torch.Tensor:
+        length_of_first = batch[0].size(0)
+        are_tensors_same_length = all(x.size(0) == length_of_first for x in batch)
+        if are_tensors_same_length:
+            return torch.stack(batch, dim=0)
+        else:
+            if self.tokenizer._pad_token is None:
+                raise ValueError(
+                    "You are attempting to pad samples but the tokenizer you are using"
+                    f" ({self.tokenizer.__class__.__name__}) does not have one."
+                )
+            return pad_sequence(batch, batch_first=True, padding_value=pad_token)
+
+    def mask_tokens(self, inputs: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Prepare masked tokens inputs/labels for masked language modeling: 80% MASK, 10% random, 10% original.
+        """
+
+        if self.tokenizer.mask_token is None:
+            raise ValueError(
+                "This tokenizer does not have a mask token which is necessary for masked language modeling. Remove the --mlm flag if you want to use this tokenizer."
+            )
+
+        labels = inputs.clone()
+        # We sample a few tokens in each sequence for masked-LM training (with probability args.mlm_probability defaults to 0.15 in Bert/RoBERTa)
+        probability_matrix = torch.full(labels.shape, self.mlm_probability)
+        special_tokens_mask = [
+            self.tokenizer.get_special_tokens_mask(val, already_has_special_tokens=True) for val in labels.tolist()
+        ]
+        probability_matrix.masked_fill_(torch.tensor(special_tokens_mask, dtype=torch.bool), value=0.0)
+        if self.tokenizer._pad_token is not None:
+            padding_mask = labels.eq(self.tokenizer.pad_token_id)
+            probability_matrix.masked_fill_(padding_mask, value=0.0)
+        masked_indices = torch.bernoulli(probability_matrix).bool()
+        labels[~masked_indices] = -100  # We only compute loss on masked tokens
+
+        # 80% of the time, we replace masked input tokens with tokenizer.mask_token ([MASK])
+        indices_replaced = torch.bernoulli(torch.full(labels.shape, 0.8)).bool() & masked_indices
+        inputs[indices_replaced] = self.tokenizer.convert_tokens_to_ids(self.tokenizer.mask_token)
+
+        # 10% of the time, we replace masked input tokens with random word
+        indices_random = torch.bernoulli(torch.full(labels.shape, 0.5)).bool() & masked_indices & ~indices_replaced
+        random_words = torch.randint(len(self.tokenizer), labels.shape, dtype=torch.long)
+        inputs[indices_random] = random_words[indices_random]
+
+        # The rest of the time (10% of the time) we keep the masked input tokens unchanged
+        return inputs, labels
+
+
+@dataclass
 class DataCollatorForPermutationLanguageModeling:
     """
     Data collator used for permutation language modeling.

--- a/src/transformers/data/datasets/__init__.py
+++ b/src/transformers/data/datasets/__init__.py
@@ -3,5 +3,5 @@
 # module, but to preserve other warnings. So, don't check this module at all.
 
 from .glue import GlueDataset, GlueDataTrainingArguments
-from .language_modeling import LineByLineTextDataset, TextDataset
+from .language_modeling import LineByLineTextDataset, TextDataset, LineByLineTextMaskDataset
 from .squad import SquadDataset, SquadDataTrainingArguments

--- a/src/transformers/data/datasets/__init__.py
+++ b/src/transformers/data/datasets/__init__.py
@@ -3,5 +3,5 @@
 # module, but to preserve other warnings. So, don't check this module at all.
 
 from .glue import GlueDataset, GlueDataTrainingArguments
-from .language_modeling import LineByLineTextDataset, TextDataset, LineByLineTextMaskDataset
+from .language_modeling import LineByLineTextDataset, TextDataset
 from .squad import SquadDataset, SquadDataTrainingArguments

--- a/src/transformers/data/datasets/language_modeling.py
+++ b/src/transformers/data/datasets/language_modeling.py
@@ -2,6 +2,7 @@ import logging
 import os
 import pickle
 import time
+from typing import List
 
 import torch
 from filelock import FileLock
@@ -99,3 +100,25 @@ class LineByLineTextDataset(Dataset):
 
     def __getitem__(self, i) -> torch.Tensor:
         return torch.tensor(self.examples[i], dtype=torch.long)
+
+
+class LineByLineTextMaskDataset(Dataset):
+
+    def __init__(self, tokenizer: PreTrainedTokenizer, file_path: str, block_size: int):
+        assert os.path.isfile(file_path)
+        logger.info("Creating features from dataset file at %s", file_path)
+
+        with open(file_path, encoding="utf-8") as f:
+            lines = [line for line in f.read().splitlines() if (len(line) > 0 and not line.isspace())]
+
+        batch_encoding = tokenizer(lines, add_special_tokens=True, truncation=True, max_length=block_size)
+        self.examples = batch_encoding
+
+    def __len__(self):
+        return len(self.examples["input_ids"])
+
+    def __getitem__(self, i) -> List[torch.Tensor]:
+        input_ids = torch.tensor(self.examples["input_ids"][i], dtype=torch.long)
+        token_type_ids = torch.tensor(self.examples["token_type_ids"][i], dtype=torch.long)
+        attention_mask = torch.tensor(self.examples["attention_mask"][i], dtype=torch.long)
+        return [input_ids, token_type_ids, attention_mask]

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -115,6 +115,7 @@ class DataCollatorIntegrationTest(unittest.TestCase):
         batch = data_collator(examples)
         self.assertIsInstance(batch, dict)
         self.assertEqual(batch["input_ids"].shape, torch.Size((31, 107)))
+        self.assertEqual(batch["attention_mask"].shape, torch.Size((31, 107)))
         self.assertEqual(batch["labels"].shape, torch.Size((31, 107)))
 
         dataset = TextDataset(tokenizer, file_path=PATH_SAMPLE_TEXT, block_size=512, overwrite_cache=True)
@@ -134,6 +135,7 @@ class DataCollatorIntegrationTest(unittest.TestCase):
         batch = data_collator(examples)
         self.assertIsInstance(batch, dict)
         self.assertEqual(batch["input_ids"].shape, torch.Size((31, 112)))
+        self.assertEqual(batch["attention_mask"].shape, torch.Size((31, 112)))
         self.assertEqual(batch["perm_mask"].shape, torch.Size((31, 112, 112)))
         self.assertEqual(batch["target_mapping"].shape, torch.Size((31, 112, 112)))
         self.assertEqual(batch["labels"].shape, torch.Size((31, 112)))


### PR DESCRIPTION
For models like BERT, we should mask the padding ids as invalidate to avoid attention on them. Therefore, in addition to `input_ids`, the feature `attention_mask` should also be fed to the model. 
Add a data collator `DataCollatorForMaskedLanguageModeling` which will return all of above data, and add a dataset class `LineByLineTextMaskDataset` which is related with the former.