### PR TITLE
Create an XLA parameter and fix the mixed precision

### DIFF
--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -531,10 +531,6 @@ class TFTrainer:
 
             tf.summary.experimental.set_step(self.global_step)
 
-            if self.args.fp16:
-                policy = tf.keras.mixed_precision.experimental.Policy("mixed_float16")
-                tf.keras.mixed_precision.experimental.set_policy(policy)
-
             with self.tb_writer.as_default():
                 tf.summary.text("args", self.args.to_json_string())
 

--- a/src/transformers/training_args_tf.py
+++ b/src/transformers/training_args_tf.py
@@ -2,8 +2,6 @@ import warnings
 from dataclasses import dataclass, field
 from typing import Tuple
 
-from tensorflow.python.keras.mixed_precision.experimental import policy
-
 from .file_utils import cached_property, is_tf_available, tf_required
 from .training_args import TrainingArguments
 from .utils import logging
@@ -112,10 +110,7 @@ class TFTrainingArguments(TrainingArguments):
         metadata={"help": "Name of TPU"},
     )
 
-    xla: bool = field(
-        default=False,
-        metadata={"help": "Whether to activate the XLA compilation or not"}
-    )
+    xla: bool = field(default=False, metadata={"help": "Whether to activate the XLA compilation or not"})
 
     @cached_property
     @tf_required
@@ -144,7 +139,7 @@ class TFTrainingArguments(TrainingArguments):
                 tpu = None
 
             if tpu:
-                # Set to bfloat16 in case of TPU 
+                # Set to bfloat16 in case of TPU
                 if self.fp16:
                     policy = tf.keras.mixed_precision.experimental.Policy("mixed_bfloat16")
                     tf.keras.mixed_precision.experimental.set_policy(policy)
@@ -153,7 +148,7 @@ class TFTrainingArguments(TrainingArguments):
                 tf.tpu.experimental.initialize_tpu_system(tpu)
 
                 strategy = tf.distribute.experimental.TPUStrategy(tpu)
-                
+
             elif len(gpus) == 0:
                 strategy = tf.distribute.OneDeviceStrategy(device="/cpu:0")
             elif len(gpus) == 1:

--- a/src/transformers/training_args_tf.py
+++ b/src/transformers/training_args_tf.py
@@ -2,6 +2,8 @@ import warnings
 from dataclasses import dataclass, field
 from typing import Tuple
 
+from tensorflow.python.keras.mixed_precision.experimental import policy
+
 from .file_utils import cached_property, is_tf_available, tf_required
 from .training_args import TrainingArguments
 from .utils import logging
@@ -88,7 +90,7 @@ class TFTrainingArguments(TrainingArguments):
         tpu_num_cores (:obj:`int`, `optional`):
             When training on TPU, the mumber of TPU cores (automatically passed by launcher script).
         debug (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            Wheter to activate the trace to record computation graphs and profiling information or not.
+            Whether to activate the trace to record computation graphs and profiling information or not.
         dataloader_drop_last (:obj:`bool`, `optional`, defaults to :obj:`False`):
             Whether to drop the last incomplete batch (if the length of the dataset is not divisible by the batch size)
             or not.
@@ -110,11 +112,25 @@ class TFTrainingArguments(TrainingArguments):
         metadata={"help": "Name of TPU"},
     )
 
+    xla: bool = field(
+        default=False,
+        metadata={"help": "Whether to activate the XLA compilation or not"}
+    )
+
     @cached_property
     @tf_required
     def _setup_strategy(self) -> Tuple["tf.distribute.Strategy", int]:
         logger.info("Tensorflow: setting up strategy")
+
+        if self.args.xla:
+            tf.config.optimizer.set_jit(True)
+
         gpus = tf.config.list_physical_devices("GPU")
+
+        # Set to float16 at first
+        if self.fp16:
+            policy = tf.keras.mixed_precision.experimental.Policy("mixed_float16")
+            tf.keras.mixed_precision.experimental.set_policy(policy)
 
         if self.no_cuda:
             strategy = tf.distribute.OneDeviceStrategy(device="/cpu:0")
@@ -128,10 +144,16 @@ class TFTrainingArguments(TrainingArguments):
                 tpu = None
 
             if tpu:
+                # Set to bfloat16 in case of TPU 
+                if self.fp16:
+                    policy = tf.keras.mixed_precision.experimental.Policy("mixed_bfloat16")
+                    tf.keras.mixed_precision.experimental.set_policy(policy)
+
                 tf.config.experimental_connect_to_cluster(tpu)
                 tf.tpu.experimental.initialize_tpu_system(tpu)
 
                 strategy = tf.distribute.experimental.TPUStrategy(tpu)
+                
             elif len(gpus) == 0:
                 strategy = tf.distribute.OneDeviceStrategy(device="/cpu:0")
             elif len(gpus) == 1:

--- a/src/transformers/training_args_tf.py
+++ b/src/transformers/training_args_tf.py
@@ -103,6 +103,8 @@ class TFTrainingArguments(TrainingArguments):
             The name of the TPU the process is running on.
         run_name (:obj:`str`, `optional`):
             A descriptor for the run. Notably used for wandb logging.
+        xla (:obj:`bool`, `optional`):
+            Whether to activate the XLA compilation or not.
     """
 
     tpu_name: str = field(


### PR DESCRIPTION
This PR adds a new `XLA` parameter to activate/deactivate the XLA compilation and a bug in the mixed precision. These have to be set before the creation of the strategy and float16 is not compliant with TPU, where only bfloat16 is available.