### PR TITLE
[T5Tokenizer] add prepare_seq2seq_batch method

### DIFF
--- a/src/transformers/tokenization_t5.py
+++ b/src/transformers/tokenization_t5.py
@@ -246,7 +246,7 @@ class T5Tokenizer(PreTrainedTokenizer):
         **kwargs,
     ) -> BatchEncoding:
         """Prepare a batch that can be passed directly to an instance of T5Model.
-        
+
         Args:
             src_texts (:obj:`List[str]`):
                 list of src texts
@@ -299,4 +299,3 @@ class T5Tokenizer(PreTrainedTokenizer):
 
         self.prefix_tokens = []
         return model_inputs
-

--- a/src/transformers/tokenization_t5.py
+++ b/src/transformers/tokenization_t5.py
@@ -98,7 +98,6 @@ class T5Tokenizer(PreTrainedTokenizer):
     model_input_names = ["attention_mask"]
 
     prefix_tokens: List[int] = []
-    suffix_tokens: List[int] = []
 
     def __init__(
         self,
@@ -232,9 +231,9 @@ class T5Tokenizer(PreTrainedTokenizer):
             :obj:`List[int]`: list of `input IDs <../glossary.html#input-ids>`__ with the appropriate special tokens.
         """
         if token_ids_1 is None:
-            return self.prefix_tokens + token_ids_0 + self.suffix_tokens
+            return self.prefix_tokens + token_ids_0
         # We don't expect to process pairs, but leave the pair logic for API consistency
