### PR TITLE
configuration_utils: fix handling of `id2labels`

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -185,7 +185,10 @@ class PretrainedConfig(object):
         self.label2id = kwargs.pop("label2id", None)
         if self.id2label is not None:
             kwargs.pop("num_labels", None)
-            self.id2label = dict((int(key), value) for key, value in self.id2label.items())
+            if isinstance(self.id2label, list):
+                self.id2label = dict((int(key), value) for key, value in enumerate(self.id2label))
+            else:
+                self.id2label = dict((int(key), value) for key, value in self.id2label.items())
             # Keys are always strings in JSON so convert ids to int here.
         else:
             self.num_labels = kwargs.pop("num_labels", 2)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -185,10 +185,7 @@ class PretrainedConfig(object):
         self.label2id = kwargs.pop("label2id", None)
         if self.id2label is not None:
             kwargs.pop("num_labels", None)
-            if isinstance(self.id2label, list):
-                self.id2label = dict((int(key), value) for key, value in enumerate(self.id2label))
-            else:
-                self.id2label = dict((int(key), value) for key, value in self.id2label.items())
+            self.id2label = dict((int(key), value) for key, value in self.id2label.items())
             # Keys are always strings in JSON so convert ids to int here.
         else:
             self.num_labels = kwargs.pop("num_labels", 2)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -114,7 +114,7 @@ class PretrainedConfig(object):
           model pretrained weights.
         - **finetuning_task** (:obj:`str`, `optional`) -- Name of the task used to fine-tune the model. This can be
           used when converting from an original (TensorFlow or PyTorch) checkpoint.
-        - **id2label** (:obj:`List[str]`, `optional`) -- A map from index (for instance prediction index, or target
+        - **id2label** (:obj:`Dict[int, str]`, `optional`) -- A map from index (for instance prediction index, or target
           index) to label.
         - **label2id** (:obj:`Dict[str, int]`, `optional`) -- A map from label to index for the model.
         - **num_labels** (:obj:`int`, `optional`) -- Number of labels to use in the last layer added to the model,


### PR DESCRIPTION
# What does this PR do?

The parameter `id2labels` of class `PretrainedConfig` is documented as `List[str]`, so enumerate() should be used rather
than dict.items() in the constructor.

Since a lot of code (including test code) passes `id2labels` as a dict, enumerate() is only used if it is a list indeed.