### PR TITLE
Rewrites BERT in Flax to the new Linen API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ extras["tf-cpu"] = [
     # "keras2onnx @ git+git://github.com/onnx/keras-onnx.git@cbdc75cb950b16db7f0a67be96a278f8d2953b48#egg=keras2onnx",
 ]
 extras["torch"] = ["torch"]
-extras["flax"] = ["jaxlib==0.1.41", "jax==0.1.59", "flax==0.1.0"]
+extras["flax"] = ["jaxlib==0.1.55", "jax==0.1.76", "flax==0.2.1"]
 extras["onnxruntime"] = ["onnxruntime>=1.4.0", "onnxruntime-tools>=1.4.2"]
 
 extras["serving"] = ["pydantic", "uvicorn", "fastapi", "starlette"]

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -73,6 +73,10 @@ try:
     if USE_JAX in ENV_VARS_TRUE_VALUES:
         import flax
         import jax
+        from jax.config import config
+        # TODO(marcvanzee): Flax Linen requires JAX omnistaging. Remove this 
+        # once JAX enables it by default.
+        config.enable_omnistaging()
 
         logger.info("JAX version {}, Flax: available".format(jax.__version__))
         logger.info("Flax available: {}".format(flax))

--- a/src/transformers/modeling_flax_bert.py
+++ b/src/transformers/modeling_flax_bert.py
@@ -2,7 +2,8 @@ from typing import Callable, Dict
 
 import numpy as np
 
-import flax.nn as nn
+import flax.linen as nn
+from flax.linen import compact
 import jax
 import jax.numpy as jnp
 from transformers import BertConfig
@@ -38,17 +39,15 @@ class BertLayerNorm(nn.Module):
     """Layer normalization (https://arxiv.org/abs/1607.06450).
     Operates on the last axis of the input data.
     """
+    epsilon: float = 1e-6
+    dtype: jnp.dtype = jnp.float32
+    bias: bool = True
+    scale: bool = True
+    bias_init: jnp.ndarray = nn.initializers.zeros
+    scale_init: jnp.ndarray = nn.initializers.ones
 
-    def apply(
-        self,
-        x,
-        epsilon=1e-6,
-        dtype=jnp.float32,
-        bias=True,
-        scale=True,
-        bias_init=nn.initializers.zeros,
-        scale_init=nn.initializers.ones,
-    ):
+    @compact
+    def __call__(self, x):
         """Applies layer normalization on the input.
         It normalizes the activations of the layer for each given example in a
         batch independently, rather than across a batch like Batch Normalization.
@@ -69,14 +68,16 @@ class BertLayerNorm(nn.Module):
         """
         features = x.shape[-1]
         mean = jnp.mean(x, axis=-1, keepdims=True)
-        mean2 = jnp.mean(jnp.lax.square(x), axis=-1, keepdims=True)
-        var = mean2 - jnp.lax.square(mean)
-        mul = jnp.lax.rsqrt(var + epsilon)
-        if scale:
-            mul = mul * jnp.asarray(self.param("gamma", (features,), scale_init), dtype)
+        mean2 = jnp.mean(jax.lax.square(x), axis=-1, keepdims=True)
+        var = mean2 - jax.lax.square(mean)
+        mul = jax.lax.rsqrt(var + self.epsilon)
+        if self.scale:
+            mul = mul * jnp.asarray(self.param("gamma", (features,), self.scale_init), 
+                                    self.dtype)
         y = (x - mean) * mul
-        if bias:
-            y = y + jnp.asarray(self.param("beta", (features,), bias_init), dtype)
+        if self.bias:
+            y = y + jnp.asarray(self.param("beta", (features,), self.bias_init),
+                                self.dtype)
         return y
 
 
