### PR TITLE
remove lr_scheduler redundancy

### DIFF
--- a/examples/seq2seq/finetune.py
+++ b/examples/seq2seq/finetune.py
@@ -14,7 +14,7 @@ import torch
 from torch.utils.data import DataLoader
 
 from lightning_base import BaseTransformer, add_generic_args, generic_train
-from transformers import MarianTokenizer, MBartTokenizer, T5ForConditionalGeneration, get_linear_schedule_with_warmup
+from transformers import MarianTokenizer, MBartTokenizer, T5ForConditionalGeneration
 
 
 try:

--- a/examples/seq2seq/finetune.py
+++ b/examples/seq2seq/finetune.py
@@ -252,14 +252,12 @@ class SummarizationModule(BaseTransformer):
 
     def train_dataloader(self) -> DataLoader:
         dataloader = self.get_dataloader("train", batch_size=self.hparams.train_batch_size, shuffle=True)
-        t_total = (
+        self.t_total = (
             (len(dataloader.dataset) // (self.hparams.train_batch_size * max(1, self.hparams.gpus)))
             // self.hparams.accumulate_grad_batches
             * float(self.hparams.max_epochs)
         )
-        scheduler = get_linear_schedule_with_warmup(
-            self.opt, num_warmup_steps=self.hparams.warmup_steps, num_training_steps=t_total
-        )
+        scheduler = self.get_lr_scheduler()["scheduler"]
         if max(scheduler.get_last_lr()) > 0:
             warnings.warn("All learning rates are 0")
         self.lr_scheduler = scheduler


### PR DESCRIPTION
This PR solves https://github.com/huggingface/transformers/issues/6374
by removing a hardcoded `lr_scheduler` and switching to using the new method.