### PR TITLE
Warn if debug requested without TPU fixes (#6308)

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -624,8 +624,12 @@ class Trainer:
                 train_iterator.close()
                 break
             if self.args.tpu_metrics_debug or self.args.debug:
-                # tpu-comment: Logging debug metrics for PyTorch/XLA (compile, execute times, ops, etc.)
-                xm.master_print(met.metrics_report())
+                if is_torch_tpu_available():
+                    # tpu-comment: Logging debug metrics for PyTorch/XLA (compile, execute times, ops, etc.)
+                    xm.master_print(met.metrics_report())
+                else:
+                    logger.warning("You enabled PyTorch/XLA debug metrics but you don't have a TPU "
+                                   "configured. Check your training configuration if this is unexpected.")
 
         if self.tb_writer:
             self.tb_writer.close()

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -628,8 +628,10 @@ class Trainer:
                     # tpu-comment: Logging debug metrics for PyTorch/XLA (compile, execute times, ops, etc.)
                     xm.master_print(met.metrics_report())
                 else:
-                    logger.warning("You enabled PyTorch/XLA debug metrics but you don't have a TPU "
-                                   "configured. Check your training configuration if this is unexpected.")
+                    logger.warning(
+                        "You enabled PyTorch/XLA debug metrics but you don't have a TPU "
+                        "configured. Check your training configuration if this is unexpected."
+                    )
 
         if self.tb_writer:
             self.tb_writer.close()


### PR DESCRIPTION
Check whether a PyTorch compatible TPU is available before attempting to print TPU metrics after training has completed. This way, users who apply `--debug` without reading the documentation aren't suprised by a stacktrace.