### PR TITLE
enable easy checkout switch

### DIFF
--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -1,0 +1,11 @@
+# tests directory-specific settings - this file is run automatically
+# by pytest before any tests are run
+
+import sys
+from os.path import abspath, dirname, join
+
+
+# allow having multiple repository checkouts and not needing to remember to rerun
+# 'pip install -e .[dev]' when switching between checkouts and running tests.
+git_repo_path = abspath(join(dirname(dirname(__file__)), "src"))
+sys.path.insert(1, git_repo_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@
 import sys
 from os.path import abspath, dirname, join
 
+
 # allow having multiple repository checkouts and not needing to remember to rerun
 # 'pip install -e .[dev]' when switching between checkouts and running tests.
 git_repo_path = abspath(join(dirname(dirname(__file__)), "src"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+# tests directory-specific settings - this file is run automatically
+# by pytest before any tests are run
+
+import sys
+from os.path import abspath, dirname, join
+
+# allow having multiple repository checkouts and not needing to remember to rerun
+# 'pip install -e .[dev]' when switching between checkouts and running tests.
+git_repo_path = abspath(join(dirname(dirname(__file__)), "src"))
+sys.path.insert(1, git_repo_path)


### PR DESCRIPTION
allow having multiple repository checkouts and not needing to remember to rerun `pip install -e .[dev]` when switching between checkouts and running tests. This code will automatically do the right thing for the test suite.

Note that `python -m pytest` automatically adds `.` to the path, so normally most packages get automatically tested against the local checkout. However, since this project is under a sub-dir `src/` this feature doesn't help.
