### PR TITLE
Fixing case in which `Trainer` hung while saving model in distributed training

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1071,7 +1071,7 @@ class Trainer:
 
         Subclass and override for custom behavior.
         """
-        print(torch.distributed.get_rank(), {key: value.size for key, value in inputs.items()})
+        print(torch.distributed.get_rank(), {key: value.size() for key, value in inputs.items()})
         outputs = model(**inputs)
         # Save past state if it exists
         if self.args.past_index >= 0:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -740,6 +740,8 @@ class Trainer:
                     epoch_pbar.update(1)
                     continue
 
+                # print(inputs)
+
                 tr_loss += self.training_step(model, inputs)
                 self.total_flos += self.floating_point_ops(inputs)
 
@@ -1069,6 +1071,7 @@ class Trainer:
 
         Subclass and override for custom behavior.
         """
+        print(torch.distributed.get_rank(), {key: value.size for key, value in inputs.items()})
         outputs = model(**inputs)
         # Save past state if it exists
         if self.args.past_index >= 0:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -814,6 +814,7 @@ class Trainer:
                             checkpoint_folder += f"-run-{run_id}"
                         output_dir = os.path.join(self.args.output_dir, checkpoint_folder)
 
+                        self._store_flos()
                         self.save_model(output_dir)
 
                         if self.is_world_process_zero():
@@ -1071,7 +1072,6 @@ class Trainer:
 
         Subclass and override for custom behavior.
         """
-        print(torch.distributed.get_rank(), {key: value.size() for key, value in inputs.items()})
         outputs = model(**inputs)
         # Save past state if it exists
         if self.args.past_index >= 0:
@@ -1152,7 +1152,6 @@ class Trainer:
             raise ValueError("Trainer.model appears to not be a PreTrainedModel")
 
         xm.rendezvous("saving_checkpoint")
-        self._store_flos()
         self.model.save_pretrained(output_dir)
         if self.tokenizer is not None:
             self.tokenizer.save_pretrained(output_dir)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -740,8 +740,6 @@ class Trainer:
                     epoch_pbar.update(1)
                     continue
 
-                # print(inputs)
-
                 tr_loss += self.training_step(model, inputs)
                 self.total_flos += self.floating_point_ops(inputs)
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -814,7 +814,7 @@ class Trainer:
                             checkpoint_folder += f"-run-{run_id}"
                         output_dir = os.path.join(self.args.output_dir, checkpoint_folder)
 
-                        self._store_flos()
+                        self.store_flos()
                         self.save_model(output_dir)
 
                         if self.is_world_process_zero():
@@ -1174,7 +1174,7 @@ class Trainer:
             self.log_history, open(os.path.join(output_dir, "log_history.json"), "w"), indent=2, ensure_ascii=False
         )
 
-    def _store_flos(self):
+    def store_flos(self):
         # Storing the number of floating-point operations that went into the model
         if self.total_flos is not None:
             if self.args.local_rank != -1:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1164,7 +1164,6 @@ class Trainer:
         # They can then be reloaded using `from_pretrained()`
         if not isinstance(self.model, PreTrainedModel):
             raise ValueError("Trainer.model appears to not be a PreTrainedModel")
-        self._store_flos()
         self.model.save_pretrained(output_dir)
         if self.tokenizer is not None:
             self.tokenizer.save_pretrained(output_dir)


### PR DESCRIPTION
As found thanks to the great @mfuntowicz , the call to `store_flos` in `Trainer` can hang indefinitely, as it was only executed in the main thread and in some cases the other threads were already past this point. This PR moves this call in order to avoid this behaviour.