### PR TITLE
Make T5 Supports Gradient Checkpointing

### DIFF
--- a/src/transformers/configuration_t5.py
+++ b/src/transformers/configuration_t5.py
@@ -71,6 +71,8 @@ class T5Config(PretrainedConfig):
         initializer_factor (:obj:`float`, `optional`, defaults to 1):
             A factor for initializing all weight matrices (should be kept to 1, used internally for initialization
             testing).
+        gradient_checkpointing (:obj:`bool`, `optional`, defaults to :obj:`False`):
+            If True, use gradient checkpointing to save memory at the expense of slower backward pass.
     """
     model_type = "t5"
 
@@ -91,6 +93,7 @@ class T5Config(PretrainedConfig):
         is_encoder_decoder=True,
         pad_token_id=0,
         eos_token_id=1,
+        gradient_checkpointing=False,
         **kwargs
     ):
         super().__init__(
@@ -113,6 +116,7 @@ class T5Config(PretrainedConfig):
         self.dropout_rate = dropout_rate
         self.layer_norm_epsilon = layer_norm_epsilon
         self.initializer_factor = initializer_factor
+        self.gradient_checkpointing = gradient_checkpointing
 
     @property
     def max_position_embeddings(self):

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -762,18 +762,9 @@ class T5Stack(T5PreTrainedModel):
                         return module(*inputs, output_attentions)
 
                     return custom_forward
-                
-                def forward_wrapper(layer_module, *args, **kwargs):
-                    """
-                    Converts the forward function's output
-                    to a tuple.
-                    """
-                    return tuple(
-                        layer_module(*args, **kwargs))
 
                 layer_outputs = torch.utils.checkpoint.checkpoint(
-                    #create_custom_forward(layer_module),
-                    forward_wrapper(layer_module),
+                    create_custom_forward(layer_module),
                     hidden_states,
                     attention_mask=extended_attention_mask,
                     position_bias=position_bias,

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -762,6 +762,14 @@ class T5Stack(T5PreTrainedModel):
                         return module(*inputs, output_attentions)
 
                     return custom_forward
+                
+                def forward_wrapper(layer_module, *args, **kwargs):
+                    """
+                    Converts the forward function's output
+                    to a tuple.
+                    """
+                    return tuple(
+                        layer_module(*args, **kwargs))
 
                 layer_outputs = torch.utils.checkpoint.checkpoint(
                     #create_custom_forward(layer_module),

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -764,7 +764,8 @@ class T5Stack(T5PreTrainedModel):
                     return custom_forward
 
                 layer_outputs = torch.utils.checkpoint.checkpoint(
-                    create_custom_forward(layer_module),
+                    #create_custom_forward(layer_module),
+                    layer_module,
                     hidden_states,
                     attention_mask=extended_attention_mask,
                     position_bias=position_bias,

--- a/src/transformers/modeling_t5.py
+++ b/src/transformers/modeling_t5.py
@@ -773,7 +773,7 @@ class T5Stack(T5PreTrainedModel):
 
                 layer_outputs = torch.utils.checkpoint.checkpoint(
                     #create_custom_forward(layer_module),
-                    layer_module,
+                    forward_wrapper(layer_module),
                     hidden_states,
                     attention_mask=extended_attention_mask,
                     position_bias=position_bias,


### PR DESCRIPTION
# What does this PR do?

Since T5 3B and 11B models are really huge models to be fine-tuned on a single GPU, Gradient Checkpointing will allow this model to be fine-tuned on a single GPU but at the cost of more training time.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dimiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests), 
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to the it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests? 


## Who can review?
 T5: @patrickvonplaten
