### PR TITLE
Encoder decoder config docs

### DIFF
--- a/src/transformers/configuration_encoder_decoder.py
+++ b/src/transformers/configuration_encoder_decoder.py
@@ -56,7 +56,7 @@ class EncoderDecoderConfig(PretrainedConfig):
             >>> # Accessing the model configuration
             >>> config_encoder = model.config.encoder
             >>> config_decoder  = model.config.decoder
-            
+
             >>> Saving the model, including its configuration
             >>> model.save_pretrained('my-model')
 

--- a/src/transformers/configuration_encoder_decoder.py
+++ b/src/transformers/configuration_encoder_decoder.py
@@ -56,6 +56,13 @@ class EncoderDecoderConfig(PretrainedConfig):
             >>> # Accessing the model configuration
             >>> config_encoder = model.config.encoder
             >>> config_decoder  = model.config.decoder
+            
+            >>> Saving the model, including its configuration
+            >>> model.save_pretrained('my-model')
+
+            >>> # loading model and config from pretrained folder
+            >>> encoder_decoder_config = EncoderDecoderConfig.from_pretrained('my-model')
+            >>> model = EncoderDecoderModel.from_pretrained('my-model', config=encoder_decoder_config)
     """
     model_type = "encoder_decoder"
 

--- a/src/transformers/configuration_encoder_decoder.py
+++ b/src/transformers/configuration_encoder_decoder.py
@@ -59,7 +59,7 @@ class EncoderDecoderConfig(PretrainedConfig):
             >>> # set decoder config to causal lm
             >>> config_decoder.is_decoder = True
 
-            >>> Saving the model, including its configuration
+            >>> # Saving the model, including its configuration
             >>> model.save_pretrained('my-model')
 
             >>> # loading model and config from pretrained folder

--- a/src/transformers/configuration_encoder_decoder.py
+++ b/src/transformers/configuration_encoder_decoder.py
@@ -56,6 +56,8 @@ class EncoderDecoderConfig(PretrainedConfig):
             >>> # Accessing the model configuration
             >>> config_encoder = model.config.encoder
             >>> config_decoder  = model.config.decoder
+            >>> # set decoder config to causal lm
+            >>> config_decoder.is_decoder = True
 
             >>> Saving the model, including its configuration
             >>> model.save_pretrained('my-model')

--- a/src/transformers/modeling_encoder_decoder.py
+++ b/src/transformers/modeling_encoder_decoder.py
@@ -128,7 +128,7 @@ class EncoderDecoderModel(PreTrainedModel):
 
             >>> from transformers import EncoderDecoderModel
             >>> # initialize a bert2bert from two pretrained BERT models. Note that the cross-attention layers will be randomly initialized
-            >>> model = EncoderDecoderModel.from_encoder_decoder_pretrained('bert-base-uncased', 'bert-base-uncased') 
+            >>> model = EncoderDecoderModel.from_encoder_decoder_pretrained('bert-base-uncased', 'bert-base-uncased')
             >>> # saving model after fine-tuning
             >>> model.save_pretrained("./bert2bert")
             >>> # load fine-tuned model

--- a/src/transformers/modeling_encoder_decoder.py
+++ b/src/transformers/modeling_encoder_decoder.py
@@ -134,7 +134,7 @@ class EncoderDecoderModel(PreTrainedModel):
 
             >>> pretrained_model_name_or_path = 'bert-base-multilingual-cased'
             >>> decoder_config = BertConfig.from_pretrained(pretrained_model_name_or_path, is_decoder=True)
-            >>> model = EncoderDecoderModel.from_encoder_decoder_pretrained(pretrained_model_name_or_path, pretrained_model_name_or_path, encoder_config=encoder_config, decoder_config=decoder_config)
+            >>> model = EncoderDecoderModel.from_encoder_decoder_pretrained(pretrained_model_name_or_path, pretrained_model_name_or_path)
 
         """
 

