### PR TITLE
Added capability to quantize a model while exporting through ONNX.

### DIFF
--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -21,9 +21,10 @@ The following command shows how easy it is to export a BERT model from the libra
     python convert_graph_to_onnx.py --framework <pt, tf> --model bert-base-cased bert-base-cased.onnx
 
 The conversion tool works for both PyTorch and Tensorflow models and ensures:
-    * The model and its weights are correctly initialized from the Hugging Face model hub or a local checkpoint.
-    * The inputs and outputs are correctly generated to their ONNX counterpart.
-    * The generated model can be correctly loaded through onnxruntime.
+
+* The model and its weights are correctly initialized from the Hugging Face model hub or a local checkpoint.
+* The inputs and outputs are correctly generated to their ONNX counterpart.
+* The generated model can be correctly loaded through onnxruntime.
 
 .. note::
     Currently, inputs and outputs are always exported with dynamic sequence axes preventing some optimizations

--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -42,17 +42,17 @@ Quantization
 
 ONNX exporter supports generating a quantized version of the model to allow efficient inference.
 
-Quantization works by converting the data representation of all/some of the parameters in the network
-to a compact integer format. Commonly, parameters of a neural network are stored as single-precision float (`float32`)
-which can express a wide-range of floating-point numbers with decent precision. This properties are especially interesting
-at training where you want fine-grained representation.
+Quantization works by converting the memory representation of the parameters in the neural network
+to a compact integer format. By default, weights of a neural network are stored as single-precision float (`float32`)
+which can express a wide-range of floating-point numbers with decent precision.
+These properties are especially interesting at training where you want fine-grained representation.
 
-On the other hand, after the training phase, it has been shown the range and the precision of `float32` numbers can be
-greatly reduced without necessary changing the performances of the neural network.
+On the other hand, after the training phase, it has been shown one can greatly reduce the range and the precision of `float32` numbers
+without changing the performances of the neural network.
 
-More technically, `float32` parameters are converted to a type requiring less bits to represent each number, thus reducing
-the overall size of the model. Here, we are enabling `int8` conversion which basically maps every `float32` values
-to non-floating, single byte, number representation according to the following formula:
+More technically, `float32` parameters are converted to a type requiring fewer bits to represent each number, thus reducing
+the overall size of the model. Here, we are enabling `float32` mapping to `int8` values (a non-floating, single byte, number representation)
+according to the following formula:
 
 .. math::
     y_{float32} = scale * x_{int8} - zero\_point
@@ -67,7 +67,7 @@ Leveraging tiny-integers has numerous advantages when it comes to inference:
 * Integer operations require less power to do the computations
 
 In order to convert a transformers model to ONNX IR with quantized weights you just need to specify ``--quantize``
-when using ``convert_graph_to_onnx.py`` or you can have a look at the ``quantize()`` utility-method in this
+when using ``convert_graph_to_onnx.py``. Also, you can have a look at the ``quantize()`` utility-method in this
 same script file.
 
 Example of quantized BERT model export:
@@ -80,8 +80,10 @@ Example of quantized BERT model export:
     Quantization support requires ONNX Runtime >= 1.4.0
 
 .. note::
