### PR TITLE
feat: allow prefix for any generative model

### DIFF
--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -182,7 +182,7 @@ def main():
     parser.add_argument("--k", type=int, default=0)
     parser.add_argument("--p", type=float, default=0.9)
 
-    parser.add_argument("--padding_text", type=str, default="", help="Padding text for Transfo-XL and XLNet.")
+    parser.add_argument("--padding_text", type=str, default="", help="Padding text.")
     parser.add_argument("--xlm_language", type=str, default="", help="Optional language when used with the XLM model.")
 
     parser.add_argument("--seed", type=int, default=42, help="random seed for initialization")
@@ -241,7 +241,9 @@ def main():
             preprocessed_prompt_text, add_special_tokens=False, return_tensors="pt", **tokenizer_kwargs
         )
     else:
-        encoded_prompt = tokenizer.encode(prompt_text, add_special_tokens=False, return_tensors="pt")
+        encoded_prompt = tokenizer.encode(
+            args.padding_text + prompt_text, add_special_tokens=False, return_tensors="pt"
+        )
     encoded_prompt = encoded_prompt.to(args.device)
 
     if encoded_prompt.size()[-1] == 0:

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -61,7 +61,7 @@ MODEL_CLASSES = {
 # Padding text to help Transformer-XL and XLNet with short prompts as proposed by Aman Rusia
 # in https://github.com/rusiaaman/XLNet-gen#methodology
 # and https://medium.com/@amanrusia/xlnet-speaks-comparison-to-gpt-2-ea1a4e9ba39e
-PADDING_TEXT = """In 1991, the remains of Russian Tsar Nicholas II and his family
+PREFIX = """In 1991, the remains of Russian Tsar Nicholas II and his family
 (except for Alexei and Maria) are discovered.
 The voice of Nicholas's young son, Tsarevich Alexei Nikolaevich, narrates the
 remainder of the story. 1883 Western Siberia,
@@ -122,12 +122,14 @@ def prepare_xlm_input(args, model, tokenizer, prompt_text):
 
 
 def prepare_xlnet_input(args, _, tokenizer, prompt_text):
-    prompt_text = (args.padding_text if args.padding_text else PADDING_TEXT) + prompt_text
+    prefix = args.prefix if args.prefix else args.padding_text if args.padding_text else PREFIX
+    prompt_text = prefix + prompt_text
     return prompt_text
 
 
 def prepare_transfoxl_input(args, _, tokenizer, prompt_text):
-    prompt_text = (args.padding_text if args.padding_text else PADDING_TEXT) + prompt_text
+    prefix = args.prefix if args.prefix else args.padding_text if args.padding_text else PREFIX
+    prompt_text = prefix + prompt_text
     return prompt_text
 
 
@@ -182,7 +184,8 @@ def main():
     parser.add_argument("--k", type=int, default=0)
     parser.add_argument("--p", type=float, default=0.9)
 
-    parser.add_argument("--padding_text", type=str, default="", help="Padding text.")
+    parser.add_argument("--prefix", type=str, default="", help="Text added prior to input.")
+    parser.add_argument("--padding_text", type=str, default="", help="Deprecated, the use of `--prefix` is preferred.")
     parser.add_argument("--xlm_language", type=str, default="", help="Optional language when used with the XLM model.")
 
     parser.add_argument("--seed", type=int, default=42, help="random seed for initialization")
@@ -241,9 +244,8 @@ def main():
             preprocessed_prompt_text, add_special_tokens=False, return_tensors="pt", **tokenizer_kwargs
         )
     else:
-        encoded_prompt = tokenizer.encode(
-            args.padding_text + prompt_text, add_special_tokens=False, return_tensors="pt"
-        )
+        prefix = args.prefix if args.prefix else args.padding_text
+        encoded_prompt = tokenizer.encode(prefix + prompt_text, add_special_tokens=False, return_tensors="pt")
     encoded_prompt = encoded_prompt.to(args.device)
 
     if encoded_prompt.size()[-1] == 0:

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -847,7 +847,7 @@ class TextGenerationPipeline(Pipeline):
                     "TFTransfoXLLMHeadModel",
                 ]:
                     if padding_text == "":
