### PR TITLE
[WIP] add DeFormer (ACL 2020) example

### DIFF
--- a/examples/deformer/README.md
+++ b/examples/deformer/README.md
@@ -1,0 +1,35 @@
+# **DeFormer**: **De**composing Pre-trained Trans**former**s for Faster Question Answering
+
+This example is the [DeFormer paper](https://awk.ai/assets/deformer.pdf) (ACL 2020), adapted from the [author's codebase](https://github.com/StonyBrookNLP/deformer)
+
+<img style="margin:auto;width:50%" src="https://awk.ai/assets/deformer-sketch.png" alt="deformer"/>
+
+# TODOs
+
+- [ ] use HF preprocessing (use HF nlp library)
+- [ ] convert original TF DeFormer to HF version
+- [ ] convert pre-trained checkpoints 
+- [ ] compare and test accuracy for SQuAD, RACE, and BoolQ
+- [ ] prepare demo and upload to model cards
+
+## Citation
+
+If you find our work useful to your research, please consider using the following citation:
+
+````bib
+@inproceedings{cao-etal-2020-deformer,
+    title = "{D}e{F}ormer: Decomposing Pre-trained Transformers for Faster Question Answering",
+    author = "Cao, Qingqing  and
+      Trivedi, Harsh  and
+      Balasubramanian, Aruna  and
+      Balasubramanian, Niranjan",
+    booktitle = "Proceedings of the 58th Annual Mdeformering of the Association for Computational Linguistics",
+    month = jul,
+    year = "2020",
+    address = "Online",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/2020.acl-main.411",
+    pages = "4487--4497",
+}
+````
+


### PR DESCRIPTION
Hi there, I'm one of the authors of the [DeFormer paper](https://www.aclweb.org/anthology/2020.acl-main.411/), and I'd like to adapt the [DeFormer codebase](https://github.com/StonyBrookNLP/deformer) to this awesome transformers library. To get the adaptation done, I put a few high-level todos in the README (also here). I plan to get a working example by/before August but don't have a precise timeline yet. Let me hear what you think. Thanks.

- [ ] use HF preprocessing (use HF nlp library)
- [ ] convert original TF DeFormer to HF version
- [ ] convert pre-trained checkpoints 
- [ ] compare and test accuracy for SQuAD, RACE, and BoolQ
- [ ] prepare demo and upload to model cards
