### PR TITLE
[transformers-cli] fix logger getter

### DIFF
--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -25,7 +25,7 @@ except (ImportError, AttributeError):
     _serve_dependencies_installed = False
 
 
-logger = logging.getLogger("transformers-cli/serving")
+logger = logging.get_logger("transformers-cli/serving")
 
 
 def serve_command_factory(args: Namespace):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+# Copyright 2019-present, the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import sys
+import unittest
+from unittest.mock import patch
+
+from transformers.testing_utils import CaptureStd
+
+
+class CLITest(unittest.TestCase):
+    @patch("sys.argv", ["fakeprogrampath", "env"])
+    def test_cli_env(self):
+        import transformers.commands.transformers_cli
+
+        with CaptureStd() as cs:
+            transformers.commands.transformers_cli.main()
+        assert "Python version" in cs.out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-import sys
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,8 +24,11 @@ from transformers.testing_utils import CaptureStd
 class CLITest(unittest.TestCase):
     @patch("sys.argv", ["fakeprogrampath", "env"])
     def test_cli_env(self):
+        # test transformers-cli env
         import transformers.commands.transformers_cli
 
         with CaptureStd() as cs:
             transformers.commands.transformers_cli.main()
         assert "Python version" in cs.out
+        assert "Platform" in cs.out
+        assert "Using distributed or parallel set-up in script?" in cs.out


### PR DESCRIPTION
`transformers-cli` is currently broken:
```
  File "src/transformers/commands/transformers_cli.py", line 8, in <module>
    from transformers.commands.serving import ServeCommand
  File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/commands/serving.py", line 28, in <module>
    logger = logging.getLogger("transformers-cli/serving")
AttributeError: module 'transformers.utils.logging' has no attribute 'getLogger'
```
this fixes it.

plus added a basic test.
