### PR TITLE
Trainer automatically drops unused columns in nlp datasets

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -81,6 +81,7 @@ from .file_utils import (
     add_start_docstrings,
     cached_path,
     is_apex_available,
+    is_nlp_available,
     is_psutil_available,
     is_py3nvml_available,
     is_tf_available,

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -65,6 +65,14 @@ except (ImportError, AssertionError):
 
 
 try:
+    import nlp  # noqa: F401
+
+    _nlp_available = True
+
+except ImportError:
+    _nlp_available = False
+
+try:
     from torch.hub import _get_torch_home
 
     torch_cache_home = _get_torch_home()
@@ -142,6 +150,10 @@ def is_tf_available():
 
 def is_torch_tpu_available():
     return _torch_tpu_available
+
+
+def is_nlp_available():
+    return _nlp_available
 
 
 def is_psutil_available():

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -252,7 +252,7 @@ class Trainer:
         eval_dataset: "nlp.dataset_dict.Dataset" = None,
         data_collator: Optional[DataCollator] = None,
         metrics: Optional[Union["nlp.Metric", List["nlp.Metric"]]] = None,
-        final_activation: Optional[Union[str, FinalActivation]] = False,
+        final_activation: Optional[Union[str, FinalActivation, Callable]] = False,
         tb_writer: Optional["SummaryWriter"] = None,
         optimizers: Tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR] = (None, None),
     ):
@@ -285,7 +285,7 @@ class Trainer:
                 The function to use to form a batch from a list of elements from the :obj:`dataset`.
             metrics (:obj:`nlp.Metric` or :obj:`List[nlp.Metric]`, `optional`):
                 One or several metrics loaded via the :obj:`nlp` library.
-            final_activation (:obj:`str` or :class:`~transformers.trainer_utils.FinalActivation`, `optional`):
+            final_activation (:obj:`str` or :class:`~transformers.trainer_utils.FinalActivation` or :obj:`Callable`, `optional`):
                 The final activation to apply to the model output before feeding them to the :obj:`metrics`.
             tb_writer (:obj:`SummaryWriter`, `optional`):
                 Object to write to TensorBoard.

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -274,13 +274,13 @@ class Trainer:
                 The arguments to tweak for training.
             dataset_dict (:obj:`nlp.dataset_dict.DatasetDict`, `optional`):
                 The full (train + eval) dataset, loaded and preprocessed via the :obj:`nlp` library. Alternatively, you
-                can pass one or both of :nlp:`train_dataset` and :nlp:`eval_dataset`.
+                can pass one or both of :obj:`train_dataset` and :obj:`eval_dataset`.
             train_dataset (:obj:`nlp.dataset_dict.Dataset`, `optional`):
                 The training dataset, loaded and preprocessed via the :obj:`nlp` library. Alternatively, you
-                can pass the full dataset in :nlp:`dataset_dict`.
+                can pass the full dataset in :obj:`dataset_dict`.
             eval_dataset (:obj:`nlp.dataset_dict.Dataset`, `optional`):
                 The validation dataset, loaded and preprocessed via the :obj:`nlp` library. Alternatively, you
-                can pass the full dataset in :nlp:`dataset_dict`.
+                can pass the full dataset in :obj:`dataset_dict`.
             data_collator (:obj:`DataCollator`, `optional`, defaults to :func:`~transformers.default_data_collator`):
                 The function to use to form a batch from a list of elements from the :obj:`dataset`.
             metrics (:obj:`nlp.Metric` or :obj:`List[nlp.Metric]`, `optional`):
@@ -330,6 +330,10 @@ class Trainer:
             signature_columns += ["label", "label_ids"]
             dataset_columns = (train_dataset if train_dataset is not None else eval_dataset).column_names
             columns = [k for k in signature_columns if k in dataset_columns]
+            ignored_columns = list(set(dataset_columns) - set(signature_columns))
+            logger.info(
+                f"The following columns don't have a corresponding argument in {model.__class__.__name__} and have been ignored: {', '.join(ignored_columns)}."
+            )
             train_dataset.set_format(columns=columns)
             eval_dataset.set_format(columns=columns)
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -258,26 +258,24 @@ class Trainer:
         Creates an instance of :class:`~transformers.Trainer` from a nlp :obj:`DatasetDict` and `Metric`.
 
         Args:
