### PR TITLE
make the tmp dir configurable/persistent in tokenizer tests

### DIFF
--- a/tests/test_tokenization_albert.py
+++ b/tests/test_tokenization_albert.py
@@ -19,13 +19,14 @@ import unittest
 
 from transformers.tokenization_albert import AlbertTokenizer
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 
 
 SAMPLE_VOCAB = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures/spiece.model")
 
 
-class AlbertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class AlbertTokenizationTest(TokenizerCommonTester):
+    __test__ = True
 
     tokenizer_class = AlbertTokenizer
 

--- a/tests/test_tokenization_albert.py
+++ b/tests/test_tokenization_albert.py
@@ -15,7 +15,6 @@
 
 
 import os
-import unittest
 
 from transformers.tokenization_albert import AlbertTokenizer
 

--- a/tests/test_tokenization_bart.py
+++ b/tests/test_tokenization_bart.py
@@ -7,10 +7,11 @@ from transformers.file_utils import cached_property
 from transformers.testing_utils import require_torch
 from transformers.tokenization_roberta import VOCAB_FILES_NAMES
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 
 
-class TestTokenizationBart(TokenizerTesterMixin, unittest.TestCase):
+class TestTokenizationBart(TokenizerCommonTester):
+    __test__ = True
     tokenizer_class = BartTokenizer
 
     def setUp(self):

--- a/tests/test_tokenization_bart.py
+++ b/tests/test_tokenization_bart.py
@@ -1,6 +1,5 @@
 import json
 import os
-import unittest
 
 from transformers import BartTokenizer, BartTokenizerFast, BatchEncoding
 from transformers.file_utils import cached_property

--- a/tests/test_tokenization_bert.py
+++ b/tests/test_tokenization_bert.py
@@ -29,10 +29,11 @@ from transformers.tokenization_bert import (
     _is_whitespace,
 )
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 
 
-class BertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class BertTokenizationTest(TokenizerCommonTester):
+    __test__ = True
 
     tokenizer_class = BertTokenizer
     test_rust_tokenizer = True

--- a/tests/test_tokenization_bert.py
+++ b/tests/test_tokenization_bert.py
@@ -15,7 +15,6 @@
 
 
 import os
