### PR TITLE
a transparent solution for  DataParallel.gather not supporting ModelOutput (dataclass)

### DIFF
--- a/examples/question-answering/run_squad.py
+++ b/examples/question-answering/run_squad.py
@@ -199,9 +199,6 @@ def train(args, train_dataset, model, tokenizer):
                         {"langs": (torch.ones(batch[0].shape, dtype=torch.int64) * args.lang_id).to(args.device)}
                     )
 
-            if isinstance(model, torch.nn.DataParallel):
-                inputs["return_tuple"] = True
-
             outputs = model(**inputs)
             # model outputs are always tuple in transformers (see doc)
             loss = outputs[0]

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -622,9 +622,6 @@ class Trainer:
 
         if self.args.past_index >= 0 and self._past is not None:
             inputs["mems"] = self._past
-        # Our model outputs do not work with DataParallel, so forcing return tuple.
-        if isinstance(model, nn.DataParallel):
-            inputs["return_tuple"] = True
 
         outputs = model(**inputs)
         loss = outputs[0]  # model outputs are always tuple in transformers (see doc)
@@ -825,9 +822,6 @@ class Trainer:
                     inputs[k] = v.to(self.args.device)
             if self.args.past_index >= 0:
                 inputs["mems"] = past
-            # Our model outputs do not work with DataParallel, so forcing return tuple.
-            if isinstance(model, nn.DataParallel):
-                inputs["return_tuple"] = True
 
             with torch.no_grad():
                 outputs = model(**inputs)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -803,8 +803,7 @@ class ModelTesterMixin:
 
             # Wrap model in nn.DataParallel
             model = torch.nn.DataParallel(model)
-            # Our model outputs do not work with DataParallel, so forcing return tuple.
-            inputs_dict["return_tuple"] = True
+
             with torch.no_grad():
                 _ = model(**self._prepare_for_class(inputs_dict, model_class))
 


### PR DESCRIPTION
1. Modify torch/nn/parallel/scatter_gather.gather function to support ModelOutput (dataclass) outputs. We override the torch.nn.DataParallel.gather method with this custom method. 

2. remove previously committed workarounds

implementation: @sgugger 
integration/testing: me

This should transparently solve https://github.com/huggingface/transformers/issues/5693
