### PR TITLE
Moved feature generation into getitem to save ram

### DIFF
--- a/src/transformers/data/datasets/squad.py
+++ b/src/transformers/data/datasets/squad.py
@@ -181,7 +181,8 @@ class SquadDataset(Dataset):
                 max_query_length = self.args.max_query_length,
                 doc_stride = self.args.doc_stride,
                 is_training = self.mode == Split.train,
-                threads = self.args.threads
+                threads = self.args.threads,
+                tqdm_enabled = False
             )
             # It's returned as a list with the length of 1, 
             # so we only need to take the first index


### PR DESCRIPTION
# What does this PR do?
I had this issue that my Colab Notebook would run out of memory when creating the feature in the SQuAD dataset, so I basically just moved it to the getitem section. I also added a function to force create the features immediatly incase somehow for some reason would want the features created in the beginning

Fixes # (issue)


## Before submitting
- I submitted an issue, but never got any feedback.
- I did not update the documentation due to the fact that it doesn't exist
- I did not write tests either since I couldn't get the tests to work out on my machine. However I did test it while training the model. However I could easily write tests if you believe it's necessary. 


## Who can review?
@patrickvonplaten, maybe you can take a look at the pull request?
