### PR TITLE
control framework loglevel in scripts and tests

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -299,7 +299,7 @@ class CaptureLogger:
         self.logger = logger
         self.io = StringIO()
         self.sh = logging.StreamHandler(self.io)
-        self.out = ''
+        self.out = ""
 
     def __enter__(self):
         self.logger.addHandler(self.sh)

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -299,6 +299,7 @@ class CaptureLogger:
         self.logger = logger
         self.io = StringIO()
         self.sh = logging.StreamHandler(self.io)
+        self.out = ''
 
     def __enter__(self):
         self.logger.addHandler(self.sh)

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -15,7 +15,6 @@
 """ Logging utilities. """
 
 import logging
-import re
 import threading
 from logging import CRITICAL  # NOQA
 from logging import DEBUG  # NOQA
@@ -164,40 +163,3 @@ def enable_propagation() -> None:
 
     _configure_library_root_logger()
     _get_library_root_logger().propagate = True
-
-
-log_levels = {
-    "debug": logging.DEBUG,
-    "info": logging.INFO,
-    "warning": logging.WARNING,
-    "error": logging.ERROR,
-    "critical": logging.CRITICAL,
-}
-
-
-def logging_levels_as_strings():
-    return log_levels.keys()
-
-
-def logging_level_str_to_code(level_str):
-    if level_str in log_levels:
-        return log_levels[level_str]
-    else:
-        raise ValueError(f"unknown level {level_str}, has to be one of: { log_levels.keys() }")
-
-
-def set_global_logging_level(level=logging.ERROR, prefices=[""]):
-    """
-    Override logging levels of different modules based on their name as a prefix.
-    It needs to be invoked after the modules have been loaded so that their loggers have been initialized.
-
-    Args:
-        - level: desired level. e.g. logging.INFO. Optional. Default is logging.ERROR
-        - prefices: list of one or more str prefices to match (e.g. ["transformers", "torch"]). Optional.
-          Default is `[""]` to match all active loggers.
-          The match is a case-sensitive `module_name.startswith(prefix)`
-    """
-    prefix_re = re.compile(fr'^(?:{ "|".join(prefices) })')
-    for name in logging.root.manager.loggerDict:
-        if re.match(prefix_re, name):
-            logging.getLogger(name).setLevel(level)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,31 @@
 import sys
 from os.path import abspath, dirname, join
 
+import pytest
+
 
 # allow having multiple repository checkouts and not needing to remember to rerun
 # 'pip install -e .[dev]' when switching between checkouts and running tests.
 git_repo_path = abspath(join(dirname(dirname(__file__)), "src"))
 sys.path.insert(1, git_repo_path)
+
+# import local modules after fixing up sys.path
+from transformers.utils.logging import logging_level_str_to_code, logging_levels_as_strings, set_global_logging_level
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--loglevel",
+        type=str,
+        default=False,
+        choices=logging_levels_as_strings(),
+        help="set global logger level before each test",
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def run_this_before_each_test(request):
+    # set the loglevel for all loggers to the desired level
+    loglevel = request.config.getoption("--loglevel")
+    if loglevel:
+        set_global_logging_level(level=logging_level_str_to_code(loglevel))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,17 +13,12 @@ git_repo_path = abspath(join(dirname(dirname(__file__)), "src"))
 sys.path.insert(1, git_repo_path)
 
 # import local modules after fixing up sys.path
-if 1:  # flake be quiet
-    from transformers.utils.logging import (
-        logging_level_str_to_code,
-        logging_levels_as_strings,
-        set_global_logging_level,
-    )
+from transformers.testing_utils import logging_level_str_to_code, logging_levels_as_strings, set_verbosity_all  # NOQA
 
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--loglevel",
+        "--log-level-all",
         type=str,
         default=False,
         choices=logging_levels_as_strings(),
@@ -33,7 +28,9 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope="session", autouse=True)
 def run_this_before_each_test(request):
-    # set the loglevel for all loggers to the desired level
-    loglevel = request.config.getoption("--loglevel")
+    # set the loglevel for all loggers (not just transformers) to the desired level
+    # note: as --log-level-all=error override is intended to be run only for one test
+    # under debugging, this practically will have no impact on the test suite at large
+    loglevel = request.config.getoption("--log-level-all")
     if loglevel:
-        set_global_logging_level(level=logging_level_str_to_code(loglevel))
+        set_verbosity_all(level=logging_level_str_to_code(loglevel))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,12 @@ git_repo_path = abspath(join(dirname(dirname(__file__)), "src"))
 sys.path.insert(1, git_repo_path)
 
 # import local modules after fixing up sys.path
-from transformers.utils.logging import logging_level_str_to_code, logging_levels_as_strings, set_global_logging_level
+if 1:  # flake be quiet
+    from transformers.utils.logging import (
+        logging_level_str_to_code,
+        logging_levels_as_strings,
+        set_global_logging_level,
+    )
 
 
 def pytest_addoption(parser):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -33,7 +33,6 @@ class HfArgumentParserTest(unittest.TestCase):
         logger = logging.get_logger("transformers.tokenization_bart")
         msg = "Testing 1, 2, 3"
 
