### PR TITLE
fix ZeroDivisionError and epoch counting

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -299,3 +299,19 @@ class TrainerIntegrationTest(unittest.TestCase):
         trainer = Trainer(model=model, args=training_args, train_dataset=train_dataset)
         loader = trainer.get_train_dataloader()
         self.assertIsInstance(loader, torch.utils.data.DataLoader)
+
+    @require_non_multigpu
+    def test_num_train_epochs_in_training(self):
+        # len(train_dl) < gradient_accumulation_steps shouldn't give ``ZeroDivisionError`` when ``max_steps`` is given.
+        # It should give 1 update step for each epoch.
+        trainer = get_regression_trainer(
+            max_steps=3, train_len=64, per_device_train_batch_size=16, gradient_accumulation_steps=5
+        )
+        train_output = trainer.train()
+        self.assertEqual(train_output.global_step, 3)
+
+        # Even ``max_steps`` is not specified, we still expect 1 update step for each epoch if
+        # len(train_dl) < gradient_accumulation_steps.
+        trainer = get_regression_trainer(train_len=64, per_device_train_batch_size=16, gradient_accumulation_steps=5)
+        train_output = trainer.train()
+        self.assertEqual(train_output.global_step, int(self.n_epochs))

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -300,7 +300,6 @@ class TrainerIntegrationTest(unittest.TestCase):
         loader = trainer.get_train_dataloader()
         self.assertIsInstance(loader, torch.utils.data.DataLoader)
 
-    @require_non_multigpu
     def test_num_train_epochs_in_training(self):
         # len(train_dl) < gradient_accumulation_steps shouldn't give ``ZeroDivisionError`` when ``max_steps`` is given.
         # It should give 1 update step for each epoch.


### PR DESCRIPTION
@sgugger 

This PR fix 2 minor bugs in `trainer.py`.

First, the two lines
            
    num_train_epochs = (
        self.args.max_steps // (len(train_dataloader) // self.args.gradient_accumulation_steps) + 1
    )

and

    epochs_trained = self.global_step // (len(train_dataloader) // self.args.gradient_accumulation_steps)

gives `ZeroDivisionError` when `len(train_dataloader) < self.args.gradient_accumulation_steps`.

The fix takes into account the code below the comment

     # last step in epoch but step is always smaller than gradient_accumulation_steps

therefore when `len(train_dataloader) < self.args.gradient_accumulation_steps`, we still have 1 step in each epoch.

The second bug is due to the `+ 1` in the

    num_train_epochs = (
        self.args.max_steps // (len(train_dataloader) // self.args.gradient_accumulation_steps) + 1
    )

In the example below, we have

    len(train_dataloader) == 40
    self.args.gradient_accumulation_steps = 4
    self.args.max_steps = 10

However we get `num_train_epochs == 2` from the original code, which should be `1`.

    python utils/download_glue_data.py --data_dir ./examples/text-classification/glue/ --tasks all

    python3 run_glue.py \
        --task_name wnli \
        --data_dir ./glue/WNLI \
        --model_name_or_path distilbert-base-uncased \
        --output_dir ./glue/WNLI/ \
        --max_seq_length  16 \
        --num_train_epochs 1 \
        --per_device_train_batch_size 16 \
        --gradient_accumulation_steps 4 \
        --max_steps 10 \
        --logging_steps 1 \
        --save_steps 5 \
        --seed 1 \
        --do_train \
        --do_eval \
        --do_predict \
        --overwrite_output_dir


    (Pdb) len(train_dataloader)
    40
    (Pdb) self.args.gradient_accumulation_steps
    4
    (Pdb) self.args.max_steps
    10
    (Pdb) p num_train_epochs
    2