### PR TITLE
Fix the HF logger

### DIFF
--- a/examples/adversarial/run_hans.py
+++ b/examples/adversarial/run_hans.py
@@ -23,7 +23,18 @@ from typing import Dict, List, Optional
 import numpy as np
 import torch
 
+from transformers import (
+    AutoConfig,
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    HfArgumentParser,
+    Trainer,
+    TrainingArguments,
+    default_data_collator,
+)
 from transformers import logging as hf_logging
+from transformers import set_seed
+from utils_hans import HansDataset, InputFeatures, hans_processors, hans_tasks_num_labels
 
 
 handler = logging.StreamHandler()
@@ -35,18 +46,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-from transformers import (
-    AutoConfig,
-    AutoModelForSequenceClassification,
-    AutoTokenizer,
-    HfArgumentParser,
-    Trainer,
-    TrainingArguments,
-    default_data_collator,
-    set_seed,
-)
-from utils_hans import HansDataset, InputFeatures, hans_processors, hans_tasks_num_labels
 
 
 @dataclass

--- a/examples/adversarial/run_hans.py
+++ b/examples/adversarial/run_hans.py
@@ -23,6 +23,19 @@ from typing import Dict, List, Optional
 import numpy as np
 import torch
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import (
     AutoConfig,
     AutoModelForSequenceClassification,
@@ -34,9 +47,6 @@ from transformers import (
     set_seed,
 )
 from utils_hans import HansDataset, InputFeatures, hans_processors, hans_tasks_num_labels
-
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/examples/adversarial/utils_hans.py
+++ b/examples/adversarial/utils_hans.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import os
 from dataclasses import dataclass
 from typing import List, Optional, Union
@@ -33,9 +32,10 @@ from transformers import (
     is_tf_available,
     is_torch_available,
 )
+from transformers import logging as hf_logging
 
 
-logger = logging.getLogger(__name__)
+logger = hf_logging.get_logger(__name__)
 
 
 @dataclass(frozen=True)

--- a/examples/bert-loses-patience/pabee/modeling_pabee_albert.py
+++ b/examples/bert-loses-patience/pabee/modeling_pabee_albert.py
@@ -14,12 +14,11 @@
 # limitations under the License.
 """PyTorch ALBERT model with Patience-based Early Exit. """
 
-import logging
-
 import torch
 import torch.nn as nn
 from torch.nn import CrossEntropyLoss, MSELoss
 
+from transformers import logging as hf_logging
 from transformers.file_utils import add_start_docstrings, add_start_docstrings_to_callable
 from transformers.modeling_albert import (
     ALBERT_INPUTS_DOCSTRING,
@@ -30,7 +29,7 @@ from transformers.modeling_albert import (
 )
 
 
-logger = logging.getLogger(__name__)
+logger = hf_logging.get_logger(__name__)
 
 
 class AlbertTransformerWithPabee(AlbertTransformer):

--- a/examples/bert-loses-patience/pabee/modeling_pabee_bert.py
+++ b/examples/bert-loses-patience/pabee/modeling_pabee_bert.py
@@ -15,13 +15,11 @@
 # limitations under the License.
 """PyTorch BERT model with Patience-based Early Exit. """
 
-
-import logging
-
 import torch
 from torch import nn
 from torch.nn import CrossEntropyLoss, MSELoss
 
+from transformers import logging as hf_logging
 from transformers.file_utils import add_start_docstrings, add_start_docstrings_to_callable
 from transformers.modeling_bert import (
     BERT_INPUTS_DOCSTRING,
@@ -32,7 +30,7 @@ from transformers.modeling_bert import (
 )
 
 
-logger = logging.getLogger(__name__)
+logger = hf_logging.get_logger(__name__)
 
 
 class BertEncoderWithPabee(BertEncoder):

--- a/examples/bert-loses-patience/run_glue_with_pabee.py
+++ b/examples/bert-loses-patience/run_glue_with_pabee.py
@@ -29,6 +29,19 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, Tenso
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from pabee.modeling_pabee_albert import AlbertForSequenceClassificationWithPabee
 from pabee.modeling_pabee_bert import BertForSequenceClassificationWithPabee
 from transformers import (
@@ -51,8 +64,6 @@ try:
 except ImportError:
     from tensorboardX import SummaryWriter
 
-
-logger = logging.getLogger(__name__)
 
 MODEL_CLASSES = {
     "bert": (BertConfig, BertForSequenceClassificationWithPabee, BertTokenizer),
@@ -721,7 +732,7 @@ def main():
             checkpoints = list(
                 os.path.dirname(c) for c in sorted(glob.glob(args.output_dir + "/**/" + WEIGHTS_NAME, recursive=True))
             )
-
+            hf_logging.get_logger("transformers.modeling_utils").setLevel(logging.WARN)  # Reduce logging
         logger.info("Evaluate the following checkpoints: %s", checkpoints)
 
         for checkpoint in checkpoints:

--- a/examples/bert-loses-patience/run_glue_with_pabee.py
+++ b/examples/bert-loses-patience/run_glue_with_pabee.py
@@ -29,19 +29,6 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, Tenso
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
-from transformers import logging as hf_logging
-
-
-handler = logging.StreamHandler()
-formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
-handler.setFormatter(formatter)
-
-logger = hf_logging.get_logger()
-
-logger.handlers.clear()
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
-
 from pabee.modeling_pabee_albert import AlbertForSequenceClassificationWithPabee
 from pabee.modeling_pabee_bert import BertForSequenceClassificationWithPabee
 from transformers import (
@@ -57,12 +44,24 @@ from transformers import glue_compute_metrics as compute_metrics
 from transformers import glue_convert_examples_to_features as convert_examples_to_features
 from transformers import glue_output_modes as output_modes
 from transformers import glue_processors as processors
+from transformers import logging as hf_logging
 
 
 try:
     from torch.utils.tensorboard import SummaryWriter
 except ImportError:
     from tensorboardX import SummaryWriter
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 MODEL_CLASSES = {

--- a/examples/bert-loses-patience/test_run_glue_with_pabee.py
+++ b/examples/bert-loses-patience/test_run_glue_with_pabee.py
@@ -4,12 +4,19 @@ import sys
 from unittest.mock import patch
 
 import run_glue_with_pabee
+from transformers import logging as hf_logging
 from transformers.testing_utils import TestCasePlus
 
 
-logging.basicConfig(level=logging.DEBUG)
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
 
-logger = logging.getLogger()
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)
 
 
 def get_setup_file():
@@ -21,9 +28,6 @@ def get_setup_file():
 
 class PabeeTests(TestCasePlus):
     def test_run_glue(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_glue_with_pabee.py

--- a/examples/bertology/run_bertology.py
+++ b/examples/bertology/run_bertology.py
@@ -30,7 +30,18 @@ from torch.utils.data import DataLoader, SequentialSampler, Subset
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
+from transformers import (
+    AutoConfig,
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    GlueDataset,
+    default_data_collator,
+    glue_compute_metrics,
+    glue_output_modes,
+    glue_processors,
+)
 from transformers import logging as hf_logging
+from transformers import set_seed
 
 
 handler = logging.StreamHandler()
@@ -42,18 +53,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-from transformers import (
-    AutoConfig,
-    AutoModelForSequenceClassification,
-    AutoTokenizer,
-    GlueDataset,
-    default_data_collator,
-    glue_compute_metrics,
-    glue_output_modes,
-    glue_processors,
-    set_seed,
-)
 
 
 def entropy(p):

--- a/examples/bertology/run_bertology.py
+++ b/examples/bertology/run_bertology.py
@@ -30,6 +30,19 @@ from torch.utils.data import DataLoader, SequentialSampler, Subset
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import (
     AutoConfig,
     AutoModelForSequenceClassification,
@@ -41,9 +54,6 @@ from transformers import (
     glue_processors,
     set_seed,
 )
-
-
-logger = logging.getLogger(__name__)
 
 
 def entropy(p):

--- a/examples/contrib/mm-imdb/run_mmimdb.py
+++ b/examples/contrib/mm-imdb/run_mmimdb.py
@@ -31,6 +31,19 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import (
     WEIGHTS_NAME,
     AdamW,
@@ -48,9 +61,6 @@ try:
     from torch.utils.tensorboard import SummaryWriter
 except ImportError:
     from tensorboardX import SummaryWriter
-
-
-logger = logging.getLogger(__name__)
 
 
 def set_seed(args):
@@ -547,7 +557,7 @@ def main():
             checkpoints = list(
                 os.path.dirname(c) for c in sorted(glob.glob(args.output_dir + "/**/" + WEIGHTS_NAME, recursive=True))
             )
-
+            hf_logging.get_logger("transformers.modeling_utils").setLevel(logging.WARN)  # Reduce logging
         logger.info("Evaluate the following checkpoints: %s", checkpoints)
         for checkpoint in checkpoints:
             global_step = checkpoint.split("-")[-1] if len(checkpoints) > 1 else ""

--- a/examples/contrib/mm-imdb/run_mmimdb.py
+++ b/examples/contrib/mm-imdb/run_mmimdb.py
@@ -31,7 +31,24 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
+from transformers import (
+    WEIGHTS_NAME,
+    AdamW,
+    AutoConfig,
+    AutoModel,
+    AutoTokenizer,
+    MMBTConfig,
+    MMBTForClassification,
+    get_linear_schedule_with_warmup,
+)
 from transformers import logging as hf_logging
+from utils_mmimdb import ImageEncoder, JsonlDataset, collate_fn, get_image_transforms, get_mmimdb_labels
+
+
+try:
+    from torch.utils.tensorboard import SummaryWriter
+except ImportError:
+    from tensorboardX import SummaryWriter
 
 
 handler = logging.StreamHandler()
@@ -43,24 +60,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-from transformers import (
-    WEIGHTS_NAME,
-    AdamW,
-    AutoConfig,
-    AutoModel,
-    AutoTokenizer,
-    MMBTConfig,
-    MMBTForClassification,
-    get_linear_schedule_with_warmup,
-)
-from utils_mmimdb import ImageEncoder, JsonlDataset, collate_fn, get_image_transforms, get_mmimdb_labels
-
-
-try:
-    from torch.utils.tensorboard import SummaryWriter
-except ImportError:
-    from tensorboardX import SummaryWriter
 
 
 def set_seed(args):

--- a/examples/contrib/run_openai_gpt.py
+++ b/examples/contrib/run_openai_gpt.py
@@ -38,6 +38,14 @@ import torch
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, TensorDataset
 from tqdm import tqdm, trange
 
+from transformers import (
+    CONFIG_NAME,
+    WEIGHTS_NAME,
+    AdamW,
+    OpenAIGPTDoubleHeadsModel,
+    OpenAIGPTTokenizer,
+    get_linear_schedule_with_warmup,
+)
 from transformers import logging as hf_logging
 
 
@@ -50,15 +58,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-from transformers import (
-    CONFIG_NAME,
-    WEIGHTS_NAME,
-    AdamW,
-    OpenAIGPTDoubleHeadsModel,
-    OpenAIGPTTokenizer,
-    get_linear_schedule_with_warmup,
-)
 
 
 def accuracy(out, labels):

--- a/examples/contrib/run_openai_gpt.py
+++ b/examples/contrib/run_openai_gpt.py
@@ -38,6 +38,19 @@ import torch
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, TensorDataset
 from tqdm import tqdm, trange
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import (
     CONFIG_NAME,
     WEIGHTS_NAME,
@@ -46,12 +59,6 @@ from transformers import (
     OpenAIGPTTokenizer,
     get_linear_schedule_with_warmup,
 )
-
-
-logging.basicConfig(
-    format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s", datefmt="%m/%d/%Y %H:%M:%S", level=logging.INFO
-)
-logger = logging.getLogger(__name__)
 
 
 def accuracy(out, labels):

--- a/examples/contrib/run_swag.py
+++ b/examples/contrib/run_swag.py
@@ -31,7 +31,15 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, Tenso
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
+from transformers import WEIGHTS_NAME, AdamW, AutoConfig, AutoTokenizer, get_linear_schedule_with_warmup
 from transformers import logging as hf_logging
+from transformers.modeling_auto import AutoModelForMultipleChoice
+
+
+try:
+    from torch.utils.tensorboard import SummaryWriter
+except ImportError:
+    from tensorboardX import SummaryWriter
 
 
 handler = logging.StreamHandler()
@@ -43,15 +51,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-from transformers import WEIGHTS_NAME, AdamW, AutoConfig, AutoTokenizer, get_linear_schedule_with_warmup
-from transformers.modeling_auto import AutoModelForMultipleChoice
-
-
-try:
-    from torch.utils.tensorboard import SummaryWriter
-except ImportError:
-    from tensorboardX import SummaryWriter
 
 
 class SwagExample(object):

--- a/examples/contrib/run_swag.py
+++ b/examples/contrib/run_swag.py
@@ -31,6 +31,19 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, Tenso
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import WEIGHTS_NAME, AdamW, AutoConfig, AutoTokenizer, get_linear_schedule_with_warmup
 from transformers.modeling_auto import AutoModelForMultipleChoice
 
@@ -39,9 +52,6 @@ try:
     from torch.utils.tensorboard import SummaryWriter
 except ImportError:
     from tensorboardX import SummaryWriter
-
-
-logger = logging.getLogger(__name__)
 
 
 class SwagExample(object):
@@ -681,6 +691,7 @@ def main():
             checkpoints = list(
                 os.path.dirname(c) for c in sorted(glob.glob(args.output_dir + "/**/" + WEIGHTS_NAME, recursive=True))
             )
+            hf_logging.get_logger("transformers.modeling_utils").setLevel(logging.WARN)  # Reduce model loading logs
 
         logger.info("Evaluate the following checkpoints: %s", checkpoints)
 

--- a/examples/contrib/run_transfo_xl.py
+++ b/examples/contrib/run_transfo_xl.py
@@ -29,12 +29,18 @@ import time
 import torch
 
 from transformers import TransfoXLCorpus, TransfoXLLMHeadModel
+from transformers import logging as hf_logging
 
 
-logging.basicConfig(
-    format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s", datefmt="%m/%d/%Y %H:%M:%S", level=logging.INFO
-)
-logger = logging.getLogger(__name__)
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 def main():

--- a/examples/deebert/run_glue_deebert.py
+++ b/examples/deebert/run_glue_deebert.py
@@ -13,6 +13,19 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, Tenso
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from src.modeling_highway_bert import DeeBertForSequenceClassification
 from src.modeling_highway_roberta import DeeRobertaForSequenceClassification
 from transformers import (
@@ -34,9 +47,6 @@ try:
     from torch.utils.tensorboard import SummaryWriter
 except ImportError:
     from tensorboardX import SummaryWriter
-
-
-logger = logging.getLogger(__name__)
 
 
 MODEL_CLASSES = {
@@ -677,7 +687,7 @@ def main():
             checkpoints = list(
                 os.path.dirname(c) for c in sorted(glob.glob(args.output_dir + "/**/" + WEIGHTS_NAME, recursive=True))
             )
-
+            hf_logging.get_logger("transformers.modeling_utils").setLevel(logging.WARN)  # Reduce logging
         logger.info("Evaluate the following checkpoints: %s", checkpoints)
         for checkpoint in checkpoints:
             global_step = checkpoint.split("-")[-1] if len(checkpoints) > 1 else ""

--- a/examples/deebert/run_glue_deebert.py
+++ b/examples/deebert/run_glue_deebert.py
@@ -13,19 +13,6 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, Tenso
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
-from transformers import logging as hf_logging
-
-
-handler = logging.StreamHandler()
-formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
-handler.setFormatter(formatter)
-
-logger = hf_logging.get_logger()
-
-logger.handlers.clear()
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
-
 from src.modeling_highway_bert import DeeBertForSequenceClassification
 from src.modeling_highway_roberta import DeeRobertaForSequenceClassification
 from transformers import (
@@ -41,12 +28,24 @@ from transformers import glue_compute_metrics as compute_metrics
 from transformers import glue_convert_examples_to_features as convert_examples_to_features
 from transformers import glue_output_modes as output_modes
 from transformers import glue_processors as processors
+from transformers import logging as hf_logging
 
 
 try:
     from torch.utils.tensorboard import SummaryWriter
 except ImportError:
     from tensorboardX import SummaryWriter
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 MODEL_CLASSES = {

--- a/examples/deebert/test_glue_deebert.py
+++ b/examples/deebert/test_glue_deebert.py
@@ -5,12 +5,19 @@ import unittest
 from unittest.mock import patch
 
 import run_glue_deebert
+from transformers import logging as hf_logging
 from transformers.testing_utils import slow
 
 
-logging.basicConfig(level=logging.DEBUG)
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
 
-logger = logging.getLogger()
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)
 
 
 def get_setup_file():
@@ -21,10 +28,6 @@ def get_setup_file():
 
 
 class DeeBertTests(unittest.TestCase):
-    def setup(self) -> None:
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
     @slow
     def test_glue_deebert_train(self):
 

--- a/examples/distillation/run_squad_w_distillation.py
+++ b/examples/distillation/run_squad_w_distillation.py
@@ -30,19 +30,6 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
-from transformers import logging as hf_logging
-
-
-handler = logging.StreamHandler()
-formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
-handler.setFormatter(formatter)
-
-logger = hf_logging.get_logger()
-
-logger.handlers.clear()
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
-
 from transformers import (
     WEIGHTS_NAME,
     AdamW,
@@ -62,8 +49,9 @@ from transformers import (
     XLNetForQuestionAnswering,
     XLNetTokenizer,
     get_linear_schedule_with_warmup,
-    squad_convert_examples_to_features,
 )
+from transformers import logging as hf_logging
+from transformers import squad_convert_examples_to_features
 from transformers.data.metrics.squad_metrics import (
     compute_predictions_log_probs,
     compute_predictions_logits,
@@ -76,6 +64,17 @@ try:
     from torch.utils.tensorboard import SummaryWriter
 except ImportError:
     from tensorboardX import SummaryWriter
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 MODEL_CLASSES = {

--- a/examples/distillation/run_squad_w_distillation.py
+++ b/examples/distillation/run_squad_w_distillation.py
@@ -30,6 +30,19 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import (
     WEIGHTS_NAME,
     AdamW,
@@ -63,9 +76,6 @@ try:
     from torch.utils.tensorboard import SummaryWriter
 except ImportError:
     from tensorboardX import SummaryWriter
-
-
-logger = logging.getLogger(__name__)
 
 
 MODEL_CLASSES = {
@@ -842,6 +852,7 @@ def main():
             checkpoints = list(
                 os.path.dirname(c) for c in sorted(glob.glob(args.output_dir + "/**/" + WEIGHTS_NAME, recursive=True))
             )
+            hf_logging.get_logger("transformers.modeling_utils").setLevel(logging.WARN)  # Reduce model loading logs
 
         logger.info("Evaluate the following checkpoints: %s", checkpoints)
 

--- a/examples/distillation/scripts/binarized_data.py
+++ b/examples/distillation/scripts/binarized_data.py
@@ -24,12 +24,18 @@ import time
 import numpy as np
 
 from transformers import BertTokenizer, GPT2Tokenizer, RobertaTokenizer
+from transformers import logging as hf_logging
 
 
-logging.basicConfig(
-    format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s", datefmt="%m/%d/%Y %H:%M:%S", level=logging.INFO
-)
-logger = logging.getLogger(__name__)
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 def main():

--- a/examples/distillation/scripts/token_counts.py
+++ b/examples/distillation/scripts/token_counts.py
@@ -20,11 +20,18 @@ import logging
 import pickle
 from collections import Counter
 
+from transformers import logging as hf_logging
 
-logging.basicConfig(
-    format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s", datefmt="%m/%d/%Y %H:%M:%S", level=logging.INFO
-)
-logger = logging.getLogger(__name__)
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(

--- a/examples/distillation/utils.py
+++ b/examples/distillation/utils.py
@@ -16,7 +16,6 @@
     adapted in part from Facebook, Inc XLM model (https://github.com/facebookresearch/XLM)
 """
 import json
-import logging
 import os
 import socket
 

--- a/examples/distillation/utils.py
+++ b/examples/distillation/utils.py
@@ -24,13 +24,10 @@ import git
 import numpy as np
 import torch
 
+from transformers import logging as hf_logging
 
-logging.basicConfig(
-    format="%(asctime)s - %(levelname)s - %(name)s - PID: %(process)d -  %(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-    level=logging.INFO,
-)
-logger = logging.getLogger(__name__)
+
+logger = hf_logging.get_logger(__name__)
 
 
 def git_log(folder_path: str):

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -26,19 +26,6 @@ import os
 from dataclasses import dataclass, field
 from typing import Optional
 
-from transformers import logging as hf_logging
-
-
-handler = logging.StreamHandler()
-formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
-handler.setFormatter(formatter)
-
-logger = hf_logging.get_logger()
-
-logger.handlers.clear()
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
-
 from transformers import (
     CONFIG_MAPPING,
     MODEL_WITH_LM_HEAD_MAPPING,
@@ -53,8 +40,20 @@ from transformers import (
     TextDataset,
     Trainer,
     TrainingArguments,
-    set_seed,
 )
+from transformers import logging as hf_logging
+from transformers import set_seed
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 MODEL_CONFIG_CLASSES = list(MODEL_WITH_LM_HEAD_MAPPING.keys())

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -26,6 +26,19 @@ import os
 from dataclasses import dataclass, field
 from typing import Optional
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import (
     CONFIG_MAPPING,
     MODEL_WITH_LM_HEAD_MAPPING,
@@ -42,9 +55,6 @@ from transformers import (
     TrainingArguments,
     set_seed,
 )
-
-
-logger = logging.getLogger(__name__)
 
 
 MODEL_CONFIG_CLASSES = list(MODEL_WITH_LM_HEAD_MAPPING.keys())

--- a/examples/lightning_base.py
+++ b/examples/lightning_base.py
@@ -1,5 +1,4 @@
 import argparse
-import logging
 import os
 from pathlib import Path
 from typing import Any, Dict
@@ -21,6 +20,7 @@ from transformers import (
     PretrainedConfig,
     PreTrainedTokenizer,
 )
+from transformers import logging as hf_logging
 from transformers.optimization import (
     Adafactor,
     get_cosine_schedule_with_warmup,
@@ -30,7 +30,7 @@ from transformers.optimization import (
 )
 
 
-logger = logging.getLogger(__name__)
+logger = hf_logging.get_logger(__name__)
 
 
 MODEL_MODES = {

--- a/examples/movement-pruning/emmental/configuration_bert_masked.py
+++ b/examples/movement-pruning/emmental/configuration_bert_masked.py
@@ -17,12 +17,11 @@
 and adapts it to the specificities of MaskedBert (`pruning_method`, `mask_init` and `mask_scale`."""
 
 
-import logging
-
+from transformers import logging as hf_logging
 from transformers.configuration_utils import PretrainedConfig
 
 
-logger = logging.getLogger(__name__)
+logger = hf_logging.get_logger(__name__)
 
 
 class MaskedBertConfig(PretrainedConfig):

--- a/examples/movement-pruning/emmental/modeling_bert_masked.py
+++ b/examples/movement-pruning/emmental/modeling_bert_masked.py
@@ -18,8 +18,6 @@
 compute the adaptive mask.
 Built on top of `transformers.modeling_bert`"""
 
-
-import logging
 import math
 
 import torch
@@ -28,12 +26,13 @@ from torch.nn import CrossEntropyLoss, MSELoss
 
 from emmental import MaskedBertConfig
 from emmental.modules import MaskedLinear
+from transformers import logging as hf_logging
 from transformers.file_utils import add_start_docstrings, add_start_docstrings_to_callable
 from transformers.modeling_bert import ACT2FN, BertLayerNorm, load_tf_weights_in_bert
 from transformers.modeling_utils import PreTrainedModel, prune_linear_layer
 
 
-logger = logging.getLogger(__name__)
+logger = hf_logging.get_logger(__name__)
 
 
 class BertEmbeddings(nn.Module):

--- a/examples/movement-pruning/masked_run_glue.py
+++ b/examples/movement-pruning/masked_run_glue.py
@@ -30,6 +30,19 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, Tenso
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from emmental import MaskedBertConfig, MaskedBertForSequenceClassification
 from transformers import (
     WEIGHTS_NAME,
@@ -50,8 +63,6 @@ try:
 except ImportError:
     from tensorboardX import SummaryWriter
 
-
-logger = logging.getLogger(__name__)
 
 MODEL_CLASSES = {
     "bert": (BertConfig, BertForSequenceClassification, BertTokenizer),
@@ -934,7 +945,7 @@ def main():
             checkpoints = list(
                 os.path.dirname(c) for c in sorted(glob.glob(args.output_dir + "/**/" + WEIGHTS_NAME, recursive=True))
             )
-
+            hf_logging.get_logger("transformers.modeling_utils").setLevel(logging.WARN)  # Reduce logging
         logger.info("Evaluate the following checkpoints: %s", checkpoints)
         for checkpoint in checkpoints:
             global_step = checkpoint.split("-")[-1] if len(checkpoints) > 1 else ""

--- a/examples/movement-pruning/masked_run_glue.py
+++ b/examples/movement-pruning/masked_run_glue.py
@@ -30,19 +30,6 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, Tenso
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
-from transformers import logging as hf_logging
-
-
-handler = logging.StreamHandler()
-formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
-handler.setFormatter(formatter)
-
-logger = hf_logging.get_logger()
-
-logger.handlers.clear()
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
-
 from emmental import MaskedBertConfig, MaskedBertForSequenceClassification
 from transformers import (
     WEIGHTS_NAME,
@@ -56,12 +43,24 @@ from transformers import glue_compute_metrics as compute_metrics
 from transformers import glue_convert_examples_to_features as convert_examples_to_features
 from transformers import glue_output_modes as output_modes
 from transformers import glue_processors as processors
+from transformers import logging as hf_logging
 
 
 try:
     from torch.utils.tensorboard import SummaryWriter
 except ImportError:
     from tensorboardX import SummaryWriter
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 MODEL_CLASSES = {

--- a/examples/movement-pruning/masked_run_squad.py
+++ b/examples/movement-pruning/masked_run_squad.py
@@ -31,19 +31,6 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
-from transformers import logging as hf_logging
-
-
-handler = logging.StreamHandler()
-formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
-handler.setFormatter(formatter)
-
-logger = hf_logging.get_logger()
-
-logger.handlers.clear()
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
-
 from emmental import MaskedBertConfig, MaskedBertForQuestionAnswering
 from transformers import (
     WEIGHTS_NAME,
@@ -52,8 +39,9 @@ from transformers import (
     BertForQuestionAnswering,
     BertTokenizer,
     get_linear_schedule_with_warmup,
-    squad_convert_examples_to_features,
 )
+from transformers import logging as hf_logging
+from transformers import squad_convert_examples_to_features
 from transformers.data.metrics.squad_metrics import (
     compute_predictions_log_probs,
     compute_predictions_logits,
@@ -66,6 +54,17 @@ try:
     from torch.utils.tensorboard import SummaryWriter
 except ImportError:
     from tensorboardX import SummaryWriter
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 MODEL_CLASSES = {

--- a/examples/movement-pruning/masked_run_squad.py
+++ b/examples/movement-pruning/masked_run_squad.py
@@ -31,6 +31,19 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from emmental import MaskedBertConfig, MaskedBertForQuestionAnswering
 from transformers import (
     WEIGHTS_NAME,
@@ -54,8 +67,6 @@ try:
 except ImportError:
     from tensorboardX import SummaryWriter
 
-
-logger = logging.getLogger(__name__)
 
 MODEL_CLASSES = {
     "bert": (BertConfig, BertForQuestionAnswering, BertTokenizer),
@@ -1098,7 +1109,9 @@ def main():
                     os.path.dirname(c)
                     for c in sorted(glob.glob(args.output_dir + "/**/" + WEIGHTS_NAME, recursive=True))
                 )
-
+                hf_logging.get_logger("transformers.modeling_utils").setLevel(
+                    logging.WARN
+                )  # Reduce model loading logs
         else:
             logger.info("Loading checkpoint %s for evaluation", args.model_name_or_path)
             checkpoints = [args.model_name_or_path]

--- a/examples/multiple-choice/run_multiple_choice.py
+++ b/examples/multiple-choice/run_multiple_choice.py
@@ -23,6 +23,19 @@ from typing import Dict, Optional
 
 import numpy as np
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import (
     AutoConfig,
     AutoModelForMultipleChoice,
@@ -34,9 +47,6 @@ from transformers import (
     set_seed,
 )
 from utils_multiple_choice import MultipleChoiceDataset, Split, processors
-
-
-logger = logging.getLogger(__name__)
 
 
 def simple_accuracy(preds, labels):

--- a/examples/multiple-choice/run_multiple_choice.py
+++ b/examples/multiple-choice/run_multiple_choice.py
@@ -23,7 +23,18 @@ from typing import Dict, Optional
 
 import numpy as np
 
+from transformers import (
+    AutoConfig,
+    AutoModelForMultipleChoice,
+    AutoTokenizer,
+    EvalPrediction,
+    HfArgumentParser,
+    Trainer,
+    TrainingArguments,
+)
 from transformers import logging as hf_logging
+from transformers import set_seed
+from utils_multiple_choice import MultipleChoiceDataset, Split, processors
 
 
 handler = logging.StreamHandler()
@@ -35,18 +46,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-from transformers import (
-    AutoConfig,
-    AutoModelForMultipleChoice,
-    AutoTokenizer,
-    EvalPrediction,
-    HfArgumentParser,
-    Trainer,
-    TrainingArguments,
-    set_seed,
-)
-from utils_multiple_choice import MultipleChoiceDataset, Split, processors
 
 
 def simple_accuracy(preds, labels):

--- a/examples/multiple-choice/run_tf_multiple_choice.py
+++ b/examples/multiple-choice/run_tf_multiple_choice.py
@@ -23,6 +23,19 @@ from typing import Dict, Optional
 
 import numpy as np
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import (
     AutoConfig,
     AutoTokenizer,
@@ -34,9 +47,6 @@ from transformers import (
     set_seed,
 )
 from utils_multiple_choice import Split, TFMultipleChoiceDataset, processors
-
-
-logger = logging.getLogger(__name__)
 
 
 def simple_accuracy(preds, labels):

--- a/examples/multiple-choice/run_tf_multiple_choice.py
+++ b/examples/multiple-choice/run_tf_multiple_choice.py
@@ -23,7 +23,18 @@ from typing import Dict, Optional
 
 import numpy as np
 
+from transformers import (
+    AutoConfig,
+    AutoTokenizer,
+    EvalPrediction,
+    HfArgumentParser,
+    TFAutoModelForMultipleChoice,
+    TFTrainer,
+    TFTrainingArguments,
+)
 from transformers import logging as hf_logging
+from transformers import set_seed
+from utils_multiple_choice import Split, TFMultipleChoiceDataset, processors
 
 
 handler = logging.StreamHandler()
@@ -35,18 +46,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-from transformers import (
-    AutoConfig,
-    AutoTokenizer,
-    EvalPrediction,
-    HfArgumentParser,
-    TFAutoModelForMultipleChoice,
-    TFTrainer,
-    TFTrainingArguments,
-    set_seed,
-)
-from utils_multiple_choice import Split, TFMultipleChoiceDataset, processors
 
 
 def simple_accuracy(preds, labels):

--- a/examples/multiple-choice/utils_multiple_choice.py
+++ b/examples/multiple-choice/utils_multiple_choice.py
@@ -19,7 +19,6 @@
 import csv
 import glob
 import json
-import logging
 import os
 from dataclasses import dataclass
 from enum import Enum
@@ -29,9 +28,10 @@ import tqdm
 
 from filelock import FileLock
 from transformers import PreTrainedTokenizer, is_tf_available, is_torch_available
+from transformers import logging as hf_logging
 
 
-logger = logging.getLogger(__name__)
+logger = hf_logging.get_logger(__name__)
 
 
 @dataclass(frozen=True)

--- a/examples/question-answering/run_squad.py
+++ b/examples/question-answering/run_squad.py
@@ -29,19 +29,6 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
-from transformers import logging as hf_logging
-
-
-handler = logging.StreamHandler()
-formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
-handler.setFormatter(formatter)
-
-logger = hf_logging.get_logger()
-
-logger.handlers.clear()
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
-
 from transformers import (
     MODEL_FOR_QUESTION_ANSWERING_MAPPING,
     WEIGHTS_NAME,
@@ -50,8 +37,9 @@ from transformers import (
     AutoModelForQuestionAnswering,
     AutoTokenizer,
     get_linear_schedule_with_warmup,
-    squad_convert_examples_to_features,
 )
+from transformers import logging as hf_logging
+from transformers import squad_convert_examples_to_features
 from transformers.data.metrics.squad_metrics import (
     compute_predictions_log_probs,
     compute_predictions_logits,
@@ -64,6 +52,17 @@ try:
     from torch.utils.tensorboard import SummaryWriter
 except ImportError:
     from tensorboardX import SummaryWriter
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 MODEL_CONFIG_CLASSES = list(MODEL_FOR_QUESTION_ANSWERING_MAPPING.keys())

--- a/examples/question-answering/run_squad.py
+++ b/examples/question-answering/run_squad.py
@@ -29,6 +29,19 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import (
     MODEL_FOR_QUESTION_ANSWERING_MAPPING,
     WEIGHTS_NAME,
@@ -52,8 +65,6 @@ try:
 except ImportError:
     from tensorboardX import SummaryWriter
 
-
-logger = logging.getLogger(__name__)
 
 MODEL_CONFIG_CLASSES = list(MODEL_FOR_QUESTION_ANSWERING_MAPPING.keys())
 MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
@@ -792,7 +803,9 @@ def main():
                     os.path.dirname(c)
                     for c in sorted(glob.glob(args.output_dir + "/**/" + WEIGHTS_NAME, recursive=True))
                 )
-
+                hf_logging.get_logger("transformers.modeling_utils").setLevel(
+                    logging.WARN
+                )  # Reduce model loading logs
         else:
             logger.info("Loading checkpoint %s for evaluation", args.model_name_or_path)
             checkpoints = [args.model_name_or_path]

--- a/examples/question-answering/run_squad_trainer.py
+++ b/examples/question-answering/run_squad_trainer.py
@@ -22,12 +22,22 @@ import sys
 from dataclasses import dataclass, field
 from typing import Optional
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import AutoConfig, AutoModelForQuestionAnswering, AutoTokenizer, HfArgumentParser, SquadDataset
 from transformers import SquadDataTrainingArguments as DataTrainingArguments
 from transformers import Trainer, TrainingArguments
-
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/examples/question-answering/run_squad_trainer.py
+++ b/examples/question-answering/run_squad_trainer.py
@@ -22,6 +22,9 @@ import sys
 from dataclasses import dataclass, field
 from typing import Optional
 
+from transformers import AutoConfig, AutoModelForQuestionAnswering, AutoTokenizer, HfArgumentParser, SquadDataset
+from transformers import SquadDataTrainingArguments as DataTrainingArguments
+from transformers import Trainer, TrainingArguments
 from transformers import logging as hf_logging
 
 
@@ -34,10 +37,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-from transformers import AutoConfig, AutoModelForQuestionAnswering, AutoTokenizer, HfArgumentParser, SquadDataset
-from transformers import SquadDataTrainingArguments as DataTrainingArguments
-from transformers import Trainer, TrainingArguments
 
 
 @dataclass

--- a/examples/question-answering/run_tf_squad.py
+++ b/examples/question-answering/run_tf_squad.py
@@ -23,7 +23,17 @@ from typing import Optional
 
 import tensorflow as tf
 
+from transformers import (
+    AutoConfig,
+    AutoTokenizer,
+    HfArgumentParser,
+    TFAutoModelForQuestionAnswering,
+    TFTrainer,
+    TFTrainingArguments,
+)
 from transformers import logging as hf_logging
+from transformers import squad_convert_examples_to_features
+from transformers.data.processors.squad import SquadV1Processor, SquadV2Processor
 
 
 handler = logging.StreamHandler()
@@ -35,17 +45,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-from transformers import (
-    AutoConfig,
-    AutoTokenizer,
-    HfArgumentParser,
-    TFAutoModelForQuestionAnswering,
-    TFTrainer,
-    TFTrainingArguments,
-    squad_convert_examples_to_features,
-)
-from transformers.data.processors.squad import SquadV1Processor, SquadV2Processor
 
 
 @dataclass

--- a/examples/question-answering/run_tf_squad.py
+++ b/examples/question-answering/run_tf_squad.py
@@ -23,6 +23,19 @@ from typing import Optional
 
 import tensorflow as tf
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import (
     AutoConfig,
     AutoTokenizer,
@@ -33,9 +46,6 @@ from transformers import (
     squad_convert_examples_to_features,
 )
 from transformers.data.processors.squad import SquadV1Processor, SquadV2Processor
-
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/examples/seq2seq/bertabs/configuration_bertabs.py
+++ b/examples/seq2seq/bertabs/configuration_bertabs.py
@@ -14,12 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ BertAbs configuration """
-import logging
-
 from transformers import PretrainedConfig
+from transformers import logging as hf_logging
 
 
-logger = logging.getLogger(__name__)
+logger = hf_logging.get_logger(__name__)
 
 
 BERTABS_FINETUNED_CONFIG_MAP = {

--- a/examples/seq2seq/bertabs/convert_bertabs_original_pytorch_checkpoint.py
+++ b/examples/seq2seq/bertabs/convert_bertabs_original_pytorch_checkpoint.py
@@ -28,11 +28,18 @@ import torch
 from model_bertabs import BertAbsSummarizer
 from models.model_builder import AbsSummarizer  # The authors' implementation
 from transformers import BertTokenizer
+from transformers import logging as hf_logging
 
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
 
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 SAMPLE_TEXT = "Hello world! cécé herlolip"
 

--- a/examples/seq2seq/bertabs/run_summarization.py
+++ b/examples/seq2seq/bertabs/run_summarization.py
@@ -9,6 +9,19 @@ import torch
 from torch.utils.data import DataLoader, SequentialSampler
 from tqdm import tqdm
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from modeling_bertabs import BertAbs, build_predictor
 from transformers import BertTokenizer
 
@@ -19,10 +32,6 @@ from .utils_summarization import (
     encode_for_summarization,
     truncate_or_pad,
 )
-
-
-logger = logging.getLogger(__name__)
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 
 Batch = namedtuple("Batch", ["document_names", "batch_size", "src", "segs", "mask_src", "tgt_str"])

--- a/examples/seq2seq/bertabs/run_summarization.py
+++ b/examples/seq2seq/bertabs/run_summarization.py
@@ -2,14 +2,23 @@
 import argparse
 import logging
 import os
-import sys
 from collections import namedtuple
 
 import torch
 from torch.utils.data import DataLoader, SequentialSampler
 from tqdm import tqdm
 
+from modeling_bertabs import BertAbs, build_predictor
+from transformers import BertTokenizer
 from transformers import logging as hf_logging
+
+from .utils_summarization import (
+    CNNDMDataset,
+    build_mask,
+    compute_token_type_ids,
+    encode_for_summarization,
+    truncate_or_pad,
+)
 
 
 handler = logging.StreamHandler()
@@ -21,17 +30,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-from modeling_bertabs import BertAbs, build_predictor
-from transformers import BertTokenizer
-
-from .utils_summarization import (
-    CNNDMDataset,
-    build_mask,
-    compute_token_type_ids,
-    encode_for_summarization,
-    truncate_or_pad,
-)
 
 
 Batch = namedtuple("Batch", ["document_names", "batch_size", "src", "segs", "mask_src", "tgt_str"])

--- a/examples/seq2seq/callbacks.py
+++ b/examples/seq2seq/callbacks.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from pathlib import Path
 
@@ -8,6 +7,8 @@ import torch
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
 from pytorch_lightning.utilities import rank_zero_only
 
+from transformers import logging as hf_logging
+
 
 def count_trainable_parameters(model):
     model_parameters = filter(lambda p: p.requires_grad, model.parameters())
@@ -15,7 +16,7 @@ def count_trainable_parameters(model):
     return params
 
 
-logger = logging.getLogger(__name__)
+logger = hf_logging.get_logger(__name__)
 
 
 class Seq2SeqLoggingCallback(pl.Callback):

--- a/examples/seq2seq/convert_pl_checkpoint_to_hf.py
+++ b/examples/seq2seq/convert_pl_checkpoint_to_hf.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 from typing import Dict, List

--- a/examples/seq2seq/convert_pl_checkpoint_to_hf.py
+++ b/examples/seq2seq/convert_pl_checkpoint_to_hf.py
@@ -6,10 +6,18 @@ import fire
 import torch
 
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
-from transformers.utils.logging import get_logger
+from transformers import logging as hf_logging
 
 
-logger = get_logger(__name__)
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 def remove_prefix(text: str, prefix: str):

--- a/examples/seq2seq/finetune.py
+++ b/examples/seq2seq/finetune.py
@@ -14,7 +14,19 @@ from torch.utils.data import DataLoader
 
 from lightning_base import BaseTransformer, add_generic_args, generic_train
 from transformers import MBartTokenizer, T5ForConditionalGeneration
+from transformers import logging as hf_logging
 from transformers.modeling_bart import shift_tokens_right
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 try:
@@ -55,8 +67,6 @@ except ImportError:
         save_json,
         use_task_specific_params,
     )
-
-logger = logging.getLogger(__name__)
 
 
 class SummarizationModule(BaseTransformer):

--- a/examples/seq2seq/run_distributed_eval.py
+++ b/examples/seq2seq/run_distributed_eval.py
@@ -13,26 +13,6 @@ from tqdm import tqdm
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 from transformers import logging as hf_logging
 
-
-try:
-    from .utils import Seq2SeqDataset, parse_numeric_cl_kwargs, save_json, use_task_specific_params
-except ImportError:
-    from utils import Seq2SeqDataset, parse_numeric_cl_kwargs, save_json, use_task_specific_params
-
-
-handler = logging.StreamHandler()
-formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
-handler.setFormatter(formatter)
-
-logger = hf_logging.get_logger()
-
-logger.handlers.clear()
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
-
-from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
-
-
 try:
     from .utils import (
         Seq2SeqDataset,
@@ -57,6 +37,17 @@ except ImportError:
         use_task_specific_params,
         write_txt_file,
     )
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 DEFAULT_DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 

--- a/examples/seq2seq/run_distributed_eval.py
+++ b/examples/seq2seq/run_distributed_eval.py
@@ -1,8 +1,8 @@
 import argparse
+import logging
+from json import JSONDecodeError
 import shutil
 import time
-from json import JSONDecodeError
-from logging import getLogger
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -10,10 +10,21 @@ import torch
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 
-
-logger = getLogger(__name__)
 
 try:
     from .utils import (

--- a/examples/seq2seq/run_distributed_eval.py
+++ b/examples/seq2seq/run_distributed_eval.py
@@ -13,6 +13,7 @@ from tqdm import tqdm
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 from transformers import logging as hf_logging
 
+
 try:
     from .utils import (
         Seq2SeqDataset,

--- a/examples/seq2seq/run_distributed_eval.py
+++ b/examples/seq2seq/run_distributed_eval.py
@@ -10,7 +10,14 @@ import torch
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 from transformers import logging as hf_logging
+
+
+try:
+    from .utils import Seq2SeqDataset, parse_numeric_cl_kwargs, save_json, use_task_specific_params
+except ImportError:
+    from utils import Seq2SeqDataset, parse_numeric_cl_kwargs, save_json, use_task_specific_params
 
 
 handler = logging.StreamHandler()
@@ -24,7 +31,6 @@ logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
-
 
 try:
     from .utils import (
@@ -50,6 +56,8 @@ except ImportError:
         use_task_specific_params,
         write_txt_file,
     )
+
+DEFAULT_DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
 
 def eval_data_dir(

--- a/examples/seq2seq/run_distributed_eval.py
+++ b/examples/seq2seq/run_distributed_eval.py
@@ -1,8 +1,8 @@
 import argparse
 import logging
-from json import JSONDecodeError
 import shutil
 import time
+from json import JSONDecodeError
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -31,6 +31,7 @@ logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+
 
 try:
     from .utils import (

--- a/examples/seq2seq/run_eval.py
+++ b/examples/seq2seq/run_eval.py
@@ -1,18 +1,29 @@
 import argparse
 import json
+import logging
 import time
 import warnings
-from logging import getLogger
 from pathlib import Path
 from typing import Dict, List
 
 import torch
 from tqdm import tqdm
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 
-
-logger = getLogger(__name__)
 
 try:
     from .utils import calculate_bleu, calculate_rouge, parse_numeric_cl_kwargs, use_task_specific_params

--- a/examples/seq2seq/run_eval.py
+++ b/examples/seq2seq/run_eval.py
@@ -9,7 +9,14 @@ from typing import Dict, List
 import torch
 from tqdm import tqdm
 
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 from transformers import logging as hf_logging
+
+
+try:
+    from .utils import calculate_bleu, calculate_rouge, parse_numeric_cl_kwargs, use_task_specific_params
+except ImportError:
+    from utils import calculate_bleu, calculate_rouge, parse_numeric_cl_kwargs, use_task_specific_params
 
 
 handler = logging.StreamHandler()
@@ -22,13 +29,6 @@ logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 
-from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
-
-
-try:
-    from .utils import calculate_bleu, calculate_rouge, parse_numeric_cl_kwargs, use_task_specific_params
-except ImportError:
-    from utils import calculate_bleu, calculate_rouge, parse_numeric_cl_kwargs, use_task_specific_params
 
 DEFAULT_DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 

--- a/examples/seq2seq/test_seq2seq_examples.py
+++ b/examples/seq2seq/test_seq2seq_examples.py
@@ -12,7 +12,19 @@ import pytorch_lightning as pl
 import torch
 from torch.utils.data import DataLoader
 
+import lightning_base
+from transformers import AutoConfig, AutoModelForSeq2SeqLM, AutoTokenizer
 from transformers import logging as hf_logging
+from transformers.hf_api import HfApi
+from transformers.modeling_bart import shift_tokens_right
+from transformers.testing_utils import CaptureStderr, CaptureStdout, require_multigpu, require_torch_and_cuda, slow
+
+from .convert_pl_checkpoint_to_hf import convert_pl_to_hf
+from .distillation import distill_main, evaluate_checkpoint
+from .finetune import SummarizationModule, main
+from .pack_dataset import pack_data_dir
+from .run_eval import generate_summaries_or_translations, run_generate
+from .utils import LegacySeq2SeqDataset, Seq2SeqDataset, label_smoothed_nll_loss, lmap, load_json
 
 
 handler = logging.StreamHandler(sys.stdout)
@@ -24,19 +36,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.DEBUG)
-
-import lightning_base
-from transformers import AutoConfig, AutoModelForSeq2SeqLM, AutoTokenizer
-from transformers.hf_api import HfApi
-from transformers.modeling_bart import shift_tokens_right
-from transformers.testing_utils import CaptureStderr, CaptureStdout, require_multigpu, require_torch_and_cuda, slow
-
-from .convert_pl_checkpoint_to_hf import convert_pl_to_hf
-from .distillation import distill_main, evaluate_checkpoint
-from .finetune import SummarizationModule, main
-from .pack_dataset import pack_data_dir
-from .run_eval import generate_summaries_or_translations, run_generate
-from .utils import LegacySeq2SeqDataset, Seq2SeqDataset, label_smoothed_nll_loss, lmap, load_json
 
 
 CUDA_AVAILABLE = torch.cuda.is_available()

--- a/examples/seq2seq/test_seq2seq_examples.py
+++ b/examples/seq2seq/test_seq2seq_examples.py
@@ -12,6 +12,19 @@ import pytorch_lightning as pl
 import torch
 from torch.utils.data import DataLoader
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)
+
 import lightning_base
 from transformers import AutoConfig, AutoModelForSeq2SeqLM, AutoTokenizer
 from transformers.hf_api import HfApi
@@ -26,9 +39,6 @@ from .run_eval import generate_summaries_or_translations, run_generate
 from .utils import LegacySeq2SeqDataset, Seq2SeqDataset, label_smoothed_nll_loss, lmap, load_json
 
 
-logging.basicConfig(level=logging.DEBUG)
-
-logger = logging.getLogger()
 CUDA_AVAILABLE = torch.cuda.is_available()
 CHEAP_ARGS = {
     "supervise_forward": True,

--- a/examples/seq2seq/utils.py
+++ b/examples/seq2seq/utils.py
@@ -18,12 +18,10 @@ from torch.utils.data import Dataset, Sampler
 
 from transformers import BartTokenizer
 from transformers import logging as hf_logging
+from transformers.file_utils import cached_property
 
 
 logger = hf_logging.get_logger(__name__)
-
-from transformers import BartTokenizer
-from transformers.file_utils import cached_property
 
 
 def label_smoothed_nll_loss(lprobs, target, epsilon, ignore_index=-100):

--- a/examples/seq2seq/utils.py
+++ b/examples/seq2seq/utils.py
@@ -16,6 +16,7 @@ from sacrebleu import corpus_bleu
 from torch import nn
 from torch.utils.data import Dataset, Sampler
 
+from transformers import BartTokenizer
 from transformers import logging as hf_logging
 
 

--- a/examples/seq2seq/utils.py
+++ b/examples/seq2seq/utils.py
@@ -4,7 +4,6 @@ import linecache
 import math
 import os
 import pickle
-from logging import getLogger
 from pathlib import Path
 from typing import Callable, Dict, Iterable, List, Union
 
@@ -16,6 +15,11 @@ from rouge_score import rouge_scorer, scoring
 from sacrebleu import corpus_bleu
 from torch import nn
 from torch.utils.data import Dataset, Sampler
+
+from transformers import logging as hf_logging
+
+
+logger = hf_logging.get_logger(__name__)
 
 from transformers import BartTokenizer
 from transformers.file_utils import cached_property
@@ -272,9 +276,6 @@ class DistributedSortishSampler(Sampler):
 
     def set_epoch(self, epoch):
         self.epoch = epoch
-
-
-logger = getLogger(__name__)
 
 
 def use_task_specific_params(model, task):

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -22,8 +22,20 @@ from unittest.mock import patch
 
 import torch
 
+from transformers import logging as hf_logging
 from transformers.file_utils import is_apex_available
 from transformers.testing_utils import TestCasePlus, torch_device
+
+
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)
 
 
 SRC_DIRS = [
@@ -39,19 +51,6 @@ if SRC_DIRS is not None:
     import run_language_modeling
     import run_pl_glue
     import run_squad
-
-from transformers import logging as hf_logging
-
-
-handler = logging.StreamHandler(sys.stdout)
-formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
-handler.setFormatter(formatter)
-
-logger = hf_logging.get_logger()
-
-logger.handlers.clear()
-logger.addHandler(handler)
-logger.setLevel(logging.DEBUG)
 
 
 def get_setup_file():

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -40,10 +40,18 @@ if SRC_DIRS is not None:
     import run_pl_glue
     import run_squad
 
+from transformers import logging as hf_logging
 
-logging.basicConfig(level=logging.DEBUG)
 
-logger = logging.getLogger()
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)
 
 
 def get_setup_file():

--- a/examples/test_xla_examples.py
+++ b/examples/test_xla_examples.py
@@ -20,12 +20,19 @@ import unittest
 from time import time
 from unittest.mock import patch
 
+from transformers import logging as hf_logging
 from transformers.testing_utils import require_torch_tpu
 
 
-logging.basicConfig(level=logging.DEBUG)
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
 
-logger = logging.getLogger()
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)
 
 
 @require_torch_tpu

--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -25,7 +25,18 @@ from typing import Callable, Dict, Optional
 
 import numpy as np
 
+from transformers import AutoConfig, AutoModelForSequenceClassification, AutoTokenizer, EvalPrediction, GlueDataset
+from transformers import GlueDataTrainingArguments as DataTrainingArguments
+from transformers import (
+    HfArgumentParser,
+    Trainer,
+    TrainingArguments,
+    glue_compute_metrics,
+    glue_output_modes,
+    glue_tasks_num_labels,
+)
 from transformers import logging as hf_logging
+from transformers import set_seed
 
 
 handler = logging.StreamHandler()
@@ -37,18 +48,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-from transformers import AutoConfig, AutoModelForSequenceClassification, AutoTokenizer, EvalPrediction, GlueDataset
-from transformers import GlueDataTrainingArguments as DataTrainingArguments
-from transformers import (
-    HfArgumentParser,
-    Trainer,
-    TrainingArguments,
-    glue_compute_metrics,
-    glue_output_modes,
-    glue_tasks_num_labels,
-    set_seed,
-)
 
 
 @dataclass

--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -25,6 +25,19 @@ from typing import Callable, Dict, Optional
 
 import numpy as np
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import AutoConfig, AutoModelForSequenceClassification, AutoTokenizer, EvalPrediction, GlueDataset
 from transformers import GlueDataTrainingArguments as DataTrainingArguments
 from transformers import (
@@ -36,9 +49,6 @@ from transformers import (
     glue_tasks_num_labels,
     set_seed,
 )
-
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/examples/text-classification/run_pl_glue.py
+++ b/examples/text-classification/run_pl_glue.py
@@ -9,6 +9,12 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader, TensorDataset
 
+from lightning_base import BaseTransformer, add_generic_args, generic_train
+from transformers import glue_compute_metrics as compute_metrics
+from transformers import glue_convert_examples_to_features as convert_examples_to_features
+from transformers import glue_output_modes
+from transformers import glue_processors as processors
+from transformers import glue_tasks_num_labels
 from transformers import logging as hf_logging
 
 
@@ -21,13 +27,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-from lightning_base import BaseTransformer, add_generic_args, generic_train
-from transformers import glue_compute_metrics as compute_metrics
-from transformers import glue_convert_examples_to_features as convert_examples_to_features
-from transformers import glue_output_modes
-from transformers import glue_processors as processors
-from transformers import glue_tasks_num_labels
 
 
 class GLUETransformer(BaseTransformer):

--- a/examples/text-classification/run_pl_glue.py
+++ b/examples/text-classification/run_pl_glue.py
@@ -9,15 +9,25 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader, TensorDataset
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from lightning_base import BaseTransformer, add_generic_args, generic_train
 from transformers import glue_compute_metrics as compute_metrics
 from transformers import glue_convert_examples_to_features as convert_examples_to_features
 from transformers import glue_output_modes
 from transformers import glue_processors as processors
 from transformers import glue_tasks_num_labels
-
-
-logger = logging.getLogger(__name__)
 
 
 class GLUETransformer(BaseTransformer):

--- a/examples/text-classification/run_tf_glue.py
+++ b/examples/text-classification/run_tf_glue.py
@@ -8,19 +8,6 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Optional
 
-from transformers import logging as hf_logging
-
-
-handler = logging.StreamHandler()
-formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
-handler.setFormatter(formatter)
-
-logger = hf_logging.get_logger()
-
-logger.handlers.clear()
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
-
 import numpy as np
 import tensorflow as tf
 import tensorflow_datasets as tfds
@@ -40,6 +27,18 @@ from transformers import (
     glue_processors,
     glue_tasks_num_labels,
 )
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 class Split(Enum):

--- a/examples/text-classification/run_tf_glue.py
+++ b/examples/text-classification/run_tf_glue.py
@@ -8,6 +8,19 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Optional
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 import numpy as np
 import tensorflow as tf
 import tensorflow_datasets as tfds
@@ -60,9 +73,6 @@ def get_tfds(
     ds = ds.apply(tf.data.experimental.assert_cardinality(info.splits[mode.value].num_examples))
 
     return ds
-
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/examples/text-classification/run_xnli.py
+++ b/examples/text-classification/run_xnli.py
@@ -29,7 +29,25 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, Tenso
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
+from transformers import (
+    WEIGHTS_NAME,
+    AdamW,
+    AutoConfig,
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    get_linear_schedule_with_warmup,
+)
+from transformers import glue_convert_examples_to_features as convert_examples_to_features
 from transformers import logging as hf_logging
+from transformers import xnli_compute_metrics as compute_metrics
+from transformers import xnli_output_modes as output_modes
+from transformers import xnli_processors as processors
+
+
+try:
+    from torch.utils.tensorboard import SummaryWriter
+except ImportError:
+    from tensorboardX import SummaryWriter
 
 
 handler = logging.StreamHandler()
@@ -41,25 +59,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-from transformers import (
-    WEIGHTS_NAME,
-    AdamW,
-    AutoConfig,
-    AutoModelForSequenceClassification,
-    AutoTokenizer,
-    get_linear_schedule_with_warmup,
-)
-from transformers import glue_convert_examples_to_features as convert_examples_to_features
-from transformers import xnli_compute_metrics as compute_metrics
-from transformers import xnli_output_modes as output_modes
-from transformers import xnli_processors as processors
-
-
-try:
-    from torch.utils.tensorboard import SummaryWriter
-except ImportError:
-    from tensorboardX import SummaryWriter
 
 
 def set_seed(args):

--- a/examples/text-classification/run_xnli.py
+++ b/examples/text-classification/run_xnli.py
@@ -29,6 +29,19 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, Tenso
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import (
     WEIGHTS_NAME,
     AdamW,
@@ -47,9 +60,6 @@ try:
     from torch.utils.tensorboard import SummaryWriter
 except ImportError:
     from tensorboardX import SummaryWriter
-
-
-logger = logging.getLogger(__name__)
 
 
 def set_seed(args):
@@ -602,7 +612,7 @@ def main():
             checkpoints = list(
                 os.path.dirname(c) for c in sorted(glob.glob(args.output_dir + "/**/" + WEIGHTS_NAME, recursive=True))
             )
-
+            hf_logging.get_logger("transformers.modeling_utils").setLevel(logging.WARN)  # Reduce logging
         logger.info("Evaluate the following checkpoints: %s", checkpoints)
         for checkpoint in checkpoints:
             global_step = checkpoint.split("-")[-1] if len(checkpoints) > 1 else ""

--- a/examples/text-generation/run_generation.py
+++ b/examples/text-generation/run_generation.py
@@ -38,14 +38,18 @@ from transformers import (
     XLNetLMHeadModel,
     XLNetTokenizer,
 )
+from transformers import logging as hf_logging
 
 
-logging.basicConfig(
-    format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-    level=logging.INFO,
-)
-logger = logging.getLogger(__name__)
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 MAX_LENGTH = int(10000)  # Hardcoded max length to avoid infinite loop
 

--- a/examples/token-classification/run_ner.py
+++ b/examples/token-classification/run_ner.py
@@ -25,6 +25,19 @@ import numpy as np
 from seqeval.metrics import accuracy_score, f1_score, precision_score, recall_score
 from torch import nn
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import (
     AutoConfig,
     AutoModelForTokenClassification,
@@ -36,9 +49,6 @@ from transformers import (
     set_seed,
 )
 from utils_ner import Split, TokenClassificationDataset, TokenClassificationTask
-
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/examples/token-classification/run_ner.py
+++ b/examples/token-classification/run_ner.py
@@ -25,7 +25,18 @@ import numpy as np
 from seqeval.metrics import accuracy_score, f1_score, precision_score, recall_score
 from torch import nn
 
+from transformers import (
+    AutoConfig,
+    AutoModelForTokenClassification,
+    AutoTokenizer,
+    EvalPrediction,
+    HfArgumentParser,
+    Trainer,
+    TrainingArguments,
+)
 from transformers import logging as hf_logging
+from transformers import set_seed
+from utils_ner import Split, TokenClassificationDataset, TokenClassificationTask
 
 
 handler = logging.StreamHandler()
@@ -37,18 +48,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-from transformers import (
-    AutoConfig,
-    AutoModelForTokenClassification,
-    AutoTokenizer,
-    EvalPrediction,
-    HfArgumentParser,
-    Trainer,
-    TrainingArguments,
-    set_seed,
-)
-from utils_ner import Split, TokenClassificationDataset, TokenClassificationTask
 
 
 @dataclass

--- a/examples/token-classification/run_pl_ner.py
+++ b/examples/token-classification/run_pl_ner.py
@@ -11,11 +11,21 @@ from seqeval.metrics import accuracy_score, f1_score, precision_score, recall_sc
 from torch.nn import CrossEntropyLoss
 from torch.utils.data import DataLoader, TensorDataset
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from lightning_base import BaseTransformer, add_generic_args, generic_train
 from utils_ner import TokenClassificationTask
-
-
-logger = logging.getLogger(__name__)
 
 
 class NERTransformer(BaseTransformer):

--- a/examples/token-classification/run_pl_ner.py
+++ b/examples/token-classification/run_pl_ner.py
@@ -11,7 +11,9 @@ from seqeval.metrics import accuracy_score, f1_score, precision_score, recall_sc
 from torch.nn import CrossEntropyLoss
 from torch.utils.data import DataLoader, TensorDataset
 
+from lightning_base import BaseTransformer, add_generic_args, generic_train
 from transformers import logging as hf_logging
+from utils_ner import TokenClassificationTask
 
 
 handler = logging.StreamHandler()
@@ -23,9 +25,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-from lightning_base import BaseTransformer, add_generic_args, generic_train
-from utils_ner import TokenClassificationTask
 
 
 class NERTransformer(BaseTransformer):

--- a/examples/token-classification/run_tf_ner.py
+++ b/examples/token-classification/run_tf_ner.py
@@ -31,7 +31,7 @@ handler = logging.StreamHandler()
 formatter = logging.Formatter('[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s')
 handler.setFormatter(formatter)
 
-logger = hf_logging.getLogger()
+logger = hf_logging.get_logger()
 
 logger.handlers.clear()
 logger.addHandler(handler)

--- a/examples/token-classification/run_tf_ner.py
+++ b/examples/token-classification/run_tf_ner.py
@@ -23,12 +23,12 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 from seqeval.metrics import classification_report, f1_score, precision_score, recall_score
-import tensorflow as tf
 
 from transformers import logging as hf_logging
 
+
 handler = logging.StreamHandler()
-formatter = logging.Formatter('[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s')
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
 handler.setFormatter(formatter)
 
 logger = hf_logging.get_logger()
@@ -36,10 +36,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-tf.get_logger().handlers.clear()
-tf.get_logger().addHandler(handler)
-tf.get_logger().setLevel(logging.INFO)
 
 from transformers import (
     AutoConfig,

--- a/examples/token-classification/run_tf_ner.py
+++ b/examples/token-classification/run_tf_ner.py
@@ -23,6 +23,23 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 from seqeval.metrics import classification_report, f1_score, precision_score, recall_score
+import tensorflow as tf
+
+from transformers import logging as hf_logging
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter('[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s')
+handler.setFormatter(formatter)
+
+logger = hf_logging.getLogger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
+tf.get_logger().handlers.clear()
+tf.get_logger().addHandler(handler)
+tf.get_logger().setLevel(logging.INFO)
 
 from transformers import (
     AutoConfig,
@@ -34,9 +51,6 @@ from transformers import (
     TFTrainingArguments,
 )
 from utils_ner import Split, TFTokenClassificationDataset, TokenClassificationTask
-
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/examples/token-classification/run_tf_ner.py
+++ b/examples/token-classification/run_tf_ner.py
@@ -24,7 +24,17 @@ from typing import Dict, List, Optional, Tuple
 import numpy as np
 from seqeval.metrics import classification_report, f1_score, precision_score, recall_score
 
+from transformers import (
+    AutoConfig,
+    AutoTokenizer,
+    EvalPrediction,
+    HfArgumentParser,
+    TFAutoModelForTokenClassification,
+    TFTrainer,
+    TFTrainingArguments,
+)
 from transformers import logging as hf_logging
+from utils_ner import Split, TFTokenClassificationDataset, TokenClassificationTask
 
 
 handler = logging.StreamHandler()
@@ -36,17 +46,6 @@ logger = hf_logging.get_logger()
 logger.handlers.clear()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-from transformers import (
-    AutoConfig,
-    AutoTokenizer,
-    EvalPrediction,
-    HfArgumentParser,
-    TFAutoModelForTokenClassification,
-    TFTrainer,
-    TFTrainingArguments,
-)
-from utils_ner import Split, TFTokenClassificationDataset, TokenClassificationTask
 
 
 @dataclass

--- a/examples/token-classification/tasks.py
+++ b/examples/token-classification/tasks.py
@@ -1,13 +1,13 @@
-import logging
 import os
 from typing import List, TextIO, Union
 
 from conllu import parse_incr
 
+from transformers import logging as hf_logging
 from utils_ner import InputExample, Split, TokenClassificationTask
 
 
-logger = logging.getLogger(__name__)
+logger = hf_logging.get_logger(__name__)
 
 
 class NER(TokenClassificationTask):

--- a/examples/token-classification/test_ner_examples.py
+++ b/examples/token-classification/test_ner_examples.py
@@ -4,12 +4,19 @@ import unittest
 from unittest.mock import patch
 
 import run_ner
+from transformers import logging as hf_logging
 from transformers.testing_utils import slow
 
 
-logging.basicConfig(level=logging.INFO)
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
 
-logger = logging.getLogger()
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)
 
 
 class ExamplesTests(unittest.TestCase):

--- a/examples/token-classification/utils_ner.py
+++ b/examples/token-classification/utils_ner.py
@@ -27,7 +27,7 @@ from transformers import logging as hf_logging
 from transformers import PreTrainedTokenizer, is_tf_available, is_torch_available
 
 
-logger = hf_logging.getLogger()
+logger = hf_logging.get_logger()
 
 
 @dataclass

--- a/examples/token-classification/utils_ner.py
+++ b/examples/token-classification/utils_ner.py
@@ -23,10 +23,11 @@ from enum import Enum
 from typing import List, Optional, Union
 
 from filelock import FileLock
+from transformers import logging as hf_logging
 from transformers import PreTrainedTokenizer, is_tf_available, is_torch_available
 
 
-logger = logging.getLogger(__name__)
+logger = hf_logging.getLogger()
 
 
 @dataclass

--- a/examples/token-classification/utils_ner.py
+++ b/examples/token-classification/utils_ner.py
@@ -15,19 +15,17 @@
 # limitations under the License.
 """ Named entity recognition fine-tuning: utilities to work with CoNLL-2003 task. """
 
-
-import logging
 import os
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Union
 
 from filelock import FileLock
-from transformers import logging as hf_logging
 from transformers import PreTrainedTokenizer, is_tf_available, is_torch_available
+from transformers import logging as hf_logging
 
 
-logger = hf_logging.get_logger()
+logger = hf_logging.get_logger(__name__)
 
 
 @dataclass

--- a/src/transformers/configuration_lxmert.py
+++ b/src/transformers/configuration_lxmert.py
@@ -14,13 +14,11 @@
 # limitations under the License.
 """ LXMERT model configuration """
 
-
-import logging
-
 from .configuration_utils import PretrainedConfig
+from .utils import logging
 
 
-logger = logging.getLogger(__name__)
+logger = logging.get_logger(__name__)
 
 LXMERT_PRETRAINED_CONFIG_ARCHIVE_MAP = {
     "unc-nlp/lxmert-base-uncased": "",

--- a/src/transformers/modeling_lxmert.py
+++ b/src/transformers/modeling_lxmert.py
@@ -15,7 +15,6 @@
 """ PyTorch LXMERT model. """
 
 
-import logging
 import math
 import os
 from dataclasses import dataclass
@@ -35,9 +34,10 @@ from .file_utils import (
     replace_return_docstrings,
 )
 from .modeling_utils import PreTrainedModel
+from .utils import logging
 
 
-logger = logging.getLogger(__name__)
+logger = logging.get_logger(__name__)
 
 _CONFIG_FOR_DOC = "LxmertConfig"
 _TOKENIZER_FOR_DOC = "LxmertTokenizer"

--- a/src/transformers/modeling_tf_lxmert.py
+++ b/src/transformers/modeling_tf_lxmert.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 """ TF 2.0 LXMERT model. """
 
-
-import logging
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 
@@ -35,9 +33,10 @@ from .file_utils import (
     replace_return_docstrings,
 )
 from .modeling_tf_utils import TFPreTrainedModel, get_initializer, keras_serializable, shape_list
+from .utils import logging
 
 
-logger = logging.getLogger(__name__)
+logger = logging.get_logger(__name__)
 
 
 _CONFIG_FOR_DOC = "LxmertConfig"

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -29,7 +29,7 @@ from typing import Optional
 
 
 _lock = threading.Lock()
-_default_handler: Optional[logging.Handler] = None
+_root_logger = None
 
 log_levels = {
     "debug": logging.DEBUG,
@@ -60,58 +60,63 @@ def _get_default_logging_level():
 
 
 def _get_library_name() -> str:
-
     return __name__.split(".")[0]
 
 
 def _get_library_root_logger() -> logging.Logger:
-
     return logging.getLogger(_get_library_name())
 
 
 def _configure_library_root_logger() -> None:
+    global _root_logger
 
-    global _default_handler
+    if _root_logger:
+        return _root_logger
 
-    with _lock:
-        if _default_handler:
-            # This library has already configured the library root logger.
-            return
-        _default_handler = logging.StreamHandler()  # Set sys.stderr as stream.
+    _lock.acquire()
 
-        # Apply our default configuration to the library root logger.
-        library_root_logger = _get_library_root_logger()
-        library_root_logger.addHandler(_default_handler)
-        library_root_logger.setLevel(_get_default_logging_level())
-        library_root_logger.propagate = False
+    try:
+        if _root_logger:
+            return _root_logger
+
+        logger = _get_library_root_logger()
+
+        if not logging.getLogger().handlers:
+            _handler = logging.StreamHandler()
+            _handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT, None))
+            logger.addHandler(_handler)
+
+        _root_logger = logger
+
+        return _root_logger
+
+    finally:
+        _lock.release()
 
 
 def _reset_library_root_logger() -> None:
+    global _root_logger
 
-    global _default_handler
+    _lock.acquire()
 
-    with _lock:
-        if not _default_handler:
-            return
-
+    try:
         library_root_logger = _get_library_root_logger()
-        library_root_logger.removeHandler(_default_handler)
+
+        for handler in library_root_logger.handlers:
+            library_root_logger.removeHandler(handler)
+
         library_root_logger.setLevel(logging.NOTSET)
-        _default_handler = None
+    finally:
+        _lock.release()
 
 
-def get_logger(name: Optional[str] = None) -> logging.Logger:
+def get_logger() -> logging.Logger:
     """
-    Return a logger with the specified name.
+    Return a transformers root logger.
 
     This function is not supposed to be directly accessed unless you are writing a custom transformers module.
     """
-
-    if name is None:
-        name = _get_library_name()
-
-    _configure_library_root_logger()
-    return logging.getLogger(name)
+    return _configure_library_root_logger()
 
 
 def get_verbosity() -> int:
@@ -173,24 +178,6 @@ def set_verbosity_debug():
 def set_verbosity_error():
     """Set the verbosity to the :obj:`ERROR` level."""
     return set_verbosity(ERROR)
-
-
-def disable_default_handler() -> None:
-    """Disable the default handler of the HuggingFace Transformers's root logger."""
-
-    _configure_library_root_logger()
-
-    assert _default_handler is not None
-    _get_library_root_logger().removeHandler(_default_handler)
-
-
-def enable_default_handler() -> None:
-    """Enable the default handler of the HuggingFace Transformers's root logger."""
-
-    _configure_library_root_logger()
-
-    assert _default_handler is not None
-    _get_library_root_logger().addHandler(_default_handler)
 
 
 def disable_propagation() -> None:

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -110,7 +110,7 @@ def _reset_library_root_logger() -> None:
         _lock.release()
 
 
-def get_logger() -> logging.Logger:
+def get_logger(name: Optional[str]) -> logging.Logger:
     """
     Return a transformers root logger.
 

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -110,7 +110,7 @@ def _reset_library_root_logger() -> None:
         _lock.release()
 
 
-def get_logger(name: Optional[str]) -> logging.Logger:
+def get_logger(name: Optional[str] = None) -> logging.Logger:
     """
     Return a transformers root logger.
 

--- a/templates/adding_a_new_example_script/run_xxx.py
+++ b/templates/adding_a_new_example_script/run_xxx.py
@@ -27,6 +27,19 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, Tenso
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
+from transformers import logging as hf_logging
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 from transformers import (
     MODEL_FOR_QUESTION_ANSWERING_MAPPING,
     WEIGHTS_NAME,
@@ -57,8 +70,6 @@ try:
 except ImportError:
     from tensorboardX import SummaryWriter
 
-
-logger = logging.getLogger(__name__)
 
 MODEL_CONFIG_CLASSES = list(MODEL_FOR_QUESTION_ANSWERING_MAPPING.keys())
 MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
@@ -678,6 +689,7 @@ def main():
             checkpoints = list(
                 os.path.dirname(c) for c in sorted(glob.glob(args.output_dir + "/**/" + WEIGHTS_NAME, recursive=True))
             )
+            hf_logging.get_logger("transformers.modeling_utils").setLevel(logging.WARN)  # Reduce model loading logs
 
         logger.info("Evaluate the following checkpoints: %s", checkpoints)
 

--- a/templates/adding_a_new_example_script/run_xxx.py
+++ b/templates/adding_a_new_example_script/run_xxx.py
@@ -27,19 +27,6 @@ from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, Tenso
 from torch.utils.data.distributed import DistributedSampler
 from tqdm import tqdm, trange
 
-from transformers import logging as hf_logging
-
-
-handler = logging.StreamHandler()
-formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
-handler.setFormatter(formatter)
-
-logger = hf_logging.get_logger()
-
-logger.handlers.clear()
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
-
 from transformers import (
     MODEL_FOR_QUESTION_ANSWERING_MAPPING,
     WEIGHTS_NAME,
@@ -49,6 +36,7 @@ from transformers import (
     AutoTokenizer,
     get_linear_schedule_with_warmup,
 )
+from transformers import logging as hf_logging
 from utils_squad import (
     RawResult,
     RawResultExtended,
@@ -69,6 +57,17 @@ try:
     from torch.utils.tensorboard import SummaryWriter
 except ImportError:
     from tensorboardX import SummaryWriter
+
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 MODEL_CONFIG_CLASSES = list(MODEL_FOR_QUESTION_ANSWERING_MAPPING.keys())

--- a/templates/adding_a_new_example_script/utils_xxx.py
+++ b/templates/adding_a_new_example_script/utils_xxx.py
@@ -17,16 +17,16 @@
 
 import collections
 import json
-import logging
 import math
 
+from transformers import logging as hf_logging
 from transformers.tokenization_bert import BasicTokenizer, whitespace_tokenize
 
 # Required by XLNet evaluation method to compute optimal threshold (see write_predictions_extended() method)
 from utils_squad_evaluate import find_all_best_thresh_v2, get_raw_scores, make_qid_to_has_ans
 
 
-logger = logging.getLogger(__name__)
+logger = hf_logging.get_logger(__name__)
 
 
 class SquadExample(object):

--- a/templates/adding_a_new_model/configuration_xxx.py
+++ b/templates/adding_a_new_model/configuration_xxx.py
@@ -15,13 +15,13 @@
 """ XXX model configuration """
 
 
-import logging
 from typing import Callable, Union
 
 from .configuration_utils import PretrainedConfig
+from .utils import logging
 
 
-logger = logging.getLogger(__name__)
+logger = logging.get_logger(__name__)
 
 XXX_PRETRAINED_CONFIG_ARCHIVE_MAP = {
     "xxx-base-uncased": "https://s3.amazonaws.com/models.huggingface.co/bert/xxx-base-uncased-config.json",

--- a/templates/adding_a_new_model/convert_xxx_original_tf_checkpoint_to_pytorch.py
+++ b/templates/adding_a_new_model/convert_xxx_original_tf_checkpoint_to_pytorch.py
@@ -21,22 +21,31 @@ import logging
 import torch
 
 from transformers import XxxConfig, XxxForPreTraining, load_tf_weights_in_xxx
+from transformers import logging as hf_logging
 
 
-logging.basicConfig(level=logging.INFO)
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+handler.setFormatter(formatter)
+
+logger = hf_logging.get_logger()
+
+logger.handlers.clear()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 def convert_tf_checkpoint_to_pytorch(tf_checkpoint_path, config_file, pytorch_dump_path):
     # Initialise PyTorch model
     config = XxxConfig.from_json_file(config_file)
-    print("Building PyTorch model from configuration: {}".format(str(config)))
+    logger.info("Building PyTorch model from configuration: {}".format(str(config)))
     model = XxxForPreTraining(config)
 
     # Load weights from tf checkpoint
     load_tf_weights_in_xxx(model, config, tf_checkpoint_path)
 
     # Save pytorch-model
-    print("Save PyTorch model to {}".format(pytorch_dump_path))
+    logger.info("Save PyTorch model to {}".format(pytorch_dump_path))
     torch.save(model.state_dict(), pytorch_dump_path)
 
 

--- a/templates/adding_a_new_model/modeling_xxx.py
+++ b/templates/adding_a_new_model/modeling_xxx.py
@@ -37,9 +37,10 @@ from .modeling_outputs import (
     TokenClassifierOutput,
 )
 from .modeling_utils import PreTrainedModel
+from .utils import logging
 
 
-logger = logging.getLogger(__name__)
+logger = logging.get_logger(__name__)
 
 _CONFIG_FOR_DOC = "XXXConfig"
 _TOKENIZER_FOR_DOC = "XXXTokenizer"

--- a/templates/adding_a_new_model/modeling_xxx.py
+++ b/templates/adding_a_new_model/modeling_xxx.py
@@ -19,7 +19,6 @@
 ####################################################
 
 
-import logging
 import os
 
 import torch

--- a/templates/adding_a_new_model/tokenization_xxx.py
+++ b/templates/adding_a_new_model/tokenization_xxx.py
@@ -16,14 +16,14 @@
 
 
 import collections
-import logging
 import os
 from typing import List, Optional
 
 from .tokenization_utils import PreTrainedTokenizer
+from .utils import logging
 
 
-logger = logging.getLogger(__name__)
+logger = logging.get_logger(__name__)
 
 ####################################################
 # In this template, replace all the XXX (various casings) with your model name


### PR DESCRIPTION
Hello.

The current HF logger do not behave as expected. As example let's take the `run_tf_ner.py` script. With the following header:

```
import logging
import os
from dataclasses import dataclass, field
from importlib import import_module
from typing import Dict, List, Optional, Tuple

import numpy as np
from seqeval.metrics import classification_report, f1_score, precision_score, recall_score

from transformers import logging as hf_logging

handler = logging.StreamHandler()
formatter = logging.Formatter('[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s')
handler.setFormatter(formatter)

logger = hf_logging.get_logger(__name__)

logger.handlers.clear()
logger.addHandler(handler)
hf_logging.enable_propagation()
hf_logging.set_verbosity_info()
hf_logging.enable_default_handler()

from transformers import (
    AutoConfig,
    AutoTokenizer,
    EvalPrediction,
    HfArgumentParser,
    TFAutoModelForTokenClassification,
    TFTrainer,
    TFTrainingArguments,
)
from utils_ner import Split, TFTokenClassificationDataset, TokenClassificationTask
```

The formatter is fully ignored and takes the default logging format of TensorFlow.

This PR fixes the problem with the following new header:
```
import logging
import os
from dataclasses import dataclass, field
from importlib import import_module
from typing import Dict, List, Optional, Tuple

import numpy as np
from seqeval.metrics import classification_report, f1_score, precision_score, recall_score
import tensorflow as tf

from transformers import logging as hf_logging

handler = logging.StreamHandler()
formatter = logging.Formatter('[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s')
handler.setFormatter(formatter)

logger = hf_logging.get_logger()

logger.handlers.clear()
logger.addHandler(handler)
logger.setLevel(logging.INFO)

from transformers import (
    AutoConfig,
    AutoTokenizer,
    EvalPrediction,
    HfArgumentParser,
    TFAutoModelForTokenClassification,
    TFTrainer,
    TFTrainingArguments,
)
from utils_ner import Split, TFTokenClassificationDataset, TokenClassificationTask
```

But now the logger is set at library level and not at the class level anymore.

Then I wanted to know if this slitght update is a problem or if it is ok. 