### PR TITLE
Zero shot classification pipeline

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -827,6 +827,16 @@ class ZeroShotClassificationArgumentHandler(ArgumentHandler):
         return labels
 
     def __call__(self, sequences, labels, hypothesis_template):
+        if len(labels) == 0 or len(sequences) == 0:
+            raise ValueError("You must include at least one label and at least one sequence.")
+        if hypothesis_template.format(labels[0]) == hypothesis_template:
+            raise ValueError(
+                (
+                    'The provided hypothesis_template "{}" was not able to be formatted with the target labels. '
+                    "Make sure the passed template includes formatting syntax such as {{}} where the label should go."
+                ).format(hypothesis_template)
+            )
+
         if isinstance(sequences, str):
             sequences = [sequences]
         labels = self._parse_labels(labels)
@@ -918,6 +928,8 @@ class ZeroShotClassificationPipeline(Pipeline):
                 }
             )
 
+        if len(result) == 1:
+            return result[0]
         return result
 
 
@@ -1922,9 +1934,9 @@ SUPPORTED_TASKS = {
         "tf": TFAutoModelForSequenceClassification if is_tf_available() else None,
         "pt": AutoModelForSequenceClassification if is_torch_available() else None,
         "default": {
-            "model": {"pt": "facebook/bart-large-mnli", "tf": "facebook/bart-large-mnli",},
-            "config": "facebook/bart-large-mnli",
-            "tokenizer": "facebook/bart-large-mnli",
+            "model": {"pt": "facebook/bart-large-mnli", "tf": "roberta-large-mnli",},
+            "config": {"pt": "facebook/bart-large-mnli", "tf": "roberta-large-mnli",},
+            "tokenizer": {"pt": "facebook/bart-large-mnli", "tf": "roberta-large-mnli",},
         },
     },
 }

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -898,7 +898,27 @@ class ZeroShotClassificationPipeline(Pipeline):
         NLI-based zero-shot classification. Any combination of sequences and labels can be passed and each
         combination will be posed as a premise/hypothesis pair and passed to the pre-trained model. Then logit for
         `entailment` is then taken as the logit for the candidate label being valid. Any NLI model can be used as
-        long as the first output logit corresponds to `contradiction` and the last to `entailment`. """
+        long as the first output logit corresponds to `contradiction` and the last to `entailment`.
+
+        Args:
+            sequences (:obj:`str` or obj:`List`):
+                The sequence or sequences to classify.
+            candidate_labels (:obj:`str` or obj:`List`):
+                The set of possible class labels to classify each sequence into. Can be a single label, a string of
+                comma-separated labels, or a list of labels.
+            hypothesis_template (obj:`str`, defaults to "This example is {}."):
+                The template used to turn each label into an NLI-style hypothesis. This template must include a {}
+                or similar syntax for the candidate label to be inserted into the template. For example, the default
+                template is "This example is {}." With the candidate label "sports", this would be fed into the model
+                like `<cls> sequence to classify <sep> This example is sports . <sep>`. The default template works
+                well in many cases, but it may be worthwhile to experiment with different templates depending on the
+                task setting.
+            multi_class (obj:`bool`, defaults to False):
+                When False, it is assumed that only one candidate label can be true, and the scores are normalized
+                such that the sum of the label likelihoods for each sequence is 1. When True, the labels are
+                considered independent and probabilities are normalized for each candidate by doing a of softmax of
+                the entailment score vs. the contradiction score.
+        """
         outputs = super().__call__(sequences, candidate_labels, hypothesis_template)
         num_sequences = 1 if isinstance(sequences, str) else len(sequences)
         candidate_labels = self._args_parser._parse_labels(candidate_labels)

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1934,9 +1934,9 @@ SUPPORTED_TASKS = {
         "tf": TFAutoModelForSequenceClassification if is_tf_available() else None,
         "pt": AutoModelForSequenceClassification if is_torch_available() else None,
         "default": {
-            "model": {"pt": "facebook/bart-large-mnli", "tf": "roberta-large-mnli",},
-            "config": {"pt": "facebook/bart-large-mnli", "tf": "roberta-large-mnli",},
-            "tokenizer": {"pt": "facebook/bart-large-mnli", "tf": "roberta-large-mnli",},
+            "model": {"pt": "facebook/bart-large-mnli", "tf": "roberta-large-mnli"},
+            "config": {"pt": "facebook/bart-large-mnli", "tf": "roberta-large-mnli"},
+            "tokenizer": {"pt": "facebook/bart-large-mnli", "tf": "roberta-large-mnli"},
         },
     },
 }

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -182,7 +182,7 @@ class NLIForZeroShotArgumentHandler(ArgumentHandler):
         
         sequence_pairs = []
         for sequence in sequences:
