### PR TITLE
fix the warning message of overflowed sequence

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2477,7 +2477,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
             logger.warning(
                 "Token indices sequence length is longer than the specified maximum sequence length "
                 "for this model ({} > {}). Running this sequence through the model will result in "
-                "indexing errors".format(len(ids), self.model_max_length)
+                "indexing errors".format(len(encoded_inputs["input_ids"]), self.model_max_length)
             )
 
         # Padding


### PR DESCRIPTION
This PR fixes the warning message (of _**PreTrainedTokenizerBase.prepare_for_model**_) when trying to tokenize a model with a sequence that is longer than the specified maximum sequence length.

The current warning message shows the length of the first input_ids, which can be incorrect when a pair is being encoded and the first input length doesn't exceed the limit. The desired warning message should show the overall length of the encoded ids. 