### PR TITLE
[Don't merge yet][T5, Bart] Allow t5 torch trace

### DIFF
--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -843,8 +843,8 @@ class BartModel(PretrainedBartModel):
     def forward(
         self,
         input_ids,
-        attention_mask=None,
         decoder_input_ids=None,
+        attention_mask=None,
         encoder_outputs: Optional[Tuple] = None,
         decoder_attention_mask=None,
         decoder_past_key_values=None,
@@ -968,9 +968,9 @@ class BartForConditionalGeneration(PretrainedBartModel):
     def forward(
         self,
         input_ids,
+        decoder_input_ids=None,
         attention_mask=None,
         encoder_outputs=None,
-        decoder_input_ids=None,
         decoder_attention_mask=None,
         decoder_past_key_values=None,
         labels=None,
@@ -1026,8 +1026,8 @@ class BartForConditionalGeneration(PretrainedBartModel):
 
         outputs = self.model(
             input_ids,
-            attention_mask=attention_mask,
             decoder_input_ids=decoder_input_ids,
+            attention_mask=attention_mask,
             encoder_outputs=encoder_outputs,
             decoder_attention_mask=decoder_attention_mask,
             decoder_past_key_values=decoder_past_key_values,
@@ -1139,9 +1139,9 @@ class BartForSequenceClassification(PretrainedBartModel):
     def forward(
         self,
         input_ids,
+        decoder_input_ids=None,
         attention_mask=None,
         encoder_outputs=None,
-        decoder_input_ids=None,
         decoder_attention_mask=None,
         labels=None,
         use_cache=None,
@@ -1161,8 +1161,8 @@ class BartForSequenceClassification(PretrainedBartModel):
 
         outputs = self.model(
             input_ids,
-            attention_mask=attention_mask,
             decoder_input_ids=decoder_input_ids,
+            attention_mask=attention_mask,
             decoder_attention_mask=decoder_attention_mask,
             encoder_outputs=encoder_outputs,
             use_cache=use_cache,
@@ -1225,9 +1225,9 @@ class BartForQuestionAnswering(PretrainedBartModel):
     def forward(
         self,
         input_ids,
+        decoder_input_ids=None,
         attention_mask=None,
         encoder_outputs=None,
-        decoder_input_ids=None,
         decoder_attention_mask=None,
         start_positions=None,
         end_positions=None,
@@ -1252,8 +1252,8 @@ class BartForQuestionAnswering(PretrainedBartModel):
 
         outputs = self.model(
             input_ids,
-            attention_mask=attention_mask,
             decoder_input_ids=decoder_input_ids,
+            attention_mask=attention_mask,
             decoder_attention_mask=decoder_attention_mask,
             encoder_outputs=encoder_outputs,
             use_cache=use_cache,

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -922,9 +922,9 @@ class T5Model(T5PreTrainedModel):
     def forward(
         self,
         input_ids=None,
+        decoder_input_ids=None,
         attention_mask=None,
         encoder_outputs=None,
-        decoder_input_ids=None,
         decoder_attention_mask=None,
         decoder_past_key_values=None,
         use_cache=None,
@@ -1072,9 +1072,9 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
     def forward(
         self,
         input_ids=None,
+        decoder_input_ids=None,
         attention_mask=None,
         encoder_outputs=None,
-        decoder_input_ids=None,
         decoder_attention_mask=None,
         decoder_past_key_values=None,
         use_cache=None,

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -828,6 +828,12 @@ T5_INPUTS_DOCSTRING = r"""
             :func:`transformers.PreTrainedTokenizer.convert_tokens_to_ids` for details.
             To know more on how to prepare :obj:`input_ids` for pre-training take a look at
             `T5 Training <./t5.html#training>`__.
+        decoder_input_ids (:obj:`torch.LongTensor` of shape :obj:`(batch_size, target_sequence_length)`, `optional`, defaults to :obj:`None`):
+            Provide for sequence to sequence training. T5 uses the pad_token_id as the starting token for decoder_input_ids generation.
+            If `decoder_past_key_values` is used, optionally only the last `decoder_input_ids` have to be input (see `decoder_past_key_values`).
+            To know more on how to prepare :obj:`decoder_input_ids` for pre-training take a look at
+            `T5 Training <./t5.html#training>`__. If decoder_input_ids and decoder_inputs_embeds are both None,
+            decoder_input_ids takes the value of input_ids.
         attention_mask (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`, defaults to :obj:`None`):
             Mask to avoid performing attention on padding token indices.
             Mask values selected in ``[0, 1]``:
@@ -836,12 +842,6 @@ T5_INPUTS_DOCSTRING = r"""
             Tuple consists of (`last_hidden_state`, `optional`: `hidden_states`, `optional`: `attentions`)
             `last_hidden_state` of shape :obj:`(batch_size, sequence_length, hidden_size)`, `optional`, defaults to :obj:`None`) is a sequence of hidden-states at the output of the last layer of the encoder.
             Used in the cross-attention of the decoder.
-        decoder_input_ids (:obj:`torch.LongTensor` of shape :obj:`(batch_size, target_sequence_length)`, `optional`, defaults to :obj:`None`):
-            Provide for sequence to sequence training. T5 uses the pad_token_id as the starting token for decoder_input_ids generation.
-            If `decoder_past_key_values` is used, optionally only the last `decoder_input_ids` have to be input (see `decoder_past_key_values`).
-            To know more on how to prepare :obj:`decoder_input_ids` for pre-training take a look at
-            `T5 Training <./t5.html#training>`__. If decoder_input_ids and decoder_inputs_embeds are both None,
-            decoder_input_ids takes the value of input_ids.
         decoder_attention_mask (:obj:`torch.BoolTensor` of shape :obj:`(batch_size, tgt_seq_len)`, `optional`, defaults to :obj:`None`):
             Default behavior: generate a tensor that ignores pad tokens in decoder_input_ids. Causal mask will also be used by default.
         decoder_past_key_values (:obj:`tuple(tuple(torch.FloatTensor))` of length :obj:`config.n_layers` with each tuple having 4 tensors of shape :obj:`(batch_size, num_heads, sequence_length - 1, embed_size_per_head)`):

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -246,6 +246,10 @@ class ModelTesterMixin:
 
             try:
                 if model.config.is_encoder_decoder:
+                    # Bart cannot trace decoder cache for now.
+                    # see: https://github.com/huggingface/transformers/issues/6348
+                    # TODO: Remove following line when issue is fixed.
+                    model.config.use_cache = False
                     traced_model = torch.jit.trace(model, (inputs, inputs))
                 else:
                     traced_model = torch.jit.trace(model, inputs)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -245,7 +245,10 @@ class ModelTesterMixin:
             inputs = self._prepare_for_class(inputs_dict, model_class)["input_ids"]  # Let's keep only input_ids
 
             try:
-                traced_gpt2 = torch.jit.trace(model, inputs)
+                if model.__class__.__name__ in ["T5Model", "T5ForConditionalGeneration"]:
+                    traced_model = torch.jit.trace(model, (inputs, inputs))
+                else:
+                    traced_model = torch.jit.trace(model, inputs)
             except RuntimeError:
                 self.fail("Couldn't trace module.")
 
@@ -253,7 +256,7 @@ class ModelTesterMixin:
                 pt_file_name = os.path.join(tmp_dir_name, "traced_model.pt")
 
                 try:
-                    torch.jit.save(traced_gpt2, pt_file_name)
+                    torch.jit.save(traced_model, pt_file_name)
                 except Exception:
                     self.fail("Couldn't save module.")
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -245,7 +245,7 @@ class ModelTesterMixin:
             inputs = self._prepare_for_class(inputs_dict, model_class)["input_ids"]  # Let's keep only input_ids
 
             try:
-                if model.__class__.__name__ in ["T5Model", "T5ForConditionalGeneration"]:
+                if model.config.is_encoder_decoder:
                     traced_model = torch.jit.trace(model, (inputs, inputs))
                 else:
                     traced_model = torch.jit.trace(model, inputs)

--- a/tests/test_modeling_t5.py
+++ b/tests/test_modeling_t5.py
@@ -282,7 +282,7 @@ class T5ModelTest(ModelTesterMixin, unittest.TestCase):
     all_model_classes = (T5Model, T5ForConditionalGeneration) if is_torch_available() else ()
     all_generative_model_classes = (T5ForConditionalGeneration,) if is_torch_available() else ()
     test_pruning = False
-    test_torchscript = False
+    test_torchscript = True
     test_resize_embeddings = False
     is_encoder_decoder = True
 


### PR DESCRIPTION
This PR would fix #5647 .

It's not a great solution IMO though. 
The problem with torch script is that one **cannot** pass keyword arguments, but has to pass positional arguments and it is not possible to pass `None` because every input is required to be a tensor.
Because T5 requires both `input_ids` and `decoder_input_ids`, the two arguments should arguably be placed as the first two arguments.

There might be use cases though, where the same error would occur, which we could not save then, *e.g.* one wants to input `input_embeds`.

Maybe @LysandreJik @sgugger have a better idea.