### PR TITLE
Add Electra unexpected keys

### DIFF
--- a/src/transformers/modeling_electra.py
+++ b/src/transformers/modeling_electra.py
@@ -535,6 +535,7 @@ class ElectraPreTrainedModel(PreTrainedModel):
     load_tf_weights = load_tf_weights_in_electra
     base_model_prefix = "electra"
     authorized_missing_keys = [r"position_ids"]
+    authorized_unexpected_keys = [r"electra\.embeddings_project\.weight", r"electra\.embeddings_project\.bias"]
 
     # Copied from transformers.modeling_bert.BertPreTrainedModel._init_weights
     def _init_weights(self, module):


### PR DESCRIPTION
This PR adds the necessary ELECTRA unexpected keys. Some keys are only used with models that have a different embedding size to their hidden size, in order to do the projection.

Some models (such as the `large` ELECTRA variants), do not leverage these weights, as they have the same embedding/hidden sizes.

Fixes #7530.