### PR TITLE
[T5 3B Covid 19] Adapt T5 TF conversion script to handle covid-19 3b t5

### DIFF
--- a/src/transformers/convert_t5_original_tf_checkpoint_to_pytorch.py
+++ b/src/transformers/convert_t5_original_tf_checkpoint_to_pytorch.py
@@ -20,7 +20,7 @@ import logging
 
 import torch
 
-from transformers import T5Config, T5Model, load_tf_weights_in_t5
+from transformers import T5Config, T5ForConditionalGeneration, load_tf_weights_in_t5
 
 
 logging.basicConfig(level=logging.INFO)
@@ -30,7 +30,7 @@ def convert_tf_checkpoint_to_pytorch(tf_checkpoint_path, config_file, pytorch_du
     # Initialise PyTorch model
     config = T5Config.from_json_file(config_file)
     print("Building PyTorch model from configuration: {}".format(str(config)))
-    model = T5Model(config)
+    model = T5ForConditionalGeneration(config)
 
     # Load weights from tf checkpoint
     load_tf_weights_in_t5(model, config, tf_checkpoint_path)


### PR DESCRIPTION
This PR shows which changes were necessary to convert the 3B (and 11B) T5 model from this issue: https://github.com/huggingface/transformers/tree/adapt_t5_for_covid_19_3b to PyTorch. 

It might be possible that the official T5 library has changed in which case this code might be useful again. 
For now, this PR stays a draft though, but can be cleaned and merged if more T5 Conversion issues arise. 

Pinging @sshleifer @thomwolf for notification.