### PR TITLE
New TF output proposal

### DIFF
--- a/src/transformers/modeling_tf_bert.py
+++ b/src/transformers/modeling_tf_bert.py
@@ -18,8 +18,8 @@
 
 from dataclasses import dataclass
 from typing import Optional, Tuple
+import math
 
-import numpy as np
 import tensorflow as tf
 
 from .configuration_bert import BertConfig
@@ -95,6 +95,7 @@ def gelu(x):
         0.5 * x * (1 + torch.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * torch.pow(x, 3))))
         Also see https://arxiv.org/abs/1606.08415
     """
+    x = tf.convert_to_tensor(x)
     cdf = 0.5 * (1.0 + tf.math.erf(x / tf.math.sqrt(2.0)))
 
     return x * cdf
@@ -102,14 +103,17 @@ def gelu(x):
 
 def gelu_new(x):
     """Gaussian Error Linear Unit.
-    This is a smoother version of the RELU.
+    This is a smoother version of the GELU.
     Original paper: https://arxiv.org/abs/1606.08415
     Args:
         x: float Tensor to perform activation.
     Returns:
         `x` with the GELU activation applied.
     """
-    cdf = 0.5 * (1.0 + tf.tanh((np.sqrt(2 / np.pi) * (x + 0.044715 * tf.pow(x, 3)))))
+    x = tf.convert_to_tensor(x)
+    pi = tf.cast(math.pi, x.dtype)
+    coeff = tf.cast(0.044715, x.dtype)
+    cdf = 0.5 * (1.0 + tf.tanh(tf.sqrt(2.0 / pi) * (x + coeff * tf.pow(x, 3))))
 
     return x * cdf
 

--- a/src/transformers/modeling_tf_bert.py
+++ b/src/transformers/modeling_tf_bert.py
@@ -841,17 +841,19 @@ class TFBertModel(TFBertPreTrainedModel):
         return_dict=None,
         training=False
     ):
+        return_dict = return_dict if return_dict is not None else self.bert.return_dict
+
         outputs = self.bert(
-            inputs,
-            attention_mask,
-            token_type_ids,
-            position_ids,
-            head_mask,
-            inputs_embeds,
-            output_attentions,
-            output_hidden_states,
-            return_dict,
-            training,
+            inputs=inputs,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            training=training,
         )
 
         return outputs
@@ -904,22 +906,23 @@ class TFBertForPreTraining(TFBertPreTrainedModel):
             outputs = model(input_ids)
             prediction_scores, seq_relationship_scores = outputs[:2]
         """
+        return_dict = return_dict if return_dict is not None else self.bert.return_dict
+
         outputs = self.bert(
-            inputs,
-            attention_mask,
-            token_type_ids,
-            position_ids,
-            head_mask,
-            inputs_embeds,
-            output_attentions,
-            output_hidden_states,
-            return_dict,
-            training,
+            inputs=inputs,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            training=training,
         )
         sequence_output, pooled_output = outputs[:2]
         prediction_scores = self.mlm(sequence_output, training=training)
         seq_relationship_score = self.nsp(pooled_output)
-        output = (prediction_scores, seq_relationship_score) + outputs[2:]
 
         if tf.executing_eagerly():
             if return_dict:
@@ -930,7 +933,7 @@ class TFBertForPreTraining(TFBertPreTrainedModel):
                     attentions=outputs.attentions,
                 )
 
-        return output
+        return (prediction_scores, seq_relationship_score) + outputs[2:]
 
 
 @add_start_docstrings("""Bert Model with a `language modeling` head on top. """, BERT_START_DOCSTRING)
