### PR TITLE
[Longformer] fix longformer global attention output

### DIFF
--- a/src/transformers/modeling_longformer.py
+++ b/src/transformers/modeling_longformer.py
@@ -427,12 +427,9 @@ class LongformerSelfAttention(nn.Module):
         if output_attentions:
             if is_global_attn:
                 # With global attention, return global attention probabilities only
-                # batch_size x num_heads x sequence_length x max_num_global_attention_tokens
-                # which is the attention weights from tokens with global attention to all tokens
-                # It doesn't not return local attention
-                # In case of variable number of global attantion in the rows of a batch,
-                # attn_probs are padded with -10000.0 attention scores
-                # only use first global attn probs
+                # batch_size x num_heads x sequence_length x sequence_length
+                # which is the attention weights from all tokens to all tokens for global attention
+                # It doesn't not return local attention. Only tokens with global attention have values > 0.0
                 attn_probs = attn_probs[:, :, :, :max_num_global_attn_indices]
                 # pad attn_probs to max length with 0.0 since global attn did not attend there
                 attn_probs = F.pad(attn_probs, (0, seq_len - max_num_global_attn_indices), value=0.0,)

--- a/src/transformers/modeling_longformer.py
+++ b/src/transformers/modeling_longformer.py
@@ -427,12 +427,13 @@ class LongformerSelfAttention(nn.Module):
         if output_attentions:
             if is_global_attn:
                 # With global attention, return global attention probabilities only
-                # batch_size x num_heads x sequence_length x sequence_length
+                # batch_size x num_heads x sequence_length x window_size
                 # which is the attention weights from all tokens to all tokens for global attention
                 # It doesn't not return local attention. Only tokens with global attention have values > 0.0
                 attn_probs = attn_probs[:, :, :, :max_num_global_attn_indices]
                 # pad attn_probs to max length with 0.0 since global attn did not attend there
-                attn_probs = F.pad(attn_probs, (0, seq_len - max_num_global_attn_indices), value=0.0,)
+                window_size = (self.one_sided_attn_window_size * 2 + 1,)
+                attn_probs = F.pad(attn_probs, (0, window_size - max_num_global_attn_indices), value=0.0,)
                 attn_probs = attn_probs.permute(0, 2, 1, 3)
             else:
                 # without global attention, return local attention probabilities

--- a/src/transformers/modeling_longformer.py
+++ b/src/transformers/modeling_longformer.py
@@ -432,9 +432,10 @@ class LongformerSelfAttention(nn.Module):
                 # It doesn't not return local attention
                 # In case of variable number of global attantion in the rows of a batch,
                 # attn_probs are padded with -10000.0 attention scores
-
                 # only use first global attn probs
                 attn_probs = attn_probs[:, :, :, :max_num_global_attn_indices]
+                # pad attn_probs to max length
+                attn_probs = F.pad(attn_probs, (0, seq_len - max_num_global_attn_indices), value=-10000.0,)
                 attn_probs = attn_probs.permute(0, 2, 1, 3)
             else:
                 # without global attention, return local attention probabilities

--- a/src/transformers/modeling_longformer.py
+++ b/src/transformers/modeling_longformer.py
@@ -434,8 +434,8 @@ class LongformerSelfAttention(nn.Module):
                 # attn_probs are padded with -10000.0 attention scores
                 # only use first global attn probs
                 attn_probs = attn_probs[:, :, :, :max_num_global_attn_indices]
-                # pad attn_probs to max length
-                attn_probs = F.pad(attn_probs, (0, seq_len - max_num_global_attn_indices), value=-10000.0,)
+                # pad attn_probs to max length with 0.0 since global attn did not attend there
+                attn_probs = F.pad(attn_probs, (0, seq_len - max_num_global_attn_indices), value=0.0,)
                 attn_probs = attn_probs.permute(0, 2, 1, 3)
             else:
                 # without global attention, return local attention probabilities

--- a/src/transformers/modeling_longformer.py
+++ b/src/transformers/modeling_longformer.py
@@ -427,12 +427,15 @@ class LongformerSelfAttention(nn.Module):
         if output_attentions:
             if is_global_attn:
                 # With global attention, return global attention probabilities only
-                # batch_size x num_heads x max_num_global_attention_tokens x sequence_length
+                # batch_size x num_heads x sequence_length x max_num_global_attention_tokens
                 # which is the attention weights from tokens with global attention to all tokens
                 # It doesn't not return local attention
                 # In case of variable number of global attantion in the rows of a batch,
                 # attn_probs are padded with -10000.0 attention scores
-                attn_probs = attn_probs.view(batch_size, self.num_heads, max_num_global_attn_indices, seq_len)
+
+                # only use first global attn probs
+                attn_probs = attn_probs[:, :, :, :max_num_global_attn_indices]
+                attn_probs = attn_probs.permute(0, 2, 1, 3)
             else:
                 # without global attention, return local attention probabilities
                 # batch_size x num_heads x sequence_length x window_size

--- a/src/transformers/modeling_longformer.py
+++ b/src/transformers/modeling_longformer.py
@@ -432,7 +432,7 @@ class LongformerSelfAttention(nn.Module):
                 # It doesn't not return local attention. Only tokens with global attention have values > 0.0
                 attn_probs = attn_probs[:, :, :, :max_num_global_attn_indices]
                 # pad attn_probs to max length with 0.0 since global attn did not attend there
-                window_size = (self.one_sided_attn_window_size * 2 + 1,)
+                window_size = self.one_sided_attn_window_size * 2 + 1
                 attn_probs = F.pad(attn_probs, (0, window_size - max_num_global_attn_indices), value=0.0,)
                 attn_probs = attn_probs.permute(0, 2, 1, 3)
             else:


### PR DESCRIPTION
This PR fixes the attention probs that are outputted when longformer uses global attention and sets `output_attention=True`.

Thanks a million to @k141303 for very clean issue + perfect proposed solution in https://github.com/huggingface/transformers/issues/5646 .