### PR TITLE
[fix] no warning for position_ids buffer

### DIFF
--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -699,6 +699,8 @@ class BertModel(BertPreTrainedModel):
 
     """
 
+    authorized_missing_keys = [r"position_ids"]
+
     def __init__(self, config):
         super().__init__(config)
         self.config = config

--- a/src/transformers/modeling_mobilebert.py
+++ b/src/transformers/modeling_mobilebert.py
@@ -788,6 +788,8 @@ class MobileBertModel(MobileBertPreTrainedModel):
         https://arxiv.org/pdf/2004.02984.pdf
     """
 
+    authorized_missing_keys = [r"position_ids"]
+
     def __init__(self, config):
         super().__init__(config)
         self.config = config

--- a/src/transformers/modeling_openai.py
+++ b/src/transformers/modeling_openai.py
@@ -272,6 +272,7 @@ class OpenAIGPTPreTrainedModel(PreTrainedModel):
     config_class = OpenAIGPTConfig
     load_tf_weights = load_tf_weights_in_openai_gpt
     base_model_prefix = "transformer"
+    authorized_missing_keys = [r"position_ids"]
 
     def _init_weights(self, module):
         """ Initialize the weights.

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -346,7 +346,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
     """
     config_class = None
     base_model_prefix = ""
-    authorized_missing_keys = [r"position_ids"]  # a buffer that is often allocated in init and filled later.
+    authorized_missing_keys = None
 
     @property
     def dummy_inputs(self) -> Dict[str, torch.Tensor]:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -346,7 +346,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
     """
     config_class = None
     base_model_prefix = ""
-    authorized_missing_keys = None
+    authorized_missing_keys = [r"position_ids"]  # a buffer that is often allocated in init and filled later.
 
     @property
     def dummy_inputs(self) -> Dict[str, torch.Tensor]:

--- a/src/transformers/modeling_xlm.py
+++ b/src/transformers/modeling_xlm.py
@@ -375,7 +375,9 @@ XLM_INPUTS_DOCSTRING = r"""
     XLM_START_DOCSTRING,
 )
 class XLMModel(XLMPreTrainedModel):
-    def __init__(self, config):  # , dico, is_encoder, with_output):
+    authorized_missing_keys = [r"position_ids"]
+
+    def __init__(self, config):
         super().__init__(config)
 
         # encoder / decoder, output layer


### PR DESCRIPTION
Fixes [#6044](https://github.com/huggingface/transformers/issues/6044)

The failing tests check that there are no missing keys for bart, but morgan's recent change started registering a position_ids buffer in `__init__` for four models, with more expected.

Since we do not expect weights to be saved for position_ids, this PR adds the pattern `position_ids` to authorized_missing_keys for all PT models.
