### PR TITLE
Pin code quality dependencies: black,isort,flake8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ extras["all"] = extras["serving"] + ["tensorflow", "torch"]
 extras["testing"] = ["pytest", "pytest-xdist", "timeout-decorator", "psutil"]
 # sphinx-rtd-theme==0.5.0 introduced big changes in the style.
 extras["docs"] = ["recommonmark", "sphinx", "sphinx-markdown-tables", "sphinx-rtd-theme==0.4.3", "sphinx-copybutton"]
-extras["quality"] = ["black", "isort >= 5", "flake8"]
+extras["quality"] = ["black==20.8b0", "isort>=5.4.0, <5.4.3", "flake8>=3.8, <3.8.4"]  #
 extras["dev"] = extras["testing"] + extras["quality"] + extras["ja"] + ["scikit-learn", "tensorflow", "torch"]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ extras["all"] = extras["serving"] + ["tensorflow", "torch"]
 extras["testing"] = ["pytest", "pytest-xdist", "timeout-decorator", "psutil"]
 # sphinx-rtd-theme==0.5.0 introduced big changes in the style.
 extras["docs"] = ["recommonmark", "sphinx", "sphinx-markdown-tables", "sphinx-rtd-theme==0.4.3", "sphinx-copybutton"]
-extras["quality"] = ["black==20.8b0", "isort>=5.4.0, <5.4.3", "flake8>=3.8, <3.8.4"]  #
+extras["quality"] = ["black==20.8b0", "isort>=5.4.0, <5.4.3", "flake8>=3.8, <3.8.4"]
 extras["dev"] = extras["testing"] + extras["quality"] + extras["ja"] + ["scikit-learn", "tensorflow", "torch"]
 
 setup(


### PR DESCRIPTION
Goal: Prevent dependencies from causing transformers CI to be in style violation without transformers code changing. 

Tested:
all isort 5.4 versions, all flake 3.8 versions work identically well. changing black at all causes bad results. I pinned to the tested range.



