### PR TITLE
Add is_split_into_words as an argument to tokenize

### DIFF
--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -423,7 +423,7 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
     ) -> BatchEncoding:
         def get_input_ids(text):
             if isinstance(text, str):
-                tokens = self.tokenize(text, **kwargs)
+                tokens = self.tokenize(text, is_split_into_words=is_split_into_words, **kwargs)
                 return self.convert_tokens_to_ids(tokens)
             elif isinstance(text, (list, tuple)) and len(text) > 0 and isinstance(text[0], str):
                 if is_split_into_words:
@@ -512,7 +512,7 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
     ) -> BatchEncoding:
         def get_input_ids(text):
             if isinstance(text, str):
-                tokens = self.tokenize(text, **kwargs)
+                tokens = self.tokenize(text, is_split_into_words=is_split_into_words, **kwargs)
                 return self.convert_tokens_to_ids(tokens)
             elif isinstance(text, (list, tuple)) and len(text) > 0 and isinstance(text[0], str):
                 if is_split_into_words:


### PR DESCRIPTION
# What does this PR do?
Two calls to `self.tokenize` in `tokenization_utils.py` were missing the argument `is_split_into_words`. Since `is_split_into_words` is not present in the `kwargs`, `self.tokenize` resorts to the default behavior of not adding a space before every word.
This PR fixes this issue by adding the missing arguments in the calls to self.tokenize().

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests), 
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to the it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests? 


## Environment info

- `transformers` version: 3.3.0
- Platform: Linux-4.15.0-99-generic-x86_64-with-debian-buster-sid
- Python version: 3.7.7
- PyTorch version (GPU?): 1.3.0 (True)
- Tensorflow version (GPU?): not installed (NA)
- Using GPU in script?:No
- Using distributed or parallel set-up in script?: No

### Who can help
 tokenizers: @mfuntowicz
 Trainer: @sgugger (because this might be related to https://github.com/huggingface/transformers/pull/7236)
## Information

`tokenizer.encode`, `tokenizer.encode_plus`, and `tokenizer.batch_encode_plus` ignore the flag `is_split_into_words`.

## To reproduce

Steps to reproduce the behavior:

```py
from transformers import RobertaTokenizer
tokenizer = RobertaTokenizer.from_pretrained('roberta-large')
print(tokenizer.encode("happened", is_split_into_words=True))
print(tokenizer.encode_plus("happened", is_split_into_words = True)
)
print(tokenizer.batch_encode_plus(["happened"], is_split_into_words=True))
```
## Actual behavior
The word ``happened`` is tokenized without a space prefix which would be expected because of `is_split_into_words=True`:

```
[0, 298, 3340, 4490, 2]
{'input_ids': [0, 298, 3340, 4490, 2], 'attention_mask': [1, 1, 1, 1, 1]}
{'input_ids': [[0, 298, 3340, 4490, 2]], 'attention_mask': [[1, 1, 1, 1, 1]]}
```

## Expected behavior
a space should be prefixed in front of "happened" before tokenization, giving the following outputs:

```
[0, 1102, 2]
{'input_ids': [0, 1102, 2], 'attention_mask': [1, 1, 1]}
{'input_ids': [[0, 1102, 2]], 'attention_mask': [[1, 1, 1]]}
```
