### PR TITLE
Fix reproducible tests in Trainer

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -4,7 +4,7 @@ import datasets
 import numpy as np
 
 from transformers import AutoTokenizer, TrainingArguments, is_torch_available
-from transformers.testing_utils import get_tests_dir, require_non_multigpu, require_torch
+from transformers.testing_utils import get_tests_dir, require_torch
 
 
 if is_torch_available():
@@ -94,25 +94,24 @@ if is_torch_available():
 
 @require_torch
 class TrainerIntegrationTest(unittest.TestCase):
-    def check_trained_model(self, model, alternate_seed=False):
-        # Checks a training seeded with learning_rate = 0.1
-        if alternate_seed:
-            # With args.seed = 314
-            self.assertTrue(torch.abs(model.a - 1.0171) < 1e-4)
-            self.assertTrue(torch.abs(model.b - 1.2494) < 1e-4)
-        else:
-            # With default args.seed
-            self.assertTrue(torch.abs(model.a - 0.6975) < 1e-4)
-            self.assertTrue(torch.abs(model.b - 1.2415) < 1e-4)
-
     def setUp(self):
-        # Get the default values (in case they change):
         args = TrainingArguments(".")
         self.n_epochs = args.num_train_epochs
-        self.batch_size = args.per_device_train_batch_size
+        self.batch_size = args.train_batch_size
+        trainer = get_regression_trainer(learning_rate=0.1)
+        trainer.train()
+        self.default_trained_model = (trainer.model.a, trainer.model.b)
 
-    @require_non_multigpu
-    @unittest.skip("Change in seed by external dependency causing this test to fail.")
+        trainer = get_regression_trainer(learning_rate=0.1, seed=314)
+        trainer.train()
+        self.alternate_trained_model = (trainer.model.a, trainer.model.b)
+
+    def check_trained_model(self, model, alternate_seed=False):
+        # Checks a training seeded with learning_rate = 0.1
+        (a, b) = self.alternate_trained_model if alternate_seed else self.default_trained_model
+        self.assertTrue(torch.allclose(model.a, a))
+        self.assertTrue(torch.allclose(model.b, b))
+
     def test_reproducible_training(self):
         # Checks that training worked, model trained and seed made a reproducible training.
         trainer = get_regression_trainer(learning_rate=0.1)
@@ -124,7 +123,6 @@ class TrainerIntegrationTest(unittest.TestCase):
         trainer.train()
         self.check_trained_model(trainer.model, alternate_seed=True)
 
-    @require_non_multigpu
     def test_number_of_steps_in_training(self):
         # Regular training has n_epochs * len(train_dl) steps
         trainer = get_regression_trainer(learning_rate=0.1)
@@ -141,7 +139,6 @@ class TrainerIntegrationTest(unittest.TestCase):
         train_output = trainer.train()
         self.assertEqual(train_output.global_step, 10)
 
-    @require_non_multigpu
     def test_train_and_eval_dataloaders(self):
         trainer = get_regression_trainer(learning_rate=0.1, per_device_train_batch_size=16)
         self.assertEqual(trainer.get_train_dataloader().batch_size, 16)
@@ -204,8 +201,6 @@ class TrainerIntegrationTest(unittest.TestCase):
         x = trainer.eval_dataset.x
         self.assertTrue(np.allclose(preds, 1.5 * x + 2.5))
 
-    @require_non_multigpu
-    @unittest.skip("Change in seed by external dependency causing this test to fail.")
     def test_trainer_with_datasets(self):
         np.random.seed(42)
         x = np.random.normal(size=(64,)).astype(np.float32)
@@ -234,8 +229,6 @@ class TrainerIntegrationTest(unittest.TestCase):
         trainer.train()
         self.check_trained_model(trainer.model)
 
-    @require_non_multigpu
-    @unittest.skip("Change in seed by external dependency causing this test to fail.")
     def test_custom_optimizer(self):
         train_dataset = RegressionDataset()
         args = TrainingArguments("./regression")
@@ -245,12 +238,11 @@ class TrainerIntegrationTest(unittest.TestCase):
         trainer = Trainer(model, args, train_dataset=train_dataset, optimizers=(optimizer, lr_scheduler))
         trainer.train()
 
-        self.assertTrue(torch.abs(trainer.model.a - 1.8950) < 1e-4)
-        self.assertTrue(torch.abs(trainer.model.b - 2.5656) < 1e-4)
+        (a, b) = self.default_trained_model
+        self.assertFalse(torch.allclose(trainer.model.a, a))
+        self.assertFalse(torch.allclose(trainer.model.b, b))
         self.assertEqual(trainer.optimizer.state_dict()["param_groups"][0]["lr"], 1.0)
 
-    @require_non_multigpu
-    @unittest.skip("Change in seed by external dependency causing this test to fail.")
     def test_model_init(self):
         train_dataset = RegressionDataset()
         args = TrainingArguments("./regression", learning_rate=0.1)


### PR DESCRIPTION
This fixes the tests that were using hardcoded values for reproducible training by testing instead the training yields the same result as one run with the same seed during setup. As a result, it can also run in a multigpu-environment (which is why I removed the decorator).

I also fixed the batch size to count the number of steps, which should also fix those tests for multigpu-environent. @stas00, when you get a chance to run the tests on that file, it would be great to know if the fix worked as intended.
