### PR TITLE
Fix local_files_only for TF

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -787,7 +787,7 @@ def get_from_cache(
         else:
             matching_files = [
                 file
-                for file in fnmatch.filter(os.listdir(cache_dir), filename + ".*")
+                for file in fnmatch.filter(os.listdir(cache_dir), filename.split(".")[0] + ".*")
                 if not file.endswith(".json") and not file.endswith(".lock")
             ]
             if len(matching_files) > 0:


### PR DESCRIPTION
The `local_files_only` was not working for TF. The flag is to be used as such:

```py
from transformers import TFBertModel
model = TFBertModel.from_pretrained('bert-base-cased', local_files_only=True)
```
Setting it to `True` for any TF model would result in the following error:
```
Traceback (most recent call last):
  File "/Users/jik/Library/Application Support/JetBrains/PyCharm2020.1/scratches/scratch_1.py", line 7, in <module>
    model = TFBertModel.from_pretrained('bert-base-cased', local_files_only=True)
  File "/Users/jik/Workspaces/python/transformers/src/transformers/modeling_tf_utils.py", line 578, in from_pretrained
    local_files_only=local_files_only,
  File "/Users/jik/Workspaces/python/transformers/src/transformers/file_utils.py", line 663, in cached_path
    local_files_only=local_files_only,
  File "/Users/jik/Workspaces/python/transformers/src/transformers/file_utils.py", line 801, in get_from_cache
    "Cannot find the requested files in the cached path and outgoing traffic has been"
ValueError: Cannot find the requested files in the cached path and outgoing traffic has been disabled. To enable model look-ups and downloads online, set 'local_files_only' to False.
```

This is because the `file_utils.get_from_cache` method obtains the filename from the `url_to_filename` method:

https://github.com/huggingface/transformers/blob/1246b20f6d81bcd949078d26cf5ab3d0f3acccc6/src/transformers/file_utils.py#L777

The issue is that this method adds `.h5` to TF models:

https://github.com/huggingface/transformers/blob/1246b20f6d81bcd949078d26cf5ab3d0f3acccc6/src/transformers/file_utils.py#L585-L586

This works when the file is already built using `{filename}.{etag}`, resulting in `{filename}.{etag}.h5`. However, since the etag is `None` with `local_files_only=True`, this results in `{filename}.h5`. 

The method tries to find the saved files using the filename followed by `.*`:

https://github.com/huggingface/transformers/blob/1246b20f6d81bcd949078d26cf5ab3d0f3acccc6/src/transformers/file_utils.py#L788-L792

This doesn't work since it's looking for `{filename}.h5.*` which doesn't exist. It should instead be looking for `{filename}.*`, which is what it's doing now.

Fix https://github.com/huggingface/transformers/issues/5016