### PR TITLE
Remove reference to args in XLA check

### DIFF
--- a/src/transformers/training_args_tf.py
+++ b/src/transformers/training_args_tf.py
@@ -119,7 +119,7 @@ class TFTrainingArguments(TrainingArguments):
     def _setup_strategy(self) -> Tuple["tf.distribute.Strategy", int]:
         logger.info("Tensorflow: setting up strategy")
 
-        if self.args.xla:
+        if self.xla:
             tf.config.optimizer.set_jit(True)
 
         gpus = tf.config.list_physical_devices("GPU")


### PR DESCRIPTION
Previously, the TFTrainingArguments object did a check to see if XLA was enabled, but did this by referencing `self.args.xla`, when it should be `self.xla`, because it is the args object. This can be verified a few lines above, where the XLA field is set.

<!-- This line specifies which issue to close after the pull request is merged. -->
Fixes #7343 