### PR TITLE
Fix small type hinting error

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -576,7 +576,7 @@ class BatchEncoding(UserDict):
         return self
 
     @torch_required
-    def to(self, device: Union[str, torch.device]) -> "BatchEncoding":
+    def to(self, device: Union[str, "torch.device"]) -> "BatchEncoding":
         """
         Send all values to device by calling :obj:`v.to(device)` (PyTorch only).
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -576,7 +576,7 @@ class BatchEncoding(UserDict):
         return self
 
     @torch_required
-    def to(self, device: str) -> "BatchEncoding":
+    def to(self, Union[str, torch.device]) -> "BatchEncoding":
         """
         Send all values to device by calling :obj:`v.to(device)` (PyTorch only).
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -576,7 +576,7 @@ class BatchEncoding(UserDict):
         return self
 
     @torch_required
-    def to(self, Union[str, torch.device]) -> "BatchEncoding":
+    def to(self, device: Union[str, torch.device]) -> "BatchEncoding":
         """
         Send all values to device by calling :obj:`v.to(device)` (PyTorch only).
 


### PR DESCRIPTION
Fix small type hinting error which causes type warnings in some IDEs when using `torch.device` instead of a string