### PR TITLE
Check config type using `type` instead of `isinstance`

### DIFF
--- a/src/transformers/modeling_auto.py
+++ b/src/transformers/modeling_auto.py
@@ -585,7 +585,9 @@ class AutoModel:
             )
 
         if type(config) in MODEL_MAPPING.keys():
-            return MODEL_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return MODEL_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -677,7 +679,9 @@ class AutoModelForPreTraining:
             )
 
         if type(config) in MODEL_FOR_PRETRAINING_MAPPING.keys():
-            return MODEL_FOR_PRETRAINING_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return MODEL_FOR_PRETRAINING_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -787,7 +791,9 @@ class AutoModelWithLMHead:
             )
 
         if type(config) in MODEL_WITH_LM_HEAD_MAPPING.keys():
-            return MODEL_WITH_LM_HEAD_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return MODEL_WITH_LM_HEAD_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -879,7 +885,9 @@ class AutoModelForCausalLM:
             )
 
         if type(config) in MODEL_FOR_CAUSAL_LM_MAPPING.keys():
-            return MODEL_FOR_CAUSAL_LM_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return MODEL_FOR_CAUSAL_LM_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -971,7 +979,9 @@ class AutoModelForMaskedLM:
             )
 
         if type(config) in MODEL_FOR_MASKED_LM_MAPPING.keys():
-            return MODEL_FOR_MASKED_LM_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return MODEL_FOR_MASKED_LM_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1065,7 +1075,9 @@ class AutoModelForSeq2SeqLM:
             )
 
         if type(config) in MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.keys():
-            return MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1161,7 +1173,9 @@ class AutoModelForSequenceClassification:
             )
 
         if type(config) in MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.keys():
-            return MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1257,7 +1271,9 @@ class AutoModelForQuestionAnswering:
             )
 
         if type(config) in MODEL_FOR_QUESTION_ANSWERING_MAPPING.keys():
-            return MODEL_FOR_QUESTION_ANSWERING_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return MODEL_FOR_QUESTION_ANSWERING_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
 
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -1354,7 +1370,9 @@ class AutoModelForTokenClassification:
             )
 
         if type(config) in MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.keys():
-            return MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
 
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -1452,7 +1470,9 @@ class AutoModelForMultipleChoice:
             )
 
         if type(config) in MODEL_FOR_MULTIPLE_CHOICE_MAPPING.keys():
-            return MODEL_FOR_MULTIPLE_CHOICE_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return MODEL_FOR_MULTIPLE_CHOICE_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
 
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"

