### PR TITLE
[testing] a new TestCasePlus subclass + get_auto_remove_tmp_dir() 

### DIFF
--- a/examples/bert-loses-patience/test_run_glue_with_pabee.py
+++ b/examples/bert-loses-patience/test_run_glue_with_pabee.py
@@ -1,11 +1,10 @@
 import argparse
 import logging
-import shutil
 import sys
-import unittest
 from unittest.mock import patch
 
 import run_glue_with_pabee
+from transformers.testing_utils import TestCasePlus
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -20,20 +19,19 @@ def get_setup_file():
     return args.f
 
 
-def clean_test_dir(path):
-    shutil.rmtree(path, ignore_errors=True)
-
-
-class PabeeTests(unittest.TestCase):
+class PabeeTests(TestCasePlus):
     def test_run_glue(self):
         stream_handler = logging.StreamHandler(sys.stdout)
         logger.addHandler(stream_handler)
 
-        testargs = """
+        tmp_dir = self.get_auto_remove_tmp_dir()
+        testargs = f"""
             run_glue_with_pabee.py
             --model_type albert
             --model_name_or_path albert-base-v2
             --data_dir ./tests/fixtures/tests_samples/MRPC/
+            --output_dir {tmp_dir}
+            --overwrite_output_dir
             --task_name mrpc
             --do_train
             --do_eval
@@ -42,16 +40,11 @@ class PabeeTests(unittest.TestCase):
             --learning_rate=2e-5
             --max_steps=50
             --warmup_steps=2
-            --overwrite_output_dir
             --seed=42
             --max_seq_length=128
-            """
-        output_dir = "./tests/fixtures/tests_samples/temp_dir_{}".format(hash(testargs))
-        testargs += "--output_dir " + output_dir
-        testargs = testargs.split()
+            """.split()
+
         with patch.object(sys, "argv", testargs):
             result = run_glue_with_pabee.main()
             for value in result.values():
                 self.assertGreaterEqual(value, 0.75)
-
-        clean_test_dir(output_dir)

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -316,22 +316,24 @@ class TestCasePlus(unittest.TestCase):
             tmp_dir(:obj:`string`):
                 either the same value as passed via `tmp_dir` or the path to the auto-created tmp dir
         """
-        if tmp_dir is not None:  # using provided path
+        if tmp_dir is not None:
+            # using provided path
+            path = Path(tmp_dir).resolve()
+
             # to avoid nuking parts of the filesystem, only relative paths are allowed
             if not tmp_dir.startswith("./"):
                 raise ValueError(
                     f"`tmp_dir` can only be a relative path, i.e. `./some/path`, but received `{tmp_dir}`"
                 )
-            path = Path(tmp_dir).resolve()
 
+            # ensure the dir is empty to start with
             if before is True and path.exists():
-                # ensure the dir is empty to start with
                 shutil.rmtree(tmp_dir, ignore_errors=True)
 
             path.mkdir(parents=True, exist_ok=True)
 
         else:
-            # using unique tmp dir (always empty)
+            # using unique tmp dir (always empty, regardless of `before`)
             tmp_dir = tempfile.mkdtemp()
 
         if after is True:

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -302,7 +302,7 @@ class TestCasePlus(unittest.TestCase):
     def setUp(self):
         self.teardown_tmp_dirs = []
 
-    def get_auto_remove_tmp_dir(self, tmp_dir=None, before=False, after=True):
+    def get_auto_remove_tmp_dir(self, tmp_dir=None, after=True, before=False):
         """
         Args:
             tmp_dir (:obj:`string`, `optional`, defaults to :obj:`None`):

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -343,7 +343,7 @@ class TestCasePlus(unittest.TestCase):
         return tmp_dir
 
     def tearDown(self):
-        # remove registered temp dirs and delete objects
+        # remove registered temp dirs
         for path in self.teardown_tmp_dirs:
             shutil.rmtree(path, ignore_errors=True)
         self.teardown_tmp_dirs = []

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -269,21 +269,21 @@ class TestCasePlus(unittest.TestCase):
     In all the following scenarios the temp dir will be auto-removed at the end
     of test, unless `after=False`.
 
