### PR TITLE
Transformer-XL: Fixed returned outputs when using `return_tuple=True`

### DIFF
--- a/src/transformers/modeling_transfo_xl.py
+++ b/src/transformers/modeling_transfo_xl.py
@@ -1052,7 +1052,7 @@ class TransfoXLLMHeadModel(TransfoXLPreTrainedModel):
         loss = softmax_output.view(bsz, tgt_len - 1) if labels is not None else None
 
         if return_tuple:
-            output = (prediction_scores,) + outputs[1:]
+            output = (prediction_scores,) + outputs
             return ((loss,) + output) if loss is not None else output
 
         return TransfoXLLMHeadModelOutput(


### PR DESCRIPTION
Fixes #5974

`mems` are returned again when using `return_tuple=True`.