### PR TITLE
add targets arg to fill-mask pipeline

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1162,7 +1162,12 @@ class FillMaskPipeline(Pipeline):
         Fill the masked token in the text(s) given as inputs.
 
         Args:
-            args (:obj:`str` or :obj:`List[str]`): One or several texts (or one list of prompts) with masked tokens.
+            args (:obj:`str` or :obj:`List[str]`):
+                One or several texts (or one list of prompts) with masked tokens.
+            targets (:obj:`str` or :obj:`List[str]`, `optional`):
+                When passed, the model will return the scores for the passed token or tokens rather than the top k
+                predictions in the entire vocabulary. If the provided targets are not in the model vocab, they will
+                be tokenized and the first resulting token will be used (with a warning).
 
         Return:
             A list or a list of list of :obj:`dict`: Each result comes as list of dictionaries with the

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -41,6 +41,23 @@ expected_fill_mask_result = [
     ],
 ]
 
+expected_fill_mask_target_result = [
+    [
+        {
+            "sequence": "<s>My name is Patrick</s>",
+            "score": 0.004992353264242411,
+            "token": 3499,
+            "token_str": "ĠPatrick",
+        },
+        {
+            "sequence": "<s>My name is Clara</s>",
+            "score": 0.00019297805556561798,
+            "token": 13606,
+            "token_str": "ĠClara",
+        },
+    ]
+]
+
 SUMMARIZATION_KWARGS = dict(num_beams=2, min_length=2, max_length=5)
 
 
@@ -139,7 +156,7 @@ class MonoColumnInputTestCase(unittest.TestCase):
         for key in output_keys:
             self.assertIn(key, mono_result[0])
 
-        multi_result = [nlp(input) for input in valid_inputs]
+        multi_result = [nlp(input, **kwargs) for input in valid_inputs]
         self.assertIsInstance(multi_result, list)
         self.assertIsInstance(multi_result[0], (dict, list))
 
@@ -220,6 +237,36 @@ class MonoColumnInputTestCase(unittest.TestCase):
             )
 
     @require_torch
+    def test_torch_fill_mask_with_targets(self):
+        mandatory_keys = {"sequence", "score", "token"}
+        valid_inputs = ["My name is <mask>"]
+        valid_targets = [[" Teven", " Patrick", " Clara"], [" Sam"]]
+        invalid_targets = [[], [""], ""]
+        for model_name in FILL_MASK_FINETUNED_MODELS:
+            nlp = pipeline(task="fill-mask", model=model_name, tokenizer=model_name, framework="pt")
+            for targets in valid_targets:
+                outputs = nlp(valid_inputs, targets=targets)
+                self.assertIsInstance(outputs, list)
+                self.assertEqual(len(outputs), len(targets))
+            for targets in invalid_targets:
+                self.assertRaises(ValueError, nlp, valid_inputs, targets=targets)
+
+    @require_tf
+    def test_tf_fill_mask_with_targets(self):
+        mandatory_keys = {"sequence", "score", "token"}
+        valid_inputs = ["My name is <mask>"]
+        valid_targets = [[" Teven", " Patrick", " Clara"], [" Sam"]]
+        invalid_targets = [[], [""], ""]
+        for model_name in FILL_MASK_FINETUNED_MODELS:
+            nlp = pipeline(task="fill-mask", model=model_name, tokenizer=model_name, framework="tf")
+            for targets in valid_targets:
+                outputs = nlp(valid_inputs, targets=targets)
+                self.assertIsInstance(outputs, list)
+                self.assertEqual(len(outputs), len(targets))
+            for targets in invalid_targets:
+                self.assertRaises(ValueError, nlp, valid_inputs, targets=targets)
+
+    @require_torch
     @slow
     def test_torch_fill_mask_results(self):
         mandatory_keys = {"sequence", "score", "token"}
@@ -227,6 +274,7 @@ class MonoColumnInputTestCase(unittest.TestCase):
             "My name is <mask>",
             "The largest city in France is <mask>",
         ]
+        valid_targets = [" Patrick", " Clara"]
         for model_name in LARGE_FILL_MASK_FINETUNED_MODELS:
             nlp = pipeline(task="fill-mask", model=model_name, tokenizer=model_name, framework="pt", topk=2,)
             self._test_mono_column_pipeline(
@@ -235,6 +283,14 @@ class MonoColumnInputTestCase(unittest.TestCase):
                 mandatory_keys,
                 expected_multi_result=expected_fill_mask_result,
                 expected_check_keys=["sequence"],
+            )
+            self._test_mono_column_pipeline(
+                nlp,
+                valid_inputs[:1],
+                mandatory_keys,
+                expected_multi_result=expected_fill_mask_target_result,
+                expected_check_keys=["sequence"],
+                targets=valid_targets,
             )
 
     @require_tf
