### PR TITLE
[squad] make examples and dataset accessible from SquadDataset object

### DIFF
--- a/src/transformers/data/datasets/squad.py
+++ b/src/transformers/data/datasets/squad.py
@@ -103,6 +103,7 @@ class SquadDataset(Dataset):
         mode: Union[str, Split] = Split.train,
         is_language_sensitive: Optional[bool] = False,
         cache_dir: Optional[str] = None,
+        dataset_format: Optional[str] = "pt",
     ):
         self.args = args
         self.is_language_sensitive = is_language_sensitive
@@ -128,28 +129,35 @@ class SquadDataset(Dataset):
         with FileLock(lock_path):
             if os.path.exists(cached_features_file) and not args.overwrite_cache:
                 start = time.time()
-                self.features = torch.load(cached_features_file)
+                cache_dict = torch.load(cached_features_file)
+                self.features = cache_dict["features"]
+                self.dataset = cache_dict["dataset"]
+                self.examples = cache_dict["examples"]
                 logger.info(
                     f"Loading features from cached file {cached_features_file} [took %.3f s]", time.time() - start
                 )
             else:
                 if mode == Split.dev:
-                    examples = self.processor.get_dev_examples(args.data_dir)
+                    self.examples = self.processor.get_dev_examples(args.data_dir)
                 else:
-                    examples = self.processor.get_train_examples(args.data_dir)
+                    self.examples = self.processor.get_train_examples(args.data_dir)
 
-                self.features = squad_convert_examples_to_features(
-                    examples=examples,
+                self.features, self.dataset = squad_convert_examples_to_features(
+                    examples=self.examples,
                     tokenizer=tokenizer,
                     max_seq_length=args.max_seq_length,
                     doc_stride=args.doc_stride,
                     max_query_length=args.max_query_length,
                     is_training=mode == Split.train,
                     threads=args.threads,
+                    return_dataset=dataset_format,
                 )
 
                 start = time.time()
-                torch.save(self.features, cached_features_file)
+                torch.save(
+                    {"features": self.features, "dataset": self.dataset, "examples": self.examples},
+                    cached_features_file,
+                )
                 # ^ This seems to take a lot of time so I want to investigate why and how we can improve.
                 logger.info(
                     "Saving features into cached file %s [took %.3f s]", cached_features_file, time.time() - start


### PR DESCRIPTION
In order to do evaluation on the SQuAD dataset using squad_evaluate, the user needs access to both the examples loaded in the dataset and the TensorDataset that contains values like unique_id and the like that are used in constructing the list of SquadResult objects. This PR surfaces the examples and dataset to the user so that they can access it directly.

For example of why access to those is needed, see how evaluation is currently done in examples/run_squad.py. The SquadDataset object attempts to wrap up some of this functionality, but without access to examples and dataset the evaluation is not possible.