### PR TITLE
Fix re-tokenization (ignoring is_pretokenized=True) when passing a pretokenized batch to both batch_encode_plus and tokenizer.__call__ methods

### DIFF
--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -426,10 +426,10 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
                 return self.convert_tokens_to_ids(tokens)
             elif isinstance(text, (list, tuple)) and len(text) > 0 and isinstance(text[0], str):
                 if is_pretokenized:
+                    return self.convert_tokens_to_ids(text)
+                else:
                     tokens = list(itertools.chain(*(self.tokenize(t, is_pretokenized=True, **kwargs) for t in text)))
                     return self.convert_tokens_to_ids(tokens)
-                else:
-                    return self.convert_tokens_to_ids(text)
             elif isinstance(text, (list, tuple)) and len(text) > 0 and isinstance(text[0], int):
                 return text
             else:
@@ -506,10 +506,10 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
                 return self.convert_tokens_to_ids(tokens)
             elif isinstance(text, (list, tuple)) and len(text) > 0 and isinstance(text[0], str):
                 if is_pretokenized:
+                    return self.convert_tokens_to_ids(text)
+                else:
                     tokens = list(itertools.chain(*(self.tokenize(t, is_pretokenized=True, **kwargs) for t in text)))
                     return self.convert_tokens_to_ids(tokens)
-                else:
-                    return self.convert_tokens_to_ids(text)
             elif isinstance(text, (list, tuple)) and len(text) > 0 and isinstance(text[0], int):
                 return text
             else:


### PR DESCRIPTION
# Bug

> Fix unexpected behavior when passing already tokenized tokens (ignoring `is_pretokenized=True`) using `batch_encode_plus` and `self.__call__()`
 
```python
tokenizer = BertTokenizer.from_pretrained("bert-base-cased")

batch_sentences = ['The rapid expansion of the current COVID - 19 pandemic.',
                   'Hospitals around the globe have had to implement drastic changes']
batch_tokenized = [tokenizer.tokenize(x) for x in batch_sentences]
```

Correct output when passing either a single string or batch  ✅
- Applies to types:
 - `str` : one sentence
 - `List[str]` : batch of sentences

```python
# also applies when using batch_encode_plus
inputs = tokenizer(batch_sentences, add_special_tokens=False)
for ids in inputs['input_ids']: print(tokenizer.decode(ids))
...
"The rapid expansion of the current COVID - 19 pandemic."
"Hospitals around the globe have had to implement drastic changes"
```

Incorrect output when passing either a sequence of tokens or in batch  ❌
- Applies to types:
 - `List[str]`  : one sequence of string tokens
 - `List[List[str]]`  : batch of sequences of string tokens

```python
# also applies when using batch_encode_plus
inputs = tokenizer(batch_tokenized, add_special_tokens=False, is_pretokenized=True)
for ids in inputs['input_ids']: print(tokenizer.decode(ids))
...
"The rapid expansion of the current CO # # VI # # D - 19 pan # # de # # mic."
"Hospital # # s around the globe have had to implement drastic changes"
```
## Cause of issue

> The problem is when the sequences provided are a list of strings (pretokenized | batch of tokens) as we can observe in the output above, and the second condition in `get_input_ids()` completely disregards the truth that `is_pretokenized=True` by *re-tokenizing* a previously tokenized input!

```python
...
def get_input_ids(text):
    if isinstance(text, str):
        tokens = self.tokenize(text, **kwargs)
        return self.convert_tokens_to_ids(tokens)
    elif isinstance(text, (list, tuple)) and len(text) > 0 and isinstance(text[0], str):
        if is_pretokenized:
            # If the user set is_pretokenized=True, then the input is a batch of token string sequences.
            # The expected behavior is then to convert tokens to ids and not to re-tokenize - ``self.tokenize()``
            tokens = list(itertools.chain(*(self.tokenize(t, is_pretokenized=True, **kwargs) for t in text)))
            return self.convert_tokens_to_ids(tokens)
        else:
            return self.convert_tokens_to_ids(text)
            ...
```

## Fix

> All I needed to do is flip the behavior. Easy fix!

```python
...
if is_pretokenized:    # If already tokenized then, convert string tokens to token_ids
    return self.convert_tokens_to_ids(text)

else:  # Otherwise, tokenize to string tokens before converting to token_ids 
    tokens = list(itertools.chain(*(self.tokenize(t, is_pretokenized=True, **kwargs) for t in text)))
    return self.convert_tokens_to_ids(tokens)
...
```