### PR TITLE
Support new tokenizers in distillation example

### DIFF
--- a/examples/distillation/scripts/binarized_data.py
+++ b/examples/distillation/scripts/binarized_data.py
@@ -80,7 +80,7 @@ def main():
     logger.info("Finished binarization")
     logger.info(f"{len(data)} examples processed.")
 
-    dp_file = f"{args.dump_file}.{args.tokenizer_name}.pickle"
+    dp_file = f"{args.dump_file}.{args.tokenizer_name.replace('/', '-')}.pickle"
     vocab_size = tokenizer.vocab_size
     if vocab_size < (1 << 16):
         rslt_ = [np.uint16(d) for d in rslt]

--- a/examples/distillation/train.py
+++ b/examples/distillation/train.py
@@ -253,7 +253,7 @@ def main():
         special_tok_ids[tok_name] = tokenizer.all_special_ids[idx]
     logger.info(f"Special tokens {special_tok_ids}")
     args.special_tok_ids = special_tok_ids
-    args.max_model_input_size = tokenizer.max_model_input_sizes[args.teacher_name]
+    args.max_model_input_size = teacher_config_class.from_pretrained(args.teacher_name).max_position_embeddings
 
     # DATA LOADER #
     logger.info(f"Loading data from {args.data_file}")


### PR DESCRIPTION
I'm creating a distilled model based on a new transformers model, and needed these two lines from examples changed to make that process easier.

- Change filename of output binarized text vectors to replace '/' with '-'; for example tokenizer 'monsoon-nlp/hindi-bert' will output to a file and not create a new directory
- Load max_model_input_size / max_position_embeddings from teacher_config_class and not from a hardcoded list of common tokenizers in the tokenizer class