### PR TITLE
Trainer multi label

### DIFF
--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
 
 import numpy as np
 
-from .file_utils import is_tf_available, is_torch_available
+from .file_utils import is_tf_available, is_torch_available, is_torch_tpu_available
 from .tokenization_utils_base import ExplicitEnum
 
 

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -132,9 +132,49 @@ default_hp_space = {
 }
 
 
+def nested_concat(tensors, new_tensors, dim=0):
+    "Concat the `new_tensors` to `tensors` on `dim`. Works for tensors or nested list/tuples of tensors."
+    if is_torch_available():
+        assert type(tensors) == type(
+            new_tensors
+        ), f"Expected `tensors` and `new_tensors` to have the same type but found {type(tensors)} and {type(new_tensors)}."
+        if isinstance(tensors, (list, tuple)):
+            return type(tensors)(nested_concat(t, n, dim) for t, n in zip(tensors, new_tensors))
+        return torch.cat((tensors, new_tensors), dim=dim)
+    else:
+        raise ImportError("Torch must be installed to use `nested_concat`")
+
+
+def nested_numpify(tensors):
+    "Numpify `tensors` (even if it's a nested list/tuple of tensors)."
+    if isinstance(tensors, (list, tuple)):
+        return type(tensors)(nested_numpify(t) for t in tensors)
+    return tensors.cpu().numpy()
+
+
+def nested_detach(tensors):
+    "Detach `tensors` (even if it's a nested list/tuple of tensors)."
+    if isinstance(tensors, (list, tuple)):
+        return type(tensors)(nested_detach(t) for t in tensors)
+    return tensors.detach()
+
+
+def nested_xla_mesh_reduce(tensors, name):
+    if is_torch_tpu_available():
+        import torch_xla.core.xla_model as xm
+
+        if isinstance(tensors, (list, tuple)):
+            return type(tensors)(nested_xla_mesh_reduce(t, f"{name}_{i}") for i, t in enumerate(tensors))
+        return xm.mesh_reduce(name, tensors, torch.cat)
+    else:
+        raise ImportError("Torch xla must be installed to use `nested_xla_mesh_reduce`")
+
+
 def distributed_concat(tensor: "torch.Tensor", num_total_examples: Optional[int] = None) -> "torch.Tensor":
     if is_torch_available():
         try:
+            if isinstance(tensor, (tuple, list)):
+                return type(tensor)(distributed_concat(t, num_total_examples) for t in tensor)
             output_tensors = [tensor.clone() for _ in range(torch.distributed.get_world_size())]
             torch.distributed.all_gather(output_tensors, tensor)
             concat = torch.cat(output_tensors, dim=0)

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -128,10 +128,10 @@ class TrainingArguments:
             forward method.
 
             (Note: this behavior is not implemented for :class:`~transformers.TFTrainer` yet.)
-        label_names (:obj:`List[str]`, `optional)`:
+        label_names (:obj:`List[str]`, `optional`):
             The list of keys in your dictionary of inputs that correspond to the labels.
 
-            Will eventually default to :obj:`["labels"]` except if your model is one of the
+            Will eventually default to :obj:`["labels"]` except if the model used is one of the
             :obj:`XxxForQuestionAnswering` in which case it will default to
             :obj:`["start_positions", "end_positions"]`.
     """

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -2,7 +2,7 @@ import dataclasses
 import json
 import os
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from .file_utils import cached_property, is_torch_available, is_torch_tpu_available, torch_required
 from .utils import logging
@@ -128,6 +128,12 @@ class TrainingArguments:
             forward method.
 
             (Note: this behavior is not implemented for :class:`~transformers.TFTrainer` yet.)
+        label_names (:obj:`List[str]`, `optional)`:
+            The list of keys in your dictionary of inputs that correspond to the labels.
+
+            Will eventually default to :obj:`["labels"]` except if your model is one of the
+            :obj:`XxxForQuestionAnswering` in which case it will default to
+            :obj:`["start_positions", "end_positions"]`.
     """
 
     output_dir: str = field(
@@ -253,13 +259,16 @@ class TrainingArguments:
         default=None, metadata={"help": "Whether or not to disable the tqdm progress bars."}
     )
 
-    def __post_init__(self):
-        if self.disable_tqdm is None:
-            self.disable_tqdm = logger.getEffectiveLevel() > logging.WARN
-
     remove_unused_columns: Optional[bool] = field(
         default=True, metadata={"help": "Remove columns not required by the model when using an nlp.Dataset."}
     )
+    label_names: Optional[List[str]] = field(
+        default=None, metadata={"help": "The list of keys in your dictionary of inputs that correspond to the labels."}
+    )
+
+    def __post_init__(self):
+        if self.disable_tqdm is None:
+            self.disable_tqdm = logger.getEffectiveLevel() > logging.WARN
 
     @property
     def train_batch_size(self) -> int:


### PR DESCRIPTION
This is a follow-up from #7126. The same kinds of models that can output multiple predictions expect multiple labels (not named "labels") so the evaluation code needs to be changed for this. To support models built by users, I added a `label_names` field in the `TrainingArguments` which contain the label names. It then defaults to `["labels"]` for most models, `["start_positions", "end_positions"]` for question answering models if the user does not set it to work seamlessly for all Transformers models.

I ended up writing a few util functions that concat/numpify for tensors or nested lists/tuples of tensors to avoid testing everywhere in `Trainer`, I think the design is cleaner this way and it also supports model with crazy outputs (if we set `output_attentions=True` for instance). I also added a test for the multiple labels predictions.