### PR TITLE
Fixed use of memories in XLNet (caching for language generation + warning when loading improper memoryless model)

### DIFF
--- a/src/transformers/configuration_xlnet.py
+++ b/src/transformers/configuration_xlnet.py
@@ -15,11 +15,10 @@
 # limitations under the License.
 """ XLNet configuration """
 
-
 import logging
+import warnings
 
 from .configuration_utils import PretrainedConfig
-
 
 logger = logging.getLogger(__name__)
 
@@ -128,33 +127,33 @@ class XLNetConfig(PretrainedConfig):
     model_type = "xlnet"
 
     def __init__(
-        self,
-        vocab_size=32000,
-        d_model=1024,
-        n_layer=24,
-        n_head=16,
-        d_inner=4096,
-        ff_activation="gelu",
-        untie_r=True,
-        attn_type="bi",
-        initializer_range=0.02,
-        layer_norm_eps=1e-12,
-        dropout=0.1,
-        mem_len=None,
-        reuse_len=None,
-        bi_data=False,
-        clamp_len=-1,
-        same_length=False,
-        summary_type="last",
-        summary_use_proj=True,
-        summary_activation="tanh",
-        summary_last_dropout=0.1,
-        start_n_top=5,
-        end_n_top=5,
-        pad_token_id=5,
-        bos_token_id=1,
-        eos_token_id=2,
-        **kwargs
+            self,
+            vocab_size=32000,
+            d_model=1024,
+            n_layer=24,
+            n_head=16,
+            d_inner=4096,
+            ff_activation="gelu",
+            untie_r=True,
+            attn_type="bi",
+            initializer_range=0.02,
+            layer_norm_eps=1e-12,
+            dropout=0.1,
+            mem_len=None,
+            reuse_len=None,
+            bi_data=False,
+            clamp_len=-1,
+            same_length=False,
+            summary_type="last",
+            summary_use_proj=True,
+            summary_activation="tanh",
+            summary_last_dropout=0.1,
+            start_n_top=5,
+            end_n_top=5,
+            pad_token_id=5,
+            bos_token_id=1,
+            eos_token_id=2,
+            **kwargs
     ):
         """Constructs XLNetConfig.
         """
@@ -166,7 +165,7 @@ class XLNetConfig(PretrainedConfig):
         assert d_model % n_head == 0
         if "d_head" in kwargs:
             assert (
-                kwargs["d_head"] == d_model // n_head
+                    kwargs["d_head"] == d_model // n_head
             ), f"`d_head` ({kwargs['d_head']}) should be equal to `d_model // n_head` ({d_model // n_head})"
         self.d_head = d_model // n_head
         self.ff_activation = ff_activation
@@ -194,6 +193,14 @@ class XLNetConfig(PretrainedConfig):
         self.bos_token_id = bos_token_id
         self.pad_token_id = pad_token_id
         self.eos_token_id = eos_token_id
+
+        if mem_len is None or mem_len == 0:
+            warnings.warn("This config doesn't use attention memories, a core feature of XLNet."
+                          " Consider setting `men_len` to a non-zero value, for example "
+                          "`xlnet = XLNetLMHeadModel.from_pretrained('xlnet-base-cased'', mem_len=1024)`,"
+                          " for accurate training performance as well as an order of magnitude faster inference."
+                          " Starting from version 3.5.0, the default parameter will be 1024, following"
+                          " the implementation in https://arxiv.org/abs/1906.08237", FutureWarning)
 
     @property
     def max_position_embeddings(self):

--- a/src/transformers/configuration_xlnet.py
+++ b/src/transformers/configuration_xlnet.py
@@ -20,6 +20,7 @@ import warnings
 
 from .configuration_utils import PretrainedConfig
 
