### PR TITLE
Trainer should not modify its TrainingArguments

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -633,16 +633,15 @@ class Trainer:
         num_update_steps_per_epoch = len(train_dataloader) // self.args.gradient_accumulation_steps
         num_update_steps_per_epoch = max(num_update_steps_per_epoch, 1)
         if self.args.max_steps > 0:
-            t_total = self.args.max_steps
-            num_train_epochs = self.args.max_steps // num_update_steps_per_epoch + int(
+            self.max_steps = self.args.max_steps
+            self.num_train_epochs = self.args.max_steps // num_update_steps_per_epoch + int(
                 self.args.max_steps % num_update_steps_per_epoch > 0
             )
         else:
-            t_total = int(num_update_steps_per_epoch * self.args.num_train_epochs)
-            num_train_epochs = self.args.num_train_epochs
-            self.args.max_steps = t_total
+            self.max_steps = int(num_update_steps_per_epoch * self.args.num_train_epochs)
+            self.num_train_epochs = self.args.num_train_epochs
 
-        self.create_optimizer_and_scheduler(num_training_steps=t_total)
+        self.create_optimizer_and_scheduler(num_training_steps=self.max_steps)
         self.state = TrainerState()
 
         # Check if saved optimizer or scheduler states exist
@@ -699,11 +698,11 @@ class Trainer:
             )
         logger.info("***** Running training *****")
         logger.info("  Num examples = %d", self.num_examples(train_dataloader))
-        logger.info("  Num Epochs = %d", num_train_epochs)
+        logger.info("  Num Epochs = %d", self.num_train_epochs)
         logger.info("  Instantaneous batch size per device = %d", self.args.per_device_train_batch_size)
         logger.info("  Total train batch size (w. parallel, distributed & accumulation) = %d", total_train_batch_size)
         logger.info("  Gradient Accumulation steps = %d", self.args.gradient_accumulation_steps)
-        logger.info("  Total optimization steps = %d", t_total)
+        logger.info("  Total optimization steps = %d", self.max_steps)
 
         self.global_step = 0
         self.epoch = 0
@@ -734,8 +733,8 @@ class Trainer:
         logging_loss_scalar = 0.0
         model.zero_grad()
         disable_tqdm = self.args.disable_tqdm or not self.is_local_process_zero()
-        train_pbar = trange(epochs_trained, int(np.ceil(num_train_epochs)), desc="Epoch", disable=disable_tqdm)
-        for epoch in range(epochs_trained, int(np.ceil(num_train_epochs))):
+        train_pbar = trange(epochs_trained, int(np.ceil(self.num_train_epochs)), desc="Epoch", disable=disable_tqdm)
+        for epoch in range(epochs_trained, int(np.ceil(self.num_train_epochs))):
             if isinstance(train_dataloader, DataLoader) and isinstance(train_dataloader.sampler, DistributedSampler):
                 train_dataloader.sampler.set_epoch(epoch)
 
@@ -822,7 +821,7 @@ class Trainer:
                         self._save_training(model, trial)
 
                 epoch_pbar.update(1)
-                if self.args.max_steps > 0 and self.global_step >= self.args.max_steps:
+                if self.global_step >= self.max_steps:
                     break
             epoch_pbar.close()
             train_pbar.update(1)
@@ -842,7 +841,7 @@ class Trainer:
                         "You enabled PyTorch/XLA debug metrics but you don't have a TPU "
                         "configured. Check your training configuration if this is unexpected."
                     )
-            if self.args.max_steps > 0 and self.global_step >= self.args.max_steps:
+            if self.global_step >= self.max_steps:
                 break
 
         train_pbar.close()


### PR DESCRIPTION
# What does this PR do?

This fixes a bug that took me some time to track in a notebook with several trainings. The bottom line is that `Trainer` should not modify its `TrainingArguments` so this fixes that part by saving the number of `max_steps` desired in the state instead of in the args. Also storing the number of training epochs for easy access in subclasses.