### PR TITLE
[Fix] position_ids tests again

### DIFF
--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -568,6 +568,7 @@ class BertPreTrainedModel(PreTrainedModel):
     config_class = BertConfig
     load_tf_weights = load_tf_weights_in_bert
     base_model_prefix = "bert"
+    authorized_missing_keys = [r"position_ids"]
 
     def _init_weights(self, module):
         """ Initialize the weights """
@@ -698,8 +699,6 @@ class BertModel(BertPreTrainedModel):
         https://arxiv.org/abs/1706.03762
 
     """
-
-    authorized_missing_keys = [r"position_ids"]
 
     def __init__(self, config):
         super().__init__(config)

--- a/tests/test_modeling_auto.py
+++ b/tests/test_modeling_auto.py
@@ -88,9 +88,11 @@ class AutoModelTest(unittest.TestCase):
             model, loading_info = AutoModelForPreTraining.from_pretrained(model_name, output_loading_info=True)
             self.assertIsNotNone(model)
             self.assertIsInstance(model, BertForPreTraining)
+            # Only one value should not be initialized and in the missing keys.
+            missing_keys = loading_info.pop("missing_keys")
+            self.assertListEqual(["cls.predictions.decoder.bias"], missing_keys)
             for key, value in loading_info.items():
-                # Only one value should not be initialized and in the missing keys.
-                self.assertEqual(len(value), 1 if key == "missing_keys" else 0)
+                self.assertEqual(len(value), 0)
 
     @slow
     def test_lmhead_model_from_pretrained(self):


### PR DESCRIPTION
Yesterday, in my haste, I added authorized_missing_keys to `BertModel`, rather than `BertPretrainedModel`. Since position_ids are allowed to be missing for all Bert variants, we want the latter, not the former.

I also improved the traceback for the failing test.