### PR TITLE
pl version: examples/requirements.txt is single source of truth

### DIFF
--- a/examples/text-classification/run_pl.sh
+++ b/examples/text-classification/run_pl.sh
@@ -1,5 +1,3 @@
-# Install newest ptl.
-pip install -U git+http://github.com/PyTorchLightning/pytorch-lightning/
 # Install example requirements
 pip install -r ../requirements.txt
 

--- a/examples/token-classification/run_pl.sh
+++ b/examples/token-classification/run_pl.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# Install newest ptl.
-pip install -U git+http://github.com/PyTorchLightning/pytorch-lightning/
 # for seqeval metrics import
 pip install -r ../requirements.txt
 


### PR DESCRIPTION
PL git master is unstable:

```
cd examples/text-classification
./run_pl.sh
```
```
   File "run_pl_glue.py", line 12, in <module>
    from lightning_base import BaseTransformer, add_generic_args, generic_train
  File "/mnt/nvme1/code/huggingface/transformers-master/examples/lightning_base.py", line 7, in <module>
    import pytorch_lightning as pl
  File "/home/stas/anaconda3/envs/main/lib/python3.7/site-packages/pytorch_lightning/__init__.py", line 76, in <module>
    __import__('pkg_resources').declare_namespace(__name__)
  File "/home/stas/anaconda3/envs/main/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2301, in declare_namespace
    _handle_ns(packageName, path_item)
  File "/home/stas/anaconda3/envs/main/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2234, in _handle_ns
    loader.load_module(packageName)
  File "/mnt/nvme1/code/github/00pytorch/pytorch-lightning/pytorch_lightning/__init__.py", line 56, in <module>
    from pytorch_lightning.core import LightningDataModule, LightningModule
ImportError: cannot import name 'LightningDataModule' from 'pytorch_lightning.core' (/home/stas/anaconda3/envs/main/lib/python3.7/site-packages/pytorch_lightning/core/__init__.py)
```
the scripts will now rely on:

```
grep pytorch-l examples/requirements.txt
```
```
pytorch-lightning==0.8.5
```

whenever the requirement removed by this PR was added (it also helps to add why it was added):
```
# Install newest ptl.
pip install -U git+http://github.com/PyTorchLightning/pytorch-lightning/
```
seems to no longer be needed - at least the code runs to completion.