### PR TITLE
add -y to bypass prompt for transformers-cli upload

### DIFF
--- a/docs/source/model_sharing.rst
+++ b/docs/source/model_sharing.rst
@@ -136,6 +136,13 @@ Then log in using the same credentials as on huggingface.co. To upload your mode
 
 This will upload the folder containing the weights, tokenizer and configuration we prepared in the previous section.
 
+By default you will be prompted to confirm that you want these files to be uploaded. If you are uploading multiple models and need to script that process, you can add `-y` to bypass the prompt. For example:
+
+::
+
+    transformers-cli upload -y path/to/awesome-name-you-picked/
+
+
 If you want to upload a single file (a new version of your model, or the other framework checkpoint you want to add),
 just type:
 

--- a/src/transformers/commands/user.py
+++ b/src/transformers/commands/user.py
@@ -40,6 +40,7 @@ class UserCommands(BaseTransformersCLICommand):
         upload_parser.add_argument(
             "--filename", type=str, default=None, help="Optional: override individual object filename on S3."
         )
+        upload_parser.add_argument("-y", "--yes", action="store_true", help="Optional: answer Yes to the prompt")
         upload_parser.set_defaults(func=lambda args: UploadCommand(args))
 
 
@@ -221,10 +222,11 @@ class UploadCommand(BaseUserCommand):
                 )
             )
 
-        choice = input("Proceed? [Y/n] ").lower()
-        if not (choice == "" or choice == "y" or choice == "yes"):
-            print("Abort")
-            exit()
+        if not self.args.yes:
+            choice = input("Proceed? [Y/n] ").lower()
+            if not (choice == "" or choice == "y" or choice == "yes"):
+                print("Abort")
+                exit()
         print(ANSI.bold("Uploading... This might take a while if files are large"))
         for filepath, filename in files:
             try:


### PR DESCRIPTION
As discussed here: https://github.com/huggingface/transformers/issues/6934#issuecomment-687365960
adding `-y`/`--yes` to bypass prompt for scripting.

<!-- This line specifies which issue to close after the pull request is merged. -->
Fixes #6934
