### PR TITLE
cleanup: fix typo chunk_size_feed_forward in configuration_utils.py

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -195,7 +195,6 @@ class PretrainedConfig(object):
         self.pad_token_id = kwargs.pop("pad_token_id", None)
         self.eos_token_id = kwargs.pop("eos_token_id", None)
         self.decoder_start_token_id = kwargs.pop("decoder_start_token_id", None)
-        self.chunk_size_feed_forward = kwargs.pop("chunk_size_feed_forwar", 0)
 
         # task specific arguments
         self.task_specific_params = kwargs.pop("task_specific_params", None)


### PR DESCRIPTION
Problem:
 
```python
self.chunk_size_feed_forward = kwargs.pop("chunk_size_feed_forward", 0) # line 178
self.chunk_size_feed_forward = kwargs.pop("chunk_size_feed_forwar", 0)# line 198
```
in https://github.com/huggingface/transformers/blob/master/src/transformers/configuration_utils.py#L178

Solution: 
delete L198