### PR TITLE
[WIP] Trainer supports all Datasets as train_dataset, with/without __len__ #5990

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -861,9 +861,6 @@ class Trainer:
         Returns:
             A dictionary containing the evaluation loss and the potential metrics computed from the predictions.
         """
-        if eval_dataset is not None and not isinstance(eval_dataset, collections.abc.Sized):
-            raise ValueError("eval_dataset must implement __len__")
-
         eval_dataloader = self.get_eval_dataloader(eval_dataset)
 
         output = self.prediction_loop(eval_dataloader, description="Evaluation")
@@ -896,8 +893,6 @@ class Trainer:
             metrics (:obj:`Dict[str, float]`, `optional`):
                 The potential dictionary of metrics (if the dataset contained labels).
         """
-        if not isinstance(test_dataset, collections.abc.Sized):
-            raise ValueError("test_dataset must implement __len__")
         test_dataloader = self.get_test_dataloader(test_dataset)
 
         return self.prediction_loop(test_dataloader, description="Prediction")

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -813,6 +813,8 @@ class Trainer:
             metrics (:obj:`Dict[str, float]`, `optional`):
                 The potential dictionary of metrics (if the dataset contained labels).
         """
+        if not isinstance(test_dataset, collections.Sized):
+            raise ValueError("test_dataset must implement __len__")
         test_dataloader = self.get_test_dataloader(test_dataset)
 
         return self._prediction_loop(test_dataloader, description="Prediction")

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -238,7 +238,7 @@ class Trainer:
         """
         Returns the training :class:`~torch.utils.data.DataLoader`.
         """
-        if isinstance(self.train_dataset, torch.utils.data.IterableDataset):
+        if isinstance(self.train_dataset, collections.Sized):
             train_sampler = None
         elif self.train_dataset is None:
             raise ValueError("Trainer: training requires a train_dataset.")
@@ -273,7 +273,7 @@ class Trainer:
 
         eval_dataset = eval_dataset if eval_dataset is not None else self.eval_dataset
 
-        if isinstance(eval_dataset, torch.utils.data.IterableDataset):
+        if isinstance(eval_dataset, collections.Sized):
             sampler = None
         elif is_torch_tpu_available():
             sampler = SequentialDistributedSampler(
@@ -302,7 +302,7 @@ class Trainer:
             test_dataset (obj:`Dataset`): The test dataset to use.
         """
         # We use the same batch_size as for eval.
-        if isinstance(self.test_dataset, torch.utils.data.IterableDataset):
+        if isinstance(self.test_dataset, collections.Sized):
             sampler = None
         elif is_torch_tpu_available():
             sampler = SequentialDistributedSampler(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -229,16 +229,16 @@ class Trainer:
         # Some warning for the user related to the usage of datasets that do not implement __len__
         if args.max_steps > 0:
             logger.warning("max_steps is given, it will override any value given in num_train_epochs")
-        if not isinstance(train_dataset, collections.Sized) and args.max_steps == 0:
+        if not isinstance(train_dataset, collections.abc.Sized) and args.max_steps == 0:
             raise ValueError("train_dataset does not implement __len__, max_steps has to be specified")
-        if eval_dataset is not None and not isinstance(eval_dataset, collections.Sized):
-            raise ValueError("Eval Dataset: eval_dataset must implement __len__")
+        if eval_dataset is not None and not isinstance(eval_dataset, collections.abc.Sized):
+            raise ValueError("eval_dataset must implement __len__")
 
     def get_train_dataloader(self) -> DataLoader:
         """
         Returns the training :class:`~torch.utils.data.DataLoader`.
         """
-        if isinstance(self.train_dataset, collections.Sized):
+        if not isinstance(self.train_dataset, collections.abc.Sized):
             train_sampler = None
         elif self.train_dataset is None:
             raise ValueError("Trainer: training requires a train_dataset.")
@@ -273,7 +273,7 @@ class Trainer:
 
         eval_dataset = eval_dataset if eval_dataset is not None else self.eval_dataset
 
-        if isinstance(eval_dataset, collections.Sized):
+        if not isinstance(eval_dataset, collections.abc.Sized):
             sampler = None
         elif is_torch_tpu_available():
             sampler = SequentialDistributedSampler(
@@ -302,7 +302,7 @@ class Trainer:
             test_dataset (obj:`Dataset`): The test dataset to use.
         """
         # We use the same batch_size as for eval.
-        if isinstance(self.test_dataset, collections.Sized):
+        if not isinstance(self.test_dataset, collections.abc.Sized):
             sampler = None
         elif is_torch_tpu_available():
             sampler = SequentialDistributedSampler(
@@ -394,7 +394,7 @@ class Trainer:
                 training will resume from the optimizer/scheduler states loaded here.
         """
         # Keeping track whether we can can len() on the dataset or not
-        train_dataset_is_sized = isinstance(self.train_dataset, collections.Sized)
+        train_dataset_is_sized = isinstance(self.train_dataset, collections.abc.Sized)
 
         train_dataloader = self.get_train_dataloader()
         if self.args.max_steps > 0:
@@ -813,7 +813,7 @@ class Trainer:
             metrics (:obj:`Dict[str, float]`, `optional`):
                 The potential dictionary of metrics (if the dataset contained labels).
         """
-        if not isinstance(test_dataset, collections.Sized):
+        if not isinstance(test_dataset, collections.abc.Sized):
             raise ValueError("test_dataset must implement __len__")
         test_dataloader = self.get_test_dataloader(test_dataset)
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -197,7 +197,8 @@ class TrainerIntegrationTest(unittest.TestCase):
         MODEL_ID = "sshleifer/tiny-distilbert-base-cased"
         model = AutoModelForSequenceClassification.from_pretrained(MODEL_ID)
         train_dataset = SampleIterableDataset(PATH_SAMPLE_TEXT)
-        training_args = TrainingArguments(output_dir="./examples", no_cuda=True)
+        training_args = TrainingArguments(output_dir="./examples", no_cuda=True, max_steps=2)
         trainer = Trainer(model=model, args=training_args, train_dataset=train_dataset)
         loader = trainer.get_train_dataloader()
         self.assertIsInstance(loader, torch.utils.data.DataLoader)
+        trainer.train()


### PR DESCRIPTION
A first PR.

Passed:
- `make test`
- `make style`
- `make quality`

Modifies:
- trainer.py: fixes issue
- test_trainer.py: calls `Trainer.train()`

It fixes only the case where the TRAINING dataset has not the `__len__` method.

The distinction is not between `Dataset` and `IterableDataset`, but between objects that are instances of class where `__len__` is implemented or not. This is pointed in [pytorch source](https://pytorch.org/docs/stable/_modules/torch/utils/data/dataset.html#Dataset), implementation of `__len__` is up to the user.
The test is therefore: `isinstance(dataset, collections.Sized)`

NB: fixing for EVAL and TEST dataset will require more code refactor: all get funneled to `Trainer._prediction_loop()` without keeping track of whether it is EVAL or TEST, which makes the usage of `TrainingArguments.eval_steps` impossible to assume. (not to mention, there is no `test_steps` field in `TrainingArguments`)

Not all datasets have an implementation of `__len__` method, therefore the trainer should not assume it is available.

The use case is:
- Dataset with `__len__`: use `num_train_epochs` or `max_steps` to specify how long should training run
- Dataset without `__len__`: use only `max_steps`

The limitation is still valid on the EVAL / TEST dataset who still has to implement `__len__`