-import unittest
 
 from transformers.testing_utils import slow
 from transformers.tokenization_bert import (

--- a/tests/test_tokenization_bert_japanese.py
+++ b/tests/test_tokenization_bert_japanese.py
@@ -26,11 +26,12 @@ from transformers.tokenization_bert_japanese import (
     MecabTokenizer,
 )
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 
 
 @custom_tokenizers
-class BertJapaneseTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class BertJapaneseTokenizationTest(TokenizerCommonTester):
+    __test__ = True
 
     tokenizer_class = BertJapaneseTokenizer
 
@@ -178,7 +179,8 @@ class BertJapaneseTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
 
 @custom_tokenizers
-class BertJapaneseCharacterTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class BertJapaneseCharacterTokenizationTest(TokenizerCommonTester):
+    __test__ = True
 
     tokenizer_class = BertJapaneseTokenizer
 

--- a/tests/test_tokenization_bert_japanese.py
+++ b/tests/test_tokenization_bert_japanese.py
@@ -15,7 +15,6 @@
 
 
 import os
-import unittest
 
 from transformers.testing_utils import custom_tokenizers
 from transformers.tokenization_bert import WordpieceTokenizer

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -23,7 +23,7 @@ from collections import OrderedDict
 from typing import TYPE_CHECKING, Dict, List, Tuple, Union
 
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerBase, PreTrainedTokenizerFast
-from transformers.testing_utils import require_tf, require_torch, slow
+from transformers.testing_utils import TestCasePlus, require_tf, require_torch, slow
 from transformers.tokenization_utils import AddedToken
 
 
@@ -53,16 +53,28 @@ def merge_model_tokenizer_mappings(
     return model_tokenizer_mapping
 
 
-class TokenizerTesterMixin:
+DEBUG = False
+
+
+class TokenizerCommonTester(TestCasePlus):
+
+    # to ensure that these tests don't get run directly
+    __test__ = False
+    # then in the subclass set:
+    # __test__ = True
 
     tokenizer_class = None
     test_rust_tokenizer = False
 
     def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+        super().setUp()
 
-    def tearDown(self):
-        shutil.rmtree(self.tmpdirname)
+        # if you need to debug the contents of the tmpdirname, set DEBUG to True, which will then use
+        # a hardcoded path and won't delete it at the end of the test
+        if not DEBUG:
+            self.tmpdirname = self.get_auto_remove_tmp_dir()
+        else:
+            self.tmpdirname = self.get_auto_remove_tmp_dir(tmp_dir="./tmp/token-test", after=False)
 
     def get_input_output_texts(self, tokenizer):
         input_txt = self.get_clean_sequence(tokenizer)[0]

--- a/tests/test_tokenization_ctrl.py
+++ b/tests/test_tokenization_ctrl.py
@@ -19,10 +19,11 @@ import unittest
 
 from transformers.tokenization_ctrl import VOCAB_FILES_NAMES, CTRLTokenizer
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 
 
-class CTRLTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class CTRLTokenizationTest(TokenizerCommonTester):
+    __test__ = True
 
     tokenizer_class = CTRLTokenizer
 

--- a/tests/test_tokenization_ctrl.py
+++ b/tests/test_tokenization_ctrl.py
@@ -15,7 +15,6 @@
 
 import json
 import os
-import unittest
 
 from transformers.tokenization_ctrl import VOCAB_FILES_NAMES, CTRLTokenizer
 

--- a/tests/test_tokenization_gpt2.py
+++ b/tests/test_tokenization_gpt2.py
@@ -16,7 +16,6 @@
 
 import json
 import os
-import unittest
 
 from transformers.tokenization_gpt2 import VOCAB_FILES_NAMES, GPT2Tokenizer, GPT2TokenizerFast
 

--- a/tests/test_tokenization_gpt2.py
+++ b/tests/test_tokenization_gpt2.py
@@ -20,10 +20,11 @@ import unittest
 
 from transformers.tokenization_gpt2 import VOCAB_FILES_NAMES, GPT2Tokenizer, GPT2TokenizerFast
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 
 
-class GPT2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class GPT2TokenizationTest(TokenizerCommonTester):
+    __test__ = True
 
     tokenizer_class = GPT2Tokenizer
     test_rust_tokenizer = True

--- a/tests/test_tokenization_marian.py
+++ b/tests/test_tokenization_marian.py
@@ -16,7 +16,6 @@
 
 import os
 import tempfile
-import unittest
 from pathlib import Path
 from shutil import copyfile
 

--- a/tests/test_tokenization_marian.py
+++ b/tests/test_tokenization_marian.py
@@ -24,7 +24,7 @@ from transformers.testing_utils import _torch_available
 from transformers.tokenization_marian import MarianTokenizer, save_json, vocab_files_names
 from transformers.tokenization_utils import BatchEncoding
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 
 
 SAMPLE_SP = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures/test_sentencepiece.model")
@@ -35,7 +35,8 @@ ORG_NAME = "Helsinki-NLP/"
 FRAMEWORK = "pt" if _torch_available else "tf"
 
 
-class MarianTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class MarianTokenizationTest(TokenizerCommonTester):
+    __test__ = True
 
     tokenizer_class = MarianTokenizer
 

--- a/tests/test_tokenization_mbart.py
+++ b/tests/test_tokenization_mbart.py
@@ -4,7 +4,7 @@ import unittest
 from transformers import AutoTokenizer, BatchEncoding, MBartTokenizer, is_torch_available
 from transformers.testing_utils import require_torch
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 from .test_tokenization_xlm_roberta import SAMPLE_VOCAB, SPIECE_UNDERLINE
 
 
@@ -15,7 +15,8 @@ EN_CODE = 250004
 RO_CODE = 250020
 
 
-class MBartTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class MBartTokenizationTest(TokenizerCommonTester):
+    __test__ = True
     tokenizer_class = MBartTokenizer
 
     def setUp(self):

--- a/tests/test_tokenization_openai.py
+++ b/tests/test_tokenization_openai.py
@@ -16,7 +16,6 @@
 
 import json
 import os
-import unittest
 
 from transformers.tokenization_openai import VOCAB_FILES_NAMES, OpenAIGPTTokenizer
 

--- a/tests/test_tokenization_openai.py
+++ b/tests/test_tokenization_openai.py
@@ -20,10 +20,11 @@ import unittest
 
 from transformers.tokenization_openai import VOCAB_FILES_NAMES, OpenAIGPTTokenizer
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 
 
-class OpenAIGPTTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class OpenAIGPTTokenizationTest(TokenizerCommonTester):
+    __test__ = True
 
     tokenizer_class = OpenAIGPTTokenizer
 

--- a/tests/test_tokenization_pegasus.py
+++ b/tests/test_tokenization_pegasus.py
@@ -5,10 +5,11 @@ from transformers.file_utils import cached_property
 from transformers.testing_utils import require_torch
 from transformers.tokenization_pegasus import PegasusTokenizer
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 
 
-class PegasusTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class PegasusTokenizationTest(TokenizerCommonTester):
+    __test__ = True
 
     tokenizer_class = PegasusTokenizer
 

--- a/tests/test_tokenization_reformer.py
+++ b/tests/test_tokenization_reformer.py
@@ -15,7 +15,6 @@
 
 
 import os
-import unittest
 
 from transformers.file_utils import cached_property
 from transformers.testing_utils import require_torch, slow

--- a/tests/test_tokenization_reformer.py
+++ b/tests/test_tokenization_reformer.py
@@ -21,13 +21,14 @@ from transformers.file_utils import cached_property
 from transformers.testing_utils import require_torch, slow
 from transformers.tokenization_reformer import SPIECE_UNDERLINE, ReformerTokenizer
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 
 
 SAMPLE_VOCAB = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures/test_sentencepiece.model")
 
 
-class ReformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class ReformerTokenizationTest(TokenizerCommonTester):
+    __test__ = True
 
     tokenizer_class = ReformerTokenizer
 

--- a/tests/test_tokenization_roberta.py
+++ b/tests/test_tokenization_roberta.py
@@ -16,7 +16,6 @@
 
 import json
 import os
-import unittest
 
 from transformers.testing_utils import slow
 from transformers.tokenization_roberta import VOCAB_FILES_NAMES, AddedToken, RobertaTokenizer, RobertaTokenizerFast

--- a/tests/test_tokenization_roberta.py
+++ b/tests/test_tokenization_roberta.py
@@ -21,10 +21,11 @@ import unittest
 from transformers.testing_utils import slow
 from transformers.tokenization_roberta import VOCAB_FILES_NAMES, AddedToken, RobertaTokenizer, RobertaTokenizerFast
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 
 
-class RobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class RobertaTokenizationTest(TokenizerCommonTester):
+    __test__ = True
     tokenizer_class = RobertaTokenizer
 
     def setUp(self):

--- a/tests/test_tokenization_t5.py
+++ b/tests/test_tokenization_t5.py
@@ -15,7 +15,6 @@
 
 
 import os
-import unittest
 
 from transformers import BatchEncoding
 from transformers.file_utils import cached_property

--- a/tests/test_tokenization_t5.py
+++ b/tests/test_tokenization_t5.py
@@ -23,7 +23,7 @@ from transformers.testing_utils import _torch_available
 from transformers.tokenization_t5 import T5Tokenizer
 from transformers.tokenization_xlnet import SPIECE_UNDERLINE
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 
 
 SAMPLE_VOCAB = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures/test_sentencepiece.model")
@@ -31,7 +31,8 @@ SAMPLE_VOCAB = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixture
 FRAMEWORK = "pt" if _torch_available else "tf"
 
 
-class T5TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class T5TokenizationTest(TokenizerCommonTester):
+    __test__ = True
 
     tokenizer_class = T5Tokenizer
 

--- a/tests/test_tokenization_transfo_xl.py
+++ b/tests/test_tokenization_transfo_xl.py
@@ -20,7 +20,7 @@ import unittest
 from transformers import is_torch_available
 from transformers.testing_utils import require_torch
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 
 
 if is_torch_available():
@@ -28,7 +28,8 @@ if is_torch_available():
 
 
 @require_torch
-class TransfoXLTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class TransfoXLTokenizationTest(TokenizerCommonTester):
+    __test__ = True
 
     tokenizer_class = TransfoXLTokenizer if is_torch_available() else None
 

--- a/tests/test_tokenization_transfo_xl.py
+++ b/tests/test_tokenization_transfo_xl.py
@@ -15,7 +15,6 @@
 
 
 import os
-import unittest
 
 from transformers import is_torch_available
 from transformers.testing_utils import require_torch

--- a/tests/test_tokenization_xlm.py
+++ b/tests/test_tokenization_xlm.py
@@ -16,7 +16,6 @@
 
 import json
 import os
-import unittest
 
 from transformers.testing_utils import slow
 from transformers.tokenization_xlm import VOCAB_FILES_NAMES, XLMTokenizer

--- a/tests/test_tokenization_xlm.py
+++ b/tests/test_tokenization_xlm.py
@@ -21,10 +21,11 @@ import unittest
 from transformers.testing_utils import slow
 from transformers.tokenization_xlm import VOCAB_FILES_NAMES, XLMTokenizer
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 
 
-class XLMTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class XLMTokenizationTest(TokenizerCommonTester):
+    __test__ = True
 
     tokenizer_class = XLMTokenizer
 

--- a/tests/test_tokenization_xlm_roberta.py
+++ b/tests/test_tokenization_xlm_roberta.py
@@ -21,13 +21,14 @@ from transformers.file_utils import cached_property
 from transformers.testing_utils import slow
 from transformers.tokenization_xlm_roberta import SPIECE_UNDERLINE, XLMRobertaTokenizer
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 
 
 SAMPLE_VOCAB = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures/test_sentencepiece.model")
 
 
-class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class XLMRobertaTokenizationTest(TokenizerCommonTester):
+    __test__ = True
 
     tokenizer_class = XLMRobertaTokenizer
 

--- a/tests/test_tokenization_xlm_roberta.py
+++ b/tests/test_tokenization_xlm_roberta.py
@@ -15,7 +15,6 @@
 
 
 import os
-import unittest
 
 from transformers.file_utils import cached_property
 from transformers.testing_utils import slow

--- a/tests/test_tokenization_xlnet.py
+++ b/tests/test_tokenization_xlnet.py
@@ -15,7 +15,6 @@
 
 
 import os
-import unittest
 
 from transformers.testing_utils import slow
 from transformers.tokenization_xlnet import SPIECE_UNDERLINE, XLNetTokenizer

--- a/tests/test_tokenization_xlnet.py
+++ b/tests/test_tokenization_xlnet.py
@@ -20,13 +20,14 @@ import unittest
 from transformers.testing_utils import slow
 from transformers.tokenization_xlnet import SPIECE_UNDERLINE, XLNetTokenizer
 
-from .test_tokenization_common import TokenizerTesterMixin
+from .test_tokenization_common import TokenizerCommonTester
 
 
 SAMPLE_VOCAB = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures/test_sentencepiece.model")
 
 
-class XLNetTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class XLNetTokenizationTest(TokenizerCommonTester):
+    __test__ = True
 
     tokenizer_class = XLNetTokenizer
 


### PR DESCRIPTION
Currently, debugging tokenizers is difficult since the temp dir is random and it gets wiped out at the end of the test run. It can be done, but it takes so much repetitive work.

This PR uses the recently added [`TestCasePlus`](https://github.com/huggingface/transformers/pull/6494) which automatically sets up temp dirs and optionally doesn't remove them at the end of the test. It makes it very easy to configure the temp dir to be fixed rather than random, and also not delete itself.

As a side-effect of inheriting from `TestCasePlus`, the mixin approach of `FooTest(TokenizerTesterMixin, unittest.TestCase)` doesn't work - as it now tries to run the super-class tests directly and not from within the subclass.  Therefore, the code switches to normal sub-classing and instructs `unittest` not to run super-class' tests on its own, using the following machinery as explained [here](https://stackoverflow.com/a/50922971/9201239). Specifically here:

```
from transformers.testing_utils import TestCasePlus
class TokenizerCommonTester(TestCasePlus):
    __test__ = False

# and then the sub-class:
from .test_tokenization_common import TokenizerCommonTester
class BartTokenizationTest(TokenizerCommonTester):
    __test__ = True
```

The PR  makes the code ready to debug by changing just one flag:

```
       DEBUG = False
        # if you need to debug the contents of the tmpdirname, set DEBUG to True, which will then use
        # a hardcoded path and won't delete it at the end of the test
        if not DEBUG:
            self.tmpdirname = self.get_auto_remove_tmp_dir()
        else:
            self.tmpdirname = self.get_auto_remove_tmp_dir(tmp_dir="./tmp/token-test", after=False)
```
So just make `DEBUG` `True` and nothing else needs to be tweaked.

I hope this is useful for developers.

There are a few other test mixins that could be improved the same way, but let's see if this approach is welcomed first.

----

## An alternative solution

If mixin is preferable, then let's leave everything as is and do this instead:

```
# transformers/testing_utils.py
from pathlib import Path
def make_dir(path):
    Path(path).resolve().mkdir(parents=True, exist_ok=True)
    return path

# tests/test_tokenization_common.py
from transformers.testing_utils import make_dir
DEBUG = True
class TokenizerTesterMixin:

    tokenizer_class = None
    test_rust_tokenizer = False

    def setUp(self):
        if not DEBUG:
            self.tmpdirname = tempfile.mkdtemp()
        else:
            self.tmpdirname = make_dir("./tmp/test-tok")

    def tearDown(self):
        if not DEBUG:
            shutil.rmtree(self.tmpdirname)
```

