### PR TITLE
Add do_lower_case parameter to GPT2TokenizerFast and RobertaTokenizerFast tokenizers

### DIFF
--- a/src/transformers/tokenization_gpt2.py
+++ b/src/transformers/tokenization_gpt2.py
@@ -344,6 +344,8 @@ class GPT2TokenizerFast(PreTrainedTokenizerFast):
             (GPT2 tokenizer detect beginning of words by the preceeding space)
         trim_offsets (:obj:`bool`, `optional`, defaults to `True`):
             Whether the post processing step should trim offsets to avoid including whitespaces.
+        do_lower_case (:obj:`bool`, `optional`, defaults to :obj:`False`):
+            Whether to lowercase the input when tokenizing.
     """
 
     vocab_files_names = VOCAB_FILES_NAMES
@@ -360,6 +362,7 @@ class GPT2TokenizerFast(PreTrainedTokenizerFast):
         eos_token="<|endoftext|>",
         add_prefix_space=False,
         trim_offsets=True,
+        do_lower_case=False,
         **kwargs
     ):
         super().__init__(
@@ -368,6 +371,7 @@ class GPT2TokenizerFast(PreTrainedTokenizerFast):
                 merges_file=merges_file,
                 add_prefix_space=add_prefix_space,
                 trim_offsets=trim_offsets,
+                lowercase=do_lower_case,
             ),
             bos_token=bos_token,
             eos_token=eos_token,

--- a/src/transformers/tokenization_roberta.py
+++ b/src/transformers/tokenization_roberta.py
@@ -307,6 +307,8 @@ class RobertaTokenizerFast(GPT2TokenizerFast):
             (GPT2 tokenizer detect beginning of words by the preceeding space)
         trim_offsets (:obj:`bool`, `optional`, defaults to `True`):
             Whether the post processing step should trim offsets to avoid including whitespaces.
+        do_lower_case (:obj:`bool`, `optional`, defaults to :obj:`False`):
+            Whether to lowercase the input when tokenizing.
     """
 
     vocab_files_names = VOCAB_FILES_NAMES
@@ -328,6 +330,7 @@ class RobertaTokenizerFast(GPT2TokenizerFast):
         mask_token="<mask>",
         add_prefix_space=False,
         trim_offsets=True,
+        do_lower_case=False,
         **kwargs
     ):
         # Mask token behave like a normal word, i.e. include the space before it
@@ -346,6 +349,7 @@ class RobertaTokenizerFast(GPT2TokenizerFast):
             eos_token=eos_token,
             add_prefix_space=add_prefix_space,
             trim_offsets=trim_offsets,
+            do_lower_case=do_lower_case,
             **kwargs,
         )
 


### PR DESCRIPTION
Fixes #6215 

This adds lowercasing handling to GPT2TokenizerFast and RobertaTokenizerFast tokenizers