### PR TITLE
Fix TF Trainer loss calculation

### DIFF
--- a/examples/token-classification/utils_ner.py
+++ b/examples/token-classification/utils_ner.py
@@ -358,6 +358,8 @@ if is_tf_available():
                     ),
                 )
 
+            self.dataset = self.dataset.map(lambda features, labels: self.count_tokens_in_example((features, labels)))
+
         def get_dataset(self):
             self.dataset = self.dataset.apply(tf.data.experimental.assert_cardinality(len(self.features)))
 
@@ -368,3 +370,23 @@ if is_tf_available():
 
         def __getitem__(self, i) -> InputFeatures:
             return self.features[i]
+
+        def count_tokens_in_example(self, example):
+            """
+            Count the number of tokens in ``example`` whose labels are not ``self.pad_token_label_id``,
+            and inject this information into ``example``.
+
+            Args:
+                example (:obj:`Tuple[Dict, tf.Tensor]`):
+                    A tuple of unbatched features and labels.
+
+            Returns:
+                ``batch`` with injected information.
+            """
+
+            features, labels = example
+            features["nb_instances_in_example"] = tf.reduce_sum(
+                tf.cast(labels != self.pad_token_label_id, dtype=tf.int32)
+            )
+
+            return example

--- a/examples/token-classification/utils_ner.py
+++ b/examples/token-classification/utils_ner.py
@@ -358,8 +358,6 @@ if is_tf_available():
                     ),
                 )
 
-            self.dataset = self.dataset.map(lambda features, labels: self.count_tokens_in_example((features, labels)))
-
         def get_dataset(self):
             self.dataset = self.dataset.apply(tf.data.experimental.assert_cardinality(len(self.features)))
 
@@ -370,23 +368,3 @@ if is_tf_available():
 
         def __getitem__(self, i) -> InputFeatures:
             return self.features[i]
-
-        def count_tokens_in_example(self, example):
-            """
-            Count the number of tokens in ``example`` whose labels are not ``self.pad_token_label_id``,
-            and inject this information into ``example``.
-
-            Args:
-                example (:obj:`Tuple[Dict, tf.Tensor]`):
-                    A tuple of unbatched features and labels.
-
-            Returns:
-                ``batch`` with injected information.
-            """
-
-            features, labels = example
-            features["nb_instances_in_example"] = tf.reduce_sum(
-                tf.cast(labels != self.pad_token_label_id, dtype=tf.int32)
-            )
-
-            return example

--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -662,7 +662,8 @@ class TFTrainer:
 
             self.args.strategy.run(self.apply_gradients, inputs)
 
-    def _compute_nb_instances(self, batch):
+    @staticmethod
+    def _compute_nb_instances(batch):
 
         labels = batch[-1]
         if isinstance(labels, PerReplica):
@@ -672,7 +673,8 @@ class TFTrainer:
 
         return nb_instances
 
-    def _get_step_inputs(self, batch, nb_instances):
+    @staticmethod
+    def _get_step_inputs(batch, nb_instances):
 
         features, labels = batch
 

--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -442,7 +442,9 @@ class TFTrainer:
 
         return output.metrics
 
-    def prediction_step(self, features: tf.Tensor, labels: tf.Tensor, nb_instances_in_global_batch: tf.Tensor) -> tf.Tensor:
+    def prediction_step(
+        self, features: tf.Tensor, labels: tf.Tensor, nb_instances_in_global_batch: tf.Tensor
+    ) -> tf.Tensor:
         """
         Compute the prediction on features and update the loss with labels.
 
@@ -459,7 +461,7 @@ class TFTrainer:
     def distributed_prediction_steps(self, batch):
 
         nb_instances_in_batch = self._compute_nb_instances(batch)
-        inputs = self._get_step_inputs(batch, nb_instances_in_batch)   
+        inputs = self._get_step_inputs(batch, nb_instances_in_batch)
 
         logits = self.args.strategy.run(self.prediction_step, inputs)
 

--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -595,7 +595,7 @@ class TFTrainer:
 
                     self.distributed_training_steps(batch)
 
-                    training_loss = self.train_loss.result() / ((step + 1) * self.total_train_batch_size)
+                    training_loss = self.train_loss.result() / (step + 1)
 
                     if self.args.debug:
                         logs = {}
@@ -662,7 +662,7 @@ class TFTrainer:
         if self.args.gradient_accumulation_steps > 1:
             self.gradient_accumulator(gradients)
 
-        self.train_loss.update_state(per_example_loss)
+        self.train_loss.update_state(scaled_loss)
 
         if self.args.gradient_accumulation_steps == 1:
             return gradients

--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -599,6 +599,8 @@ class TFTrainer:
         Subclass and override to inject some custom behavior.
         """
         per_example_loss, _ = self.run_model(features, labels, True)
