### PR TITLE
Fix trainer callback

### DIFF
--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -443,7 +443,8 @@ class ProgressCallback(TrainerCallback):
 
     def on_evaluate(self, args, state, control, **kwargs):
         if state.is_local_process_zero:
-            self.prediction_bar.close()
+            if self.prediction_bar is not None:
+                self.prediction_bar.close()
             self.prediction_bar = None
 
     def on_log(self, args, state, control, logs=None, **kwargs):


### PR DESCRIPTION
Fix a bug that happends when subclassing Trainer and
overwriting evaluate() without calling prediciton_loop()

# What does this PR do?


Fixes #7702

@sgugger 
