### PR TITLE
[EncoderDecoder] Add xlm-roberta to encoder decoder

### DIFF
--- a/docs/source/model_doc/xlmroberta.rst
+++ b/docs/source/model_doc/xlmroberta.rst
@@ -56,6 +56,13 @@ XLMRobertaModel
     :members:
 
 
+XLMRobertaForCausalLM
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: transformers.XLMRobertaForCausalLM
+    :members:
+
+
 XLMRobertaForMaskedLM
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -418,6 +418,7 @@ if is_torch_available():
     )
     from .modeling_xlm_roberta import (
         XLM_ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST,
+        XLMRobertaForCausalLM,
         XLMRobertaForMaskedLM,
         XLMRobertaForMultipleChoice,
         XLMRobertaForQuestionAnswering,

--- a/src/transformers/modeling_auto.py
+++ b/src/transformers/modeling_auto.py
@@ -156,6 +156,7 @@ from .modeling_xlm import (
     XLMWithLMHeadModel,
 )
 from .modeling_xlm_roberta import (
+    XLMRobertaForCausalLM,
     XLMRobertaForMaskedLM,
     XLMRobertaForMultipleChoice,
     XLMRobertaForQuestionAnswering,
@@ -255,6 +256,7 @@ MODEL_WITH_LM_HEAD_MAPPING = OrderedDict(
 MODEL_FOR_CAUSAL_LM_MAPPING = OrderedDict(
     [
         (CamembertConfig, CamembertForCausalLM),
+        (XLMRobertaConfig, XLMRobertaForCausalLM),
         (RobertaConfig, RobertaForCausalLM),
         (BertConfig, BertLMHeadModel),
         (OpenAIGPTConfig, OpenAIGPTLMHeadModel),

--- a/src/transformers/modeling_xlm_roberta.py
+++ b/src/transformers/modeling_xlm_roberta.py
@@ -18,6 +18,7 @@
 from .configuration_xlm_roberta import XLMRobertaConfig
 from .file_utils import add_start_docstrings
 from .modeling_roberta import (
+    RobertaForCausalLM,
     RobertaForMaskedLM,
     RobertaForMultipleChoice,
     RobertaForQuestionAnswering,
@@ -61,6 +62,19 @@ XLM_ROBERTA_START_DOCSTRING = r"""
 class XLMRobertaModel(RobertaModel):
     """
     This class overrides :class:`~transformers.RobertaModel`. Please check the
+    superclass for the appropriate documentation alongside usage examples.
+    """
+
+    config_class = XLMRobertaConfig
+
+
+@add_start_docstrings(
+    "XLM-RoBERTa Model with a `language modeling` head on top for CLM fine-tuning.",
+    XLM_ROBERTA_START_DOCSTRING,
+)
+class XLMRobertaForCausalLM(RobertaForCausalLM):
+    """
+    This class overrides :class:`~transformers.RobertaForCausalLM`. Please check the
     superclass for the appropriate documentation alongside usage examples.
     """
 


### PR DESCRIPTION
This PR adds `XLM-Roberta` to the EncoderDecoder framework by adding a new `XLMRobertaForCausalLM` to the models.

The XLM-Roberta EncoderDecoder can be used as follows:

```python 
from transformers import EncoderDecoderModel
import torch

model = EncoderDecoderModel.from_encoder_decoder_pretrained("xlm-roberta-base", "xlm-roberta-base")
input_ids = torch.tensor([10 * [0]])
outputs = model(input_ids, decoder_input_ids=input_ids, labels=input_ids, return_dict=True)
print("Loss", outputs.loss)
```
