### PR TITLE
Distributed Trainer: 2 little fixes

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -246,7 +246,6 @@ class Trainer:
         if model is None and model_init is not None:
             model = model_init()
         self.model = model.to(args.device) if model is not None else None
-
         default_collator = default_data_collator if tokenizer is None else DataCollatorWithPadding(tokenizer)
         self.data_collator = data_collator if data_collator is not None else default_collator
         self.train_dataset = train_dataset

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -675,14 +675,12 @@ class Trainer:
 
         # Distributed training (should be after apex fp16 initialization)
         if self.args.local_rank != -1:
-            config = model.config
             model = torch.nn.parallel.DistributedDataParallel(
                 model,
                 device_ids=[self.args.local_rank],
                 output_device=self.args.local_rank,
                 find_unused_parameters=not getattr(model.config, "gradient_checkpointing", False),
             )
-            model.config = config
         # find_unused_parameters breaks checkpointing as per
         # https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021
 

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -203,7 +203,7 @@ def distributed_broadcast_scalars(
 ) -> "torch.Tensor":
     if is_torch_available():
         try:
-            tensorized_scalar = torch.Tensor(scalars).cuda()
+            tensorized_scalar = torch.tensor(scalars).cuda()
             output_tensors = [tensorized_scalar.clone() for _ in range(torch.distributed.get_world_size())]
             torch.distributed.all_gather(output_tensors, tensorized_scalar)
             concat = torch.cat(output_tensors, dim=0)


### PR DESCRIPTION
1) fix DDP access to `model.config`. We could also set `self.config = model.config` earlier in `__init__`
2) switch torch.Tensor -> torch.tensor. The latter "infers the dtype automatically"
After which the command in #7460 works.



CC @patil-suraj , @TevenLeScao 