### PR TITLE
Improve type annotations in many places

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -9,7 +9,7 @@ __version__ = "3.0.2"
 # see: https://github.com/abseil/abseil-py/issues/99
 # and: https://github.com/tensorflow/tensorflow/issues/26691#issuecomment-500369493
 try:
-    import absl.logging
+    import absl.logging  # type: ignore
 except ImportError:
     pass
 else:

--- a/src/transformers/configuration_auto.py
+++ b/src/transformers/configuration_auto.py
@@ -17,6 +17,7 @@
 
 import logging
 from collections import OrderedDict
+from typing import Any, Dict, Literal, Optional, Tuple, overload
 
 from .configuration_albert import ALBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, AlbertConfig
 from .configuration_bart import BART_PRETRAINED_CONFIG_ARCHIVE_MAP, BartConfig, MBartConfig
@@ -128,6 +129,36 @@ class AutoConfig:
                 model_type, ", ".join(CONFIG_MAPPING.keys())
             )
         )
+
+    @overload
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *,
+        return_unused_kwargs: Literal[True],
+        cache_dir: Optional[str] = None,
+        force_download: bool = False,
+        resume_download: bool = False,
+        proxies: Optional[Dict[str, str]] = None,
+        **kwargs: Any
+    ) -> Tuple[PretrainedConfig, Dict[str, str]]:
+        ...
+
+    @overload
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *,
+        return_unused_kwargs: Literal[False] = False,
+        cache_dir: Optional[str] = None,
+        force_download: bool = False,
+        resume_download: bool = False,
+        proxies: Optional[Dict[str, str]] = None,
+        **kwargs: Any
+    ) -> PretrainedConfig:
+        ...
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):

--- a/src/transformers/data/processors/utils.py
+++ b/src/transformers/data/processors/utils.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import abc
 import csv
 import dataclasses
 import json
@@ -44,7 +45,7 @@ class InputExample:
             specified for train and dev examples, but not for test examples.
     """
 
-    guid: str
+    guid: Optional[str]
     text_a: str
     text_b: Optional[str] = None
     label: Optional[str] = None
@@ -81,9 +82,10 @@ class InputFeatures:
         return json.dumps(dataclasses.asdict(self)) + "\n"
 
 
-class DataProcessor:
+class DataProcessor(abc.ABC):
     """Base class for data converters for sequence classification data sets."""
 
+    @abc.abstractmethod
     def get_example_from_tensor_dict(self, tensor_dict: Mapping[Any, Any]) -> InputExample:
         """Gets an example from a dict with tensorflow tensors.
 
@@ -91,23 +93,26 @@ class DataProcessor:
             tensor_dict: Keys and values should match the corresponding Glue
                 tensorflow_dataset examples.
         """
-        raise NotImplementedError()
+        pass
 
+    @abc.abstractmethod
     def get_train_examples(self, data_dir: str) -> List[InputExample]:
         """Gets a collection of :class:`InputExample` for the train set."""
-        raise NotImplementedError()
+        pass
 
+    @abc.abstractmethod
     def get_dev_examples(self, data_dir: str) -> List[InputExample]:
         """Gets a collection of :class:`InputExample` for the dev set."""
-        raise NotImplementedError()
+        pass
 
     def get_test_examples(self, data_dir: str) -> List[InputExample]:
         """Gets a collection of :class:`InputExample` for the test set."""
-        raise NotImplementedError()
+        pass
 
+    @abc.abstractmethod
     def get_labels(self) -> List[str]:
         """Gets the list of labels for this data set."""
-        raise NotImplementedError()
+        pass
 
     def tfds_map(self, example: InputExample) -> InputExample:
         """Some tensorflow_datasets datasets are not formatted the same way the GLUE datasets are.
@@ -117,8 +122,8 @@ class DataProcessor:
             example.label = self.get_labels()[int(example.label)]
         return example
 
-    @classmethod
-    def _read_tsv(cls, input_file: str, quotechar: Optional[str] = None) -> List[List[str]]:
+    @staticmethod
+    def _read_tsv(input_file: str, quotechar: Optional[str] = None) -> List[List[str]]:
         """Reads a tab separated value file."""
         with open(input_file, "r", encoding="utf-8-sig") as f:
             return list(csv.reader(f, delimiter="\t", quotechar=quotechar))

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -191,7 +191,7 @@ class HfArgumentParser(ArgumentParser):
             outputs.append(obj)
         return (*outputs,)
 
