### PR TITLE
Update tokenizers to 0.8.1.rc to fix Mac OS X issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(
     packages=find_packages("src"),
     install_requires=[
         "numpy",
-        "tokenizers == 0.8.1.rc1",
+        "tokenizers == 0.8.1.rc2",
         # dataclasses for Python versions that don't have it
         "dataclasses;python_version<'3.7'",
         # utilities from PyPA to e.g. compare versions


### PR DESCRIPTION
As mentioned in huggingface/tokenizers#321 tokenizers and thus transformers fails on macOS 10.11+. The issue was fixed in `0.8.1.rc2` so this PR updates the dependency to the new version.

I ran all tests on my mac with Mac OS High Sierra 10.13.6 as desribed in the [readme](https://github.com/huggingface/transformers/blob/master/README.md#tests), but not the examples: 

```
1607 passed, 304 skipped, 15294 warnings in 465.74s (0:07:45)
```

