### PR TITLE
add a final report to all pytest jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
                 key: v0.3-{{ checksum "setup.py" }}
                 paths:
                     - '~/.cache/pip'
-            - run: python -m pytest -n 8 --dist=loadfile -s ./tests/ --cov  | tee output.txt
+            - run: python -m pytest -n 8 --dist=loadfile -rA -s ./tests/ --cov  | tee output.txt
             - run: codecov
             - store_artifacts:
                   path: ~/transformers/output.txt
@@ -110,7 +110,7 @@ jobs:
                   key: v0.3-torch-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: python -m pytest -n 8 --dist=loadfile -s ./tests/ | tee output.txt
+            - run: python -m pytest -n 8 --dist=loadfile -rA -s ./tests/ | tee output.txt
             - store_artifacts:
                   path: ~/transformers/output.txt
                   destination: test_output.txt
@@ -135,7 +135,7 @@ jobs:
                   key: v0.3-tf-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: python -m pytest -n 8 --dist=loadfile -s ./tests/ | tee output.txt
+            - run: python -m pytest -n 8 --dist=loadfile -rA -s ./tests/ | tee output.txt
             - store_artifacts:
                path: ~/transformers/output.txt
                destination: test_output.txt


### PR DESCRIPTION
we had it added for one job (run_examples_torch), please add it to all pytest jobs - we need the output of what tests were run to debug the codecov issue. thank you!

To remind  `pytest -rA` finalizes the test run with a report like this:
```
PASSED examples/seq2seq/test_seq2seq_examples.py::test_seq2seq_dataset_truncation[patrickvonplaten/t5-tiny-random]
PASSED examples/seq2seq/test_seq2seq_examples.py::test_seq2seq_dataset_truncation[sshleifer/bart-tiny-random]
PASSED examples/seq2seq/test_seq2seq_examples.py::test_seq2seq_dataset_truncation[google/pegasus-xsum]
PASSED examples/seq2seq/test_seq2seq_examples.py::test_legacy_dataset_truncation[sshleifer/bart-tiny-random]
PASSED examples/seq2seq/test_seq2seq_examples.py::test_legacy_dataset_truncation[bert-base-cased]
PASSED examples/test_examples.py::ExamplesTests::test_run_language_modeling
PASSED examples/test_examples.py::ExamplesTests::test_run_pl_glue
PASSED examples/test_examples.py::ExamplesTests::test_run_squad
PASSED examples/bert-loses-patience/test_run_glue_with_pabee.py::PabeeTests::test_run_glue
SKIPPED [1] examples/seq2seq/test_bash_script.py:25: too slow to run on CPU
SKIPPED [1] examples/seq2seq/test_bash_script.py:32: too slow to run on CPU
```