### PR TITLE
[seq2seq] pack_dataset.py rewrites dataset in max_tokens format

### DIFF
--- a/examples/seq2seq/pack_dataset.py
+++ b/examples/seq2seq/pack_dataset.py
@@ -1,0 +1,54 @@
+"""Fill examples with bitext up to max_tokens without breaking up examples.
+[['I went', 'yo fui'],
+['to the store', 'a la tienda']
+]
+=> ['I went to the store', 'yo fui a la tienda']
+"""
+
+from pathlib import Path
+from tqdm import tqdm
+
+
+def pack_examples(tok, src_examples, tgt_examples, max_tokens=1024):
+
+    finished_src, finished_tgt = [], []
+    new_src, new_tgt = '', ''
+    sorted_examples = list(sorted(zip(src_examples, tgt_examples), key=lambda x: len(x[0])))
+    def is_too_big(strang):
+        return tok(strang, return_tensors='pt').input_ids.shape[1] > max_tokens
+    for src, tgt in tqdm(sorted_examples):
+        cand_src = new_src + ' ' + src
+        cand_tgt = new_tgt + ' ' + tgt
+        if is_too_big(cand_src) or is_too_big(cand_tgt):  # cant fit, finalize example
+            finished_src.append(new_src)
+            finished_tgt.append(new_tgt)
+            new_src, new_tgt = src, tgt
+        else:  # can fit, keep adding
+            new_src, new_tgt = cand_src, cand_tgt
+
+    return finished_src, finished_tgt
+
+
+def pack_ds(tok, data_dir: Path, max_tokens, save_path):
+    save_path = Path(save_path)
+    save_path.mkdir(exist_ok=True)
+    for split in [ 'val', 'test', 'train']:
+        src_path, tgt_path = data_dir / f'{split}.source', data_dir / f'{split}.target'
+        src_docs = list(Path(src_path).open().readlines())
+        tgt_docs = list(Path(tgt_path).open().readlines())
+        src, tgt = pack_examples(tok, src_docs, tgt_docs, max_tokens)
+        print(f'split: {split}: from {len(src_docs)} -> {len(src)}')
+        Path(save_path / f'{split}.source').open('w').write('\n'.join(src))
+        Path(save_path / f'{split}.target').open('w').write('\n'.join(tgt))
+
+import argparse
+from transformers import AutoTokenizer
+def packer_cli():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tok_name", type=str, help="like facebook/bart-large-cnn,t5-base, etc.")
+    parser.add_argument('--max_seq_len', type=int, default=128)
+    parser.add_argument('--data_dir', type=str)
+    parser.add_argument('--save_path', type=int)
+    args = parser.parse_args()
+    tokenizer = AutoTokenizer.from_pretrained(args.tok_name)
+    return pack_ds(tokenizer, Path(args.data_dir), args.max_tokens, args.save_path)

