### PR TITLE
Pipelines should use tuples instead of namedtuples

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -2119,6 +2119,6 @@ def pipeline(
                 "Model might be a PyTorch model (ending with `.bin`) but PyTorch is not available. "
                 "Trying to load the model with Tensorflow."
             )
-        model = model_class.from_pretrained(model, config=config, **model_kwargs)
+        model = model_class.from_pretrained(model, config=config, return_tuple=True, **model_kwargs)
 
     return task_class(model=model, tokenizer=tokenizer, modelcard=modelcard, framework=framework, task=task, **kwargs)


### PR DESCRIPTION
Fix https://github.com/huggingface/transformers/issues/5713

The ONNX conversion cannot handle other objects than tuples, lists and variables. Since calling the conversion script via the command line uses a pipeline, and pipelines cannot be configured with specific model kwargs, the change is so that pipelines manage tuples instead of namedtuples (not a breaking change).