-        return self.prefix_tokens + token_ids_0 + token_ids_1 + self.suffix_tokens
+        return self.prefix_tokens + token_ids_0 + token_ids_1
 
     def prepare_seq2seq_batch(
         self,
@@ -292,8 +291,6 @@ class T5Tokenizer(PreTrainedTokenizer):
 
     def set_src_special_tokens(self) -> None:
         self.prefix_tokens = []
-        self.suffix_tokens = [self.eos_token_id]
 
     def set_tgt_special_tokens(self) -> None:
         self.prefix_tokens = [self.pad_token_id]
-        self.suffix_tokens = [self.eos_token_id]

--- a/src/transformers/tokenization_t5.py
+++ b/src/transformers/tokenization_t5.py
@@ -268,7 +268,7 @@ class T5Tokenizer(PreTrainedTokenizer):
         """
         if max_length is None:
             max_length = self.max_len
-        self.set_src_special_tokens()
+        self.prefix_tokens = []
         model_inputs: BatchEncoding = self(
             src_texts,
             add_special_tokens=True,
@@ -283,7 +283,8 @@ class T5Tokenizer(PreTrainedTokenizer):
         # Process tgt_texts
         if max_target_length is None:
             max_target_length = max_length
-        self.set_tgt_special_tokens()
+        # set prefix_tokens for target text
+        self.prefix_tokens = [self.pad_token_id]
         decoder_inputs: BatchEncoding = self(
             tgt_texts,
             add_special_tokens=True,
@@ -296,11 +297,6 @@ class T5Tokenizer(PreTrainedTokenizer):
         for k, v in decoder_inputs.items():
             model_inputs[f"decoder_{k}"] = v
 
-        self.set_src_special_tokens()
+        self.prefix_tokens = []
         return model_inputs
 
-    def set_src_special_tokens(self) -> None:
-        self.prefix_tokens = []
-
-    def set_tgt_special_tokens(self) -> None:
-        self.prefix_tokens = [self.pad_token_id]

--- a/src/transformers/tokenization_t5.py
+++ b/src/transformers/tokenization_t5.py
@@ -216,7 +216,7 @@ class T5Tokenizer(PreTrainedTokenizer):
         """
         Build model inputs from a sequence or a pair of sequence for sequence classification tasks
         by concatenating and adding special tokens. The special tokens depend on calling source text or target text.
-        An T5 sequence has the following format, where ``X`` represents the sequence:
+        A T5 sequence has the following format, where ``X`` represents the sequence:
         - ``input_ids`` (for encoder) ``X [eos]``
         - ``decoder_input_ids``: (for decoder) ``[pad] X [eos]``
         Pairs of sequences are not the expected use case, but they will be handled without a separator.
@@ -224,11 +224,11 @@ class T5Tokenizer(PreTrainedTokenizer):
         Args:
             token_ids_0 (:obj:`List[int]`):
                 List of IDs to which the special tokens will be added
-            token_ids_1 (:obj:`List[int]`, `optional`, defaults to :obj:`None`):
+            token_ids_1 (:obj:`List[int]`, `optional`):
                 Optional second list of IDs for sequence pairs.
 
         Returns:
-            :obj:`List[int]`: list of `input IDs <../glossary.html#input-ids>`__ with the appropriate special tokens.
+            :obj:`List[int]`: List of `input IDs <../glossary.html#input-ids>`__ with the appropriate special tokens.
         """
         if token_ids_1 is None:
             return self.prefix_tokens + token_ids_0
@@ -246,15 +246,25 @@ class T5Tokenizer(PreTrainedTokenizer):
         **kwargs,
     ) -> BatchEncoding:
         """Prepare a batch that can be passed directly to an instance of T5Model.
-        Arguments:
-            src_texts: list of src language texts
-            tgt_texts: list of tgt language texts
-            max_length: (default=None, which defers to the config value of 512 for t5*
-            padding: strategy for padding input_ids and decoder_input_ids. Should be max_length or longest.
-            **kwargs: passed to self.__call__
+        
+        Args:
+            src_texts (:obj:`List[str]`):
+                list of src texts
+            tgt_texts (:obj:`List[str]`, `optional`):
+                list of tgt texts
+            max_length (:obj:`int`, `optional`):
+                maximum length for the source text which defers to the config value of 512 for t5*
+            max_target_length (:obj:`int`, `optional`):
+                maximum length for the target text which defers to the config value of 512 for t5*
+            padding (:obj:`str`, `optional`, defaults to "longest"):
+                strategy for padding `input_ids` and `decoder_input_ids`. Should be "max_length" or "longest".
+            return_tensors (:obj:`str`, `optional`):
+                Can be set to ‘tf’, ‘pt’ or ‘np’ to return respectively TensorFlow `tf.constant`, PyTorch `torch.Tensor` or Numpy :oj: np.ndarray instead of a list of python integers.
+            **kwargs:
+                passed to self.__call__
 
         Returns:
-            :obj:`BatchEncoding`: with keys input_ids, attention_mask, decoder_input_ids, decoder_attention_mask.
+            :class:`~transformers.BatchEncoding`: with keys input_ids, attention_mask, decoder_input_ids, decoder_attention_mask.
         """
         if max_length is None:
             max_length = self.max_len

--- a/src/transformers/tokenization_t5.py
+++ b/src/transformers/tokenization_t5.py
@@ -243,28 +243,62 @@ class T5Tokenizer(PreTrainedTokenizer):
         max_target_length: Optional[int] = None,
         padding: str = "longest",
         return_tensors: str = None,
+        truncation: bool = True,
         **kwargs,
     ) -> BatchEncoding:
-        """Prepare a batch that can be passed directly to an instance of T5Model.
-
+        r"""
+        Prepare a batch that can be passed directly to an instance of :class:`~transformers.T5Model`.
         Args:
-            src_texts (:obj:`List[str]`):
-                list of src texts
-            tgt_texts (:obj:`List[str]`, `optional`):
-                list of tgt texts
+            src_texts: (:obj:`List[str]`):
+                List of documents to summarize or source language texts.
+            tgt_texts: (:obj:`List[str]`, `optional`):
+                List of summaries or target language texts.
             max_length (:obj:`int`, `optional`):
-                maximum length for the source text which defers to the config value of 512 for t5*
+                Controls the maximum length for encoder inputs (documents to summarize or source language texts).
+                If left unset or set to :obj:`None`, this will use the predefined model maximum length if a maximum
+                length is required by one of the truncation/padding parameters. If the model has no specific maximum
+                input length (like XLNet) truncation/padding to a maximum length will be deactivated.
             max_target_length (:obj:`int`, `optional`):
-                maximum length for the target text which defers to the config value of 512 for t5*
-            padding (:obj:`str`, `optional`, defaults to "longest"):
-                strategy for padding `input_ids` and `decoder_input_ids`. Should be "max_length" or "longest".
-            return_tensors (:obj:`str`, `optional`):
-                Can be set to ‘tf’, ‘pt’ or ‘np’ to return respectively TensorFlow `tf.constant`, PyTorch `torch.Tensor` or Numpy :oj: np.ndarray instead of a list of python integers.
+                Controls the maximum length of decoder inputs (target language texts or summaries).
+                If left unset or set to :obj:`None`, this will use the max_length value.
+            padding (:obj:`bool`, :obj:`str` or :class:`~transformers.tokenization_utils_base.PaddingStrategy`, `optional`, defaults to :obj:`False`):
+                Activates and controls padding. Accepts the following values:
+                * :obj:`True` or :obj:`'longest'`: Pad to the longest sequence in the batch (or no padding if only a
+                  single sequence if provided).
+                * :obj:`'max_length'`: Pad to a maximum length specified with the argument :obj:`max_length` or to the
+                  maximum acceptable input length for the model if that argument is not provided.
+                * :obj:`False` or :obj:`'do_not_pad'` (default): No padding (i.e., can output a batch with sequences of
+                  different lengths).
+            return_tensors (:obj:`str` or :class:`~transformers.tokenization_utils_base.TensorType`, `optional`, defaults to "pt"):
+                If set, will return tensors instead of list of python integers. Acceptable values are:
+                * :obj:`'tf'`: Return TensorFlow :obj:`tf.constant` objects.
+                * :obj:`'pt'`: Return PyTorch :obj:`torch.Tensor` objects.
+                * :obj:`'np'`: Return Numpy :obj:`np.ndarray` objects.
+            truncation (:obj:`bool`, :obj:`str` or :class:`~transformers.tokenization_utils_base.TruncationStrategy`, `optional`, defaults to :obj:`True`):
+                Activates and controls truncation. Accepts the following values:
+                * :obj:`True` or :obj:`'longest_first'`: Truncate to a maximum length specified with the argument
+                  :obj:`max_length` or to the maximum acceptable input length for the model if that argument is not
+                  provided. This will truncate token by token, removing a token from the longest sequence in the pair
+                  if a pair of sequences (or a batch of pairs) is provided.
+                * :obj:`'only_first'`: Truncate to a maximum length specified with the argument :obj:`max_length` or to
+                  the maximum acceptable input length for the model if that argument is not provided. This will only
+                  truncate the first sequence of a pair if a pair of sequences (or a batch of pairs) is provided.
+                * :obj:`'only_second'`: Truncate to a maximum length specified with the argument :obj:`max_length` or
+                  to the maximum acceptable input length for the model if that argument is not provided. This will only
+                  truncate the second sequence of a pair if a pair of sequences (or a batch of pairs) is provided.
+                * :obj:`False` or :obj:`'do_not_truncate'` (default): No truncation (i.e., can output batch with
+                  sequence lengths greater than the model maximum admissible input size).
             **kwargs:
-                passed to self.__call__
-
+                Additional keyword arguments passed along to :obj:`self.__call__`.
         Returns:
-            :class:`~transformers.BatchEncoding`: with keys input_ids, attention_mask, decoder_input_ids, decoder_attention_mask.
+            :class:`~transformers.BatchEncoding`: A :class:`~transformers.BatchEncoding` with the following fields:
+            - **input_ids** -- List of token ids to be fed to the encoder.
+            - **attention_mask** -- List of indices specifying which tokens should be attended to by the model.
+            - **decoder_input_ids** -- List of token ids to be fed to the decoder.
+            - **decoder_attention_mask** -- List of indices specifying which tokens should be attended to by the decoder.
+                This does not include causal mask, which is built by the model.
+            The full set of keys ``[input_ids, attention_mask, decoder_input_ids,  decoder_attention_mask]``,
+            will only be returned if tgt_texts is passed. Otherwise, input_ids, attention_mask will be the only keys.
         """
         if max_length is None:
             max_length = self.max_len
@@ -275,7 +309,7 @@ class T5Tokenizer(PreTrainedTokenizer):
             return_tensors=return_tensors,
             max_length=max_length,
             padding=padding,
-            truncation=True,
+            truncation=truncation,
             **kwargs,
         )
         if tgt_texts is None:
@@ -291,7 +325,7 @@ class T5Tokenizer(PreTrainedTokenizer):
             return_tensors=return_tensors,
             padding=padding,
             max_length=max_target_length,
-            truncation=True,
+            truncation=truncation,
             **kwargs,
         )
         for k, v in decoder_inputs.items():