-
         # should be able to log warnings (default setting)
         with CaptureLogger(logger) as cl:
             logger.warn(msg)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,11 +1,14 @@
 import unittest
 
 from transformers import logging
+from transformers.testing_utils import CaptureLogger
 
 
 class HfArgumentParserTest(unittest.TestCase):
     def test_set_level(self):
         logger = logging.get_logger()
+
+        level_origin = logging.get_verbosity_error()
 
         logging.set_verbosity_error()
         self.assertEqual(logger.getEffectiveLevel(), logging.get_verbosity())
@@ -18,3 +21,32 @@ class HfArgumentParserTest(unittest.TestCase):
 
         logging.set_verbosity_debug()
         self.assertEqual(logger.getEffectiveLevel(), logging.get_verbosity())
+
+        # restore
+        logging.set_verbosity(level_origin)
+
+
+    def test_integration(self):
+        import transformers.tokenization_bart
+
+        logger = logging.get_logger("transformers.tokenization_bart")
+        msg = "Testing 1, 2, 3"
+
+        # should be able to log info (default setting)
+        with CaptureLogger(logger) as cl:
+            logger.info(msg)
+        self.assertEqual(cl.out, msg + "\n")
+
+        # this is setting the level for all of `transformers.*` loggers
+        logging.set_verbosity_error()
+
+        # should not be able to log info
+        with CaptureLogger(logger) as cl:
+            logger.info(msg)
+        self.assertEqual(cl.out, "")
+
+        # should be able to log info again
+        logging.set_verbosity_info()
+        with CaptureLogger(logger) as cl:
+            logger.info(msg)
+        self.assertEqual(cl.out, msg + "\n")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -8,7 +8,7 @@ class HfArgumentParserTest(unittest.TestCase):
     def test_set_level(self):
         logger = logging.get_logger()
 
-        level_origin = logging.get_verbosity_error()
+        level_origin = logging.get_verbosity()
 
         logging.set_verbosity_error()
         self.assertEqual(logger.getEffectiveLevel(), logging.get_verbosity())
@@ -25,7 +25,6 @@ class HfArgumentParserTest(unittest.TestCase):
         # restore
         logging.set_verbosity(level_origin)
 
-
     def test_integration(self):
         import transformers.tokenization_bart
 
@@ -33,6 +32,7 @@ class HfArgumentParserTest(unittest.TestCase):
         msg = "Testing 1, 2, 3"
 
         # should be able to log info (default setting)
+        logging.set_verbosity_info()
         with CaptureLogger(logger) as cl:
             logger.info(msg)
         self.assertEqual(cl.out, msg + "\n")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -31,22 +31,21 @@ class HfArgumentParserTest(unittest.TestCase):
         logger = logging.get_logger("transformers.tokenization_bart")
         msg = "Testing 1, 2, 3"
 
-        # should be able to log info (default setting)
-        logging.set_verbosity_info()
+        # should be able to log warn (default setting)
         with CaptureLogger(logger) as cl:
-            logger.info(msg)
+            logger.warn(msg)
         self.assertEqual(cl.out, msg + "\n")
 
         # this is setting the level for all of `transformers.*` loggers
         logging.set_verbosity_error()
 
-        # should not be able to log info
+        # should not be able to log warn
         with CaptureLogger(logger) as cl:
-            logger.info(msg)
+            logger.warn(msg)
         self.assertEqual(cl.out, "")
 
-        # should be able to log info again
-        logging.set_verbosity_info()
+        # should be able to log warn again
+        logging.set_verbosity_warning()
         with CaptureLogger(logger) as cl:
-            logger.info(msg)
+            logger.warn(msg)
         self.assertEqual(cl.out, msg + "\n")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -9,6 +9,7 @@ class HfArgumentParserTest(unittest.TestCase):
         logger = logging.get_logger()
 
         level_origin = logging.get_verbosity()
+        self.assertEqual(level_origin, logging.WARNING)
 
         logging.set_verbosity_error()
         self.assertEqual(logger.getEffectiveLevel(), logging.get_verbosity())
@@ -26,12 +27,14 @@ class HfArgumentParserTest(unittest.TestCase):
         logging.set_verbosity(level_origin)
 
     def test_integration(self):
-        import transformers.tokenization_bart
+
+        import transformers.tokenization_bart  # noqa
 
         logger = logging.get_logger("transformers.tokenization_bart")
         msg = "Testing 1, 2, 3"
 
-        # should be able to log warn (default setting)
+
+        # should be able to log warnings (default setting)
         with CaptureLogger(logger) as cl:
             logger.warn(msg)
         self.assertEqual(cl.out, msg + "\n")
@@ -39,13 +42,13 @@ class HfArgumentParserTest(unittest.TestCase):
         # this is setting the level for all of `transformers.*` loggers
         logging.set_verbosity_error()
 
-        # should not be able to log warn
+        # should not be able to log warnings
         with CaptureLogger(logger) as cl:
             logger.warn(msg)
         self.assertEqual(cl.out, "")
 