-            sequence_pairs += [[sequence, hypothesis_template.format(label)] for label in labels]
+            sequence_pairs.extend([[sequence, hypothesis_template.format(label)] for label in labels])
         
         return sequence_pairs
 
@@ -838,7 +838,7 @@ class NLIForZeroShotPipeline(Pipeline):
     def __init__(self, args_parser=NLIForZeroShotArgumentHandler(), *args, **kwargs):
         super().__init__(*args, args_parser=args_parser, **kwargs)
 
-    def __call__(self, sequences, candidate_labels, hypothesis_template="This text is about {}.", multi_class=False):
+    def __call__(self, sequences, candidate_labels, hypothesis_template="This example is {}.", multi_class=False):
         outputs = super().__call__(sequences, candidate_labels, hypothesis_template)
         num_sequences = 1 if isinstance(sequences, str) else len(sequences)
         num_labels = 1 if isinstance(candidate_labels, str) else len(candidate_labels)

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -893,6 +893,18 @@ class ZeroShotClassificationPipeline(Pipeline):
     def __init__(self, args_parser=ZeroShotClassificationArgumentHandler(), *args, **kwargs):
         super().__init__(*args, args_parser=args_parser, **kwargs)
 
+    def _parse_and_tokenize(self, *args, padding=True, add_special_tokens=True, **kwargs):
+        """
+        Parse arguments and tokenize only_first so that hypothesis (label) is not truncated
+        """
+        inputs = self._args_parser(*args, **kwargs)
+        inputs = self.tokenizer(
+            inputs, add_special_tokens=add_special_tokens, return_tensors=self.framework, padding=padding,
+            truncation='only_first'
+        )
+
+        return inputs
+
     def __call__(self, sequences, candidate_labels, hypothesis_template="This example is {}.", multi_class=False):
         """
         NLI-based zero-shot classification. Any combination of sequences and labels can be passed and each
@@ -902,7 +914,7 @@ class ZeroShotClassificationPipeline(Pipeline):
 
         Args:
             sequences (:obj:`str` or obj:`List`):
-                The sequence or sequences to classify.
+                The sequence or sequences to classify. Truncated if model input is too large.
             candidate_labels (:obj:`str` or obj:`List`):
                 The set of possible class labels to classify each sequence into. Can be a single label, a string of
                 comma-separated labels, or a list of labels.

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -899,8 +899,11 @@ class ZeroShotClassificationPipeline(Pipeline):
         """
         inputs = self._args_parser(*args, **kwargs)
         inputs = self.tokenizer(
-            inputs, add_special_tokens=add_special_tokens, return_tensors=self.framework, padding=padding,
-            truncation='only_first'
+            inputs,
+            add_special_tokens=add_special_tokens,
+            return_tensors=self.framework,
+            padding=padding,
+            truncation="only_first",
         )
 
         return inputs

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -174,11 +174,15 @@ class NLIForZeroShotArgumentHandler(ArgumentHandler):
     premise/hypothesis pair.
     """
 
+    def _parse_labels(self, labels):
+        if isinstance(labels, str):
+            labels = [label.strip() for label in labels.split(',')]
+        return labels
+
     def __call__(self, sequences, labels, hypothesis_template):
         if isinstance(sequences, str):
             sequences = [sequences]
-        if isinstance(labels, str):
-            labels = [labels]
+        labels = self._parse_labels(labels)
         
         sequence_pairs = []
         for sequence in sequences:
@@ -841,10 +845,10 @@ class NLIForZeroShotPipeline(Pipeline):
     def __call__(self, sequences, candidate_labels, hypothesis_template="This example is {}.", multi_class=False):
         outputs = super().__call__(sequences, candidate_labels, hypothesis_template)
         num_sequences = 1 if isinstance(sequences, str) else len(sequences)
-        num_labels = 1 if isinstance(candidate_labels, str) else len(candidate_labels)
-        reshaped_outputs = outputs.reshape((num_sequences, num_labels, -1))
+        candidate_labels = self._args_parser._parse_labels(candidate_labels)
+        reshaped_outputs = outputs.reshape((num_sequences, len(candidate_labels), -1))
 
-        if num_labels == 1:
+        if len(candidate_labels) == 1:
             multi_class = True
         
         if not multi_class:

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -15,7 +15,6 @@ NER_FINETUNED_MODELS = ["sshleifer/tiny-dbmdz-bert-large-cased-finetuned-conll03
 FEATURE_EXTRACT_FINETUNED_MODELS = ["sshleifer/tiny-distilbert-base-cased"]
 TEXT_CLASSIF_FINETUNED_MODELS = ["sshleifer/tiny-distilbert-base-uncased-finetuned-sst-2-english"]
 TEXT_GENERATION_FINETUNED_MODELS = ["sshleifer/tiny-ctrl"]
-ZERO_SHOT_CLASSIFICATION_FINETUNED_MODELS = ["huggingface/distilbert-base-uncased-finetuned-mnli"]
 
 FILL_MASK_FINETUNED_MODELS = ["sshleifer/tiny-distilroberta-base"]
 LARGE_FILL_MASK_FINETUNED_MODELS = ["distilroberta-base"]  # @slow
@@ -320,6 +319,12 @@ QA_FINETUNED_MODELS = ["sshleifer/tiny-distilbert-base-cased-distilled-squad"]
 
 
 class ZeroShotClassificationPipelineTests(unittest.TestCase):
+    def _test_scores_sum_to_one(self, result):
+        sum = 0.0
+        for score in result["scores"]:
+            sum += score
+        self.assertAlmostEqual(sum, 1.0)
+
     def _test_zero_shot_pipeline(self, nlp):
         output_keys = {"sequence", "labels", "scores"}
         valid_mono_inputs = [
@@ -364,6 +369,8 @@ class ZeroShotClassificationPipelineTests(unittest.TestCase):
         for mono_input in valid_mono_inputs:
             mono_result = nlp(**mono_input)
             self.assertIsInstance(mono_result, dict)
+            if len(mono_result["labels"]) > 1:
+                self._test_scores_sum_to_one(mono_result)
 
             for key in output_keys:
                 self.assertIn(key, mono_result)
@@ -371,24 +378,76 @@ class ZeroShotClassificationPipelineTests(unittest.TestCase):
         multi_result = nlp(**valid_multi_input)
         self.assertIsInstance(multi_result, list)
         self.assertIsInstance(multi_result[0], dict)
+        self.assertEqual(len(multi_result), len(valid_multi_input["sequences"]))
 
         for result in multi_result:
             for key in output_keys:
                 self.assertIn(key, result)
+
+            if len(result["labels"]) > 1:
+                self._test_scores_sum_to_one(result)
+
         for bad_input in invalid_inputs:
             self.assertRaises(Exception, nlp, **bad_input)
 
+    def _test_zero_shot_pipeline_outputs(self, nlp):
+        inputs = [
+            {
+                "sequences": "Who are you voting for in 2020?",
+                "candidate_labels": ["politics", "public health", "science"],
+            },
+            {
+                "sequences": "The dominant sequence transduction models are based on complex recurrent or convolutional neural networks in an encoder-decoder configuration. The best performing models also connect the encoder and decoder through an attention mechanism. We propose a new simple network architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence and convolutions entirely. Experiments on two machine translation tasks show these models to be superior in quality while being more parallelizable and requiring significantly less time to train. Our model achieves 28.4 BLEU on the WMT 2014 English-to-German translation task, improving over the existing best results, including ensembles by over 2 BLEU. On the WMT 2014 English-to-French translation task, our model establishes a new single-model state-of-the-art BLEU score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the training costs of the best models from the literature. We show that the Transformer generalizes well to other tasks by applying it successfully to English constituency parsing both with large and limited training data.",
+                "candidate_labels": ["machine learning", "statistics", "translation", "vision"],
+                "multi_class": True,
+            },
+        ]
+
+        expected_outputs = [
+            {
+                "sequence": "Who are you voting for in 2020?",
+                "labels": ["politics", "public health", "science"],
+                "scores": [0.9759403467178345, 0.015444041229784489, 0.00861559621989727],
+            },
+            {
+                "sequence": "The dominant sequence transduction models are based on complex recurrent or convolutional neural networks in an encoder-decoder configuration. The best performing models also connect the encoder and decoder through an attention mechanism. We propose a new simple network architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence and convolutions entirely. Experiments on two machine translation tasks show these models to be superior in quality while being more parallelizable and requiring significantly less time to train. Our model achieves 28.4 BLEU on the WMT 2014 English-to-German translation task, improving over the existing best results, including ensembles by over 2 BLEU. On the WMT 2014 English-to-French translation task, our model establishes a new single-model state-of-the-art BLEU score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the training costs of the best models from the literature. We show that the Transformer generalizes well to other tasks by applying it successfully to English constituency parsing both with large and limited training data.",
+                "labels": ["translation", "machine learning", "vision", "statistics"],
+                "scores": [0.8173951506614685, 0.7125081419944763, 0.018082918599247932, 0.017706245183944702],
+            },
+        ]
+
+        for input, expected_output in zip(inputs, expected_outputs):
+            output = nlp(**input)
+            for key in output:
+                if key == "scores":
+                    for output_score, expected_score in zip(output[key], expected_output[key]):
+                        self.assertAlmostEqual(output_score, expected_score, places=4)
+                else:
+                    self.assertEqual(output[key], expected_output[key])
+
     @require_torch
     def test_torch_zero_shot_classification(self):
-        for model_name in ZERO_SHOT_CLASSIFICATION_FINETUNED_MODELS:
+        for model_name in TEXT_CLASSIF_FINETUNED_MODELS:
             nlp = pipeline(task="zero-shot-classification", model=model_name, tokenizer=model_name)
             self._test_zero_shot_pipeline(nlp)
 
     @require_tf
     def test_tf_zero_shot_classification(self):
-        for model_name in ZERO_SHOT_CLASSIFICATION_FINETUNED_MODELS:
+        for model_name in TEXT_CLASSIF_FINETUNED_MODELS:
             nlp = pipeline(task="zero-shot-classification", model=model_name, tokenizer=model_name, framework="tf")
             self._test_zero_shot_pipeline(nlp)
+
+    @slow
+    @require_torch
+    def test_torch_zero_shot_outputs(self):
+        nlp = pipeline(task="zero-shot-classification", model="roberta-large-mnli")
+        self._test_zero_shot_pipeline_outputs(nlp)
+
+    @slow
+    @require_tf
+    def test_tf_zero_shot_outputs(self):
+        nlp = pipeline(task="zero-shot-classification", model="roberta-large-mnli", framework="tf")
+        self._test_zero_shot_pipeline_outputs(nlp)
 
 
 class QAPipelineTests(unittest.TestCase):

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -407,12 +407,12 @@ class ZeroShotClassificationPipelineTests(unittest.TestCase):
             {
                 "sequence": "Who are you voting for in 2020?",
                 "labels": ["politics", "public health", "science"],
-                "scores": [0.9759403467178345, 0.015444041229784489, 0.00861559621989727],
+                "scores": [0.975, 0.015, 0.008]
             },
             {
                 "sequence": "The dominant sequence transduction models are based on complex recurrent or convolutional neural networks in an encoder-decoder configuration. The best performing models also connect the encoder and decoder through an attention mechanism. We propose a new simple network architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence and convolutions entirely. Experiments on two machine translation tasks show these models to be superior in quality while being more parallelizable and requiring significantly less time to train. Our model achieves 28.4 BLEU on the WMT 2014 English-to-German translation task, improving over the existing best results, including ensembles by over 2 BLEU. On the WMT 2014 English-to-French translation task, our model establishes a new single-model state-of-the-art BLEU score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the training costs of the best models from the literature. We show that the Transformer generalizes well to other tasks by applying it successfully to English constituency parsing both with large and limited training data.",
                 "labels": ["translation", "machine learning", "vision", "statistics"],
-                "scores": [0.8173951506614685, 0.7125081419944763, 0.018082918599247932, 0.017706245183944702],
+                "scores": [0.817, 0.712, 0.018, 0.017]
             },
         ]
 
@@ -421,7 +421,7 @@ class ZeroShotClassificationPipelineTests(unittest.TestCase):
             for key in output:
                 if key == "scores":
                     for output_score, expected_score in zip(output[key], expected_output[key]):
-                        self.assertAlmostEqual(output_score, expected_score, places=4)
+                        self.assertAlmostEqual(output_score, expected_score, places=2)
                 else:
                     self.assertEqual(output[key], expected_output[key])
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -407,12 +407,12 @@ class ZeroShotClassificationPipelineTests(unittest.TestCase):
             {
                 "sequence": "Who are you voting for in 2020?",
                 "labels": ["politics", "public health", "science"],
-                "scores": [0.975, 0.015, 0.008]
+                "scores": [0.975, 0.015, 0.008],
             },
             {
                 "sequence": "The dominant sequence transduction models are based on complex recurrent or convolutional neural networks in an encoder-decoder configuration. The best performing models also connect the encoder and decoder through an attention mechanism. We propose a new simple network architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence and convolutions entirely. Experiments on two machine translation tasks show these models to be superior in quality while being more parallelizable and requiring significantly less time to train. Our model achieves 28.4 BLEU on the WMT 2014 English-to-German translation task, improving over the existing best results, including ensembles by over 2 BLEU. On the WMT 2014 English-to-French translation task, our model establishes a new single-model state-of-the-art BLEU score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the training costs of the best models from the literature. We show that the Transformer generalizes well to other tasks by applying it successfully to English constituency parsing both with large and limited training data.",
                 "labels": ["translation", "machine learning", "vision", "statistics"],
-                "scores": [0.817, 0.712, 0.018, 0.017]
+                "scores": [0.817, 0.712, 0.018, 0.017],
             },
         ]
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -385,7 +385,7 @@ class ZeroShotClassificationPipelineTests(unittest.TestCase):
             self._test_zero_shot_pipeline(nlp)
 
     @require_tf
-    def test_torch_zero_shot_classification(self):
+    def test_tf_zero_shot_classification(self):
         for model_name in ZERO_SHOT_CLASSIFICATION_FINETUNED_MODELS:
             nlp = pipeline(task="zero-shot-classification", model=model_name, tokenizer=model_name, framework="tf")
             self._test_zero_shot_pipeline(nlp)


### PR DESCRIPTION
This PR adds a pipeline for zero-shot classification using pre-trained NLI models as demonstrated in our [zero-shot topic classification demo](https://huggingface.co/zero-shot/) and [blog post](https://joeddav.github.io/blog/2020/05/29/ZSL.html). 

Addresses #5756, where @clmnt requested zero-shot classification in the inference API. However, it should be noted that this model has a max sequence size of `1024`, so long documents would be truncated to this length when classifying.

The pipeline takes in collection of sequences and labels. The labels are converted into a hypothesis, e.g. `vulgar` ➡ `this example is vulgar.` Each sequence and each candidate label must be paired and passed through the model, so the total number of forward passes is `num_labels * num_sequences`.

#### Usage

The pipeline can be initialized using the `pipeline` factory:

```python
from transformers import pipeline
nlp = pipeline("zero-shot-classification")
```
Then any combination of sequences and candidate labels can be passed.
```python
sequence_to_classify = "Who are you voting for in 2020?"
candidate_labels = ["Europe", "public health", "politics"]
nlp(sequence_to_classify, candidate_labels)
>>> {'sequence': 'Who are you voting for in 2020?',
     'labels': ['politics', 'Europe', 'public health'],
     'scores': [0.9676316380500793, 0.019536184147000313, 0.012832209467887878]}
```
When more than one label is passed, we assume that there is only one true label and that the others are false so that the output probabilities add up to 1. This can be changed by passing `multi_class=True`:
```python
sequence_to_classify = "Who are you voting for in 2020?"
candidate_labels = ["Europe", "public health", "politics", "elections"]
nlp(sequence_to_classify, candidate_labels, multi_class=True)
>>> {'sequence': 'Who are you voting for in 2020?',
     'labels': ['politics', 'elections', 'Europe', 'public health'],
     'scores': [0.9720695614814758,
      0.967610776424408,
      0.060417089611291885,
      0.03248738870024681]}
```
The single-label case is likely to be more reliable, however, since the guarantee of only one true label provides strong signal to the model which is very useful in the zero-shot setting.

By default, labels are turned into NLI-format hypotheses with the template `This example is {label}.`. You can change this by with the `hypothesis_template` argument, but the default template seems to work well in most settings I've experimented with.

A couple more examples:
```python
reviews = [
     "I didn't care for this film, but the ending was o.k.",
     "There were some weak moments, but the movie was pretty good overall"
]
nlp(reviews, ["positive", "negative"])
>>> [{'sequence': "I didn't care for this film, but the ending was o.k.",
      'labels': ['negative', 'positive'],
      'scores': [0.9887893199920654, 0.011210653930902481]},
     {'sequence': 'There were some weak moments, but the movie was pretty good overall',
      'labels': ['positive', 'negative'],
      'scores': [0.6071907877922058, 0.3928091824054718]}]
```
```python
reviews = [
     "I didn't care for this film, but the ending was o.k.",
     "There were some weak moments, but the movie was pretty good overall"
]
hypothesis_template = 'The sentiment of this review is {}.'
nlp(reviews, ["positive", "negative"], hypothesis_template=hypothesis_template)
>>> [{'sequence': "I didn't care for this film, but the ending was o.k.",
      'labels': ['negative', 'positive'],
      'scores': [0.9774571061134338, 0.022542938590049744]},
     {'sequence': 'There were some weak moments, but the movie was pretty good overall',
      'labels': ['positive', 'negative'],
      'scores': [0.9787198305130005, 0.021280216053128242]}]
```
```python
nlp("I am a bit discouraged by my grades.", ["sad", "happy", "angry"])
>>> {'sequence': 'I am a bit discouraged by my grades.',
     'labels': ['sad', 'angry', 'happy'],
     'scores': [0.9630885124206543, 0.0311590563505888, 0.005752446595579386]}
```