### PR TITLE
Generate up to max_target_length sequences

### DIFF
--- a/examples/seq2seq/finetune.py
+++ b/examples/seq2seq/finetune.py
@@ -167,6 +167,7 @@ class SummarizationModule(BaseTransformer):
         t0 = time.time()
         generated_ids = self.model.generate(
             input_ids=source_ids,
+            max_length=self.hparams.max_target_length,
             attention_mask=source_mask,
             use_cache=True,
             decoder_start_token_id=self.decoder_start_token_id,


### PR DESCRIPTION
* Modifies the generate() call to allow for generation of sequences up to and including max_target_length number of tokens.
* Previous to this commit, implementation caps generation at 20 tokens and may result in poor performance. 
* See related recent generation_utils.py commit: https://github.com/huggingface/transformers/blob/c4d4e8bdbd25d9463d41de6398940329c89b7fb6/src/transformers/generation_utils.py#L139