### PR TITLE
Fix Trainer in DataParallel setting

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -620,7 +620,7 @@ class Trainer:
             inputs["mems"] = self._past
         # Our model outputs do not work with DataParallel, so forcing return tuple.
         if self.args.n_gpu > 1:
-            inputs["retun_tuple"] = True
+            inputs["return_tuple"] = True
 
         outputs = model(**inputs)
         loss = outputs[0]  # model outputs are always tuple in transformers (see doc)
@@ -823,7 +823,7 @@ class Trainer:
                 inputs["mems"] = past
             # Our model outputs do not work with DataParallel, so forcing return tuple.
             if self.args.n_gpu > 1:
-                inputs["retun_tuple"] = True
+                inputs["return_tuple"] = True
 
             with torch.no_grad():
                 outputs = model(**inputs)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -618,6 +618,9 @@ class Trainer:
 
         if self.args.past_index >= 0 and self._past is not None:
             inputs["mems"] = self._past
+        # Our model outputs do not work with DataParallel, so forcing return tuple.
+        if self.args.n_gpu > 1:
+            inputs["retun_tuple"] = True
 
         outputs = model(**inputs)
         loss = outputs[0]  # model outputs are always tuple in transformers (see doc)
@@ -818,6 +821,9 @@ class Trainer:
                     inputs[k] = v.to(self.args.device)
             if self.args.past_index >= 0:
                 inputs["mems"] = past
+            # Our model outputs do not work with DataParallel, so forcing return tuple.
+            if self.args.n_gpu > 1:
+                inputs["retun_tuple"] = True
 
             with torch.no_grad():
                 outputs = model(**inputs)


### PR DESCRIPTION
The new output types seem to break data parallel FYI, see comment on #5671. This is is because of the line 
```
return type(out)(map(gather_map, zip(*outputs)))
```
in `scatter_gather` which tries to reconstruct an output of the same type as ours (and fails since it does not provide the necessary arguments). There is no  way to fix our `ModelOutput` to work with this AFAICT.

However, we have the `return_tuple` argument to fix the issue :-)