-    # 1. give me a unique temp dir, `tmp_dir` will contain the path to the created temp dir
+    # 1. create a unique temp dir, `tmp_dir` will contain the path to the created temp dir
     def test_whatever(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
 
-    # 2. create the temp dir of my choice and delete it at the end - useful for debug when you want to
+    # 2. create a temp dir of my choice and delete it at the end - useful for debug when you want to
     # monitor a specific directory
     def test_whatever(self):
         tmp_dir = self.get_auto_remove_tmp_dir(tmp_dir="./tmp/run/test")
 
-    # 3. create the temp dir of my choice and do not delete it at the end - useful for when you want
+    # 3. create a temp dir of my choice and do not delete it at the end - useful for when you want
     # to look at the temp results
     def test_whatever(self):
         tmp_dir = self.get_auto_remove_tmp_dir(tmp_dir="./tmp/run/test", after=False)
 
-    # 4. create the temp dir of my choice and ensure to delete it right away - useful for when you
+    # 4. create a temp dir of my choice and ensure to delete it right away - useful for when you
     # disabled deletion in the previous test run and want to make sure the that tmp dir is empty
     # before the new test is run
     def test_whatever(self):
@@ -301,7 +301,6 @@ class TestCasePlus(unittest.TestCase):
 
     def setUp(self):
         self.teardown_tmp_dirs = []
-        self.teardown_tmp_objs = []
 
     def get_auto_remove_tmp_dir(self, tmp_dir=None, before=False, after=True):
         """
@@ -331,20 +330,18 @@ class TestCasePlus(unittest.TestCase):
 
             path.mkdir(parents=True, exist_ok=True)
 
-            if after is True:
-                # register for deletion
-                self.teardown_tmp_dirs.append(tmp_dir)
-
-            return tmp_dir
         else:
-            # using unique tmp dir
-            obj = tempfile.TemporaryDirectory()
-            self.teardown_tmp_objs.append(obj)
-            return obj.name
+            # using unique tmp dir (always empty)
+            tmp_dir = tempfile.mkdtemp()
+
+        if after is True:
+            # register for deletion
+            self.teardown_tmp_dirs.append(tmp_dir)
+
+        return tmp_dir
 
     def tearDown(self):
         # remove registered temp dirs and delete objects
         for path in self.teardown_tmp_dirs:
             shutil.rmtree(path, ignore_errors=True)
         self.teardown_tmp_dirs = []
-        self.teardown_tmp_objs = []


### PR DESCRIPTION
I present to you a new `TestCasePlus` class, which is an extension of `testutil.TestCase`. Currently it only has one extra feature, but I'm sure there will be more in the future, hence the more generic name.

So the intention was to provide:
- an easy way to create unique temp dirs in test modules and get them automatically removed at the end of the test, regardless of whether a test succeeded or not. 
- an easy way not to remove the temp dir for debug purposes
- provide a hardcoded temp dir for debug purposes (and secure so that `rm -r /something` won't happen)
- optionally, clean up the temp dir right away if a hardcoded path is provided

Some ideas were discussed here: https://github.com/huggingface/transformers/issues/6471

So this PR implements this feature and uses it in 2 test modules that currently don't have a complete solution, and removing much much code on the way. 

Usage:

Feature 1: Flexible auto-removable temp dirs which are guaranteed to get removed at the end of test.

In all the following scenarios the temp dir will be auto-removed at the end of test, unless `after=False`.

1. create a unique temp dir and delete it at the end, `tmp_dir` will contain the path to the created temp dir
```
def test_whatever(self):
    tmp_dir = self.get_auto_remove_tmp_dir()
```
2. create a temp dir of my choice and delete it at the end - useful for debug when you want to monitor a specific directory
```
def test_whatever(self):
    tmp_dir = self.get_auto_remove_tmp_dir(tmp_dir="./tmp/run/test")
```
or just:
```
    tmp_dir = self.get_auto_remove_tmp_dir("./tmp/run/test")
```

3. create a temp dir of my choice and do not delete it at the end - useful for when you want to look at the temp results
```
def test_whatever(self):
    tmp_dir = self.get_auto_remove_tmp_dir(tmp_dir="./tmp/run/test", after=False)
```
or just:
```
    tmp_dir = self.get_auto_remove_tmp_dir("./tmp/run/test", False)
```

4. create a temp dir of my choice and ensure to delete it right away - useful for when you disabled deletion in the previous test run and want to make sure the that tmp dir is empty before the new test is run
```
def test_whatever(self):
    tmp_dir = self.get_auto_remove_tmp_dir(tmp_dir="./tmp/run/test", before=True)
```

Note 1: In order to run the equivalent of `rm -r` safely, only subdirs of the project repository checkout are allowed if an explicit `tmp_dir` is used, so that by mistake no `/tmp` or similar important part of the filesystem will get nuked. i.e. please always pass paths that start with `./`

Note 2: Each test can register multiple temp dirs and they all will get auto-removed, unless requested otherwise.

So you can see from the 4 main possible scenarios, during debug one needs to tweak only one line of code.

There is only one small remaining deficiency: Since the temp dir is pre-created, the tests will not be able to test things like `--output_dir` creation in examples - i.e. the dir will already be there. So if needed, the code can be extended to have a flag to not create the dir, but only register it for deletion. Though it'd be tricky for when `tmp_dir` is not passed explicitly and we rely on `tempfile`- I guess it can create and immediately delete the temp dir and save and reuse its path - I don't know whether there might be a race condition here. But chances are that this is not really needed.

Thank you for reading. Ideas and suggestions for improvements are welcome.

@JetRunner, @LysandreJik, @sshleifer, @sgugger