### PR TITLE
Ensure that integrations are imported before transformers or ml libs

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -19,7 +19,7 @@ else:
 
 # Integrations: this needs to come before other ml imports
 # in order to allow any 3rd-party code to initialize properly
-from .integrations import (
+from .integrations import (  # isort:skip
     is_comet_available,
     is_optuna_available,
     is_ray_available,

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -17,6 +17,16 @@ else:
     absl.logging.set_stderrthreshold("info")
     absl.logging._warn_preinit_stderr = False
 
+# Integrations: this needs to come before other ml imports
+# in order to allow any 3rd-party code to initialize properly
+from .integrations import (
+    is_comet_available,
+    is_optuna_available,
+    is_ray_available,
+    is_tensorboard_available,
+    is_wandb_available,
+)
+
 # Configurations
 from .configuration_albert import ALBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, AlbertConfig
 from .configuration_auto import ALL_PRETRAINED_CONFIG_ARCHIVE_MAP, CONFIG_MAPPING, AutoConfig
@@ -95,15 +105,6 @@ from .file_utils import (
     is_torch_tpu_available,
 )
 from .hf_argparser import HfArgumentParser
-
-# Integrations
-from .integrations import (
-    is_comet_available,
-    is_optuna_available,
-    is_ray_available,
-    is_tensorboard_available,
-    is_wandb_available,
-)
 
 # Model Cards
 from .modelcard import ModelCard

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -58,6 +58,7 @@ except ImportError:
 
 ## Integration functions:
 
+
 def is_wandb_available():
     return _has_wandb
 

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -37,7 +37,7 @@ except (ImportError):
     _has_ray = False
 
 
-## No ML framework or transformer imports above this point
+# No ML framework or transformer imports above this point
 
 from .trainer_utils import PREFIX_CHECKPOINT_DIR, BestRun  # isort:skip
 from .utils import logging  # isort:skip
@@ -57,7 +57,7 @@ except ImportError:
     except ImportError:
         _has_tensorboard = False
 
-## Integration functions:
+# Integration functions:
 
 
 def is_wandb_available():

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -39,8 +39,8 @@ except (ImportError):
 
 ## No ML framework or transformer imports above this point
 
-from .trainer_utils import PREFIX_CHECKPOINT_DIR, BestRun # isort:skip
-from .utils import logging # isort:skip
+from .trainer_utils import PREFIX_CHECKPOINT_DIR, BestRun  # isort:skip
+from .utils import logging  # isort:skip
 
 logger = logging.get_logger(__name__)
 

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -1,13 +1,6 @@
 # Integrations with other Python libraries
+import math
 import os
-
-import numpy as np
-
-from .trainer_utils import PREFIX_CHECKPOINT_DIR, BestRun
-from .utils import logging
-
-
-logger = logging.get_logger(__name__)
 
 try:
     import comet_ml  # noqa: F401
@@ -15,7 +8,6 @@ try:
     _has_comet = True
 except (ImportError):
     _has_comet = False
-
 
 try:
     import wandb
@@ -28,18 +20,6 @@ try:
         _has_wandb = False if os.getenv("WANDB_DISABLED") else True
 except (ImportError, AttributeError):
     _has_wandb = False
-
-try:
-    from torch.utils.tensorboard import SummaryWriter  # noqa: F401
-
-    _has_tensorboard = True
-except ImportError:
-    try:
-        from tensorboardX import SummaryWriter  # noqa: F401
-
-        _has_tensorboard = True
-    except ImportError:
-        _has_tensorboard = False
 
 try:
     import optuna  # noqa: F401
@@ -55,6 +35,28 @@ try:
 except (ImportError):
     _has_ray = False
 
+
+## No ML framework or transformer imports above this point
+
+from .trainer_utils import PREFIX_CHECKPOINT_DIR, BestRun
+from .utils import logging
+
+logger = logging.get_logger(__name__)
+
+
+try:
+    from torch.utils.tensorboard import SummaryWriter  # noqa: F401
+
+    _has_tensorboard = True
+except ImportError:
+    try:
+        from tensorboardX import SummaryWriter  # noqa: F401
+
+        _has_tensorboard = True
+    except ImportError:
+        _has_tensorboard = False
+
+## Integration functions:
 
 def is_wandb_available():
     return _has_wandb
@@ -135,7 +137,7 @@ def run_hp_search_ray(trainer, n_trials: int, direction: str, **kwargs) -> BestR
         n_jobs = int(kwargs.pop("n_jobs", 1))
         num_gpus_per_trial = trainer.args.n_gpu
         if num_gpus_per_trial / n_jobs >= 1:
-            num_gpus_per_trial = int(np.ceil(num_gpus_per_trial / n_jobs))
+            num_gpus_per_trial = int(math.ceil(num_gpus_per_trial / n_jobs))
         kwargs["resources_per_trial"] = {"gpu": num_gpus_per_trial}
 
     if "reporter" not in kwargs:

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -2,6 +2,7 @@
 import math
 import os
 
+
 try:
     import comet_ml  # noqa: F401
 
@@ -38,8 +39,8 @@ except (ImportError):
 
 ## No ML framework or transformer imports above this point
 
-from .trainer_utils import PREFIX_CHECKPOINT_DIR, BestRun
-from .utils import logging
+from .trainer_utils import PREFIX_CHECKPOINT_DIR, BestRun # isort:skip
+from .utils import logging # isort:skip
 
 logger = logging.get_logger(__name__)
 


### PR DESCRIPTION
This PR fixes a problem with some 3rd-party integrations that need to be imported before any transformers or other machine learning framework Python modules.

This PR makes the following changes:

1. Moves `import .integrations` in `__init__.py` before any other transformers imports
2. Moves ML imports in .integrations below 3rd-party imports
3. Used math.ceil() rather than numpy.ceil() as that was overkill

Before PR:

* failed with comet_ml

After PR:

* works with comet_ml