### PR TITLE
don't complain about missing W&B when WANDB_DISABLED=true

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -203,12 +203,11 @@ class Trainer:
             )
         if is_wandb_available():
             self.setup_wandb()
-        else:
-            if os.environ.get("WANDB_DISABLED") != "true":
-                logger.info(
-                    "You are instantiating a Trainer but W&B is not installed. To use wandb logging, "
-                    "run `pip install wandb; wandb login` see https://docs.wandb.com/huggingface."
-                )
+        elif os.environ.get("WANDB_DISABLED") != "true":
+            logger.info(
+                "You are instantiating a Trainer but W&B is not installed. To use wandb logging, "
+                "run `pip install wandb; wandb login` see https://docs.wandb.com/huggingface."
+            )
         set_seed(self.args.seed)
         # Create output directory if needed
         if self.is_world_master():

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -204,10 +204,11 @@ class Trainer:
         if is_wandb_available():
             self.setup_wandb()
         else:
-            logger.info(
-                "You are instantiating a Trainer but W&B is not installed. To use wandb logging, "
-                "run `pip install wandb; wandb login` see https://docs.wandb.com/huggingface."
-            )
+            if os.environ.get("WANDB_DISABLED") != "true":
+                logger.info(
+                    "You are instantiating a Trainer but W&B is not installed. To use wandb logging, "
+                    "run `pip install wandb; wandb login` see https://docs.wandb.com/huggingface."
+                )
         set_seed(self.args.seed)
         # Create output directory if needed
         if self.is_world_master():

--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -91,10 +91,11 @@ class TFTrainer:
         if is_wandb_available():
             self._setup_wandb()
         else:
-            logger.info(
-                "You are instantiating a Trainer but W&B is not installed. To use wandb logging, "
-                "run `pip install wandb; wandb login` see https://docs.wandb.com/huggingface."
-            )
+            if os.environ.get("WANDB_DISABLED") != "true":
+                logger.info(
+                    "You are instantiating a Trainer but W&B is not installed. To use wandb logging, "
+                    "run `pip install wandb; wandb login` see https://docs.wandb.com/huggingface."
+                )
 
         set_seed(self.args.seed)
 

--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -90,12 +90,11 @@ class TFTrainer:
 
         if is_wandb_available():
             self._setup_wandb()
-        else:
-            if os.environ.get("WANDB_DISABLED") != "true":
-                logger.info(
-                    "You are instantiating a Trainer but W&B is not installed. To use wandb logging, "
-                    "run `pip install wandb; wandb login` see https://docs.wandb.com/huggingface."
-                )
+        elsif os.environ.get("WANDB_DISABLED") != "true":
+            logger.info(
+                "You are instantiating a Trainer but W&B is not installed. To use wandb logging, "
+                "run `pip install wandb; wandb login` see https://docs.wandb.com/huggingface."
+            )
 
         set_seed(self.args.seed)
 

--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -90,7 +90,7 @@ class TFTrainer:
 
         if is_wandb_available():
             self._setup_wandb()
-        elsif os.environ.get("WANDB_DISABLED") != "true":
+        elif os.environ.get("WANDB_DISABLED") != "true":
             logger.info(
                 "You are instantiating a Trainer but W&B is not installed. To use wandb logging, "
                 "run `pip install wandb; wandb login` see https://docs.wandb.com/huggingface."


### PR DESCRIPTION
I get a lot of crashes with W&B in transformers examples: https://github.com/huggingface/transformers/pull/5835 so I have to use `WANDB_DISABLED=true` - this PR removes a complaint that shouldn't be there when this env var is used.