### PR TITLE
Disable missing weight warning for RobertaForMaskedLM/CamembertForMaskedLM

### DIFF
--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -303,6 +303,7 @@ class RobertaForCausalLM(BertPreTrainedModel):
 class RobertaForMaskedLM(BertPreTrainedModel):
     config_class = RobertaConfig
     base_model_prefix = "roberta"
+    authorized_missing_keys = [r"position_ids", r"lm_head\.decoder\.bias"]
 
     def __init__(self, config):
         super().__init__(config)


### PR DESCRIPTION
Fixes #7167, #6193

When loading RobertaForMaskedLM/CamembertForMaskedLM checkpoints, a warning is displayed because "lm_head.decoder.bias" is not loaded. This warning is an artifact of the way the bias are stored in RobertaLMHead.
This PR adds `lm_head.decoder.bias` to the authorized missing keys list for RobertaForMaskedLM.