### PR TITLE
Add model cards for new pre-trained BERTweet-COVID19 models

### DIFF
--- a/model_cards/vinai/bertweet-covid19-base-cased/README.md
+++ b/model_cards/vinai/bertweet-covid19-base-cased/README.md
@@ -44,8 +44,8 @@ Two pre-trained models `vinai/bertweet-covid19-base-cased` and `vinai/bertweet-c
 import torch
 from transformers import AutoModel, AutoTokenizer 
 
-bertweet = AutoModel.from_pretrained("vinai/bertweet-base")
-tokenizer = AutoTokenizer.from_pretrained("vinai/bertweet-base")
+bertweet = AutoModel.from_pretrained("vinai/bertweet-covid19-base-cased")
+tokenizer = AutoTokenizer.from_pretrained("vinai/bertweet-covid19-base-cased")
 
 # INPUT TWEET IS ALREADY NORMALIZED!
 line = "SC has first two presumptive cases of coronavirus , DHEC confirms HTTPURL via @USER :cry:"
@@ -57,7 +57,7 @@ with torch.no_grad():
     
 ## With TensorFlow 2.0+:
 # from transformers import TFAutoModel
-# bertweet = TFAutoModel.from_pretrained("vinai/bertweet-base")
+# bertweet = TFAutoModel.from_pretrained("vinai/bertweet-covid19-base-cased")
 ```
 
 ### <a name="preprocess"></a> Normalize raw input Tweets 
@@ -69,10 +69,10 @@ import torch
 from transformers import AutoTokenizer
 
 # Load the AutoTokenizer with a normalization mode if the input Tweet is raw
-tokenizer = AutoTokenizer.from_pretrained("vinai/bertweet-base", normalization=True)
+tokenizer = AutoTokenizer.from_pretrained("vinai/bertweet-covid19-base-cased", normalization=True)
 
 # from transformers import BertweetTokenizer
-# tokenizer = BertweetTokenizer.from_pretrained("vinai/bertweet-base", normalization=True)
+# tokenizer = BertweetTokenizer.from_pretrained("vinai/bertweet-covid19-base-cased", normalization=True)
 
 line = "SC has first two presumptive cases of coronavirus, DHEC confirms https://postandcourier.com/health/covid19/sc-has-first-two-presumptive-cases-of-coronavirus-dhec-confirms/article_bddfe4ae-5fd3-11ea-9ce4-5f495366cee6.html?utm_medium=social&utm_source=twitter&utm_campaign=user-share… via @postandcourier"
 

--- a/model_cards/vinai/bertweet-covid19-base-uncased/README.md
+++ b/model_cards/vinai/bertweet-covid19-base-uncased/README.md
@@ -44,8 +44,8 @@ Two pre-trained models `vinai/bertweet-covid19-base-cased` and `vinai/bertweet-c
 import torch
 from transformers import AutoModel, AutoTokenizer 
 
-bertweet = AutoModel.from_pretrained("vinai/bertweet-base")
-tokenizer = AutoTokenizer.from_pretrained("vinai/bertweet-base")
+bertweet = AutoModel.from_pretrained("vinai/bertweet-covid19-base-uncased")
+tokenizer = AutoTokenizer.from_pretrained("vinai/bertweet-covid19-base-uncased")
 
 # INPUT TWEET IS ALREADY NORMALIZED!
 line = "SC has first two presumptive cases of coronavirus , DHEC confirms HTTPURL via @USER :cry:"
@@ -57,7 +57,7 @@ with torch.no_grad():
     
 ## With TensorFlow 2.0+:
 # from transformers import TFAutoModel
-# bertweet = TFAutoModel.from_pretrained("vinai/bertweet-base")
+# bertweet = TFAutoModel.from_pretrained("vinai/bertweet-covid19-base-uncased")
 ```
 
 ### <a name="preprocess"></a> Normalize raw input Tweets 
@@ -69,10 +69,10 @@ import torch
 from transformers import AutoTokenizer
 
 # Load the AutoTokenizer with a normalization mode if the input Tweet is raw
