### PR TITLE
Bug fix: NER pipeline shouldn't group separate entities of same type

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1114,7 +1114,7 @@ class TokenClassificationPipeline(Pipeline):
             # The split is meant to account for the "B" and "I" suffixes
             if (
                 entity["entity"].split("-")[-1] == entity_group_disagg[-1]["entity"].split("-")[-1]
-                and entity["entity"].split("-")[0] != 'B'
+                and entity["entity"].split("-")[0] != "B"
                 and entity["index"] == entity_group_disagg[-1]["index"] + 1
             ):
                 entity_group_disagg += [entity]

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1114,6 +1114,7 @@ class TokenClassificationPipeline(Pipeline):
             # The split is meant to account for the "B" and "I" suffixes
             if (
                 entity["entity"].split("-")[-1] == entity_group_disagg[-1]["entity"].split("-")[-1]
+                and entity["entity"].split("-")[0] != 'B'
                 and entity["index"] == entity_group_disagg[-1]["index"] + 1
             ):
                 entity_group_disagg += [entity]


### PR DESCRIPTION
## Effects
nlp=pipeline('ner', ... , grouped_entities=True)

## Fixes 
Separate entities of same type shouldn't be grouped together even if they are same type 
( B-type1 B-type1 ) != ( B-type1 I-type1 )

## Example 
"something something Istanbul Los Angeles something something"

Current output: [ (O O) (B-type1 B-type1 I-type1) (O O) ]
Fixed output: [ (O O) (B-type1) (B-type1 I-type1) (O O) ]


