### PR TITLE
Don't use `store_xxx` on optional bools

### DIFF
--- a/examples/test_xla_examples.py
+++ b/examples/test_xla_examples.py
@@ -59,7 +59,7 @@ class TorchXLAExamplesTests(unittest.TestCase):
             --model_name_or_path=bert-base-cased
             --per_device_train_batch_size=64
             --per_device_eval_batch_size=64
-            --evaluate_during_training
+            --evaluation_strategy steps
             --overwrite_cache
             """.split()
         with patch.object(sys, "argv", testargs):

--- a/examples/text-classification/README.md
+++ b/examples/text-classification/README.md
@@ -43,7 +43,7 @@ python run_tf_text_classification.py \
   --do_eval \
   --do_predict \
   --logging_steps 10 \
-  --evaluate_during_training \
+  --evaluation_strategy steps \
   --save_steps 10 \
   --overwrite_output_dir \
   --max_seq_length 128

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -64,8 +64,11 @@ class HfArgumentParser(ArgumentParser):
                 kwargs["type"] = field.type
                 if field.default is not dataclasses.MISSING:
                     kwargs["default"] = field.default
-            elif field.type is bool or (field.type is Optional[bool] and field.default is not None):
-                kwargs["action"] = "store_false" if field.default is True else "store_true"
+            elif field.type is bool or field.type is Optional[bool]:
+                if field.type is Optional[bool] and (
+                    field.default is not None and field.default is not dataclasses.MISSING
+                ):
+                    kwargs["action"] = "store_false" if field.default is True else "store_true"
                 if field.default is True:
                     field_name = f"--no-{field.name}"
                     kwargs["dest"] = field.name

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -65,9 +65,7 @@ class HfArgumentParser(ArgumentParser):
                 if field.default is not dataclasses.MISSING:
                     kwargs["default"] = field.default
             elif field.type is bool or field.type is Optional[bool]:
-                if field.type is Optional[bool] and (
-                    field.default is not None and field.default is not dataclasses.MISSING
-                ):
+                if field.type is bool or (field.default is not None and field.default is not dataclasses.MISSING):
                     kwargs["action"] = "store_false" if field.default is True else "store_true"
                 if field.default is True:
                     field_name = f"--no-{field.name}"

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -64,7 +64,7 @@ class HfArgumentParser(ArgumentParser):
                 kwargs["type"] = field.type
                 if field.default is not dataclasses.MISSING:
                     kwargs["default"] = field.default
-            elif field.type is bool or field.type is Optional[bool]:
+            elif field.type is bool or (field.type is Optional[bool] and field.default is not None):
                 kwargs["action"] = "store_false" if field.default is True else "store_true"
                 if field.default is True:
                     field_name = f"--no-{field.name}"

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -187,7 +187,7 @@ class TrainingArguments:
     do_eval: bool = field(default=None, metadata={"help": "Whether to run eval on the dev set."})
     do_predict: bool = field(default=False, metadata={"help": "Whether to run predictions on the test set."})
     evaluate_during_training: bool = field(
-        default=None,
+        default=False,
         metadata={"help": "Run evaluation during training at each logging step."},
     )
     evaluation_strategy: EvaluationStrategy = field(

--- a/valohai.yaml
+++ b/valohai.yaml
@@ -85,7 +85,7 @@
         pass-as: --output_dir={v}
         type: string
         default: /valohai/outputs
-      - name: evaluate_during_training
-        description: Run evaluation during training at each logging step.
-        type: flag
-        default: true
+      - name: evaluation_strategy
+        description: The evaluation strategy to use.
+        type: string
+        default: steps


### PR DESCRIPTION
# What does this PR do?

Optional bool fields in `TrainingArguments` are given the `store_true` attribute by `HFArgumentParser` which can yield to bugs (as highlighted in #7755). This PR fixes this and to avoid breaking existing scripts, removes the optional in the `evaluate_during_training` argument.

It also fixes a few instances with the right argument called (since that argument is deprecated).

Fixes #7755