### PR TITLE
Add option to pass parameters to the loss function.

### DIFF
--- a/src/transformers/modeling_auto.py
+++ b/src/transformers/modeling_auto.py
@@ -1350,7 +1350,7 @@ class AutoModelForSequenceClassification:
         )
 
     @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
+    def from_pretrained(cls, pretrained_model_name_or_path, *model_args, loss_function_params=None, **kwargs):
         r"""Instantiates one of the sequence classification model classes of the library
         from a pre-trained model configuration.
 
@@ -1433,7 +1433,11 @@ class AutoModelForSequenceClassification:
 
         for config_class, model_class in MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.items():
             if isinstance(config, config_class):
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+                return model_class.from_pretrained(
+                    pretrained_model_name_or_path,
+                    *model_args, config=config, loss_function_params=loss_function_params,
+                    **kwargs
+                )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(

--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -1277,8 +1277,9 @@ class BertForNextSentencePrediction(BertPreTrainedModel):
     BERT_START_DOCSTRING,
 )
 class BertForSequenceClassification(BertPreTrainedModel):
-    def __init__(self, config):
+    def __init__(self, config, loss_function_params=None):
         super().__init__(config)
+        self.loss_function_params = {} if loss_function_params is None else loss_function_params
         self.num_labels = config.num_labels
 
         self.bert = BertModel(config)
@@ -1340,7 +1341,7 @@ class BertForSequenceClassification(BertPreTrainedModel):
                 loss_fct = MSELoss()
                 loss = loss_fct(logits.view(-1), labels.view(-1))
             else:
-                loss_fct = CrossEntropyLoss()
+                loss_fct = CrossEntropyLoss(**self.loss_function_params)
                 loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))
 
         if not return_dict:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -706,7 +706,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
         logger.info("Model weights saved in {}".format(output_model_file))
 
     @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
+    def from_pretrained(cls, pretrained_model_name_or_path, *model_args, loss_function_params=None, **kwargs):
         r"""
         Instantiate a pretrained pytorch model from a pre-trained model configuration.
 
@@ -903,7 +903,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
             resolved_archive_file = None
 
         # Instantiate model.
-        model = cls(config, *model_args, **model_kwargs)
+        model = cls(config, *model_args, loss_function_params=loss_function_params, **model_kwargs)
 
         if state_dict is None and not from_tf:
             try:


### PR DESCRIPTION
This PR is by far not finished. In the current state it is just a demo how I would implement it. See #7024

- loss_function_params is a dict that gets passed to the CrossEntropyLoss constructor
- that way you can set class_weights for the `CrossEntropyLoss ` for example
- this is a very important thing to do when working with unbalanced data and can improve your metric by a large amount
- it should be no breaking change since `loss_function_params` is always initialized with `None` which is just the current behavior

Example:
```python
model_name = 'bert-base-german-dbmdz-uncased'

config = AutoConfig.from_pretrained(
    model_name,
    num_labels=3,
)

model = AutoModelForSequenceClassification.from_pretrained(
    model_name,
    config=config,
    loss_function_params={"weight": [0.8, 1.2, 0.97]}
)
```

## ToDo
- [ ] discuss with @LysandreJik @sgugger @nvs-abhilash
- [ ] implement for other models
- [ ] add docstrings
- [ ] write tests
- [ ] maybe implement for TF also