### PR TITLE
Transformer-XL: Remove unused parameters

### DIFF
--- a/examples/contrib/run_transfo_xl.py
+++ b/examples/contrib/run_transfo_xl.py
@@ -88,7 +88,7 @@ def main():
         )
     )
 
-    model.reset_length(args.tgt_len, args.ext_len, args.mem_len)
+    model.reset_memory_length(args.mem_len)
     if args.clamp_len > 0:
         model.clamp_len = args.clamp_len
     if args.same_length:

--- a/src/transformers/configuration_transfo_xl.py
+++ b/src/transformers/configuration_transfo_xl.py
@@ -180,7 +180,7 @@ class TransfoXLConfig(PretrainedConfig):
     @property
     def max_position_embeddings(self):
         # Message copied from Transformer-XL documentation
-        logger.warning(f"The model {self.model_type} is one of the few models that has no sequence length limit.")
+        logger.info(f"The model {self.model_type} is one of the few models that has no sequence length limit.")
         return -1
 
     @property

--- a/src/transformers/configuration_transfo_xl.py
+++ b/src/transformers/configuration_transfo_xl.py
@@ -28,7 +28,7 @@ TRANSFO_XL_PRETRAINED_CONFIG_ARCHIVE_MAP = {
     "transfo-xl-wt103": "https://s3.amazonaws.com/models.huggingface.co/bert/transfo-xl-wt103-config.json",
 }
 
-
+# TODO: delete params form docstring
 class TransfoXLConfig(PretrainedConfig):
     """
     This is the configuration class to store the configuration of a :class:`~transformers.TransfoXLModel`.
@@ -125,8 +125,8 @@ class TransfoXLConfig(PretrainedConfig):
         div_val=4,
         pre_lnorm=False,
         n_layer=18,
-        tgt_len=128,
-        ext_len=0,
+        # tgt_len=128,
+        # ext_len=0,
         mem_len=1600,
         clamp_len=1000,
         same_length=True,
@@ -168,8 +168,8 @@ class TransfoXLConfig(PretrainedConfig):
         self.pre_lnorm = pre_lnorm
         self.n_layer = n_layer
         self.n_head = n_head
-        self.tgt_len = tgt_len
-        self.ext_len = ext_len
+        # self.tgt_len = tgt_len
+        # self.ext_len = ext_len
         self.mem_len = mem_len
         self.same_length = same_length
         self.attn_type = attn_type
@@ -187,7 +187,10 @@ class TransfoXLConfig(PretrainedConfig):
 
     @property
     def max_position_embeddings(self):
-        return self.tgt_len + self.ext_len + self.mem_len
+        # Message copied from Transformer-XL documentation
+        logger.warning(f"The model {self.model_type} is one of the few models that has no sequence length limit.")
+        return -1
+        # self.tgt_len + self.ext_len + self.mem_len
 
     @property
     def n_token(self):  # Backward compatibility

--- a/src/transformers/configuration_transfo_xl.py
+++ b/src/transformers/configuration_transfo_xl.py
@@ -28,7 +28,7 @@ TRANSFO_XL_PRETRAINED_CONFIG_ARCHIVE_MAP = {
     "transfo-xl-wt103": "https://s3.amazonaws.com/models.huggingface.co/bert/transfo-xl-wt103-config.json",
 }
 
-# TODO: delete params form docstring
+
 class TransfoXLConfig(PretrainedConfig):
     """
     This is the configuration class to store the configuration of a :class:`~transformers.TransfoXLModel`.
@@ -62,10 +62,6 @@ class TransfoXLConfig(PretrainedConfig):
             Apply LayerNorm to the input instead of the output
         n_layer (:obj:`int`, optional, defaults to 18):
             Number of hidden layers in the Transformer encoder.
-        tgt_len (:obj:`int`, optional, defaults to 128):
-            Number of tokens to predict
-        ext_len (:obj:`int`, optional, defaults to 0):
-            Length of the extended context
         mem_len (:obj:`int`, optional, defaults to 1600):
             Length of the retained previous heads
         clamp_len (:obj:`int`, optional, defaults to 1000):
