### PR TITLE
fix wandb/comet problems

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -10,12 +10,9 @@ try:
     import comet_ml  # noqa: F401
 
     # XXX: there should be comet_ml.ensure_configured(), like `wandb`, for now emulate it
-    try:
-        comet_ml.Experiment(project_name="ensure_configured")
-        _has_comet = True
-    except (ValueError):
-        _has_comet = False
-except (ImportError):
+    comet_ml.Experiment(project_name="ensure_configured")
+    _has_comet = True
+except (ImportError, ValueError):
     _has_comet = False
 
 try:

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -271,7 +271,7 @@ class WandbCallback(TrainerCallback):
                 'Automatic Weights & Biases logging enabled, to disable set os.environ["WANDB_DISABLED"] = "true"'
             )
             combined_dict = {**args.to_sanitized_dict()}
-            if hasattr(model, "config") and model.config is not None:
+            if getattr(model, "config", None) is not None:
                 combined_dict = {**model.config.to_dict(), **combined_dict}
             wandb.init(project=os.getenv("WANDB_PROJECT", "huggingface"), config=combined_dict, name=args.run_name)
             # keep track of model topology and gradients, unsupported on TPU

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -9,7 +9,12 @@ try:
     # Comet needs to be imported before any ML frameworks
     import comet_ml  # noqa: F401
 
-    _has_comet = True
+    # XXX: there should be comet_ml.ensure_configured(), like `wandb`, for now emulate it
+    try:
+        comet_ml.Experiment(project_name="ensure_configured")
+        _has_comet = True
+    except (ValueError):
+        _has_comet = False
 except (ImportError):
     _has_comet = False
 
@@ -269,7 +274,7 @@ class WandbCallback(TrainerCallback):
                 'Automatic Weights & Biases logging enabled, to disable set os.environ["WANDB_DISABLED"] = "true"'
             )
             combined_dict = {**args.to_sanitized_dict()}
-            if hasattr(model, "config"):
+            if hasattr(model, "config") and model.config is not None:
                 combined_dict = {**model.config.to_dict(), **combined_dict}
             wandb.init(project=os.getenv("WANDB_PROJECT", "huggingface"), config=combined_dict, name=args.run_name)
             # keep track of model topology and gradients, unsupported on TPU


### PR DESCRIPTION
As discussed in https://github.com/huggingface/transformers/issues/7821

* handle the case where `comet_ml` is installed but not configured
* fix error in wandb code:
```
>               combined_dict = {**model.config.to_dict(), **combined_dict}
E               AttributeError: 'NoneType' object has no attribute 'to_dict'
```

Fixes: #7821

@sgugger 