-                        # For XLNet and TransformerXL we had an article to the prompt to give more state to the model.
+                        # For XLNet and TransformerXL we add an article to the prompt to give more state to the model.
                         padding_text = self.PADDING_TEXT
 
                 padding = self._parse_and_tokenize(padding_text, padding=False, add_special_tokens=False)

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -853,7 +853,7 @@ class TextGenerationPipeline(Pipeline):
                 padding = self._parse_and_tokenize(padding_text, padding=False, add_special_tokens=False)
                 # This impacts max_length and min_length argument that need adjusting.
                 padding_length = padding["input_ids"].shape[-1]
-                if "max_length" in generate_kwargs and generate_kwargs["max_length"] is not None:
+                if generate_kwargs.get("max_length", None) is not None:
                     generate_kwargs["max_length"] += padding_length
                 if "min_length" in generate_kwargs and generate_kwargs["min_length"] is not None:
                     generate_kwargs["min_length"] += padding_length

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -827,7 +827,7 @@ class TextGenerationPipeline(Pipeline):
                 Whether or not to include the decoded texts in the outputs.
             clean_up_tokenization_spaces (:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to clean up the potential extra spaces in the text output.
-            prefix (:obj:`str`, defaults to :obj:`None`):
+            prefix (:obj:`str`, `optional`):
                 Prefix added to prompt.
             generate_kwargs:
                 Additional keyword arguments to pass along to the generate method of the model (see the generate

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -754,7 +754,7 @@ class TextGenerationPipeline(Pipeline):
     # in https://github.com/rusiaaman/XLNet-gen#methodology
     # and https://medium.com/@amanrusia/xlnet-speaks-comparison-to-gpt-2-ea1a4e9ba39e
 
-    PREFIX = """In 1991, the remains of Russian Tsar Nicholas II and his family
+    XL_PREFIX = """In 1991, the remains of Russian Tsar Nicholas II and his family
     (except for Alexei and Maria) are discovered.
     The voice of Nicholas's young son, Tsarevich Alexei Nikolaevich, narrates the
     remainder of the story. 1883 Western Siberia,
@@ -855,7 +855,7 @@ class TextGenerationPipeline(Pipeline):
                     "TFTransfoXLLMHeadModel",
                 ]:
                     # For XLNet and TransformerXL we add an article to the prompt to give more state to the model.
-                    prefix = self.PREFIX
+                    prefix = self.XL_PREFIX
 
                 if prefix:
                     prefix_inputs = self._parse_and_tokenize(prefix, padding=False, add_special_tokens=False)
@@ -863,7 +863,7 @@ class TextGenerationPipeline(Pipeline):
                     prefix_length = prefix_inputs["input_ids"].shape[-1]
                     if generate_kwargs.get("max_length", None) is not None:
                         generate_kwargs["max_length"] += prefix_length
-                    if "min_length" in generate_kwargs and generate_kwargs["min_length"] is not None:
+                    if generate_kwargs.get("min_length", None) is not None:
                         generate_kwargs["min_length"] += prefix_length
 
                 prefix = prefix or ""

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -839,24 +839,24 @@ class TextGenerationPipeline(Pipeline):
         for prompt_text in text_inputs:
             # Manage correct placement of the tensors
             with self.device_placement():
-                prefix = generate_kwargs.get("prefix", getattr(self.model.config, "prefix", ""))
-                if self.model.__class__.__name__ in [
+                prefix = generate_kwargs.get("prefix", self.model.config.prefix) or ""
+                if not prefix and self.model.__class__.__name__ in [
                     "XLNetLMHeadModel",
                     "TransfoXLLMHeadModel",
                     "TFXLNetLMHeadModel",
                     "TFTransfoXLLMHeadModel",
                 ]:
-                    if prefix == "":
-                        # For XLNet and TransformerXL we add an article to the prompt to give more state to the model.
-                        prefix = self.PREFIX
+                    # For XLNet and TransformerXL we add an article to the prompt to give more state to the model.
+                    prefix = self.PREFIX
 
-                prefix_inputs = self._parse_and_tokenize(prefix, padding=False, add_special_tokens=False)
-                # This impacts max_length and min_length argument that need adjusting.
-                prefix_length = prefix_inputs["input_ids"].shape[-1]
-                if generate_kwargs.get("max_length", None) is not None:
-                    generate_kwargs["max_length"] += prefix_length
-                if "min_length" in generate_kwargs and generate_kwargs["min_length"] is not None:
-                    generate_kwargs["min_length"] += prefix_length
+                if prefix:
+                    prefix_inputs = self._parse_and_tokenize(prefix, padding=False, add_special_tokens=False)
+                    # This impacts max_length and min_length argument that need adjusting.
+                    prefix_length = prefix_inputs["input_ids"].shape[-1]
+                    if generate_kwargs.get("max_length", None) is not None:
+                        generate_kwargs["max_length"] += prefix_length
+                    if "min_length" in generate_kwargs and generate_kwargs["min_length"] is not None:
+                        generate_kwargs["min_length"] += prefix_length
 
                 inputs = self._parse_and_tokenize(prefix + prompt_text, padding=False, add_special_tokens=False)
 

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -847,9 +847,7 @@ class TextGenerationPipeline(Pipeline):
         for prompt_text in text_inputs:
             # Manage correct placement of the tensors
             with self.device_placement():
-                prefix = (
-                    prefix if prefix is not None else self.model.config.prefix
-                )
+                prefix = prefix if prefix is not None else self.model.config.prefix
                 if prefix is None and self.model.__class__.__name__ in [
                     "XLNetLMHeadModel",
                     "TransfoXLLMHeadModel",

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -399,12 +399,14 @@ class MonoColumnInputTestCase(unittest.TestCase):
         for model_name in TEXT_GENERATION_FINETUNED_MODELS:
             nlp = pipeline(task="text-generation", model=model_name, tokenizer=model_name, framework="pt")
             self._test_mono_column_pipeline(nlp, VALID_INPUTS, {})
+        self._test_mono_column_pipeline(nlp, VALID_INPUTS, {}, prefix="This is ")
 
     @require_tf
     def test_tf_text_generation(self):
         for model_name in TEXT_GENERATION_FINETUNED_MODELS:
             nlp = pipeline(task="text-generation", model=model_name, tokenizer=model_name, framework="tf")
             self._test_mono_column_pipeline(nlp, VALID_INPUTS, {})
+        self._test_mono_column_pipeline(nlp, VALID_INPUTS, {}, prefix="This is ")
 
     @slow
     @require_torch


### PR DESCRIPTION
Allow `padding_text` for any generative model.

### Motivations

* some models require some text at the beginning such as GPT-2 which should always have a white space. GPT-2 model could now have `config.padding_text` set to `" "` to ensure this is done
* this argument adds more customization to huggingface inference widget (related issue #5553). For huggingtweets models I can set `model.config.task_specific_params['text-generation']['padding_text'] = '<|endoftext|> '`

See [example](https://gist.github.com/borisdayma/89aaf1587390340add44c3c7081bffcd) of use of `padding_text` to create negative/positive sentences.

*Side note*: this is not completely obvious that a leading space should always be added for GPT-2 as `" \n This"` is not tokenized the same as `" \nThis"` which GPT-2 may have seen more in its training data (unless white spaces are added after new lines as well)

### Future improvements

In the future, we should also add `prefix` and `suffix`. This could let us do things similar to GPT-3 with the inference widget and specific tasks:
* `padding_text` would be used to initialize tasks (ex: 10 examples conversation with a bot). This is always cropped out and never displayed in the output
* `prefix` would add required text (ex: `" Human: "`). This is displayed in output.
* `suffix` would add required text after prompt (ex: `" \n AI: "`). This is displayed in output.