--- a/tests/test_tokenization_t5.py
+++ b/tests/test_tokenization_t5.py
@@ -114,17 +114,16 @@ class T5TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             "Summary of the text.",
             "Another summary.",
         ]
-        expected_src_tokens = [71, 307, 8986, 21, 4505, 51, 52, 1707, 5, 1]
+        expected_src_tokens = [71, 307, 8986, 21, 4505, 51, 52, 1707, 5]
         batch = tokenizer.prepare_seq2seq_batch(
             src_text, tgt_texts=tgt_text, max_length=len(expected_src_tokens), return_tensors=FRAMEWORK
         )
         self.assertIsInstance(batch, BatchEncoding)
 
-        self.assertEqual((2, 10), batch.input_ids.shape)
-        self.assertEqual((2, 10), batch.attention_mask.shape)
+        self.assertEqual((2, 9), batch.input_ids.shape)
+        self.assertEqual((2, 9), batch.attention_mask.shape)
         result = batch.input_ids.tolist()[0]
         self.assertListEqual(expected_src_tokens, result)
-        self.assertEqual(1, batch.decoder_input_ids[0, -1])  # EOS
         # Test that special tokens are reset
         self.assertEqual(tokenizer.prefix_tokens, [])
-        self.assertEqual(tokenizer.suffix_tokens, [tokenizer.eos_token_id])
+

