### PR TITLE
Add empty random document case to DataCollatorForNextSentencePrediction

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -505,10 +505,11 @@ class DataCollatorForNextSentencePrediction:
                         # This should rarely go for more than one iteration for large
                         # corpora. However, just to be careful, we try to make sure that
                         # the random document is not the same as the document
-                        # we're processing.
+                        # we're processing. Also check to make sure that the random document
+                        # is not empty.
                         for _ in range(10):
                             random_document_index = random.randint(0, len(examples) - 1)
-                            if random_document_index != doc_index:
+                            if random_document_index != doc_index and len(examples[random_document_index]) > 0:
                                 break
 
                         random_document = examples[random_document_index]


### PR DESCRIPTION
This PR proposes a simple fix for an issue in `DataCollatorForNextSentencePrediction` that occurs when a document chosen at random for Token B for the NSP job turns out to be an empty document. The issue that occurs in this case shows up here, where we look for a random starting place to start Token B.

https://github.com/huggingface/transformers/blob/b00cafbde575b21ff21f2664e297c50b4c5bb63a/src/transformers/data/data_collator.py#L514-L516

Although this issue should not arise if the data has been cleaned and formatted perfectly, it seems like a good precautionary measure to have in place.