### PR TITLE
Make the order of additional special tokens deterministic

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -924,7 +924,7 @@ class SpecialTokensMixin:
         set_attr = self.special_tokens_map_extended
         for attr_value in set_attr.values():
             all_toks = all_toks + (list(attr_value) if isinstance(attr_value, (list, tuple)) else [attr_value])
-        all_toks = list(set(all_toks))
+        all_toks = sorted(list(set(all_toks)))
         return all_toks
 
     @property

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -23,7 +23,7 @@ import json
 import logging
 import os
 import warnings
-from collections import UserDict
+from collections import OrderedDict, UserDict
 from enum import Enum
 from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Tuple, Union
 
@@ -924,7 +924,7 @@ class SpecialTokensMixin:
         set_attr = self.special_tokens_map_extended
         for attr_value in set_attr.values():
             all_toks = all_toks + (list(attr_value) if isinstance(attr_value, (list, tuple)) else [attr_value])
-        all_toks = sorted(list(set(all_toks)))
+        all_toks = list(OrderedDict.fromkeys(all_toks))
         return all_toks
 
     @property


### PR DESCRIPTION
In `SpecialTokensMixin.all_special_tokens_extended`, deduplication is performed by `all_toks = list(set(all_toks))`. However, this will change the ordering of additional special tokens, and the order depends on the hash seed of set data structure. This will result in non-deterministic id of additional special tokens added to `AutoTokenizer.from_pretrained` method. Therefore, I changed this problematic line to `all_toks = list(OrderedDict.fromkeys(all_toks))`. This line will deduplicate `all_toks` while still keeping the original ordering.
