### PR TITLE
Formatter

### DIFF
--- a/docs/source/main_classes/logging.rst
+++ b/docs/source/main_classes/logging.rst
@@ -52,3 +52,7 @@ Other functions
 .. autofunction:: transformers.logging.set_verbosity
 
 .. autofunction:: transformers.logging.get_logger
+
+.. autofunction:: transformers.logging.enable_explicit_format
+
+.. autofunction:: transformers.logging.reset_format

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -210,3 +210,18 @@ def enable_propagation() -> None:
 
     _configure_library_root_logger()
     _get_library_root_logger().propagate = True
+
+
+def enable_explicit_format() -> None:
+    handlers = _get_library_root_logger().handlers
+
+    for handler in handlers:
+        formatter = logging.Formatter("[%(levelname)s|%(filename)s:%(lineno)s] %(asctime)s >> %(message)s")
+        handler.setFormatter(formatter)
+
+
+def reset_format() -> None:
+    handlers = _get_library_root_logger().handlers
+
+    for handler in handlers:
+        handler.setFormatter(None)

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -213,6 +213,15 @@ def enable_propagation() -> None:
 
 
 def enable_explicit_format() -> None:
+    """
+    Enable explicit formatting for every HuggingFace Transformers's logger. The explicit formatter is as follows:
+
+    ::
+
+        [LEVELNAME|FILENAME|LINE NUMBER] TIME >> MESSAGE
+
+    All handlers currently bound to the root logger are affected by this method.
+    """
     handlers = _get_library_root_logger().handlers
 
     for handler in handlers:
@@ -221,6 +230,11 @@ def enable_explicit_format() -> None:
 
 
 def reset_format() -> None:
+    """
+    Resets the formatting for HuggingFace Transformers's loggers.
+
+    All handlers currently bound to the root logger are affected by this method.
+    """
     handlers = _get_library_root_logger().handlers
 
     for handler in handlers:


### PR DESCRIPTION
Add two new methods to the logging utility to automatically set the format like it is done in the `examples/` folder.