### PR TITLE
[Don't merge] Run make style on templates

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -65,7 +65,6 @@ from .data import (
     xnli_processors,
     xnli_tasks_num_labels,
 )
-
 # Files and general utilities
 from .file_utils import (
     CONFIG_NAME,
@@ -87,10 +86,8 @@ from .file_utils import (
     is_torch_tpu_available,
 )
 from .hf_argparser import HfArgumentParser
-
 # Model Cards
 from .modelcard import ModelCard
-
 # TF 2.0 <=> PyTorch conversion utilities
 from .modeling_tf_pytorch_utils import (
     convert_tf_weight_name_to_pt_weight_name,
@@ -101,7 +98,6 @@ from .modeling_tf_pytorch_utils import (
     load_tf2_model_in_pytorch_model,
     load_tf2_weights_in_pytorch_model,
 )
-
 # Pipelines
 from .pipelines import (
     CsvPipelineDataFormat,
@@ -120,7 +116,6 @@ from .pipelines import (
     TranslationPipeline,
     pipeline,
 )
-
 # Tokenizers
 from .tokenization_albert import AlbertTokenizer
 from .tokenization_auto import TOKENIZER_MAPPING, AutoTokenizer
@@ -162,7 +157,6 @@ from .tokenization_utils_fast import PreTrainedTokenizerFast
 from .tokenization_xlm import XLMTokenizer
 from .tokenization_xlm_roberta import XLMRobertaTokenizer
 from .tokenization_xlnet import SPIECE_UNDERLINE, XLNetTokenizer
-
 # Trainer
 from .trainer_utils import EvalPrediction, set_seed
 from .training_args import TrainingArguments

--- a/templates/adding_a_new_example_script/run_xxx.py
+++ b/templates/adding_a_new_example_script/run_xxx.py
@@ -44,7 +44,6 @@ from utils_squad import (
     write_predictions,
     write_predictions_extended,
 )
-
 # The follwing import is the official SQuAD evaluation script (2.0).
 # You can remove it from the dependencies if you are using this script outside of the library
 # We've added it here for automated tests (see examples/test_examples.py file)

--- a/templates/adding_a_new_example_script/utils_xxx.py
+++ b/templates/adding_a_new_example_script/utils_xxx.py
@@ -21,7 +21,6 @@ import logging
 import math
 
 from transformers.tokenization_bert import BasicTokenizer, whitespace_tokenize
-
 # Required by XLNet evaluation method to compute optimal threshold (see write_predictions_extended() method)
 from utils_squad_evaluate import find_all_best_thresh_v2, get_raw_scores, make_qid_to_has_ans
 


### PR DESCRIPTION
When run `make style` locally, these files got modified. 

I noticed that `black` and `isort` seem to have conflicts on these files. Is there a solution?

```
> make style
black --line-length 119 --target-version py35 examples templates tests src utils
reformatted /Users/canwenxu/transformers/src/transformers/__init__.py
reformatted /Users/canwenxu/transformers/templates/adding_a_new_example_script/run_xxx.py
reformatted /Users/canwenxu/transformers/templates/adding_a_new_example_script/utils_xxx.py
All done! ✨ 🍰 ✨
3 files reformatted, 339 files left unchanged.
isort --recursive examples templates tests src utils
Fixing /Users/canwenxu/transformers/templates/adding_a_new_example_script/run_xxx.py
Fixing /Users/canwenxu/transformers/templates/adding_a_new_example_script/utils_xxx.py
Fixing /Users/canwenxu/transformers/src/transformers/__init__.py
```