### PR TITLE
fix incorrect codecov reports

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,7 @@ coverage:
       default:
         informational: true
     patch: off
+comment:
+  require_changes: true    # only comment if there was change in coverage
+  require_head: yes        # don't report if there is no head coverage report
+  require_base: yes        # don't report if there is no base coverage report


### PR DESCRIPTION
As discussed at https://github.com/huggingface/transformers/issues/6317 codecov currently sends an invalid report when it fails to find a code coverage report for the base it checks against. When this happens it goes looking for the nearest hash with report, which often leads to a report that is not representative of the true impact of the proposed PR.

This PR fixes it by adding:

 `require_base: yes`        # don't report if there is no base coverage report

And then:

-  let's add this for clarity, this supposedly is already the default.

    `require_head: yes`        # don't report if there is no head coverage report 

- and perhaps no point reporting on doc changes as they don't make any difference to the coverage and the 0% change comment just generates noise:

   `require_changes: true`    # only comment if there was a change in coverage

These options are documented here: https://docs.codecov.io/docs/codecovyml-reference#comment