### PR TITLE
Enable ONNX/ONNXRuntime optimizations through converter script

### DIFF
--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -45,7 +45,7 @@ Optimizations
 ------------------------------------------------
 
 ONNXRuntime includes some transformers-specific transformations to leverage optimized operations in the graph.
-Below are some of the operators which can be enabled to speed up inference through ONNXRuntime (see 1.):
+Below are some of the operators which can be enabled to speed up inference through ONNXRuntime (*see note below*):
 
 * Constant folding
 * Attention Layer fusing
@@ -63,7 +63,7 @@ Example:
     python convert_graph_to_onnx.py --framework <pt, tf> --model bert-base-cased --optimize bert-base-cased.onnx
 
 .. note::
-    (1) For more information about the optimizations enabled by ONNXRuntime, please have a look at the (`ONNXRuntime Github <https://github.com/microsoft/onnxruntime/tree/master/onnxruntime/python/tools/transformers>`_)
+    For more information about the optimizations enabled by ONNXRuntime, please have a look at the (`ONNXRuntime Github <https://github.com/microsoft/onnxruntime/tree/master/onnxruntime/python/tools/transformers>`_)
 
 Quantization
 ------------------------------------------------
@@ -105,7 +105,7 @@ Example of quantized BERT model export:
     python convert_graph_to_onnx.py --framework <pt, tf> --model bert-base-cased --quantize bert-base-cased.onnx
 
 .. note::
-    (1) Quantization support requires ONNX Runtime >= 1.4.0
+    Quantization support requires ONNX Runtime >= 1.4.0
 
 .. note::
     When exporting quantized model you will end up with two different ONNX files. The one specified at the end of the

--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -5,7 +5,7 @@ Exporting transformers models
 ONNX / ONNXRuntime
 ==============================================
 
-Projects ONNX (Open Neural Network eXchange) and ONNXRuntime (ORT) are part of an effort from leading industries in the AI field
+Projects `ONNX (Open Neural Network eXchange) <http://onnx.ai>`_ and `ONNXRuntime (ORT) <https://microsoft.github.io/onnxruntime/>`_ are part of an effort from leading industries in the AI field
 to provide a unified and community-driven format to store and, by extension, efficiently execute neural network leveraging a variety
 of hardware and dedicated optimizations.
 
@@ -34,9 +34,36 @@ The conversion tool works for both PyTorch and Tensorflow models and ensures:
 
 Also, the conversion tool supports different options which let you tune the behavior of the generated model:
 
-* Change the target opset version of the generated model: More recent opset generally supports more operator and enables faster inference.
-* Export pipeline specific prediction heads: Allow to export model along with its task-specific prediction head(s).
-* Use the external data format (PyTorch only): Lets you export model which size is above 2Gb (`More info <https://github.com/pytorch/pytorch/pull/33062>`_).
+* **Change the target opset version of the generated model.**  (More recent opset generally supports more operator and enables faster inference)
+
+* **Export pipeline specific prediction heads.**  (Allow to export model along with its task-specific prediction head(s))
+
+* **Use the external data format (PyTorch only).**  (Lets you export model which size is above 2Gb (`More info <https://github.com/pytorch/pytorch/pull/33062>`_))
+
+
+Optimizations
+------------------------------------------------
+
+ONNXRuntime includes some transformers-specific transformations to leverage optimized operations in the graph.
+Below are some of the operators which can be enabled to speed up inference through ONNXRuntime (1):
+
+* Constant folding
+* Attention Layer fusing
+* Skip connection LayerNormalization fusing
+* FastGeLU approximation
+
+
+Fortunately, you can let ONNXRuntime find all the possible optimized operators for you. Simply add ``--optimize``
+when exporting your model through ``convert_graph_to_onnx.py``.
+
+Example:
+
+.. code-block:: bash
+
+    python convert_graph_to_onnx.py --framework <pt, tf> --model bert-base-cased --optimize bert-base-cased.onnx
+
+.. note::
+    (1) For more information about the optimizations enabled by ONNXRuntime, please have a look at the (`ONNXRuntime Github <https://github.com/microsoft/onnxruntime/tree/master/onnxruntime/python/tools/transformers>`_)
 
 Quantization
 ------------------------------------------------
@@ -78,13 +105,15 @@ Example of quantized BERT model export:
     python convert_graph_to_onnx.py --framework <pt, tf> --model bert-base-cased --quantize bert-base-cased.onnx
 
 .. note::
-    Quantization support requires ONNX Runtime >= 1.4.0
+    (1) Quantization support requires ONNX Runtime >= 1.4.0
 
 .. note::
     When exporting quantized model you will end up with two different ONNX files. The one specified at the end of the
     above command will contain the original ONNX model storing `float32` weights.
     The second one, with ``-quantized`` suffix, will hold the quantized parameters.
 
+.. note::
+    The quantization export gives the best performances when used in combination with ``--optimize``.
 
 TorchScript
 =======================================

--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -34,7 +34,7 @@ The conversion tool works for both PyTorch and Tensorflow models and ensures:
 
 Also, the conversion tool supports different options which let you tune the behavior of the generated model:
 
