### PR TITLE
BART ce loss ignores pad_token_id instead of -100

### DIFF
--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -1066,7 +1066,6 @@ class BartForConditionalGeneration(PretrainedBartModel):
         masked_lm_loss = None
         if labels is not None:
             loss_fct = CrossEntropyLoss(ignore_index=self.config.pad_token_id)
-            # TODO(SS): do we need to ignore pad tokens in labels?
             masked_lm_loss = loss_fct(lm_logits.view(-1, self.config.vocab_size), labels.view(-1))
 
         if not return_dict:

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -1065,7 +1065,7 @@ class BartForConditionalGeneration(PretrainedBartModel):
 
         masked_lm_loss = None
         if labels is not None:
-            loss_fct = CrossEntropyLoss()
+            loss_fct = CrossEntropyLoss(ignore_index=self.config.pad_token_id)
             # TODO(SS): do we need to ignore pad tokens in labels?
             masked_lm_loss = loss_fct(lm_logits.view(-1, self.config.vocab_size), labels.view(-1))
 


### PR DESCRIPTION
cc @ibeltagy who noticed this.

I think it is better to ignore pad_token_id then -100, but this is semi-breaking because old training code might have replaced pad token id with -100 in labels.

Maybe I should check for both?