### PR TITLE
Fix missing reference titles in retrieval evaluation of RAG

### DIFF
--- a/examples/rag/eval_rag.py
+++ b/examples/rag/eval_rag.py
@@ -72,7 +72,7 @@ def get_precision_at_k(args, preds_path, gold_data_path):
     em = total = 0
     for hypo, reference in zip(hypos, references):
         hypo_provenance = set(hypo.split("\t")[:k])
-        ref_provenance = set(reference.split("\t")[1 : (k + 1)])
+        ref_provenance = set(reference.split("\t"))
         total += 1
         em += len(hypo_provenance & ref_provenance) / k
 


### PR DESCRIPTION
There's currently a bug in the retrieval evaluation script of RAG where for each sample, the first reference title is discarded.
Moreover only `k` reference titles were taken into account while we need all of them to compute the Precision @ k.

Because of this bug the index provided by the RAG team (hnsw M=128 + SQ8 with the "inner product to L2" trick) only had 35% of Precision @ k. With this fix it is back to 70%, which is consistent with what they had internally as far as I know.

Apparently the original parsing script used to add the question before the titles, that's why it was discarding the first entry.

cc @ola13 