### PR TITLE
Enable debug with TF2 and eager execution

### DIFF
--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -637,7 +637,7 @@ class TFTrainer:
         scaled_loss = per_example_loss / tf.cast(nb_instances_in_global_batch, dtype=per_example_loss.dtype)
         gradients = tape.gradient(scaled_loss, self.model.trainable_variables)
         gradients = [
-                g if g is not None else tf.zeros_like(v) for g, v in zip(gradients, self.model.trainable_variables)
+            g if g is not None else tf.zeros_like(v) for g, v in zip(gradients, self.model.trainable_variables)
         ]
 
         if self.args.gradient_accumulation_steps > 1:

--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -633,11 +633,12 @@ class TFTrainer:
 
         with tf.GradientTape() as tape:
             per_example_loss, _ = self.run_model(features, labels, True)
-            scaled_loss = per_example_loss / tf.cast(nb_instances_in_global_batch, dtype=per_example_loss.dtype)
-            gradients = tape.gradient(scaled_loss, self.model.trainable_variables)
-            gradients = [
+
+        scaled_loss = per_example_loss / tf.cast(nb_instances_in_global_batch, dtype=per_example_loss.dtype)
+        gradients = tape.gradient(scaled_loss, self.model.trainable_variables)
+        gradients = [
                 g if g is not None else tf.zeros_like(v) for g, v in zip(gradients, self.model.trainable_variables)
-            ]
+        ]
 
         if self.args.gradient_accumulation_steps > 1:
             self.gradient_accumulator(gradients)

--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -630,12 +630,14 @@ class TFTrainer:
 
         Subclass and override to inject some custom behavior.
         """
-        per_example_loss, _ = self.run_model(features, labels, True)
-        scaled_loss = per_example_loss / tf.cast(nb_instances_in_global_batch, dtype=per_example_loss.dtype)
-        gradients = tf.gradients(scaled_loss, self.model.trainable_variables)
-        gradients = [
-            g if g is not None else tf.zeros_like(v) for g, v in zip(gradients, self.model.trainable_variables)
-        ]
+
+        with tf.GradientTape() as tape:
+            per_example_loss, _ = self.run_model(features, labels, True)
+            scaled_loss = per_example_loss / tf.cast(nb_instances_in_global_batch, dtype=per_example_loss.dtype)
+            gradients = tape.gradient(scaled_loss, self.model.trainable_variables)
+            gradients = [
+                g if g is not None else tf.zeros_like(v) for g, v in zip(gradients, self.model.trainable_variables)
+            ]
 
         if self.args.gradient_accumulation_steps > 1:
             self.gradient_accumulator(gradients)


### PR DESCRIPTION
TF2 with eager execution  and tf.gradients not supported anymore.
In order to run the code with eager execution and not collapse instead of tf.gradients should be tf.GradientTape. 

[how-to-compute-gradient-of-output-wrt-input-in-tensorflow-2-0](https://stackoverflow.com/questions/59145221/how-to-compute-gradient-of-output-wrt-input-in-tensorflow-2-0)