### PR TITLE
Fix tokenization in SQuAD for RoBERTa, Longformer, BART

### DIFF
--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -107,9 +107,13 @@ def squad_convert_example_to_features(
     tok_to_orig_index = []
     orig_to_tok_index = []
     all_doc_tokens = []
+    tokenizer_type = type(tokenizer).__name__.replace("Tokenizer", "").lower()
     for (i, token) in enumerate(example.doc_tokens):
         orig_to_tok_index.append(len(all_doc_tokens))
-        sub_tokens = tokenizer.tokenize(token)
+        if tokenizer_type in ("roberta", "longformer", "bart"):
+            sub_tokens = tokenizer.tokenize(token, add_prefix_space=True)
+        else:
+            sub_tokens = tokenizer.tokenize(token)
         for sub_token in sub_tokens:
             tok_to_orig_index.append(i)
             all_doc_tokens.append(sub_token)
@@ -133,7 +137,6 @@ def squad_convert_example_to_features(
 
     # Tokenizers who insert 2 SEP tokens in-between <context> & <question> need to have special handling
     # in the way they compute mask of added tokens.
-    tokenizer_type = type(tokenizer).__name__.replace("Tokenizer", "").lower()
     sequence_added_tokens = (
         tokenizer.max_len - tokenizer.max_len_single_sentence + 1
         if tokenizer_type in MULTI_SEP_TOKENS_TOKENIZERS_SET

--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -7,8 +7,8 @@ import numpy as np
 from tqdm import tqdm
 
 from ...file_utils import is_tf_available, is_torch_available
-from ...tokenization_bert import whitespace_tokenize
 from ...tokenization_bart import BartTokenizer
+from ...tokenization_bert import whitespace_tokenize
 from ...tokenization_longformer import LongformerTokenizer
 from ...tokenization_roberta import RobertaTokenizer
 from ...tokenization_utils_base import TruncationStrategy

--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -8,6 +8,9 @@ from tqdm import tqdm
 
 from ...file_utils import is_tf_available, is_torch_available
 from ...tokenization_bert import whitespace_tokenize
+from ...tokenization_bart import BartTokenizer
+from ...tokenization_longformer import LongformerTokenizer
+from ...tokenization_roberta import RobertaTokenizer
 from ...tokenization_utils_base import TruncationStrategy
 from ...utils import logging
 from .utils import DataProcessor
@@ -107,10 +110,9 @@ def squad_convert_example_to_features(
     tok_to_orig_index = []
     orig_to_tok_index = []
     all_doc_tokens = []
-    tokenizer_type = type(tokenizer).__name__.replace("Tokenizer", "").lower()
     for (i, token) in enumerate(example.doc_tokens):
         orig_to_tok_index.append(len(all_doc_tokens))
-        if tokenizer_type in ("roberta", "longformer", "bart"):
+        if isinstance(tokenizer, (RobertaTokenizer, LongformerTokenizer, BartTokenizer)):
             sub_tokens = tokenizer.tokenize(token, add_prefix_space=True)
         else:
             sub_tokens = tokenizer.tokenize(token)
@@ -137,6 +139,7 @@ def squad_convert_example_to_features(
 
     # Tokenizers who insert 2 SEP tokens in-between <context> & <question> need to have special handling
     # in the way they compute mask of added tokens.
+    tokenizer_type = type(tokenizer).__name__.replace("Tokenizer", "").lower()
     sequence_added_tokens = (
         tokenizer.max_len - tokenizer.max_len_single_sentence + 1
         if tokenizer_type in MULTI_SEP_TOKENS_TOKENIZERS_SET


### PR DESCRIPTION
Originating from this discussion: https://github.com/huggingface/transformers/pull/4615#issuecomment-697725357

**Issue:** 
Tokenization of context in `squad_convert_example_to_features()` for RoBERTA-like tokenizers is not preserving whitespace, because we call the tokenizer on previously splitted, individual words.

**Example:**
Q =  Who was Jim Henson?
Context = Jim Henson was a nice puppet
Expected Tokens: ['< s>', 'who', 'Ġwas', 'Ġj', 'im', 'Ġhen', 'son', '?', '</s>', '</s>', 'Ġj', 'im', 'Ġhen', 'son', 'Ġwas', 'Ġa', 'Ġnice', 'Ġpuppet', '</s>']
Actual Tokens:         ['< s>', 'who', 'Ġwas', 'Ġj', 'im', 'Ġhen', 'son', '?', '</s>', '</s>', 'j', 'im', 'hen', 'son', 'was', 'a', 'nice', 'p', 'uppet', '</s>']
Decoded string: Who was Jim Henson?JimHensonwasanicepuppet

**Why a problem?**
- Inconsistency: The question gets tokenized incl. whitespace while the context doesn't. If we have the same word in question and context, we will encode them to different ids.
- Model performance: Eval metrics of `deepset/roberta-base-squad2` on SQuAD 2 dev are significantly lower than originally (F1: 69.6 vs. 81.7). After this fix, it's back to normal (F1: 81.91).  

Evalated via: 
```
run_squad.py  \
    --model_type roberta   \
    --model_name_or_path deepset/roberta-base-squad2  \
    --output_dir results/deepset-roberta-base-squad2 \
    --data_dir .   \
    --predict_file dev-v2.0.json \
    --do_eval \
    --version_2_with_negative \
    --per_gpu_eval_batch_size 16   \
    --max_seq_length 384   \
    --doc_stride 128 \
    --seed 42 \
    --threads 12 \
```

**Fix:** 
Enable `add_prefix_space` for RoBERTa-like tokenizers

**Limitations:** 
- not the most elegant solution
- not sure if there are more tokenizers with similar behavior that we should add

**Related to:** 
https://github.com/huggingface/transformers/issues/7249

@patrickvonplaten @patil-suraj 