### PR TITLE
update min tf requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,9 +68,11 @@ extras = {}
 extras["mecab"] = ["mecab-python3<1"]
 extras["sklearn"] = ["scikit-learn"]
 
+tf_min_ver = "2.2.0"
+
 # keras2onnx and onnxconverter-common version is specific through a commit until 1.7.0 lands on pypi
 extras["tf"] = [
-    "tensorflow",
+    f"tensorflow >= {tf_min_ver}",
     # "onnxconverter-common",
     # "keras2onnx"
     "onnxconverter-common @ git+git://github.com/microsoft/onnxconverter-common.git@f64ca15989b6dc95a1f3507ff6e4c395ba12dff5#egg=onnxconverter-common",
@@ -97,7 +99,7 @@ extras["quality"] = [
     "isort @ git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e528357650281a3d3ec22#egg=isort",
     "flake8",
 ]
-extras["dev"] = extras["testing"] + extras["quality"] + ["mecab-python3<1", "scikit-learn", "tensorflow", "torch"]
+extras["dev"] = extras["testing"] + extras["quality"] + ["mecab-python3<1", "scikit-learn", f"tensorflow >= {tf_min_ver}", "torch"]
 
 setup(
     name="transformers",


### PR DESCRIPTION
All of the test suite is failing w/o this update - need to re-run `pip install -e .[dev]`

note that the failing tests don't show `"You need to run the TensorFlow trainer with at least the version 2.2.0, your version is {` anywhere so perhaps need some extra tweaks for the test fixtures, but then since non-tf tests fail too, the problem is in the core.

Not sure if perhaps this code needs to be replaced with an assert - then the error message will always be there regardless where it's used.
```
if parse(tf.__version__).release < (2, 2, 0):
    logger.info(
        "You need to run the TensorFlow trainer with at least the version 2.2.0, your version is {}".format(
            tf.__version__
        )
    )
    sys.exit(1)
```

Currently, if I run **any** test, including pytorch-only tests, with tf < 2.2 I get:

```
____________________________________________________________ ERROR collecting tests/test_benchmark.py ____________________________________________________________
tests/test_benchmark.py:6: in <module>
    from transformers import AutoConfig, is_torch_available
src/transformers/__init__.py:659: in <module>
    from .trainer_tf import TFTrainer
src/transformers/trainer_tf.py:34: in <module>
    sys.exit(1)
E   SystemExit: 1
======================================================================== warnings summary ========================================================================
```

To reproduce:

```
pip install tensorflow==2.0.1
pytest -ra tests/test_benchmark.py 
```

@jplu 

