### PR TITLE
Remove masked_lm_labels from returned dictionary in DataCollatorForNextSentencePrediction

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -449,8 +449,6 @@ class DataCollatorForNextSentencePrediction:
             "labels": mlm_labels if self.mlm else None,
             "next_sentence_label": torch.tensor(nsp_labels),
         }
-        if self.mlm:
-            result["masked_lm_labels"] = mlm_labels
         return result
 
     def _tensorize_batch(self, examples: List[torch.Tensor]) -> torch.Tensor:


### PR DESCRIPTION
# What does this PR do?

This PR removes ```masked_lm_labels``` from dictionary returned in DataCollatorForNextSentencePrediction ```__call__``` method. I noticed the warning while BERT pre-training. I removed the lines (452,453) and the warning was finally gone. See discussion George (@gmihaila) and I already had in the [merged PR](https://github.com/huggingface/transformers/pull/7595)

<!-- Remove if not applicable -->


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests), 
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to the it if that's the case. **Discussed on forum but on previously merged [PR](https://github.com/huggingface/transformers/pull/7595) **
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation). **Not needed**
- [x] Did you write any new necessary tests? **Not needed**


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors which may be interested in your PR.

@LysandreJik, @sgugger, and @gmihaila can review
