### PR TITLE
[DataCollatorForLanguageModeling] fix labels 

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -87,7 +87,8 @@ class DataCollatorForLanguageModeling:
             return {"input_ids": inputs, "labels": labels}
         else:
             labels = batch.clone().detach()
-            labels[labels == self.tokenizer.pad_token_id] = -100
+            if self.tokenizer.pad_token_id is not None:
+                labels[labels == self.tokenizer.pad_token_id] = -100
             return {"input_ids": batch, "labels": labels}
 
     def _tensorize_batch(self, examples: List[torch.Tensor]) -> torch.Tensor:


### PR DESCRIPTION
This PR fixes #6211. Only set ignore index (-100) when `pad_token_id` is not `None`

@sgugger 