### PR TITLE
Return cross-attention from T5 models

### DIFF
--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -780,11 +780,12 @@ class T5Stack(T5PreTrainedModel):
                 present_key_value_states = present_key_value_states + (present_key_value_state,)
 
             if output_attentions:
-                if len(layer_outputs) >= 5:
-                    all_attentions = all_attentions + (layer_outputs[2],) + (layer_outputs[4],)
-                else:
-                    all_attentions = all_attentions + (layer_outputs[2],)
-
+                all_attentions = all_attentions + (layer_outputs[2],)
+                if self.is_decoder:
+                    if i == 0:
+                        all_attentions = all_attentions + (layer_outputs[4],)  # append cross-attention weights
+                    else:
+                        all_attentions = all_attentions + (layer_outputs[3],)  # append cross-attention weights
 
         hidden_states = self.final_layer_norm(hidden_states)
         hidden_states = self.dropout(hidden_states)

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -780,7 +780,11 @@ class T5Stack(T5PreTrainedModel):
                 present_key_value_states = present_key_value_states + (present_key_value_state,)
 
             if output_attentions:
-                all_attentions = all_attentions + (layer_outputs[2],)  # We keep only self-attention weights for now
+                if len(layer_outputs) >= 5:
+                    all_attentions = all_attentions + (layer_outputs[2],) + (layer_outputs[4],)
+                else:
+                    all_attentions = all_attentions + (layer_outputs[2],)
+
 
         hidden_states = self.final_layer_norm(hidden_states)
         hidden_states = self.dropout(hidden_states)

--- a/src/transformers/modeling_tf_t5.py
+++ b/src/transformers/modeling_tf_t5.py
@@ -140,9 +140,7 @@ class TFT5Attention(tf.keras.layers.Layer):
 
         if self.has_relative_attention_bias:
             self.relative_attention_bias = tf.keras.layers.Embedding(
-                self.relative_attention_num_buckets,
-                self.n_heads,
-                name="relative_attention_bias",
+                self.relative_attention_num_buckets, self.n_heads, name="relative_attention_bias",
             )
         self.pruned_heads = set()
 
@@ -201,9 +199,7 @@ class TFT5Attention(tf.keras.layers.Layer):
         memory_position = tf.range(klen)[None, :]
         relative_position = memory_position - context_position  # shape (qlen, klen)
         rp_bucket = self._relative_position_bucket(
-            relative_position,
-            bidirectional=not self.is_decoder,
-            num_buckets=self.relative_attention_num_buckets,
+            relative_position, bidirectional=not self.is_decoder, num_buckets=self.relative_attention_num_buckets,
         )
         values = self.relative_attention_bias(rp_bucket)  # shape (qlen, klen, num_heads)
         values = tf.expand_dims(tf.transpose(values, [2, 0, 1]), axis=0)  # shape (1, num_heads, qlen, klen)
@@ -320,9 +316,7 @@ class TFT5LayerSelfAttention(tf.keras.layers.Layer):
     def __init__(self, config, has_relative_attention_bias=False, **kwargs):
         super().__init__(**kwargs)
         self.SelfAttention = TFT5Attention(
-            config,
-            has_relative_attention_bias=has_relative_attention_bias,
-            name="SelfAttention",
+            config, has_relative_attention_bias=has_relative_attention_bias, name="SelfAttention",
         )
         self.layer_norm = TFT5LayerNorm(epsilon=config.layer_norm_epsilon, name="layer_norm")
         self.dropout = tf.keras.layers.Dropout(config.dropout_rate)
@@ -359,9 +353,7 @@ class TFT5LayerCrossAttention(tf.keras.layers.Layer):
     def __init__(self, config, has_relative_attention_bias=False, **kwargs):
         super().__init__(**kwargs)
         self.EncDecAttention = TFT5Attention(
-            config,
-            has_relative_attention_bias=has_relative_attention_bias,
-            name="EncDecAttention",
+            config, has_relative_attention_bias=has_relative_attention_bias, name="EncDecAttention",
         )
         self.layer_norm = TFT5LayerNorm(epsilon=config.layer_norm_epsilon, name="layer_norm")
         self.dropout = tf.keras.layers.Dropout(config.dropout_rate)