@@ -86,79 +87,80 @@ class BertEmbedding(nn.Module):
     as Flax's one use 'embedding' for the parameter name
     and PyTorch use 'weight'
     """
+    vocab_size: int
+    hidden_size: int
+    emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1)
 
-    def apply(
-        self,
-        input,
-        vocab_size: int,
-        hidden_size: int,
-        emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1),
-    ):
-
-        embedding = self.param("weight", (vocab_size, hidden_size), emb_init)
+    @compact
+    def __call__(self, input):
+        embedding = self.param("weight", (self.vocab_size, self.hidden_size), self.emb_init)
         return jnp.take(embedding, input, axis=0)
 
 
 class BertEmbeddings(nn.Module):
-    def apply(
-        self,
-        input_ids,
-        token_type_ids,
-        position_ids,
-        attention_mask,
-        vocab_size: int,
-        hidden_size: int,
-        type_vocab_size: int,
-        max_length: int,
-    ):
+    vocab_size: int
+    hidden_size: int
+    type_vocab_size: int
+    max_length: int
+
+    @compact
+    def __call__(self, input_ids, token_type_ids, position_ids, attention_mask):
 
         # Embed
-        w_emb = BertEmbedding(jnp.atleast_2d(input_ids.astype("i4")), vocab_size, hidden_size, name="word_embeddings")
-        p_emb = BertEmbedding(
-            jnp.atleast_2d(position_ids.astype("i4")), max_length, hidden_size, name="position_embeddings"
-        )
-        t_emb = BertEmbedding(
-            jnp.atleast_2d(token_type_ids.astype("i4")), type_vocab_size, hidden_size, name="token_type_embeddings"
-        )
+        w_emb = BertEmbedding(vocab_size, hidden_size, name="word_embeddings")(jnp.atleast_2d(input_ids.astype("i4")))
+        p_emb = BertEmbedding(max_length, hidden_size, name="position_embeddings")(jnp.atleast_2d(position_ids.astype("i4")))
+        t_emb = BertEmbedding(type_vocab_size, hidden_size, , name="token_type_embeddings")(jnp.atleast_2d(token_type_ids.astype("i4")))
 
         # Sum all embeddings
         summed_emb = w_emb + jnp.broadcast_to(p_emb, w_emb.shape) + t_emb
 
         # Layer Norm
-        norm = BertLayerNorm(summed_emb, name="layer_norm")
+        layer_norm = BertLayerNorm()(summed_emb)
 
-        return norm
+        return layer_norm
 
 
 class BertAttention(nn.Module):
-    def apply(self, hidden_state, attention_mask, num_heads: int, head_size: int):
-        self_att = nn.attention.SelfAttention(
-            hidden_state, num_heads=num_heads, qkv_features=head_size, padding_mask=attention_mask, name="self"
-        )
+    num_heads: int
+    head_size: int
 
-        return BertLayerNorm(self_att + hidden_state, name="layer_norm")
+    @compact
+    def __call__(self, hidden_state, attention_mask):
+        self_att = nn.attention.SelfAttention(
+            num_heads=self.num_heads, qkv_features=self.head_size, name="self")(hidden_state, attention_mask)
+
+        layer_norm = BertLayerNorm()(self_att + hidden_state)
+        return layer_norm
 
 
 class BertIntermediate(nn.Module):
-    def apply(self, hidden_state, output_size: int):
+    output_size: int
+
+    @compact
+    def __call__(self, hidden_state):
         # TODO: Add ACT2FN reference to change activation function
-        h = nn.Dense(hidden_state, features=output_size, name="dense")
-        return gelu(h)
+        dense = nn.Dense(features=output_size, name="dense")(hidden_state)
+        return gelu(dense)
 
 
 class BertOutput(nn.Module):
-    def apply(self, intermediate_output, attention_output):
-        h = nn.Dense(intermediate_output, attention_output.shape[-1], name="dense")
-        h = BertLayerNorm(h + attention_output, name="layer_norm")
-
+    @compact
+    def __call__(self, intermediate_output, attention_output):
+        h = nn.Dense(attention_output.shape[-1], name="dense")(intermediate_output)
+        h = BertLayerNorm(name="layer_norm")(h + attention_output)
         return h
 
 
 class BertLayer(nn.Module):
-    def apply(self, hidden_state, attention_mask, num_heads: int, head_size: int, intermediate_size: int):
-        attention = BertAttention(hidden_state, attention_mask, num_heads, head_size, name="attention")
-        intermediate = BertIntermediate(attention, intermediate_size, name="intermediate")
-        output = BertOutput(intermediate, attention, name="output")
+    num_heads: int
+    head_size: int
+    intermediate_size: int
+
+    @compact
+    def __call__(self, hidden_state, attention_mask):
+        attention = BertAttention(num_heads, head_size, name="attention")(hidden_state, attention_mask)
+        intermediate = BertIntermediate(intermediate_size, name="intermediate")(attention)
+        output = BertOutput(name="output")(intermediate, attention)
 
         return output
 
@@ -167,75 +169,71 @@ class BertLayerCollection(nn.Module):
     """
     Stores N BertLayer(s)
     """
+    num_layers: int
+    num_heads: int
+    head_size: int
+    intermediate_size: int
 
-    def apply(self, input, attention_mask, num_layers: int, num_heads: int, head_size: int, intermediate_size: int):
-        assert num_layers > 0, "num_layers should be >= 1, got ({})".format(num_layers)
+    @compact
+    def _call__(self, inputs, attention_mask):
+        assert num_layers > 0, "num_layers should be >= 1, got ({})".format(self.num_layers)
 
         # Initialize input / output
-        input_i = output_i = input
+        input_i = output_i = self.inputs
 
         # Forward over all encoders
         for i in range(num_layers):
-            output_i = BertLayer(input_i, attention_mask, num_heads, head_size, intermediate_size, name="{}".format(i))
+            layer = BertLayer(num_heads, head_size, intermediate_size, name="{}".format(i))
+            output_i = layer(input_i, attention_mask)
             input_i = output_i
         return output_i
 
 
 class BertEncoder(nn.Module):
-    def apply(
-        self, hidden_state, attention_mask, num_layers: int, num_heads: int, head_size: int, intermediate_size: int
-    ):
-        encodings = BertLayerCollection(
-            hidden_state, attention_mask, num_layers, num_heads, head_size, intermediate_size, name="layer"
-        )
-        return encodings
+    num_layers: int
+    num_heads: int
+    head_size: int
+    intermediate_size: int
+
+    @compact
+    def __call__(self, hidden_state, attention_mask):
+        layer = BertLayerCollection(num_layers, num_heads, head_size, 
+            intermediate_size, name="layer")(hidden_state, attention_mask)
+        return layer
 
 
 class BertPooler(nn.Module):
-    def apply(self, hidden_state):
+    @compact
+    def __call__(self, hidden_state):
         first_token = hidden_state[:, 0]
-        out = nn.Dense(first_token, hidden_state.shape[-1], name="dense")
+        out = nn.Dense(hidden_state.shape[-1], name="dense")(first_token)
         return jax.lax.tanh(out)
 
 
 class BertModel(nn.Module):
-    def apply(
-        self,
-        input_ids,
-        token_type_ids,
-        position_ids,
-        attention_mask,
-        vocab_size: int,
-        hidden_size: int,
-        type_vocab_size: int,
-        max_length: int,
-        num_encoder_layers: int,
-        num_heads: int,
-        head_size: int,
-        intermediate_size: int,
-        padding_idx: int,
-        emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1),
-    ):
+    vocab_size: int
+    hidden_size: int
+    type_vocab_size: int
+    max_length: int
+    num_encoder_layers: int
+    num_heads: int
+    head_size: int
+    intermediate_size: int
+    padding_idx: int
+    emb_init: Callable[..., np.ndarray] = nn.initializers.normal(stddev=0.1)
+
+    @compact
+    def __call__(self, input_ids, token_type_ids, position_ids, attention_mask):
 
         # Embedding
-        embeddings = BertEmbeddings(
-            input_ids,
-            token_type_ids,
-            position_ids,
-            attention_mask,
-            vocab_size,
-            hidden_size,
-            type_vocab_size,
-            max_length,
-            name="embeddings",
-        )
+        embeddings = BertEmbeddings(vocab_size, hidden_size, type_vocab_size,
+            max_length, name="embeddings")(input_ids, token_type_ids, position_ids, attention_mask)
 
         # N stacked encoding layers
-        encoder = BertEncoder(
-            embeddings, attention_mask, num_encoder_layers, num_heads, head_size, intermediate_size, name="encoder"
-        )
+        encoder = BertEncoder(num_encoder_layers, num_heads, head_size, intermediate_size, 
+            name="encoder")(embeddings, attention_mask)
 
-        pooled = BertPooler(encoder, name="pooler")
+        pooled = BertPooler(name="pooler")(encoder)
         return encoder, pooled
 
 
@@ -318,7 +316,7 @@ class FlaxBertModel(FlaxPreTrainedModel):
         return jax_state
 
     def __init__(self, config: BertConfig, state: dict, seed: int = 0, **kwargs):
-        model_def = BertModel.partial(
+        model = BertModel(
             vocab_size=config.vocab_size,
             hidden_size=config.hidden_size,
             type_vocab_size=config.type_vocab_size,
@@ -330,7 +328,7 @@ class FlaxBertModel(FlaxPreTrainedModel):
             padding_idx=config.pad_token_id,
         )
 
-        super().__init__(config, model_def, state, seed)
+        super().__init__(config, model, state, seed)
 
     @property
     def module(self) -> BertModel:
@@ -343,7 +341,8 @@ class FlaxBertModel(FlaxPreTrainedModel):
     def __call__(self, input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
         @jax.jit
         def predict(input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
-            return self.model(
+            return self.module.apply(
+                {"params": self.state},
                 jnp.array(input_ids, dtype="i4"),
                 jnp.array(token_type_ids, dtype="i4"),
                 jnp.array(position_ids, dtype="i4"),

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from pickle import UnpicklingError
 from typing import Dict
 
-from flax.linen import Model, Module
+from flax.linen import Module
 from flax.serialization import to_bytes
 from flax.traverse_util import unflatten_dict
 from jax.random import PRNGKey
@@ -142,5 +142,5 @@ class FlaxPreTrainedModel(ABC):
             os.mkdir(folder_abs)
 
         with open(os.path.join(folder_abs, "{}.flax".format(self._config.model_type)), "wb") as f:
-            model_bytes = to_bytes(self.model)
+            model_bytes = to_bytes(self.init_params)
             f.write(model_bytes)

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -17,14 +17,14 @@ class FlaxPreTrainedModel(ABC):
     base_model_prefix = ""
     model_class = None
 
-    def __init__(self, config: PretrainedConfig, module: Module, state: Dict, seed: int = 0):
+    def __init__(self, config: PretrainedConfig, module: Module, params: Dict, seed: int = 0):
         if config is None:
             raise ValueError("config cannot be None")
 
         if module is None:
             raise ValueError("module cannot be None")
 
-        if state is None:
+        if params is None:
             raise ValueError("state cannot be None")
 
         # Those are private to be exposed as typed property on derived classes.
@@ -33,7 +33,7 @@ class FlaxPreTrainedModel(ABC):
 
         # Those are public as their type is generic to every derived classes.
         self.key = PRNGKey(seed)
-        self.state = state
+        self.params = params
         self.model = module
 
     @staticmethod
@@ -44,7 +44,7 @@ class FlaxPreTrainedModel(ABC):
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
         r"""
