### PR TITLE
Expand test to locate flakiness

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -193,7 +193,9 @@ class TrainerIntegrationTest(unittest.TestCase):
         trainer = get_regression_trainer()
         trainer.train()
         args = TrainingArguments("./regression")
-        self.assertEqual(args.to_dict(), trainer.args.to_dict())
+        dict1, dict2 = args.to_dict(), trainer.args.to_dict()
+        for key in dict1.keys():
+            self.assertEqual(dict1[key], dict2[key])
 
     def test_reproducible_training(self):
         # Checks that training worked, model trained and seed made a reproducible training.


### PR DESCRIPTION
# What does this PR do?

`test_training_arguments_are_left_untouched` in `test_trainer.py` is a bit flaky, this PR just expands in a loop the assertEqual so we can hopefully locate the source of the flakiness.