### PR TITLE
[generation] decoder priority for choosing decoder_start_token_id value

### DIFF
--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -381,10 +381,10 @@ class GenerationMixin:
         if self.config.is_encoder_decoder:
             if decoder_start_token_id is None:
                 # see if BOS token can be used for decoder_start_token_id
-                if bos_token_id is not None:
-                    decoder_start_token_id = bos_token_id
-                elif hasattr(self.config, "decoder") and hasattr(self.config.decoder, "bos_token_id"):
+                if hasattr(self.config, "decoder") and hasattr(self.config.decoder, "bos_token_id"):
                     decoder_start_token_id = self.config.decoder.bos_token_id
+                elif bos_token_id is not None:
+                    decoder_start_token_id = bos_token_id
                 else:
                     raise ValueError(
                         "decoder_start_token_id or bos_token_id has to be defined for encoder-decoder generation"


### PR DESCRIPTION
`config.decoder` needs to be checked first before model's `config` to set `decoder_start_token_id`. 

This is needed for https://github.com/huggingface/transformers/pull/6940 where I think for the first time there is an actual `config.decoder`
