### PR TITLE
Expose padding_strategy on squad processor to fix QA pipeline performance regression

### DIFF
--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -88,7 +88,9 @@ def _is_whitespace(c):
     return False
 
 
-def squad_convert_example_to_features(example, max_seq_length, doc_stride, max_query_length, is_training):
+def squad_convert_example_to_features(
+    example, max_seq_length, doc_stride, max_query_length, padding_strategy, is_training
+):
     features = []
     if is_training and not example.is_impossible:
         # Get start and end position
@@ -156,7 +158,7 @@ def squad_convert_example_to_features(example, max_seq_length, doc_stride, max_q
             texts,
             pairs,
             truncation=truncation,
-            padding=PaddingStrategy.LONGEST.value,
+            padding=padding_strategy,
             max_length=max_seq_length,
             return_overflowing_tokens=True,
             stride=max_seq_length - doc_stride - len(truncated_query) - sequence_pair_added_tokens,
@@ -296,6 +298,7 @@ def squad_convert_examples_to_features(
     doc_stride,
     max_query_length,
     is_training,
+    padding_strategy="max_length",
     return_dataset=False,
     threads=1,
     tqdm_enabled=True,
@@ -311,6 +314,7 @@ def squad_convert_examples_to_features(
         doc_stride: The stride used when the context is too large and is split across several features.
         max_query_length: The maximum length of the query.
         is_training: whether to create features for model evaluation or model training.
+        padding_strategy: Default to "max_length". Which padding strategy to use
         return_dataset: Default False. Either 'pt' or 'tf'.
             if 'pt': returns a torch.data.TensorDataset,
             if 'tf': returns a tf.data.Dataset
@@ -344,6 +348,7 @@ def squad_convert_examples_to_features(
             max_seq_length=max_seq_length,
             doc_stride=doc_stride,
             max_query_length=max_query_length,
+            padding_strategy=padding_strategy,
             is_training=is_training,
         )
         features = list(

--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 
 from ...file_utils import is_tf_available, is_torch_available
 from ...tokenization_bert import whitespace_tokenize
-from ...tokenization_utils_base import PaddingStrategy, TruncationStrategy
+from ...tokenization_utils_base import TruncationStrategy
 from .utils import DataProcessor
 
 

--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -146,11 +146,11 @@ def squad_convert_example_to_features(example, max_seq_length, doc_stride, max_q
         if tokenizer.padding_side == "right":
             texts = truncated_query
             pairs = span_doc_tokens
-            truncation = TruncationStrategy.ONLY_SECOND
+            truncation = TruncationStrategy.ONLY_SECOND.value
         else:
             texts = span_doc_tokens
             pairs = truncated_query
-            truncation = TruncationStrategy.ONLY_FIRST
+            truncation = TruncationStrategy.ONLY_FIRST.value
 
         encoded_dict = tokenizer.encode_plus(  # TODO(thom) update this logic
             texts,

--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -13,6 +13,8 @@ from .utils import DataProcessor
 
 
 # Store the tokenizers which insert 2 separators tokens
+from ...tokenization_utils_base import PaddingStrategy, TruncationStrategy
+
 MULTI_SEP_TOKENS_TOKENIZERS_SET = {"roberta", "camembert", "bart"}
 
 
@@ -144,8 +146,8 @@ def squad_convert_example_to_features(example, max_seq_length, doc_stride, max_q
         encoded_dict = tokenizer.encode_plus(  # TODO(thom) update this logic
             truncated_query if tokenizer.padding_side == "right" else span_doc_tokens,
             span_doc_tokens if tokenizer.padding_side == "right" else truncated_query,
-            truncation="only_second" if tokenizer.padding_side == "right" else "only_first",
-            padding="max_length",
+            truncation=TruncationStrategy.ONLY_SECOND.value if tokenizer.padding_side == "right" else TruncationStrategy.ONLY_FIRST.value,
+            padding=PaddingStrategy.LONGEST.value,
             max_length=max_seq_length,
             return_overflowing_tokens=True,
             stride=max_seq_length - doc_stride - len(truncated_query) - sequence_pair_added_tokens,

--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -9,11 +9,11 @@ from tqdm import tqdm
 
 from ...file_utils import is_tf_available, is_torch_available
 from ...tokenization_bert import whitespace_tokenize
-from .utils import DataProcessor
-
 
 # Store the tokenizers which insert 2 separators tokens
 from ...tokenization_utils_base import PaddingStrategy, TruncationStrategy
+from .utils import DataProcessor
+
 
 MULTI_SEP_TOKENS_TOKENIZERS_SET = {"roberta", "camembert", "bart"}
 
@@ -146,7 +146,9 @@ def squad_convert_example_to_features(example, max_seq_length, doc_stride, max_q
         encoded_dict = tokenizer.encode_plus(  # TODO(thom) update this logic
             truncated_query if tokenizer.padding_side == "right" else span_doc_tokens,
             span_doc_tokens if tokenizer.padding_side == "right" else truncated_query,
-            truncation=TruncationStrategy.ONLY_SECOND.value if tokenizer.padding_side == "right" else TruncationStrategy.ONLY_FIRST.value,
+            truncation=TruncationStrategy.ONLY_SECOND.value
+            if tokenizer.padding_side == "right"
+            else TruncationStrategy.ONLY_FIRST.value,
             padding=PaddingStrategy.LONGEST.value,
             max_length=max_seq_length,
             return_overflowing_tokens=True,

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -36,6 +36,7 @@ from .modelcard import ModelCard
 from .tokenization_auto import AutoTokenizer
 from .tokenization_bert import BasicTokenizer
 from .tokenization_utils import PreTrainedTokenizer
+from .tokenization_utils_base import PaddingStrategy
 
 
 if is_tf_available():
@@ -1318,6 +1319,7 @@ class QuestionAnsweringPipeline(Pipeline):
                 max_seq_length=kwargs["max_seq_len"],
                 doc_stride=kwargs["doc_stride"],
                 max_query_length=kwargs["max_question_len"],
+                padding_strategy=PaddingStrategy.DO_NOT_PAD.value,
                 is_training=False,
                 tqdm_enabled=False,
             )


### PR DESCRIPTION
**Before this PR**:
The squad processor was padding the sequence up to the provided `max_length` parameter which results in a tensor with 512 tokens, mostly padding, making the QA pipeline very slow.

- QA Pipeline (`model="distilbert-base-uncased-distilled-squad"`) = 4.8secs

**After this PR**:
The processor will not be padding at all when coming from the QA pipeline.

- QA Pipeline (`model="distilbert-base-uncased-distilled-squad"`) = 1.29secs