### PR TITLE
[doc] remove BartForConditionalGeneration.generate

### DIFF
--- a/docs/source/model_doc/bart.rst
+++ b/docs/source/model_doc/bart.rst
@@ -32,7 +32,7 @@ BartForConditionalGeneration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: transformers.BartForConditionalGeneration
-    :members: generate, forward
+    :members: forward
 
 
 BartConfig


### PR DESCRIPTION
As suggested here: https://github.com/huggingface/transformers/issues/6651#issuecomment-678594233
this removes a generic `generate` doc with a large group of generate examples, none of which is relevant to BART. the BART class pre-amble doc already provides the examples.

Fixes #6651