-    def parse_dict(self, args: dict) -> Tuple[DataClass, ...]:
+    def parse_dict(self, args: dict) -> Tuple[DataClassProtocol, ...]:
         """
         Alternative helper method that does not use `argparse` at all,
         instead uses a dict and populating the dataclass types.

--- a/src/transformers/modeling_auto.py
+++ b/src/transformers/modeling_auto.py
@@ -18,6 +18,7 @@
 import logging
 import warnings
 from collections import OrderedDict
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Type, overload
 
 from .configuration_auto import (
     AlbertConfig,
@@ -168,10 +169,13 @@ from .modeling_xlnet import (
 )
 
 
+if TYPE_CHECKING:
+    from .modeling_utils import PreTrainedModel
+
 logger = logging.getLogger(__name__)
 
 
-MODEL_MAPPING = OrderedDict(
+MODEL_MAPPING: Mapping[Type[PretrainedConfig], Type["PreTrainedModel"]] = OrderedDict(
     [
         (RetriBertConfig, RetriBertModel),
         (T5Config, T5Model),
@@ -196,7 +200,7 @@ MODEL_MAPPING = OrderedDict(
     ]
 )
 
-MODEL_FOR_PRETRAINING_MAPPING = OrderedDict(
+MODEL_FOR_PRETRAINING_MAPPING: Mapping[Type[PretrainedConfig], Type["PreTrainedModel"]] = OrderedDict(
     [
         (RetriBertConfig, RetriBertModel),
         (T5Config, T5ForConditionalGeneration),
@@ -220,7 +224,7 @@ MODEL_FOR_PRETRAINING_MAPPING = OrderedDict(
     ]
 )
 
-MODEL_WITH_LM_HEAD_MAPPING = OrderedDict(
+MODEL_WITH_LM_HEAD_MAPPING: Mapping[Type[PretrainedConfig], Type["PreTrainedModel"]] = OrderedDict(
     [
         (T5Config, T5ForConditionalGeneration),
         (DistilBertConfig, DistilBertForMaskedLM),
@@ -246,7 +250,7 @@ MODEL_WITH_LM_HEAD_MAPPING = OrderedDict(
     ]
 )
 
-MODEL_FOR_CAUSAL_LM_MAPPING = OrderedDict(
+MODEL_FOR_CAUSAL_LM_MAPPING: Mapping[Type[PretrainedConfig], Type["PreTrainedModel"]] = OrderedDict(
     [
         (BertConfig, BertLMHeadModel),
         (OpenAIGPTConfig, OpenAIGPTLMHeadModel),
@@ -262,7 +266,7 @@ MODEL_FOR_CAUSAL_LM_MAPPING = OrderedDict(
     ]
 )
 
-MODEL_FOR_MASKED_LM_MAPPING = OrderedDict(
+MODEL_FOR_MASKED_LM_MAPPING: Mapping[Type[PretrainedConfig], Type["PreTrainedModel"]] = OrderedDict(
     [
         (DistilBertConfig, DistilBertForMaskedLM),
         (AlbertConfig, AlbertForMaskedLM),
@@ -280,7 +284,7 @@ MODEL_FOR_MASKED_LM_MAPPING = OrderedDict(
     ]
 )
 
-MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING = OrderedDict(
+MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING: Mapping[Type[PretrainedConfig], Type["PreTrainedModel"]] = OrderedDict(
     [
         (T5Config, T5ForConditionalGeneration),
         (MarianConfig, MarianMTModel),
@@ -289,7 +293,7 @@ MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING = OrderedDict(
     ]
 )
 
-MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING = OrderedDict(
+MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING: Mapping[Type[PretrainedConfig], Type["PreTrainedModel"]] = OrderedDict(
     [
         (DistilBertConfig, DistilBertForSequenceClassification),
         (AlbertConfig, AlbertForSequenceClassification),
@@ -307,7 +311,7 @@ MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING = OrderedDict(
     ]
 )
 
-MODEL_FOR_QUESTION_ANSWERING_MAPPING = OrderedDict(
+MODEL_FOR_QUESTION_ANSWERING_MAPPING: Mapping[Type[PretrainedConfig], Type["PreTrainedModel"]] = OrderedDict(
     [
         (DistilBertConfig, DistilBertForQuestionAnswering),
         (AlbertConfig, AlbertForQuestionAnswering),
@@ -326,7 +330,7 @@ MODEL_FOR_QUESTION_ANSWERING_MAPPING = OrderedDict(
     ]
 )
 
-MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING = OrderedDict(
+MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING: Mapping[Type[PretrainedConfig], Type["PreTrainedModel"]] = OrderedDict(
     [
         (DistilBertConfig, DistilBertForTokenClassification),
         (CamembertConfig, CamembertForTokenClassification),
@@ -344,7 +348,7 @@ MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING = OrderedDict(
     ]
 )
 
-MODEL_FOR_MULTIPLE_CHOICE_MAPPING = OrderedDict(
+MODEL_FOR_MULTIPLE_CHOICE_MAPPING: Mapping[Type[PretrainedConfig], Type["PreTrainedModel"]] = OrderedDict(
     [
         (CamembertConfig, CamembertForMultipleChoice),
         (ElectraConfig, ElectraForMultipleChoice),
@@ -380,7 +384,7 @@ class AutoModel:
         )
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config: PretrainedConfig) -> "PreTrainedModel":
         r""" Instantiates one of the base model classes of the library
         from a configuration.
 
