### PR TITLE
Add possibility to evaluate every epoch

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -39,6 +39,7 @@ from .trainer_utils import (
     PREFIX_CHECKPOINT_DIR,
     BestRun,
     EvalPrediction,
+    EvaluationStrategy,
     HPSearchBackend,
     PredictionOutput,
     TrainOutput,
@@ -782,7 +783,10 @@ class Trainer:
 
                         self.log(logs)
 
-                    if self.args.evaluation_strategy == "steps" and self.global_step % self.args.eval_steps == 0:
+                    if (
+                        self.args.evaluation_strategy == EvaluationStrategy.STEPS
+                        and self.global_step % self.args.eval_steps == 0
+                    ):
                         metrics = self.evaluate()
                         self._report_to_hp_search(trial, epoch, metrics)
 
@@ -820,7 +824,7 @@ class Trainer:
                             torch.save(self.lr_scheduler.state_dict(), os.path.join(output_dir, "scheduler.pt"))
 
                 epoch_pbar.update(1)
-                if self.args.evaluation_strategy == "epoch":
+                if self.args.evaluation_strategy == EvaluationStrategy.EPOCH:
                     metrics = self.evaluate()
                     self._report_to_hp_search(trial, epoch, metrics)
                 if self.args.max_steps > 0 and self.global_step >= self.args.max_steps:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -782,7 +782,7 @@ class Trainer:
 
                         self.log(logs)
 
-                    if self.args.evaluate_during_training and self.global_step % self.args.eval_steps == 0:
+                    if self.args.evaluation_strategy == "steps" and self.global_step % self.args.eval_steps == 0:
                         metrics = self.evaluate()
                         self._report_to_hp_search(trial, epoch, metrics)
 
@@ -820,6 +820,9 @@ class Trainer:
                             torch.save(self.lr_scheduler.state_dict(), os.path.join(output_dir, "scheduler.pt"))
 
                 epoch_pbar.update(1)
+                if self.args.evaluation_strategy == "epoch":
+                    metrics = self.evaluate()
+                    self._report_to_hp_search(trial, epoch, metrics)
                 if self.args.max_steps > 0 and self.global_step >= self.args.max_steps:
                     break
             epoch_pbar.close()

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -60,6 +60,12 @@ class TrainOutput(NamedTuple):
 PREFIX_CHECKPOINT_DIR = "checkpoint"
 
 
+class EvaluationStrategy(ExplicitEnum):
+    NO = "no"
+    STEPS = "steps"
+    EPOCH = "epoch"
+
+
 class BestRun(NamedTuple):
     """
     The best run found by an hyperparameter search (see :class:`~transformers.Trainer.hyperparameter_search`).

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1,8 +1,9 @@
 import dataclasses
 import json
 import os
+import warnings
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from .file_utils import cached_property, is_torch_available, is_torch_tpu_available, torch_required
 from .utils import logging
@@ -50,8 +51,13 @@ class TrainingArguments:
             Whether to run evaluation on the dev set or not.
         do_predict (:obj:`bool`, `optional`, defaults to :obj:`False`):
             Whether to run predictions on the test set or not.
-        evaluate_during_training (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            Whether to run evaluation during training at each logging step or not.
+        evaluation_strategy(:obj:`bool` or :obj:`str`, `optional`, defaults to :obj:`"False"`):
+            The evulation strategy to adopt during training. Possible values are:
+
+                * :obj:`False` or :obj:`"no"`: No evaluation is done during training.
+                * :obj:`True` or :obj:`"steps"`: Evaluation is done (and logged) ever :obj:`eval_steps`.
+                * :obj:`"epoch"`: Evaluation is done at the end of each epoch.
+
         prediction_loss_only (:obj:`bool`, `optional`, defaults to `False`):
             When performing evaluation and predictions, only returns the loss.
         per_device_train_batch_size (:obj:`int`, `optional`, defaults to 8):
@@ -111,8 +117,9 @@ class TrainingArguments:
         dataloader_drop_last (:obj:`bool`, `optional`, defaults to :obj:`False`):
             Whether to drop the last incomplete batch (if the length of the dataset is not divisible by the batch size)
             or not.
-        eval_steps (:obj:`int`, `optional`, defaults to 1000):
-            Number of update steps between two evaluations.
+        eval_steps (:obj:`int`, `optional`):
+            Number of update steps between two evaluations if :obj:`evaluation_strategy="steps"`. Will default to the
+            same value as :obj:`logging_steps` if not set.
         past_index (:obj:`int`, `optional`, defaults to -1):
             Some models like :doc:`TransformerXL <../model_doc/transformerxl>` or :doc`XLNet <../model_doc/xlnet>` can
             make use of the past hidden states for their predictions. If this argument is set to a positive int, the
@@ -153,7 +160,11 @@ class TrainingArguments:
     do_eval: bool = field(default=False, metadata={"help": "Whether to run eval on the dev set."})
     do_predict: bool = field(default=False, metadata={"help": "Whether to run predictions on the test set."})
     evaluate_during_training: bool = field(
-        default=False,
+        default=None,
+        metadata={"help": "Run evaluation during training at each logging step."},
+    )
+    evaluation_strategy: Union[bool, str] = field(
+        default="no",
         metadata={"help": "Run evaluation during training at each logging step."},
     )
     prediction_loss_only: bool = field(
@@ -245,7 +256,7 @@ class TrainingArguments:
     dataloader_drop_last: bool = field(
         default=False, metadata={"help": "Drop the last incomplete batch if it is not divisible by the batch size."}
     )
-    eval_steps: int = field(default=1000, metadata={"help": "Run an evaluation every X steps."})
+    eval_steps: int = field(default=None, metadata={"help": "Run an evaluation every X steps."})
 
     past_index: int = field(
         default=-1,
@@ -269,6 +280,19 @@ class TrainingArguments:
     def __post_init__(self):
         if self.disable_tqdm is None:
             self.disable_tqdm = logger.getEffectiveLevel() > logging.WARN
+        if self.evaluate_during_training is not None:
+            self.evaluation_strategy = self.evaluate_during_training
+            warnings.warn(
+                "The `evaluate_during_training` argument is deprecated in favor of `evaluation_strategy` (which has more options)",
+                FutureWarning,
+            )
+        if self.evaluation_strategy is True:
+            self.evaluation_strategy = "steps"
+        elif self.evaluation_strategy is False:
+            self.evaluation_strategy = "no"
+
+        if self.eval_steps is None:
+            self.eval_steps = self.logging_steps
 
     @property
     def train_batch_size(self) -> int:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -54,10 +54,10 @@ class TrainingArguments:
         do_predict (:obj:`bool`, `optional`, defaults to :obj:`False`):
             Whether to run predictions on the test set or not.
         evaluation_strategy(:obj:`str` or :class:`~transformers.trainer_utils.EvaluationStrategy`, `optional`, defaults to :obj:`"no"`):
-            The evaulation strategy to adopt during training. Possible values are:
+            The evaluation strategy to adopt during training. Possible values are:
 
                 * :obj:`"no"`: No evaluation is done during training.
-                * :obj:`"steps"`: Evaluation is done (and logged) ever :obj:`eval_steps`.
+                * :obj:`"steps"`: Evaluation is done (and logged) every :obj:`eval_steps`.
                 * :obj:`"epoch"`: Evaluation is done at the end of each epoch.
 
         prediction_loss_only (:obj:`bool`, `optional`, defaults to `False`):
@@ -283,7 +283,7 @@ class TrainingArguments:
         if self.disable_tqdm is None:
             self.disable_tqdm = logger.getEffectiveLevel() > logging.WARN
         if self.evaluate_during_training is not None:
-            self.evaluation_strategy = "steps" if self.evaluate_during_training else "no"
+            self.evaluation_strategy = EvaluationStrategy.STEPS if self.evaluate_during_training else EvaluationStrategy.NO
             warnings.warn(
                 "The `evaluate_during_training` argument is deprecated in favor of `evaluation_strategy` (which has more options)",
                 FutureWarning,

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -283,12 +283,15 @@ class TrainingArguments:
         if self.disable_tqdm is None:
             self.disable_tqdm = logger.getEffectiveLevel() > logging.WARN
         if self.evaluate_during_training is not None:
-            self.evaluation_strategy = EvaluationStrategy.STEPS if self.evaluate_during_training else EvaluationStrategy.NO
+            self.evaluation_strategy = (
+                EvaluationStrategy.STEPS if self.evaluate_during_training else EvaluationStrategy.NO
+            )
             warnings.warn(
                 "The `evaluate_during_training` argument is deprecated in favor of `evaluation_strategy` (which has more options)",
                 FutureWarning,
             )
-        self.evaluation_strategy = EvaluationStrategy(self.evaluation_strategy)
+        else:
+            self.evaluation_strategy = EvaluationStrategy(self.evaluation_strategy)
 
         if self.eval_steps is None:
             self.eval_steps = self.logging_steps

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -51,11 +51,11 @@ class TrainingArguments:
             Whether to run evaluation on the dev set or not.
         do_predict (:obj:`bool`, `optional`, defaults to :obj:`False`):
             Whether to run predictions on the test set or not.
-        evaluation_strategy(:obj:`bool` or :obj:`str`, `optional`, defaults to :obj:`"False"`):
-            The evulation strategy to adopt during training. Possible values are:
+        evaluation_strategy(:obj:`str`, `optional`, defaults to :obj:`"no"`):
+            The evaulation strategy to adopt during training. Possible values are:
 
-                * :obj:`False` or :obj:`"no"`: No evaluation is done during training.
-                * :obj:`True` or :obj:`"steps"`: Evaluation is done (and logged) ever :obj:`eval_steps`.
+                * :obj:`"no"`: No evaluation is done during training.
+                * :obj:`"steps"`: Evaluation is done (and logged) ever :obj:`eval_steps`.
                 * :obj:`"epoch"`: Evaluation is done at the end of each epoch.
 
         prediction_loss_only (:obj:`bool`, `optional`, defaults to `False`):
@@ -163,7 +163,7 @@ class TrainingArguments:
         default=None,
         metadata={"help": "Run evaluation during training at each logging step."},
     )
-    evaluation_strategy: Union[bool, str] = field(
+    evaluation_strategy: str = field(
         default="no",
         metadata={"help": "Run evaluation during training at each logging step."},
     )
@@ -281,15 +281,11 @@ class TrainingArguments:
         if self.disable_tqdm is None:
             self.disable_tqdm = logger.getEffectiveLevel() > logging.WARN
         if self.evaluate_during_training is not None:
-            self.evaluation_strategy = self.evaluate_during_training
+            self.evaluation_strategy = "steps" if self.evaluate_during_training else "no"
             warnings.warn(
                 "The `evaluate_during_training` argument is deprecated in favor of `evaluation_strategy` (which has more options)",
                 FutureWarning,
             )
-        if self.evaluation_strategy is True:
-            self.evaluation_strategy = "steps"
-        elif self.evaluation_strategy is False:
-            self.evaluation_strategy = "no"
 
         if self.eval_steps is None:
             self.eval_steps = self.logging_steps

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -3,7 +3,7 @@ import json
 import os
 import warnings
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 from .file_utils import cached_property, is_torch_available, is_torch_tpu_available, torch_required
 from .utils import logging


### PR DESCRIPTION
This PR deprecates the argument `evaluate_during_training` and replaces it by `evaluation_strategy` (which supports more than just two values). The goal is to add support to easily evaluate the model every epoch (currently evaluation is done every n steps).

Evaluating every epoch is the most commonly used evaluation strategy, taught in pretty much every course and done in every basic training loop. While it's possible to do that right now, it require a bit of gymnastic (by building the dataloader and grabbing its length or dividing the number of samples in the dataset by the effective batch size). There have been two issues opened about that (but I'm too lazy to track their numbers ^^).

In passing, I made `eval_steps` default to the same as `logging_steps` because it seemed more natural.