-tokenizer = AutoTokenizer.from_pretrained("vinai/bertweet-base", normalization=True)
+tokenizer = AutoTokenizer.from_pretrained("vinai/bertweet-covid19-base-uncased", normalization=True)
 
 # from transformers import BertweetTokenizer
-# tokenizer = BertweetTokenizer.from_pretrained("vinai/bertweet-base", normalization=True)
+# tokenizer = BertweetTokenizer.from_pretrained("vinai/bertweet-covid19-base-uncased", normalization=True)
 
 line = "SC has first two presumptive cases of coronavirus, DHEC confirms https://postandcourier.com/health/covid19/sc-has-first-two-presumptive-cases-of-coronavirus-dhec-confirms/article_bddfe4ae-5fd3-11ea-9ce4-5f495366cee6.html?utm_medium=social&utm_source=twitter&utm_campaign=user-share… via @postandcourier"
 

--- a/model_cards/vinai/phobert-base/README.md
+++ b/model_cards/vinai/phobert-base/README.md
@@ -1,6 +1,6 @@
 # <a name="introduction"></a> PhoBERT: Pre-trained language models for Vietnamese 
-
-Pre-trained PhoBERT models are the state-of-the-art language models for Vietnamese ([Pho](https://en.wikipedia.org/wiki/Pho), i.e. "Phở", is a popular food in Vietnam): 
+  
+Pre-trained PhoBERT models are the state-of-the-art language models for Vietnamese ([Pho](https://en.wikipedia.org/wiki/Pho), i.e. "Phở", is a popular food in Vietnam):
 
  - Two PhoBERT versions of "base" and "large" are the first public large-scale monolingual language models pre-trained for Vietnamese. PhoBERT pre-training approach is based on [RoBERTa](https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md)  which optimizes the [BERT](https://github.com/google-research/bert) pre-training procedure for more robust performance.
  - PhoBERT outperforms previous monolingual and multilingual approaches, obtaining new state-of-the-art performances on four downstream Vietnamese NLP tasks of Part-of-speech tagging, Dependency parsing, Named-entity recognition and Natural language inference.
@@ -18,28 +18,28 @@ The general architecture and experimental results of PhoBERT can be found in our
 
 For further information or requests, please go to [PhoBERT's homepage](https://github.com/VinAIResearch/PhoBERT)!
 
-## Installation <a name="install2"></a>
- - Python version >= 3.6
- - [PyTorch](http://pytorch.org/) version >= 1.4.0
- - `pip3 install transformers`
+### Installation <a name="install2"></a>
+ -  Python 3.6+, and PyTorch 1.1.0+ (or TensorFlow 2.0+)
+ -  Install `transformers`:
+        - `git clone https://github.com/huggingface/transformers.git`
+        - `cd transformers`
+        - `pip3 install --upgrade .`
 
-## Pre-trained models <a name="models2"></a>
+### Pre-trained models <a name="models2"></a>
 
-
-Model | #params | Arch.	 | Pre-training data
+Model | #params | Arch.  | Pre-training data
 ---|---|---|---
 `vinai/phobert-base` | 135M | base | 20GB  of texts
 `vinai/phobert-large` | 370M | large | 20GB  of texts
 
-## Example usage <a name="usage2"></a>
+### Example usage <a name="usage2"></a>
 
 ```python
 import torch
-from transformers import AutoModel, AutoTokenizer #, PhobertTokenizer
+from transformers import AutoModel, AutoTokenizer
 
 phobert = AutoModel.from_pretrained("vinai/phobert-base")
 tokenizer = AutoTokenizer.from_pretrained("vinai/phobert-base")
-#tokenizer = PhobertTokenizer.from_pretrained("vinai/phobert-base")
 
 # INPUT TEXT MUST BE ALREADY WORD-SEGMENTED!
 line = "Tôi là sinh_viên trường đại_học Công_nghệ ."
@@ -48,4 +48,8 @@ input_ids = torch.tensor([tokenizer.encode(line)])
 
 with torch.no_grad():
     features = phobert(input_ids)  # Models outputs are now tuples
+
+## With TensorFlow 2.0+:
+# from transformers import TFAutoModel
+# phobert = TFAutoModel.from_pretrained("vinai/phobert-base")
 ```

--- a/model_cards/vinai/phobert-large/README.md
+++ b/model_cards/vinai/phobert-large/README.md
@@ -1,6 +1,6 @@
 # <a name="introduction"></a> PhoBERT: Pre-trained language models for Vietnamese 
-
-Pre-trained PhoBERT models are the state-of-the-art language models for Vietnamese ([Pho](https://en.wikipedia.org/wiki/Pho), i.e. "Phở", is a popular food in Vietnam): 
+  
+Pre-trained PhoBERT models are the state-of-the-art language models for Vietnamese ([Pho](https://en.wikipedia.org/wiki/Pho), i.e. "Phở", is a popular food in Vietnam):
 
  - Two PhoBERT versions of "base" and "large" are the first public large-scale monolingual language models pre-trained for Vietnamese. PhoBERT pre-training approach is based on [RoBERTa](https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md)  which optimizes the [BERT](https://github.com/google-research/bert) pre-training procedure for more robust performance.
  - PhoBERT outperforms previous monolingual and multilingual approaches, obtaining new state-of-the-art performances on four downstream Vietnamese NLP tasks of Part-of-speech tagging, Dependency parsing, Named-entity recognition and Natural language inference.
@@ -18,28 +18,28 @@ The general architecture and experimental results of PhoBERT can be found in our
 
 For further information or requests, please go to [PhoBERT's homepage](https://github.com/VinAIResearch/PhoBERT)!
 
-## Installation <a name="install2"></a>
- - Python version >= 3.6
- - [PyTorch](http://pytorch.org/) version >= 1.4.0
- - `pip3 install transformers`
+### Installation <a name="install2"></a>
+ -  Python 3.6+, and PyTorch 1.1.0+ (or TensorFlow 2.0+)
+ -  Install `transformers`:
+        - `git clone https://github.com/huggingface/transformers.git`
+        - `cd transformers`
+        - `pip3 install --upgrade .`
 
-## Pre-trained models <a name="models2"></a>
+### Pre-trained models <a name="models2"></a>
 
-
-Model | #params | Arch.	 | Pre-training data
+Model | #params | Arch.  | Pre-training data
 ---|---|---|---
 `vinai/phobert-base` | 135M | base | 20GB  of texts
 `vinai/phobert-large` | 370M | large | 20GB  of texts
 
-## Example usage <a name="usage2"></a>
+### Example usage <a name="usage2"></a>
 
 ```python
 import torch
-from transformers import AutoModel, AutoTokenizer #, PhobertTokenizer
+from transformers import AutoModel, AutoTokenizer
 
 phobert = AutoModel.from_pretrained("vinai/phobert-large")
 tokenizer = AutoTokenizer.from_pretrained("vinai/phobert-large")
-#tokenizer = PhobertTokenizer.from_pretrained("vinai/phobert-base")
 
 # INPUT TEXT MUST BE ALREADY WORD-SEGMENTED!
 line = "Tôi là sinh_viên trường đại_học Công_nghệ ."
@@ -48,4 +48,8 @@ input_ids = torch.tensor([tokenizer.encode(line)])
 
 with torch.no_grad():
     features = phobert(input_ids)  # Models outputs are now tuples
+
+## With TensorFlow 2.0+:
+# from transformers import TFAutoModel
+# phobert = TFAutoModel.from_pretrained("vinai/phobert-large")
 ```


### PR DESCRIPTION
Two new pre-trained models "vinai/bertweet-covid19-base-cased" and "vinai/bertweet-covid19-base-uncased" are resulted by further pre-training the pre-trained model "vinai/bertweet-base" on a  corpus of 23M COVID-19 English Tweets for 40 epochs.