+
 logger = logging.getLogger(__name__)
 
 XLNET_PRETRAINED_CONFIG_ARCHIVE_MAP = {
@@ -127,33 +128,33 @@ class XLNetConfig(PretrainedConfig):
     model_type = "xlnet"
 
     def __init__(
-            self,
-            vocab_size=32000,
-            d_model=1024,
-            n_layer=24,
-            n_head=16,
-            d_inner=4096,
-            ff_activation="gelu",
-            untie_r=True,
-            attn_type="bi",
-            initializer_range=0.02,
-            layer_norm_eps=1e-12,
-            dropout=0.1,
-            mem_len=None,
-            reuse_len=None,
-            bi_data=False,
-            clamp_len=-1,
-            same_length=False,
-            summary_type="last",
-            summary_use_proj=True,
-            summary_activation="tanh",
-            summary_last_dropout=0.1,
-            start_n_top=5,
-            end_n_top=5,
-            pad_token_id=5,
-            bos_token_id=1,
-            eos_token_id=2,
-            **kwargs
+        self,
+        vocab_size=32000,
+        d_model=1024,
+        n_layer=24,
+        n_head=16,
+        d_inner=4096,
+        ff_activation="gelu",
+        untie_r=True,
+        attn_type="bi",
+        initializer_range=0.02,
+        layer_norm_eps=1e-12,
+        dropout=0.1,
+        mem_len=None,
+        reuse_len=None,
+        bi_data=False,
+        clamp_len=-1,
+        same_length=False,
+        summary_type="last",
+        summary_use_proj=True,
+        summary_activation="tanh",
+        summary_last_dropout=0.1,
+        start_n_top=5,
+        end_n_top=5,
+        pad_token_id=5,
+        bos_token_id=1,
+        eos_token_id=2,
+        **kwargs
     ):
         """Constructs XLNetConfig.
         """
@@ -165,7 +166,7 @@ class XLNetConfig(PretrainedConfig):
         assert d_model % n_head == 0
         if "d_head" in kwargs:
             assert (
-                    kwargs["d_head"] == d_model // n_head
+                kwargs["d_head"] == d_model // n_head
             ), f"`d_head` ({kwargs['d_head']}) should be equal to `d_model // n_head` ({d_model // n_head})"
         self.d_head = d_model // n_head
         self.ff_activation = ff_activation
@@ -195,12 +196,15 @@ class XLNetConfig(PretrainedConfig):
         self.eos_token_id = eos_token_id
 
         if mem_len is None or mem_len == 0:
-            warnings.warn("This config doesn't use attention memories, a core feature of XLNet."
-                          " Consider setting `men_len` to a non-zero value, for example "
-                          "`xlnet = XLNetLMHeadModel.from_pretrained('xlnet-base-cased'', mem_len=1024)`,"
-                          " for accurate training performance as well as an order of magnitude faster inference."
-                          " Starting from version 3.5.0, the default parameter will be 1024, following"
-                          " the implementation in https://arxiv.org/abs/1906.08237", FutureWarning)
+            warnings.warn(
+                "This config doesn't use attention memories, a core feature of XLNet."
+                " Consider setting `men_len` to a non-zero value, for example "
+                "`xlnet = XLNetLMHeadModel.from_pretrained('xlnet-base-cased'', mem_len=1024)`,"
+                " for accurate training performance as well as an order of magnitude faster inference."
+                " Starting from version 3.5.0, the default parameter will be 1024, following"
+                " the implementation in https://arxiv.org/abs/1906.08237",
+                FutureWarning,
+            )
 
     @property
     def max_position_embeddings(self):

--- a/src/transformers/modeling_tf_xlnet.py
+++ b/src/transformers/modeling_tf_xlnet.py
@@ -883,10 +883,16 @@ class TFXLNetLMHeadModel(TFXLNetPreTrainedModel, TFCausalLanguageModelingLoss):
 
     def prepare_inputs_for_generation(self, inputs, past, **kwargs):
         # Add dummy token at the end (no attention on this one)
+        
+        offset = 2
 
         effective_batch_size = inputs.shape[0]
         dummy_token = tf.zeros((effective_batch_size, 1), dtype=tf.int32)
-        inputs = tf.concat([inputs, dummy_token], axis=1)
+
+        if past:
+            inputs = tf.concat([inputs[:, -offset:], dummy_token], dim=1)
+        else:
+            inputs = tf.concat([inputs, dummy_token], axis=1)
 
         # Build permutation mask so that previous tokens don't see last token
         sequence_length = inputs.shape[1]
@@ -908,7 +914,7 @@ class TFXLNetLMHeadModel(TFXLNetPreTrainedModel, TFCausalLanguageModelingLoss):
 
         # if past is defined in model kwargs then use it for faster decoding
         if past:
-            inputs["mems"] = past
+            inputs["mems"] = tuple(layer_past[:-offset, :, :] for layer_past in past)
 
         return inputs
 

--- a/src/transformers/modeling_tf_xlnet.py
+++ b/src/transformers/modeling_tf_xlnet.py
@@ -883,14 +883,14 @@ class TFXLNetLMHeadModel(TFXLNetPreTrainedModel, TFCausalLanguageModelingLoss):
 
     def prepare_inputs_for_generation(self, inputs, past, **kwargs):
         # Add dummy token at the end (no attention on this one)
-        
+
         offset = 2
 
         effective_batch_size = inputs.shape[0]
         dummy_token = tf.zeros((effective_batch_size, 1), dtype=tf.int32)
 
         if past:
-            inputs = tf.concat([inputs[:, -offset:], dummy_token], dim=1)
+            inputs = tf.concat([inputs[:, -offset:], dummy_token], axis=1)
         else:
             inputs = tf.concat([inputs, dummy_token], axis=1)
 

--- a/src/transformers/modeling_tf_xlnet.py
+++ b/src/transformers/modeling_tf_xlnet.py
@@ -884,6 +884,9 @@ class TFXLNetLMHeadModel(TFXLNetPreTrainedModel, TFCausalLanguageModelingLoss):
     def prepare_inputs_for_generation(self, inputs, past, **kwargs):
         # Add dummy token at the end (no attention on this one)
 
+        # At every pass, the attention values for the new token and the two last generated tokens
+        # are computed, the rest is reloaded from the `past` cache. A purely auto-regressive model would have
+        # offset = 1; offset = 2 seems to have slightly better computation.
         offset = 2
 
         effective_batch_size = inputs.shape[0]

--- a/src/transformers/modeling_xlnet.py
+++ b/src/transformers/modeling_xlnet.py
@@ -1001,8 +1001,9 @@ class XLNetLMHeadModel(XLNetPreTrainedModel):
         effective_batch_size = input_ids.shape[0]
         dummy_token = torch.zeros((effective_batch_size, 1), dtype=torch.long, device=input_ids.device)
 
-        # at every pass, the attention values for the new token and the two last generated tokens
-        # are computed, the rest is reloaded from the `past` cache
+        # At every pass, the attention values for the new token and the two last generated tokens
+        # are computed, the rest is reloaded from the `past` cache. A purely auto-regressive model would have
+        # offset = 1; offset = 2 seems to have slightly better computation.
         offset = 2
 
         if past:

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -653,7 +653,12 @@ class TextGenerationPipeline(Pipeline):
         for prompt_text in text_inputs:
             # Manage correct placement of the tensors
             with self.device_placement():
-                if self.model.__class__.__name__ in ["XLNetLMHeadModel", "TransfoXLLMHeadModel"]:
+                if self.model.__class__.__name__ in [
+                    "XLNetLMHeadModel",
+                    "TransfoXLLMHeadModel",
+                    "TFXLNetLMHeadModel",
+                    "TFTransfoXLLMHeadModel",
+                ]:
                     # For XLNet and TransformerXL we had an article to the prompt to give more state to the model.
                     padding_text = self.PADDING_TEXT + self.tokenizer.eos_token
                     padding = self._parse_and_tokenize(padding_text, padding=False, add_special_tokens=False)

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -687,38 +687,36 @@ class TextGenerationPipeline(Pipeline):
 
                 output_sequences = self.model.generate(input_ids=input_ids, **generate_kwargs)  # BS x SL
 
-                result = []
-                for generated_sequence in output_sequences:
-                    if self.framework == "pt" and generated_sequence is not None:
-                        generated_sequence = generated_sequence.cpu()
-                    generated_sequence = generated_sequence.numpy().tolist()
-                    record = {}
-                    if return_tensors:
-                        record["generated_token_ids"] = generated_sequence
-                    if return_text:
-                        # Decode text
-                        text = self.tokenizer.decode(
-                            generated_sequence,
-                            skip_special_tokens=True,
-                            clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+            result = []
+            for generated_sequence in output_sequences:
+                generated_sequence = generated_sequence.numpy().tolist()
+                record = {}
+                if return_tensors:
+                    record["generated_token_ids"] = generated_sequence
+                if return_text:
+                    # Decode text
+                    text = self.tokenizer.decode(
+                        generated_sequence,
+                        skip_special_tokens=True,
+                        clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+                    )
+
+                    # Remove PADDING prompt of the sequence if XLNet or Transfo-XL model is used
+                    if input_ids is None:
+                        prompt_length = 0
+                    else:
+                        prompt_length = len(
+                            self.tokenizer.decode(
+                                input_ids[0],
+                                skip_special_tokens=True,
+                                clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+                            )
                         )
 
-                        # Remove PADDING prompt of the sequence if XLNet or Transfo-XL model is used
-                        if input_ids is None:
-                            prompt_length = 0
-                        else:
-                            prompt_length = len(
-                                self.tokenizer.decode(
-                                    input_ids[0],
-                                    skip_special_tokens=True,
-                                    clean_up_tokenization_spaces=clean_up_tokenization_spaces,
-                                )
-                            )
+                    record["generated_text"] = prompt_text + text[prompt_length:]
 
-                        record["generated_text"] = prompt_text + text[prompt_length:]
-
-                    result.append(record)
-                results += [result]
+                result.append(record)
+            results += [result]
 
         if len(results) == 1:
             return results[0]


### PR DESCRIPTION
The default XLNet model is loaded with 0 memory length, which is an issue both at training time (improper performance) and inference time (as there's no caching speed-up since it doesn't return former attentions). As discussed with @LysandreJik , this PR introduces a warning that in the future, the default XLNet model will have 1024 memory length, in accordance with [the original paper](https://arxiv.org/abs/1906.08237). It also fixes the re-use of cached memory, which was broken similarly to TransfoXL (#4752).