### PR TITLE
Minor dead code clean-up

### DIFF
--- a/src/transformers/modeling_albert.py
+++ b/src/transformers/modeling_albert.py
@@ -347,7 +347,6 @@ class AlbertLayer(nn.Module):
         self.ffn = nn.Linear(config.hidden_size, config.intermediate_size)
         self.ffn_output = nn.Linear(config.intermediate_size, config.hidden_size)
         self.activation = ACT2FN[config.hidden_act]
-        self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
     def forward(
         self, hidden_states, attention_mask=None, head_mask=None, output_attentions=False, output_hidden_states=False

--- a/src/transformers/modeling_xlnet.py
+++ b/src/transformers/modeling_xlnet.py
@@ -240,19 +240,6 @@ class XLNetRelativeAttention(nn.Module):
         raise NotImplementedError
 
     @staticmethod
-    def rel_shift(x, klen=-1):
-        """perform relative shift to form the relative attention score."""
-        x_size = x.shape
-
-        x = x.reshape(x_size[1], x_size[0], x_size[2], x_size[3])
-        x = x[1:, ...]
-        x = x.reshape(x_size[0], x_size[1] - 1, x_size[2], x_size[3])
-        # x = x[:, 0:klen, :, :]
-        x = torch.index_select(x, 1, torch.arange(klen, device=x.device, dtype=torch.long))
-
-        return x
-
-    @staticmethod
     def rel_shift_bnij(x, klen=-1):
         x_size = x.shape
 
@@ -495,7 +482,6 @@ class XLNetLayer(nn.Module):
         super().__init__()
         self.rel_attn = XLNetRelativeAttention(config)
         self.ff = XLNetFeedForward(config)
-        self.dropout = nn.Dropout(config.dropout)
         self.chunk_size_feed_forward = config.chunk_size_feed_forward
         self.seq_len_dim = 1
 


### PR DESCRIPTION
Hello,

I am not sure how sensitive you generally are about dead code in the repository. I have identified a few places with dead code, where I believe a clean-up would improve readability.

- removal of a couple of unused dropouts I came across in Albert and XLNet
- removal of an unused code block for relative attention shift for XLNet

## Who can review?

@LysandreJik , @TevenLeScao 
