### PR TITLE
ci/gh/self-scheduled: add newline to make examples tests run even if src/ tests fail

### DIFF
--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -58,6 +58,7 @@ jobs:
       run: |
         source .env/bin/activate
         python -m pytest -n 1 --dist=loadfile -s ./tests/
+
     - name: Run examples tests on GPU
       env:
         TF_FORCE_GPU_ALLOW_GROWTH: "true"


### PR DESCRIPTION
At the moment, the examples tests dont run if the src/ tests don't
this is not the case for self-push I don't think. I don't know why. 

Maybe you have an idea @julien-c ?

https://github.com/huggingface/transformers/runs/1024137280?check_suite_focus=true
![image](https://user-images.githubusercontent.com/6045025/91119061-5a08da80-e660-11ea-8b48-916a2a54c019.png)


Gunna merge this tomorrow cause it can't hurt, then try harder/stackoverflow if it doesn't work.