@@ -125,8 +121,6 @@ class TransfoXLConfig(PretrainedConfig):
         div_val=4,
         pre_lnorm=False,
         n_layer=18,
-        # tgt_len=128,
-        # ext_len=0,
         mem_len=1600,
         clamp_len=1000,
         same_length=True,
@@ -168,8 +162,6 @@ class TransfoXLConfig(PretrainedConfig):
         self.pre_lnorm = pre_lnorm
         self.n_layer = n_layer
         self.n_head = n_head
-        # self.tgt_len = tgt_len
-        # self.ext_len = ext_len
         self.mem_len = mem_len
         self.same_length = same_length
         self.attn_type = attn_type
@@ -190,7 +182,6 @@ class TransfoXLConfig(PretrainedConfig):
         # Message copied from Transformer-XL documentation
         logger.warning(f"The model {self.model_type} is one of the few models that has no sequence length limit.")
         return -1
-        # self.tgt_len + self.ext_len + self.mem_len
 
     @property
     def n_token(self):  # Backward compatibility

--- a/src/transformers/modeling_tf_transfo_xl.py
+++ b/src/transformers/modeling_tf_transfo_xl.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 """ TF 2.0 Transformer XL model.
 """
-
-
+import warnings
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
@@ -108,9 +107,6 @@ class TFRelPartialLearnableMultiHeadAttn(tf.keras.layers.Layer):
         d_head,
         dropout,
         dropatt=0.0,
-        # tgt_len=None,
-        # ext_len=None,
-        # mem_len=None,
         pre_lnorm=False,
         r_r_bias=None,
         r_w_bias=None,
@@ -261,9 +257,6 @@ class TFRelPartialLearnableDecoderLayer(tf.keras.layers.Layer):
         d_head,
         d_inner,
         dropout,
-        # tgt_len=None,
-        # ext_len=None,
-        # mem_len=None,
         dropatt=0.0,
         pre_lnorm=False,
         r_w_bias=None,
@@ -280,9 +273,6 @@ class TFRelPartialLearnableDecoderLayer(tf.keras.layers.Layer):
             d_model,
             d_head,
             dropout,
-            # tgt_len=tgt_len,
-            # ext_len=ext_len,
-            # mem_len=mem_len,
             dropatt=dropatt,
             pre_lnorm=pre_lnorm,
             r_w_bias=r_w_bias,
@@ -414,12 +404,7 @@ class TFTransfoXLMainLayer(tf.keras.layers.Layer):
         self.drop = tf.keras.layers.Dropout(config.dropout)
 
         self.n_layer = config.n_layer
-
-        # self.tgt_len = config.tgt_len
         self.mem_len = config.mem_len
-        # self.ext_len = config.ext_len
-        # self.max_klen = config.tgt_len + config.ext_len + config.mem_len
-
         self.attn_type = config.attn_type
 
         self.layers = []
@@ -432,9 +417,6 @@ class TFTransfoXLMainLayer(tf.keras.layers.Layer):
                         config.d_head,
                         config.d_inner,
                         config.dropout,
-                        # tgt_len=config.tgt_len,
-                        # ext_len=config.ext_len,
-                        # mem_len=config.mem_len,
                         dropatt=config.dropatt,
                         pre_lnorm=config.pre_lnorm,
                         r_w_bias=None if self.untie_r else self.r_w_bias,
@@ -479,9 +461,7 @@ class TFTransfoXLMainLayer(tf.keras.layers.Layer):
         self.sample_softmax = -1
 
     def reset_memory_length(self, mem_len):
-        # self.tgt_len = tgt_len
         self.mem_len = mem_len
-        # self.ext_len = ext_len
 
     def _prune_heads(self, heads):
         raise NotImplementedError
@@ -505,12 +485,7 @@ class TFTransfoXLMainLayer(tf.keras.layers.Layer):
         # mems is not None
         assert len(hids) == len(mems), "len(hids) != len(mems)"
 
