### PR TITLE
Regression test for pegasus bugfix

### DIFF
--- a/src/transformers/configuration_pegasus.py
+++ b/src/transformers/configuration_pegasus.py
@@ -22,6 +22,7 @@ from .file_utils import add_start_docstrings_to_callable
 
 logger = logging.getLogger(__name__)
 
+# These config values do not vary between checkpoints
 DEFAULTS = dict(
     vocab_size=96103,
     max_position_embeddings=512,
@@ -46,19 +47,7 @@ DEFAULTS = dict(
     num_beams=8,
     activation_function="relu",
 )
-
-
-@add_start_docstrings_to_callable(BART_CONFIG_ARGS_DOC)
-class PegasusConfig(BartConfig):
-    r"""
-        :class:`~transformers.PegasusConfig` is the configuration class to store the configuration of a
-        `PegasusModel`.
-    """
-    model_type = "pegasus"
-    # The implementation of the config object is in BartConfig
-
-
-# Expected values for testing (these vary between checkpoints)
+# Config values that vary between checkpoints: for testing and conversion
 max_gen_length = {
     # See appendix C of paper
     "xsum": 64,
@@ -99,3 +88,13 @@ expected_alpha = {
     "aeslc": 0.6,
     "billsum": 0.6,
 }  # otherwise 0.8
+
+
+@add_start_docstrings_to_callable(BART_CONFIG_ARGS_DOC)
+class PegasusConfig(BartConfig):
+    r"""
+        :class:`~transformers.PegasusConfig` is the configuration class to store the configuration of a
+        `PegasusModel`.
+    """
+    model_type = "pegasus"
+    # The implementation of the config object is in BartConfig

--- a/src/transformers/configuration_pegasus.py
+++ b/src/transformers/configuration_pegasus.py
@@ -57,12 +57,8 @@ class PegasusConfig(BartConfig):
     model_type = "pegasus"
     # The implementation of the config object is in BartConfig
 
-    @property
-    def default_config_parameters(self):
-        return DEFAULTS
 
-
-# Expected values for testing
+# Expected values for testing (these vary between checkpoints)
 max_gen_length = {
     # See appendix C of paper
     "xsum": 64,

--- a/src/transformers/configuration_pegasus.py
+++ b/src/transformers/configuration_pegasus.py
@@ -60,3 +60,46 @@ class PegasusConfig(BartConfig):
     @property
     def default_config_parameters(self):
         return DEFAULTS
+
+
+# Expected values for testing
+max_gen_length = {
+    # See appendix C of paper
+    "xsum": 64,
+    "cnn_dailymail": 128,
+    "newsroom": 128,
+    "wikihow": 256,
+    "multi_news": 256,
+    "reddit_tifu": 128,
+    "big_patent": 256,
+    "arxiv": 256,
+    "pubmed": 256,
+    "gigaword": 32,
+    "aeslc": 32,
+    "billsum": 256,
+    "large": 256,  # @sshleifer chose arbitrarily
+}
+max_model_length = {
+    "xsum": 512,
+    "cnn_dailymail": 1024,
+    "newsroom": 512,
+    "wikihow": 512,
+    "multi_news": 1024,
+    "reddit_tifu": 512,
+    "big_patent": 1024,
+    "arxiv": 1024,
+    "pubmed": 1024,
+    "gigaword": 128,
+    "aeslc": 512,
+    "billsum": 1024,
+    "large": 1024,
+}
+expected_alpha = {
+    "multinews": 0.9,
+    "wikihow": 0.6,
+    "reddit_tifu": 0.6,
+    "big_patent": 0.7,
+    "gigaword": 0.6,
+    "aeslc": 0.6,
+    "billsum": 0.6,
+}  # otherwise 0.8

--- a/src/transformers/modeling_pegasus.py
+++ b/src/transformers/modeling_pegasus.py
@@ -23,6 +23,13 @@ from .modeling_bart import BART_START_DOCSTRING, BartForConditionalGeneration
 @add_start_docstrings("The Pegasus Model for summarization ", BART_START_DOCSTRING)
 class PegasusForConditionalGeneration(BartForConditionalGeneration):
     config_class = PegasusConfig
+    authorized_missing_keys = [
+        r"final_logits_bias",
+        r"encoder\.version",
+        r"decoder\.version",
+        r"model.encoder.embed_positions",
+        "model.decoder.embed_positions",
+    ]
     r"""
     Pytorch version of google's pegasus model for summarization.
     Model API is identical to BartForConditionalGeneration.

--- a/tests/test_modeling_pegasus.py
+++ b/tests/test_modeling_pegasus.py
@@ -1,6 +1,7 @@
 import unittest
 
-from transformers import AutoConfig, is_torch_available
+from transformers import AutoConfig, AutoTokenizer, is_torch_available
+from transformers.configuration_pegasus import max_gen_length, max_model_length
 from transformers.file_utils import cached_property
 from transformers.testing_utils import require_torch, slow, torch_device
 
@@ -16,7 +17,7 @@ XSUM_ENTRY_LONGER = """ The London trio are up for best UK act and best album, a
 
 @require_torch
 class PegasusXSUMIntegrationTest(AbstractSeq2SeqIntegrationTest):
-    checkpoint_name = "google/pegasus-xsum"
+    checkpoint_name = "google/pegasus-cnn_dailymail"
     src_text = [PGE_ARTICLE, XSUM_ENTRY_LONGER]
     tgt_text = [
         "California's largest electricity provider has turned off power to tens of thousands of customers.",
@@ -29,10 +30,8 @@ class PegasusXSUMIntegrationTest(AbstractSeq2SeqIntegrationTest):
 
     @slow
     def test_pegasus_xsum_summary(self):
-        assert self.tokenizer.model_max_length == 512
-        inputs = self.tokenizer(self.src_text, return_tensors="pt", truncation=True, max_length=512, padding=True).to(
-            torch_device
-        )
+        # assert self.tokenizer.model_max_length == 512
+        inputs = self.tokenizer(self.src_text, return_tensors="pt", truncation=True, padding=True).to(torch_device)
         assert inputs.input_ids.shape == (2, 421)
         translated_tokens = self.model.generate(**inputs)
         decoded = self.tokenizer.batch_decode(translated_tokens, skip_special_tokens=True)
@@ -50,28 +49,26 @@ class PegasusXSUMIntegrationTest(AbstractSeq2SeqIntegrationTest):
 
 class PegasusConfigTests(unittest.TestCase):
     def test_all_config_max_lengths(self):
-        expected_max_length = {
-            # See appendix C of paper
-            "xsum": 64,
-            "cnn_dailymail": 128,
-            "newsroom": 128,
-            "wikihow": 256,
-            "multi_news": 256,
-            "reddit_tifu": 128,
-            "big_patent": 256,
-            "arxiv": 256,
-            "pubmed": 256,
-            "gigaword": 32,
-            "aeslc": 32,
-            "billsum": 256,
-        }
         failures = []
         pegasus_prefix = "google/pegasus"
-        for dataset, max_len in expected_max_length.items():
+        for dataset, max_len in max_gen_length.items():
             mname = f"{pegasus_prefix}-{dataset}"
             cfg = AutoConfig.from_pretrained(mname)
+
             if cfg.max_length != max_len:
                 failures.append(f"config for {mname} had max_length: {cfg.max_length}, expected {max_len}")
+
+            if cfg.max_position_embeddings < max_model_length[dataset]:
+                failures.append(
+                    f"config for {mname} had max_position_embeddings: {cfg.max_position_embeddings}, expected {max_model_length[dataset]}"
+                )
+
+            tokenizer = AutoTokenizer.from_pretrained(mname)
+            if max_model_length[dataset] != tokenizer.model_max_length:
+                failures.append(
+                    f"tokenizer.model_max_length {tokenizer.model_max_length} expected {max_model_length[dataset]}"
+                )
+
         if failures == []:
             return
         # error


### PR DESCRIPTION
The bug was that tokenizer.max_model_length (set through `tokenizer_config.json`) was sometimes 1024, but `max_position_embeddings` was only 512.  This means that the tokenizer can produce inputs of length 513, which will produce an IndexError when we try to get the from the embedding table.

Since the position embeddings are static for pegasus, the fix was on s3: set the max_position_embeddings to the correct value, and remove the saved, incorrectly sized position embeddings from the state dict.

The tradeoff here is that users can now pass max_position_embeddings=HUGE to the model without error, and pass huge inputs, and either OOM or get shitty performance. But if you are modifying config you sort of know what you are doing so I'm OK with it.


This PR:
- suppresses the warning created by the S3 change
- adds a regression test that `config.max_position_embeddings >= tokenizer.max_model_length`
