### PR TITLE
fixed fast tokenizer use in QA pipeline and added corresponding test

### DIFF
--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -137,9 +137,11 @@ def squad_convert_example_to_features(
     # Handle case where tokenized query is empty, since the fast tokenizer doesn't do so
     if len(tokenized_query) == 0:
         raise ValueError(
-            f"Input {tokenized_query} is not valid. Should be a string or a list/tuple of strings when `is_pretokenized=True`.")
+            f"Input {tokenized_query} is not valid. Should be a string or a list/tuple of strings when `is_pretokenized=True`."
+        )
     truncated_query_len = len(
-        tokenizer.truncate_sequences(ids=tokenized_query, truncation_strategy=truncation, stride=doc_stride))
+        tokenizer.truncate_sequences(ids=tokenized_query, truncation_strategy=truncation, stride=doc_stride)
+    )
 
     # Tokenizers who insert 2 SEP tokens in-between <context> & <question> need to have special handling
     # in the way they compute mask of added tokens.
@@ -171,11 +173,11 @@ def squad_convert_example_to_features(
             return_overflowing_tokens=True,
             stride=max_seq_length - doc_stride - truncated_query_len - sequence_pair_added_tokens,
             return_token_type_ids=True,
-            is_pretokenized=True
+            is_pretokenized=True,
         )
 
         # Handle case where fast tokenizer returns list[list[int]]
-        if isinstance(encoded_dict['input_ids'][0], list):
+        if isinstance(encoded_dict["input_ids"][0], list):
             encoded_dict = {k: v[0] for k, v in encoded_dict.items()}
 
         paragraph_len = min(
@@ -188,10 +190,9 @@ def squad_convert_example_to_features(
                 non_padded_ids = encoded_dict["input_ids"][: encoded_dict["input_ids"].index(tokenizer.pad_token_id)]
             else:
                 last_padding_id_position = (
-                        len(encoded_dict["input_ids"]) - 1 - encoded_dict["input_ids"][::-1].index(
-                    tokenizer.pad_token_id)
+                    len(encoded_dict["input_ids"]) - 1 - encoded_dict["input_ids"][::-1].index(tokenizer.pad_token_id)
                 )
-                non_padded_ids = encoded_dict["input_ids"][last_padding_id_position + 1:]
+                non_padded_ids = encoded_dict["input_ids"][last_padding_id_position + 1 :]
 
         else:
             non_padded_ids = encoded_dict["input_ids"]
@@ -214,7 +215,7 @@ def squad_convert_example_to_features(
         spans.append(encoded_dict)
 
         if "overflowing_tokens" not in encoded_dict or (
-                "overflowing_tokens" in encoded_dict and len(encoded_dict["overflowing_tokens"]) == 0
+            "overflowing_tokens" in encoded_dict and len(encoded_dict["overflowing_tokens"]) == 0
         ):
             break
         span_doc_tokens = encoded_dict["overflowing_tokens"]
@@ -237,9 +238,9 @@ def squad_convert_example_to_features(
         # Original TF implem also keep the classification token (set to 0)
         p_mask = np.ones_like(span["token_type_ids"])
         if tokenizer.padding_side == "right":
-            p_mask[truncated_query_len + sequence_added_tokens:] = 0
+            p_mask[truncated_query_len + sequence_added_tokens :] = 0
         else:
-            p_mask[-len(span["tokens"]): -(truncated_query_len + sequence_added_tokens)] = 0
+            p_mask[-len(span["tokens"]) : -(truncated_query_len + sequence_added_tokens)] = 0
 
         pad_token_indices = np.where(span["input_ids"] == tokenizer.pad_token_id)
         special_token_indices = np.asarray(

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -645,6 +645,8 @@ class QAPipelineTests(unittest.TestCase):
         for model_name in QA_FINETUNED_MODELS:
             nlp = pipeline(task="question-answering", model=model_name, tokenizer=model_name)
             self._test_qa_pipeline(nlp)
+            nlp = pipeline(task="question-answering", model=model_name, tokenizer=(model_name, {"use_fast": True}))
+            self._test_qa_pipeline(nlp)
 
     @require_tf
     def test_tf_question_answering(self):


### PR DESCRIPTION
This PR fixes https://github.com/huggingface/transformers/issues/6545

The problem is that the behavior of the python tokenizer and the rust based fast tokenizer is very different.
The python tokenizer handles cases where inputs are in different formats (str tokens and int tokens and vice versa), where as the fast tokenizer is unable to do so.

My modifications include pretokenizing the query and along side the context, but not encoding it as is done now.
Both the query and context are encoded together by the the tokenizer's `encode_plus` method with `is_pretokenized` set to True.

Some edge cases where the fast tokenizer fails because of limited functionality (compare to python tok) have been added and I've included comments in those places.