### PR TITLE
Small fixes to NotebookProgressCallback

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -153,7 +153,7 @@ try:
     import IPython  # noqa: F401
 
     _in_notebook = True
-except:  # noqa: E722
+except (AttributeError, ImportError, KeyError):
     _in_notebook = False
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes a few things in the `NotebookProgressCallback`, mainly:
- triggering forced updates after an evaluation (as an evaluation is longer than just a training step)
- fixing the behavior when an evaluation strategy is not epochs
- removing empty except in the `is_in_notebook` test
