### PR TITLE
Green tests: update torch-hub test dependencies (add protobuf and pin tokenizer 0.9.0-RC2)

### DIFF
--- a/.github/workflows/github-torch-hub.yml
+++ b/.github/workflows/github-torch-hub.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install torch
-        pip install numpy filelock requests tqdm regex sentencepiece sacremoses packaging
+        pip install numpy filelock protobuf requests tqdm regex sentencepiece sacremoses packaging
         pip install tokenizers==0.9.0.rc2
 
     - name: Torch hub list

--- a/.github/workflows/github-torch-hub.yml
+++ b/.github/workflows/github-torch-hub.yml
@@ -30,7 +30,8 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install torch
-        pip install numpy tokenizers filelock requests tqdm regex sentencepiece sacremoses packaging
+        pip install numpy filelock requests tqdm regex sentencepiece sacremoses packaging
+        pip install tokenizers==0.9.0.rc2
 
     - name: Torch hub list
       run: |


### PR DESCRIPTION
# What does this PR do?

Update the torch-hub CI test dependencies to add protobuf and pin tokenizer on 0.9.0-rc2 until final release.

## Who can review?

@sgugger @n1t0 