-* **Change the target opset version of the generated model.**  (More recent opset generally supports more operator and enables faster inference)
+* **Change the target opset version of the generated model.**  (More recent opset generally supports more operators and enables faster inference)
 
 * **Export pipeline-specific prediction heads.**  (Allow to export model along with its task-specific prediction head(s))
 

--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -36,7 +36,7 @@ Also, the conversion tool supports different options which let you tune the beha
 
 * **Change the target opset version of the generated model.**  (More recent opset generally supports more operator and enables faster inference)
 
-* **Export pipeline specific prediction heads.**  (Allow to export model along with its task-specific prediction head(s))
+* **Export pipeline-specific prediction heads.**  (Allow to export model along with its task-specific prediction head(s))
 
 * **Use the external data format (PyTorch only).**  (Lets you export model which size is above 2Gb (`More info <https://github.com/pytorch/pytorch/pull/33062>`_))
 

--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -45,7 +45,7 @@ Optimizations
 ------------------------------------------------
 
 ONNXRuntime includes some transformers-specific transformations to leverage optimized operations in the graph.
-Below are some of the operators which can be enabled to speed up inference through ONNXRuntime (1):
+Below are some of the operators which can be enabled to speed up inference through ONNXRuntime (see 1.):
 
 * Constant folding
 * Attention Layer fusing

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -55,9 +55,6 @@ class OnnxConverterArgumentParser(ArgumentParser):
             "--use-external-format", action="store_true", help="Allow exporting model >= than 2Gb",
         )
         self.add_argument(
-            "--optimize", action="store_true", help="Let ONNX Runtime apply all the optimisations on the graph"
-        )
-        self.add_argument(
             "--quantize", action="store_true", help="Quantize the neural network to be run with int8",
         )
         self.add_argument("output")

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -3,7 +3,7 @@ from os import listdir, makedirs
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from packaging.version import parse, Version
+from packaging.version import Version, parse
 
 from transformers import is_tf_available, is_torch_available
 from transformers.file_utils import ModelOutput

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -367,6 +367,13 @@ def quantize(onnx_model_path: Path) -> Path:
         from onnxruntime.quantization import quantize, QuantizationMode
 
         onnx_model = onnx.load(onnx_model_path.as_posix())
+
+        # Discussed with @yufenglee from ONNX runtime, this will be address in the next release of onnxruntime
+        print(
+            "As of onnxruntime 1.4.0, models larger than 2GB will fail to quantize due to protobuf constraint.\n"
+            "This limitation will be removed in the next release of onnxruntime."
+        )
+
         quantized_model = quantize(
             model=onnx_model, quantization_mode=QuantizationMode.IntegerOps, force_fusions=True, symmetric_weight=True,
         )

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -427,7 +427,10 @@ if __name__ == "__main__":
             # onnxruntime optimizations doesn't provide the same level of performances on TensorFlow than PyTorch
             if args.framework == "tf":
                 print(
-                    "\t Using TensorFlow might not provide the same level of optimization compared to the PyTorch one."
+                    "\t Using TensorFlow might not provide the same optimization level compared to PyTorch.\n"
+                    "\t For TensorFlow users you can try optimizing the model directly through onnxruntime_tools.\n"
+                    "\t For more information, please refer to the onnxruntime documentation:\n"
+                    "\t\thttps://github.com/microsoft/onnxruntime/tree/master/onnxruntime/python/tools/transformers\n"
                 )
 
             # Quantization works best when using the optimized version of the model

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -421,6 +421,12 @@ if __name__ == "__main__":
 
         print("\n====== Optimizing ONNX model ======")
         if args.optimize:
+            if args.framework == "tf":
+                print(
+                    "\t Using TensorFlow exported might not provide the same level of optimization"
+                    " compared to the PyTorch one."
+                )
+
             check_onnxruntime_requirements(ORT_TRANSFORMERS_OPTIM_MINIMUM_VERSION)
             args.optimized_output = optimize(args.output)
 

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -423,7 +423,6 @@ if __name__ == "__main__":
             args.pipeline,
         )
 
-        print("\n====== Optimizing ONNX model ======")
         if args.quantize:
             # Ensure requirements for quantization on onnxruntime is met
             check_onnxruntime_requirements(ORT_QUANTIZE_MINIMUM_VERSION)
@@ -436,6 +435,8 @@ if __name__ == "__main__":
                     "\t For more information, please refer to the onnxruntime documentation:\n"
                     "\t\thttps://github.com/microsoft/onnxruntime/tree/master/onnxruntime/python/tools/transformers\n"
                 )
+
+            print("\n====== Optimizing ONNX model ======")
 
             # Quantization works best when using the optimized version of the model
             args.optimized_output = optimize(args.output)


### PR DESCRIPTION
Introduce `--optimize` CLI argument and `optimize()` method to allow ONNXRuntime to operates all the possible optimizations on the raw ONNX IR.

Added documentation for this parameter in the ONNX/ONNXRuntime section on the doc.