### PR TITLE
Update normalising method in oneshot classifier

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1099,9 +1099,10 @@ class ZeroShotClassificationPipeline(Pipeline):
             multi_class = True
 
         if not multi_class:
-            # softmax the "entailment" logits over all candidate labels
-            entail_logits = reshaped_outputs[..., -1]
-            scores = np.exp(entail_logits) / np.exp(entail_logits).sum(-1, keepdims=True)
+            #softmax over contradiction vs neutral vs entailment
+            entailment = F.softmax(reshaped_outputs, -1)[...,-1]
+            # noramlise entailment probabilities to sum to one
+            scores = entailment / entailment.sum(-1, keepdims=True)
         else:
             # softmax over the entailment vs. contradiction dim for each label independently
             entail_contr_logits = reshaped_outputs[..., [0, -1]]

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1100,7 +1100,8 @@ class ZeroShotClassificationPipeline(Pipeline):
 
         if not multi_class:
             #softmax over contradiction vs neutral vs entailment
-            entailment = torch.nn.functional.softmax(reshaped_outputs, -1)[...,-1]
+            ps = np.exp(reshaped_outputs)
+            entailment = ps[..., -1] / ps.sum(-1, keepdims=True)
             # noramlise entailment probabilities to sum to one
             scores = entailment / entailment.sum(-1, keepdims=True)
         else:

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1100,7 +1100,7 @@ class ZeroShotClassificationPipeline(Pipeline):
 
         if not multi_class:
             #softmax over contradiction vs neutral vs entailment
-            entailment = F.softmax(reshaped_outputs, -1)[...,-1]
+            entailment = torch.nn.functional.softmax(reshaped_outputs, -1)[...,-1]
             # noramlise entailment probabilities to sum to one
             scores = entailment / entailment.sum(-1, keepdims=True)
         else:


### PR DESCRIPTION
Hi, I know I raised this issue before here: https://github.com/huggingface/transformers/pull/5760#issuecomment-673840015 but I do think that it is worth taking a second look atleast.

So my main concern is, since we are dealing with logits, currently all that happens is to take the softmax over the entailment logits. This does guarantee summing to one, however, it doesn't care for the scale of the logits. For example suppose the logits for two possible classes for a given sentence came out as:
```
[[1000, 10, 10],
 [0.1, 0.1, 0.9]]
```
at the current method would give class1 the higher probability, even though, it can clearly be seen that class1 is a contradiction (since it is 100x contradiction in the log scale), and similarly class2 is clearly an entailment.

Now I do understand that this is an extreme case, but just to cover the bases, what I propose is that:
1. We softmax across every single sentence-class pair to get everything in the same scale.
2. Get a probability measurement over entailment by simply dividing by sum of probabilities. As seen [here](https://github.com/huggingface/transformers/pull/5760#issuecomment-673840015 ) the numbers that we get are different but only slightly for the example shown.

I do apologise about raising this again, just simply trying to help.