### PR TITLE
[code quality] fix confused flake8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,7 +244,7 @@ jobs:
                   key: v0.3-code_quality-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: black --check --line-length 119 --target-version py35 examples templates tests src utils
+            - run: black --check examples templates tests src utils
             - run: isort --check-only examples templates tests src utils
             - run: flake8 examples templates tests src utils
             - run: python utils/check_repo.py

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Check that source code meets quality standards
 
 quality:
-	black --check --line-length 119 --target-version py35 examples templates tests src utils
+	black --check examples templates tests src utils
 	isort --check-only examples templates tests src utils
 	flake8 examples templates tests src utils
 	python utils/check_repo.py
@@ -11,7 +11,7 @@ quality:
 # Format source code automatically
 
 style:
-	black --line-length 119 --target-version py35 examples templates tests src utils
+	black examples templates tests src utils
 	isort examples templates tests src utils
 
 # Run tests for the library

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 119
+target-version = ['py35']


### PR DESCRIPTION
We run `black  --target-version py35 ...` but flake8 doesn't know that we want this specific `target-version`, so currently with py38 flake8 fails suggesting that black should have reformatted 63 files. Indeed if I run:

```
black --line-length 119 --target-version py38 examples templates tests src utils
```
it indeed reformats 63 files.

The only solution I found is to create a black config file as explained at https://github.com/psf/black#configuration-format, which is what this PR adds.

Now flake8 knows that py35 is the standard and no longer gets confused regardless of the user's python version.

We can now edit out `--line-length 119 --target-version py35` from Makefile and the CI jobs, so that we have one config to rule them all. I pushed that change as well.

@sgugger, @LysandreJik 
