### PR TITLE
Allow numpy array as tokenizer input

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(
     packages=find_packages("src"),
     install_requires=[
         "numpy",
-        "tokenizers == 0.8.1.rc2",
+        "tokenizers == 0.9.0.dev0",
         # dataclasses for Python versions that don't have it
         "dataclasses;python_version<'3.7'",
         # utilities from PyPA to e.g. compare versions

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1897,7 +1897,10 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
                 len(text) == 0
                 or (
                     isinstance(text[0], str)
-                    or (isinstance(text[0], (list, tuple, np.ndarray)) and (len(text[0]) == 0 or isinstance(text[0][0], str)))
+                    or (
+                        isinstance(text[0], (list, tuple, np.ndarray))
+                        and (len(text[0]) == 0 or isinstance(text[0][0], str))
+                    )
                 )
             )
         ), (
@@ -1928,7 +1931,12 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
 
         is_batched = bool(
             (not is_pretokenized and isinstance(text, (list, tuple, np.ndarray)))
-            or (is_pretokenized and isinstance(text, (list, tuple, np.ndarray)) and len(text) and isinstance(text[0], (list, tuple, np.ndarray)))
+            or (
+                is_pretokenized
+                and isinstance(text, (list, tuple, np.ndarray))
+                and len(text)
+                and isinstance(text[0], (list, tuple, np.ndarray))
+            )
         )
 
         if is_batched:

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1892,12 +1892,12 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
         """
         # Input type checking for clearer error
         assert isinstance(text, str) or (
-            isinstance(text, (list, tuple))
+            isinstance(text, (list, tuple, np.ndarray))
             and (
                 len(text) == 0
                 or (
                     isinstance(text[0], str)
-                    or (isinstance(text[0], (list, tuple)) and (len(text[0]) == 0 or isinstance(text[0][0], str)))
+                    or (isinstance(text[0], (list, tuple, np.ndarray)) and (len(text[0]) == 0 or isinstance(text[0][0], str)))
                 )
             )
         ), (
@@ -1909,13 +1909,13 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
             text_pair is None
             or isinstance(text_pair, str)
             or (
-                isinstance(text_pair, (list, tuple))
+                isinstance(text_pair, (list, tuple, np.ndarray))
                 and (
                     len(text_pair) == 0
                     or (
                         isinstance(text_pair[0], str)
                         or (
-                            isinstance(text_pair[0], (list, tuple))
+                            isinstance(text_pair[0], (list, tuple, np.ndarray))
                             and (len(text_pair[0]) == 0 or isinstance(text_pair[0][0], str))
                         )
                     )
@@ -1927,8 +1927,8 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
         )
 
         is_batched = bool(
-            (not is_pretokenized and isinstance(text, (list, tuple)))
-            or (is_pretokenized and isinstance(text, (list, tuple)) and text and isinstance(text[0], (list, tuple)))
+            (not is_pretokenized and isinstance(text, (list, tuple, np.ndarray)))
+            or (is_pretokenized and isinstance(text, (list, tuple, np.ndarray)) and len(text) and isinstance(text[0], (list, tuple, np.ndarray)))
         )
 
         if is_batched:

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -21,6 +21,7 @@ import os
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import numpy as np
 from tokenizers import Encoding as EncodingFast
 from tokenizers.decoders import Decoder as DecoderFast
 from tokenizers.implementations import BaseTokenizer as BaseTokenizerFast
@@ -341,7 +342,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         **kwargs
     ) -> BatchEncoding:
 
-        if not isinstance(batch_text_or_text_pairs, list):
+        if not isinstance(batch_text_or_text_pairs, (list, np.ndarray)):
             raise ValueError(
                 "batch_text_or_text_pairs has to be a list (got {})".format(type(batch_text_or_text_pairs))
             )


### PR DESCRIPTION
Tokenizers allow numpy arrays since https://pypi.org/project/tokenizers/0.9.0.dev0/ thanks to @n1t0 

This is related to issue #5729