### PR TITLE
Seq2SeqDataset: avoid passing src_lang everywhere

### DIFF
--- a/examples/seq2seq/test_datasets.py
+++ b/examples/seq2seq/test_datasets.py
@@ -1,19 +1,19 @@
 import os
+import argparse
 import tempfile
 from pathlib import Path
 
 import numpy as np
 import pytest
-from torch.utils.data import DataLoader
-
 from pack_dataset import pack_data_dir
 from save_len_file import save_len_file
 from test_seq2seq_examples import ARTICLES, BART_TINY, MARIAN_TINY, MBART_TINY, SUMMARIES, T5_TINY, make_test_data_dir
+from torch.utils.data import DataLoader
+
 from transformers import AutoTokenizer
 from transformers.modeling_bart import shift_tokens_right
 from transformers.testing_utils import slow
 from utils import FAIRSEQ_AVAILABLE, DistributedSortishSampler, LegacySeq2SeqDataset, Seq2SeqDataset
-
 
 BERT_BASE_CASED = "bert-base-cased"
 PEGASUS_XSUM = "google/pegasus-xsum"
@@ -185,3 +185,42 @@ def test_distributed_sortish_sampler_splits_indices_between_procs():
     ids1 = set(DistributedSortishSampler(ds, 256, num_replicas=2, rank=0, add_extra_examples=False))
     ids2 = set(DistributedSortishSampler(ds, 256, num_replicas=2, rank=1, add_extra_examples=False))
     assert ids1.intersection(ids2) == set()
+
+
+@pytest.mark.parametrize(
+    "tok_name",
+    [
+        MBART_TINY,
+        MARIAN_TINY,
+        T5_TINY,
+        BART_TINY,
+        PEGASUS_XSUM,
+    ],
+)
+def test_dataset_kwargs_for_t5_tokenizer(tok_name):
+    tokenizer = AutoTokenizer.from_pretrained(tok_name)
+    if tok_name == MBART_TINY:
+        train_dataset = Seq2SeqDataset(
+            tokenizer,
+            data_dir=make_test_data_dir(),
+            type_path="train",
+            max_source_length=4,
+            max_target_length=8,
+            src_lang='EN',
+            tgt_lang='FR'
+        )
+        kwargs = train_dataset.dataset_kwargs
+        assert 'src_lang' in kwargs and 'tgt_lang' in kwargs
+    else:
+        train_dataset = Seq2SeqDataset(
+            tokenizer,
+            data_dir=make_test_data_dir(),
+            type_path="train",
+            max_source_length=4,
+            max_target_length=8
+        )
+        kwargs = train_dataset.dataset_kwargs
+        assert 'add_prefix_space' not in  kwargs if tok_name != BART_TINY else 'add_prefix_space' in kwargs
+        assert len(kwargs) == 1 if tok_name == BART_TINY else len(kwargs) == 0
+
+

--- a/examples/seq2seq/test_datasets.py
+++ b/examples/seq2seq/test_datasets.py
@@ -1,19 +1,19 @@
 import os
-import argparse
 import tempfile
 from pathlib import Path
 
 import numpy as np
 import pytest
+from torch.utils.data import DataLoader
+
 from pack_dataset import pack_data_dir
 from save_len_file import save_len_file
 from test_seq2seq_examples import ARTICLES, BART_TINY, MARIAN_TINY, MBART_TINY, SUMMARIES, T5_TINY, make_test_data_dir
-from torch.utils.data import DataLoader
-
 from transformers import AutoTokenizer
 from transformers.modeling_bart import shift_tokens_right
 from transformers.testing_utils import slow
 from utils import FAIRSEQ_AVAILABLE, DistributedSortishSampler, LegacySeq2SeqDataset, Seq2SeqDataset
+
 
 BERT_BASE_CASED = "bert-base-cased"
 PEGASUS_XSUM = "google/pegasus-xsum"
@@ -197,7 +197,7 @@ def test_distributed_sortish_sampler_splits_indices_between_procs():
         PEGASUS_XSUM,
     ],
 )