-    When exporting quantized model you will end up with two different ONNX models. The one specified at the end of the
-    above command will contains the original ONNX model storing `float32` weights and a second one, with ``-quantized`` suffix.
+    When exporting quantized model you will end up with two different ONNX files. The one specified at the end of the
+    above command will contain the original ONNX model storing `float32` weights.
+    The second one, with ``-quantized`` suffix, will hold the quantized parameters.
+
 
 TorchScript
 =======================================

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -28,7 +28,7 @@ class OnnxConverterArgumentParser(ArgumentParser):
     """
 
     def __init__(self):
-        super(OnnxConverterArgumentParser, self).__init__("ONNX Converter")
+        super().__init__("ONNX Converter")
 
         self.add_argument(
             "--pipeline", type=str, choices=SUPPORTED_PIPELINES, default="feature-extraction",

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -31,14 +31,43 @@ class OnnxConverterArgumentParser(ArgumentParser):
     def __init__(self):
         super(OnnxConverterArgumentParser, self).__init__("ONNX Converter")
 
-        self.add_argument("--pipeline", type=str, choices=SUPPORTED_PIPELINES, default="feature-extraction")
-        self.add_argument("--model", type=str, required=True, help="Model's id or path (ex: bert-base-cased)")
-        self.add_argument("--tokenizer", type=str, help="Tokenizer's id or path (ex: bert-base-cased)")
-        self.add_argument("--framework", type=str, choices=["pt", "tf"], help="Framework for loading the model")
+        self.add_argument(
+            "--pipeline",
+            type=str,
+            choices=SUPPORTED_PIPELINES,
+            default="feature-extraction",
+        )
+        self.add_argument(
+            "--model",
+            type=str,
+            required=True,
+            help="Model's id or path (ex: bert-base-cased)",
+        )
+        self.add_argument(
+            "--tokenizer", type=str, help="Tokenizer's id or path (ex: bert-base-cased)"
+        )
+        self.add_argument(
+            "--framework",
+            type=str,
+            choices=["pt", "tf"],
+            help="Framework for loading the model",
+        )
         self.add_argument("--opset", type=int, default=11, help="ONNX opset to use")
-        self.add_argument("--check-loading", action="store_true", help="Check ONNX is able to load the model")
-        self.add_argument("--use-external-format", action="store_true", help="Allow exporting model >= than 2Gb")
-        self.add_argument("--quantize", action="store_true", help="Quantize the neural network to be run with int8")
+        self.add_argument(
+            "--check-loading",
+            action="store_true",
+            help="Check ONNX is able to load the model",
+        )
+        self.add_argument(
+            "--use-external-format",
+            action="store_true",
+            help="Allow exporting model >= than 2Gb",
+        )
+        self.add_argument(
+            "--quantize",
+            action="store_true",
+            help="Quantize the neural network to be run with int8",
+        )
         self.add_argument("output")
 
 
@@ -51,7 +80,9 @@ def generate_identified_filename(filename: Path, identifier: str) -> Path:
 
     Returns: String with concatenated indentifier at the end of the filename
     """
-    return filename.parent.joinpath(filename.stem + identifier).with_suffix(filename.suffix)
+    return filename.parent.joinpath(filename.stem + identifier).with_suffix(
+        filename.suffix
+    )
 
 
 def ensure_onnxruntime_installed():
@@ -99,14 +130,16 @@ def ensure_valid_input(model, tokens, input_names):
             ordered_input_names.append(arg_name)
             model_args.append(tokens[arg_name])
         else:
-            print("{} is not present in the generated input list.".format(arg_name))
+            print(f"{arg_name} is not present in the generated input list.")
             break
 
     print("Generated inputs order: {}".format(ordered_input_names))
     return ordered_input_names, tuple(model_args)
 
 
-def infer_shapes(nlp: Pipeline, framework: str) -> Tuple[List[str], List[str], Dict, BatchEncoding]:
+def infer_shapes(
+    nlp: Pipeline, framework: str
+) -> Tuple[List[str], List[str], Dict, BatchEncoding]:
     """
     Attempt to infer the static vs dynamic axes for each input and output tensors for a specific model.
     Args:
@@ -119,23 +152,32 @@ def infer_shapes(nlp: Pipeline, framework: str) -> Tuple[List[str], List[str], D
         - Dictionary with input/output variables names as key and shape tensor as value
         - a BatchEncoding reference which was used to infer all the above information
     """
+
     def build_shape_dict(name: str, tensor, is_input: bool, seq_len: int):
         if isinstance(tensor, (tuple, list)):
             return [build_shape_dict(name, t, is_input, seq_len) for t in tensor]
 
         else:
             # Let's assume batch is the first axis with only 1 element (~~ might not be always true ...)
