### PR TITLE
Problems with TFT5

### DIFF
--- a/src/transformers/modeling_tf_t5.py
+++ b/src/transformers/modeling_tf_t5.py
@@ -1067,7 +1067,7 @@ class TFT5Model(TFT5PreTrainedModel):
 
 
 @add_start_docstrings("""T5 Model with a `language modeling` head on top. """, T5_START_DOCSTRING)
-class TFT5ForConditionalGeneration(TFT5PreTrainedModel, TFCausalLanguageModelingLoss):
+class TFT5ForConditionalGeneration(TFT5PreTrainedModel, TFCausalLanguageModeling ):
     def __init__(self, config, *inputs, **kwargs):
         super().__init__(config, *inputs, **kwargs)
         self.model_dim = config.d_model
@@ -1269,7 +1269,6 @@ class TFT5ForConditionalGeneration(TFT5PreTrainedModel, TFCausalLanguageModeling
 
         if labels is not None:
             loss = self.compute_loss(labels, logits)
-            loss = tf.reduce_mean(loss)
             decoder_outputs = (loss,) + decoder_outputs
 
         return decoder_outputs + encoder_outputs

--- a/src/transformers/modeling_tf_t5.py
+++ b/src/transformers/modeling_tf_t5.py
@@ -782,11 +782,9 @@ class TFT5PreTrainedModel(TFPreTrainedModel):
             decoder_start_token_id is not None
         ), "self.model.config.decoder_start_token_id has to be defined. In TF T5 it is usually set to the pad_token_id. See T5 docs for more information"
 
-        # shift inputs to the right
-        shifted_input_ids = tf.zeros_like(input_ids, dtype=tf.int32)
-        shifted_input_ids = tf.roll(shifted_input_ids, 1, axis=-1)
-        start_tokens = tf.fill((shape_list(shifted_input_ids)[0], 1), decoder_start_token_id)
-        shifted_input_ids = tf.concat([start_tokens, shifted_input_ids[:, 1:]], -1)
+        shifted_input_ids = tf.roll(input_ids, 1, axis=-1)
+        start_tokens = tf.fill([shape_list(input_ids)[0], 1], tokenizer.pad_token_id)
+        shifted_input_ids = tf.concat([start_tokens, shifted_input_ids[:, 1:]], axis=-1)
 
         assert pad_token_id is not None, "self.model.config.pad_token_id has to be defined."
         # replace possible -100 values in labels by `pad_token_id`

--- a/src/transformers/modeling_tf_t5.py
+++ b/src/transformers/modeling_tf_t5.py
@@ -1067,7 +1067,7 @@ class TFT5Model(TFT5PreTrainedModel):
 
 
 @add_start_docstrings("""T5 Model with a `language modeling` head on top. """, T5_START_DOCSTRING)
-class TFT5ForConditionalGeneration(TFT5PreTrainedModel, TFCausalLanguageModeling ):
+class TFT5ForConditionalGeneration(TFT5PreTrainedModel, TFCausalLanguageModelingLoss):
     def __init__(self, config, *inputs, **kwargs):
         super().__init__(config, *inputs, **kwargs)
         self.model_dim = config.d_model

--- a/src/transformers/modeling_tf_t5.py
+++ b/src/transformers/modeling_tf_t5.py
@@ -783,7 +783,7 @@ class TFT5PreTrainedModel(TFPreTrainedModel):
         ), "self.model.config.decoder_start_token_id has to be defined. In TF T5 it is usually set to the pad_token_id. See T5 docs for more information"
 
         shifted_input_ids = tf.roll(input_ids, 1, axis=-1)
-        start_tokens = tf.fill([shape_list(input_ids)[0], 1], tokenizer.pad_token_id)
+        start_tokens = tf.fill([shape_list(input_ids)[0], 1], pad_token_id)
         shifted_input_ids = tf.concat([start_tokens, shifted_input_ids[:, 1:]], axis=-1)
 
         assert pad_token_id is not None, "self.model.config.pad_token_id has to be defined."

--- a/src/transformers/modeling_tf_t5.py
+++ b/src/transformers/modeling_tf_t5.py
@@ -782,7 +782,7 @@ class TFT5PreTrainedModel(TFPreTrainedModel):
             decoder_start_token_id is not None
         ), "self.model.config.decoder_start_token_id has to be defined. In TF T5 it is usually set to the pad_token_id. See T5 docs for more information"
 
-        shifted_input_ids = tf.roll(input_ids, 1, axis=-1)
+        shifted_input_ids = tf.cast(tf.roll(input_ids, 1, axis=-1), tf.int32)
         start_tokens = tf.fill([shape_list(input_ids)[0], 1], pad_token_id)
         shifted_input_ids = tf.concat([start_tokens, shifted_input_ids[:, 1:]], axis=-1)
 

--- a/src/transformers/modeling_tf_t5.py
+++ b/src/transformers/modeling_tf_t5.py
@@ -1269,6 +1269,7 @@ class TFT5ForConditionalGeneration(TFT5PreTrainedModel, TFCausalLanguageModeling
 
         if labels is not None:
             loss = self.compute_loss(labels, logits)
+            loss = tf.reduce_mean(loss)
             decoder_outputs = (loss,) + decoder_outputs
 
         return decoder_outputs + encoder_outputs

--- a/test-hf.py
+++ b/test-hf.py
@@ -1,9 +1,0 @@
-import transformers
-import tensorflow as tf
-
-model = transformers.TFT5ForConditionalGeneration.from_pretrained('t5-small')
-input_ids = tf.random.uniform([1, 512], maxval=1000, dtype=tf.int32)
-labels = tf.random.uniform([1, 512], maxval=1000, dtype=tf.int32)
-
-loss, *_ = model(dict(input_ids=input_ids, labels=labels))
-print(loss)

--- a/test-hf.py
+++ b/test-hf.py
@@ -1,0 +1,9 @@
+import transformers
+import tensorflow as tf
+
+model = transformers.TFT5ForConditionalGeneration.from_pretrained('t5-small')
+input_ids = tf.random.uniform([1, 512], maxval=1000, dtype=tf.int32)
+labels = tf.random.uniform([1, 512], maxval=1000, dtype=tf.int32)
+
+loss, *_ = model(dict(input_ids=input_ids, labels=labels))
+print(loss)


### PR DESCRIPTION
As far as we are concerned, Tensorflow T5 has some problems:

- Shifting inputs right should add at the beginning of the sequences a *Start of Sequence token* (padding token in T5 case), but currently, it generates a useless sequence of zeros. This is due to this line of code:

```python
shifted_input_ids = tf.zeros_like(input_ids, dtype=tf.int32) # No matter what, this generates zeros
# ... carry this 0s all over the function
```

*Note*

We observe, that PyTorch's `T5ForConditionalGeneration` loss is a scalar. Contrary, with the `TFT5ForConditionalGeneration`, the loss is a tensor where each loss element corresponds to a *non-ignored* label. We think that the loss should be reduced. Is there any reason for keeping the loss *as is* instead of reducing it? 

