### PR TITLE
[wip/s2s] DistributedSortishSampler

### DIFF
--- a/examples/seq2seq/finetune.py
+++ b/examples/seq2seq/finetune.py
@@ -67,6 +67,10 @@ class SummarizationModule(BaseTransformer):
     default_val_metric = "rouge2"
 
     def __init__(self, hparams, **kwargs):
+        if hparams.sortish_sampler and hparams.gpus > 1:
+            hparams.replace_sampler_ddp = False
+            # self.hparams.sortish_sampler = False
+            # warnings.warn("ignoring sortish_sampler as it is unsupported on multiple GPUs")
         super().__init__(hparams, num_labels=None, mode=self.mode, **kwargs)
         use_task_specific_params(self.model, "summarization")
         save_git_info(self.hparams.output_dir)
@@ -93,9 +97,6 @@ class SummarizationModule(BaseTransformer):
             "val": self.hparams.val_max_target_length,
             "test": self.hparams.test_max_target_length,
         }
-        if self.hparams.sortish_sampler and self.hparams.gpus > 1:
-            self.hparams.sortish_sampler = False
-            warnings.warn("ignoring sortish_sampler as it is unsupported on multiple GPUs")
         assert self.target_lens["train"] <= self.target_lens["val"], f"target_lens: {self.target_lens}"
         assert self.target_lens["train"] <= self.target_lens["test"], f"target_lens: {self.target_lens}"
 
@@ -257,8 +258,7 @@ class SummarizationModule(BaseTransformer):
         dataset = self.get_dataset(type_path)
         sampler = None
         if self.hparams.sortish_sampler and type_path == "train":
-            assert self.hparams.gpus <= 1  # this should never break because of the assertion in __init__
-            sampler = dataset.make_sortish_sampler(batch_size)
+            sampler = dataset.make_sortish_sampler(batch_size, distributed=self.hparams.gpus > 1)
             shuffle = False
 
         dataloader = DataLoader(

--- a/examples/seq2seq/finetune.py
+++ b/examples/seq2seq/finetune.py
@@ -3,7 +3,6 @@ import glob
 import logging
 import os
 import time
-import warnings
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Tuple
@@ -69,8 +68,6 @@ class SummarizationModule(BaseTransformer):
     def __init__(self, hparams, **kwargs):
         if hparams.sortish_sampler and hparams.gpus > 1:
             hparams.replace_sampler_ddp = False
-            # self.hparams.sortish_sampler = False
-            # warnings.warn("ignoring sortish_sampler as it is unsupported on multiple GPUs")
         super().__init__(hparams, num_labels=None, mode=self.mode, **kwargs)
         use_task_specific_params(self.model, "summarization")
         save_git_info(self.hparams.output_dir)

--- a/examples/seq2seq/test_seq2seq_examples.py
+++ b/examples/seq2seq/test_seq2seq_examples.py
@@ -149,7 +149,7 @@ class TestSummarizationDistiller(unittest.TestCase):
             no_teacher=True,
             freeze_encoder=True,
             gpus=2,
-            sortish_sampler=False,
+            sortish_sampler=True,
         )
         self._test_distiller_cli(updates)
 

--- a/examples/seq2seq/test_seq2seq_examples.py
+++ b/examples/seq2seq/test_seq2seq_examples.py
@@ -151,7 +151,7 @@ class TestSummarizationDistiller(unittest.TestCase):
             gpus=2,
             sortish_sampler=True,
         )
-        self._test_distiller_cli(updates)
+        self._test_distiller_cli(updates, check_contents=False)
 
     def test_distill_no_teacher(self):
         updates = dict(student_encoder_layers=2, student_decoder_layers=1, no_teacher=True)


### PR DESCRIPTION
This allows sortish sampler logic to work on multiple GPU.

The strategy is 
1) find the indices that the current rank's data loader should be using (like `DistributedSampler`)
2) reorder those using the `SortishSampler` logic.

### Results 
The results on a small MT task are similar to the 1 GPU setting. 
+ 2 GPU, random sampler: 13 mins/epoch  BLEU 8.6
+ 2 GPU, `DistributedSortishSampler`: 10 mins/epoch, BLEU 8.6

In the chart below, you can see that the sortish sampler gets to a higher BLEU score in the same number of minutes (x axis) (because it has finished a full epoch rather than 70% of one).

![image](https://user-images.githubusercontent.com/6045025/92787937-87030000-f377-11ea-822a-69e50debe95d.png)

@sgugger let me know if you want this in Trainer!