### PR TITLE
Logs should not be hidden behind a logger.info

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -646,7 +646,7 @@ class Trainer:
         if iterator is not None:
             iterator.write(output)
         else:
-            logger.info(output)
+            print(output)
 
     def _prepare_inputs(
         self, inputs: Dict[str, Union[torch.Tensor, Any]], model: nn.Module


### PR DESCRIPTION
Currently the logs that are printed when the global step is a multiple of the `logging_steps` are printed using a `logger.info`. In the case where a user did not set its logging level to INFO, these logs are not shown, even if the user has set a `logging_steps > 0`. This PR fixes that by putting back a print statement.

Closes https://github.com/huggingface/transformers/issues/5901
