### PR TITLE
Small fixes to HP search

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -520,7 +520,7 @@ class Trainer:
     ):
         if self.hp_search_backend is None or trial is None:
             return
-        self.objective = self.compute_objective(metrics)
+        self.objective = self.compute_objective(metrics.copy())
         if self.hp_search_backend == HPSearchBackend.OPTUNA:
             trial.report(self.objective, epoch)
             if trial.should_prune():

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -112,6 +112,7 @@ def default_compute_objective(metrics: Dict[str, float]) -> float:
     """
     loss = metrics.pop("eval_loss", None)
     _ = metrics.pop("epoch", None)
+    _ = metrics.pop("total_flos", None)
     return loss if len(metrics) == 0 else sum(metrics.values())
 
 


### PR DESCRIPTION
# What does this PR do?

HP search has two small bugs in `Trainer` right now:
- it pops things form the metrics dict, which are then improperly logged
- it doesn't pop out the `total_flos`, so the hp search tries to maximize the flos (which I guess is @TevenLeScao master plan to conquer the universe ;-) )