### PR TITLE
Fixed label datatype for STS-B

### DIFF
--- a/src/transformers/data/processors/glue.py
+++ b/src/transformers/data/processors/glue.py
@@ -17,10 +17,9 @@
 
 import logging
 import os
+from dataclasses import asdict
 from enum import Enum
 from typing import List, Optional, Union
-
-from dataclasses import asdict
 
 from ...file_utils import is_tf_available
 from ...tokenization_utils import PreTrainedTokenizer

--- a/src/transformers/data/processors/glue.py
+++ b/src/transformers/data/processors/glue.py
@@ -79,7 +79,7 @@ if is_tf_available():
         processor = glue_processors[task]()
         examples = [processor.tfds_map(processor.get_example_from_tensor_dict(example)) for example in examples]
         features = glue_convert_examples_to_features(examples, tokenizer, max_length=max_length, task=task)
-        label_datatype = tf.float32 if task == 'sts-b' else tf.int64
+        label_type = tf.float32 if task == 'sts-b' else tf.int64
 
         def gen():
             for ex in features:
@@ -91,7 +91,7 @@ if is_tf_available():
 
         return tf.data.Dataset.from_generator(
             gen,
-            ({k: tf.int32 for k in input_names}, label_datatype),
+            ({k: tf.int32 for k in input_names}, label_type),
             ({k: tf.TensorShape([None]) for k in input_names}, tf.TensorShape([])),
         )
 

--- a/src/transformers/data/processors/glue.py
+++ b/src/transformers/data/processors/glue.py
@@ -17,9 +17,10 @@
 
 import logging
 import os
-from dataclasses import asdict
 from enum import Enum
 from typing import List, Optional, Union
+
+from dataclasses import asdict
 
 from ...file_utils import is_tf_available
 from ...tokenization_utils import PreTrainedTokenizer
@@ -79,7 +80,7 @@ if is_tf_available():
         processor = glue_processors[task]()
         examples = [processor.tfds_map(processor.get_example_from_tensor_dict(example)) for example in examples]
         features = glue_convert_examples_to_features(examples, tokenizer, max_length=max_length, task=task)
-        label_type = tf.float32 if task == 'sts-b' else tf.int64
+        label_type = tf.float32 if task == "sts-b" else tf.int64
 
         def gen():
             for ex in features:

--- a/src/transformers/data/processors/glue.py
+++ b/src/transformers/data/processors/glue.py
@@ -79,6 +79,7 @@ if is_tf_available():
         processor = glue_processors[task]()
         examples = [processor.tfds_map(processor.get_example_from_tensor_dict(example)) for example in examples]
         features = glue_convert_examples_to_features(examples, tokenizer, max_length=max_length, task=task)
+        label_datatype = tf.float32 if task == 'sts-b' else tf.int64
 
         def gen():
             for ex in features:
@@ -90,7 +91,7 @@ if is_tf_available():
 
         return tf.data.Dataset.from_generator(
             gen,
-            ({k: tf.int32 for k in input_names}, tf.int64),
+            ({k: tf.int32 for k in input_names}, label_datatype),
             ({k: tf.TensorShape([None]) for k in input_names}, tf.TensorShape([])),
         )
 


### PR DESCRIPTION
The STS Benchmark has decimal labels instead of integers.
But inside the `glue_convert_examples_to_features` function, when you're using TensorFlow datasets it is casting the label as an integer in the returned TF data generator.
With this simple edit, the function changes its casting datatype according to the selected task.