### PR TITLE
Add typing.overload for convert_ids_tokens

### DIFF
--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -662,9 +662,7 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
         ...
 
     @overload
-    def convert_ids_to_tokens(
-        self, ids: List[int], skip_special_tokens: bool = False
-    ) -> List[str]:
+    def convert_ids_to_tokens(self, ids: List[int], skip_special_tokens: bool = False) -> List[str]:
         ...
 
     def convert_ids_to_tokens(

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -20,7 +20,7 @@ import itertools
 import logging
 import re
 import unicodedata
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, overload
 
 from .file_utils import add_end_docstrings
 from .tokenization_utils_base import (
@@ -656,6 +656,16 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
             A list of integers in the range [0, 1]: 1 for a special token, 0 for a sequence token.
         """
         return [0] * ((len(token_ids_1) if token_ids_1 else 0) + len(token_ids_0))
+
+    @overload
+    def convert_ids_to_tokens(self, ids: int, skip_special_tokens: bool = False) -> str:
+        ...
+
+    @overload
+    def convert_ids_to_tokens(
+        self, ids: List[int], skip_special_tokens: bool = False
+    ) -> List[str]:
+        ...
 
     def convert_ids_to_tokens(
         self, ids: Union[int, List[int]], skip_special_tokens: bool = False


### PR DESCRIPTION
The annotation of `convert_ids_tokens` is not sufficient. When `ids` are `List[str]` and `str`, the return type are always `List[int]` and `int` respectively.
It can be solved with [typing.overload](https://docs.python.org/3/library/typing.html#typing.overload)