@@ -420,6 +424,30 @@ class AutoModel:
                 config.__class__, cls.__name__, ", ".join(c.__name__ for c in MODEL_MAPPING.keys())
             )
         )
+
+    # To avoid touching the actual implementation while doing type annotations,
+    # at least two "overloads" are required, if we're to avoid stub files.
+    @overload
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: str,) -> "PreTrainedModel":
+        ...
+
+    @overload
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *model_args: Any,
+        config: Optional[PretrainedConfig] = None,
+        state_dict: Optional[Mapping[str, Any]] = None,
+        cache_dir: Optional[str] = None,
+        force_download: bool = False,
+        resume_download: bool = False,
+        proxies: Optional[Mapping[str, str]] = None,
+        output_loading_info: bool = ...,
+        **kwargs: Any
+    ) -> "PreTrainedModel":
+        ...
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
@@ -536,7 +564,7 @@ class AutoModelForPreTraining:
         )
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config: PretrainedConfig) -> "PreTrainedModel":
         r""" Instantiates one of the base model classes of the library
         from a configuration.
 
@@ -576,6 +604,30 @@ class AutoModelForPreTraining:
                 config.__class__, cls.__name__, ", ".join(c.__name__ for c in MODEL_FOR_PRETRAINING_MAPPING.keys())
             )
         )
+
+    # To avoid touching the actual implementation while doing type annotations,
+    # at least two "overloads" are required, if we're to avoid stub files.
+    @overload
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: str) -> "PreTrainedModel":
+        ...
+
+    @overload
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *model_args: Any,
+        config: Optional[PretrainedConfig] = None,
+        state_dict: Optional[Mapping[str, Any]] = None,
+        cache_dir: Optional[str] = None,
+        force_download: bool = False,
+        resume_download: bool = False,
+        proxies: Optional[Mapping[str, str]] = None,
+        output_loading_info: bool = ...,
+        **kwargs: Any
+    ) -> "PreTrainedModel":
+        ...
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
@@ -686,7 +738,7 @@ class AutoModelWithLMHead:
         )
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config: PretrainedConfig) -> "PreTrainedModel":
         r""" Instantiates one of the base model classes of the library
         from a configuration.
 
@@ -730,6 +782,30 @@ class AutoModelWithLMHead:
                 config.__class__, cls.__name__, ", ".join(c.__name__ for c in MODEL_WITH_LM_HEAD_MAPPING.keys())
             )
         )
+
+    # To avoid touching the actual implementation while doing type annotations,
+    # at least two "overloads" are required, if we're to avoid stub files.
+    @overload
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: str) -> "PreTrainedModel":
+        ...
+
+    @overload
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *model_args: Any,
+        config: Optional[PretrainedConfig] = None,
+        state_dict: Optional[Mapping[str, Any]] = None,
+        cache_dir: Optional[str] = None,
+        force_download: bool = False,
+        resume_download: bool = False,
+        proxies: Optional[Mapping[str, str]] = None,
+        output_loading_info: bool = ...,
+        **kwargs: Any
+    ) -> "PreTrainedModel":
+        ...
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
@@ -845,7 +921,7 @@ class AutoModelForCausalLM:
         )
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config: PretrainedConfig) -> "PreTrainedModel":
         r""" Instantiates one of the base model classes of the library
         from a configuration.
 
@@ -880,6 +956,30 @@ class AutoModelForCausalLM:
                 config.__class__, cls.__name__, ", ".join(c.__name__ for c in MODEL_FOR_CAUSAL_LM_MAPPING.keys())
             )
         )
+
+    # To avoid touching the actual implementation while doing type annotations,
+    # at least two "overloads" are required, if we're to avoid stub files.
+    @overload
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: str) -> "PreTrainedModel":
+        ...
+
+    @overload
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *model_args: Any,
+        config: Optional[PretrainedConfig] = None,
+        state_dict: Optional[Mapping[str, Any]] = None,
+        cache_dir: Optional[str] = None,
+        force_download: bool = False,
+        resume_download: bool = False,
+        proxies: Optional[Mapping[str, str]] = None,
+        output_loading_info: bool = ...,
+        **kwargs: Any
+    ) -> "PreTrainedModel":
+        ...
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
@@ -982,7 +1082,7 @@ class AutoModelForMaskedLM:
         )
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config: PretrainedConfig) -> "PreTrainedModel":
         r""" Instantiates one of the base model classes of the library
         from a configuration.
 
