### PR TITLE
[BertGeneration] Clean naming

### DIFF
--- a/src/transformers/configuration_auto.py
+++ b/src/transformers/configuration_auto.py
@@ -99,7 +99,7 @@ CONFIG_MAPPING = OrderedDict(
             AlbertConfig,
         ),
         (
-            "bert-for-seq-generation",
+            "bert-generation",
             BertGenerationConfig,
         ),
         (

--- a/src/transformers/configuration_bert_generation.py
+++ b/src/transformers/configuration_bert_generation.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""  BertForSeqGeneration model configuration """
+"""  BertGeneration model configuration """
 
 from .configuration_utils import PretrainedConfig
 
@@ -29,8 +29,8 @@ class BertGenerationConfig(PretrainedConfig):
 
     Args:
         vocab_size (:obj:`int`, `optional`, defaults to 50358):
-            Vocabulary size of the BertForSeqGeneration model. Defines the different tokens that
-            can be represented by the `inputs_ids` passed to the forward method of :class:`~transformers.BertForSeqGeneration`.
+            Vocabulary size of the BertGeneration model. Defines the different tokens that
+            can be represented by the `inputs_ids` passed to the forward method of :class:`~transformers.BertGeneration`.
         hidden_size (:obj:`int`, `optional`, defaults to 1024):
             Dimensionality of the encoder layers and the pooler layer.
         num_hidden_layers (:obj:`int`, `optional`, defaults to 24):
@@ -60,7 +60,7 @@ class BertGenerationConfig(PretrainedConfig):
 
         >>> from transformers import BertGenerationConfig, BertGenerationEncoder
 
-        >>> # Initializing a BertForSeqGeneration config
+        >>> # Initializing a BertGeneration config
         >>> configuration = BertGenerationConfig()
 
         >>> # Initializing a modelfrom the config
@@ -69,7 +69,7 @@ class BertGenerationConfig(PretrainedConfig):
         >>> # Accessing the model configuration
         >>> configuration = model.config
     """
-    model_type = "bert-for-seq-generation"
+    model_type = "bert-generation"
 
     def __init__(
         self,

--- a/src/transformers/modeling_bert_generation.py
+++ b/src/transformers/modeling_bert_generation.py
@@ -238,7 +238,7 @@ BERT_GENERATION_INPUTS_DOCSTRING = r"""
 
 
 @add_start_docstrings(
-    "The bare BertForSeqGeneration model transformer outputting raw hidden-states without any specific head on top.",
+    "The bare BertGeneration model transformer outputting raw hidden-states without any specific head on top.",
     BERT_GENERATION_START_DOCSTRING,
 )
 class BertGenerationEncoder(BertGenerationPreTrainedModel):

--- a/src/transformers/tokenization_bert_generation.py
+++ b/src/transformers/tokenization_bert_generation.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Tokenization class for model BertForSeqGeneration."""
+""" Tokenization class for model BertGeneration."""
 
 
 import os

--- a/tests/test_modeling_encoder_decoder.py
+++ b/tests/test_modeling_encoder_decoder.py
@@ -493,7 +493,7 @@ class BertEncoderDecoderModelTest(EncoderDecoderMixin, unittest.TestCase):
         self.assertEqual(summary, EXPECTED_SUMMARY)
 
 
-class BertForSeqGenerationEncoderDecoderModelTest(EncoderDecoderMixin, unittest.TestCase):
+class BertGenerationEncoderDecoderModelTest(EncoderDecoderMixin, unittest.TestCase):
     def get_pretrained_model(self):
         return EncoderDecoderModel.from_encoder_decoder_pretrained(
             "google/bert_for_seq_generation_L-24_bbc_encoder", "google/bert_for_seq_generation_L-24_bbc_encoder"

--- a/tests/test_tokenization_bert_generation.py
+++ b/tests/test_tokenization_bert_generation.py
@@ -29,7 +29,7 @@ SPIECE_UNDERLINE = "▁"
 SAMPLE_VOCAB = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures/test_sentencepiece.model")
 
 
-class BertForSeqGenerationTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+class BertGenerationTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     tokenizer_class = BertGenerationTokenizer
 


### PR DESCRIPTION
This PR removes all "old" naming of "bert-for-seq-generation" and "BertForSeqGeneration" repectively.
