### PR TITLE
fix: ignore padding tokens in Bart loss

### DIFF
--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -1089,7 +1089,9 @@ class BartForConditionalGeneration(PretrainedBartModel):
             past_key_values = unused.pop("decoder_past_key_values")
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
+        assert -100 not in input_ids
         if labels is not None:
+            assert -100 not in labels
             use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(labels, self.config.pad_token_id)

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -1090,7 +1090,7 @@ class BartForConditionalGeneration(PretrainedBartModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
-            assert -100 not in labels
+            assert labels.min() > 0, f'negative labels are not supported, got {labels.min()}'
             use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(labels, self.config.pad_token_id)

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -1110,8 +1110,7 @@ class BartForConditionalGeneration(PretrainedBartModel):
 
         masked_lm_loss = None
         if labels is not None:
-            loss_fct = CrossEntropyLoss()
-            # TODO(SS): do we need to ignore pad tokens in labels?
+            loss_fct = CrossEntropyLoss(ignore_index=self.config.pad_token_id)
             masked_lm_loss = loss_fct(lm_logits.view(-1, self.config.vocab_size), labels.view(-1))
 
         if not return_dict:

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -1089,7 +1089,6 @@ class BartForConditionalGeneration(PretrainedBartModel):
             past_key_values = unused.pop("decoder_past_key_values")
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        assert -100 not in input_ids
         if labels is not None:
             assert -100 not in labels
             use_cache = False

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -1045,9 +1045,9 @@ class BartForConditionalGeneration(PretrainedBartModel):
         r"""
         labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`):
             Labels for computing the masked language modeling loss.
-            Indices should either be in ``[0, ..., config.vocab_size]`` or -100 (see ``input_ids`` docstring).
-            Tokens with indices set to ``-100`` are ignored (masked), the loss is only computed for the tokens
-            with labels in ``[0, ..., config.vocab_size]``.
+            Indices should either be in ``[0, ..., config.vocab_size]`` (see ``input_ids`` docstring).
+            Tokens with indices set to ``config.pad_token_id`` are ignored (masked), the loss is only computed for the tokens
+            with labels in ``[0, ..., config.vocab_size]`` excluding ``config.pad_token_id``.
 
         Returns:
 


### PR DESCRIPTION
# What does this PR do?
There is a discrepancy between the [fine-tuning script](https://github.com/huggingface/transformers/blob/e7aa64838cc604abf7a49e69ca0ffe7af683d8ca/examples/seq2seq/finetune.py#L153) and the [BartForConditionalGeneration](https://github.com/huggingface/transformers/blob/e7aa64838cc604abf7a49e69ca0ffe7af683d8ca/src/transformers/modeling_bart.py#L1113) which is also noted in the comments. 

From `examples/seq2seq/finetune.py`:
```python
# Same behavior as modeling_bart.py, besides ignoring pad_token_id
ce_loss_fct = torch.nn.CrossEntropyLoss(ignore_index=pad_token_id)
```

From `transformers/src/modeling_bart.py`:
```python
loss_fct = CrossEntropyLoss()
# TODO(SS): do we need to ignore pad tokens in labels?
```

Training with the `Trainer` and `BartForConditionalGeneration` results in a model that produces garbled text (lots of repetitions and no coherence). Adding the `ignore_index=self.config.pad_token_id` in the `CrossEntropyLoss` resolves the issue.

Besides a before and after run I did not study the behaviour in a systematic way since training the model requires a significant amount of time and compute. If you would like to see more testing let me know what you think is the best way to test this thoroughly.

