### PR TITLE
Restore PaddingStrategy.MAX_LENGTH on QAPipeline while no v2.

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1674,7 +1674,7 @@ class QuestionAnsweringPipeline(Pipeline):
                 max_seq_length=kwargs["max_seq_len"],
                 doc_stride=kwargs["doc_stride"],
                 max_query_length=kwargs["max_question_len"],
-                padding_strategy=PaddingStrategy.DO_NOT_PAD.value,
+                padding_strategy=PaddingStrategy.MAX_LENGTH.value,
                 is_training=False,
                 tqdm_enabled=False,
             )


### PR DESCRIPTION
QA Pipeline will be slower but will work in all situations. 

Need to shift towards pipeline v2 with priority on QA Pipeline to provide a workaround. 

Signed-off-by: Morgan Funtowicz <funtowiczmo@gmail.com>
