### PR TITLE
[utils/check_copies.py] fix DeprecationWarning

### DIFF
--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -49,7 +49,7 @@ def find_code_in_transformers(object_name):
     indent = ""
     line_index = 0
     for name in parts[i + 1 :]:
-        while line_index < len(lines) and re.search(f"^{indent}(class|def)\s+{name}", lines[line_index]) is None:
+        while line_index < len(lines) and re.search(fr"^{indent}(class|def)\s+{name}", lines[line_index]) is None:
             line_index += 1
         indent += "    "
         line_index += 1


### PR DESCRIPTION
in `tests/test_utils_check_copies.py` I was getting intermittently:
```
utils/check_copies.py:52
  /mnt/nvme1/code/transformers-comet/utils/check_copies.py:52: DeprecationWarning: invalid escape sequence \s
    while line_index < len(lines) and re.search(f"^{indent}(class|def)\s+{name}", lines[line_index]) is None:
```
So this should fix it. Not sure why it wasn't showing up all the time.

@sgugger 