@@ -1020,6 +1120,30 @@ class AutoModelForMaskedLM:
                 config.__class__, cls.__name__, ", ".join(c.__name__ for c in MODEL_FOR_MASKED_LM_MAPPING.keys())
             )
         )
+
+    # To avoid touching the actual implementation while doing type annotations,
+    # at least two "overloads" are required, if we're to avoid stub files.
+    @overload
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: str) -> "PreTrainedModel":
+        ...
+
+    @overload
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *model_args: Any,
+        config: Optional[PretrainedConfig] = None,
+        state_dict: Optional[Mapping[str, Any]] = None,
+        cache_dir: Optional[str] = None,
+        force_download: bool = False,
+        resume_download: bool = False,
+        proxies: Optional[Mapping[str, str]] = None,
+        output_loading_info: bool = ...,
+        **kwargs: Any
+    ) -> "PreTrainedModel":
+        ...
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
@@ -1125,7 +1249,7 @@ class AutoModelForSeq2SeqLM:
         )
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config: PretrainedConfig) -> "PreTrainedModel":
         r""" Instantiates one of the base model classes of the library
         from a configuration.
 
@@ -1159,6 +1283,30 @@ class AutoModelForSeq2SeqLM:
                 ", ".join(c.__name__ for c in MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.keys()),
             )
         )
+
+    # To avoid touching the actual implementation while doing type annotations,
+    # at least two "overloads" are required, if we're to avoid stub files.
+    @overload
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: str) -> "PreTrainedModel":
+        ...
+
+    @overload
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *model_args: Any,
+        config: Optional[PretrainedConfig] = None,
+        state_dict: Optional[Mapping[str, Any]] = None,
+        cache_dir: Optional[str] = None,
+        force_download: bool = False,
+        resume_download: bool = False,
+        proxies: Optional[Mapping[str, str]] = None,
+        output_loading_info: bool = ...,
+        **kwargs: Any
+    ) -> "PreTrainedModel":
+        ...
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
@@ -1260,7 +1408,7 @@ class AutoModelForSequenceClassification:
         )
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config: PretrainedConfig) -> "PreTrainedModel":
         r""" Instantiates one of the base model classes of the library
         from a configuration.
 
@@ -1300,6 +1448,30 @@ class AutoModelForSequenceClassification:
                 ", ".join(c.__name__ for c in MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.keys()),
             )
         )
+
+    # To avoid touching the actual implementation while doing type annotations,
+    # at least two "overloads" are required, if we're to avoid stub files.
+    @overload
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: str) -> "PreTrainedModel":
+        ...
+
+    @overload
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *model_args: Any,
+        config: Optional[PretrainedConfig] = None,
+        state_dict: Optional[Mapping[str, Any]] = None,
+        cache_dir: Optional[str] = None,
+        force_download: bool = False,
+        resume_download: bool = False,
+        proxies: Optional[Mapping[str, str]] = None,
+        output_loading_info: bool = ...,
+        **kwargs: Any
+    ) -> "PreTrainedModel":
+        ...
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
@@ -1412,7 +1584,7 @@ class AutoModelForQuestionAnswering:
         )
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config: PretrainedConfig) -> "PreTrainedModel":
         r""" Instantiates one of the base model classes of the library
         from a configuration.
 
@@ -1449,6 +1621,30 @@ class AutoModelForQuestionAnswering:
                 ", ".join(c.__name__ for c in MODEL_FOR_QUESTION_ANSWERING_MAPPING.keys()),
             )
         )
+
+    # To avoid touching the actual implementation while doing type annotations,
+    # at least two "overloads" are required, if we're to avoid stub files.
+    @overload
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: str) -> "PreTrainedModel":
+        ...
+
+    @overload
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *model_args: Any,
+        config: Optional[PretrainedConfig] = None,
+        state_dict: Optional[Mapping[str, Any]] = None,
+        cache_dir: Optional[str] = None,
+        force_download: bool = False,
+        resume_download: bool = False,
+        proxies: Optional[Mapping[str, str]] = None,
+        output_loading_info: bool = ...,
+        **kwargs: Any
+    ) -> "PreTrainedModel":
+        ...
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
@@ -1557,7 +1753,7 @@ class AutoModelForTokenClassification:
         )
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config: PretrainedConfig) -> "PreTrainedModel":
         r""" Instantiates one of the base model classes of the library
         from a configuration.
 