--- a/tests/test_tokenization_t5.py
+++ b/tests/test_tokenization_t5.py
@@ -132,10 +132,10 @@ class T5TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         src_text = ["A long paragraph for summrization.", "Another paragraph for summrization."]
         batch = tokenizer.prepare_seq2seq_batch(src_text, return_tensors=FRAMEWORK)
         # check if input_ids are returned and no decoder_input_ids
-        self.assertIn("input_ids", batch.keys())
-        self.assertIn("attention_mask", batch.keys())
-        self.assertNotIn("decoder_input_ids", batch.keys())
-        self.assertNotIn("decoder_attention_mask", batch.keys())
+        self.assertIn("input_ids", batch)
+        self.assertIn("attention_mask", batch)
+        self.assertNotIn("decoder_input_ids", batch)
+        self.assertNotIn("decoder_attention_mask", batch)
 
     def test_max_target_length(self):
         tokenizer = T5Tokenizer.from_pretrained("t5-small")

--- a/tests/test_tokenization_t5.py
+++ b/tests/test_tokenization_t5.py
@@ -122,7 +122,7 @@ class T5TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.assertEqual((2, 9), batch.input_ids.shape)
         self.assertEqual((2, 9), batch.attention_mask.shape)
-        result = batch.input_ids.tolist()[0]
+        result = list(batch.input_ids.numpy()[0])
         self.assertListEqual(expected_src_tokens, result)
         # Test that special tokens are reset
         self.assertEqual(tokenizer.prefix_tokens, [])
@@ -175,8 +175,8 @@ class T5TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         batch = tokenizer.prepare_seq2seq_batch(src_text, tgt_texts=tgt_text, return_tensors=FRAMEWORK)
 
-        src_ids = batch.input_ids.tolist()[0]
-        tgt_ids = batch.decoder_input_ids.tolist()[0]
+        src_ids = list(batch.input_ids.numpy()[0])
+        tgt_ids = list(batch.decoder_input_ids.numpy()[0])
 
         self.assertEqual(expected_src_tokens, src_ids)
         self.assertEqual(expected_tgt_tokens, tgt_ids)


### PR DESCRIPTION
This PR adds `prepare_seq2seq_batch` method to `T5Tokenizer` as per the proposal in #6080

@sshleifer 