### PR TITLE
remove a TODO item to use a tiny model

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -79,7 +79,6 @@ class ExamplesTests(unittest.TestCase):
     def test_run_language_modeling(self):
         stream_handler = logging.StreamHandler(sys.stdout)
         logger.addHandler(stream_handler)
-        # TODO: switch to smaller model like sshleifer/tiny-distilroberta-base
 
         testargs = """
             run_language_modeling.py


### PR DESCRIPTION
as discussed with @sshleifer, removing this TODO to switch to a tiny model, since it won't be able to test the qualitative results of the evaluation (i.e. the results are meaningless).