-def test_dataset_kwargs_for_t5_tokenizer(tok_name):
+def test_dataset_kwargs(tok_name):
     tokenizer = AutoTokenizer.from_pretrained(tok_name)
     if tok_name == MBART_TINY:
         train_dataset = Seq2SeqDataset(
@@ -206,21 +206,15 @@ def test_dataset_kwargs_for_t5_tokenizer(tok_name):
             type_path="train",
             max_source_length=4,
             max_target_length=8,
-            src_lang='EN',
-            tgt_lang='FR'
+            src_lang="EN",
+            tgt_lang="FR",
         )
         kwargs = train_dataset.dataset_kwargs
-        assert 'src_lang' in kwargs and 'tgt_lang' in kwargs
+        assert "src_lang" in kwargs and "tgt_lang" in kwargs
     else:
         train_dataset = Seq2SeqDataset(
-            tokenizer,
-            data_dir=make_test_data_dir(),
-            type_path="train",
-            max_source_length=4,
-            max_target_length=8
+            tokenizer, data_dir=make_test_data_dir(), type_path="train", max_source_length=4, max_target_length=8
         )
         kwargs = train_dataset.dataset_kwargs
-        assert 'add_prefix_space' not in  kwargs if tok_name != BART_TINY else 'add_prefix_space' in kwargs
+        assert "add_prefix_space" not in kwargs if tok_name != BART_TINY else "add_prefix_space" in kwargs
         assert len(kwargs) == 1 if tok_name == BART_TINY else len(kwargs) == 0
-
-

--- a/examples/seq2seq/utils.py
+++ b/examples/seq2seq/utils.py
@@ -51,6 +51,7 @@ def label_smoothed_nll_loss(lprobs, target, epsilon, ignore_index=-100):
     loss = (1.0 - epsilon) * nll_loss + eps_i * smooth_loss
     return loss, nll_loss
 
+
 def lmap(f: Callable, x: Iterable) -> List:
     """list(map(f, x))"""
     return list(map(f, x))
@@ -106,7 +107,7 @@ class AbstractSeq2SeqDataset(Dataset):
             self.src_lens = self.src_lens[:n_obs]
         self.pad_token_id = self.tokenizer.pad_token_id
         self.dataset_kwargs = dataset_kwargs
-        dataset_kwargs.update({'add_prefix_space' : True} if isinstance(self.tokenizer, BartTokenizer) else {})
+        dataset_kwargs.update({"add_prefix_space": True} if isinstance(self.tokenizer, BartTokenizer) else {})
 
     def __len__(self):
         return len(self.src_lens)
@@ -186,7 +187,7 @@ class LegacySeq2SeqDataset(AbstractSeq2SeqDataset):
             padding="max_length" if pad_to_max_length else None,
             truncation=True,
             return_tensors=return_tensors,
-            **self.dataset_kwargs
+            **self.dataset_kwargs,
         )
 
     def collate_fn(self, batch) -> Dict[str, torch.Tensor]:
@@ -223,7 +224,7 @@ class Seq2SeqDataset(AbstractSeq2SeqDataset):
             max_length=self.max_source_length,
             max_target_length=self.max_target_length,
             return_tensors="pt",
-            **self.dataset_kwargs
+            **self.dataset_kwargs,
         ).data
         batch_encoding["ids"] = torch.tensor([x["id"] for x in batch])
         return batch_encoding

--- a/examples/seq2seq/utils.py
+++ b/examples/seq2seq/utils.py
@@ -51,20 +51,6 @@ def label_smoothed_nll_loss(lprobs, target, epsilon, ignore_index=-100):
     loss = (1.0 - epsilon) * nll_loss + eps_i * smooth_loss
     return loss, nll_loss
 
-
-def encode_line(tokenizer, line, max_length, pad_to_max_length=True, return_tensors="pt"):
-    """Only used by LegacyDataset"""
-    extra_kw = {"add_prefix_space": True} if isinstance(tokenizer, BartTokenizer) else {}
-    return tokenizer(
-        [line],
-        max_length=max_length,
-        padding="max_length" if pad_to_max_length else None,
-        truncation=True,
-        return_tensors=return_tensors,
-        **extra_kw,
-    )
-
-
 def lmap(f: Callable, x: Iterable) -> List:
     """list(map(f, x))"""
     return list(map(f, x))
