### PR TITLE
Docker GPU Images: Add NVIDIA/apex to the cuda images with pytorch

### DIFF
--- a/docker/transformers-gpu/Dockerfile
+++ b/docker/transformers-gpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04
+FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
 LABEL maintainer="Hugging Face"
 LABEL repository="transformers"
 
@@ -17,6 +17,11 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip && \
     jupyter \
     tensorflow \
     torch
+
+RUN git clone https://github.com/NVIDIA/apex
+RUN cd apex && \
+    python3 setup.py install && \
+    pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 
 WORKDIR /workspace
 COPY . transformers/

--- a/docker/transformers-pytorch-gpu/Dockerfile
+++ b/docker/transformers-pytorch-gpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04
+FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
 LABEL maintainer="Hugging Face"
 LABEL repository="transformers"
 
@@ -16,6 +16,11 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip && \
     python3 -m pip install --no-cache-dir \
     mkl \
     torch
+
+RUN git clone https://github.com/NVIDIA/apex
+RUN cd apex && \
+    python3 setup.py install && \
+    pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 
 WORKDIR /workspace
 COPY . transformers/


### PR DESCRIPTION
# What does this PR do?
- Use cuda:10.2 image instead of 10.1 (to address version mismatch  warning with pytorch)
- Use `devel` version that is built on the `runtime` and includes headers and development tools (it was otherwise failing to build apex). For a description of the different flavors, see:  https://hub.docker.com/r/nvidia/cuda -> Overview of Images
- Download and build `apex` for pytorch. https://github.com/NVIDIA/apex#quick-start

## Docs
- https://github.com/NVIDIA/apex
- https://nvidia.github.io/apex/
- https://hub.docker.com/r/nvidia/cuda

## Who can review?
- @mfuntowicz co-authored the Dockerfiles in 71c87119