### PR TITLE
Fix zero-shot pipeline single seq output shape

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -959,7 +959,7 @@ class ZeroShotClassificationPipeline(Pipeline):
             top_inds = list(reversed(scores[iseq].argsort()))
             result.append(
                 {
-                    "sequence": sequences if num_sequences == 1 else sequences[iseq],
+                    "sequence": sequences if isinstance(sequences, str) else sequences[iseq],
                     "labels": [candidate_labels[i] for i in top_inds],
                     "scores": scores[iseq][top_inds].tolist(),
                 }


### PR DESCRIPTION
Fixes zero shot pipelines bug that returns sequence as a list rather than a str when a single sequence is passed as a list.