### PR TITLE
[examples] add pytest dependency

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -14,3 +14,4 @@ elasticsearch
 pandas
 nlp
 fire
+pytest


### PR DESCRIPTION
Not really a new dependency, since already installed by `pip install -e .[testing]` but some examples users just run:
```
pip install -r examples/requirements.txt
```
so they don't have it, and tests break.