--- a/src/transformers/modeling_auto.py
+++ b/src/transformers/modeling_auto.py
@@ -545,7 +545,7 @@ class AutoModel:
             >>> model = AutoModel.from_config(config)
         """
         for config_class, model_class in MODEL_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -586,7 +586,7 @@ class AutoModel:
             )
 
         for config_class, model_class in MODEL_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -639,7 +639,7 @@ class AutoModelForPreTraining:
             >>> model = AutoModelForPreTraining.from_config(config)
         """
         for config_class, model_class in MODEL_FOR_PRETRAINING_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -680,7 +680,7 @@ class AutoModelForPreTraining:
             )
 
         for config_class, model_class in MODEL_FOR_PRETRAINING_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -745,7 +745,7 @@ class AutoModelWithLMHead:
             FutureWarning,
         )
         for config_class, model_class in MODEL_WITH_LM_HEAD_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -792,7 +792,7 @@ class AutoModelWithLMHead:
             )
 
         for config_class, model_class in MODEL_WITH_LM_HEAD_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -845,7 +845,7 @@ class AutoModelForCausalLM:
             >>> model = AutoModelForCausalLM.from_config(config)
         """
         for config_class, model_class in MODEL_FOR_CAUSAL_LM_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -886,7 +886,7 @@ class AutoModelForCausalLM:
             )
 
         for config_class, model_class in MODEL_FOR_CAUSAL_LM_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -939,7 +939,7 @@ class AutoModelForMaskedLM:
             >>> model = AutoModelForMaskedLM.from_config(config)
         """
         for config_class, model_class in MODEL_FOR_MASKED_LM_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -980,7 +980,7 @@ class AutoModelForMaskedLM:
             )
 
         for config_class, model_class in MODEL_FOR_MASKED_LM_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -1033,7 +1033,7 @@ class AutoModelForSeq2SeqLM:
             >>> model = AutoModelForSeq2SeqLM.from_config(config)
         """
         for config_class, model_class in MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -1076,7 +1076,7 @@ class AutoModelForSeq2SeqLM:
             )
 
         for config_class, model_class in MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -1131,7 +1131,7 @@ class AutoModelForSequenceClassification:
             >>> model = AutoModelForSequenceClassification.from_config(config)
         """
         for config_class, model_class in MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -1174,7 +1174,7 @@ class AutoModelForSequenceClassification:
             )
 
         for config_class, model_class in MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -1228,7 +1228,7 @@ class AutoModelForQuestionAnswering:
             >>> model = AutoModelForQuestionAnswering.from_config(config)
         """
         for config_class, model_class in MODEL_FOR_QUESTION_ANSWERING_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
 
         raise ValueError(
@@ -1272,7 +1272,7 @@ class AutoModelForQuestionAnswering:
             )
 
         for config_class, model_class in MODEL_FOR_QUESTION_ANSWERING_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
 
         raise ValueError(
@@ -1327,7 +1327,7 @@ class AutoModelForTokenClassification:
             >>> model = AutoModelForTokenClassification.from_config(config)
         """
         for config_class, model_class in MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
 
         raise ValueError(
@@ -1371,7 +1371,7 @@ class AutoModelForTokenClassification:
             )
 
         for config_class, model_class in MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
 
         raise ValueError(
@@ -1427,7 +1427,7 @@ class AutoModelForMultipleChoice:
             >>> model = AutoModelForMultipleChoice.from_config(config)
         """
         for config_class, model_class in MODEL_FOR_MULTIPLE_CHOICE_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
 
         raise ValueError(
@@ -1471,7 +1471,7 @@ class AutoModelForMultipleChoice:
             )
 
         for config_class, model_class in MODEL_FOR_MULTIPLE_CHOICE_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
 
         raise ValueError(

--- a/src/transformers/modeling_auto.py
+++ b/src/transformers/modeling_auto.py
@@ -544,9 +544,8 @@ class AutoModel:
             >>> config = AutoConfig.from_pretrained('bert-base-uncased')
             >>> model = AutoModel.from_config(config)
         """
-        for config_class, model_class in MODEL_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in MODEL_MAPPING.keys():
+            return MODEL_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -585,9 +584,8 @@ class AutoModel:
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in MODEL_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in MODEL_MAPPING.keys():
+            return MODEL_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -638,9 +636,8 @@ class AutoModelForPreTraining:
             >>> config = AutoConfig.from_pretrained('bert-base-uncased')
             >>> model = AutoModelForPreTraining.from_config(config)
         """
-        for config_class, model_class in MODEL_FOR_PRETRAINING_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in MODEL_FOR_PRETRAINING_MAPPING.keys():
+            return MODEL_FOR_PRETRAINING_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -679,9 +676,8 @@ class AutoModelForPreTraining:
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in MODEL_FOR_PRETRAINING_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in MODEL_FOR_PRETRAINING_MAPPING.keys():
+            return MODEL_FOR_PRETRAINING_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -744,9 +740,8 @@ class AutoModelWithLMHead:
             "`AutoModelForSeq2SeqLM` for encoder-decoder models.",
             FutureWarning,
         )
-        for config_class, model_class in MODEL_WITH_LM_HEAD_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in MODEL_WITH_LM_HEAD_MAPPING.keys():
+            return MODEL_WITH_LM_HEAD_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -791,9 +786,8 @@ class AutoModelWithLMHead:
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in MODEL_WITH_LM_HEAD_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in MODEL_WITH_LM_HEAD_MAPPING.keys():
+            return MODEL_WITH_LM_HEAD_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -844,9 +838,8 @@ class AutoModelForCausalLM:
             >>> config = AutoConfig.from_pretrained('gpt2')
             >>> model = AutoModelForCausalLM.from_config(config)
         """
-        for config_class, model_class in MODEL_FOR_CAUSAL_LM_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in MODEL_FOR_CAUSAL_LM_MAPPING.keys():
+            return MODEL_FOR_CAUSAL_LM_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -885,9 +878,8 @@ class AutoModelForCausalLM:
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in MODEL_FOR_CAUSAL_LM_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in MODEL_FOR_CAUSAL_LM_MAPPING.keys():
+            return MODEL_FOR_CAUSAL_LM_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -938,9 +930,8 @@ class AutoModelForMaskedLM:
             >>> config = AutoConfig.from_pretrained('bert-base-uncased')
             >>> model = AutoModelForMaskedLM.from_config(config)
         """
-        for config_class, model_class in MODEL_FOR_MASKED_LM_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in MODEL_FOR_MASKED_LM_MAPPING.keys():
+            return MODEL_FOR_MASKED_LM_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -979,9 +970,8 @@ class AutoModelForMaskedLM:
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in MODEL_FOR_MASKED_LM_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in MODEL_FOR_MASKED_LM_MAPPING.keys():
+            return MODEL_FOR_MASKED_LM_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1032,9 +1022,8 @@ class AutoModelForSeq2SeqLM:
             >>> config = AutoConfig.from_pretrained('t5')
             >>> model = AutoModelForSeq2SeqLM.from_config(config)
         """
-        for config_class, model_class in MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.keys():
+            return MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1075,9 +1064,8 @@ class AutoModelForSeq2SeqLM:
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.keys():
+            return MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1130,9 +1118,8 @@ class AutoModelForSequenceClassification:
             >>> config = AutoConfig.from_pretrained('bert-base-uncased')
             >>> model = AutoModelForSequenceClassification.from_config(config)
         """
-        for config_class, model_class in MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.keys():
+            return MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1173,9 +1160,8 @@ class AutoModelForSequenceClassification:
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.keys():
+            return MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1227,9 +1213,8 @@ class AutoModelForQuestionAnswering:
             >>> config = AutoConfig.from_pretrained('bert-base-uncased')
             >>> model = AutoModelForQuestionAnswering.from_config(config)
         """
-        for config_class, model_class in MODEL_FOR_QUESTION_ANSWERING_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in MODEL_FOR_QUESTION_ANSWERING_MAPPING.keys():
+            return MODEL_FOR_QUESTION_ANSWERING_MAPPING[type(config)](config)
 
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -1271,9 +1256,8 @@ class AutoModelForQuestionAnswering:
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in MODEL_FOR_QUESTION_ANSWERING_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in MODEL_FOR_QUESTION_ANSWERING_MAPPING.keys():
+            return MODEL_FOR_QUESTION_ANSWERING_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
 
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -1326,9 +1310,8 @@ class AutoModelForTokenClassification:
             >>> config = AutoConfig.from_pretrained('bert-base-uncased')
             >>> model = AutoModelForTokenClassification.from_config(config)
         """
-        for config_class, model_class in MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.keys():
+            return MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING[type(config)](config)
 
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -1370,9 +1353,8 @@ class AutoModelForTokenClassification:
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.keys():
+            return MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
 
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -1426,9 +1408,8 @@ class AutoModelForMultipleChoice:
             >>> config = AutoConfig.from_pretrained('bert-base-uncased')
             >>> model = AutoModelForMultipleChoice.from_config(config)
         """
-        for config_class, model_class in MODEL_FOR_MULTIPLE_CHOICE_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in MODEL_FOR_MULTIPLE_CHOICE_MAPPING.keys():
+            return MODEL_FOR_MULTIPLE_CHOICE_MAPPING[type(config)](config)
 
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"
@@ -1470,9 +1451,8 @@ class AutoModelForMultipleChoice:
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in MODEL_FOR_MULTIPLE_CHOICE_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in MODEL_FOR_MULTIPLE_CHOICE_MAPPING.keys():
+            return MODEL_FOR_MULTIPLE_CHOICE_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
 
         raise ValueError(
             "Unrecognized configuration class {} for this kind of AutoModel: {}.\n"

--- a/src/transformers/modeling_tf_auto.py
+++ b/src/transformers/modeling_tf_auto.py
@@ -453,9 +453,8 @@ class TFAutoModel(object):
             >>> config = TFAutoConfig.from_pretrained('bert-base-uncased')
             >>> model = TFAutoModel.from_config(config)
         """
-        for config_class, model_class in TF_MODEL_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in TF_MODEL_MAPPING.keys():
+            return TF_MODEL_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -494,9 +493,8 @@ class TFAutoModel(object):
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in TF_MODEL_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in TF_MODEL_MAPPING.keys():
+            return TF_MODEL_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -547,9 +545,8 @@ class TFAutoModelForPreTraining(object):
             >>> config = AutoConfig.from_pretrained('bert-base-uncased')
             >>> model = TFAutoModelForPreTraining.from_config(config)
         """
-        for config_class, model_class in TF_MODEL_FOR_PRETRAINING_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in TF_MODEL_FOR_PRETRAINING_MAPPING.keys():
+            return TF_MODEL_FOR_PRETRAINING_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -588,9 +585,8 @@ class TFAutoModelForPreTraining(object):
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in TF_MODEL_FOR_PRETRAINING_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in TF_MODEL_FOR_PRETRAINING_MAPPING.keys():
+            return TF_MODEL_FOR_PRETRAINING_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -653,9 +649,8 @@ class TFAutoModelWithLMHead(object):
             "and `TFAutoModelForSeq2SeqLM` for encoder-decoder models.",
             FutureWarning,
         )
-        for config_class, model_class in TF_MODEL_WITH_LM_HEAD_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in TF_MODEL_WITH_LM_HEAD_MAPPING.keys():
+            return TF_MODEL_WITH_LM_HEAD_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -701,10 +696,8 @@ class TFAutoModelWithLMHead(object):
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in TF_MODEL_WITH_LM_HEAD_MAPPING.items():
-            # Not using isinstance() here to do not take into account inheritance
-            if config_class == type(config):
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in TF_MODEL_WITH_LM_HEAD_MAPPING.keys():
+            return TF_MODEL_WITH_LM_HEAD_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -755,9 +748,8 @@ class TFAutoModelForCausalLM:
             >>> config = AutoConfig.from_pretrained('gpt2')
             >>> model = TFAutoModelForCausalLM.from_config(config)
         """
-        for config_class, model_class in TF_MODEL_FOR_CAUSAL_LM_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in TF_MODEL_FOR_CAUSAL_LM_MAPPING.keys():
+            return TF_MODEL_FOR_CAUSAL_LM_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -796,9 +788,8 @@ class TFAutoModelForCausalLM:
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in TF_MODEL_FOR_CAUSAL_LM_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in TF_MODEL_FOR_CAUSAL_LM_MAPPING.keys():
+            return TF_MODEL_FOR_CAUSAL_LM_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -849,9 +840,8 @@ class TFAutoModelForMaskedLM:
             >>> config = AutoConfig.from_pretrained('bert-base-uncased')
             >>> model = TFAutoModelForMaskedLM.from_config(config)
         """
-        for config_class, model_class in TF_MODEL_FOR_MASKED_LM_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in TF_MODEL_FOR_MASKED_LM_MAPPING.keys():
+            return TF_MODEL_FOR_MASKED_LM_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -890,9 +880,8 @@ class TFAutoModelForMaskedLM:
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in TF_MODEL_FOR_MASKED_LM_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in TF_MODEL_FOR_MASKED_LM_MAPPING.keys():
+            return TF_MODEL_FOR_MASKED_LM_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -943,9 +932,8 @@ class TFAutoModelForSeq2SeqLM:
             >>> config = AutoConfig.from_pretrained('t5')
             >>> model = TFAutoModelForSeq2SeqLM.from_config(config)
         """
-        for config_class, model_class in TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.keys():
+            return TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -986,9 +974,8 @@ class TFAutoModelForSeq2SeqLM:
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.keys():
+            return TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1041,9 +1028,8 @@ class TFAutoModelForSequenceClassification(object):
             >>> config = AutoConfig.from_pretrained('bert-base-uncased')
             >>> model = TFAutoModelForSequenceClassification.from_config(config)
         """
-        for config_class, model_class in TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.keys():
+            return TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1084,9 +1070,8 @@ class TFAutoModelForSequenceClassification(object):
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.keys():
+            return TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1138,9 +1123,8 @@ class TFAutoModelForQuestionAnswering(object):
             >>> config = AutoConfig.from_pretrained('bert-base-uncased')
             >>> model = TFAutoModelForQuestionAnswering.from_config(config)
         """
-        for config_class, model_class in TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING.keys():
+            return TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1181,9 +1165,8 @@ class TFAutoModelForQuestionAnswering(object):
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING.keys():
+            return TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1235,9 +1218,8 @@ class TFAutoModelForTokenClassification:
             >>> config = AutoConfig.from_pretrained('bert-base-uncased')
             >>> model = TFAutoModelForTokenClassification.from_config(config)
         """
-        for config_class, model_class in TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.keys():
+            return TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1278,9 +1260,8 @@ class TFAutoModelForTokenClassification:
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.keys():
+            return TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1333,9 +1314,8 @@ class TFAutoModelForMultipleChoice:
             >>> config = AutoConfig.from_pretrained('bert-base-uncased')
             >>> model = TFAutoModelForMultipleChoice.from_config(config)
         """
-        for config_class, model_class in TF_MODEL_FOR_MULTIPLE_CHOICE_MAPPING.items():
-            if type(config) == config_class:
-                return model_class(config)
+        if type(config) in TF_MODEL_FOR_MULTIPLE_CHOICE_MAPPING.keys():
+            return TF_MODEL_FOR_MULTIPLE_CHOICE_MAPPING[type(config)](config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1376,9 +1356,8 @@ class TFAutoModelForMultipleChoice:
                 pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
             )
 
-        for config_class, model_class in TF_MODEL_FOR_MULTIPLE_CHOICE_MAPPING.items():
-            if type(config) == config_class:
-                return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+        if type(config) in TF_MODEL_FOR_MULTIPLE_CHOICE_MAPPING.keys():
+            return TF_MODEL_FOR_MULTIPLE_CHOICE_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(

--- a/src/transformers/modeling_tf_auto.py
+++ b/src/transformers/modeling_tf_auto.py
@@ -494,7 +494,9 @@ class TFAutoModel(object):
             )
 
         if type(config) in TF_MODEL_MAPPING.keys():
-            return TF_MODEL_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return TF_MODEL_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -586,7 +588,9 @@ class TFAutoModelForPreTraining(object):
             )
 
         if type(config) in TF_MODEL_FOR_PRETRAINING_MAPPING.keys():
-            return TF_MODEL_FOR_PRETRAINING_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return TF_MODEL_FOR_PRETRAINING_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -697,7 +701,9 @@ class TFAutoModelWithLMHead(object):
             )
 
         if type(config) in TF_MODEL_WITH_LM_HEAD_MAPPING.keys():
-            return TF_MODEL_WITH_LM_HEAD_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return TF_MODEL_WITH_LM_HEAD_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -789,7 +795,9 @@ class TFAutoModelForCausalLM:
             )
 
         if type(config) in TF_MODEL_FOR_CAUSAL_LM_MAPPING.keys():
-            return TF_MODEL_FOR_CAUSAL_LM_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return TF_MODEL_FOR_CAUSAL_LM_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -881,7 +889,9 @@ class TFAutoModelForMaskedLM:
             )
 
         if type(config) in TF_MODEL_FOR_MASKED_LM_MAPPING.keys():
-            return TF_MODEL_FOR_MASKED_LM_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return TF_MODEL_FOR_MASKED_LM_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -975,7 +985,9 @@ class TFAutoModelForSeq2SeqLM:
             )
 
         if type(config) in TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.keys():
-            return TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1071,7 +1083,9 @@ class TFAutoModelForSequenceClassification(object):
             )
 
         if type(config) in TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.keys():
-            return TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1166,7 +1180,9 @@ class TFAutoModelForQuestionAnswering(object):
             )
 
         if type(config) in TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING.keys():
-            return TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1261,7 +1277,9 @@ class TFAutoModelForTokenClassification:
             )
 
         if type(config) in TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.keys():
-            return TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(
@@ -1357,7 +1375,9 @@ class TFAutoModelForMultipleChoice:
             )
 
         if type(config) in TF_MODEL_FOR_MULTIPLE_CHOICE_MAPPING.keys():
-            return TF_MODEL_FOR_MULTIPLE_CHOICE_MAPPING[type(config)].from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
+            return TF_MODEL_FOR_MULTIPLE_CHOICE_MAPPING[type(config)].from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, **kwargs
+            )
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
             "Model type should be one of {}.".format(

--- a/src/transformers/modeling_tf_auto.py
+++ b/src/transformers/modeling_tf_auto.py
@@ -454,7 +454,7 @@ class TFAutoModel(object):
             >>> model = TFAutoModel.from_config(config)
         """
         for config_class, model_class in TF_MODEL_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -495,7 +495,7 @@ class TFAutoModel(object):
             )
 
         for config_class, model_class in TF_MODEL_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -548,7 +548,7 @@ class TFAutoModelForPreTraining(object):
             >>> model = TFAutoModelForPreTraining.from_config(config)
         """
         for config_class, model_class in TF_MODEL_FOR_PRETRAINING_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -589,7 +589,7 @@ class TFAutoModelForPreTraining(object):
             )
 
         for config_class, model_class in TF_MODEL_FOR_PRETRAINING_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -654,7 +654,7 @@ class TFAutoModelWithLMHead(object):
             FutureWarning,
         )
         for config_class, model_class in TF_MODEL_WITH_LM_HEAD_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -756,7 +756,7 @@ class TFAutoModelForCausalLM:
             >>> model = TFAutoModelForCausalLM.from_config(config)
         """
         for config_class, model_class in TF_MODEL_FOR_CAUSAL_LM_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -797,7 +797,7 @@ class TFAutoModelForCausalLM:
             )
 
         for config_class, model_class in TF_MODEL_FOR_CAUSAL_LM_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -850,7 +850,7 @@ class TFAutoModelForMaskedLM:
             >>> model = TFAutoModelForMaskedLM.from_config(config)
         """
         for config_class, model_class in TF_MODEL_FOR_MASKED_LM_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -891,7 +891,7 @@ class TFAutoModelForMaskedLM:
             )
 
         for config_class, model_class in TF_MODEL_FOR_MASKED_LM_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -944,7 +944,7 @@ class TFAutoModelForSeq2SeqLM:
             >>> model = TFAutoModelForSeq2SeqLM.from_config(config)
         """
         for config_class, model_class in TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -987,7 +987,7 @@ class TFAutoModelForSeq2SeqLM:
             )
 
         for config_class, model_class in TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -1042,7 +1042,7 @@ class TFAutoModelForSequenceClassification(object):
             >>> model = TFAutoModelForSequenceClassification.from_config(config)
         """
         for config_class, model_class in TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -1085,7 +1085,7 @@ class TFAutoModelForSequenceClassification(object):
             )
 
         for config_class, model_class in TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -1139,7 +1139,7 @@ class TFAutoModelForQuestionAnswering(object):
             >>> model = TFAutoModelForQuestionAnswering.from_config(config)
         """
         for config_class, model_class in TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -1182,7 +1182,7 @@ class TFAutoModelForQuestionAnswering(object):
             )
 
         for config_class, model_class in TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -1236,7 +1236,7 @@ class TFAutoModelForTokenClassification:
             >>> model = TFAutoModelForTokenClassification.from_config(config)
         """
         for config_class, model_class in TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -1279,7 +1279,7 @@ class TFAutoModelForTokenClassification:
             )
 
         for config_class, model_class in TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -1334,7 +1334,7 @@ class TFAutoModelForMultipleChoice:
             >>> model = TFAutoModelForMultipleChoice.from_config(config)
         """
         for config_class, model_class in TF_MODEL_FOR_MULTIPLE_CHOICE_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class(config)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"