-        # TODO: remove comment with ext_len
         # There are `mlen + qlen` steps that can be cached into mems
-        # For the next step, the last `ext_len` of the `qlen` tokens
-        # will be used as the extended context. Hence, we only cache
-        # the tokens from `mlen + qlen - self.ext_len - self.mem_len`
-        # to `mlen + qlen - self.ext_len`.
         new_mems = []
         end_idx = mlen + max(0, qlen)
         beg_idx = max(0, end_idx - self.mem_len)
@@ -866,6 +841,13 @@ class TFTransfoXLLMHeadModel(TFTransfoXLPreTrainedModel):
         if len(self.crit.out_layers) > 0:
             return self.crit.out_layers[-1]
         return None
+
+    def reset_length(self, tgt_len, ext_len, mem_len):
+        warnings.warn(
+            "The method `reset_length` is deprecated and will be removed in a future version, use `reset_memory_length` instead.",
+            FutureWarning,
+        )
+        self.transformer.reset_memory_length(mem_len)
 
     def reset_memory_length(self, mem_len):
         self.transformer.reset_memory_length(mem_len)

--- a/src/transformers/modeling_transfo_xl.py
+++ b/src/transformers/modeling_transfo_xl.py
@@ -234,9 +234,9 @@ class RelPartialLearnableMultiHeadAttn(nn.Module):
         d_head,
         dropout,
         dropatt=0,
-        tgt_len=None,
-        ext_len=None,
-        mem_len=None,
+        # tgt_len=None,
+        # ext_len=None,
+        # mem_len=None,
         pre_lnorm=False,
         r_r_bias=None,
         r_w_bias=None,
@@ -738,10 +738,10 @@ class TransfoXLModel(TransfoXLPreTrainedModel):
 
         self.n_layer = config.n_layer
 
-        self.tgt_len = config.tgt_len
+        # self.tgt_len = config.tgt_len
         self.mem_len = config.mem_len
-        self.ext_len = config.ext_len
-        self.max_klen = config.tgt_len + config.ext_len + config.mem_len
+        # self.ext_len = config.ext_len
+        # self.max_klen = config.tgt_len + config.ext_len + config.mem_len
 
         self.attn_type = config.attn_type
 
@@ -759,9 +759,9 @@ class TransfoXLModel(TransfoXLPreTrainedModel):
                         config.d_head,
                         config.d_inner,
                         config.dropout,
-                        tgt_len=config.tgt_len,
-                        ext_len=config.ext_len,
-                        mem_len=config.mem_len,
+                        # tgt_len=config.tgt_len,
+                        # ext_len=config.ext_len,
+                        # mem_len=config.mem_len,
                         dropatt=config.dropatt,
                         pre_lnorm=config.pre_lnorm,
                         r_w_bias=None if config.untie_r else self.r_w_bias,
@@ -791,10 +791,8 @@ class TransfoXLModel(TransfoXLPreTrainedModel):
     def backward_compatible(self):
         self.sample_softmax = -1
 
-    def reset_length(self, tgt_len, ext_len, mem_len):
-        self.tgt_len = tgt_len
+    def reset_memory_length(self, mem_len):
         self.mem_len = mem_len
-        self.ext_len = ext_len
 
     def _prune_heads(self, heads):
         logger.info("Head pruning is not implemented for Transformer-XL model")
@@ -820,6 +818,7 @@ class TransfoXLModel(TransfoXLPreTrainedModel):
         # mems is not None
         assert len(hids) == len(mems), "len(hids) != len(mems)"
 
+        # TODO: remove comment with ext_len
         # There are `mlen + qlen` steps that can be cached into mems
         # For the next step, the last `ext_len` of the `qlen` tokens
         # will be used as the extended context. Hence, we only cache
@@ -827,7 +826,7 @@ class TransfoXLModel(TransfoXLPreTrainedModel):
         # to `mlen + qlen - self.ext_len`.
         with torch.no_grad():
             new_mems = []
-            end_idx = mlen + max(0, qlen - 0 - self.ext_len)
+            end_idx = mlen + max(0, qlen)
             beg_idx = max(0, end_idx - self.mem_len)
             for i in range(len(hids)):
 
