### PR TITLE
Speedup check_copies script

### DIFF
--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -138,10 +138,6 @@ def is_copy_consistent(filename, overwrite=False):
                 obj1, obj2 = search_patterns.groups()
                 theoretical_code = re.sub(obj1, obj2, theoretical_code)
 
-        # Blackify each version before comparing them.
-        observed_code = blackify(observed_code)
-        theoretical_code = blackify(theoretical_code)
-
         # Test for a diff and act accordingly.
         if observed_code != theoretical_code:
             found_diff = True


### PR DESCRIPTION
Checking the copies by using black was slowing down the script quite a lot, so removing this check makes the script way faster. Removing `blackify` use could make the script less robust though, so leaving the function for now even if we don't use it anymore. If a situation arises where we see the script fail, I can code a (more complex) way of using black that would be fast.

With the two lines removed, the script takes 0.129s on my setup (instead of 18s).

cc @stas00 for information.