--- a/examples/seq2seq/pack_dataset.py
+++ b/examples/seq2seq/pack_dataset.py
@@ -5,20 +5,26 @@
 => ['I went to the store', 'yo fui a la tienda']
 """
 
+import argparse
 from pathlib import Path
+
 from tqdm import tqdm
+
+from transformers import AutoTokenizer
 
 
 def pack_examples(tok, src_examples, tgt_examples, max_tokens=1024):
 
     finished_src, finished_tgt = [], []
-    new_src, new_tgt = '', ''
+    new_src, new_tgt = "", ""
     sorted_examples = list(sorted(zip(src_examples, tgt_examples), key=lambda x: len(x[0])))
+
     def is_too_big(strang):
-        return tok(strang, return_tensors='pt').input_ids.shape[1] > max_tokens
+        return tok(strang, return_tensors="pt").input_ids.shape[1] > max_tokens
+
     for src, tgt in tqdm(sorted_examples):
-        cand_src = new_src + ' ' + src
-        cand_tgt = new_tgt + ' ' + tgt
+        cand_src = new_src + " " + src
+        cand_tgt = new_tgt + " " + tgt
         if is_too_big(cand_src) or is_too_big(cand_tgt):  # cant fit, finalize example
             finished_src.append(new_src)
             finished_tgt.append(new_tgt)
@@ -29,26 +35,29 @@ def pack_examples(tok, src_examples, tgt_examples, max_tokens=1024):
     return finished_src, finished_tgt
 
 
-def pack_ds(tok, data_dir: Path, max_tokens, save_path):
+def pack_data_dir(tok, data_dir: Path, max_tokens, save_path):
     save_path = Path(save_path)
     save_path.mkdir(exist_ok=True)
-    for split in [ 'val', 'test', 'train']:
-        src_path, tgt_path = data_dir / f'{split}.source', data_dir / f'{split}.target'
+    for split in ["val", "test", "train"]:
+        src_path, tgt_path = data_dir / f"{split}.source", data_dir / f"{split}.target"
         src_docs = list(Path(src_path).open().readlines())
         tgt_docs = list(Path(tgt_path).open().readlines())
         src, tgt = pack_examples(tok, src_docs, tgt_docs, max_tokens)
-        print(f'split: {split}: from {len(src_docs)} -> {len(src)}')
-        Path(save_path / f'{split}.source').open('w').write('\n'.join(src))
-        Path(save_path / f'{split}.target').open('w').write('\n'.join(tgt))
+        print(f"packed {split} split from {len(src_docs)} examples -> {len(src)}.")
+        Path(save_path / f"{split}.source").open("w").write("\n".join(src))
+        Path(save_path / f"{split}.target").open("w").write("\n".join(tgt))
 
-import argparse
-from transformers import AutoTokenizer
+
 def packer_cli():
     parser = argparse.ArgumentParser()
     parser.add_argument("--tok_name", type=str, help="like facebook/bart-large-cnn,t5-base, etc.")
-    parser.add_argument('--max_seq_len', type=int, default=128)
-    parser.add_argument('--data_dir', type=str)
-    parser.add_argument('--save_path', type=int)
+    parser.add_argument("--max_seq_len", type=int, default=128)
+    parser.add_argument("--data_dir", type=str)
+    parser.add_argument("--save_path", type=str)
     args = parser.parse_args()
     tokenizer = AutoTokenizer.from_pretrained(args.tok_name)
-    return pack_ds(tokenizer, Path(args.data_dir), args.max_tokens, args.save_path)
+    return pack_data_dir(tokenizer, Path(args.data_dir), args.max_seq_len, args.save_path)
+
+
+if __name__ == "__main__":
+    packer_cli()

--- a/examples/seq2seq/test_seq2seq_examples.py
+++ b/examples/seq2seq/test_seq2seq_examples.py
@@ -16,6 +16,7 @@ from transformers.testing_utils import require_multigpu
 
 from .distillation import distill_main, evaluate_checkpoint
 from .finetune import main
+from .pack_dataset import pack_ds
 from .run_eval import generate_summaries_or_translations, run_generate
 from .utils import SummarizationDataset, lmap, load_json
 
@@ -248,9 +249,9 @@ def test_finetune(model):
         assert bart.decoder.embed_tokens == bart.encoder.embed_tokens
         assert bart.decoder.embed_tokens == bart.shared
 
-from .pack_dataset import pack_ds, packer_cli
+
 def test_pack_dataset():
-    tokenizer = AutoTokenizer.from_pretrained('facebook/mbart-large-cc25')
+    tokenizer = AutoTokenizer.from_pretrained("facebook/mbart-large-cc25")
     tmp_dir = Path(make_test_data_dir())
     save_dir = Path(tempfile.mkdtemp(prefix="output_"))
     pack_ds(tokenizer, tmp_dir, 128, save_dir)

--- a/examples/seq2seq/test_seq2seq_examples.py
+++ b/examples/seq2seq/test_seq2seq_examples.py
@@ -16,7 +16,7 @@ from transformers.testing_utils import require_multigpu
 
 from .distillation import distill_main, evaluate_checkpoint
 from .finetune import main
-from .pack_dataset import pack_ds
+from .pack_dataset import pack_data_dir
 from .run_eval import generate_summaries_or_translations, run_generate
 from .utils import SummarizationDataset, lmap, load_json
 
@@ -253,10 +253,10 @@ def test_finetune(model):
 def test_pack_dataset():
     tokenizer = AutoTokenizer.from_pretrained("facebook/mbart-large-cc25")
     tmp_dir = Path(make_test_data_dir())
-    save_dir = Path(tempfile.mkdtemp(prefix="output_"))
-    pack_ds(tokenizer, tmp_dir, 128, save_dir)
-    orig_paths = set(tmp_dir.listdir())
-    new_paths = set(save_dir.listdir())
+    save_dir = Path(tempfile.mkdtemp(prefix="packed_"))
+    pack_data_dir(tokenizer, tmp_dir, 128, save_dir)
+    orig_paths = {x.name for x in tmp_dir.iterdir()}
+    new_paths = {x.name for x in save_dir.iterdir()}
     assert orig_paths == new_paths
 
 

--- a/examples/seq2seq/test_seq2seq_examples.py
+++ b/examples/seq2seq/test_seq2seq_examples.py
@@ -248,6 +248,16 @@ def test_finetune(model):
         assert bart.decoder.embed_tokens == bart.encoder.embed_tokens
         assert bart.decoder.embed_tokens == bart.shared
 
+from .pack_dataset import pack_ds, packer_cli
+def test_pack_dataset():
+    tokenizer = AutoTokenizer.from_pretrained('facebook/mbart-large-cc25')
+    tmp_dir = Path(make_test_data_dir())
+    save_dir = Path(tempfile.mkdtemp(prefix="output_"))
+    pack_ds(tokenizer, tmp_dir, 128, save_dir)
+    orig_paths = set(tmp_dir.listdir())
+    new_paths = set(save_dir.listdir())
+    assert orig_paths == new_paths
+
 
 @pytest.mark.parametrize(
     ["tok"], [pytest.param(T5_TINY), pytest.param(BART_TINY), pytest.param(MBART_TINY), pytest.param(MARIAN_TINY)]


### PR DESCRIPTION
Inspired by fairseq max_tokens_dataset.
This works on disk, by regenerating the data directory, so it can work with or without @Pradhy729 's PR.
It is especially useful for avoiding padding computation in a multigpu setup, where SortishSampler doesn't work.

It will also play nice with TPU by allowing us to always of the same `input_ids` shape, rather than trimming batches to avoid padding computation.

Empirically, it reduces epoch time for mbart finetuning on 8GPU from 2.5hrs to 1.5 hrs. (You can increase batch size to 8 from 4), by cutting the number of examples by a factor of 2, and spending a bit more time on each example.

It also doesn't lead to that much more truncation than the previous approach, although I haven't quantified this.

### Example
```
wget https://s3.amazonaws.com/datasets.huggingface.co/translation/wmt_en_ro_128.tgz
tar -czvf wmt_en_ro_128.tgz
```
Creates a directory called `wmt_en_ro_packed/` with fewer examples


### Usage
```bash
python pack_dataset.py --tok_name facebook/mbart-large-en-ro --max_seq_len 128 --data_dir wmt_en_ro --save_path wmt_en_ro_packed_128
```
Output:
```bash
100%|██████████████████████████████████████████| 1999/1999 [00:01<00:00, 1533.19it/s]
packed val split from 1999 examples -> 683.
100%|██████████████████████████████████████████| 1999/1999 [00:01<00:00, 1590.80it/s]
packed test split from 1999 examples -> 652.
```