@@ -1009,8 +1008,8 @@ class TransfoXLLMHeadModel(TransfoXLPreTrainedModel):
                     else:
                         self.crit.out_projs[i] = self.transformer.word_emb.emb_projs[i]
 
-    def reset_length(self, tgt_len, ext_len, mem_len):
-        self.transformer.reset_length(tgt_len, ext_len, mem_len)
+    def reset_memory_length(self, mem_len):
+        self.transformer.reset_memory_length(mem_len)
 
     def init_mems(self, bsz):
         return self.transformer.init_mems(bsz)

--- a/src/transformers/modeling_transfo_xl.py
+++ b/src/transformers/modeling_transfo_xl.py
@@ -17,8 +17,7 @@
     Adapted from https://github.com/kimiyoung/transformer-xl.
     In particular https://github.com/kimiyoung/transformer-xl/blob/master/pytorch/mem_transformer.py
 """
-
-
+import warnings
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
@@ -234,9 +233,6 @@ class RelPartialLearnableMultiHeadAttn(nn.Module):
         d_head,
         dropout,
         dropatt=0,
-        # tgt_len=None,
-        # ext_len=None,
-        # mem_len=None,
         pre_lnorm=False,
         r_r_bias=None,
         r_w_bias=None,
@@ -737,12 +733,7 @@ class TransfoXLModel(TransfoXLPreTrainedModel):
         self.drop = nn.Dropout(config.dropout)
 
         self.n_layer = config.n_layer
-
-        # self.tgt_len = config.tgt_len
         self.mem_len = config.mem_len
-        # self.ext_len = config.ext_len
-        # self.max_klen = config.tgt_len + config.ext_len + config.mem_len
-
         self.attn_type = config.attn_type
 
         if not config.untie_r:
@@ -759,9 +750,6 @@ class TransfoXLModel(TransfoXLPreTrainedModel):
                         config.d_head,
                         config.d_inner,
                         config.dropout,
-                        # tgt_len=config.tgt_len,
-                        # ext_len=config.ext_len,
-                        # mem_len=config.mem_len,
                         dropatt=config.dropatt,
                         pre_lnorm=config.pre_lnorm,
                         r_w_bias=None if config.untie_r else self.r_w_bias,
@@ -818,12 +806,7 @@ class TransfoXLModel(TransfoXLPreTrainedModel):
         # mems is not None
         assert len(hids) == len(mems), "len(hids) != len(mems)"
 
-        # TODO: remove comment with ext_len
         # There are `mlen + qlen` steps that can be cached into mems
-        # For the next step, the last `ext_len` of the `qlen` tokens
-        # will be used as the extended context. Hence, we only cache
-        # the tokens from `mlen + qlen - self.ext_len - self.mem_len`
-        # to `mlen + qlen - self.ext_len`.
         with torch.no_grad():
             new_mems = []
             end_idx = mlen + max(0, qlen)
@@ -1007,6 +990,13 @@ class TransfoXLLMHeadModel(TransfoXLPreTrainedModel):
                         self.crit.out_projs[i] = nn.Parameter(self.transformer.word_emb.emb_projs[i].clone())
                     else:
                         self.crit.out_projs[i] = self.transformer.word_emb.emb_projs[i]
+
+    def reset_length(self, tgt_len, ext_len, mem_len):
+        warnings.warn(
+            "The method `reset_length` is deprecated and will be removed in a future version, use `reset_memory_length` instead.",
+            FutureWarning,
+        )
+        self.transformer.reset_memory_length(mem_len)
 
     def reset_memory_length(self, mem_len):
         self.transformer.reset_memory_length(mem_len)


### PR DESCRIPTION
Fixes #6943

Since `tgt_len` and `ext_len` is removed, the method `reset_length` was renamed to `reset_memory_length` to be more meaningful.

I'm not sure whether a deprecation warning should be included in `TransfoXLConfig`. Maybe someone can make suggestions regarding this.