### PR TITLE
Fix seq2seq example test

### DIFF
--- a/examples/seq2seq/finetune_trainer.py
+++ b/examples/seq2seq/finetune_trainer.py
@@ -276,6 +276,7 @@ def main():
         # For convenience, we also re-save the tokenizer to the same directory,
         # so that you can share your model easily on huggingface.co/models =)
         if trainer.is_world_process_zero():
+            trainer.state.save_to_json(os.path.join(training_args.output_dir, "trainer_state.json"))
             tokenizer.save_pretrained(training_args.output_dir)
 
     # Evaluation

--- a/examples/seq2seq/test_finetune_trainer.py
+++ b/examples/seq2seq/test_finetune_trainer.py
@@ -8,7 +8,6 @@ from transformers.trainer_utils import TrainerState, set_seed
 
 from .finetune_trainer import main
 from .test_seq2seq_examples import MBART_TINY
-from .utils import load_json
 
 
 set_seed(42)
@@ -17,7 +16,7 @@ MARIAN_MODEL = "sshleifer/student_marian_en_ro_6_1"
 
 def test_finetune_trainer():
     output_dir = run_trainer(1, "12", MBART_TINY, 1)
-    logs = TrainerState.load_from_json(os.path.join(checkpoint, "trainer_state.json")).log_history
+    logs = TrainerState.load_from_json(os.path.join(output_dir, "trainer_state.json")).log_history
     eval_metrics = [log for log in logs if "eval_loss" in log.keys()]
     first_step_stats = eval_metrics[0]
     assert "eval_bleu" in first_step_stats
@@ -30,7 +29,7 @@ def test_finetune_trainer_slow():
     output_dir = run_trainer(eval_steps=2, max_len="32", model_name=MARIAN_MODEL, num_train_epochs=3)
 
     # Check metrics
-    logs = TrainerState.load_from_json(os.path.join(checkpoint, "trainer_state.json")).log_history
+    logs = TrainerState.load_from_json(os.path.join(output_dir, "trainer_state.json")).log_history
     eval_metrics = [log for log in logs if "eval_loss" in log.keys()]
     first_step_stats = eval_metrics[0]
     last_step_stats = eval_metrics[-1]

--- a/examples/seq2seq/test_finetune_trainer.py
+++ b/examples/seq2seq/test_finetune_trainer.py
@@ -4,7 +4,7 @@ import tempfile
 from unittest.mock import patch
 
 from transformers.testing_utils import slow
-from transformers.trainer_utils import set_seed
+from transformers.trainer_utils import TrainerState, set_seed
 
 from .finetune_trainer import main
 from .test_seq2seq_examples import MBART_TINY
@@ -17,7 +17,7 @@ MARIAN_MODEL = "sshleifer/student_marian_en_ro_6_1"
 
 def test_finetune_trainer():
     output_dir = run_trainer(1, "12", MBART_TINY, 1)
-    logs = load_json(os.path.join(output_dir, "log_history.json"))
+    logs = TrainerState.load_from_json(os.path.join(checkpoint, "trainer_state.json")).log_history
     eval_metrics = [log for log in logs if "eval_loss" in log.keys()]
     first_step_stats = eval_metrics[0]
     assert "eval_bleu" in first_step_stats
@@ -30,7 +30,7 @@ def test_finetune_trainer_slow():
     output_dir = run_trainer(eval_steps=2, max_len="32", model_name=MARIAN_MODEL, num_train_epochs=3)
 
     # Check metrics
-    logs = load_json(os.path.join(output_dir, "log_history.json"))
+    logs = TrainerState.load_from_json(os.path.join(checkpoint, "trainer_state.json")).log_history
     eval_metrics = [log for log in logs if "eval_loss" in log.keys()]
     first_step_stats = eval_metrics[0]
     last_step_stats = eval_metrics[-1]

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -601,6 +601,7 @@ class Trainer:
             output_dir = os.path.join(self.args.output_dir, f"{PREFIX_CHECKPOINT_DIR}-{self.state.global_step}")
             self.save_model(output_dir)
             if self.is_world_master():
+                self.state.save_to_json(os.path.join(output_dir, "trainer_state.json"))
                 torch.save(self.optimizer.state_dict(), os.path.join(output_dir, "optimizer.pt"))
                 torch.save(self.lr_scheduler.state_dict(), os.path.join(output_dir, "scheduler.pt"))
 


### PR DESCRIPTION
# What does this PR do?

#7490 removed the log_history save since it is now saved along inside the `TrainerState`. I didn't catch it was used in the seq2seq examples (must be due to a more recent PR because the tests were passing) so this PR adapts the part that loads `log_history` in those tests to fix them.