### PR TITLE
[cleanups] make Marian save as Marian

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -22,7 +22,7 @@ import logging
 # Configurations
 from .configuration_albert import ALBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, AlbertConfig
 from .configuration_auto import ALL_PRETRAINED_CONFIG_ARCHIVE_MAP, CONFIG_MAPPING, AutoConfig
-from .configuration_bart import BartConfig
+from .configuration_bart import BartConfig, MBartConfig
 from .configuration_bert import BERT_PRETRAINED_CONFIG_ARCHIVE_MAP, BertConfig
 from .configuration_camembert import CAMEMBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, CamembertConfig
 from .configuration_ctrl import CTRL_PRETRAINED_CONFIG_ARCHIVE_MAP, CTRLConfig

--- a/src/transformers/modeling_marian.py
+++ b/src/transformers/modeling_marian.py
@@ -15,6 +15,7 @@
 """PyTorch MarianMTModel model, ported from the Marian C++ repo."""
 
 
+from transformers.configuration_marian import MarianConfig
 from transformers.modeling_bart import BartForConditionalGeneration
 
 
@@ -24,6 +25,7 @@ MARIAN_PRETRAINED_MODEL_ARCHIVE_LIST = [
 
 
 class MarianMTModel(BartForConditionalGeneration):
+    config_class = MarianConfig
     r"""
     Pytorch version of marian-nmt's transformer.h (c++). Designed for the OPUS-NMT translation checkpoints.
     Model API is identical to BartForConditionalGeneration.


### PR DESCRIPTION
allow `MarianTokenizer.prepare_translation_batch` to ignore kwargs like `src_lang`