### PR TITLE
Fixed the default number of attention heads in Reformer Configuration

### DIFF
--- a/src/transformers/configuration_reformer.py
+++ b/src/transformers/configuration_reformer.py
@@ -158,7 +158,7 @@ class ReformerConfig(PretrainedConfig):
         lsh_num_chunks_before=1,
         lsh_num_chunks_after=0,
         max_position_embeddings=4096,
-        num_attention_heads=2,
+        num_attention_heads=12,
         num_buckets=None,
         num_hashes=1,
         pad_token_id=0,


### PR DESCRIPTION
<!-- This line specifies which issue to close after the pull request is merged. -->
Just a simple fix. The default number of attention heads was 2 instead of 12.