-        model (:class:`~transformers.PreTrainedModel`):
-            The model to train, evaluate or use for predictions.
-        args (:class:`~transformers.TrainingArguments`):
-            The arguments to tweak training.
-        dataset (:obj:`nlp.dataset_dict.DatasetDict`):
-            The dataset loaded and preprocessed via the :obj:`nlp` library.
-        data_collator (:obj:`DataCollator`, `optional`, defaults to :func:`~transformers.default_data_collator`):
-            The function to use to form a batch from a list of elements from the :obj:`dataset`.
-        metrics (:obj:`nlp.Metric` or :obj:`List[nlp.Metric]`, `optional`):
-            One or several metrics loaded via the :obj:`nlp` library.
-        final_activation (:obj:`str` or :class:`~transformers.trainer_utils.FinalActivation`, `optional`):
-            The final activation to apply to the model output before feeding them to the :obj:`metrics`.
-        tb_writer (:obj:`SummaryWriter`, `optional`):
-            Object to write to TensorBoard.
-        optimizers (:obj:`Tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR`, `optional`):
-            A tuple containing the optimizer and the scheduler to use. Will default to an instance of
-            :class:`~transformers.AdamW` on your model and a scheduler given by
-            :func:`~transformers.get_linear_schedule_with_warmup` controlled by :obj:`args`.
-        kwargs:
-            Deprecated keyword arguments.
+            model (:class:`~transformers.PreTrainedModel`):
+                The model to train, evaluate or use for predictions.
+            args (:class:`~transformers.TrainingArguments`):
+                The arguments to tweak training.
+            dataset (:obj:`nlp.dataset_dict.DatasetDict`):
+                The dataset loaded and preprocessed via the :obj:`nlp` library.
+            data_collator (:obj:`DataCollator`, `optional`, defaults to :func:`~transformers.default_data_collator`):
+                The function to use to form a batch from a list of elements from the :obj:`dataset`.
+            metrics (:obj:`nlp.Metric` or :obj:`List[nlp.Metric]`, `optional`):
+                One or several metrics loaded via the :obj:`nlp` library.
+            final_activation (:obj:`str` or :class:`~transformers.trainer_utils.FinalActivation`, `optional`):
+                The final activation to apply to the model output before feeding them to the :obj:`metrics`.
+            tb_writer (:obj:`SummaryWriter`, `optional`):
+                Object to write to TensorBoard.
+            optimizers (:obj:`Tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR`, `optional`):
+                A tuple containing the optimizer and the scheduler to use. Will default to an instance of
+                :class:`~transformers.AdamW` on your model and a scheduler given by
+                :func:`~transformers.get_linear_schedule_with_warmup` controlled by :obj:`args`.
 
         Examples:
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -313,7 +313,9 @@ class Trainer:
             {'eval_loss': 0.3902028881816018, 'eval_accuracy': 0.9105504587155964, 'step': 0}
         """
         assert is_nlp_available(), "This method requires the nlp library: `pip install nlp`."
-        assert dataset_dict is None or (train_dataset is None and eval_dataset is None), "This method accept either `dataset_dict` or `train_dataset`/ `eval_dataset`, but not both."
+        assert dataset_dict is None or (
+            train_dataset is None and eval_dataset is None
+        ), "This method accept either `dataset_dict` or `train_dataset`/ `eval_dataset`, but not both."
         if metrics is not None:
             compute_metrics = ComputeNLPMetrics(metrics, activation=final_activation)
         if dataset_dict is not None:

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -89,5 +89,6 @@ class ComputeNLPMetrics:
         for metric in metrics:
             if self.activation is not None:
                 preds = ACTIVATION_NAME_TO_FUNCTION[self.activation](preds)
+            # TODO: when https://github.com/huggingface/nlp/pull/466 is merged, remove the `tolist`.
             result = {**result, **metric.compute(preds.tolist(), references=labels.tolist())}
         return result

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -6,17 +6,6 @@ import numpy as np
 from .file_utils import is_tf_available, is_torch_available
 
 
-SEQUENCE_CLASSIFICATION_MODELS = []
-if is_torch_available():
-    from .modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
-
-    SEQUENCE_CLASSIFICATION_MODELS = MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.values()
-elif is_tf_available():
-    from .modeling_tf_auto import TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
-
-    SEQUENCE_CLASSIFICATION_MODELS = TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.values()
-
-
 def set_seed(seed: int):
     """
     Helper function for reproducible behavior to set the seed in ``random``, ``numpy``, ``torch`` and/or ``tf``

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -11,9 +11,11 @@ from .tokenization_utils_base import ExplicitEnum
 SEQUENCE_CLASSIFICATION_MODELS = []
 if is_torch_available():
     from .modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
+
     SEQUENCE_CLASSIFICATION_MODELS = MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.values()
 elif is_tf_available():
     from .modeling_tf_auto import TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
+
     SEQUENCE_CLASSIFICATION_MODELS = TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.values()
 
 

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -5,8 +5,16 @@ from typing import Callable, Dict, List, NamedTuple, Optional, Union
 import numpy as np
 
 from .file_utils import is_tf_available, is_torch_available
-from .modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
 from .tokenization_utils_base import ExplicitEnum
+
+
+SEQUENCE_CLASSIFICATION_MODELS = []
+if is_torch_available():
+    from .modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
+    SEQUENCE_CLASSIFICATION_MODELS = MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.values()
+elif is_tf_available():
+    from .modeling_tf_auto import TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
+    SEQUENCE_CLASSIFICATION_MODELS = TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.values()
 
 
 def set_seed(seed: int):
@@ -80,7 +88,7 @@ ACTIVATION_NAME_TO_FUNCTION = {
 
 def auto_activation(model) -> FinalActivation:
     model_class = model.__class__
-    if model_class in MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.values():
+    if model_class in SEQUENCE_CLASSIFICATION_MODELS:
         return FinalActivation.ARGMAX
     return FinalActivation.NONE
 


### PR DESCRIPTION
Here is a basic example of use for evaluation on SST-2:
```
from nlp import load_dataset, load_metric
from transformers import AutoModelForSequenceClassification, AutoTokenizer, Trainer, TrainingArguments
dataset = load_dataset('glue', 'sst2')
metric = load_metric('glue', 'sst2')

model_name = "distilbert-base-uncased-finetuned-sst-2-english"
tokenizer = AutoTokenizer.from_pretrained(model_name)
model = AutoModelForSequenceClassification.from_pretrained(model_name)

encoded_dataset = dataset.map(lambda examples: tokenizer(examples['sentence'], padding=True), batched=True)
args = TrainingArguments(output_dir = "test")

def compute_metrics(eval_pred):
    predictions, labels = eval_pred
    return metric.compute(predictions.argmax(axis=-1), labels)

trainer = Trainer(
    model,
    args,
    train_dataset=encoded_dataset["train"],
    eval_dataset=encoded_dataset["validation"],
    compute_metrics=compute_metrics,
)
trainer.evaluate()
```

The goal is to then refine this new API by trying to use it in all examples.