-        # should be able to log warn again
+        # should be able to log warnings again
         logging.set_verbosity_warning()
         with CaptureLogger(logger) as cl:
-            logger.warn(msg)
+            logger.warning(msg)
         self.assertEqual(cl.out, msg + "\n")

--- a/tests/test_modeling_pegasus.py
+++ b/tests/test_modeling_pegasus.py
@@ -4,7 +4,6 @@ from transformers import AutoConfig, AutoTokenizer, is_torch_available
 from transformers.configuration_pegasus import task_specific_params
 from transformers.file_utils import cached_property
 from transformers.testing_utils import require_torch, slow, torch_device
-from transformers.utils.logging import ERROR, set_verbosity
 
 from .test_modeling_bart import PGE_ARTICLE
 from .test_modeling_mbart import AbstractSeq2SeqIntegrationTest
@@ -14,8 +13,6 @@ if is_torch_available():
     from transformers import AutoModelForSeq2SeqLM
 
 XSUM_ENTRY_LONGER = """ The London trio are up for best UK act and best album, as well as getting two nominations in the best song category."We got told like this morning 'Oh I think you're nominated'", said Dappy."And I was like 'Oh yeah, which one?' And now we've got nominated for four awards. I mean, wow!"Bandmate Fazer added: "We thought it's best of us to come down and mingle with everyone and say hello to the cameras. And now we find we've got four nominations."The band have two shots at the best song prize, getting the nod for their Tynchy Stryder collaboration Number One, and single Strong Again.Their album Uncle B will also go up against records by the likes of Beyonce and Kanye West.N-Dubz picked up the best newcomer Mobo in 2007, but female member Tulisa said they wouldn't be too disappointed if they didn't win this time around."At the end of the day we're grateful to be where we are in our careers."If it don't happen then it don't happen - live to fight another day and keep on making albums and hits for the fans."Dappy also revealed they could be performing live several times on the night.The group will be doing Number One and also a possible rendition of the War Child single, I Got Soul.The charity song is a  re-working of The Killers' All These Things That I've Done and is set to feature artists like Chipmunk, Ironik and Pixie Lott.This year's Mobos will be held outside of London for the first time, in Glasgow on 30 September.N-Dubz said they were looking forward to performing for their Scottish fans and boasted about their recent shows north of the border."We just done Edinburgh the other day," said Dappy."We smashed up an N-Dubz show over there. We done Aberdeen about three or four months ago - we smashed up that show over there! Everywhere we go we smash it up!" """
-
-set_verbosity(ERROR)
 
 
 @require_torch


### PR DESCRIPTION
There is too much logging going on at times under `transformers` and friends. One needs to be able to turn the noise off easily. This is a follow up to https://github.com/huggingface/transformers/issues/3050#issuecomment-682167272

**edit**: The default was changed yesterday to`logging.WARNING` https://github.com/huggingface/transformers/commit/4561f05c5fafc2b636a2fc1d0dded9057d439745 so there is much less noise now.

**edit**: this PR has evolved since it was initially submitted, so this OP has been updated to reflect the current state of things.

This PR introduces 2 things.

# 1.  new function: `set_verbosity_all`

Usage:

a. override all module-specific loggers to a desired level (except whatever got logged during modules importing)
```
import everything, you, need
import transformers
transformers.testing_utils.set_verbosity_all(transformers.logging.ERROR)
```

b. If you want to disable specific loggers you can call it with specific top level names:
```
import transformers, torch, ...
transformers.testing_utils.set_verbosity_all(transformers.logging.ERROR, ["transformers", "nlp", "torch", "tensorflow", "tensorboard", "wandb"])
```
add/remove module name prefices as needed.

I initially placed it under `transformers.utils.logging` but then since it's beyond the core functionality, I moved it to testing_utils, since this is where we really want it. Please correct me if it should better belong elsewhere.

# 2.  new pytest option: `--log-level-all=error`

when debugging tests, sometimes framework-wide logging gets seriously in the way, e.g. try:

```
RUN_SLOW=1 pytest -sv --disable-warnings tests/test_modeling_bart.py::BartModelIntegrationTests::test_inference_no_head
```
gives a lot of noise. (it was so until `s/info/warn` recent change mention above, but there is noise still)

Now you will be able to turn it off, focusing only on the debug you want, by adding `--loglevel=error ` to the `pytest` options (or another level of your choice):

```
RUN_SLOW=1 pytest -sv --log-level-all=error --disable-warnings tests/test_modeling_bart.py::BartModelIntegrationTests::test_inference_no_head
```
voila - the noise is gone, while you can still do debug printing, etc.

```
pytest -h
  [...]
  --log-level-all={debug,info,warning,error,critical}
                        set global logger level before each test
```


# 3. new test + `CaptureLogger` context manager

While working on this a few integration tests were added and a helper `CaptureLogger` context manager
 to easily test the logger outputs.

# 4. cleaned up one test

removed verbosity setting in one test, which impacted other tests as it wasn't resetting the level to the original

-----

Quite a few testing features were added recently, I guess it's time to start `testing.md` or something. 

----

Fixes: https://github.com/huggingface/transformers/issues/3050