-            axes = {[axis for axis, numel in enumerate(tensor.shape) if numel == 1][0]: "batch"}
+            axes = {
+                [axis for axis, numel in enumerate(tensor.shape) if numel == 1][
+                    0
+                ]: "batch"
+            }
             if is_input:
                 if len(tensor.shape) == 2:
                     axes[1] = "sequence"
                 else:
-                    raise ValueError("Unable to infer tensor axes ({})".format(len(tensor.shape)))
+                    raise ValueError(
+                        f"Unable to infer tensor axes ({len(tensor.shape)})"
+                    )
             else:
-                seq_axes = [dim for dim, shape in enumerate(tensor.shape) if shape == seq_len]
+                seq_axes = [
+                    dim for dim, shape in enumerate(tensor.shape) if shape == seq_len
+                ]
                 axes.update({dim: "sequence" for dim in seq_axes})
 
-        print("Found {} {} with shape: {}".format("input" if is_input else "output", name, axes))
+        print(f"Found {'input' if is_input else 'output'} {name} with shape: {axes}")
         return axes
 
     tokens = nlp.tokenizer("This is a sample output", return_tensors=framework)
@@ -148,7 +190,9 @@ def infer_shapes(nlp: Pipeline, framework: str) -> Tuple[List[str], List[str], D
 
     # Generate input names & axes
     input_vars = list(tokens.keys())
-    input_dynamic_axes = {k: build_shape_dict(k, v, True, seq_len) for k, v in tokens.items()}
+    input_dynamic_axes = {
+        k: build_shape_dict(k, v, True, seq_len) for k, v in tokens.items()
+    }
 
     # flatten potentially grouped outputs (past for gpt2, attentions)
     outputs_flat = []
@@ -159,15 +203,20 @@ def infer_shapes(nlp: Pipeline, framework: str) -> Tuple[List[str], List[str], D
             outputs_flat.append(output)
 
     # Generate output names & axes
-    output_names = ["output_{}".format(i) for i in range(len(outputs_flat))]
-    output_dynamic_axes = {k: build_shape_dict(k, v, False, seq_len) for k, v in zip(output_names, outputs_flat)}
+    output_names = [f"output_{i}" for i in range(len(outputs_flat))]
+    output_dynamic_axes = {
+        k: build_shape_dict(k, v, False, seq_len)
+        for k, v in zip(output_names, outputs_flat)
+    }
 
     # Create the aggregated axes representation
     dynamic_axes = dict(input_dynamic_axes, **output_dynamic_axes)
     return input_vars, output_names, dynamic_axes, tokens
 
 
-def load_graph_from_args(pipeline_name: str, framework: str, model: str, tokenizer: Optional[str] = None) -> Pipeline:
+def load_graph_from_args(
+    pipeline_name: str, framework: str, model: str, tokenizer: Optional[str] = None
+) -> Pipeline:
     """
     Convert the set of arguments provided through the CLI to an actual pipeline reference (tokenizer + model)
     Args:
@@ -185,14 +234,20 @@ def load_graph_from_args(pipeline_name: str, framework: str, model: str, tokeniz
 
     # Check the wanted framework is available
     if framework == "pt" and not is_torch_available():
-        raise Exception("Cannot convert because PyTorch is not installed. Please install torch first.")
+        raise Exception(
+            "Cannot convert because PyTorch is not installed. Please install torch first."
+        )
     if framework == "tf" and not is_tf_available():
-        raise Exception("Cannot convert because TF is not installed. Please install tensorflow first.")
+        raise Exception(
+            "Cannot convert because TF is not installed. Please install tensorflow first."
+        )
 
-    print("Loading pipeline (model: {}, tokenizer: {})".format(model, tokenizer))
+    print(f"Loading pipeline (model: {model}, tokenizer: {tokenizer})")
 
     # Allocate tokenizer and model
-    return pipeline(pipeline_name, model=model, tokenizer=tokenizer, framework=framework)
+    return pipeline(
+        pipeline_name, model=model, tokenizer=tokenizer, framework=framework
+    )
 
 
 def convert_pytorch(nlp: Pipeline, opset: int, output: Path, use_external_format: bool):
@@ -208,16 +263,20 @@ def convert_pytorch(nlp: Pipeline, opset: int, output: Path, use_external_format
 
     """
     if not is_torch_available():
-        raise Exception("Cannot convert because PyTorch is not installed. Please install torch first.")
+        raise Exception(
+            "Cannot convert because PyTorch is not installed. Please install torch first."
+        )
 
     import torch
     from torch.onnx import export
 
-    print("Using framework PyTorch: {}".format(torch.__version__))
+    print(f"Using framework PyTorch: {torch.__version__}")
 
     with torch.no_grad():
         input_names, output_names, dynamic_axes, tokens = infer_shapes(nlp, "pt")
-        ordered_input_names, model_args = ensure_valid_input(nlp.model, tokens, input_names)
+        ordered_input_names, model_args = ensure_valid_input(
+            nlp.model, tokens, input_names
+        )
 
         export(
             nlp.model,
@@ -245,7 +304,9 @@ def convert_tensorflow(nlp: Pipeline, opset: int, output: Path):
 
     """
     if not is_tf_available():
-        raise Exception("Cannot convert because TF is not installed. Please install tensorflow first.")
+        raise Exception(
+            "Cannot convert because TF is not installed. Please install tensorflow first."
+        )
 
     print("/!\\ Please note TensorFlow doesn't support exporting model > 2Gb /!\\")
 
@@ -253,7 +314,7 @@ def convert_tensorflow(nlp: Pipeline, opset: int, output: Path):
         import tensorflow as tf
         from keras2onnx import convert_keras, save_model, __version__ as k2ov
 
-        print("Using framework TensorFlow: {}, keras2onnx: {}".format(tf.version.VERSION, k2ov))
+        print(f"Using framework TensorFlow: {tf.version.VERSION}, keras2onnx: {k2ov}")
 
         # Build
         input_names, output_names, dynamic_axes, tokens = infer_shapes(nlp, "tf")
@@ -265,7 +326,7 @@ def convert_tensorflow(nlp: Pipeline, opset: int, output: Path):
 
     except ImportError as e:
         raise Exception(
-            "Cannot import {} required to convert TF model to ONNX. Please install {} first.".format(e.name, e.name)
+            f"Cannot import {e.name} required to convert TF model to ONNX. Please install {e.name} first."
         )
 
 
@@ -292,16 +353,18 @@ def convert(
     Returns:
 
     """
-    print("ONNX opset version set to: {}".format(opset))
+    print(f"ONNX opset version set to: {opset}")
 
     # Load the pipeline
     nlp = load_graph_from_args(pipeline_name, framework, model, tokenizer)
 
     if not output.parent.exists():
-        print("Creating folder {}".format(output.parent))
+        print(f"Creating folder {output.parent}")
         makedirs(output.parent.as_posix())
     elif len(listdir(output.parent.as_posix())) > 0:
-        raise Exception("Folder {} is not empty, aborting conversion".format(output.parent.as_posix()))
+        raise Exception(
+            f"Folder {output.parent.as_posix()} is not empty, aborting conversion"
+        )
 
     # Export the graph
     if framework == "pt":
@@ -330,11 +393,16 @@ def quantize(onnx_model_path: Path) -> Path:
 
         onnx_model = onnx.load(onnx_model_path.as_posix())
         quantized_model = quantize(
-            model=onnx_model, quantization_mode=QuantizationMode.IntegerOps, force_fusions=True, symmetric_weight=True
+            model=onnx_model,
+            quantization_mode=QuantizationMode.IntegerOps,
+            force_fusions=True,
+            symmetric_weight=True,
         )
 
         # Append "-quantized" at the end of the model's name
-        quantized_model_path = generate_identified_filename(onnx_model_path, "-quantized")
+        quantized_model_path = generate_identified_filename(
+            onnx_model_path, "-quantized"
+        )
 
         # Save model
         print(f"Storing quantized model at {quantized_model_path}")
@@ -349,13 +417,15 @@ def verify(path: Path):
     from onnxruntime import InferenceSession, SessionOptions
     from onnxruntime.capi.onnxruntime_pybind11_state import RuntimeException
 
-    print("Checking ONNX model loading from: {}".format(path))
+    print(f"Checking ONNX model loading from: {path}")
     try:
         onnx_options = SessionOptions()
-        _ = InferenceSession(path.as_posix(), onnx_options, providers=["CPUExecutionProvider"])
-        print("Model {} correctly loaded: \N{heavy check mark}".format(path))
+        _ = InferenceSession(
+            path.as_posix(), onnx_options, providers=["CPUExecutionProvider"]
+        )
+        print(f"Model {path} correctly loaded: \N{heavy check mark}")
     except RuntimeException as re:
-        print("Error while loading the model {}: \N{heavy ballot x}".format(re))
+        print(f"Error while loading the model {re}: \N{heavy ballot x}")
 
 
 if __name__ == "__main__":
@@ -388,5 +458,5 @@ if __name__ == "__main__":
                 verify(args.quantized_output)
 
     except Exception as e:
-        print("Error while converting the model: {}".format(e))
+        print(f"Error while converting the model: {e}")
         exit(1)

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -1,8 +1,9 @@
 from argparse import ArgumentParser
 from os import listdir, makedirs
-from packaging.version import parse
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
+
+from packaging.version import parse
 
 from transformers import is_tf_available, is_torch_available
 from transformers.file_utils import ModelOutput

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -86,14 +86,14 @@ def ensure_onnxruntime_installed():
 
         # We require 1.4.0 minimum
         if ort_version < ORT_QUANTIZE_MINIMUM_VERSION:
-            ImportError(
+            raise ImportError(
                 f"We found an older version of onnxruntime ({onnxruntime.__version__}) "
                 f"but we require onnxruntime to be >= 1.4.0 to enable all the conversions options.\n"
                 f"Please update onnxruntime by running `pip install --upgrade onnxruntime`"
             )
 
     except ImportError:
-        ImportError(
+        raise ImportError(
             "onnxruntime doesn't seem to be currently installed. "
             "Please install the onnxruntime by running `pip install onnxruntime`"
             " and relaunch the conversion."

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -59,7 +59,7 @@ def ensure_onnxruntime_installed():
 
         # We require 1.4.0 minimum
         if int(onnxruntime.__version__.split(".")[1]) < 4:
-            print(
+            ImportError(
                 f"We found an older version of onnxruntime ({onnxruntime.__version__}) "
                 f"but we require onnxruntime to be >= 1.4.0 to enable all the conversions options.\n"
                 f"Please update onnxruntime by running `pip install --upgrade onnxruntime`"
@@ -249,7 +249,7 @@ def convert(
 
 def quantize(onnx_model_path: Path) -> Path:
     """
-    Quantize the weights of the model from float32 to in8 to allow very efficient inference on modern CP.
+    Quantize the weights of the model from float32 to in8 to allow very efficient inference on modern CPU.
     :param onnx_model_path: Path to location the exported ONNX model is stored
     :return: The path generated for the quantized
     """
@@ -276,7 +276,7 @@ def quantize(onnx_model_path: Path) -> Path:
 
         return quantized_model_path
     except ImportError as ie:
-        print(str(ie))
+        print(f"Error while quantizing the model:\n{str(ie)}")
 
 
 def verify(path: Path):

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -59,15 +59,18 @@ def ensure_onnxruntime_installed():
 
         # We require 1.4.0 minimum
         if int(onnxruntime.__version__.split(".")[1]) < 4:
-            print(f"We found an older version of onnxruntime ({onnxruntime.__version__}) "
-                  f"but we require onnxruntime to be >= 1.4.0 to enable all the conversions options.\n"
-                  f"Please update onnxruntime by running `pip install --upgrade onnxruntime`")
+            print(
+                f"We found an older version of onnxruntime ({onnxruntime.__version__}) "
+                f"but we require onnxruntime to be >= 1.4.0 to enable all the conversions options.\n"
+                f"Please update onnxruntime by running `pip install --upgrade onnxruntime`"
+            )
 
     except ImportError:
         ImportError(
             "onnxruntime doesn't seem to be currently installed. "
             "Please install the onnxruntime by running `pip install onnxruntime`"
-            " and relaunch the conversion.")
+            " and relaunch the conversion."
+        )
 
 
 def ensure_valid_input(model, tokens, input_names):
@@ -261,10 +264,7 @@ def quantize(onnx_model_path: Path) -> Path:
 
         onnx_model = onnx.load(onnx_model_path.as_posix())
         quantized_model = quantize(
-            model=onnx_model,
-            quantization_mode=QuantizationMode.IntegerOps,
-            force_fusions=True,
-            symmetric_weight=True
+            model=onnx_model, quantization_mode=QuantizationMode.IntegerOps, force_fusions=True, symmetric_weight=True
         )
 
         # Append "-quantized" at the end of the model's name

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -297,12 +297,11 @@ def convert(
     # Load the pipeline
     nlp = load_graph_from_args(pipeline_name, framework, model, tokenizer)
 
-    parent = dirname(output)
-    if not exists(parent):
-        print("Creating folder {}".format(parent))
-        makedirs(parent)
-    elif len(listdir(parent)) > 0:
-        raise Exception("Folder {} is not empty, aborting conversion".format(parent))
+    if not output.parent.exists():
+        print("Creating folder {}".format(output.parent))
+        makedirs(output.parent.as_posix())
+    elif len(listdir(output.parent.as_posix())) > 0:
+        raise Exception("Folder {} is not empty, aborting conversion".format(output.parent.as_posix()))
 
     # Export the graph
     if framework == "pt":

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser
 from os import listdir, makedirs
+from packaging.version import parse
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -7,6 +8,11 @@ from transformers import is_tf_available, is_torch_available
 from transformers.file_utils import ModelOutput
 from transformers.pipelines import Pipeline, pipeline
 from transformers.tokenization_utils import BatchEncoding
+
+
+# This is the minimal required version to
+# support some ONNX Runtime features
+ORT_QUANTIZE_MINIMUM_VERSION = parse("1.4.0")
 
 
 SUPPORTED_PIPELINES = [
@@ -74,8 +80,11 @@ def ensure_onnxruntime_installed():
     try:
         import onnxruntime
 
+        # Parse the version of the installed onnxruntime
+        ort_version = parse(onnxruntime.__version__)
+
         # We require 1.4.0 minimum
-        if int(onnxruntime.__version__.split(".")[1]) < 4:
+        if ort_version < ORT_QUANTIZE_MINIMUM_VERSION:
             ImportError(
                 f"We found an older version of onnxruntime ({onnxruntime.__version__}) "
                 f"but we require onnxruntime to be >= 1.4.0 to enable all the conversions options.\n"

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -172,4 +172,4 @@ class OnnxExportTestCase(unittest.TestCase):
 
     def test_generate_identified_name(self):
         generated = generate_identified_filename(Path("/home/something/my_fake_model.onnx"), "-test")
-        self.assertEqual("/home/something/my_fake_model-test.onnx", generated)
+        self.assertEqual("/home/something/my_fake_model-test.onnx", generated.as_posix())

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -8,9 +8,9 @@ from transformers import BertConfig, BertTokenizerFast, FeatureExtractionPipelin
 from transformers.convert_graph_to_onnx import (
     convert,
     ensure_valid_input,
+    generate_identified_filename,
     infer_shapes,
     quantize,
-    generate_identified_filename,
 )
 from transformers.testing_utils import require_tf, require_torch, slow
 

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -5,8 +5,13 @@ from shutil import rmtree
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 from transformers import BertConfig, BertTokenizerFast, FeatureExtractionPipeline
-from transformers.convert_graph_to_onnx import convert, ensure_valid_input, infer_shapes, quantize, \
-    generate_identified_filename
+from transformers.convert_graph_to_onnx import (
+    convert,
+    ensure_valid_input,
+    infer_shapes,
+    quantize,
+    generate_identified_filename,
+)
 from transformers.testing_utils import require_tf, require_torch, slow
 
 
@@ -72,7 +77,7 @@ class OnnxExportTestCase(unittest.TestCase):
             # Ensure the actual quantized model is not bigger than the original one
             if quantized_path.stat().st_size >= Path(path).stat().st_size:
                 self.fail("Quantized model is bigger than initial ONNX model")
-            
+
     def _test_export(self, model, framework, opset, tokenizer=None):
         try:
             # Compute path

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -1,10 +1,12 @@
 import unittest
 from os.path import dirname, exists
+from pathlib import Path
 from shutil import rmtree
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 from transformers import BertConfig, BertTokenizerFast, FeatureExtractionPipeline
-from transformers.convert_graph_to_onnx import convert, ensure_valid_input, infer_shapes
+from transformers.convert_graph_to_onnx import convert, ensure_valid_input, infer_shapes, quantize, \
+    generate_identified_filename
 from transformers.testing_utils import require_tf, require_torch, slow
 
 
@@ -25,13 +27,13 @@ class OnnxExportTestCase(unittest.TestCase):
     @slow
     def test_export_tensorflow(self):
         for model in OnnxExportTestCase.MODEL_TO_TEST:
-            self._test_export(model, "tf", 11)
+            self._test_export(model, "tf", 12)
 
     @require_torch
     @slow
     def test_export_pytorch(self):
         for model in OnnxExportTestCase.MODEL_TO_TEST:
-            self._test_export(model, "pt", 11)
+            self._test_export(model, "pt", 12)
 
     @require_torch
     @slow
@@ -47,8 +49,30 @@ class OnnxExportTestCase(unittest.TestCase):
         with TemporaryDirectory() as bert_save_dir:
             model = BertModel(BertConfig(vocab_size=len(vocab)))
             model.save_pretrained(bert_save_dir)
-            self._test_export(bert_save_dir, "pt", 11, tokenizer)
+            self._test_export(bert_save_dir, "pt", 12, tokenizer)
 
+    @require_tf
+    @slow
+    def test_quantize_tf(self):
+        for model in OnnxExportTestCase.MODEL_TO_TEST:
+            path = self._test_export(model, "tf", 12)
+            quantized_path = quantize(Path(path))
+
+            # Ensure the actual quantized model is not bigger than the original one
+            if quantized_path.stat().st_size >= Path(path).stat().st_size:
+                self.fail("Quantized model is bigger than initial ONNX model")
+
+    @require_torch
+    @slow
+    def test_quantize_pytorch(self):
+        for model in OnnxExportTestCase.MODEL_TO_TEST:
+            path = self._test_export(model, "pt", 12)
+            quantized_path = quantize(Path(path))
+
+            # Ensure the actual quantized model is not bigger than the original one
+            if quantized_path.stat().st_size >= Path(path).stat().st_size:
+                self.fail("Quantized model is bigger than initial ONNX model")
+            
     def _test_export(self, model, framework, opset, tokenizer=None):
         try:
             # Compute path
@@ -61,6 +85,8 @@ class OnnxExportTestCase(unittest.TestCase):
 
                 # Export
                 convert(framework, model, path, opset, tokenizer)
+
+                return path
         except Exception as e:
             self.fail(e)
 
@@ -138,3 +164,7 @@ class OnnxExportTestCase(unittest.TestCase):
         # Should have only "input_ids"
         self.assertEqual(inputs_args[0], tokens["input_ids"])
         self.assertEqual(ordered_input_names[0], "input_ids")
+
+    def test_generate_identified_name(self):
+        generated = generate_identified_filename(Path("/home/something/my_fake_model.onnx"), "-test")
+        self.assertEqual("/home/something/my_fake_model-test.onnx", generated)


### PR DESCRIPTION
Add quantization support as part of our collaboration with ONNX team.

Quantization is available through the new method `quantize` which takes the path to the initial ONNX model and operate the conversion.

From a CLI point of view, adding `--quantize` allows to seamlessly export the quantized model.

Signed-off-by: Morgan Funtowicz <morgan@huggingface.co>