### PR TITLE
Add bos and eos to gpt2 tokenizer

### DIFF
--- a/src/transformers/tokenization_gpt2.py
+++ b/src/transformers/tokenization_gpt2.py
@@ -187,6 +187,11 @@ class GPT2Tokenizer(PreTrainedTokenizer):
     def get_vocab(self):
         return dict(self.encoder, **self.added_tokens_encoder)
 
+    def build_inputs_with_special_tokens(
+        self, token_ids_0: List[int], token_ids_1: Optional[List[int]] = None
+    ) -> List[int]:
+        return [self.bos_token_id] + token_ids_0 + [self.eos_token_id]
+
     def bpe(self, token):
         if token in self.cache:
             return self.cache[token]


### PR DESCRIPTION
Fix https://github.com/huggingface/transformers/issues/3311

Test:
```
tokenizer = GPT2Tokenizer.from_pretrained('gpt2-medium')
tokenizer.add_special_tokens({'pad_token': '<pad>'})
inputs = tokenizer.batch_encode_plus(["My cute dog", "My cute dog is is"], add_special_tokens=True, padding=True, return_tensors="pt")
```

output:
before:
```
{'input_ids': tensor([[ 3666, 13779,  3290, 50257, 50257],
        [ 3666, 13779,  3290,   318,   318]]), 'attention_mask': tensor([[1, 1, 1, 0, 0],
        [1, 1, 1, 1, 1]])}
```

after:
```
{'input_ids': tensor([[50256,  3666, 13779,  3290, 50256, 50257, 50257],
        [50256,  3666, 13779,  3290,   318,   318, 50256]]), 'attention_mask': tensor([[1, 1, 1, 1, 1, 0, 0],
        [1, 1, 1, 1, 1, 1, 1]])}
```