### PR TITLE
Enhance TFTrainer.save_model()

### DIFF
--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -16,6 +16,7 @@
 import datetime
 import math
 import os
+import warnings
 from typing import Callable, Dict, Optional, Tuple
 
 from .file_utils import ENV_VARS_TRUE_VALUES

--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -787,7 +787,7 @@ class TFTrainer:
 
         if not isinstance(self.model, TFPreTrainedModel):
             warnings.warn(
-                "Trainer.model appears to not be a PreTrainedModel. The model will still be saved as a usual tf.keras.models.Model model, but no PretrainedConfig will be saved."
+                "`Trainer.model` appears to not be a `PreTrainedModel`. The model will still be saved as a usual `tf.keras.models.Model model`, but no `PretrainedConfig` will be saved."
             )
 
             if os.path.isfile(output_dir):


### PR DESCRIPTION
# What does this PR do?

@jplu , could you close PR #7597, please? This PR is a clean one, without the file `modeling_tf_utils` being changed at all.

Currently, TFTrainer.save_model() raises errors if the model is not TFPreTrainedModel . However Trainer works fine with torch.nn.modules.Module.

This is a step to make TFTrainer work with usual tf.keras.models.Model models. The idea (from @sgugger) is that a user is building their own models that work like ours (e.g., return the loss as the first output) and can train them with Trainer.

Furthermore, a SavedModel is also saved using tf.saved_model.save().

For @jplu and @sgugger .