### PR TITLE
Trainer + wandb quality of life logging tweaks

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -383,7 +383,14 @@ class Trainer:
             logger.info(
                 'Automatic Weights & Biases logging enabled, to disable set os.environ["WANDB_DISABLED"] = "true"'
             )
-            wandb.init(project=os.getenv("WANDB_PROJECT", "huggingface"), config=self.args.to_sanitized_dict())
+            combined_dict = {**self.model.config.to_dict(), **self.args.to_sanitized_dict()}
+            common_keys = self.model.config.to_dict().keys() & self.args.to_sanitized_dict().keys()
+            if common_keys:
+                warnings.warn(
+                    f"Using trainer values in wandb initial logging for keys {common_keys} shared"
+                    f" between model and trainer configs."
+                )
+            wandb.init(project=os.getenv("WANDB_PROJECT", "huggingface"), config=combined_dict, name=self.args.name)
             # keep track of model topology and gradients, unsupported on TPU
             if not is_torch_tpu_available() and os.getenv("WANDB_WATCH") != "false":
                 wandb.watch(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -384,13 +384,9 @@ class Trainer:
                 'Automatic Weights & Biases logging enabled, to disable set os.environ["WANDB_DISABLED"] = "true"'
             )
             combined_dict = {**self.model.config.to_dict(), **self.args.to_sanitized_dict()}
-            common_keys = self.model.config.to_dict().keys() & self.args.to_sanitized_dict().keys()
-            if common_keys:
-                warnings.warn(
-                    f"Using trainer values in wandb initial logging for keys {common_keys} shared"
-                    f" between model and trainer configs."
-                )
-            wandb.init(project=os.getenv("WANDB_PROJECT", "huggingface"), config=combined_dict, name=self.args.name)
+            wandb.init(
+                project=os.getenv("WANDB_PROJECT", "huggingface"), config=combined_dict, name=self.args.run_name
+            )
             # keep track of model topology and gradients, unsupported on TPU
             if not is_torch_tpu_available() and os.getenv("WANDB_WATCH") != "false":
                 wandb.watch(

--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -215,7 +215,8 @@ class TFTrainer:
             return self._setup_wandb()
 
         logger.info('Automatic Weights & Biases logging enabled, to disable set os.environ["WANDB_DISABLED"] = "true"')
-        wandb.init(project=os.getenv("WANDB_PROJECT", "huggingface"), config=vars(self.args))
+        combined_dict = {**self.model.config.to_dict(), **self.args.to_sanitized_dict()}
+        wandb.init(project=os.getenv("WANDB_PROJECT", "huggingface"), config=combined_dict, name=self.args.run_name)
 
     def prediction_loop(
         self,

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -109,7 +109,7 @@ class TrainingArguments:
             make use of the past hidden states for their predictions. If this argument is set to a positive int, the
             ``Trainer`` will use the corresponding output (usually index 2) as the past state and feed it to the model
             at the next training step under the keyword argument ``mems``.
-        name (:obj:`str`, `optional`):
+        run_name (:obj:`str`, `optional`):
             A descriptor for the run. Notably used for wandb logging.
     """
 
@@ -224,7 +224,7 @@ class TrainingArguments:
         metadata={"help": "If >=0, uses the corresponding part of the output as the past state for next step."},
     )
 
-    name: Optional[str] = field(
+    run_name: Optional[str] = field(
         default=None, metadata={"help": "An optional descriptor for the run. Notably used for wandb logging."}
     )
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -109,6 +109,8 @@ class TrainingArguments:
             make use of the past hidden states for their predictions. If this argument is set to a positive int, the
             ``Trainer`` will use the corresponding output (usually index 2) as the past state and feed it to the model
             at the next training step under the keyword argument ``mems``.
+        name (:obj:`str`, `optional`, defaults to :obj:`None`):
+            A descriptor for the run. Notably used for wandb logging.
     """
 
     output_dir: str = field(
@@ -220,6 +222,10 @@ class TrainingArguments:
     past_index: int = field(
         default=-1,
         metadata={"help": "If >=0, uses the corresponding part of the output as the past state for next step."},
+    )
+
+    name: Optional[str] = field(
+        default=None, metadata={"help": "An optional descriptor for the run. Notably used for wandb logging."}
     )
 
     @property

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -109,7 +109,7 @@ class TrainingArguments:
             make use of the past hidden states for their predictions. If this argument is set to a positive int, the
             ``Trainer`` will use the corresponding output (usually index 2) as the past state and feed it to the model
             at the next training step under the keyword argument ``mems``.
-        name (:obj:`str`, `optional`, defaults to :obj:`None`):
+        name (:obj:`str`, `optional`):
             A descriptor for the run. Notably used for wandb logging.
     """
 

--- a/src/transformers/training_args_tf.py
+++ b/src/transformers/training_args_tf.py
@@ -95,6 +95,8 @@ class TFTrainingArguments(TrainingArguments):
             at the next training step under the keyword argument ``mems``.
         tpu_name (:obj:`str`, `optional`):
             The name of the TPU the process is running on.
+        run_name (:obj:`str`, `optional`):
+            A descriptor for the run. Notably used for wandb logging.
     """
 
     tpu_name: str = field(


### PR DESCRIPTION
As discussed on Slack, this PR adds the possibility for users to specify a `name` for the run in their wandb project, and logs the model config in addition to the trainer args in the `wandb.init` call (if there is a duplicate key, it is overriden by the trainer args)