### PR TITLE
Fix docs and bad word tokens generation_utils.py

### DIFF
--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -937,7 +937,7 @@ def calc_banned_bad_words_ids(prev_input_ids, bad_words_ids):
             # if bad word tokens is just one token always ban it
             return True
         if len(tokens) > len(prev_tokens):
-            # if bad word tokens are longer then prev tokens they can't be equal
+            # if bad word tokens are longer than prev tokens they can't be equal
             return False
 
         if prev_tokens[-len(tokens) :] == tokens:

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -163,7 +163,7 @@ class TFGenerationMixin:
             model = TFAutoModelWithLMHead.from_pretrained('distilgpt2')    # Download model and configuration from S3 and cache.
             input_context = 'The dog'
             input_ids = tokenizer.encode(input_context, return_tensors='tf')  # encode input context
-            outputs = model.generate(input_ids=input_ids, max_length=40, temperature=0.7, num_return_sequences=3, do_sample=True)  # 3 generate sequences using by sampling
+            outputs = model.generate(input_ids=input_ids, max_length=40, temperature=0.7, num_return_sequences=3, do_sample=True)  # generate 3 candidates using sampling
             for i in range(3): #  3 output sequences were generated
                 print('Generated {}: {}'.format(i, tokenizer.decode(outputs[i], skip_special_tokens=True)))
 

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -163,7 +163,7 @@ class TFGenerationMixin:
             model = TFAutoModelWithLMHead.from_pretrained('distilgpt2')    # Download model and configuration from S3 and cache.
             input_context = 'The dog'
             input_ids = tokenizer.encode(input_context, return_tensors='tf')  # encode input context
-            outputs = model.generate(input_ids=input_ids, max_length=40, temperature=0.7, num_return_sequences=3)  # 3 generate sequences using by sampling
+            outputs = model.generate(input_ids=input_ids, max_length=40, temperature=0.7, num_return_sequences=3, do_sample=True)  # 3 generate sequences using by sampling
             for i in range(3): #  3 output sequences were generated
                 print('Generated {}: {}'.format(i, tokenizer.decode(outputs[i], skip_special_tokens=True)))
 
@@ -936,8 +936,8 @@ def calc_banned_bad_words_ids(prev_input_ids, bad_words_ids):
         if len(tokens) == 0:
             # if bad word tokens is just one token always ban it
             return True
-        if len(tokens) > len(prev_input_ids):
-            # if bad word tokens are longer then prev input_ids they can't be equal
+        if len(tokens) > len(prev_tokens):
+            # if bad word tokens are longer then prev tokens they can't be equal
             return False
 
         if prev_tokens[-len(tokens) :] == tokens:

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -226,7 +226,7 @@ class GenerationMixin:
             model = AutoModelWithLMHead.from_pretrained('distilgpt2')    # Download model and configuration from S3 and cache.
             input_context = 'The dog'
             input_ids = tokenizer.encode(input_context, return_tensors='pt')  # encode input context
-            outputs = model.generate(input_ids=input_ids, max_length=40, temperature=0.7, num_return_sequences=3, do_sample=True)  # 3 generate sequences using by sampling
+            outputs = model.generate(input_ids=input_ids, max_length=40, temperature=0.7, num_return_sequences=3, do_sample=True)  # generate 3 candidates using sampling
             for i in range(3): #  3 output sequences were generated
                 print('Generated {}: {}'.format(i, tokenizer.decode(outputs[i], skip_special_tokens=True)))
 

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -877,7 +877,7 @@ def calc_banned_bad_words_ids(prev_input_ids: Iterable[int], bad_words_ids: Iter
             # if bad word tokens is just one token always ban it
             return True
         if len(tokens) > len(prev_tokens):
-            # if bad word tokens are longer then prev tokens they can't be equal
+            # if bad word tokens are longer than prev tokens they can't be equal
             return False
 
         if prev_tokens[-len(tokens) :] == tokens:

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -226,7 +226,7 @@ class GenerationMixin:
             model = AutoModelWithLMHead.from_pretrained('distilgpt2')    # Download model and configuration from S3 and cache.
             input_context = 'The dog'
             input_ids = tokenizer.encode(input_context, return_tensors='pt')  # encode input context
-            outputs = model.generate(input_ids=input_ids, max_length=40, temperature=0.7, num_return_sequences=3)  # 3 generate sequences using by sampling
+            outputs = model.generate(input_ids=input_ids, max_length=40, temperature=0.7, num_return_sequences=3, do_sample=True)  # 3 generate sequences using by sampling
             for i in range(3): #  3 output sequences were generated
                 print('Generated {}: {}'.format(i, tokenizer.decode(outputs[i], skip_special_tokens=True)))
 
@@ -876,8 +876,8 @@ def calc_banned_bad_words_ids(prev_input_ids: Iterable[int], bad_words_ids: Iter
         if len(tokens) == 0:
             # if bad word tokens is just one token always ban it
             return True
-        if len(tokens) > len(prev_input_ids):
-            # if bad word tokens are longer then prev input_ids they can't be equal
+        if len(tokens) > len(prev_tokens):
+            # if bad word tokens are longer then prev tokens they can't be equal
             return False
 
         if prev_tokens[-len(tokens) :] == tokens:


### PR DESCRIPTION
This PR fixes two issues:

1.
The codes
https://github.com/huggingface/transformers/blob/6028ed92bd9e5471e6f8a1d23cfd95a3a63018fb/src/transformers/generation_utils.py#L224-L228
throw an exception
`AssertionError: Greedy decoding will always produce the same output for num_beams == 1 and num_return_sequences > 1. Please set num_return_sequences = 1`

2.
The codes
```python
from transformers.generation_utils import calc_banned_bad_words_ids
prev_input_ids = torch.tensor([[1, 2, 3, 4, 5]])
bad_words_ids = [[4, 5, 9]]
banned_tokens = calc_banned_bad_words_ids(prev_input_ids, bad_words_ids)
print(banned_tokens)
```
output `[[]]`，but we expect to output  `[[9]]`.
