### PR TITLE
Added sampler'set_epoch when use distributed training

### DIFF
--- a/examples/question-answering/run_squad.py
+++ b/examples/question-answering/run_squad.py
@@ -167,7 +167,9 @@ def train(args, train_dataset, model, tokenizer):
     # Added here for reproductibility
     set_seed(args)
 
-    for _ in train_iterator:
+    for e in train_iterator:
+        if args.local_rank != -1:
+            train_dataloader.sampler.set_epoch(e)
         epoch_iterator = tqdm(train_dataloader, desc="Iteration", disable=args.local_rank not in [-1, 0])
         for step, batch in enumerate(epoch_iterator):
 


### PR DESCRIPTION
`run_squad.py` file is independent of `Trainer Class`(https://github.com/huggingface/transformers/issues/4398). Therefore, there is no method related to `set_epoch` in distributed training.