### PR TITLE
[Reformer] fix default generators for pytorch < 1.6

### DIFF
--- a/src/transformers/modeling_reformer.py
+++ b/src/transformers/modeling_reformer.py
@@ -1400,7 +1400,7 @@ class ReformerLayer(nn.Module):
 
         # randomize seeds
         # use cuda generator if available
-        if len(torch.cuda.default_generators) > 0:
+        if hasattr(torch.cuda, "default_generators") and len(torch.cuda.default_generators) > 0:
             # GPU
             device_idx = torch.cuda.current_device()
             self.attention_seed = torch.cuda.default_generators[device_idx].seed()
@@ -1420,7 +1420,7 @@ class ReformerLayer(nn.Module):
         """
         # randomize seeds
         # use cuda generator if available
-        if len(torch.cuda.default_generators) > 0:
+        if hasattr(torch.cuda, "default_generators") and len(torch.cuda.default_generators) > 0:
             # GPU
             device_idx = torch.cuda.current_device()
             self.feed_forward_seed = torch.cuda.default_generators[device_idx].seed()


### PR DESCRIPTION
As far as I know in PyTorch < 1.6 torch.cuda.default_generators is only defined when running on GPU => so we can simply add a `hasattr(torch.cuda, "default_generators")` to fix Reformer for PyTorch < 1.6.