### PR TITLE
Fixing beam search output shapes

### DIFF
--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -500,6 +500,7 @@ class GenerationMixin:
                 model_kwargs=model_kwargs,
             )
 
+        output = [[output[i * num_beams + j] for j in range(num_beams)] for i in range(batch_size)]
         return output
 
     def _generate_no_beam_search(


### PR DESCRIPTION
# What does this PR do?

`generate` in `generation_utils.py` returns a list of size `batch_size * num_beams` where it is much more practical if it returns a list of lists. The first list of size `batch_size` and all internal lists of size `num_beams`. In this way, one can generate using mini-batches of variable size and no do reshapes each time.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dimiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests), 
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to the it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests? 


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors which may be interested in your PR.

@patrickvonplaten , @TevenLeScao 