### PR TITLE
tensor.nonzero() is deprecated in PyTorch 1.6

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1224,7 +1224,7 @@ class FillMaskPipeline(Pipeline):
                     values = tf.gather_nd(values, tf.reshape(sort_inds, (-1, 1))).numpy()
                     predictions = target_inds[sort_inds.numpy()]
             else:
-                masked_index = (input_ids == self.tokenizer.mask_token_id).nonzero()
+                masked_index = torch.nonzero(input_ids == self.tokenizer.mask_token_id, as_tuple=False)
 
                 # Fill mask pipeline supports only one ${mask_token} per sample
                 self.ensure_exactly_one_mask_token(masked_index.numpy())


### PR DESCRIPTION
It also seems to make the api-inference crash ... 

Signed-off-by: Morgan Funtowicz <funtowiczmo@gmail.com>
