### PR TITLE
[test schedulers] adjust to test the first step's reading

### DIFF
--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -39,16 +39,16 @@ if is_torch_available():
 def unwrap_schedule(scheduler, num_steps=10):
     lrs = []
     for _ in range(num_steps):
+        lrs.append(scheduler.get_lr()[0])
         scheduler.step()
-        lrs.append(scheduler.get_lr())
     return lrs
 
 
 def unwrap_and_save_reload_schedule(scheduler, num_steps=10):
     lrs = []
     for step in range(num_steps):
+        lrs.append(scheduler.get_lr()[0])
         scheduler.step()
-        lrs.append(scheduler.get_lr())
         if step == num_steps // 2:
             with tempfile.TemporaryDirectory() as tmpdirname:
                 file_name = os.path.join(tmpdirname, "schedule.bin")
@@ -101,23 +101,23 @@ class ScheduleInitTest(unittest.TestCase):
             get_constant_schedule: ({}, [10.0] * self.num_steps),
             get_constant_schedule_with_warmup: (
                 {"num_warmup_steps": 4},
-                [2.5, 5.0, 7.5, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0],
+                [0.0, 2.5, 5.0, 7.5, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0],
             ),
             get_linear_schedule_with_warmup: (
                 {**common_kwargs},
-                [5.0, 10.0, 8.75, 7.5, 6.25, 5.0, 3.75, 2.5, 1.25, 0.0],
+                [0.0, 5.0, 10.0, 8.75, 7.5, 6.25, 5.0, 3.75, 2.5, 1.25],
             ),
             get_cosine_schedule_with_warmup: (
                 {**common_kwargs},
-                [5.0, 10.0, 9.61, 8.53, 6.91, 5.0, 3.08, 1.46, 0.38, 0.0],
+                [0.0, 5.0, 10.0, 9.61, 8.53, 6.91, 5.0, 3.08, 1.46, 0.38],
             ),
             get_cosine_with_hard_restarts_schedule_with_warmup: (
                 {**common_kwargs, "num_cycles": 2},
-                [5.0, 10.0, 8.53, 5.0, 1.46, 10.0, 8.53, 5.0, 1.46, 0.0],
+                [0.0, 5.0, 10.0, 8.53, 5.0, 1.46, 10.0, 8.53, 5.0, 1.46],
             ),
             get_polynomial_decay_schedule_with_warmup: (
                 {**common_kwargs, "power": 2.0, "lr_end": 1e-7},
-                [5.0, 10.0, 7.656, 5.625, 3.906, 2.5, 1.406, 0.625, 0.156, 1e-07],
+                [0.0, 5.0, 10.0, 7.656, 5.625, 3.906, 2.5, 1.406, 0.625, 0.156],
             ),
         }
 
@@ -125,17 +125,13 @@ class ScheduleInitTest(unittest.TestCase):
             kwargs, expected_learning_rates = data
 
             scheduler = scheduler_func(self.optimizer, **kwargs)
+            self.assertEqual(len([scheduler.get_lr()[0]]), 1)
             lrs_1 = unwrap_schedule(scheduler, self.num_steps)
-            self.assertEqual(len(lrs_1[0]), 1)
+            print(scheduler_func, lrs_1)
             self.assertListAlmostEqual(
-                [l[0] for l in lrs_1],
-                expected_learning_rates,
-                tol=1e-2,
-                msg=f"failed for {scheduler_func} in normal scheduler",
+                lrs_1, expected_learning_rates, tol=1e-2, msg=f"failed for {scheduler_func} in normal scheduler",
             )
 
             scheduler = scheduler_func(self.optimizer, **kwargs)
             lrs_2 = unwrap_and_save_reload_schedule(scheduler, self.num_steps)
-            self.assertListEqual(
-                [l[0] for l in lrs_1], [l[0] for l in lrs_2], msg=f"failed for {scheduler_func} in save and reload"
-            )
+            self.assertListEqual(lrs_1, lrs_2, msg=f"failed for {scheduler_func} in save and reload")

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -127,7 +127,6 @@ class ScheduleInitTest(unittest.TestCase):
             scheduler = scheduler_func(self.optimizer, **kwargs)
             self.assertEqual(len([scheduler.get_lr()[0]]), 1)
             lrs_1 = unwrap_schedule(scheduler, self.num_steps)
-            print(scheduler_func, lrs_1)
             self.assertListAlmostEqual(
                 lrs_1, expected_learning_rates, tol=1e-2, msg=f"failed for {scheduler_func} in normal scheduler",
             )


### PR DESCRIPTION
As I was working on a new scheduler, it was difficult to match numbers since the first step's reading was dropped in `unwrap_schedule` wrappers (they were taking the measurement after stepping). This PR adjusts the wrappers to first take a reading and then step.

This PR also makes a small refactoring to move all the unwrapping into the script, so the test just compares 2 lists. (avoiding multiple `[l[0] for l in lrs_1]`)

The updated table is:
```
        scheds = {
            get_constant_schedule: ({}, [10.0] * self.num_steps),
            get_constant_schedule_with_warmup: (
                {"num_warmup_steps": 4},
                [0.0, 2.5, 5.0, 7.5, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0],
            ),
            get_linear_schedule_with_warmup: (
                {**common_kwargs},
                [0.0, 5.0, 10.0, 8.75, 7.5, 6.25, 5.0, 3.75, 2.5, 1.25],
            ),
            get_cosine_schedule_with_warmup: (
                {**common_kwargs},
                [0.0, 5.0, 10.0, 9.61, 8.53, 6.91, 5.0, 3.08, 1.46, 0.38],
            ),
            get_cosine_with_hard_restarts_schedule_with_warmup: (
                {**common_kwargs, "num_cycles": 2},
                [0.0, 5.0, 10.0, 8.53, 5.0, 1.46, 10.0, 8.53, 5.0, 1.46],
            ),
            get_polynomial_decay_schedule_with_warmup: (
                {**common_kwargs, "power": 2.0, "lr_end": 1e-7},
                [0.0, 5.0, 10.0, 7.656, 5.625, 3.906, 2.5, 1.406, 0.625, 0.156],
            ),
        }
```
Unrelated to the changes suggestion in this PR, it exposes 2 minor issues:

1. We definitely have a one off problem there, as the last step's reading is one reading too early (which this change exposes) - it doesn't complete the intended cycle. This is probably unimportant for 100s of steps, but it definitely stands out when developing a new scheduler.

To illustrate, see this change in reported number for `get_polynomial_decay_schedule_with_warmup`:

```
-                [5.0, 10.0, 7.656, 5.625, 3.906, 2.5, 1.406, 0.625, 0.156, 1e-07],
+                [0.0, 5.0, 10.0, 7.656, 5.625, 3.906, 2.5, 1.406, 0.625, 0.156],
```
the expected last step of `1e-07` is not there. It never was.

2. Also the first step's reading is `0.0` in all schedulers, except in `get_constant_schedule`, so the first step does nothing. This can be fixed with a potentially added `min_lr=1e-7` to all schedulers, as it was suggested by @sshleifer in one of the recent scheduler-related PRs.

Let me know if this better fits into its own issue, as these issues have nothing to do with the PR itself. Or perhaps the 2 issues are just unimportant...