@@ -245,6 +301,7 @@ class MonoColumnInputTestCase(unittest.TestCase):
             "My name is <mask>",
             "The largest city in France is <mask>",
         ]
+        valid_targets = [" Patrick", " Clara"]
         for model_name in LARGE_FILL_MASK_FINETUNED_MODELS:
             nlp = pipeline(task="fill-mask", model=model_name, tokenizer=model_name, framework="tf", topk=2)
             self._test_mono_column_pipeline(
@@ -253,6 +310,14 @@ class MonoColumnInputTestCase(unittest.TestCase):
                 mandatory_keys,
                 expected_multi_result=expected_fill_mask_result,
                 expected_check_keys=["sequence"],
+            )
+            self._test_mono_column_pipeline(
+                nlp,
+                valid_inputs[:1],
+                mandatory_keys,
+                expected_multi_result=expected_fill_mask_target_result,
+                expected_check_keys=["sequence"],
+                targets=valid_targets,
             )
 
     @require_torch

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -238,7 +238,6 @@ class MonoColumnInputTestCase(unittest.TestCase):
 
     @require_torch
     def test_torch_fill_mask_with_targets(self):
-        mandatory_keys = {"sequence", "score", "token"}
         valid_inputs = ["My name is <mask>"]
         valid_targets = [[" Teven", " Patrick", " Clara"], [" Sam"]]
         invalid_targets = [[], [""], ""]
@@ -253,7 +252,6 @@ class MonoColumnInputTestCase(unittest.TestCase):
 
     @require_tf
     def test_tf_fill_mask_with_targets(self):
-        mandatory_keys = {"sequence", "score", "token"}
         valid_inputs = ["My name is <mask>"]
         valid_targets = [[" Teven", " Patrick", " Clara"], [" Sam"]]
         invalid_targets = [[], [""], ""]


### PR DESCRIPTION
Proposal to add a `targets` arg when calling `FillMaskPipeline`, allowing a user to compare different target tokens in addition to getting the top k predictions. This could be useful in a number of areas, such as in probing model behavior:

```python
nlp = pipeline('fill-mask', topk=2)
nlp("<mask> should be at home and take care of their children.")
> [{'sequence': '<s>Parents should be at home and take care of their children.</s>',
    'score': 0.32749035954475403,
    'token': 35835,
    'token_str': 'Parents'},
   {'sequence': '<s> parents should be at home and take care of their children.</s>',
    'score': 0.12840420007705688,
    'token': 1041,
    'token_str': 'Ġparents'}]

nlp("<mask> should be at home and take care of their children.", targets=["Men", "Women"])
> [{'sequence': '<s>Women should be at home and take care of their children.</s>',
    'score': 0.04439367726445198,
    'token': 19814,
    'token_str': 'Women'},
   {'sequence': '<s>Men should be at home and take care of their children.</s>',
    'score': 0.01326736994087696,
    'token': 17762,
    'token_str': 'Men'}]
```

This could also prove useful in the setting of using MLMs for cloze tasks and few/zero-shot prediction:

```python
nlp("The acting was believable and the action was outstanding. The sentiment of this review is <mask>.")
> [{'sequence': '<s>The acting was believable and the action was outstanding. The sentiment of this review is clear.</s>',
    'score': 0.10008594393730164,
    'token': 699,
    'token_str': 'Ġclear'},
   {'sequence': '<s>The acting was believable and the action was outstanding. The sentiment of this review is undeniable.</s>',
    'score': 0.05471134930849075,
    'token': 29941,
    'token_str': 'Ġundeniable'}]

nlp("The acting was believable and the action was outstanding. The sentiment of this review is <mask>.",
    targets=[' positive', ' negative'])
> [{'sequence': '<s>The acting was believable and the action was outstanding. The sentiment of this review is positive.</s>',
    'score': 0.04867269843816757,
    'token': 1313,
    'token_str': 'Ġpositive'},
   {'sequence': '<s>The acting was believable and the action was outstanding. The sentiment of this review is negative.</s>',
    'score': 0.0009897189447656274,
    'token': 2430,
    'token_str': 'Ġnegative'}]
```

Notes:
- Passed targets must be in model vocab. If they're not, the target word is tokenized and the first token is used (with a user warning)
- Could possibly also be done with text-generation, but that might go against the spirit of that pipeline
- Current implem. can't do multi-input with different targets for each instance. Adding this would be a little less clean because you'd have to handle different output shapes for each instance, but I can add it in if that is important.