+        # TODO: Fix the loss calculation for the issue:
+        #       https://github.com/huggingface/transformers/issues/6968
         scaled_loss = per_example_loss / self.total_train_batch_size
         gradients = tf.gradients(scaled_loss, self.model.trainable_variables)
         gradients = [

--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -230,6 +230,7 @@ class TFTrainer:
             .batch(self.args.eval_batch_size, drop_remainder=self.args.dataloader_drop_last)
             .prefetch(tf.data.experimental.AUTOTUNE)
         )
+        ds = ds.map(lambda features, labels: count_instances_in_batch((features, labels)))
 
         return self.args.strategy.experimental_distribute_dataset(ds), steps, num_examples
 
@@ -260,6 +261,7 @@ class TFTrainer:
             .batch(self.args.eval_batch_size, drop_remainder=self.args.dataloader_drop_last)
             .prefetch(tf.data.experimental.AUTOTUNE)
         )
+        ds = ds.map(lambda features, labels: count_instances_in_batch((features, labels)))
 
         return self.args.strategy.experimental_distribute_dataset(ds), steps, num_examples
 


### PR DESCRIPTION
<!-- This line specifies which issue to close after the pull request is merged. -->
Fixes #6968

## Description
Issue #6968 is about the incorrect loss calculation due to dividing the per example losses by the number of sentences, rather than by the number of tokens (not ignored, i.e. label != -100) - if the task is a token level task.

## Implementation
Before a whole batch being distributed to replicas, we compute the number of instances in that batch. Depending on the task types (sentence level or token level), the word `instance` means different things:
- sentence level task: it means examples
- token level task: it means the tokens with label != -100

This information (number of instances) is injected into global batches. While each replica receives a small batch, it use this information to correctly computing the scaled losses.

If no information is provided in the dataset, the default behavior is to use the number of examples in a global batch.
This way, the code change is minimal.

## Test code

    import os
    import random
    import shutil
    
    
    shutil.rmtree("./tmp/", ignore_errors=True)
    os.mkdir("./tmp/")
    
    nb_sentences = 70
    words = ["i", "like", "dogs", "but", "you", "prefer", "cats"]
    with open("./tmp/train.txt", "w", encoding="UTF-8") as fp:
        for i in range(nb_sentences):
            if i == 0:
                for word in words:
                    fp.write(f"{word} O\n")
            else:
                fp.write(f" \n")
    
            fp.write("\n")
    
    os.system("cp ./tmp/train.txt ./tmp/dev.txt")
    
    labels = ["O", "B-MISC", "I-MISC", "B-PER", "I-PER", "B-ORG", "I-ORG", "B-LOC", "I-LOC"]
    with open("./tmp/test.txt", "w", encoding="UTF-8") as fp:
        for i in range(nb_sentences):
            for word in words:
                label = random.choice(labels)
                fp.write(f"{word} {label}\n")
    
            fp.write("\n")
    
    command = (
        "python run_tf_ner.py "
        + "--model_name_or_path distilbert-base-uncased "
        + "--data_dir ./tmp/ --seed 2020 --output_dir ./tmp/ "
        + "--overwrite_output_dir --logging_steps 1 "
        + "--do_train --do_eval --do_predict "
        + "--num_train_epochs 1 "
        + f"--per_device_train_batch_size {nb_sentences} "
        + f"--per_device_eval_batch_size {nb_sentences} --labels '' "
        + "--max_seq_length 16"
    )
    
    print(command)
    
    os.system(command)

Testing it against master, you will see the loss values is smaller (~0.3) than testing against this PR code, you will (1.0 ~ 2.0), because on master, the denominator is `70` (but 69 of them having only ignored tokens) while on this PR, the denominator is `7` (the number of tokens).