### PR TITLE
[makefile] 10x speed up checking/fixing 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: extra_quality_checks quality style fixup test test-examples docs
+.PHONY: modified_only_fixup extra_quality_checks quality style fixup fix-copies test test-examples docs
 
 # get modified files since the branch was made
 fork_point_sha := $(shell git merge-base --fork-point master)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 .PHONY: modified_only_fixup extra_quality_checks quality style fixup fix-copies test test-examples docs
 
-dirs := examples templates tests src utils
+
+check_dirs := examples templates tests src utils
 
 # get modified files since the branch was made
 fork_point_sha := $(shell git merge-base --fork-point master)
-modified_files := $(shell git diff --name-only $(fork_point_sha) | egrep '^(examples|templates|tests|src|utils)')
+joined_dirs := $(shell echo $(check_dirs) | tr " " "|")
+modified_files := $(shell git diff --name-only $(fork_point_sha) | egrep '^($(joined_dirs))')
 #$(info modified files are: $(modified_files))
 
 modified_only_fixup:
@@ -25,16 +27,16 @@ extra_quality_checks:
 
 # this target runs checks on all files
 quality:
-	black --check $(dirs)
-	isort --check-only $(dirs)
-	flake8 $(dirs)
+	black --check $(check_dirs)
+	isort --check-only $(check_dirs)
+	flake8 $(check_dirs)
 	${MAKE} extra_quality_checks
 
 # Format source code automatically and check is there are any problems left that need manual fixing
 
 style:
-	black $(dirs)
-	isort $(dirs)
+	black $(check_dirs)
+	isort $(check_dirs)
 
 # Super fast fix and check target that only works on relevant modified files since the branch was made
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: modified_only_fixup extra_quality_checks quality style fixup fix-copies test test-examples docs
 
+dirs := examples templates tests src utils
+
 # get modified files since the branch was made
 fork_point_sha := $(shell git merge-base --fork-point master)
 modified_files := $(shell git diff --name-only $(fork_point_sha) | egrep '^(examples|templates|tests|src|utils)')
@@ -23,16 +25,16 @@ extra_quality_checks:
 
 # this target runs checks on all files
 quality:
-	black --check examples templates tests src utils
-	isort --check-only examples templates tests src utils
-	flake8 examples templates tests src utils
+	black --check $(dirs)
+	isort --check-only $(dirs)
+	flake8 $(dirs)
 	${MAKE} extra_quality_checks
 
 # Format source code automatically and check is there are any problems left that need manual fixing
 
 style:
-	black examples templates tests src utils
-	isort examples templates tests src utils
+	black $(dirs)
+	isort $(dirs)
 
 # Super fast fix and check target that only works on relevant modified files since the branch was made
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ check_dirs := examples templates tests src utils
 
 # get modified files since the branch was made
 fork_point_sha := $(shell git merge-base --fork-point master)
-joined_dirs := $(shell echo $(check_dirs) | tr " " "|")
+joined_dirs    := $(shell echo $(check_dirs) | tr " " "|")
 modified_files := $(shell git diff --name-only $(fork_point_sha) | egrep '^($(joined_dirs))')
 #$(info modified files are: $(modified_files))
 

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,32 @@
-.PHONY: quality_checks quality style fixup test test-examples docs
+.PHONY: extra_quality_checks quality style fixup test test-examples docs
+
+# get modified files since the branch was made
+fork_point_sha := $(shell git merge-base --fork-point master)
+modified_files := $(shell git diff --name-only $(fork_point_sha) | egrep '^(examples|templates|tests|src|utils)')
+#$(info modified files are: $(modified_files))
+
+modified_only_fixup:
+	@if [ -n "$(modified_files)" ]; then \
+		echo "Checking/fixing $(modified_files)"; \
+		black $(modified_files); \
+		isort $(modified_files); \
+		flake8 $(modified_files); \
+	else \
+		echo "No relevant files were modified"; \
+	fi
 
 # Check that source code meets quality standards
 
-quality_checks:
-	flake8 examples templates tests src utils
+extra_quality_checks:
 	python utils/check_copies.py
 	python utils/check_repo.py
 
+# this target runs checks on all files
 quality:
 	black --check examples templates tests src utils
 	isort --check-only examples templates tests src utils
-	${MAKE} quality_checks
+	flake8 examples templates tests src utils
+	${MAKE} extra_quality_checks
 
 # Format source code automatically and check is there are any problems left that need manual fixing
 
@@ -18,7 +34,9 @@ style:
 	black examples templates tests src utils
 	isort examples templates tests src utils
 
-fixup: style quality_checks
+# Super fast fix and check target that only works on relevant modified files since the branch was made
+
+fixup: modified_only_fixup extra_quality_checks
 
 # Make marked copies of snippets of codes conform to the original
 


### PR DESCRIPTION
I present to you an updated `fixup` target which is now super-fast, as it only fixes and validates files that were modified since the branching point, which usually is ~5 out of ~1000. Whoah! Give it a try:

```
make fixup
```
Because of the start up overhead and the 2 customs scripts aren't optimized yet (to check only modified files), currently it's about 10 times faster.

before this PR:
```
time make fixup
real    0m19.272s
user    2m28.253s
sys     0m2.794s
```
after this PR:
```
time make fixup
real    0m2.864s
user    0m2.849s
sys     0m0.778s
```


So what's happening here:

1. `git merge-base --fork-point master` - get a sha of the branching point
2. `git diff --name-only $(git merge-base --fork-point master)` - give us all the filenames that were modified since the branching point (regardless of whether they were staged, and/or pushed or they are still local). The only missing parts would be newly added files that aren't under git yet - shouldn't be a problem though.
3. finally we want to check only specific top-folders so:
`git diff --name-only $(git merge-base --fork-point master) | egrep '^(examples|templates|tests|src|utils)'`
4. now feed that to flake8, black, isort, etc.:
`flake8 $(git diff --name-only $(git merge-base --fork-point master) | egrep '^(examples|templates|tests|src|utils)')`

   but only if there were modified files, so there is an `if` check in the Makefile. otherwise if we get no match - it runs wild on the whole repo and reports things we don't care about.

@sgugger, so if you modify `utils/check_copies.py` to optionally get specific filenames - we can unleash its full power. If you are up for it, do the required modifications and I will take care of the Makefile to pass them on.

----

## refactor repeated dir listings

This PR also refactors repeated dirs  into a single variable on top of the file

@sgugger, @LysandreJik, @sshleifer 