### PR TITLE
CamembertForCausalLM

### DIFF
--- a/docs/source/model_doc/camembert.rst
+++ b/docs/source/model_doc/camembert.rst
@@ -49,6 +49,13 @@ CamembertModel
     :members:
 
 
+CamembertForCausalLM
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: transformers.CamembertForCausalLM
+    :members:
+
+
 CamembertForMaskedLM
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -330,6 +330,7 @@ if is_torch_available():
         CamembertForMultipleChoice,
         CamembertForTokenClassification,
         CamembertForQuestionAnswering,
+        CamembertForCausalLM,
         CAMEMBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
     )
     from .modeling_encoder_decoder import EncoderDecoderModel

--- a/src/transformers/modeling_auto.py
+++ b/src/transformers/modeling_auto.py
@@ -73,12 +73,12 @@ from .modeling_bert import (
     BertModel,
 )
 from .modeling_camembert import (
+    CamembertForCausalLM,
     CamembertForMaskedLM,
     CamembertForMultipleChoice,
     CamembertForQuestionAnswering,
     CamembertForSequenceClassification,
     CamembertForTokenClassification,
-    CamembertForCausalLM,
     CamembertModel,
 )
 from .modeling_ctrl import CTRLLMHeadModel, CTRLModel

--- a/src/transformers/modeling_auto.py
+++ b/src/transformers/modeling_auto.py
@@ -78,6 +78,7 @@ from .modeling_camembert import (
     CamembertForQuestionAnswering,
     CamembertForSequenceClassification,
     CamembertForTokenClassification,
+    CamembertForCausalLM,
     CamembertModel,
 )
 from .modeling_ctrl import CTRLLMHeadModel, CTRLModel
@@ -253,6 +254,7 @@ MODEL_WITH_LM_HEAD_MAPPING = OrderedDict(
 
 MODEL_FOR_CAUSAL_LM_MAPPING = OrderedDict(
     [
+        (CamembertConfig, CamembertForCausalLM),
         (RobertaConfig, RobertaForCausalLM),
         (BertConfig, BertLMHeadModel),
         (OpenAIGPTConfig, OpenAIGPTLMHeadModel),

--- a/src/transformers/modeling_camembert.py
+++ b/src/transformers/modeling_camembert.py
@@ -26,6 +26,7 @@ from .modeling_roberta import (
     RobertaForSequenceClassification,
     RobertaForTokenClassification,
     RobertaModel,
+    RobertaForCausalLM,
 )
 
 
@@ -132,4 +133,15 @@ class CamembertForQuestionAnswering(RobertaForQuestionAnswering):
     superclass for the appropriate documentation alongside usage examples.
     """
 
+    config_class = CamembertConfig
+
+
+@add_start_docstrings(
+    """CamemBERT Model with a `language modeling` head on top for CLM fine-tuning. """, CAMEMBERT_START_DOCSTRING
+)
+class CamembertForCausalLM(RobertaForCausalLM):
+    """
+    This class overrides :class:`~transformers.RobertaForCausalLM`. Please check the
+    superclass for the appropriate documentation alongside usage examples.
+    """
     config_class = CamembertConfig

--- a/src/transformers/modeling_camembert.py
+++ b/src/transformers/modeling_camembert.py
@@ -20,13 +20,13 @@ import logging
 from .configuration_camembert import CamembertConfig
 from .file_utils import add_start_docstrings
 from .modeling_roberta import (
+    RobertaForCausalLM,
     RobertaForMaskedLM,
     RobertaForMultipleChoice,
     RobertaForQuestionAnswering,
     RobertaForSequenceClassification,
     RobertaForTokenClassification,
     RobertaModel,
-    RobertaForCausalLM,
 )
 
 
@@ -144,4 +144,5 @@ class CamembertForCausalLM(RobertaForCausalLM):
     This class overrides :class:`~transformers.RobertaForCausalLM`. Please check the
     superclass for the appropriate documentation alongside usage examples.
     """
+
     config_class = CamembertConfig


### PR DESCRIPTION
This PR adds `CamembertForCausalLM` by subclassing `RobertaForCausalLM`, so that it can be used with the `EncoderDecoderModel`.

@patrickvonplaten 