### PR TITLE
[Bug Fix] Fix run_squad.py evaluation code doesn't use probabilities

### DIFF
--- a/examples/question-answering/run_squad.py
+++ b/examples/question-answering/run_squad.py
@@ -18,6 +18,7 @@
 
 import argparse
 import glob
+import json
 import logging
 import os
 import random
@@ -394,8 +395,14 @@ def evaluate(args, model, tokenizer, prefix=""):
             tokenizer,
         )
 
+    # Get the answers probabilities from file saved by compute_predictions_logits
+    with open(output_nbest_file, "r") as file:
+        nbest_preds = json.load(file)
+        # change the answer probs to no answer probs
+        na_probs = {id: 1 - preds[0]["probability"] for id, preds in nbest_preds.items()}
+
     # Compute the F1 and exact scores.
-    results = squad_evaluate(examples, predictions)
+    results = squad_evaluate(examples, predictions, na_probs)
     return results
 
 


### PR DESCRIPTION
Modification of run_squad.py fine tuning example so it will use the answer correctness probabilities the models produce while evaluating the model and calculating the best thresholds.

Evaluation was done without the evaluated model probabilities but rather with default zero values. It corrupted the evaluation results and the best thresholds (which evaluated always as 0.0).

**Notice: many squad models were evaluated without the probabilities, therefore, the results published in their model cards are possibly wrong.**

Example: [ahotrod/electra_large_discriminator_squad2_512](https://huggingface.co/ahotrod/electra_large_discriminator_squad2_512)

The results with current evaluation script:
```
"exact": 87.09677419354838,
  "f1": 89.98343832723452,
  "total": 11873,
  "HasAns_exact": 84.66599190283401,
  "HasAns_f1": 90.44759839056285,
  "HasAns_total": 5928,
  "NoAns_exact": 89.52060555088309,
  "NoAns_f1": 89.52060555088309,
  "NoAns_total": 5945,
  "best_exact": 87.09677419354838,
  "best_exact_thresh": 0.0,
  "best_f1": 89.98343832723432,
  "best_f1_thresh": 0.0
```

The results after the fix:
```
'exact': 87.00412701086499,
 'f1': 89.77725380276271,
 'total': 11873,
 'HasAns_exact': 83.80566801619433,
 'HasAns_f1': 89.35987422405582,
 'HasAns_total': 5928,
 'NoAns_exact': 90.19343986543313,
 'NoAns_f1': 90.19343986543313,
 'NoAns_total': 5945,
 'best_exact': 87.34102585698643,
'best_exact_thresh': 0.09882385462915344,
 'best_f1': 90.07804792988485,
'best_f1_thresh': 0.09882385462915344
```