@@ -1598,6 +1794,30 @@ class AutoModelForTokenClassification:
                 ", ".join(c.__name__ for c in MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.keys()),
             )
         )
+
+    # To avoid touching the actual implementation while doing type annotations,
+    # at least two "overloads" are required, if we're to avoid stub files.
+    @overload
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: str) -> "PreTrainedModel":
+        ...
+
+    @overload
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *model_args: Any,
+        config: Optional[PretrainedConfig] = None,
+        state_dict: Optional[Mapping[str, Any]] = None,
+        cache_dir: Optional[str] = None,
+        force_download: bool = False,
+        resume_download: bool = False,
+        proxies: Optional[Mapping[str, str]] = None,
+        output_loading_info: bool = ...,
+        **kwargs: Any
+    ) -> "PreTrainedModel":
+        ...
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
@@ -1709,7 +1929,7 @@ class AutoModelForMultipleChoice:
         )
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config: PretrainedConfig) -> "PreTrainedModel":
         for config_class, model_class in MODEL_FOR_MULTIPLE_CHOICE_MAPPING.items():
             if isinstance(config, config_class):
                 return model_class(config)
@@ -1724,7 +1944,7 @@ class AutoModelForMultipleChoice:
         )
 
     @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
+    def from_pretrained(cls, pretrained_model_name_or_path: str, *model_args: Any, **kwargs: Any):
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
             config, kwargs = AutoConfig.from_pretrained(

--- a/src/transformers/tokenization_auto.py
+++ b/src/transformers/tokenization_auto.py
@@ -17,6 +17,7 @@
 
 import logging
 from collections import OrderedDict
+from typing import TYPE_CHECKING, Any, Dict, Optional, overload
 
 from .configuration_auto import (
     AlbertConfig,
@@ -66,6 +67,10 @@ from .tokenization_transfo_xl import TransfoXLTokenizer, TransfoXLTokenizerFast
 from .tokenization_xlm import XLMTokenizer
 from .tokenization_xlm_roberta import XLMRobertaTokenizer
 from .tokenization_xlnet import XLNetTokenizer
+
+
+if TYPE_CHECKING:
+    from .tokenization_utils_base import PreTrainedTokenizerBase
 
 
 logger = logging.getLogger(__name__)
@@ -133,6 +138,28 @@ class AutoTokenizer:
             "AutoTokenizer is designed to be instantiated "
             "using the `AutoTokenizer.from_pretrained(pretrained_model_name_or_path)` method."
         )
+
+    # To avoid touching the actual implementation while doing type annotations,
+    # at least two "overloads" are required, if we're to avoid stub files.
+    @overload
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: str,) -> "PreTrainedTokenizerBase":
+        ...
+
+    @overload
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *inputs: Any,
+        cache_dir: Optional[str] = None,
+        force_download: bool = False,
+        resume_download: bool = False,
+        proxies: Optional[Dict[str, str]] = None,
+        use_fast: bool = False,
+        **kwargs: Any
+    ) -> "PreTrainedTokenizerBase":
+        ...
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *inputs, **kwargs):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -66,12 +66,12 @@ except ImportError:
         _has_tensorboard = False
 
 
-def is_tensorboard_available():
+def is_tensorboard_available() -> bool:
     return _has_tensorboard
 
 
 if is_wandb_available():
-    import wandb
+    import wandb  # type: ignore
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
1. This is purely a type annotation PR( pinging @sgugger  ), except for number 3 below.
2. Admittedly, this PR orients type annotations as a code-correctness tool rather than a documentation tool, which I haven't seen in the repo before.
3. The only non-type-annotation change is making `DataProcessor` inherit from `abc.ABC`. Along with that, the methods that previously had `raise NotImplementedError()` are now decorated by `@abc.abstractmethod`. This change was motivated by the fact that the static analyzers like mypy can correctly identify unimplemented methods in subclasses.

This PR is a result of a question on  [post on the forum](https://discuss.huggingface.co/t/static-type-checking-with-mypy-whats-the-official-position/464).

Closes #6118 too.