### PR TITLE
fix deprecation warnings

### DIFF
--- a/src/transformers/modeling_funnel.py
+++ b/src/transformers/modeling_funnel.py
@@ -127,7 +127,7 @@ def load_tf_weights_in_funnel(model, config, tf_checkpoint_path):
         skipped = False
         for m_name in name[1:]:
             if not isinstance(pointer, FunnelPositionwiseFFN) and re.fullmatch(r"layer_\d+", m_name):
-                layer_index = int(re.search("layer_(\d+)", m_name).groups()[0])
+                layer_index = int(re.search(r"layer_(\d+)", m_name).groups()[0])
                 if layer_index < config.num_hidden_layers:
                     block_idx = 0
                     while layer_index >= config.block_sizes[block_idx]:

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -699,7 +699,7 @@ class TFConv1D(tf.keras.layers.Layer):
 
 
 class TFSharedEmbeddings(tf.keras.layers.Layer):
-    """
+    r"""
     Construct shared token embeddings.
 
     The weights of the embedding layer is usually shared with the weights of the linear decoder when doing

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -881,6 +881,41 @@ class TokenizerTesterMixin:
                 assert sequence_length == padded_sequence_left_length
                 assert encoded_sequence == padded_sequence_left
 
+    def test_padding_to_max_length(self):
+        """We keep this test for backward compatibility but it should be remove when `pad_to_max_length` will e deprecated"""
+        tokenizers = self.get_tokenizers(do_lower_case=False)
+        for tokenizer in tokenizers:
+            with self.subTest(f"{tokenizer.__class__.__name__}"):
+                sequence = "Sequence"
+                padding_size = 10
+
+                # check correct behaviour if no pad_token_id exists and add it eventually
+                self._check_no_pad_token_padding(tokenizer, sequence)
+
+                padding_idx = tokenizer.pad_token_id
+
+                # Check that it correctly pads when a maximum length is specified along with the padding flag set to True
+                tokenizer.padding_side = "right"
+                encoded_sequence = tokenizer.encode(sequence)
+                sequence_length = len(encoded_sequence)
+                # FIXME: the next line should be padding(max_length) to avoid warning
+                padded_sequence = tokenizer.encode(
+                    sequence, max_length=sequence_length + padding_size, pad_to_max_length=True
+                )
+                padded_sequence_length = len(padded_sequence)
+                assert sequence_length + padding_size == padded_sequence_length
+                assert encoded_sequence + [padding_idx] * padding_size == padded_sequence
+
+                # Check that nothing is done when a maximum length is not specified
+                encoded_sequence = tokenizer.encode(sequence)
+                sequence_length = len(encoded_sequence)
+
+                tokenizer.padding_side = "right"
+                padded_sequence_right = tokenizer.encode(sequence, pad_to_max_length=True)
+                padded_sequence_right_length = len(padded_sequence_right)
+                assert sequence_length == padded_sequence_right_length
+                assert encoded_sequence == padded_sequence_right
+
     def test_padding_to_multiple_of(self):
         tokenizers = self.get_tokenizers()
         for tokenizer in tokenizers:

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -881,41 +881,6 @@ class TokenizerTesterMixin:
                 assert sequence_length == padded_sequence_left_length
                 assert encoded_sequence == padded_sequence_left
 
-    def test_padding_to_max_length(self):
-        """We keep this test for backward compatibility but it should be remove when `pad_to_max_length` will e deprecated"""
-        tokenizers = self.get_tokenizers(do_lower_case=False)
-        for tokenizer in tokenizers:
-            with self.subTest(f"{tokenizer.__class__.__name__}"):
-                sequence = "Sequence"
-                padding_size = 10
-
-                # check correct behaviour if no pad_token_id exists and add it eventually
-                self._check_no_pad_token_padding(tokenizer, sequence)
-
-                padding_idx = tokenizer.pad_token_id
-
-                # Check that it correctly pads when a maximum length is specified along with the padding flag set to True
-                tokenizer.padding_side = "right"
-                encoded_sequence = tokenizer.encode(sequence)
-                sequence_length = len(encoded_sequence)
-                # FIXME: the next line should be padding(max_length) to avoid warning
-                padded_sequence = tokenizer.encode(
-                    sequence, max_length=sequence_length + padding_size, padding="max_length"
-                )
-                padded_sequence_length = len(padded_sequence)
-                assert sequence_length + padding_size == padded_sequence_length
-                assert encoded_sequence + [padding_idx] * padding_size == padded_sequence
-
-                # Check that nothing is done when a maximum length is not specified
-                encoded_sequence = tokenizer.encode(sequence)
-                sequence_length = len(encoded_sequence)
-
-                tokenizer.padding_side = "right"
-                padded_sequence_right = tokenizer.encode(sequence, padding="max_length")
-                padded_sequence_right_length = len(padded_sequence_right)
-                assert sequence_length == padded_sequence_right_length
-                assert encoded_sequence == padded_sequence_right
-
     def test_padding_to_multiple_of(self):
         tokenizers = self.get_tokenizers()
         for tokenizer in tokenizers:

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -156,7 +156,7 @@ class TokenizerTesterMixin:
         tokenizers = self.get_tokenizers()
         for tokenizer in tokenizers:
             with self.subTest(f"{tokenizer.__class__.__name__}"):
