### PR TITLE
Fix post_init of some TrainingArguments

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -324,18 +324,15 @@ class TrainingArguments:
     def __post_init__(self):
         if self.disable_tqdm is None:
             self.disable_tqdm = logger.getEffectiveLevel() > logging.WARN
-        if self.evaluate_during_training is not None:
-            self.evaluation_strategy = (
-                EvaluationStrategy.STEPS if self.evaluate_during_training else EvaluationStrategy.NO
-            )
+        if self.evaluate_during_training is True:
+            self.evaluation_strategy = EvaluationStrategy.STEPS
             warnings.warn(
                 "The `evaluate_during_training` argument is deprecated in favor of `evaluation_strategy` (which has more options)",
                 FutureWarning,
             )
-        else:
-            self.evaluation_strategy = EvaluationStrategy(self.evaluation_strategy)
-        if self.do_eval is None:
-            self.do_eval = self.evaluation_strategy != EvaluationStrategy.NO
+        self.evaluation_strategy = EvaluationStrategy(self.evaluation_strategy)
+        if self.do_eval is False and self.evaluation_strategy != EvaluationStrategy.NO:
+            self.do_eval = True
         if self.eval_steps is None:
             self.eval_steps = self.logging_steps
 


### PR DESCRIPTION
# What does this PR do?

The `HFArgumentParser` doesn't actually support bools that are None and wants them `True` or `False`. Therefore, some changes I made to a few fields of `TrainingArguments` do not work when invoked on the command line. This PR fixes that.