@@ -978,6 +981,8 @@ class TFBertForMaskedLM(TFBertPreTrainedModel, TFMaskedLanguageModelingLoss):
             Tokens with indices set to ``-100`` are ignored (masked), the loss is only computed for the tokens with labels
             in ``[0, ..., config.vocab_size]``
         """
+        return_dict = return_dict if return_dict is not None else self.bert.return_dict
+
         if isinstance(inputs, (tuple, list)):
             labels = inputs[9] if len(inputs) > 9 else labels
 
@@ -987,24 +992,22 @@ class TFBertForMaskedLM(TFBertPreTrainedModel, TFMaskedLanguageModelingLoss):
             labels = inputs.pop("labels", labels)
 
         outputs = self.bert(
-            inputs,
-            attention_mask,
-            token_type_ids,
-            position_ids,
-            head_mask,
-            inputs_embeds,
-            output_attentions,
-            output_hidden_states,
-            return_dict,
-            training,
+            inputs=inputs,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            training=training,
         )
 
         sequence_output = outputs[0]
         prediction_scores = self.mlm(sequence_output, training=training)
 
         loss = None if labels is None else self.compute_loss(labels, prediction_scores)
-        output = (prediction_scores,) + outputs[2:]
-        output = ((loss,) + output) if loss is not None else output
 
         if tf.executing_eagerly():
             if return_dict:
@@ -1014,6 +1017,9 @@ class TFBertForMaskedLM(TFBertPreTrainedModel, TFMaskedLanguageModelingLoss):
                     hidden_states=outputs.hidden_states,
                     attentions=outputs.attentions,
                 )
+
+        output = (prediction_scores,) + outputs[2:]
+        output = ((loss,) + output) if loss is not None else output
 
         return output
 
@@ -1056,6 +1062,8 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
             Labels for computing the cross entropy classification loss.
             Indices should be in ``[0, ..., config.vocab_size - 1]``.
         """
+        return_dict = return_dict if return_dict is not None else self.bert.return_dict
+
         if isinstance(inputs, (tuple, list)):
             labels = inputs[9] if len(inputs) > 9 else labels
 
@@ -1065,16 +1073,16 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
             labels = inputs.pop("labels", labels)
 
         outputs = self.bert(
-            inputs,
-            attention_mask,
-            token_type_ids,
-            position_ids,
-            head_mask,
-            inputs_embeds,
-            output_attentions,
-            output_hidden_states,
-            return_dict,
-            training,
+            inputs=inputs,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            training=training,
         )
 
         sequence_output = outputs[0]
@@ -1087,9 +1095,6 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
             labels = labels[:, 1:]
             loss = self.compute_loss(labels, logits)
 
-        output = (logits,) + outputs[2:]
-        output = ((loss,) + output) if loss is not None else output
-
         if tf.executing_eagerly():
             if return_dict:
                 return TFCausalLMOutput(
@@ -1098,6 +1103,9 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
                     hidden_states=outputs.hidden_states,
                     attentions=outputs.attentions,
                 )
+
+        output = (logits,) + outputs[2:]
+        output = ((loss,) + output) if loss is not None else output
 
         return output
 
@@ -1147,22 +1155,23 @@ class TFBertForNextSentencePrediction(TFBertPreTrainedModel):
             logits = model(encoding['input_ids'], token_type_ids=encoding['token_type_ids'])[0]
             assert logits[0][0] < logits[0][1] # the next sentence was random
         """
+        return_dict = return_dict if return_dict is not None else self.bert.return_dict
+
         outputs = self.bert(
-            inputs,
-            attention_mask,
-            token_type_ids,
-            position_ids,
-            head_mask,
-            inputs_embeds,
-            output_attentions,
-            output_hidden_states,
-            return_dict,
-            training,
+            inputs=inputs,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            training=training,
         )
 
         pooled_output = outputs[1]
         seq_relationship_score = self.nsp(pooled_output)
-        output = (seq_relationship_score,) + outputs[2:]
 
         if tf.executing_eagerly():
             if return_dict:
@@ -1171,6 +1180,8 @@ class TFBertForNextSentencePrediction(TFBertPreTrainedModel):
                     hidden_states=outputs.hidden_states,
                     attentions=outputs.attentions,
                 )
+
+        output = (seq_relationship_score,) + outputs[2:]
 
         return output
 
@@ -1219,6 +1230,8 @@ class TFBertForSequenceClassification(TFBertPreTrainedModel, TFSequenceClassific
             If :obj:`config.num_labels == 1` a regression loss is computed (Mean-Square loss),
             If :obj:`config.num_labels > 1` a classification loss is computed (Cross-Entropy).
         """
+        return_dict = return_dict if return_dict is not None else self.bert.return_dict
+
         if isinstance(inputs, (tuple, list)):
             labels = inputs[9] if len(inputs) > 9 else labels
 
