### PR TITLE
Fix issue #7781

### DIFF
--- a/src/transformers/modeling_encoder_decoder.py
+++ b/src/transformers/modeling_encoder_decoder.py
@@ -327,7 +327,7 @@ class EncoderDecoderModel(PreTrainedModel):
 
                 kwargs_decoder["config"] = decoder_config
 
-            if kwargs_decoder["config"].is_decoder is False or decoder_config.add_cross_attention is False:
+            if kwargs_decoder["config"].is_decoder is False or kwargs_decoder["config"].add_cross_attention is False:
                 logger.warning(
                     f"Decoder model {decoder_pretrained_model_name_or_path} is not initialized as a decoder. In order to initialize {decoder_pretrained_model_name_or_path} as a decoder, make sure that the attributes `is_decoder` and `add_cross_attention` of `decoder_config` passed to `.from_encoder_decoder_pretrained(...)` are set to `True` or do not pass a `decoder_config` to `.from_encoder_decoder_pretrained(...)`"
                 )


### PR DESCRIPTION
`decoder_config` may not be defined at this line, use `kwargs_decoder["config"]` instead. This is also consistent with the rest of the function.

Fixes # 7781
https://github.com/huggingface/transformers/issues/7781

## Who can review?

Anybody can review, though @patrickvonplaten gave an informal approval in the issue discussion.