### PR TITLE
[s2s] fix --gpus clarg collision

### DIFF
--- a/examples/lightning_base.py
+++ b/examples/lightning_base.py
@@ -277,11 +277,6 @@ def add_generic_args(parser, root_dir) -> None:
         required=True,
         help="The output directory where the model predictions and checkpoints will be written.",
     )
-
-    parser.add_argument(
-        "--gpus", default=0, type=int, help="The number of GPUs allocated for this, it is by default 0 meaning none",
-    )
-
     parser.add_argument(
         "--fp16",
         action="store_true",

--- a/examples/text-classification/run_pl_glue.py
+++ b/examples/text-classification/run_pl_glue.py
@@ -155,7 +155,10 @@ class GLUETransformer(BaseTransformer):
         parser.add_argument(
             "--task", default="", type=str, required=True, help="The GLUE task to run",
         )
-
+        parser.add_argument(
+            "--gpus", default=0, type=int,
+            help="The number of GPUs allocated for this, it is by default 0 meaning none",
+        )
         parser.add_argument(
             "--data_dir",
             default=None,

--- a/examples/text-classification/run_pl_glue.py
+++ b/examples/text-classification/run_pl_glue.py
@@ -156,7 +156,9 @@ class GLUETransformer(BaseTransformer):
             "--task", default="", type=str, required=True, help="The GLUE task to run",
         )
         parser.add_argument(
-            "--gpus", default=0, type=int,
+            "--gpus",
+            default=0,
+            type=int,
             help="The number of GPUs allocated for this, it is by default 0 meaning none",
         )
         parser.add_argument(

--- a/examples/token-classification/run_pl_ner.py
+++ b/examples/token-classification/run_pl_ner.py
@@ -169,7 +169,9 @@ class NERTransformer(BaseTransformer):
             help="Path to a file containing all labels. If not specified, CoNLL-2003 labels are used.",
         )
         parser.add_argument(
-            "--gpus", default=0, type=int,
+            "--gpus",
+            default=0,
+            type=int,
             help="The number of GPUs allocated for this, it is by default 0 meaning none",
         )
 

--- a/examples/token-classification/run_pl_ner.py
+++ b/examples/token-classification/run_pl_ner.py
@@ -168,6 +168,10 @@ class NERTransformer(BaseTransformer):
             type=str,
             help="Path to a file containing all labels. If not specified, CoNLL-2003 labels are used.",
         )
+        parser.add_argument(
+            "--gpus", default=0, type=int,
+            help="The number of GPUs allocated for this, it is by default 0 meaning none",
+        )
 
         parser.add_argument(
             "--data_dir",


### PR DESCRIPTION
### Problem
finetune.py adds all the default pl args with this line

```
parser = pl.Trainer.add_argparse_args(parser)
```
and all the generic args from `add_generic_args`.

### Solution
This moves the overlapping arg from lightning_base.py to the 2 pl examples that need it.

CC @stas00  @patil-suraj 