### PR TITLE
s2s distillation uses AutoModelForSeqToSeqLM

### DIFF
--- a/examples/seq2seq/test_seq2seq_examples.py
+++ b/examples/seq2seq/test_seq2seq_examples.py
@@ -186,6 +186,7 @@ class TestSummarizationDistiller(unittest.TestCase):
             tgt_lang="ro_RO",
         )
         model = self._test_distiller_cli(updates, check_contents=False)
+        assert model.model.config.model_type == "mbart"
 
         ckpts = list(Path(model.output_dir).glob("*.ckpt"))
         self.assertEqual(1, len(ckpts))


### PR DESCRIPTION
hard coding bart caused subsequent AutoTokenizer to fail for marian/mbart distillation.