### PR TITLE
Reintroduce clean_text on BertTokenizer call which was removed by mistake in #4723

### DIFF
--- a/src/transformers/tokenization_bert.py
+++ b/src/transformers/tokenization_bert.py
@@ -398,6 +398,7 @@ class BasicTokenizer(object):
         """
         # union() returns a new set by concatenating the two sets.
         never_split = self.never_split.union(set(never_split)) if never_split else self.never_split
+        text = self._clean_text(text)
 
         # This was added on November 1st, 2018 for the multilingual and Chinese
         # models. This is also applied to the English models now, but it doesn't

--- a/tests/test_tokenization_bert.py
+++ b/tests/test_tokenization_bert.py
@@ -223,32 +223,14 @@ class BertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertFalse(_is_punctuation(" "))
 
     def test_clean_text(self):
-        tokenizer = self.get_tokenizer(clean_text=True)
-        rust_tokenizer = self.get_rust_tokenizer(clean_text=True)
+        tokenizer = self.get_tokenizer()
+        rust_tokenizer = self.get_rust_tokenizer()
 
         # Example taken from the issue https://github.com/huggingface/tokenizers/issues/340
-        self.assertListEqual(
-            [tokenizer.tokenize(t) for t in ['Test', '\xad', 'test']],
-            [['[UNK]'], [], ['[UNK]']]
-        )
+        self.assertListEqual([tokenizer.tokenize(t) for t in ["Test", "\xad", "test"]], [["[UNK]"], [], ["[UNK]"]])
 
         self.assertListEqual(
-            [rust_tokenizer.tokenize(t) for t in ['Test', '\xad', 'test']],
-            [['[UNK]'], [], ['[UNK]']]
-        )
-
-        tokenizer = self.get_tokenizer(clean_text=False)
-        rust_tokenizer = self.get_rust_tokenizer(clean_text=False)
-
-        # Example taken from the issue https://github.com/huggingface/tokenizers/issues/340
-        self.assertListEqual(
-            [tokenizer.tokenize(t) for t in ['Test', '\xad', 'test']],
-            [['[UNK]'], ['[UNK]'], ['[UNK]']]
-        )
-
-        self.assertListEqual(
-            [rust_tokenizer.tokenize(t) for t in ['Test', '\xad', 'test']],
-            [['[UNK]'], ['[UNK]'], ['[UNK]']]
+            [rust_tokenizer.tokenize(t) for t in ["Test", "\xad", "test"]], [["[UNK]"], [], ["[UNK]"]]
         )
 
     @slow

--- a/tests/test_tokenization_bert.py
+++ b/tests/test_tokenization_bert.py
@@ -222,7 +222,7 @@ class BertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertFalse(_is_punctuation("A"))
         self.assertFalse(_is_punctuation(" "))
 
-    def test_clean_up_text(self):
+    def test_clean_text(self):
         tokenizer = self.get_tokenizer(clean_text=True)
         rust_tokenizer = self.get_rust_tokenizer(clean_text=True)
 

--- a/tests/test_tokenization_bert.py
+++ b/tests/test_tokenization_bert.py
@@ -229,12 +229,26 @@ class BertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         # Example taken from the issue https://github.com/huggingface/tokenizers/issues/340
         self.assertListEqual(
             [tokenizer.tokenize(t) for t in ['Test', '\xad', 'test']],
-            [['Test'], [], ['test']]
+            [['[UNK]'], [], ['[UNK]']]
         )
 
         self.assertListEqual(
             [rust_tokenizer.tokenize(t) for t in ['Test', '\xad', 'test']],
-            [['Test'], [], ['test']]
+            [['[UNK]'], [], ['[UNK]']]
+        )
+
+        tokenizer = self.get_tokenizer(clean_text=False)
+        rust_tokenizer = self.get_rust_tokenizer(clean_text=False)
+
+        # Example taken from the issue https://github.com/huggingface/tokenizers/issues/340
+        self.assertListEqual(
+            [tokenizer.tokenize(t) for t in ['Test', '\xad', 'test']],
+            [['[UNK]'], ['[UNK]'], ['[UNK]']]
+        )
+
+        self.assertListEqual(
+            [rust_tokenizer.tokenize(t) for t in ['Test', '\xad', 'test']],
+            [['[UNK]'], ['[UNK]'], ['[UNK]']]
         )
 
     @slow

--- a/tests/test_tokenization_bert.py
+++ b/tests/test_tokenization_bert.py
@@ -222,6 +222,21 @@ class BertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertFalse(_is_punctuation("A"))
         self.assertFalse(_is_punctuation(" "))
 
+    def test_clean_up_text(self):
+        tokenizer = self.get_tokenizer(clean_text=True)
+        rust_tokenizer = self.get_rust_tokenizer(clean_text=True)
+
+        # Example taken from the issue https://github.com/huggingface/tokenizers/issues/340
+        self.assertListEqual(
+            [tokenizer.tokenize(t) for t in ['Test', '\xad', 'test']],
+            [['Test'], [], ['test']]
+        )
+
+        self.assertListEqual(
+            [rust_tokenizer.tokenize(t) for t in ['Test', '\xad', 'test']],
+            [['Test'], [], ['test']]
+        )
+
     @slow
     def test_sequence_builders(self):
         tokenizer = self.tokenizer_class.from_pretrained("bert-base-uncased")


### PR DESCRIPTION
Signed-off-by: Morgan Funtowicz <funtowiczmo@gmail.com>

closes #7665 