### PR TITLE
github issue template suggests who to tag

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -18,14 +18,17 @@ assignees: ''
  Model Cards: @julien-c
  Translation: @sshleifer
  Summarization: @sshleifer
+ TextGeneration: @TevenLeScao 
  examples/distillation: @VictorSanh
- nlp datasets: different repo
- rust tokenizers: different repo
+ nlp datasets: [different repo](https://github.com/huggingface/nlp)
+ rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
  blenderbot: @mariamabarham
  Bart: @sshleifer
  T5: @patrickvonplaten
  Longformer/Reformer: @patrickvonplaten
+ TransfoXL/XLNet: @TevenLeScao 
  examples/seq2seq: @sshleifer
+ tensorflow: @jplu 
  -->
 
 ## Information

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -46,6 +46,7 @@ assignees: ''
  TransfoXL/XLNet: @TevenLeScao 
  examples/seq2seq: @sshleifer
  tensorflow: @jplu 
+documentation: @sgugger
  -->
 
 ## Information
@@ -75,4 +76,3 @@ Steps to reproduce the behavior:
 ## Expected behavior
 
 <!-- A clear and concise description of what you would expect to happen. -->
-

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -11,11 +11,11 @@ assignees: ''
  If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of who to tag.
  Please tag fewer than 3 people.
  
- albert, bert, GPT2, XLM: @lysandre
+ albert, bert, GPT2, XLM: @LysandreJik 
  tokenizers: @mfuntowicz
- Trainer: @julienc
+ Trainer: @julien-c
  Speed and Memory Benchmarks: @patrickvonplaten
- Model Cards: @julienc
+ Model Cards: @julien-c
  Translation: @sshleifer
  Summarization: @sshleifer
  examples/distillation: @VictorSanh
@@ -69,5 +69,4 @@ Steps to reproduce the behavior:
 ## Expected behavior
 
 <!-- A clear and concise description of what you would expect to happen. -->
-
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -27,7 +27,7 @@ assignees: ''
  
  albert, bert, GPT2, XLM: @LysandreJik 
  tokenizers: @mfuntowicz
- Trainer: @julien-c
+ Trainer: @sgugger
  Speed and Memory Benchmarks: @patrickvonplaten
  Model Cards: @julien-c
  Translation: @sshleifer

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,7 +7,26 @@ assignees: ''
 
 ---
 
-# 🐛 Bug
+<!-- Your issue will be replied to more quickly if you can figure out the right person to tag with @
+ If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of who to tag.
+ Please tag fewer than 3 people.
+ 
+ albert, bert, GPT2, XLM: @lysandre
+ tokenizers: @mfuntowicz
+ Trainer: @julienc
+ Speed and Memory Benchmarks: @patrickvonplaten
+ Model Cards: @julienc
+ Translation: @sshleifer
+ Summarization: @sshleifer
+ examples/distillation: @VictorSanh
+ nlp datasets: different repo
+ rust tokenizers: different repo
+ blenderbot: @mariamabarham
+ Bart: @sshleifer
+ T5: @patrickvonplaten
+ Longformer/Reformer: @patrickvonplaten
+ examples/seq2seq: @sshleifer
+ -->
 
 ## Information
 
@@ -22,6 +41,18 @@ The problem arises when using:
 The tasks I am working on is:
 * [ ] an official GLUE/SQUaD task: (give the name)
 * [ ] my own task or dataset: (give details below)
+
+## Environment info
+<!-- You can run the command `transformers-cli env` and copy-and-paste its output below.
+     Don't forget to fill out the missing fields in that output! -->
+     
+- `transformers` version:
+- Platform:
+- Python version:
+- PyTorch version (GPU?):
+- Tensorflow version (GPU?):
+- Using GPU in script?:
+- Using distributed or parallel set-up in script?:
 
 ## To reproduce
 
@@ -39,14 +70,4 @@ Steps to reproduce the behavior:
 
 <!-- A clear and concise description of what you would expect to happen. -->
 
-## Environment info
-<!-- You can run the command `transformers-cli env` and copy-and-paste its output below.
-     Don't forget to fill out the missing fields in that output! -->
-     
-- `transformers` version:
-- Platform:
-- Python version:
-- PyTorch version (GPU?):
-- Tensorflow version (GPU?):
-- Using GPU in script?:
-- Using distributed or parallel set-up in script?:
+

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,8 +7,22 @@ assignees: ''
 
 ---
 
+
+## Environment info
+<!-- You can run the command `transformers-cli env` and copy-and-paste its output below.
+     Don't forget to fill out the missing fields in that output! -->
+     
+- `transformers` version:
+- Platform:
+- Python version:
+- PyTorch version (GPU?):
+- Tensorflow version (GPU?):
+- Using GPU in script?:
+- Using distributed or parallel set-up in script?:
+
+### Who can help
 <!-- Your issue will be replied to more quickly if you can figure out the right person to tag with @
- If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of who to tag.
+ If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
  Please tag fewer than 3 people.
  
  albert, bert, GPT2, XLM: @LysandreJik 
@@ -22,8 +36,11 @@ assignees: ''
  examples/distillation: @VictorSanh
  nlp datasets: [different repo](https://github.com/huggingface/nlp)
  rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
+ TransfoXL/XLNet: @TevenLeScao
+ Text Generation: @TevenLeScao
  blenderbot: @mariamabarham
  Bart: @sshleifer
+ Marian: @sshleifer
  T5: @patrickvonplaten
  Longformer/Reformer: @patrickvonplaten
  TransfoXL/XLNet: @TevenLeScao 
@@ -35,8 +52,6 @@ assignees: ''
 
 Model I am using (Bert, XLNet ...):
 
-Language I am using the model on (English, Chinese ...):
-
 The problem arises when using:
 * [ ] the official example scripts: (give details below)
 * [ ] my own modified scripts: (give details below)
@@ -44,18 +59,6 @@ The problem arises when using:
 The tasks I am working on is:
 * [ ] an official GLUE/SQUaD task: (give the name)
 * [ ] my own task or dataset: (give details below)
-
-## Environment info
-<!-- You can run the command `transformers-cli env` and copy-and-paste its output below.
-     Don't forget to fill out the missing fields in that output! -->
-     
-- `transformers` version:
-- Platform:
-- Python version:
-- PyTorch version (GPU?):
-- Tensorflow version (GPU?):
-- Using GPU in script?:
-- Using distributed or parallel set-up in script?:
 
 ## To reproduce
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -36,7 +36,6 @@ assignees: ''
  examples/distillation: @VictorSanh
  nlp datasets: [different repo](https://github.com/huggingface/nlp)
  rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
- TransfoXL/XLNet: @TevenLeScao
  Text Generation: @TevenLeScao
  blenderbot: @mariamabarham
  Bart: @sshleifer


### PR DESCRIPTION
Fewer issues get lost if people tag the relevant developer. It also saves @LysandreJik time.
While he is out, I figured we could experiment with trying to nudge issue raisers to tag.

Here is the comment at the beginning of the "Bug Report" template:

Your issue will be replied to more quickly if you can figure out the right person to tag with @
 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of who to tag.
 Please tag fewer than 3 people.
 
 albert, bert, GPT2, XLM: @LysandreJik 
 tokenizers: @mfuntowicz
 Trainer: @julien-c
 Speed and Memory Benchmarks: @patrickvonplaten
 Model Cards: @julien-c
 Translation: @sshleifer
 Summarization: @sshleifer
 TextGeneration: @TevenLeScao 
 examples/distillation: @VictorSanh
 nlp datasets: [different repo](https://github.com/huggingface/nlp)
 rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
 blenderbot: @mariamabarham
 Bart: @sshleifer
 T5: @patrickvonplaten
 Longformer/Reformer: @patrickvonplaten
 TransfoXL/XLNet: @TevenLeScao 
 examples/seq2seq: @sshleifer
 tensorflow: @jplu 


I wrote it in 3 minutes in case people hate this idea, so I am sure it is missing people!
Suggestions very much appreciated.