-        Instantiate a pretrained pytorch model from a pre-trained model configuration.
+        Instantiate a pretrained Flax model from a pre-trained model configuration.
         """
         config = kwargs.pop("config", None)
         # state_dict = kwargs.pop("state_dict", None)
@@ -142,5 +142,5 @@ class FlaxPreTrainedModel(ABC):
             os.mkdir(folder_abs)
 
         with open(os.path.join(folder_abs, "{}.flax".format(self._config.model_type)), "wb") as f:
-            model_bytes = to_bytes(self.init_params)
+            model_bytes = to_bytes(self.params)
             f.write(model_bytes)

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from pickle import UnpicklingError
 from typing import Dict
 
-from flax.nn import Model, Module
+from flax.linen import Model, Module
 from flax.serialization import to_bytes
 from flax.traverse_util import unflatten_dict
 from jax.random import PRNGKey
@@ -34,7 +34,7 @@ class FlaxPreTrainedModel(ABC):
         # Those are public as their type is generic to every derived classes.
         self.key = PRNGKey(seed)
         self.state = state
-        self.model = Model(module, state)
+        self.model = module
 
     @staticmethod
     @abstractmethod


### PR DESCRIPTION
One small caveat: we renamed `param` in Module to `params`, so we may have to update this once we created a new pypi wheel, but I will make sure that this is the case.

Otherwise it seems good to go!