### PR TITLE
Fix TF savedmodel in Roberta

### DIFF
--- a/src/transformers/modeling_tf_longformer.py
+++ b/src/transformers/modeling_tf_longformer.py
@@ -125,7 +125,7 @@ class TFLongformerEmbeddings(tf.keras.layers.Layer):
     """
 
     def __init__(self, config, **kwargs):
-        super().__init__(config, **kwargs)
+        super().__init__(**kwargs)
 
         self.padding_idx = 1
         self.vocab_size = config.vocab_size

--- a/src/transformers/modeling_tf_roberta.py
+++ b/src/transformers/modeling_tf_roberta.py
@@ -70,7 +70,7 @@ class TFRobertaEmbeddings(tf.keras.layers.Layer):
     """
 
     def __init__(self, config, **kwargs):
-        super().__init__(config, **kwargs)
+        super().__init__(**kwargs)
 
         self.padding_idx = 1
         self.vocab_size = config.vocab_size


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue in the TensorFlow version of Roberta. The issue prevented to save any Roberta model in SavedModel format.

Fixes #7783
