### PR TITLE
Bump isort version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ extras["retrieval"] = ["faiss-cpu", "datasets"]
 extras["testing"] = ["pytest", "pytest-xdist", "timeout-decorator", "parameterized", "psutil"] + extras["retrieval"]
 # sphinx-rtd-theme==0.5.0 introduced big changes in the style.
 extras["docs"] = ["recommonmark", "sphinx", "sphinx-markdown-tables", "sphinx-rtd-theme==0.4.3", "sphinx-copybutton"]
-extras["quality"] = ["black >= 20.8b1", "isort >= 5", "flake8 >= 3.8.3"]
+extras["quality"] = ["black >= 20.8b1", "isort >= 5.5.4", "flake8 >= 3.8.3"]
 extras["dev"] = extras["testing"] + extras["quality"] + extras["ja"] + ["scikit-learn", "tensorflow", "torch"]
 
 setup(


### PR DESCRIPTION
# What does this PR do?

Had some problem on my local setup with isort wanting to change `test_modeling_deberta.py`. Updating to 5.5.4 (from 5.4.2) fixed the issue so I think we should pin our setup to it.