### PR TITLE
[WIP] Added token_type_id support to GPT2Model

### DIFF
--- a/src/transformers/configuration_gpt2.py
+++ b/src/transformers/configuration_gpt2.py
@@ -46,6 +46,9 @@ class GPT2Config(PretrainedConfig):
         vocab_size (:obj:`int`, optional, defaults to 50257):
             Vocabulary size of the GPT-2 model. Defines the different tokens that
             can be represented by the `inputs_ids` passed to the forward method of :class:`~transformers.GPT2Model`.
+        type_vocab_size (:obj:`int`, optional, defaults to None):
+            The vocabulary size of the `token_type_ids` passed into :class:`~transformers.GPT2Model`.
+            :obj:`None` will disable token_type embeddings.
         n_positions (:obj:`int`, optional, defaults to 1024):
             The maximum sequence length that this model might ever be used with.
             Typically set this to something large just in case (e.g., 512 or 1024 or 2048).
@@ -117,6 +120,7 @@ class GPT2Config(PretrainedConfig):
     def __init__(
         self,
         vocab_size=50257,
+        type_vocab_size=None,
         n_positions=1024,
         n_ctx=1024,
         n_embd=768,
@@ -141,6 +145,7 @@ class GPT2Config(PretrainedConfig):
         super().__init__(bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
 
         self.vocab_size = vocab_size
+        self.type_vocab_size = type_vocab_size
         self.n_ctx = n_ctx
         self.n_positions = n_positions
         self.n_embd = n_embd


### PR DESCRIPTION
Fixes #6794 #4922 #1339

Added token type embedding support to GPT2Model.

To use `token_type_ids` with `GPT2Model` the user can now supply `type_vocab_size` to the `GPT2Config` constructor and then pass `token_type_ids` as input to the `forward` method as with other models.

Using all the default parameters, the model should continue to work as before, since I have set `type_vocab_size=None` as the default of the `GPT2Config` class, which disables my token type embeddings.

If the user tries to pass `token_type_ids` to the `forward` method when token type embeddings have not been enabled for a model, it will raise an informative error message. The same is true for when the user does not pass `token_type_ids` to the `forward` method when token type embeddings have been enabled for a model.