### PR TITLE
[RAG] Add `attention_mask` to RAG generate

### DIFF
--- a/examples/rag/eval_rag.py
+++ b/examples/rag/eval_rag.py
@@ -115,11 +115,15 @@ def evaluate_batch_retrieval(args, rag_model, questions):
 
 def evaluate_batch_e2e(args, rag_model, questions):
     with torch.no_grad():
-        input_ids = rag_model.retriever.question_encoder_tokenizer.batch_encode_plus(
+        inputs_dict = rag_model.retriever.question_encoder_tokenizer.batch_encode_plus(
             questions, return_tensors="pt", padding=True, truncation=True
-        )["input_ids"].to(args.device)
+        )
+
+        input_ids = inputs_dict.input_ids.to(args.device)
+        attention_mask = inputs_dict.attention_mask.to(args.device)
         outputs = rag_model.generate(  # rag_model overwrites generate
             input_ids,
+            attention_mask=attention_mask,
             num_beams=args.num_beams,
             min_length=args.min_length,
             max_length=args.max_length,

--- a/src/transformers/modeling_rag.py
+++ b/src/transformers/modeling_rag.py
@@ -814,7 +814,8 @@ class RagSequenceForGeneration(RagPreTrainedModel):
     @torch.no_grad()
     def generate(
         self,
-        input_ids,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.LongTensor] = None,
         context_input_ids=None,
         do_deduplication=None,  # defaults to True
         num_return_sequences=None,  # defaults to 1
@@ -859,7 +860,7 @@ class RagSequenceForGeneration(RagPreTrainedModel):
 
         # TODO(patrick) - clean up generate here
         if self.retriever is not None and context_input_ids is None:
-            question_hidden_states = self.question_encoder(input_ids)[0]
+            question_hidden_states = self.question_encoder(input_ids, attention_mask=attention_mask)[0]
             context_input_ids = self.retriever(
                 input_ids,
                 question_hidden_states.cpu().detach().to(torch.float32).numpy(),
@@ -1180,6 +1181,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
     def generate(
         self,
         input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.LongTensor] = None,
         context_input_ids=None,
         context_attention_mask=None,
         doc_scores=None,
@@ -1293,7 +1295,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
 
         # retrieve docs
         if self.retriever is not None and context_input_ids is None:
-            question_hidden_states = self.question_encoder(input_ids)[0]
+            question_hidden_states = self.question_encoder(input_ids, attention_mask=attention_mask)[0]
             out = self.retriever(
                 input_ids,
                 question_hidden_states.cpu().detach().to(torch.float32).numpy(),


### PR DESCRIPTION
Previously the attention mask was not passed to the generate function so that the encoder_outputs were possibly working if the batch has different sizes of input ids.

@ola13  Also fixed in eval script