@@ -97,9 +83,8 @@ class AbstractSeq2SeqDataset(Dataset):
         max_target_length,
         type_path="train",
         n_obs=None,
-        src_lang=None,
-        tgt_lang=None,
         prefix="",
+        **dataset_kwargs
     ):
         super().__init__()
         self.src_file = Path(data_dir).joinpath(type_path + ".source")
@@ -120,9 +105,8 @@ class AbstractSeq2SeqDataset(Dataset):
         if n_obs is not None:
             self.src_lens = self.src_lens[:n_obs]
         self.pad_token_id = self.tokenizer.pad_token_id
-        self.src_lang = src_lang
-        self.tgt_lang = tgt_lang
-        self.add_prefix_space = isinstance(self.tokenizer, BartTokenizer)
+        self.dataset_kwargs = dataset_kwargs
+        dataset_kwargs.update({'add_prefix_space' : True} if isinstance(self.tokenizer, BartTokenizer) else {})
 
     def __len__(self):
         return len(self.src_lens)
@@ -182,8 +166,8 @@ class LegacySeq2SeqDataset(AbstractSeq2SeqDataset):
         tgt_line = linecache.getline(str(self.tgt_file), index).rstrip("\n")
         assert source_line, f"empty source line for index {index}"
         assert tgt_line, f"empty tgt line for index {index}"
-        source_inputs = encode_line(self.tokenizer, source_line, self.max_source_length)
-        target_inputs = encode_line(self.tokenizer, tgt_line, self.max_target_length)
+        source_inputs = self.encode_line(self.tokenizer, source_line, self.max_source_length)
+        target_inputs = self.encode_line(self.tokenizer, tgt_line, self.max_target_length)
 
         source_ids = source_inputs["input_ids"].squeeze()
         target_ids = target_inputs["input_ids"].squeeze()
@@ -193,6 +177,17 @@ class LegacySeq2SeqDataset(AbstractSeq2SeqDataset):
             "attention_mask": src_mask,
             "labels": target_ids,
         }
+
+    def encode_line(self, tokenizer, line, max_length, pad_to_max_length=True, return_tensors="pt"):
+        """Only used by LegacyDataset"""
+        return tokenizer(
+            [line],
+            max_length=max_length,
+            padding="max_length" if pad_to_max_length else None,
+            truncation=True,
+            return_tensors=return_tensors,
+            **self.dataset_kwargs
+        )
 
     def collate_fn(self, batch) -> Dict[str, torch.Tensor]:
         input_ids = torch.stack([x["input_ids"] for x in batch])
@@ -224,13 +219,11 @@ class Seq2SeqDataset(AbstractSeq2SeqDataset):
         """Call prepare_seq2seq_batch."""
         batch_encoding: Dict[str, torch.Tensor] = self.tokenizer.prepare_seq2seq_batch(
             [x["src_texts"] for x in batch],
-            src_lang=self.src_lang,
             tgt_texts=[x["tgt_texts"] for x in batch],
-            tgt_lang=self.tgt_lang,
             max_length=self.max_source_length,
             max_target_length=self.max_target_length,
             return_tensors="pt",
-            add_prefix_space=self.add_prefix_space,
+            **self.dataset_kwargs
         ).data
         batch_encoding["ids"] = torch.tensor([x["id"] for x in batch])
         return batch_encoding


### PR DESCRIPTION
Changed Constructor argument for AbstractSeq2SeqDataset to kwargs to avoid passing unwanted parameters to tokenizers, 
eg. src and tgt lang to T5 tokenizer.

# What does this PR do?
tokenization_util.py was generating unnecessary warning statements continuously for tokenizer arguments for seq2seq batch processing that shouldn't have been passed in the first place. Fixed this phenomenon and added a test case as suggested.

Fixes # (issue)
#7454 

## Before submitting
- This PR fixes a typo or improves the docs (you can dimiss the other checks if that's the case).
N/A
-Did you read the [contributor guideline]
Yes
- Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to the it if that's the case.
Yes, #7454 
- Did you make sure to update the documentation with your changes? Here are the
  N/A
-Did you write any new necessary tests? 
Yes, added a relevant test in examples/seq2seq/test_datasets.py


## Who can review?
@sshleifer 