### PR TITLE
[Longformer] fix longformer slow-down

### DIFF
--- a/src/transformers/modeling_longformer.py
+++ b/src/transformers/modeling_longformer.py
@@ -311,7 +311,7 @@ class LongformerSelfAttention(nn.Module):
         # is index masked or global attention
         is_index_masked = attention_mask < 0
         is_index_global_attn = attention_mask > 0
-        is_global_attn = any(is_index_global_attn.flatten())
+        is_global_attn = is_index_global_attn.flatten().any().item()
 
         hidden_states = hidden_states.transpose(0, 1)
 


### PR DESCRIPTION
A drastic slow-down of Longformer after the PR: https://github.com/huggingface/transformers/pull/5219 was deteced by @HHousen (thanks a lot!) here: https://github.com/huggingface/transformers/issues/4406#issuecomment-658483050 .

After digging a bit into the code it can be seen that the line:
`is_global_attn = any(is_index_global_attn.flatten())` is the reason of the drastic slow-down.

Running the following benchmark on master:
```
python examples/benchmarking/run_benchmark.py --models allenai/longformer-base-4096 --no_memory --sequence_length 512 1024
```

yields the following result:

```
====================       INFERENCE - SPEED - RESULT       ====================
--------------------------------------------------------------------------------
          Model Name             Batch Size     Seq Length     Time in s   
--------------------------------------------------------------------------------
 allenai/longformer-base-4096        8              512            0.647     
 allenai/longformer-base-4096        8              1024           1.284     
--------------------------------------------------------------------------------

====================        ENVIRONMENT INFORMATION         ====================
- transformers_version: 3.0.2
- framework: PyTorch
- use_torchscript: False
- framework_version: 1.5.0
- python_version: 3.7.7
- system: Linux
- cpu: x86_64
- architecture: 64bit
- date: 2020-07-16
- time: 14:07:02.719531
- fp16: False
- use_multiprocessing: True
- only_pretrain_model: False
- cpu_ram_mb: 32089
- use_gpu: True
- num_gpus: 1
- gpu: TITAN RTX
- gpu_ram_mb: 24217
- gpu_power_watts: 280.0
- gpu_performance_state: 0
- use_tpu: False
```

Now on this branch the results are as follows:

```
====================       INFERENCE - SPEED - RESULT       ====================
--------------------------------------------------------------------------------
          Model Name             Batch Size     Seq Length     Time in s   
--------------------------------------------------------------------------------
 allenai/longformer-base-4096        8              512            0.141     
 allenai/longformer-base-4096        8              1024           0.271     
--------------------------------------------------------------------------------

====================        ENVIRONMENT INFORMATION         ====================
- transformers_version: 3.0.2
- framework: PyTorch
- use_torchscript: False
- framework_version: 1.5.0
- python_version: 3.7.7
- system: Linux
- cpu: x86_64
- architecture: 64bit
- date: 2020-07-16
- time: 14:07:57.623378
- fp16: False
- use_multiprocessing: True
- only_pretrain_model: False
- cpu_ram_mb: 32089
- use_gpu: True
- num_gpus: 1
- gpu: TITAN RTX
- gpu_ram_mb: 24217
- gpu_power_watts: 280.0
- gpu_performance_state: 0
- use_tpu: False
```

So this simple line is responsible for a slow-down of factor 4.

Moral of the story: Never use `any()` on a PyTorch tensor => always use tensor.any(). I wonder if this is actually a known problem of PyTorch/Python. It might be a good to check our code if we have more statements like this. 

Another lesson for me is that one should always run the benchmarking before and after doing such a big refactoring as in https://github.com/huggingface/transformers/pull/5219 . 
It's very simple to run the benchmark script for a model and takes usually only a couple of seconds. Ideally we should have performance regression tests to automatically detect such slow downs.

Pinging @thomwolf @mfuntowicz @sshleifer @LysandreJik @ibeltagy - think this is quite interesting.