@@ -1377,7 +1377,7 @@ class TFAutoModelForMultipleChoice:
             )
 
         for config_class, model_class in TF_MODEL_FOR_MULTIPLE_CHOICE_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, config=config, **kwargs)
         raise ValueError(
             "Unrecognized configuration class {} for this kind of TFAutoModel: {}.\n"

--- a/src/transformers/tokenization_auto.py
+++ b/src/transformers/tokenization_auto.py
@@ -243,12 +243,12 @@ class AutoTokenizer:
                 )
             config = config.encoder
 
-        for config_class, (tokenizer_class_py, tokenizer_class_fast) in TOKENIZER_MAPPING.items():
-            if type(config) == config_class:
-                if tokenizer_class_fast and use_fast:
-                    return tokenizer_class_fast.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
-                else:
-                    return tokenizer_class_py.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
+        if type(config) in TOKENIZER_MAPPING.keys():
+            tokenizer_class_py, tokenizer_class_fast = TOKENIZER_MAPPING[type(config)]
+            if tokenizer_class_fast and use_fast:
+                return tokenizer_class_fast.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
+            else:
+                return tokenizer_class_py.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
 
         raise ValueError(
             "Unrecognized configuration class {} to build an AutoTokenizer.\n"

--- a/src/transformers/tokenization_auto.py
+++ b/src/transformers/tokenization_auto.py
@@ -244,7 +244,7 @@ class AutoTokenizer:
             config = config.encoder
 
         for config_class, (tokenizer_class_py, tokenizer_class_fast) in TOKENIZER_MAPPING.items():
-            if isinstance(config, config_class):
+            if type(config) == config_class:
                 if tokenizer_class_fast and use_fast:
                     return tokenizer_class_fast.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
                 else:


### PR DESCRIPTION
This seems like the textbook case where using `type` should be preferred over using `isinstance`.

Thanks to @hjptriplebee for showing the way in https://github.com/huggingface/transformers/pull/6870, this PR does the same for all remaining cases.