### PR TITLE
Fix RobertaForCausalLM docs

### DIFF
--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -762,9 +762,8 @@ class RobertaForCausalLM(RobertaPreTrainedModel):
             >>> import torch
 
             >>> tokenizer = RobertaTokenizer.from_pretrained('roberta-base')
-            >>> config = RobertaConfig.from_pretrained("roberta-base")
+            >>> config = RobertaConfig.from_pretrained("roberta-base", return_dict=True)
             >>> config.is_decoder = True
-            >>> config.return_dict = True
             >>> model = RobertaForCausalLM.from_pretrained('roberta-base', config=config)
 
             >>> inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")

--- a/src/transformers/modeling_roberta.py
+++ b/src/transformers/modeling_roberta.py
@@ -758,13 +758,14 @@ class RobertaForCausalLM(RobertaPreTrainedModel):
 
         Example::
 
-            >>> from transformers import RobertaTokenizer, RobertaLMHeadModel, RobertaConfig
+            >>> from transformers import RobertaTokenizer, RobertaForCausalLM, RobertaConfig
             >>> import torch
 
             >>> tokenizer = RobertaTokenizer.from_pretrained('roberta-base')
             >>> config = RobertaConfig.from_pretrained("roberta-base")
             >>> config.is_decoder = True
-            >>> model = RobertaLMHeadModel.from_pretrained('roberta-base', config=config, return_dict=True)
+            >>> config.return_dict = True
+            >>> model = RobertaForCausalLM.from_pretrained('roberta-base', config=config)
 
             >>> inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
             >>> outputs = model(**inputs)


### PR DESCRIPTION
`RobertaLMHeadModel` does not exist, and we can't pass the `return_dict` value if a config has already been passed during instantiation.

closes #7635