### PR TITLE
[WIP] Proposal for TF model outputs

### DIFF
--- a/src/transformers/modeling_tf_outputs.py
+++ b/src/transformers/modeling_tf_outputs.py
@@ -1,0 +1,82 @@
+from collections import OrderedDict
+from dataclasses import dataclass, fields
+from typing import Optional, Tuple
+
+import tensorflow as tf
+
+
+class TFModelOutput(OrderedDict):
+    def __post_init__(self):
+        class_fields = fields(self)
+
+        # Safety and consistency checks
+        assert len(class_fields), f"{self.__class__.__name__} has no fields."
+        assert all(
+            field.default is None for field in class_fields[1:]
+        ), f"{self.__class__.__name__} should not have more than one required field."
+
+        first_field = getattr(self, class_fields[0].name)
+        other_fields_are_none = all(getattr(self, field.name) is None for field in class_fields[1:])
+
+        if other_fields_are_none and not isinstance(first_field, tf.Tensor):
+            try:
+                iterator = iter(first_field)
+                first_field_iterator = True
+            except TypeError:
+                first_field_iterator = False
+
+            # if we provided an iterator as first field and the iterator is a (key, value) iterator
+            # set the associated fields
+            if first_field_iterator:
+                for element in iterator:
+                    if (
+                        not isinstance(element, (list, tuple))
+                        or not len(element) == 2
+                        or not isinstance(element[0], str)
+                    ):
+                        break
+                    setattr(self, element[0], element[1])
+                    if element[1] is not None:
+                        self[element[0]] = element[1]
+        else:
+            for field in class_fields:
+                v = getattr(self, field.name)
+                if v is not None:
+                    self[field.name] = v
+
+    def __delitem__(self, *args, **kwargs):
+        raise Exception(f"You cannot use ``__delitem__`` on a {self.__class__.__name__} instance.")
+
+    def setdefault(self, *args, **kwargs):
+        raise Exception(f"You cannot use ``setdefault`` on a {self.__class__.__name__} instance.")
+
+    def pop(self, *args, **kwargs):
+        raise Exception(f"You cannot use ``pop`` on a {self.__class__.__name__} instance.")
+
+    def update(self, *args, **kwargs):
+        raise Exception(f"You cannot use ``update`` on a {self.__class__.__name__} instance.")
+
+    def __getitem__(self, k):
+        if isinstance(k, str):
+            inner_dict = {k: v for (k, v) in self.items()}
+            return inner_dict[k]
+        else:
+            return self.to_tuple()[k]
+
+    def to_tuple(self):
+        return tuple(self[k] for k in self.keys())
+
+
+@dataclass
+class TFBaseModelOutput(TFModelOutput):
+    last_hidden_state: tf.Tensor = None
+    hidden_states: Optional[Tuple[tf.Tensor]] = None
+    attentions: Optional[Tuple[tf.Tensor]] = None
+
+
+@dataclass
+class TFBaseModelOutputWithPooling(TFModelOutput):
+    last_hidden_state: tf.Tensor = None
+    pooler_output: tf.Tensor = None
+    hidden_states: Optional[Tuple[tf.Tensor]] = None
+    attentions: Optional[Tuple[tf.Tensor]] = None

--- a/tests/test_modeling_tf_bert.py
+++ b/tests/test_modeling_tf_bert.py
@@ -130,9 +130,9 @@ class TFBertModelTester:
         sequence_output, pooled_output = model(inputs)
 
         inputs = [input_ids, input_mask]
-        sequence_output, pooled_output = model(inputs)
+        sequence_output, pooled_output = model(inputs)[:2]
 
-        sequence_output, pooled_output = model(input_ids)
+        sequence_output, pooled_output = model(input_ids)[:2]
 
         result = {
             "sequence_output": sequence_output.numpy(),

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -183,6 +183,8 @@ class TFModelTesterMixin:
         # Make sure we don't have nans
         if isinstance(after_outputs, tf.Tensor):
             out_1 = after_outputs.numpy()
+        elif isinstance(after_outputs, dict):
+            out_1 = after_outputs[list(after_outputs.keys())[0]].numpy()
         else:
             out_1 = after_outputs[0].numpy()
         out_2 = outputs[0].numpy()


### PR DESCRIPTION
This picks up on the work @thomwolf did on #5740 to have self-documented outputs in TensorFlow that are compatible with the AutoGraph system.
`TFModelOuput` subclasses `OrderedDict` while still being a dataclass, with some tweaks in the `post_init`:
- only the not-None attributes are set as values for the dictionary because tensorflow refuses None as outputs.
- a `TFModelOutput` can be instantiated with the regular keyword arguments but also with an iterator passed as the first argument (as a dict would) like @thomwolf suggested in #5740, with a fix to make sure the first input is not a tensor (because tensors are iterables).

This breaks two things for the TensorFlow side of the library:
1. when unpacking `outputs`, a slice needs to be used, otherwise the keys of the dictionary are returned, not the values:
```
loss, logits = outputs
```
will fail, it needs to be changed to
```
loss, logits = outputs[:2]
```
2. when loading and saving a model using `SavedModel`, the subclass is lost and the output becomes a regular dictionary (see the change in `test_keras_save_load`).

Apart from those, these model outputs are fully backward compatible (you can index with an int or a slice and get the same behavior as before).

If this is accepted, I would strongly recommend using the same base class for PyTorch model outputs, which would imply the breaking change number 1 but would have the added benefit of:
1. fixing the problem with `DataParallel`
2. have consistent outputs between TF and PyTorch.