### PR TITLE
test_tf_common: remove un_used mixin class parameters

### DIFF
--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -73,8 +73,6 @@ class TFModelTesterMixin:
     model_tester = None
     all_model_classes = ()
     all_generative_model_classes = ()
-    test_torchscript = True
-    test_pruning = True
     test_resize_embeddings = True
     is_encoder_decoder = False
 

--- a/tests/test_modeling_tf_distilbert.py
+++ b/tests/test_modeling_tf_distilbert.py
@@ -184,9 +184,6 @@ class TFDistilBertModelTest(TFModelTesterMixin, unittest.TestCase):
         if is_tf_available()
         else None
     )
-    test_pruning = True
-    test_torchscript = True
-    test_head_masking = True
 
     def setUp(self):
         self.model_tester = TFDistilBertModelTester(self)

--- a/tests/test_modeling_tf_longformer.py
+++ b/tests/test_modeling_tf_longformer.py
@@ -264,9 +264,6 @@ class TFLongformerModelTester:
 
 @require_tf
 class TFLongformerModelTest(TFModelTesterMixin, unittest.TestCase):
-    test_pruning = False  # pruning is not supported
-    test_headmasking = False  # head masking is not supported
-    test_torchscript = False
 
     all_model_classes = (
         (

--- a/tests/test_modeling_tf_transfo_xl.py
+++ b/tests/test_modeling_tf_transfo_xl.py
@@ -145,8 +145,6 @@ class TFTransfoXLModelTest(TFModelTesterMixin, unittest.TestCase):
     all_model_classes = (TFTransfoXLModel, TFTransfoXLLMHeadModel) if is_tf_available() else ()
     all_generative_model_classes = () if is_tf_available() else ()
     # TODO: add this test when TFTransfoXLLMHead has a linear output layer implemented
-    test_pruning = False
-    test_torchscript = False
     test_resize_embeddings = False
 
     def setUp(self):

--- a/tests/test_modeling_tf_xlnet.py
+++ b/tests/test_modeling_tf_xlnet.py
@@ -348,7 +348,6 @@ class TFXLNetModelTest(TFModelTesterMixin, unittest.TestCase):
     all_generative_model_classes = (
         (TFXLNetLMHeadModel,) if is_tf_available() else ()
     )  # TODO (PVP): Check other models whether language generation is also applicable
-    test_pruning = False
 
     def setUp(self):
         self.model_tester = TFXLNetModelTester(self)


### PR DESCRIPTION

Fixes #6590 

@sshleifer Is that all for this issue? are there any other cleaning left which I did not understand ❗  

Thanks