### PR TITLE
Ensure OpenAI GPT position_ids is correctly initialized and registered at init.

### DIFF
--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -192,7 +192,7 @@ class BertEmbeddings(nn.Module):
         seq_length = input_shape[1]
 
         if position_ids is None:
-            position_ids = self.position_ids[: seq_length]
+            position_ids = self.position_ids[:, :seq_length]
 
         if token_type_ids is None:
             token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=self.position_ids.device)

--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -180,6 +180,9 @@ class BertEmbeddings(nn.Module):
         self.LayerNorm = BertLayerNorm(config.hidden_size, eps=config.layer_norm_eps)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
+        # position_ids (1, len position emb) is contiguous in memory and exported when serialized
+        self.register_buffer("position_ids", torch.arange(config.max_position_embeddings).expand((1, -1)))
+
     def forward(self, input_ids=None, token_type_ids=None, position_ids=None, inputs_embeds=None):
         if input_ids is not None:
             input_shape = input_ids.size()
@@ -187,12 +190,12 @@ class BertEmbeddings(nn.Module):
             input_shape = inputs_embeds.size()[:-1]
 
         seq_length = input_shape[1]
-        device = input_ids.device if input_ids is not None else inputs_embeds.device
+
         if position_ids is None:
-            position_ids = torch.arange(seq_length, dtype=torch.long, device=device)
-            position_ids = position_ids.unsqueeze(0).expand(input_shape)
+            position_ids = self.position_ids[: seq_length]
+
         if token_type_ids is None:
-            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
+            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=self.position_ids.device)
 
         if inputs_embeds is None:
             inputs_embeds = self.word_embeddings(input_ids)

--- a/src/transformers/modeling_mobilebert.py
+++ b/src/transformers/modeling_mobilebert.py
@@ -191,7 +191,7 @@ class MobileBertEmbeddings(nn.Module):
         seq_length = input_shape[1]
 
         if position_ids is None:
-            position_ids = self.position_ids[: seq_length]
+            position_ids = self.position_ids[:, :seq_length]
 
         if token_type_ids is None:
             token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=self.position_ids.device)

--- a/src/transformers/modeling_openai.py
+++ b/src/transformers/modeling_openai.py
@@ -391,6 +391,7 @@ class OpenAIGPTModel(OpenAIGPTPreTrainedModel):
         self.drop = nn.Dropout(config.embd_pdrop)
         self.h = nn.ModuleList([Block(config.n_ctx, config, scale=True) for _ in range(config.n_layer)])
 
+        self.register_buffer('position_ids', torch.arange(config.n_positions))
         self.init_weights()
 
     def get_input_embeddings(self):
@@ -443,9 +444,8 @@ class OpenAIGPTModel(OpenAIGPTPreTrainedModel):
 
         if position_ids is None:
             # Code is different from when we had a single embedding matrice from position and token embeddings
-            device = input_ids.device if input_ids is not None else inputs_embeds.device
-            position_ids = torch.arange(input_shape[-1], dtype=torch.long, device=device)
-            position_ids = position_ids.unsqueeze(0).view(-1, input_shape[-1])
+            # position_ids = torch.arange(input_shape[-1], dtype=torch.long, device=device)
+            position_ids = self.position_ids[None, input_shape[-1]]
 
         # Attention mask.
         if attention_mask is not None:

--- a/src/transformers/modeling_openai.py
+++ b/src/transformers/modeling_openai.py
@@ -444,8 +444,7 @@ class OpenAIGPTModel(OpenAIGPTPreTrainedModel):
 
         if position_ids is None:
             # Code is different from when we had a single embedding matrice from position and token embeddings
-            # position_ids = torch.arange(input_shape[-1], dtype=torch.long, device=device)
-            position_ids = self.position_ids[None, input_shape[-1]]
+            position_ids = self.position_ids[None, :input_shape[-1]]
 
         # Attention mask.
         if attention_mask is not None:

--- a/src/transformers/modeling_openai.py
+++ b/src/transformers/modeling_openai.py
@@ -391,7 +391,7 @@ class OpenAIGPTModel(OpenAIGPTPreTrainedModel):
         self.drop = nn.Dropout(config.embd_pdrop)
         self.h = nn.ModuleList([Block(config.n_ctx, config, scale=True) for _ in range(config.n_layer)])
 
-        self.register_buffer('position_ids', torch.arange(config.n_positions))
+        self.register_buffer("position_ids", torch.arange(config.n_positions))
         self.init_weights()
 
     def get_input_embeddings(self):
@@ -444,7 +444,7 @@ class OpenAIGPTModel(OpenAIGPTPreTrainedModel):
 
         if position_ids is None:
             # Code is different from when we had a single embedding matrice from position and token embeddings
-            position_ids = self.position_ids[None, :input_shape[-1]]
+            position_ids = self.position_ids[None, : input_shape[-1]]
 
         # Attention mask.
         if attention_mask is not None:

--- a/src/transformers/modeling_xlm.py
+++ b/src/transformers/modeling_xlm.py
@@ -442,6 +442,7 @@ class XLMModel(XLMPreTrainedModel):
                     self.prune_heads({int(layer): list(map(int, heads))})
 
         self.init_weights()
+        self.register_buffer("position_ids", torch.arange(config.max_position_embeddings).expand((1, -1)))
 
     def get_input_embeddings(self):
         return self.embeddings
@@ -511,12 +512,9 @@ class XLMModel(XLMPreTrainedModel):
         # if self.is_decoder and src_enc is not None:
         #     src_mask = torch.arange(src_len.max(), dtype=torch.long, device=lengths.device) < src_len[:, None]
 
-        device = input_ids.device if input_ids is not None else inputs_embeds.device
-
         # position_ids
         if position_ids is None:
-            position_ids = torch.arange(slen, dtype=torch.long, device=device)
-            position_ids = position_ids.unsqueeze(0).expand((bs, slen))
+            position_ids = self.position_ids[:, :slen]
         else:
             assert position_ids.size() == (bs, slen)  # (slen, bs)
             # position_ids = position_ids.transpose(0, 1)


### PR DESCRIPTION
This will make it compatible with TorchScript export and avoid hardcoded `position_ids` tensor's device in the generated graph.

Solve the following issue: #5664 	

Signed-off-by: Morgan Funtowicz <morgan@huggingface.co>