-                self.assertNotEqual(tokenizer.max_len, 42)
+                self.assertNotEqual(tokenizer.model_max_length, 42)
 
         # Now let's start the test
         tokenizers = self.get_tokenizers()
@@ -900,7 +900,7 @@ class TokenizerTesterMixin:
                 sequence_length = len(encoded_sequence)
                 # FIXME: the next line should be padding(max_length) to avoid warning
                 padded_sequence = tokenizer.encode(
-                    sequence, max_length=sequence_length + padding_size, pad_to_max_length=True
+                    sequence, max_length=sequence_length + padding_size, padding="max_length"
                 )
                 padded_sequence_length = len(padded_sequence)
                 assert sequence_length + padding_size == padded_sequence_length
@@ -911,7 +911,7 @@ class TokenizerTesterMixin:
                 sequence_length = len(encoded_sequence)
 
                 tokenizer.padding_side = "right"
-                padded_sequence_right = tokenizer.encode(sequence, pad_to_max_length=True)
+                padded_sequence_right = tokenizer.encode(sequence, padding="max_length")
                 padded_sequence_right_length = len(padded_sequence_right)
                 assert sequence_length == padded_sequence_right_length
                 assert encoded_sequence == padded_sequence_right


### PR DESCRIPTION
Fixing:

```
pytest tests/test_tokenization_xlm.py

src/transformers/modeling_tf_utils.py:702
  /mnt/nvme1/code/huggingface/transformers-xlm/src/transformers/modeling_tf_utils.py:702: DeprecationWarning: 
invalid escape sequence \s
    """

src/transformers/modeling_funnel.py:130
  /mnt/nvme1/code/huggingface/transformers-xlm/src/transformers/modeling_funnel.py:130: DeprecationWarning: 
invalid escape sequence \d
    layer_index = int(re.search("layer_(\d+)", m_name).groups()[0])

tests/test_tokenization_xlm.py::XLMTokenizationTest::test_padding_to_max_length
  /mnt/nvme1/code/huggingface/transformers-xlm/src/transformers/tokenization_utils_base.py:1764: FutureWarning: 
The `pad_to_max_length` argument is deprecated and will be removed in a future version, use `padding=True` or `padding='longest'` to pad to the longest sequence in the batch, or use `padding='max_length'` to pad to a max length. In this case, you can give a specific length with `max_length` (e.g. `max_length=45`) or leave max_length to None to pad to the maximal input size of the model (e.g. 512 for Bert).
    warnings.warn(

tests/test_tokenization_xlm.py::XLMTokenizationTest::test_save_and_load_tokenizer
  /mnt/nvme1/code/huggingface/transformers-xlm/src/transformers/tokenization_utils_base.py:1319: FutureWarning: 
The `max_len` attribute has been deprecated and will be removed in a future version, use `model_max_length` instead.
    warnings.warn(
```
ok, removing `tests/test_tokenization_common.py`'s `test_padding_to_max_length` as suggested there:
```
    def test_padding_to_max_length(self):
        """We keep this test for backward compatibility but it should be remove when `pad_to_max_length` will e deprecated"""
```
these 2 fail with that test:
```
FAILED tests/test_tokenization_marian.py::MarianTokenizationTest::test_padding_to_max_length
FAILED tests/test_tokenization_pegasus.py::PegasusTokenizationTest::test_padding_to_max_length
```
if I try to fix it:
```
-               padded_sequence_right = tokenizer.encode(sequence, pad_to_max_length=True)
+               padded_sequence_right = tokenizer.encode(sequence, padding="max_length")
```
So there is no salvaging it, right?

Oh and I realized that this one was a `FutureWarning` for end users, but the test suite is under our control, so this is the right action, correct? If I'm wrong, please let me know and I will revert this part.