### PR TITLE
Get a better error when check_copies fails

### DIFF
--- a/tests/test_utils_check_copies.py
+++ b/tests/test_utils_check_copies.py
@@ -55,7 +55,7 @@ class CopyCheckTester(unittest.TestCase):
         with open(fname, "w") as f:
             f.write(code)
         if overwrite_result is None:
-            self.assertTrue(check_copies.is_copy_consistent(fname))
+            self.assertTrue(len(check_copies.is_copy_consistent(fname)) == 0)
         else:
             check_copies.is_copy_consistent(f.name, overwrite=True)
             with open(fname, "r") as f:


### PR DESCRIPTION
# What does this PR do?

Prints a cleaner error message when `check_copies.py` encounters a bad copy.