### PR TITLE
Remove outdated BERT tips

### DIFF
--- a/docs/source/model_doc/bert.rst
+++ b/docs/source/model_doc/bert.rst
@@ -24,6 +24,7 @@ accuracy to 86.7% (4.6% absolute improvement), SQuAD v1.1 question answering Tes
 improvement) and SQuAD v2.0 Test F1 to 83.1 (5.1 point absolute improvement).*
 
 Tips:
+
 - BERT is a model with absolute position embeddings so it's usually advised to pad the inputs on
   the right rather than the left.
 - BERT was trained with the masked language modeling (MLM) and next sentence prediction (NSP) objectives. It is efficient at predicting masked

--- a/docs/source/model_doc/bert.rst
+++ b/docs/source/model_doc/bert.rst
@@ -23,18 +23,6 @@ language processing tasks, including pushing the GLUE score to 80.5% (7.7% point
 accuracy to 86.7% (4.6% absolute improvement), SQuAD v1.1 question answering Test F1 to 93.2 (1.5 point absolute
 improvement) and SQuAD v2.0 Test F1 to 83.1 (5.1 point absolute improvement).*
 
-Tips:
-
-- BERT is a model with absolute position embeddings so it's usually advised to pad the inputs on
-  the right rather than the left.
-- BERT was trained with a masked language modeling (MLM) objective. It is therefore efficient at predicting masked
-  tokens and at NLU in general, but is not optimal for text generation. Models trained with a causal language
-  modeling (CLM) objective are better in that regard.
-- Alongside MLM, BERT was trained using a next sentence prediction (NSP) objective using the [CLS] token as a sequence
-  approximate. The user may use this token (the first token in a sequence built with special tokens) to get a sequence
-  prediction rather than a token prediction. However, averaging over the sequence may yield better results than using
-  the [CLS] token.
-
 The original code can be found `here <https://github.com/google-research/bert>`_.
 
 BertConfig

--- a/docs/source/model_doc/bert.rst
+++ b/docs/source/model_doc/bert.rst
@@ -23,6 +23,12 @@ language processing tasks, including pushing the GLUE score to 80.5% (7.7% point
 accuracy to 86.7% (4.6% absolute improvement), SQuAD v1.1 question answering Test F1 to 93.2 (1.5 point absolute
 improvement) and SQuAD v2.0 Test F1 to 83.1 (5.1 point absolute improvement).*
 
+Tips:
+- BERT is a model with absolute position embeddings so it's usually advised to pad the inputs on
+  the right rather than the left.
+- BERT was trained with the masked language modeling (MLM) and next sentence prediction (NSP) objectives. It is efficient at predicting masked
+  tokens and at NLU in general, but is not optimal for text generation.
+
 The original code can be found `here <https://github.com/google-research/bert>`_.
 
 BertConfig

--- a/src/transformers/modeling_outputs.py
+++ b/src/transformers/modeling_outputs.py
@@ -45,10 +45,6 @@ class BaseModelOutputWithPooling(ModelOutput):
             further processed by a Linear layer and a Tanh activation function. The Linear
             layer weights are trained from the next sentence prediction (classification)
             objective during pretraining.
-
-            This output is usually *not* a good summary
-            of the semantic content of the input, you're often better with averaging or pooling
-            the sequence of hidden-states for the whole input sequence.
         hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
             Tuple of :obj:`torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer)
             of shape :obj:`(batch_size, sequence_length, hidden_size)`.


### PR DESCRIPTION
Why remove the tips:

> - BERT is a model with absolute position embeddings so it's usually advised to pad the inputs on
>   the right rather than the left.

Yes but since we don't provide an option to pad from the left I think it's not necessary.

> - BERT was trained with a masked language modeling (MLM) objective. It is therefore efficient at predicting masked
>   tokens and at NLU in general, but is not optimal for text generation. Models trained with a causal language
>   modeling (CLM) objective are better in that regard.

No. T5 & BART proved it wrong.

> - Alongside MLM, BERT was trained using a next sentence prediction (NSP) objective using the [CLS] token as a sequence
>   approximate. The user may use this token (the first token in a sequence built with special tokens) to get a sequence
>   prediction rather than a token prediction. However, averaging over the sequence may yield better results than using
>   the [CLS] token.

No. [CLS] can do learnable self-attention pooling, which is way much better than parameter-free average pooling especially when fine-tuned. (w.r.t. SentenceBERT)