@@ -404,18 +396,12 @@ class TFT5Block(tf.keras.layers.Layer):
         self.is_decoder = config.is_decoder
         self.layer = []
         self.layer.append(
-            TFT5LayerSelfAttention(
-                config,
-                has_relative_attention_bias=has_relative_attention_bias,
-                name="layer_._0",
-            )
+            TFT5LayerSelfAttention(config, has_relative_attention_bias=has_relative_attention_bias, name="layer_._0",)
         )
         if self.is_decoder:
             self.layer.append(
                 TFT5LayerCrossAttention(
-                    config,
-                    has_relative_attention_bias=has_relative_attention_bias,
-                    name="layer_._1",
+                    config, has_relative_attention_bias=has_relative_attention_bias, name="layer_._1",
                 )
             )
 
@@ -553,11 +539,7 @@ class TFT5MainLayer(tf.keras.layers.Layer):
         self.num_hidden_layers = config.num_layers
 
         self.block = [
-            TFT5Block(
-                config,
-                has_relative_attention_bias=bool(i == 0),
-                name="block_._{}".format(i),
-            )
+            TFT5Block(config, has_relative_attention_bias=bool(i == 0), name="block_._{}".format(i),)
             for i in range(config.num_layers)
         ]
         self.final_layer_norm = TFT5LayerNorm(epsilon=config.layer_norm_epsilon, name="final_layer_norm")
@@ -686,8 +668,7 @@ class TFT5MainLayer(tf.keras.layers.Layer):
             if self.is_decoder:
                 seq_ids = tf.range(mask_seq_length)
                 causal_mask = tf.less_equal(
-                    tf.tile(seq_ids[None, None, :], (batch_size, mask_seq_length, 1)),
-                    seq_ids[None, :, None],
+                    tf.tile(seq_ids[None, None, :], (batch_size, mask_seq_length, 1)), seq_ids[None, :, None],
                 )
                 causal_mask = tf.cast(causal_mask, dtype=tf.float32)
                 extended_attention_mask = causal_mask[:, None, :, :] * attention_mask[:, None, None, :]
@@ -770,11 +751,12 @@ class TFT5MainLayer(tf.keras.layers.Layer):
             present_key_value_states = present_key_value_states + (present_key_value_state,)
 
             if output_attentions:
-                if len(layer_outputs) >= 5:
-                    all_attentions = all_attentions + (layer_outputs[2],) + (layer_outputs[4],)
-                else:
-                    all_attentions = all_attentions + (layer_outputs[2],)
-
+                all_attentions = all_attentions + (layer_outputs[2],)
+                if self.is_decoder:
+                    if i == 0:
+                        all_attentions = all_attentions + (layer_outputs[4],)  # append cross-attention weights
+                    else:
+                        all_attentions = all_attentions + (layer_outputs[3],)  # append cross-attention weights
 
         hidden_states = self.final_layer_norm(hidden_states)
         hidden_states = self.dropout(hidden_states, training=training)

--- a/src/transformers/modeling_tf_t5.py
+++ b/src/transformers/modeling_tf_t5.py
@@ -770,7 +770,11 @@ class TFT5MainLayer(tf.keras.layers.Layer):
             present_key_value_states = present_key_value_states + (present_key_value_state,)
 
             if output_attentions:
-                all_attentions = all_attentions + (layer_outputs[2],)
+                if len(layer_outputs) >= 5:
+                    all_attentions = all_attentions + (layer_outputs[2],) + (layer_outputs[4],)
+                else:
+                    all_attentions = all_attentions + (layer_outputs[2],)
+
 
         hidden_states = self.final_layer_norm(hidden_states)
         hidden_states = self.dropout(hidden_states, training=training)


### PR DESCRIPTION
Small change to the PyTorch and TF models to support returning cross-attention alignment scores. Previously it would only return self-attention alignment scores. This should solve the problem mentioned here: https://discuss.huggingface.co/t/how-to-get-cross-attention-values-of-t5/970

The code in this PR checks to see if the outputs of T5Block contains cross-attention, and if it does, it is returned from the T5Stack.