### PR TITLE
Move threshold up for flaky test with Electra

### DIFF
--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -306,7 +306,7 @@ class TFModelTesterMixin:
 
             max_diff = np.amax(np.abs(tf_hidden_states - pt_hidden_states))
             # Debug info (remove when fixed)
-            if max_diff >= 2e-2:
+            if max_diff >= 4e-2:
                 print("===")
                 print(model_class)
                 print(config)

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -312,7 +312,7 @@ class TFModelTesterMixin:
                 print(config)
                 print(inputs_dict)
                 print(pt_inputs_dict)
-            self.assertLessEqual(max_diff, 2e-2)
+            self.assertLessEqual(max_diff, 4e-2)
 
             # Check we can load pt model in tf and vice-versa with checkpoint => model functions
             with tempfile.TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
As discussed on slack, this should take care of the Electra flaky test with PT/TF equivalence.

@LysandreJik just a ping for when you're back so you're aware.