### PR TITLE
Enhance TFTrainer.save_model()

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -321,6 +321,10 @@ def save_tf_model(model, save_directory):
     model.save_weights(output_model_file)
     logger.info("Model weights saved in {}".format(output_model_file))
 
+    # Also save to SavedModel format.
+    tf.saved_model.save(model, export_dir=save_directory)
+    logger.info("SavedModel saved in {}".format(save_directory))
+
 
 class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
     r"""

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -301,6 +301,27 @@ def load_tf_weights(model, resolved_archive_file):
     K.batch_set_value(weight_value_tuples)
 
 
+def save_tf_model(model, save_directory):
+    """
+    Save a model to a directory.
+
+    Arguments:
+        model (:obj:`tf.keras.models.Model`):
+            Model to save.
+        save_directory (:obj:`str`):
+            Directory to which to save. Will be created if it doesn't exist.
+    """
+    if os.path.isfile(save_directory):
+        logger.error("Provided path ({}) should be a directory, not a file".format(save_directory))
+        return
+    os.makedirs(save_directory, exist_ok=True)
+
+    # If we save using the predefined names, we can load using `from_pretrained` if ``model`` is an instance of class `TFPreTrainedModel`.
+    output_model_file = os.path.join(save_directory, TF2_WEIGHTS_NAME)
+    model.save_weights(output_model_file)
+    logger.info("Model weights saved in {}".format(output_model_file))
+
+
 class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
     r"""
     Base class for all TF models.
@@ -493,18 +514,11 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
             save_directory (:obj:`str`):
                 Directory to which to save. Will be created if it doesn't exist.
         """
-        if os.path.isfile(save_directory):
-            logger.error("Provided path ({}) should be a directory, not a file".format(save_directory))
-            return
-        os.makedirs(save_directory, exist_ok=True)
+        # Save model
+        save_tf_model(self, save_directory)
 
         # Save configuration file
         self.config.save_pretrained(save_directory)
-
-        # If we save using the predefined names, we can load using `from_pretrained`
-        output_model_file = os.path.join(save_directory, TF2_WEIGHTS_NAME)
-        self.save_weights(output_model_file)
-        logger.info("Model weights saved in {}".format(output_model_file))
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -321,10 +321,6 @@ def save_tf_model(model, save_directory):
     model.save_weights(output_model_file)
     logger.info("Model weights saved in {}".format(output_model_file))
 
-    # Also save to SavedModel format.
-    tf.saved_model.save(model, export_dir=save_directory)
-    logger.info("SavedModel saved in {}".format(save_directory))
-
 
 class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
     r"""

--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -791,3 +791,7 @@ class TFTrainer:
             save_tf_model(self.model, output_dir)
         else:
             self.model.save_pretrained(output_dir)
+
+        # Also save to SavedModel format.
+        tf.saved_model.save(self.model, export_dir=output_dir)
+        logger.info("SavedModel saved in {}".format(output_dir))

--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -12,7 +12,7 @@ from packaging.version import parse
 from tensorflow.python.distribute.values import PerReplica
 
 from .integrations import is_comet_available, is_wandb_available
-from .modeling_tf_utils import TFPreTrainedModel
+from .modeling_tf_utils import TFPreTrainedModel, save_tf_model
 from .optimization_tf import GradientAccumulator, create_optimizer
 from .trainer_utils import PREFIX_CHECKPOINT_DIR, EvalPrediction, PredictionOutput, set_seed
 from .training_args_tf import TFTrainingArguments
@@ -785,6 +785,9 @@ class TFTrainer:
         logger.info("Saving model in {}".format(output_dir))
 
         if not isinstance(self.model, TFPreTrainedModel):
-            raise ValueError("Trainer.model appears to not be a PreTrainedModel")
-
-        self.model.save_pretrained(output_dir)
+            warnings.warn(
+                "Trainer.model appears to not be a PreTrainedModel. The model will still be saved as a usual tf.keras.models.Model model, but no PretrainedConfig will be saved."
+            )
+            save_tf_model(self.model, output_dir)
+        else:
+            self.model.save_pretrained(output_dir)


### PR DESCRIPTION
# What does this PR do?

Currently, `TFTrainer.save_model()` raises errors if the model is not `TFPreTrainedModel` . However `Trainer` works fine with `torch.nn.modules.Module`. 

This is a step to make TFTrainer work with usual `tf.keras.models.Model` models. The idea (from @sgugger) is that a user is building their own models that work like ours (e.g., return the loss as the first output) and can train them with Trainer.

Furthermore, a SavedModel is also saved using `tf.saved_model.save()`.

I tried to avoid duplicated code (check and create output directory before saving), and therefore there is a new method `save_tf_model()` in `modeling_tf_utils`, which is used in `trainer_tf.py`.

For @jplu and @sgugger .