### PR TITLE
DataParallel fixes

### DIFF
--- a/examples/question-answering/run_squad.py
+++ b/examples/question-answering/run_squad.py
@@ -199,6 +199,9 @@ def train(args, train_dataset, model, tokenizer):
                         {"langs": (torch.ones(batch[0].shape, dtype=torch.int64) * args.lang_id).to(args.device)}
                     )
 
+            if isinstance(model, torch.nn.DataParallel):
+                inputs["return_tuple"] = True
+
             outputs = model(**inputs)
             # model outputs are always tuple in transformers (see doc)
             loss = outputs[0]

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -619,7 +619,7 @@ class Trainer:
         if self.args.past_index >= 0 and self._past is not None:
             inputs["mems"] = self._past
         # Our model outputs do not work with DataParallel, so forcing return tuple.
-        if self.args.n_gpu > 1:
+        if isinstance(model, nn.DataParallel):
             inputs["return_tuple"] = True
 
         outputs = model(**inputs)
@@ -822,7 +822,7 @@ class Trainer:
             if self.args.past_index >= 0:
                 inputs["mems"] = past
             # Our model outputs do not work with DataParallel, so forcing return tuple.
-            if self.args.n_gpu > 1:
+            if isinstance(model, nn.DataParallel):
                 inputs["return_tuple"] = True
 
             with torch.no_grad():

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -803,6 +803,8 @@ class ModelTesterMixin:
 
             # Wrap model in nn.DataParallel
             model = torch.nn.DataParallel(model)
+            # Our model outputs do not work with DataParallel, so forcing return tuple.
+            inputs_dict["return_tuple"] = True
             with torch.no_grad():
                 _ = model(**self._prepare_for_class(inputs_dict, model_class))
 


### PR DESCRIPTION
1. switched to a more precise check as suggested by @thomwolf

```
-        if self.args.n_gpu > 1:
+        if isinstance(model, nn.DataParallel):
```
  discussion: https://github.com/huggingface/transformers/issues/5693#issuecomment-657937349

2. fix tests - require the same fixup under DataParallel as the training module fix merged earlier today:
https://github.com/huggingface/transformers/pull/5685
discussion: https://github.com/huggingface/transformers/issues/5693#issuecomment-657938856

