### PR TITLE
Remove unhelpful bart warning

### DIFF
--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -550,10 +550,6 @@ class BartDecoder(nn.Module):
         positions = self.embed_positions(input_ids, use_cache=use_cache)
 
         if use_cache:
-            if input_ids.shape[1] != 1 or past_key_values is None:
-                # if you make this an AssertionError, test_benchmark breaks.
-                warnings.warn("pass decoder_past_key_value_states to use_cache")
-
             input_ids = input_ids[:, -1:]
             positions = positions[:, -1:]  # happens after we embed them
             # assert input_ids.ne(self.padding_idx).any()

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -552,7 +552,6 @@ class BartDecoder(nn.Module):
         if use_cache:
             input_ids = input_ids[:, -1:]
             positions = positions[:, -1:]  # happens after we embed them
-            # assert input_ids.ne(self.padding_idx).any()
 
         x = self.embed_tokens(input_ids) * self.embed_scale
         x += positions

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -551,7 +551,7 @@ class BartDecoder(nn.Module):
 
         if use_cache:
             input_ids = input_ids[:, -1:]
-            positions = positions[:, -1:]  # happens after we embed them
+            positions = positions[:, -1:]
 
         x = self.embed_tokens(input_ids) * self.embed_scale
         x += positions


### PR DESCRIPTION
This gets hit at the first step of generate. My bad.
The CI Failures are spurious.