@@ -1228,24 +1241,22 @@ class TFBertForSequenceClassification(TFBertPreTrainedModel, TFSequenceClassific
             labels = inputs.pop("labels", labels)
 
         outputs = self.bert(
-            inputs,
-            attention_mask,
-            token_type_ids,
-            position_ids,
-            head_mask,
-            inputs_embeds,
-            output_attentions,
-            output_hidden_states,
-            return_dict,
-            training,
+            inputs=inputs,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            heda_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            training=training,
         )
 
         pooled_output = outputs[1]
         pooled_output = self.dropout(pooled_output, training=training)
         logits = self.classifier(pooled_output)
         loss = None if labels is None else self.compute_loss(labels, logits)
-        output = (logits,) + outputs[2:]
-        output = ((loss,) + output) if loss is not None else output
 
         if tf.executing_eagerly():
             if return_dict:
@@ -1255,6 +1266,9 @@ class TFBertForSequenceClassification(TFBertPreTrainedModel, TFSequenceClassific
                     hidden_states=outputs.hidden_states,
                     attentions=outputs.attentions,
                 )
+
+        output = (logits,) + outputs[2:]
+        output = ((loss,) + output) if loss is not None else output
 
         return output
 
@@ -1310,6 +1324,8 @@ class TFBertForMultipleChoice(TFBertPreTrainedModel, TFMultipleChoiceLoss):
             Indices should be in ``[0, ..., num_choices]`` where `num_choices` is the size of the second dimension
             of the input tensors. (see `input_ids` above)
         """
+        return_dict = return_dict if return_dict is not None else self.bert.return_dict
+
         if isinstance(inputs, (tuple, list)):
             input_ids = inputs[0]
             attention_mask = inputs[1] if len(inputs) > 1 else attention_mask
@@ -1354,24 +1370,22 @@ class TFBertForMultipleChoice(TFBertPreTrainedModel, TFMultipleChoiceLoss):
             else None
         )
         outputs = self.bert(
-            flat_input_ids,
-            flat_attention_mask,
-            flat_token_type_ids,
-            flat_position_ids,
-            head_mask,
-            flat_inputs_embeds,
-            output_attentions,
-            output_hidden_states,
-            return_dict,
-            training,
+            inputs=flat_input_ids,
+            attention_mask=flat_attention_mask,
+            token_type_ids=flat_token_type_ids,
+            position_ids=flat_position_ids,
+            head_mask=head_mask,
+            inputs_embeds=flat_inputs_embeds,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            training=training,
         )
         pooled_output = outputs[1]
         pooled_output = self.dropout(pooled_output, training=training)
         logits = self.classifier(pooled_output)
         reshaped_logits = tf.reshape(logits, (-1, num_choices))
         loss = None if labels is None else self.compute_loss(labels, reshaped_logits)
-        output = (reshaped_logits,) + outputs[2:]
-        output = ((loss,) + output) if loss is not None else output
 
         if tf.executing_eagerly():
             if return_dict: 
@@ -1381,6 +1395,9 @@ class TFBertForMultipleChoice(TFBertPreTrainedModel, TFMultipleChoiceLoss):
                     hidden_states=outputs.hidden_states,
                     attentions=outputs.attentions,
                 )
+
+        output = (reshaped_logits,) + outputs[2:]
+        output = ((loss,) + output) if loss is not None else output
 
         return output
 
@@ -1427,6 +1444,8 @@ class TFBertForTokenClassification(TFBertPreTrainedModel, TFTokenClassificationL
             Labels for computing the token classification loss.
             Indices should be in ``[0, ..., config.num_labels - 1]``.
         """
+        return_dict = return_dict if return_dict is not None else self.bert.return_dict
+
         if isinstance(inputs, (tuple, list)):
             labels = inputs[9] if len(inputs) > 9 else labels
 
@@ -1436,23 +1455,21 @@ class TFBertForTokenClassification(TFBertPreTrainedModel, TFTokenClassificationL
             labels = inputs.pop("labels", labels)
 
         outputs = self.bert(
-            inputs,
-            attention_mask,
-            token_type_ids,
-            position_ids,
-            head_mask,
-            inputs_embeds,
-            output_attentions,
-            output_hidden_states,
-            return_dict,
-            training,
+            inputs=inputs,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            training=training,
         )
         sequence_output = outputs[0]
         sequence_output = self.dropout(sequence_output, training=training)
         logits = self.classifier(sequence_output)
         loss = None if labels is None else self.compute_loss(labels, logits)
-        output = (logits,) + outputs[2:]
-        output = ((loss,) + output) if loss is not None else output
 
         if tf.executing_eagerly():
             if return_dict:
@@ -1462,6 +1479,9 @@ class TFBertForTokenClassification(TFBertPreTrainedModel, TFTokenClassificationL
                     hidden_states=outputs.hidden_states,
                     attentions=outputs.attentions,
                 )
+
+        output = (logits,) + outputs[2:]
+        output = ((loss,) + output) if loss is not None else output
 
         return output
 
@@ -1513,6 +1533,8 @@ class TFBertForQuestionAnswering(TFBertPreTrainedModel, TFQuestionAnsweringLoss)
             Positions are clamped to the length of the sequence (`sequence_length`).
             Position outside of the sequence are not taken into account for computing the loss.
         """
+        return_dict = return_dict if return_dict is not None else self.bert.return_dict
+
         if isinstance(inputs, (tuple, list)):
             start_positions = inputs[9] if len(inputs) > 9 else start_positions
             end_positions = inputs[10] if len(inputs) > 10 else end_positions
@@ -1524,16 +1546,16 @@ class TFBertForQuestionAnswering(TFBertPreTrainedModel, TFQuestionAnsweringLoss)
             end_positions = inputs.pop("end_positions", start_positions)
 
         outputs = self.bert(
-            inputs,
-            attention_mask,
-            token_type_ids,
-            position_ids,
-            head_mask,
-            inputs_embeds,
-            output_attentions,
-            output_hidden_states,
-            return_dict,
-            training,
+            inputs=inputs,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            training=training,
         )
         sequence_output = outputs[0]
         logits = self.qa_outputs(sequence_output)
@@ -1547,9 +1569,6 @@ class TFBertForQuestionAnswering(TFBertPreTrainedModel, TFQuestionAnsweringLoss)
             labels["end_position"] = end_positions
             loss = self.compute_loss(labels, (start_logits, end_logits))
 
-        output = (start_logits, end_logits) + outputs[2:]
-        output = ((loss,) + output) if loss is not None else output
-
         if tf.executing_eagerly():
             if return_dict:
                 return TFQuestionAnsweringModelOutput(
@@ -1559,5 +1578,8 @@ class TFBertForQuestionAnswering(TFBertPreTrainedModel, TFQuestionAnsweringLoss)
                     hidden_states=outputs.hidden_states,
                     attentions=outputs.attentions,
                 )
+
+        output = (start_logits, end_logits) + outputs[2:]
+        output = ((loss,) + output) if loss is not None else output
 
         return output

--- a/src/transformers/modeling_tf_bert.py
+++ b/src/transformers/modeling_tf_bert.py
@@ -689,6 +689,9 @@ class TFBertMainLayer(tf.keras.layers.Layer):
                     hidden_states=encoder_outputs.hidden_states,
                     attentions=encoder_outputs.attentions,
                 )
+        else:
+            if return_dict is not None or output_attentions is not None or output_hidden_states is not None:
+                tf.print("Warning: The parameters return_dict, output_attentions and output_hidden_states are disabled in graph mode.")
 
         return output
 

--- a/src/transformers/modeling_tf_bert.py
+++ b/src/transformers/modeling_tf_bert.py
@@ -1245,7 +1245,7 @@ class TFBertForSequenceClassification(TFBertPreTrainedModel, TFSequenceClassific
             attention_mask=attention_mask,
             token_type_ids=token_type_ids,
             position_ids=position_ids,
-            heda_mask=head_mask,
+            head_mask=head_mask,
             inputs_embeds=inputs_embeds,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
@@ -1543,7 +1543,7 @@ class TFBertForQuestionAnswering(TFBertPreTrainedModel, TFQuestionAnsweringLoss)
                 inputs = inputs[:9]
         elif isinstance(inputs, (dict, BatchEncoding)):
             start_positions = inputs.pop("start_positions", start_positions)
-            end_positions = inputs.pop("end_positions", start_positions)
+            end_positions = inputs.pop("end_positions", end_positions)
 
         outputs = self.bert(
             inputs=inputs,


### PR DESCRIPTION
Hello!

Currently the TensorFlow have several issues to properly working in graph mode when `output_attentions`, `outout_hidden_states` and `return_dict` takes a boolean tensor (`tf.constant(True/False)`). This is because the graph mode doesn't allows to have an output of different sizes in its conditional branches.

To fix this and lower as much as possible a breaking change with the current behavior of these models, I propose to keep the current behavior but only in eager mode, and disabling these three features (force to have them to False) in graph mode. This is for me the best compromise between having something that works in graph mode and not having a big breaking change.

The graph mode is most of the time used to get fast training/inference and not for doing experiments, and I don't see the point to deploy a model in production that gives you all the attentions/hidden states values, or possibly getting an OOM during the training/inference mostly for the new TFLongformer model.

Here some examples.

Example 1: run in eager mode with default parameters value
```python
from transformers import TFBertForMaskedLM

model = TFBertForMaskedLM.from_pretrained("bert-base-cased")
model(tf.constant([[10,11,12]]))

# Result
(<tf.Tensor: shape=(1, 3, 28996), dtype=float32, numpy=
array([[[ -9.900146 , -10.345711 ,  -9.721893 , ...,  -7.7057724,
          -8.035212 ,  -8.271875 ],
        [ -7.866758 ,  -8.147887 ,  -7.864182 , ...,  -6.7170696,
          -6.2896423,  -6.79779  ],
        [ -9.790001 , -10.2271185,  -9.584716 , ...,  -7.539982 ,
          -7.807548 ,  -8.135937 ]]], dtype=float32)>,)
```

Example 2: run in eager mode by updating a boolean parameter value
```python
from transformers import TFBertForMaskedLM

model = TFBertForMaskedLM.from_pretrained("bert-base-cased")
model(tf.constant([[10,11,12]]), return_dict=True)

# Result
TFMaskedLMOutput(loss=None, logits=<tf.Tensor: shape=(1, 3, 28996), dtype=float32, numpy=
array([[[ -9.900146 , -10.345711 ,  -9.721893 , ...,  -7.7057724,
          -8.035212 ,  -8.271875 ],
        [ -7.866758 ,  -8.147887 ,  -7.864182 , ...,  -6.7170696,
          -6.2896423,  -6.79779  ],
        [ -9.790001 , -10.2271185,  -9.584716 , ...,  -7.539982 ,
          -7.807548 ,  -8.135937 ]]], dtype=float32)>, hidden_states=None, attentions=None)
```

Example 3: run in graph mode with default parameters value
```python
from transformers import TFBertForMaskedLM
import tensorflow as tf

model = tf.function(TFBertForMaskedLM.from_pretrained("bert-base-cased"))
model(tf.constant([[10,11,12]]))

# Result
(<tf.Tensor: shape=(1, 3, 28996), dtype=float32, numpy=
array([[[ -9.900146 , -10.345711 ,  -9.721893 , ...,  -7.7057724,
          -8.035212 ,  -8.271875 ],
        [ -7.866758 ,  -8.147887 ,  -7.864182 , ...,  -6.7170696,
          -6.2896423,  -6.79779  ],
        [ -9.790001 , -10.2271185,  -9.584716 , ...,  -7.539982 ,
          -7.807548 ,  -8.135937 ]]], dtype=float32)>,)
```

Example 4: run in graph mode by updating a boolean parameter value
```python
from transformers import TFBertForMaskedLM
import tensorflow as tf

model = tf.function(TFBertForMaskedLM.from_pretrained("bert-base-cased"))
model(tf.constant([[10,11,12]]), return_dict=tf.constant(True))

# Result
(<tf.Tensor: shape=(1, 3, 28996), dtype=float32, numpy=
array([[[ -9.900146 , -10.345711 ,  -9.721893 , ...,  -7.7057724,
          -8.035212 ,  -8.271875 ],
        [ -7.866758 ,  -8.147887 ,  -7.864182 , ...,  -6.7170696,
          -6.2896423,  -6.79779  ],
        [ -9.790001 , -10.2271185,  -9.584716 , ...,  -7.539982 ,
          -7.807548 ,  -8.135937 ]]], dtype=float32)>,)
```
As you can see for the last example, no more graph compilation error due to the `tf.constant(True)` value.

For my examples I used only `return_dict` but of course the same behavior is applied to `output_attentions` and `output_hidden_states`. Moreover, this new behavior will be detailed in the documentation of the impacted parameters.

@LysandreJik @sgugger @patrickvonplaten @sshleifer @thomwolf @julien-c What do you think of this solution?