### PR TITLE
Fix the return documentation rendering for all model outputs

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -189,8 +189,44 @@ def add_end_docstrings(*docstr):
 
 RETURN_INTRODUCTION = r"""
     Returns:
-        :class:`~{full_output_type}` or :obj:`tuple(torch.FloatTensor)` (if ``return_tuple=True`` is passed or when ``config.return_tuple=True``) comprising various elements depending on the configuration (:class:`~transformers.{config_class}`) and inputs:
+        :class:`~{full_output_type}` or :obj:`tuple(torch.FloatTensor)`:
+        A :class:`~{full_output_type}` or a tuple of :obj:`torch.FloatTensor` (if ``return_tuple=True`` is passed or
+        when ``config.return_tuple=True``) comprising various elements depending on the configuration
+        (:class:`~transformers.{config_class}`) and inputs.
+
 """
+
+
+def _get_indent(t):
+    """Returns the indentation in the first line of t"""
+    search = re.search(r'^(\s*)\S', t)
+    return "" if search is None else search.groups()[0]
+
+
+def _convert_output_args_doc(output_args_doc):
+    """Convert output_args_doc to display properly."""
+    # Split output_arg_doc in blocks argument/description
+    indent = _get_indent(output_args_doc)
+    blocks = []
+    current_block = ""
+    for line in output_args_doc.split('\n'):
+        # If the indent is the same as the beginning, the line is the name of new arg.
+        if _get_indent(line) == indent:
+            if len(current_block) > 0:
+                blocks.append(current_block[:-1])
+            current_block = f"{line}\n"
+        else:
+            # Otherwise it's part of the description of the current arg.
+            # We need to remove 2 spaces to the indentation.
+            current_block += f"{line[2:]}\n"
+    blocks.append(current_block[:-1])
+
+    # Format each block for proper rendering
+    for i in range(len(blocks)):
+        blocks[i] = re.sub(r'^(\s+)(\S+)(\s+)', r'\1- **\2**\3', blocks[i])
+        blocks[i] = re.sub(r':\s*\n\s*(\S)', r' -- \1', blocks[i])
+    
+    return '\n'.join(blocks)
 
 
 def _prepare_output_docstrings(output_type, config_class):
@@ -206,6 +242,7 @@ def _prepare_output_docstrings(output_type, config_class):
         i += 1
     if i < len(lines):
         docstrings = "\n".join(lines[(i + 1) :])
+        docstrings = _convert_output_args_doc(docstrings)
 
     # Add the return introduction
     full_output_type = f"{output_type.__module__}.{output_type.__name__}"

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -199,7 +199,7 @@ RETURN_INTRODUCTION = r"""
 
 def _get_indent(t):
     """Returns the indentation in the first line of t"""
-    search = re.search(r'^(\s*)\S', t)
+    search = re.search(r"^(\s*)\S", t)
     return "" if search is None else search.groups()[0]
 
 
@@ -209,7 +209,7 @@ def _convert_output_args_doc(output_args_doc):
     indent = _get_indent(output_args_doc)
     blocks = []
     current_block = ""
-    for line in output_args_doc.split('\n'):
+    for line in output_args_doc.split("\n"):
         # If the indent is the same as the beginning, the line is the name of new arg.
         if _get_indent(line) == indent:
             if len(current_block) > 0:
@@ -223,10 +223,10 @@ def _convert_output_args_doc(output_args_doc):
 
     # Format each block for proper rendering
     for i in range(len(blocks)):
-        blocks[i] = re.sub(r'^(\s+)(\S+)(\s+)', r'\1- **\2**\3', blocks[i])
-        blocks[i] = re.sub(r':\s*\n\s*(\S)', r' -- \1', blocks[i])
-    
-    return '\n'.join(blocks)
+        blocks[i] = re.sub(r"^(\s+)(\S+)(\s+)", r"\1- **\2**\3", blocks[i])
+        blocks[i] = re.sub(r":\s*\n\s*(\S)", r" -- \1", blocks[i])
+
+    return "\n".join(blocks)
 
 
 def _prepare_output_docstrings(output_type, config_class):

--- a/src/transformers/modeling_transfo_xl.py
+++ b/src/transformers/modeling_transfo_xl.py
@@ -629,8 +629,6 @@ class TransfoXLLMHeadModelOutput(ModelOutput):
     Base class for model's outputs that may also contain a past key/values (to speed up sequential decoding).
 
     Args:
-
-    Language modeling loss (for next-token prediction).
         losses (:obj:`torch.FloatTensor` of shape `(batch_size, sequence_length-1)`, `optional`, returned when ``labels`` is provided)
             Language modeling losses (not reduced).
         prediction_scores (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, config.vocab_size)`):


### PR DESCRIPTION
All PyTorch model outputs are documented from their output types. A problem is that just using the docstrings of the output class doesn't render properly on sphinx (this was also the case before the new model outputs were introduced).

This PR adds a function that converts the args part of the docstrings of the output class to render properly on our doc. You can see the transformation by looking [here](https://huggingface.co/transformers/master/model_doc/bert.html#transformers.BertModel.forward) for the docs before this PR and [here](https://64423-155220641-gh.circle-artifacts.com/0/docs/_build/html/model_doc/bert.html#transformers.BertModel.forward) for after it's merged (it's one example, but it will give the same result for all models). Scroll a bit to get to the return part of the doc.