### PR TITLE
[Fix] Checkpoint saving and I/O for XLNetQASimple 

### DIFF
--- a/examples/question-answering/run_squad.py
+++ b/examples/question-answering/run_squad.py
@@ -240,6 +240,9 @@ def train(args, train_dataset, model, tokenizer):
                 # Save model checkpoint
                 if args.local_rank in [-1, 0] and args.save_steps > 0 and global_step % args.save_steps == 0:
                     output_dir = os.path.join(args.output_dir, "checkpoint-{}".format(global_step))
+                    if not os.path.exists(output_dir):
+                        os.makedirs(output_dir)
+                        
                     # Take care of distributed/parallel training
                     model_to_save = model.module if hasattr(model, "module") else model
                     model_to_save.save_pretrained(output_dir)

--- a/examples/question-answering/run_squad.py
+++ b/examples/question-answering/run_squad.py
@@ -308,8 +308,8 @@ def evaluate(args, model, tokenizer, prefix=""):
 
             feature_indices = batch[3]
 
-            # XLNet and XLM use more arguments for their predictions
-            if args.model_type in ["xlnet", "xlm"]:
+            # XLM uses more arguments for its predictions
+            if args.model_type in ["xlm"]:
                 inputs.update({"cls_index": batch[4], "p_mask": batch[5]})
                 # for lang_id-sensitive xlm models
                 if hasattr(model, "config") and hasattr(model.config, "lang2id"):
@@ -325,7 +325,7 @@ def evaluate(args, model, tokenizer, prefix=""):
 
             output = [to_list(output[i]) for output in outputs]
 
-            # Some models (XLNet, XLM) use 5 arguments for their predictions, while the other "simpler"
+            # Some models (XLM) use 5 arguments for their predictions, while the other "simpler"
             # models only use two.
             if len(output) >= 5:
                 start_logits = output[0]
@@ -361,8 +361,8 @@ def evaluate(args, model, tokenizer, prefix=""):
     else:
         output_null_log_odds_file = None
 
-    # XLNet and XLM use a more complex post-processing procedure
-    if args.model_type in ["xlnet", "xlm"]:
+    # XLM uses a more complex post-processing procedure
+    if args.model_type in ["xlm"]:
         start_n_top = model.config.start_n_top if hasattr(model, "config") else model.module.config.start_n_top
         end_n_top = model.config.end_n_top if hasattr(model, "config") else model.module.config.end_n_top
 


### PR DESCRIPTION
**1.  [Fix] Create directories for model checkpoints**

Saving model checkpoints without making directories would lead to error. 
(i.e.  The output directory will not exist using the currenct script.)

The [older version](https://github.com/huggingface/transformers/blob/3f5ccb183e3cfa755dea2dd2afd9abbf1a0f93b8/examples/run_squad.py#L193) of the part of this script works fine.

**2.  [Fix] Fix wrong input/output structures for XLNet**

Running XLNet using the current script would lead to this error below.
> TypeError: forward() got an unexpected keyword argument 'cls_index'

The reason is that the [AutoModelForQuestionAnswering](https://github.com/huggingface/transformers/blob/ba2400189b2242620868096ae49babf93bd9ce00/examples/question-answering/run_squad.py#L735) would initialize XLNetForQuestionAnsweringSimple, while the I/O structures are written for XLNetForQuestionAnswering.