### PR TITLE
Colab button

### DIFF
--- a/docs/source/_static/css/huggingface.css
+++ b/docs/source/_static/css/huggingface.css
@@ -1,5 +1,36 @@
 /* Our DOM objects */
 
+/* Colab dropdown */
+
+.colab-dropdown {
+    position: relative;
+    display: inline-block;
+}
+  
+.colab-dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #f9f9f9;
+    min-width: 117px;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    z-index: 1;
+}
+  
+.colab-dropdown-content button {
+    color: #6670FF;
+    background-color: #f9f9f9;
+    font-size: 12px;
+    border: none;
+    min-width: 117px;
+    padding: 5px 5px;
+    text-decoration: none;
+    display: block;
+}
+  
+.colab-dropdown-content button:hover {background-color: #eee;}
+  
+.colab-dropdown:hover .colab-dropdown-content {display: block;}
+
 /* Version control */
 
 .version-button {

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -21,6 +21,17 @@ const versionMapping = {
     "v1.1.0": "v1.1.0",
     "v1.0.0": "v1.0.0"
 }
+// The page that have a notebook and therefore should have the open in colab badge.
+const hasNotebook = [
+    "benchmarks",
+    "multilingual",
+    "perplexity",
+    "preprocessing",
+    "quicktour",
+    "task_summary",
+    "tokenizer_summary",
+    "training"
+];
 
 function addIcon() {
     const huggingFaceLogo = "https://huggingface.co/landing/assets/transformers-docs/huggingface_logo.svg";
@@ -80,6 +91,21 @@ function addGithubButton() {
         </div>
     `;
     document.querySelector(".wy-side-nav-search .icon-home").insertAdjacentHTML('afterend', div);
+}
+
+function addColabLink() {
+    const parts = location.toString().split('/');
+    const pageName = parts[parts.length - 1].split(".")[0];
+
+    if (hasNotebook.includes(pageName)) {
+        const linkColab = `
+        <a 
+            href="https://colab.research.google.com/github/sgugger/test_nbs/blob/master/${pageName}.ipynb">
+            <img alt="Open In Colab" src="https://colab.research.google.com/assets/colab-badge.svg">
+        </a>`
+        const leftMenu = document.querySelector(".wy-breadcrumbs-aside")
+        leftMenu.innerHTML = linkColab + '\n' + leftMenu.innerHTML
+    }
 }
 
 function addVersionControl() {
@@ -255,6 +281,7 @@ function onLoad() {
     addGithubButton();
     parseGithubButtons();
     addHfMenu();
+    addColabLink();
     platformToggle();
 }
 

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -98,13 +98,17 @@ function addColabLink() {
     const pageName = parts[parts.length - 1].split(".")[0];
 
     if (hasNotebook.includes(pageName)) {
-        const linkColab = `
-        <a 
-            href="https://colab.research.google.com/github/sgugger/test_nbs/blob/master/${pageName}.ipynb">
+        const linksColab = `
+        <div class="colab-dropdown">
             <img alt="Open In Colab" src="https://colab.research.google.com/assets/colab-badge.svg">
-        </a>`
+            <div class="colab-dropdown-content">
+                <button onclick=" window.open('https://colab.research.google.com/github/sgugger/test_nbs/blob/master/${pageName}.ipynb')">Mixed</button>
+                <button onclick=" window.open('https://colab.research.google.com/github/sgugger/test_nbs/blob/master/pytorch/${pageName}.ipynb')">PyTorch</button>
+                <button onclick=" window.open('https://colab.research.google.com/github/sgugger/test_nbs/blob/master/tensorflow/${pageName}.ipynb')">TensorFlow</button>
+            </div>
+        </div>`
         const leftMenu = document.querySelector(".wy-breadcrumbs-aside")
-        leftMenu.innerHTML = linkColab + '\n' + leftMenu.innerHTML
+        leftMenu.innerHTML = linksColab + '\n' + leftMenu.innerHTML
     }
 }
 


### PR DESCRIPTION
This PR adds a "open in colab" button on the tutorials of our documentation. For each of those tutorials, three notebooks are available: mixed version (with cells PyTorch and TensorFlow), PyTorch-only and TensorFlow only, so hovering on the button makes a dropdown appear with the three different links.

Those notebooks are generated automatically from the docs rst files and the script in the [notebooks repo](https://github.com/huggingface/notebooks/blob/master/utils/convert_doc_to_notebooks.py).