### PR TITLE
Fix title level in Blenderbot doc

### DIFF
--- a/docs/source/model_doc/blenderbot.rst
+++ b/docs/source/model_doc/blenderbot.rst
@@ -1,5 +1,5 @@
 Blenderbot
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------------------------------------------------------------------------------
 **DISCLAIMER:** If you see something strange,
 file a `Github Issue <https://github.com/huggingface/transformers/issues/new?assignees=&labels=&template=bug-report.md&title>`__ .
 


### PR DESCRIPTION
# What does this PR do?

The navigation bar is a bit crazy because the documentation of BlenderBot puts title and sections at the same level. This PR fixes that.
@LysandreJik merging as soon as it's green because it's a small fix, tagging you so you're aware.