### PR TITLE
[seq2seq Example] Convert tensor to List[int] for decoding

### DIFF
--- a/examples/seq2seq/finetune.py
+++ b/examples/seq2seq/finetune.py
@@ -5,7 +5,7 @@ import os
 import time
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import pytorch_lightning as pl
@@ -127,7 +127,9 @@ class SummarizationModule(BaseTransformer):
     def forward(self, input_ids, **kwargs):
         return self.model(input_ids, **kwargs)
 
-    def ids_to_clean_text(self, generated_ids: List[int]):
+    def ids_to_clean_text(self, generated_ids: Union[List[int], torch.Tensor]):
+        if isinstance(generated_ids, torch.Tensor):
+            generated_ids = generated_ids.tolist()
         gen_text = self.tokenizer.batch_decode(
             generated_ids, skip_special_tokens=True, clean_up_tokenization_spaces=True
         )


### PR DESCRIPTION
Ran into an error today while using `finetune.py` where decoding kept failing because the output was a `torch.Tensor` instead of a `List[int]`. This fixes that.