### PR TITLE
[EncoderDecoderModel] fix indentation error 

### DIFF
--- a/src/transformers/modeling_encoder_decoder.py
+++ b/src/transformers/modeling_encoder_decoder.py
@@ -250,7 +250,7 @@ class EncoderDecoderModel(PreTrainedModel):
                     encoder_config.is_decoder = False
                     encoder_config.add_cross_attention = False
 
-                    kwargs_encoder["config"] = encoder_config
+                kwargs_encoder["config"] = encoder_config
 
             encoder = AutoModel.from_pretrained(encoder_pretrained_model_name_or_path, *model_args, **kwargs_encoder)
 


### PR DESCRIPTION
A statement regarding the encoder config init in `EncoderDecoderModel` was falsely indented which might lead to errors for very specific cases.
