### PR TITLE
Allow user to see actual error if a download has failed 

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -330,13 +330,15 @@ class PretrainedConfig(object):
                 raise EnvironmentError
             config_dict = cls._dict_from_json_file(resolved_config_file)
 
-        except EnvironmentError:
-            msg = (
-                f"Can't load config for '{pretrained_model_name_or_path}'. Make sure that:\n\n"
-                f"- '{pretrained_model_name_or_path}' is a correct model identifier listed on 'https://huggingface.co/models'\n\n"
-                f"- or '{pretrained_model_name_or_path}' is the correct path to a directory containing a {CONFIG_NAME} file\n\n"
-            )
-            raise EnvironmentError(msg)
+        except EnvironmentError as e:
+            if not str(e):
+                msg = (
+                    f"Can't load config for '{pretrained_model_name_or_path}'. Make sure that:\n\n"
+                    f"- '{pretrained_model_name_or_path}' is a correct model identifier listed on 'https://huggingface.co/models'\n\n"
+                    f"- or '{pretrained_model_name_or_path}' is the correct path to a directory containing a {CONFIG_NAME} file\n\n"
+                )
+                raise EnvironmentError(msg)
+            raise e
 
         except json.JSONDecodeError:
             msg = (

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -481,13 +481,15 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
                 )
                 if resolved_archive_file is None:
                     raise EnvironmentError
-            except EnvironmentError:
-                msg = (
-                    f"Can't load weights for '{pretrained_model_name_or_path}'. Make sure that:\n\n"
-                    f"- '{pretrained_model_name_or_path}' is a correct model identifier listed on 'https://huggingface.co/models'\n\n"
-                    f"- or '{pretrained_model_name_or_path}' is the correct path to a directory containing a file named one of {TF2_WEIGHTS_NAME}, {WEIGHTS_NAME}.\n\n"
-                )
-                raise EnvironmentError(msg)
+            except EnvironmentError as e:
+                if not str(e):
+                    msg = (
+                        f"Can't load weights for '{pretrained_model_name_or_path}'. Make sure that:\n\n"
+                        f"- '{pretrained_model_name_or_path}' is a correct model identifier listed on 'https://huggingface.co/models'\n\n"
+                        f"- or '{pretrained_model_name_or_path}' is the correct path to a directory containing a file named one of {TF2_WEIGHTS_NAME}, {WEIGHTS_NAME}.\n\n"
+                    )
+                    raise EnvironmentError(msg)
+                raise e
             if resolved_archive_file == archive_file:
                 logger.info("loading weights file {}".format(archive_file))
             else:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -656,13 +656,15 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
                 )
                 if resolved_archive_file is None:
                     raise EnvironmentError
-            except EnvironmentError:
-                msg = (
-                    f"Can't load weights for '{pretrained_model_name_or_path}'. Make sure that:\n\n"
-                    f"- '{pretrained_model_name_or_path}' is a correct model identifier listed on 'https://huggingface.co/models'\n\n"
-                    f"- or '{pretrained_model_name_or_path}' is the correct path to a directory containing a file named one of {WEIGHTS_NAME}, {TF2_WEIGHTS_NAME}, {TF_WEIGHTS_NAME}.\n\n"
-                )
-                raise EnvironmentError(msg)
+            except EnvironmentError as e:
+                if not str(e):
+                    msg = (
+                        f"Can't load weights for '{pretrained_model_name_or_path}'. Make sure that:\n\n"
+                        f"- '{pretrained_model_name_or_path}' is a correct model identifier listed on 'https://huggingface.co/models'\n\n"
+                        f"- or '{pretrained_model_name_or_path}' is the correct path to a directory containing a file named one of {WEIGHTS_NAME}, {TF2_WEIGHTS_NAME}, {TF_WEIGHTS_NAME}.\n\n"
+                    )
+                    raise EnvironmentError(msg)
+                raise e
 
             if resolved_archive_file == archive_file:
                 logger.info("loading weights file {}".format(archive_file))


### PR DESCRIPTION
Fixes #5869. Adds new logic of exception handling.
* If there was a caught exception in `cached_path` during download, and `force_download` is True, then raise it
* If `force_download` is False, save this exception and raise it later, it file is not in local cache
* If download exception in `cached_path` was raised, then re-raise it in calling function. If there's no exception, but resolved file is None, keep old message ("...is a correct model identifier...")

It would be great to know if there's a better way to dealing with this issue.