### PR TITLE
Fix flaky test in test_trainer

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -195,7 +195,9 @@ class TrainerIntegrationTest(unittest.TestCase):
         args = TrainingArguments("./regression")
         dict1, dict2 = args.to_dict(), trainer.args.to_dict()
         for key in dict1.keys():
-            self.assertEqual(dict1[key], dict2[key])
+            # Logging dir can be slightly different as they default to something with the time.
+            if key != "loggin_dir":
+                self.assertEqual(dict1[key], dict2[key])
 
     def test_reproducible_training(self):
         # Checks that training worked, model trained and seed made a reproducible training.


### PR DESCRIPTION
# What does this PR do?

As investigated with @LysandreJik today, the corresponding test was flaky because `loggin_dir` has a default that depends of time (so the test fails if the two Trainer are instantiated just before a new minute and just after).