### PR TITLE
Add Pytorch Native AMP support in Trainer

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -51,8 +51,7 @@ try:
 except ImportError:
     # Older PyTorch compatibility
     class Identity(nn.Module):
-        r"""A placeholder identity operator that is argument-insensitive.
-        """
+        r"""A placeholder identity operator that is argument-insensitive."""
 
         def __init__(self, *args, **kwargs):
             super().__init__()
@@ -157,8 +156,10 @@ class ModuleUtilsMixin:
     @property
     def device(self) -> device:
         """
-        :obj:`torch.device`: The device on which the module is (assuming that all the module parameters are on the same
-        device).
+        The device on which the module is (assuming that all the module parameters are on the same device).
+
+        Returns:
+            :obj:`torch.device` The device of the module.
         """
         try:
             return next(self.parameters()).device
@@ -176,7 +177,10 @@ class ModuleUtilsMixin:
     @property
     def dtype(self) -> dtype:
         """
-        :obj:`torch.dtype`: The dtype of the module (assuming that all the module parameters have the same dtype).
+        The dtype of the module (assuming that all the module parameters have the same dtype).
+
+        Returns:
+            :obj:`torch.dtype` The dtype of the module.
         """
         try:
             return next(self.parameters()).dtype
@@ -274,7 +278,7 @@ class ModuleUtilsMixin:
         return extended_attention_mask
 
     def get_head_mask(
-        self, head_mask: Optional[Tensor], num_hidden_layers: int, is_attention_chunked: bool = False
+        self, head_mask: Optional[Tensor], num_hidden_layers: int, is_attention_chunked: bool = False,
     ) -> Tensor:
         """
         Prepare the head mask if needed.
@@ -345,8 +349,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
 
     @property
     def dummy_inputs(self) -> Dict[str, torch.Tensor]:
-        """
-        :obj:`Dict[str, torch.Tensor]`: Dummy inputs to do a forward pass in the network.
+        """Dummy inputs to do a forward pass in the network.
+
+        Returns:
+            :obj:`Dict[str, torch.Tensor]`: The dummy inputs.
         """
         return {"input_ids": torch.tensor(DUMMY_INPUTS)}
 