--- a/src/transformers/modeling_encoder_decoder.py
+++ b/src/transformers/modeling_encoder_decoder.py
@@ -127,13 +127,12 @@ class EncoderDecoderModel(PreTrainedModel):
         Examples::
 
             >>> from transformers import EncoderDecoderModel
-            >>> model = EncoderDecoderModel.from_encoder_decoder_pretrained('bert-base-uncased', 'bert-base-uncased') # initialize Bert2Bert
-
-        Example loading pretrained configs separately::
-            >>> from transformers import BertConfig, EncoderDecoderModel
-
-            >>> pretrained_model_name_or_path = 'bert-base-multilingual-cased'
-            >>> model = EncoderDecoderModel.from_encoder_decoder_pretrained(pretrained_model_name_or_path, pretrained_model_name_or_path)
+            >>> # initialize a bert2bert from two pretrained BERT models. Note that the cross-attention layers will be randomly initialized
+            >>> model = EncoderDecoderModel.from_encoder_decoder_pretrained('bert-base-uncased', 'bert-base-uncased') 
+            >>> # saving model after fine-tuning
+            >>> model.save_pretrained("./bert2bert")
+            >>> # load fine-tuned model
+            >>> model = EncoderDecoderModel.from_pretrained("./bert2bert")
 
         """
 

--- a/src/transformers/modeling_encoder_decoder.py
+++ b/src/transformers/modeling_encoder_decoder.py
@@ -128,6 +128,15 @@ class EncoderDecoderModel(PreTrainedModel):
 
             >>> from transformers import EncoderDecoderModel
             >>> model = EncoderDecoderModel.from_encoder_decoder_pretrained('bert-base-uncased', 'bert-base-uncased') # initialize Bert2Bert
+
+        Example loading pretrained configs separately::
+            >>> from transformers import BertConfig, EncoderDecoderModel
+
+            >>> pretrained_model_name_or_path = 'bert-base-multilingual-cased'
+            >>> encoder_config = BertConfig.from_pretrained(pretrained_model_name_or_path)
+            >>> decoder_config = BertConfig.from_pretrained(pretrained_model_name_or_path, is_decoder=True)
+            >>> model = EncoderDecoderModel.from_encoder_decoder_pretrained(pretrained_model_name_or_path, pretrained_model_name_or_path, encoder_config=encoder_config, decoder_config=decoder_config)
+
         """
 
         kwargs_encoder = {

--- a/src/transformers/modeling_encoder_decoder.py
+++ b/src/transformers/modeling_encoder_decoder.py
@@ -133,7 +133,6 @@ class EncoderDecoderModel(PreTrainedModel):
             >>> from transformers import BertConfig, EncoderDecoderModel
 
             >>> pretrained_model_name_or_path = 'bert-base-multilingual-cased'
-            >>> encoder_config = BertConfig.from_pretrained(pretrained_model_name_or_path)
             >>> decoder_config = BertConfig.from_pretrained(pretrained_model_name_or_path, is_decoder=True)
             >>> model = EncoderDecoderModel.from_encoder_decoder_pretrained(pretrained_model_name_or_path, pretrained_model_name_or_path, encoder_config=encoder_config, decoder_config=decoder_config)
 

--- a/src/transformers/modeling_encoder_decoder.py
+++ b/src/transformers/modeling_encoder_decoder.py
@@ -133,7 +133,6 @@ class EncoderDecoderModel(PreTrainedModel):
             >>> from transformers import BertConfig, EncoderDecoderModel
 
             >>> pretrained_model_name_or_path = 'bert-base-multilingual-cased'
-            >>> decoder_config = BertConfig.from_pretrained(pretrained_model_name_or_path, is_decoder=True)
             >>> model = EncoderDecoderModel.from_encoder_decoder_pretrained(pretrained_model_name_or_path, pretrained_model_name_or_path)
 
         """


### PR DESCRIPTION
As discussed on #5826, this PR adds more details on how to load encoder/decoder config objects from pretrained folders and how to instantiate encoder_decoder pretrained models given their corresponding configuration objects (useful for loading pre-trained models and modifying some config members for fine-tuning).

