### PR TITLE
Update doc of the model page

### DIFF
--- a/docs/source/main_classes/model.rst
+++ b/docs/source/main_classes/model.rst
@@ -1,9 +1,11 @@
 Models
 ----------------------------------------------------
 
-The base class ``PreTrainedModel`` implements the common methods for loading/saving a model either from a local file or directory, or from a pretrained model configuration provided by the library (downloaded from HuggingFace's AWS S3 repository).
+The base class :class:`~transformers.PreTrainedModel` implements the common methods for loading/saving a model either
+from a local file or directory, or from a pretrained model configuration provided by the library (downloaded from
+HuggingFace's AWS S3 repository).
 
-``PreTrainedModel`` also implements a few methods which are common among all the models to:
+:class:`~transformers.PreTrainedModel` also implements a few methods which are common among all the models to:
 
 - resize the input token embeddings when new tokens are added to the vocabulary
 - prune the attention heads of the model.
@@ -18,7 +20,6 @@ The base class ``PreTrainedModel`` implements the common methods for loading/sav
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: transformers.apply_chunking_to_forward
-
 
 ``TFPreTrainedModel``
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes docstring to conform to sphinx syntax and rephrase when needed. Also fixed bad copy-pastes from PyTorch to TF.

Preview is [here](https://64023-155220641-gh.circle-artifacts.com/0/docs/_build/html/main_classes/model.html).