@@ -354,9 +360,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
         super().__init__()
         if not isinstance(config, PretrainedConfig):
             raise ValueError(
-                "Parameter config in `{}(config)` should be an instance of class `PretrainedConfig`. "
-                "To create a model from a pretrained model use "
-                "`model = {}.from_pretrained(PRETRAINED_MODEL_NAME)`".format(
+                "Parameter config in `{}(config)` should be an instance of class"
+                " `PretrainedConfig`. To create a model from a pretrained model use"
+                " `model = {}.from_pretrained(PRETRAINED_MODEL_NAME)`".format(
                     self.__class__.__name__, self.__class__.__name__
                 )
             )
@@ -364,10 +370,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
         self.config = config
 
     @property
-    def base_model(self) -> nn.Module:
-        """
-        :obj:`torch.nn.Module`: The main body of the model.
-        """
+    def base_model(self):
         return getattr(self, self.base_model_prefix, self)
 
     def get_input_embeddings(self) -> nn.Module:
@@ -417,8 +420,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
             self._tie_or_clone_weights(output_embeddings, self.get_input_embeddings())
 
     def _tie_or_clone_weights(self, output_embeddings, input_embeddings):
-        """ Tie or clone module weights depending of whether we are using TorchScript or not
-        """
+        """Tie or clone module weights depending of whether we are using TorchScript or not"""
         if self.config.torchscript:
             output_embeddings.weight = nn.Parameter(input_embeddings.weight.clone())
         else:
@@ -729,17 +731,16 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
                 else:
                     raise EnvironmentError(
                         "Error no file named {} found in directory {} or `from_tf` set to False".format(
-                            [WEIGHTS_NAME, TF2_WEIGHTS_NAME, TF_WEIGHTS_NAME + ".index"],
+                            [WEIGHTS_NAME, TF2_WEIGHTS_NAME, TF_WEIGHTS_NAME + ".index",],
                             pretrained_model_name_or_path,
                         )
                     )
             elif os.path.isfile(pretrained_model_name_or_path) or is_remote_url(pretrained_model_name_or_path):
                 archive_file = pretrained_model_name_or_path
             elif os.path.isfile(pretrained_model_name_or_path + ".index"):
-                assert (
-                    from_tf
-                ), "We found a TensorFlow checkpoint at {}, please set from_tf to True to load from this checkpoint".format(
-                    pretrained_model_name_or_path + ".index"
+                assert from_tf, (
+                    "We found a TensorFlow checkpoint at {}, please set from_tf to True"
+                    " to load from this checkpoint".format(pretrained_model_name_or_path + ".index")
                 )
                 archive_file = pretrained_model_name_or_path + ".index"
             else:
@@ -763,9 +764,12 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
                     raise EnvironmentError
             except EnvironmentError:
                 msg = (
-                    f"Can't load weights for '{pretrained_model_name_or_path}'. Make sure that:\n\n"
-                    f"- '{pretrained_model_name_or_path}' is a correct model identifier listed on 'https://huggingface.co/models'\n\n"
-                    f"- or '{pretrained_model_name_or_path}' is the correct path to a directory containing a file named one of {WEIGHTS_NAME}, {TF2_WEIGHTS_NAME}, {TF_WEIGHTS_NAME}.\n\n"
+                    f"Can't load weights for '{pretrained_model_name_or_path}'. Make"
+                    f" sure that:\n\n- '{pretrained_model_name_or_path}' is a correct"
+                    " model identifier listed on 'https://huggingface.co/models'\n\n-"
+                    f" or '{pretrained_model_name_or_path}' is the correct path to a"
+                    f" directory containing a file named one of {WEIGHTS_NAME},"
+                    f" {TF2_WEIGHTS_NAME}, {TF_WEIGHTS_NAME}.\n\n"
                 )
                 raise EnvironmentError(msg)
 
@@ -784,8 +788,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
                 state_dict = torch.load(resolved_archive_file, map_location="cpu")
             except Exception:
                 raise OSError(
-                    "Unable to load weights from pytorch checkpoint file. "
-                    "If you tried to load a PyTorch model from a TF 2.0 checkpoint, please set from_tf=True. "
+                    "Unable to load weights from pytorch checkpoint file. If you tried"
+                    " to load a PyTorch model from a TF 2.0 checkpoint, please set"
+                    " from_tf=True. "
                 )
 
         missing_keys = []
@@ -804,8 +809,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
                     model = load_tf2_checkpoint_in_pytorch_model(model, resolved_archive_file, allow_missing_keys=True)
                 except ImportError:
                     logger.error(
-                        "Loading a TensorFlow model in PyTorch, requires both PyTorch and TensorFlow to be installed. Please see "
-                        "https://pytorch.org/ and https://www.tensorflow.org/install/ for installation instructions."
+                        "Loading a TensorFlow model in PyTorch, requires both PyTorch"
+                        " and TensorFlow to be installed. Please see"
+                        " https://pytorch.org/ and https://www.tensorflow.org/install/"
+                        " for installation instructions."
                     )
                     raise
         else:
@@ -867,26 +874,37 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
 
             if len(unexpected_keys) > 0:
                 logger.warning(
-                    f"Some weights of the model checkpoint at {pretrained_model_name_or_path} were not used when "
-                    f"initializing {model.__class__.__name__}: {unexpected_keys}\n"
-                    f"- This IS expected if you are initializing {model.__class__.__name__} from the checkpoint of a model trained on another task "
-                    f"or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPretraining model).\n"
-                    f"- This IS NOT expected if you are initializing {model.__class__.__name__} from the checkpoint of a model that you expect "
-                    f"to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model)."
+                    "Some weights of the model checkpoint at"
+                    f" {pretrained_model_name_or_path} were not used when initializing"
+                    f" {model.__class__.__name__}: {unexpected_keys}\n- This IS"
+                    f" expected if you are initializing {model.__class__.__name__} from"
+                    " the checkpoint of a model trained on another task or with"
+                    " another architecture (e.g. initializing a"
+                    " BertForSequenceClassification model from a BertForPretraining"
+                    " model).\n- This IS NOT expected if you are initializing"
+                    f" {model.__class__.__name__} from the checkpoint of a model that"
+                    " you expect to be exactly identical (initializing a"
+                    " BertForSequenceClassification model from a"
+                    " BertForSequenceClassification model)."
                 )
             else:
                 logger.info(f"All model checkpoint weights were used when initializing {model.__class__.__name__}.\n")
             if len(missing_keys) > 0:
                 logger.warning(
-                    f"Some weights of {model.__class__.__name__} were not initialized from the model checkpoint at {pretrained_model_name_or_path} "
-                    f"and are newly initialized: {missing_keys}\n"
-                    f"You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference."
+                    f"Some weights of {model.__class__.__name__} were not initialized"
+                    f" from the model checkpoint at {pretrained_model_name_or_path} and"
+                    f" are newly initialized: {missing_keys}\nYou should probably TRAIN"
+                    " this model on a down-stream task to be able to use it for"
+                    " predictions and inference."
                 )
             else:
                 logger.info(
-                    f"All the weights of {model.__class__.__name__} were initialized from the model checkpoint at {pretrained_model_name_or_path}.\n"
-                    f"If your task is similar to the task the model of the ckeckpoint was trained on, "
-                    f"you can already use {model.__class__.__name__} for predictions without further training."
+                    f"All the weights of {model.__class__.__name__} were initialized"
+                    " from the model checkpoint at"
+                    f" {pretrained_model_name_or_path}.\nIf your task is similar to the"
+                    " task the model of the checkpoint was trained on, you can already"
+                    f" use {model.__class__.__name__} for predictions without further"
+                    " training."
                 )
             if len(error_msgs) > 0:
                 raise RuntimeError(
@@ -956,7 +974,7 @@ class PoolerStartLogits(nn.Module):
         self.dense = nn.Linear(config.hidden_size, 1)
 
     def forward(
-        self, hidden_states: torch.FloatTensor, p_mask: Optional[torch.FloatTensor] = None
+        self, hidden_states: torch.FloatTensor, p_mask: Optional[torch.FloatTensor] = None,
     ) -> torch.FloatTensor:
         """
         Args:
@@ -1170,24 +1188,24 @@ class SQuADHead(nn.Module):
         return_tuple: bool = False,
     ) -> Union[SquadHeadOutput, Tuple[torch.FloatTensor]]:
         """
-    Args:
-        hidden_states (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, seq_len, hidden_size)`):
-            Final hidden states of the model on the sequence tokens.
-        start_positions (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
-            Positions of the first token for the labeled span.
-        end_positions (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
-            Positions of the last token for the labeled span.
-        cls_index (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
-            Position of the CLS token for each sentence in the batch. If :obj:`None`, takes the last token.
-        is_impossible (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
-            Whether the question has a possible answer in the paragraph or not.
-        p_mask (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, seq_len)`, `optional`):
-            Mask for tokens at invalid position, such as query and special symbols (PAD, SEP, CLS).
-            1.0 means token should be masked.
-        return_tuple (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            Whether or not to return a plain tuple instead of a :class:`~transformers.file_utils.ModelOuput`.
+        Args:
+            hidden_states (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, seq_len, hidden_size)`):
+                Final hidden states of the model on the sequence tokens.
+            start_positions (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
+                Positions of the first token for the labeled span.
+            end_positions (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
+                Positions of the last token for the labeled span.
+            cls_index (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
+                Position of the CLS token for each sentence in the batch. If :obj:`None`, takes the last token.
+            is_impossible (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
+                Whether the question has a possible answer in the paragraph or not.
+            p_mask (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, seq_len)`, `optional`):
+                Mask for tokens at invalid position, such as query and special symbols (PAD, SEP, CLS).
+                1.0 means token should be masked.
+            return_tuple (:obj:`bool`, `optional`, defaults to :obj:`False`):
+                Whether or not to return a plain tuple instead of a :class:`~transformers.file_utils.ModelOuput`.
 
-    Returns:
+        Returns:
         """
         start_logits = self.start_logits(hidden_states, p_mask=p_mask)
 
@@ -1245,7 +1263,13 @@ class SQuADHead(nn.Module):
             cls_logits = self.answer_class(hidden_states, start_states=start_states, cls_index=cls_index)
 
             if return_tuple:
-                return (start_top_log_probs, start_top_index, end_top_log_probs, end_top_index, cls_logits)
+                return (
+                    start_top_log_probs,
+                    start_top_index,
+                    end_top_log_probs,
+                    end_top_index,
+                    cls_logits,
+                )
             else:
                 return SquadHeadOutput(
                     start_top_log_probs=start_top_log_probs,
@@ -1303,7 +1327,7 @@ class SequenceSummary(nn.Module):
             self.summary = nn.Linear(config.hidden_size, num_classes)
 
         activation_string = getattr(config, "summary_activation", None)
-        self.activation: Callable = (get_activation(activation_string) if activation_string else Identity())
+        self.activation: Callable = get_activation(activation_string) if activation_string else Identity()
 
         self.first_dropout = Identity()
         if hasattr(config, "summary_first_dropout") and config.summary_first_dropout > 0:
@@ -1314,7 +1338,7 @@ class SequenceSummary(nn.Module):
             self.last_dropout = nn.Dropout(config.summary_last_dropout)
 
     def forward(
-        self, hidden_states: torch.FloatTensor, cls_index: Optional[torch.LongTensor] = None
+        self, hidden_states: torch.FloatTensor, cls_index: Optional[torch.LongTensor] = None,
     ) -> torch.FloatTensor:
         """
         Compute a single vector summary of a sequence hidden states.
@@ -1422,7 +1446,7 @@ def prune_conv1d_layer(layer: Conv1D, index: torch.LongTensor, dim: int = 1) -> 
 
 
 def prune_layer(
-    layer: Union[torch.nn.Linear, Conv1D], index: torch.LongTensor, dim: Optional[int] = None
+    layer: Union[torch.nn.Linear, Conv1D], index: torch.LongTensor, dim: Optional[int] = None,
 ) -> Union[torch.nn.Linear, Conv1D]:
     """
     Prune a Conv1D or linear layer to keep only entries in index.
@@ -1447,7 +1471,7 @@ def prune_layer(
 
 
 def apply_chunking_to_forward(
-    chunk_size: int, chunk_dim: int, forward_fn: Callable[..., torch.Tensor], *input_tensors
+    chunk_size: int, chunk_dim: int, forward_fn: Callable[..., torch.Tensor], *input_tensors,
 ) -> torch.Tensor:
     """
     This function chunks the :obj:`input_tensors` into smaller input tensor parts of size :obj:`chunk_size` over the

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -51,7 +51,8 @@ try:
 except ImportError:
     # Older PyTorch compatibility
     class Identity(nn.Module):
-        r"""A placeholder identity operator that is argument-insensitive."""
+        r"""A placeholder identity operator that is argument-insensitive.
+        """
 
         def __init__(self, *args, **kwargs):
             super().__init__()
@@ -156,10 +157,8 @@ class ModuleUtilsMixin:
     @property
     def device(self) -> device:
         """
-        The device on which the module is (assuming that all the module parameters are on the same device).
-
-        Returns:
-            :obj:`torch.device` The device of the module.
+        :obj:`torch.device`: The device on which the module is (assuming that all the module parameters are on the same
+        device).
         """
         try:
             return next(self.parameters()).device
@@ -177,10 +176,7 @@ class ModuleUtilsMixin:
     @property
     def dtype(self) -> dtype:
         """
-        The dtype of the module (assuming that all the module parameters have the same dtype).
-
-        Returns:
-            :obj:`torch.dtype` The dtype of the module.
+        :obj:`torch.dtype`: The dtype of the module (assuming that all the module parameters have the same dtype).
         """
         try:
             return next(self.parameters()).dtype
@@ -278,7 +274,7 @@ class ModuleUtilsMixin:
         return extended_attention_mask
 
     def get_head_mask(
-        self, head_mask: Optional[Tensor], num_hidden_layers: int, is_attention_chunked: bool = False,
+        self, head_mask: Optional[Tensor], num_hidden_layers: int, is_attention_chunked: bool = False
     ) -> Tensor:
         """
         Prepare the head mask if needed.
@@ -349,10 +345,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
 
     @property
     def dummy_inputs(self) -> Dict[str, torch.Tensor]:
-        """Dummy inputs to do a forward pass in the network.
-
-        Returns:
-            :obj:`Dict[str, torch.Tensor]`: The dummy inputs.
+        """
+        :obj:`Dict[str, torch.Tensor]`: Dummy inputs to do a forward pass in the network.
         """
         return {"input_ids": torch.tensor(DUMMY_INPUTS)}
 
@@ -360,9 +354,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
         super().__init__()
         if not isinstance(config, PretrainedConfig):
             raise ValueError(
-                "Parameter config in `{}(config)` should be an instance of class"
-                " `PretrainedConfig`. To create a model from a pretrained model use"
-                " `model = {}.from_pretrained(PRETRAINED_MODEL_NAME)`".format(
+                "Parameter config in `{}(config)` should be an instance of class `PretrainedConfig`. "
+                "To create a model from a pretrained model use "
+                "`model = {}.from_pretrained(PRETRAINED_MODEL_NAME)`".format(
                     self.__class__.__name__, self.__class__.__name__
                 )
             )
@@ -370,7 +364,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
         self.config = config
 
     @property
-    def base_model(self):
+    def base_model(self) -> nn.Module:
+        """
+        :obj:`torch.nn.Module`: The main body of the model.
+        """
         return getattr(self, self.base_model_prefix, self)
 
     def get_input_embeddings(self) -> nn.Module:
@@ -420,7 +417,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
             self._tie_or_clone_weights(output_embeddings, self.get_input_embeddings())
 
     def _tie_or_clone_weights(self, output_embeddings, input_embeddings):
-        """Tie or clone module weights depending of whether we are using TorchScript or not"""
+        """ Tie or clone module weights depending of whether we are using TorchScript or not
+        """
         if self.config.torchscript:
             output_embeddings.weight = nn.Parameter(input_embeddings.weight.clone())
         else:
@@ -731,16 +729,17 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
                 else:
                     raise EnvironmentError(
                         "Error no file named {} found in directory {} or `from_tf` set to False".format(
-                            [WEIGHTS_NAME, TF2_WEIGHTS_NAME, TF_WEIGHTS_NAME + ".index",],
+                            [WEIGHTS_NAME, TF2_WEIGHTS_NAME, TF_WEIGHTS_NAME + ".index"],
                             pretrained_model_name_or_path,
                         )
                     )
             elif os.path.isfile(pretrained_model_name_or_path) or is_remote_url(pretrained_model_name_or_path):
                 archive_file = pretrained_model_name_or_path
             elif os.path.isfile(pretrained_model_name_or_path + ".index"):
-                assert from_tf, (
-                    "We found a TensorFlow checkpoint at {}, please set from_tf to True"
-                    " to load from this checkpoint".format(pretrained_model_name_or_path + ".index")
+                assert (
+                    from_tf
+                ), "We found a TensorFlow checkpoint at {}, please set from_tf to True to load from this checkpoint".format(
+                    pretrained_model_name_or_path + ".index"
                 )
                 archive_file = pretrained_model_name_or_path + ".index"
             else:
@@ -764,12 +763,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
                     raise EnvironmentError
             except EnvironmentError:
                 msg = (
-                    f"Can't load weights for '{pretrained_model_name_or_path}'. Make"
-                    f" sure that:\n\n- '{pretrained_model_name_or_path}' is a correct"
-                    " model identifier listed on 'https://huggingface.co/models'\n\n-"
-                    f" or '{pretrained_model_name_or_path}' is the correct path to a"
-                    f" directory containing a file named one of {WEIGHTS_NAME},"
-                    f" {TF2_WEIGHTS_NAME}, {TF_WEIGHTS_NAME}.\n\n"
+                    f"Can't load weights for '{pretrained_model_name_or_path}'. Make sure that:\n\n"
+                    f"- '{pretrained_model_name_or_path}' is a correct model identifier listed on 'https://huggingface.co/models'\n\n"
+                    f"- or '{pretrained_model_name_or_path}' is the correct path to a directory containing a file named one of {WEIGHTS_NAME}, {TF2_WEIGHTS_NAME}, {TF_WEIGHTS_NAME}.\n\n"
                 )
                 raise EnvironmentError(msg)
 
@@ -788,9 +784,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
                 state_dict = torch.load(resolved_archive_file, map_location="cpu")
             except Exception:
                 raise OSError(
-                    "Unable to load weights from pytorch checkpoint file. If you tried"
-                    " to load a PyTorch model from a TF 2.0 checkpoint, please set"
-                    " from_tf=True. "
+                    "Unable to load weights from pytorch checkpoint file. "
+                    "If you tried to load a PyTorch model from a TF 2.0 checkpoint, please set from_tf=True. "
                 )
 
         missing_keys = []
@@ -809,10 +804,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
                     model = load_tf2_checkpoint_in_pytorch_model(model, resolved_archive_file, allow_missing_keys=True)
                 except ImportError:
                     logger.error(
-                        "Loading a TensorFlow model in PyTorch, requires both PyTorch"
-                        " and TensorFlow to be installed. Please see"
-                        " https://pytorch.org/ and https://www.tensorflow.org/install/"
-                        " for installation instructions."
+                        "Loading a TensorFlow model in PyTorch, requires both PyTorch and TensorFlow to be installed. Please see "
+                        "https://pytorch.org/ and https://www.tensorflow.org/install/ for installation instructions."
                     )
                     raise
         else:
@@ -874,37 +867,26 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
 
             if len(unexpected_keys) > 0:
                 logger.warning(
-                    "Some weights of the model checkpoint at"
-                    f" {pretrained_model_name_or_path} were not used when initializing"
-                    f" {model.__class__.__name__}: {unexpected_keys}\n- This IS"
-                    f" expected if you are initializing {model.__class__.__name__} from"
-                    " the checkpoint of a model trained on another task or with"
-                    " another architecture (e.g. initializing a"
-                    " BertForSequenceClassification model from a BertForPretraining"
-                    " model).\n- This IS NOT expected if you are initializing"
-                    f" {model.__class__.__name__} from the checkpoint of a model that"
-                    " you expect to be exactly identical (initializing a"
-                    " BertForSequenceClassification model from a"
-                    " BertForSequenceClassification model)."
+                    f"Some weights of the model checkpoint at {pretrained_model_name_or_path} were not used when "
+                    f"initializing {model.__class__.__name__}: {unexpected_keys}\n"
+                    f"- This IS expected if you are initializing {model.__class__.__name__} from the checkpoint of a model trained on another task "
+                    f"or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPretraining model).\n"
+                    f"- This IS NOT expected if you are initializing {model.__class__.__name__} from the checkpoint of a model that you expect "
+                    f"to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model)."
                 )
             else:
                 logger.info(f"All model checkpoint weights were used when initializing {model.__class__.__name__}.\n")
             if len(missing_keys) > 0:
                 logger.warning(
-                    f"Some weights of {model.__class__.__name__} were not initialized"
-                    f" from the model checkpoint at {pretrained_model_name_or_path} and"
-                    f" are newly initialized: {missing_keys}\nYou should probably TRAIN"
-                    " this model on a down-stream task to be able to use it for"
-                    " predictions and inference."
+                    f"Some weights of {model.__class__.__name__} were not initialized from the model checkpoint at {pretrained_model_name_or_path} "
+                    f"and are newly initialized: {missing_keys}\n"
+                    f"You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference."
                 )
             else:
                 logger.info(
-                    f"All the weights of {model.__class__.__name__} were initialized"
-                    " from the model checkpoint at"
-                    f" {pretrained_model_name_or_path}.\nIf your task is similar to the"
-                    " task the model of the checkpoint was trained on, you can already"
-                    f" use {model.__class__.__name__} for predictions without further"
-                    " training."
+                    f"All the weights of {model.__class__.__name__} were initialized from the model checkpoint at {pretrained_model_name_or_path}.\n"
+                    f"If your task is similar to the task the model of the ckeckpoint was trained on, "
+                    f"you can already use {model.__class__.__name__} for predictions without further training."
                 )
             if len(error_msgs) > 0:
                 raise RuntimeError(
@@ -974,7 +956,7 @@ class PoolerStartLogits(nn.Module):
         self.dense = nn.Linear(config.hidden_size, 1)
 
     def forward(
-        self, hidden_states: torch.FloatTensor, p_mask: Optional[torch.FloatTensor] = None,
+        self, hidden_states: torch.FloatTensor, p_mask: Optional[torch.FloatTensor] = None
     ) -> torch.FloatTensor:
         """
         Args:
@@ -1188,24 +1170,24 @@ class SQuADHead(nn.Module):
         return_tuple: bool = False,
     ) -> Union[SquadHeadOutput, Tuple[torch.FloatTensor]]:
         """
-        Args:
-            hidden_states (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, seq_len, hidden_size)`):
-                Final hidden states of the model on the sequence tokens.
-            start_positions (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
-                Positions of the first token for the labeled span.
-            end_positions (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
-                Positions of the last token for the labeled span.
-            cls_index (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
-                Position of the CLS token for each sentence in the batch. If :obj:`None`, takes the last token.
-            is_impossible (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
-                Whether the question has a possible answer in the paragraph or not.
-            p_mask (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, seq_len)`, `optional`):
-                Mask for tokens at invalid position, such as query and special symbols (PAD, SEP, CLS).
-                1.0 means token should be masked.
-            return_tuple (:obj:`bool`, `optional`, defaults to :obj:`False`):
-                Whether or not to return a plain tuple instead of a :class:`~transformers.file_utils.ModelOuput`.
+    Args:
+        hidden_states (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, seq_len, hidden_size)`):
+            Final hidden states of the model on the sequence tokens.
+        start_positions (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
+            Positions of the first token for the labeled span.
+        end_positions (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
+            Positions of the last token for the labeled span.
+        cls_index (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
+            Position of the CLS token for each sentence in the batch. If :obj:`None`, takes the last token.
+        is_impossible (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
+            Whether the question has a possible answer in the paragraph or not.
+        p_mask (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, seq_len)`, `optional`):
+            Mask for tokens at invalid position, such as query and special symbols (PAD, SEP, CLS).
+            1.0 means token should be masked.
+        return_tuple (:obj:`bool`, `optional`, defaults to :obj:`False`):
+            Whether or not to return a plain tuple instead of a :class:`~transformers.file_utils.ModelOuput`.
 
-        Returns:
+    Returns:
         """
         start_logits = self.start_logits(hidden_states, p_mask=p_mask)
 
@@ -1263,13 +1245,7 @@ class SQuADHead(nn.Module):
             cls_logits = self.answer_class(hidden_states, start_states=start_states, cls_index=cls_index)
 
             if return_tuple:
-                return (
-                    start_top_log_probs,
-                    start_top_index,
-                    end_top_log_probs,
-                    end_top_index,
-                    cls_logits,
-                )
+                return (start_top_log_probs, start_top_index, end_top_log_probs, end_top_index, cls_logits)
             else:
                 return SquadHeadOutput(
                     start_top_log_probs=start_top_log_probs,
@@ -1327,7 +1303,7 @@ class SequenceSummary(nn.Module):
             self.summary = nn.Linear(config.hidden_size, num_classes)
 
         activation_string = getattr(config, "summary_activation", None)
-        self.activation: Callable = get_activation(activation_string) if activation_string else Identity()
+        self.activation: Callable = (get_activation(activation_string) if activation_string else Identity())
 
         self.first_dropout = Identity()
         if hasattr(config, "summary_first_dropout") and config.summary_first_dropout > 0:
@@ -1338,7 +1314,7 @@ class SequenceSummary(nn.Module):
             self.last_dropout = nn.Dropout(config.summary_last_dropout)
 
     def forward(
-        self, hidden_states: torch.FloatTensor, cls_index: Optional[torch.LongTensor] = None,
+        self, hidden_states: torch.FloatTensor, cls_index: Optional[torch.LongTensor] = None
     ) -> torch.FloatTensor:
         """
         Compute a single vector summary of a sequence hidden states.
@@ -1446,7 +1422,7 @@ def prune_conv1d_layer(layer: Conv1D, index: torch.LongTensor, dim: int = 1) -> 
 
 
 def prune_layer(
-    layer: Union[torch.nn.Linear, Conv1D], index: torch.LongTensor, dim: Optional[int] = None,
+    layer: Union[torch.nn.Linear, Conv1D], index: torch.LongTensor, dim: Optional[int] = None
 ) -> Union[torch.nn.Linear, Conv1D]:
     """
     Prune a Conv1D or linear layer to keep only entries in index.
@@ -1471,7 +1447,7 @@ def prune_layer(
 
 
 def apply_chunking_to_forward(
-    chunk_size: int, chunk_dim: int, forward_fn: Callable[..., torch.Tensor], *input_tensors,
+    chunk_size: int, chunk_dim: int, forward_fn: Callable[..., torch.Tensor], *input_tensors
 ) -> torch.Tensor:
     """
     This function chunks the :obj:`input_tensors` into smaller input tensor parts of size :obj:`chunk_size` over the

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -544,7 +544,7 @@ class Trainer:
                     elif self.args.fp16 and _use_apex:
                         torch.nn.utils.clip_grad_norm_(amp.master_params(optimizer), self.args.max_grad_norm)
                     else:
-                        torch.nn.utils.clip_grad_norm(model.parameters(), self.args.max_grad_norm)
+                        torch.nn.utils.clip_grad_norm_(model.parameters(), self.args.max_grad_norm)
 
                     if is_torch_tpu_available():
                         xm.optimizer_step(optimizer)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -385,8 +385,7 @@ class Trainer:
         """
         if hasattr(self, "_setup_wandb"):
             warnings.warn(
-                "The `_setup_wandb` method is deprecated and won't be called in a future version, define `setup_wandb`"
-                " in your subclass.",
+                "The `_setup_wandb` method is deprecated and won't be called in a future version, define `setup_wandb` in your subclass.",
                 FutureWarning,
             )
             return self._setup_wandb()
@@ -628,8 +627,7 @@ class Trainer:
         """
         if hasattr(self, "_log"):
             warnings.warn(
-                "The `_log` method is deprecated and won't be called in a future version, define `log` in your"
-                " subclass.",
+                "The `_log` method is deprecated and won't be called in a future version, define `log` in your subclass.",
                 FutureWarning,
             )
             return self._log(logs, iterator=iterator)
@@ -706,8 +704,7 @@ class Trainer:
         """
         if hasattr(self, "_training_step"):
             warnings.warn(
-                "The `_training_step` method is deprecated and won't be called in a future version, define"
-                " `training_step` in your subclass.",
+                "The `_training_step` method is deprecated and won't be called in a future version, define `training_step` in your subclass.",
                 FutureWarning,
             )
             return self._training_step(model, inputs, optimizer)
@@ -892,8 +889,7 @@ class Trainer:
         """
         if hasattr(self, "_prediction_loop"):
             warnings.warn(
-                "The `_prediction_loop` method is deprecated and won't be called in a future version, define"
-                " `prediction_loop` in your subclass.",
+                "The `_prediction_loop` method is deprecated and won't be called in a future version, define `prediction_loop` in your subclass.",
                 FutureWarning,
             )
             return self._prediction_loop(dataloader, description, prediction_loss_only=prediction_loss_only)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -19,7 +19,7 @@ from torch.utils.data.sampler import RandomSampler, Sampler, SequentialSampler
 from tqdm.auto import tqdm, trange
 
 from .data.data_collator import DataCollator, default_data_collator
-from .file_utils import is_apex_available, is_torch_tpu_available
+from .file_utils import is_torch_tpu_available
 from .modeling_utils import PreTrainedModel
 from .optimization import AdamW, get_linear_schedule_with_warmup
 from .trainer_utils import (
@@ -33,8 +33,19 @@ from .trainer_utils import (
 from .training_args import TrainingArguments
 
 
-if is_apex_available():
-    from apex import amp
+_use_native_amp = False
+_use_apex = False
+
+# Check if Pytorch version >= 1.6 to switch between Native AMP and Apex
+if not version.parse(torch.__version__) >= version.parse("1.6"):
+    from transformers.file_utils import is_apex_available
+
+    if is_apex_available():
+        from apex import amp
+    _use_apex = False
+else:
+    _use_native_amp = True
+    from torch.cuda.amp import autocast
 
 
 if is_torch_tpu_available():
@@ -225,6 +236,8 @@ class Trainer:
                 ),
                 FutureWarning,
             )
+        if self.args.fp16 and _use_native_amp:
+            self.scaler = torch.cuda.amp.GradScaler()
 
     def _get_train_sampler(self) -> Optional[torch.utils.data.sampler.Sampler]:
         if isinstance(self.train_dataset, torch.utils.data.IterableDataset):
@@ -372,7 +385,8 @@ class Trainer:
         """
         if hasattr(self, "_setup_wandb"):
             warnings.warn(
-                "The `_setup_wandb` method is deprecated and won't be called in a future version, define `setup_wandb` in your subclass.",
+                "The `_setup_wandb` method is deprecated and won't be called in a future version, define `setup_wandb`"
+                " in your subclass.",
                 FutureWarning,
             )
             return self._setup_wandb()
@@ -428,7 +442,7 @@ class Trainer:
             scheduler.load_state_dict(torch.load(os.path.join(model_path, "scheduler.pt")))
 
         model = self.model
-        if self.args.fp16:
+        if self.args.fp16 and _use_apex:
             if not is_apex_available():
                 raise ImportError("Please install apex from https://www.github.com/nvidia/apex to use fp16 training.")
             model, optimizer = amp.initialize(model, optimizer, opt_level=self.args.fp16_opt_level)
@@ -525,7 +539,7 @@ class Trainer:
                     len(epoch_iterator) <= self.args.gradient_accumulation_steps
                     and (step + 1) == len(epoch_iterator)
                 ):
-                    if self.args.fp16:
+                    if self.args.fp16 and _use_apex:
                         torch.nn.utils.clip_grad_norm_(amp.master_params(optimizer), self.args.max_grad_norm)
                     else:
                         torch.nn.utils.clip_grad_norm_(model.parameters(), self.args.max_grad_norm)
@@ -614,7 +628,8 @@ class Trainer:
         """
         if hasattr(self, "_log"):
             warnings.warn(
-                "The `_log` method is deprecated and won't be called in a future version, define `log` in your subclass.",
+                "The `_log` method is deprecated and won't be called in a future version, define `log` in your"
+                " subclass.",
                 FutureWarning,
             )
             return self._log(logs, iterator=iterator)
@@ -691,7 +706,8 @@ class Trainer:
         """
         if hasattr(self, "_training_step"):
             warnings.warn(
-                "The `_training_step` method is deprecated and won't be called in a future version, define `training_step` in your subclass.",
+                "The `_training_step` method is deprecated and won't be called in a future version, define"
+                " `training_step` in your subclass.",
                 FutureWarning,
             )
             return self._training_step(model, inputs, optimizer)
@@ -699,19 +715,27 @@ class Trainer:
         model.train()
         inputs = self._prepare_inputs(inputs, model)
 
-        outputs = model(**inputs)
-        # We don't use .loss here since the model may return tuples instead of ModelOutput.
-        loss = outputs[0]
+        if self.args.fp16 and _use_native_amp:
+            with autocast():
+                outputs = model(**inputs)
+                loss = outputs[0]
+        else:
+            outputs = model(**inputs)
+            # We don't use .loss here since the model may return tuples instead of ModelOutput.
+            loss = outputs[0]
 
         if self.args.past_index >= 0:
             self._past = outputs[self.args.past_index]
 
         if self.args.n_gpu > 1:
             loss = loss.mean()  # mean() to average on multi-gpu parallel training
+
         if self.args.gradient_accumulation_steps > 1:
             loss = loss / self.args.gradient_accumulation_steps
 
-        if self.args.fp16:
+        if self.args.fp16 and _use_native_amp:
+            self.scaler.scale(loss).backward()
+        elif self.args.fp16 and _use_apex:
             with amp.scale_loss(loss, optimizer) as scaled_loss:
                 scaled_loss.backward()
         else:
@@ -868,7 +892,8 @@ class Trainer:
         """
         if hasattr(self, "_prediction_loop"):
             warnings.warn(
-                "The `_prediction_loop` method is deprecated and won't be called in a future version, define `prediction_loop` in your subclass.",
+                "The `_prediction_loop` method is deprecated and won't be called in a future version, define"
+                " `prediction_loop` in your subclass.",
                 FutureWarning,
             )
             return self._prediction_loop(dataloader, description, prediction_loss_only=prediction_loss_only)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -37,7 +37,7 @@ _use_native_amp = False
 _use_apex = False
 
 # Check if Pytorch version >= 1.6 to switch between Native AMP and Apex
-if not version.parse(torch.__version__) >= version.parse("1.6"):
+if version.parse(torch.__version__) < version.parse("1.6"):
     from transformers.file_utils import is_apex_available
 
     if is_apex_available():

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -42,7 +42,7 @@ if not version.parse(torch.__version__) >= version.parse("1.6"):
 
     if is_apex_available():
         from apex import amp
-    _use_apex = False
+    _use_apex = True
 else:
     _use_native_amp = True
     from torch.cuda.amp import autocast


### PR DESCRIPTION
Pytorch 1.6 introduces Native AMP support. This eliminates the need to build and install Apex and provides improvements over problems highlighted in [Apex #818](https://github.com/NVIDIA/apex/issues/818) and flexibility. This is the recommended way to use AMP.

With this PR, Trainer will automatically use Pytorch's native AMP if 1.6 version is installed, otherwise, it will use Apex.

This PR will close [#6115](https://github.com/huggingface/transformers/issues/6115). 