### PR TITLE
wrong args name: n_gpu -> gpus

### DIFF
--- a/examples/lightning_base.py
+++ b/examples/lightning_base.py
@@ -137,7 +137,7 @@ class BaseTransformer(pl.LightningModule):
         dataloader = self.load_dataset("train", train_batch_size)
 
         t_total = (
-            (len(dataloader.dataset) // (train_batch_size * max(1, self.hparams.n_gpu)))
+            (len(dataloader.dataset) // (train_batch_size * max(1, self.hparams.gpus)))
             // self.hparams.gradient_accumulation_steps
             * float(self.hparams.num_train_epochs)
         )


### PR DESCRIPTION
The correct argument name should be `gpus`.

The change fixed the following error:
```bash
  warnings.warn(*args, **kwargs)
Traceback (most recent call last):                                                                                                                        
  File "/home/.conda/envs/hf/lib/python3.6/site-packages/pytorch_lightning/utilities/parsing.py", line 114, in __getattr__
    return self[key]
KeyError: 'n_gpu'
```