### PR TITLE
DataParallel fix: multi gpu evaluation

### DIFF
--- a/examples/question-answering/run_squad.py
+++ b/examples/question-answering/run_squad.py
@@ -316,7 +316,8 @@ def evaluate(args, model, tokenizer, prefix=""):
                     inputs.update(
                         {"langs": (torch.ones(batch[0].shape, dtype=torch.int64) * args.lang_id).to(args.device)}
                     )
-
+            if isinstance(model, torch.nn.DataParallel):
+                inputs["return_tuple"] = True
             outputs = model(**inputs)
 
         for i, feature_index in enumerate(feature_indices):


### PR DESCRIPTION
The DataParallel training was fixed in https://github.com/huggingface/transformers/pull/5733, this commit also fixes the evaluation. It's more convenient when the user enables both `do_train` and `do_eval`.