### PR TITLE
Upgrade pip ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
         steps:
             - checkout
             - run: sudo pip install --upgrade pip
-            - run: sudo pip install .[sklearn,tf-cpu,torch,testing]
+            - run: sudo pip install .[sklearn,tf-cpu,torch,testing] --no-cache-dir
             - run: sudo pip install codecov pytest-cov
             - run: python -m pytest -n 8 --dist=loadfile -s ./tests/ --cov  | tee output.txt
             - run: codecov
@@ -29,7 +29,7 @@ jobs:
         steps:
             - checkout
             - run: sudo pip install --upgrade pip
-            - run: sudo pip install .[sklearn,torch,testing]
+            - run: sudo pip install .[sklearn,torch,testing] --no-cache-dir
             - run: python -m pytest -n 8 --dist=loadfile -s ./tests/ | tee output.txt
             - store_artifacts:
                   path: ~/transformers/output.txt
@@ -46,7 +46,7 @@ jobs:
         steps:
             - checkout
             - run: sudo pip install --upgrade pip
-            - run: sudo pip install .[sklearn,tf-cpu,testing]
+            - run: sudo pip install .[sklearn,tf-cpu,testing] --no-cache-dir
             - run: python -m pytest -n 8 --dist=loadfile -s ./tests/ | tee output.txt
             - store_artifacts:
                path: ~/transformers/output.txt
@@ -76,7 +76,7 @@ jobs:
         steps:
             - checkout
             - run: sudo pip install --upgrade pip
-            - run: sudo pip install .[sklearn,torch,testing]
+            - run: sudo pip install .[sklearn,torch,testing] --no-cache-dir
             - run: sudo pip install -r examples/requirements.txt
             - run: python -m pytest -n 8 --dist=loadfile -rA -s ./examples/ | tee output.txt
             - store_artifacts:
@@ -89,7 +89,7 @@ jobs:
         steps:
             - checkout
             - run: sudo pip install --upgrade pip
-            - run: sudo pip install .[tf,torch,docs]
+            - run: sudo pip install .[tf,torch,docs] --no-cache-dir
             - run: cd docs && make html SPHINXOPTS="-W"
             - store_artifacts:
                 path: ./docs/_build
@@ -102,7 +102,7 @@ jobs:
                 fingerprints:
                     - "5b:7a:95:18:07:8c:aa:76:4c:60:35:88:ad:60:56:71"
             - checkout
-            - run: sudo pip install .[tf,torch,docs]
+            - run: sudo pip install .[tf,torch,docs] --no-cache-dir
             - run: ./.circleci/deploy.sh
     check_code_quality:
         working_directory: ~/transformers
@@ -115,7 +115,7 @@ jobs:
             - run: sudo pip install --upgrade pip
             # we need a version of isort with https://github.com/timothycrosley/isort/pull/1000
             - run: sudo pip install git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e528357650281a3d3ec22#egg=isort
-            - run: sudo pip install .[tf,torch,quality]
+            - run: sudo pip install .[tf,torch,quality] --no-cache-dir
             - run: black --check --line-length 119 --target-version py35 examples templates tests src utils
             - run: isort --check-only --recursive examples templates tests src utils
             - run: flake8 examples templates tests src utils

--- a/.github/workflows/github-torch-hub.yml
+++ b/.github/workflows/github-torch-hub.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
-        pip install torch
+        pip install torch --no-cache-dir
         pip install numpy tokenizers filelock requests tqdm regex sentencepiece sacremoses packaging
 
     - name: Torch hub list

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         source .env/bin/activate
         pip install --upgrade pip
-        pip install torch
+        pip install torch --no-cache-dir
         pip install .[sklearn,testing]
 
     - name: Are GPUs recognized by our DL frameworks

--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         source .env/bin/activate
         pip install --upgrade pip
-        pip install .[sklearn,torch,testing]
+        pip install .[sklearn,torch,testing] --no-cache-dir
 
     - name: Are GPUs recognized by our DL frameworks
       run: |


### PR DESCRIPTION
The SHA failures that made the tests flaky the last few weeks seem to come from a mismatch of SHA signatures from the pip cache and downloaded package, which may be due to incomplete/failed downloads. This PR removes the cache usage, which does not slow down the test and makes them more robust.