### PR TITLE
[Bug fix] Fixed target_mapping preparation for XLNet (Pytorch)

### DIFF
--- a/src/transformers/modeling_xlnet.py
+++ b/src/transformers/modeling_xlnet.py
@@ -1313,7 +1313,7 @@ class XLNetLMHeadModel(XLNetPreTrainedModel):
         target_mapping = torch.zeros(
             (effective_batch_size, 1, sequence_length), dtype=torch.float, device=input_ids.device
         )
-        target_mapping[0, 0, -1] = 1.0
+        target_mapping[:, 0, -1] = 1.0
 
         inputs = {
             "input_ids": input_ids,


### PR DESCRIPTION
The pytorch version of XLNet does not create the `target_mapping` correctly when the batch size > 1.
For generation, the `target_mapping` should be made of zeros, except at the last position (token to be predicted). The current Pytorch implementation is currently only non-zero at the last position of the first batch position:
https://github.com/huggingface/transformers/blob/4f6e52574248636352a746cfe6cc0b13cf3eb7f9/src/transformers/modeling_xlnet.py#L1316

This causes the model to be incorrect when multiple inputs are passed to the model, or when beam search is turned on. This PR fixes the issue by setting the last (sequence) position of `target_mapping` to 1 for all batch positions.

For reference, the Tensorflow implementation seems to be already correct:
https://github.com/huggingface/transformers/blob/4f6e52574248636352a746cfe6cc0b13cf3eb7f9/src/transformers/modeling_tf_xlnet.py#L1158