### PR TITLE
fixed trainer tr_loss memory leak

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1024,7 +1024,7 @@ class Trainer:
         else:
             loss.backward()
 
-        return loss
+        return loss.detach()
 
     def is_local_master(self) -> bool:
         """

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -683,7 +683,7 @@ class Trainer:
                 self.global_step = 0
                 logger.info("  Starting fine-tuning.")
 
-        tr_loss_scalar = 0.0
+        tr_loss = torch.tensor(0.0).to(self.args.device)
         logging_loss_scalar = 0.0
         model.zero_grad()
         disable_tqdm = self.args.disable_tqdm or not self.is_local_process_zero()
@@ -713,7 +713,7 @@ class Trainer:
                     epoch_pbar.update(1)
                     continue
 
-                tr_loss_scalar += self.training_step(model, inputs)
+                tr_loss += self.training_step(model, inputs)
 
                 if (step + 1) % self.args.gradient_accumulation_steps == 0 or (
                     # last step in epoch but step is always smaller than gradient_accumulation_steps
@@ -745,6 +745,7 @@ class Trainer:
                         self.global_step == 1 and self.args.logging_first_step
                     ):
                         logs: Dict[str, float] = {}
+                        tr_loss_scalar = tr_loss.item()
                         logs["loss"] = (tr_loss_scalar - logging_loss_scalar) / self.args.logging_steps
                         # backward compatibility for pytorch schedulers
                         logs["learning_rate"] = (
@@ -818,7 +819,7 @@ class Trainer:
             delattr(self, "_past")
 
         logger.info("\n\nTraining completed. Do not forget to share your model on huggingface.co/models =)\n\n")
-        return TrainOutput(self.global_step, tr_loss_scalar / self.global_step)
+        return TrainOutput(self.global_step, tr_loss.item() / self.global_step)
 
     def hyperparameter_search(
         self,
@@ -1023,7 +1024,7 @@ class Trainer:
         else:
             loss.backward()
 
-        return loss.item()
+        return loss
 
     def is_local_master(self) -> bool:
         """


### PR DESCRIPTION
Fixes #6939 

The Trainer class contains the memory leak described [here](https://discuss.pytorch.org/t/cpu-ram-usage-increasing-for-every-epoch/24475/6). It is not specific to any particular model type and will occur with any model trained using the trainer class.

It is fixed in this pull request.

The issue is demonstrated in [this Colab notebook](https://colab.research.google.com/drive/1KQZEiZtfY14sDiAQnfw0gkKj9eC6XpTm?usp=sharing). The model trains for around 20 000 steps (this takes around 10 minutes on a t4) before using up all 12GB of RAM.