### PR TITLE
test_tokenization_common.py: Remove redundant coverage

### DIFF
--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1065,10 +1065,6 @@ class TokenizerTesterMixin:
                 self.assertIsInstance(vocab, dict)
                 self.assertEqual(len(vocab), len(tokenizer))
 
-                for word, ind in vocab.items():
-                    self.assertEqual(tokenizer.convert_tokens_to_ids(word), ind)
-                    self.assertEqual(tokenizer.convert_ids_to_tokens(ind), word)
-
                 tokenizer.add_tokens(["asdfasdfasdfasdf"])
                 vocab = tokenizer.get_vocab()
                 self.assertIsInstance(vocab, dict)


### PR DESCRIPTION
The deleted logic is already covered [here](https://github.com/huggingface/transformers/blob/3a58d6b22d436c71ee7511dbcae5128ed787ebf5/tests/test_tokenization_common.py#L1079)

