### PR TITLE
fix: model card readme clutter

### DIFF
--- a/model_cards/csarron/roberta-base-squad-v1/README.md
+++ b/model_cards/csarron/roberta-base-squad-v1/README.md
@@ -78,7 +78,6 @@ It took about 2 hours to finish.
 
 **Model size**: `477M`
 
-lower train, cased eval
 | Metric | # Value   |
 | ------ | --------- |
 | **EM** | **83.0** |


### PR DESCRIPTION
this removes the clutter line in the readme.md of model card `csarron/roberta-base-squad-v1`. It also fixes the result table.