### PR TITLE
[DOC] Typo and fix the input of labels to `cross_entropy`

### DIFF
--- a/docs/source/training.rst
+++ b/docs/source/training.rst
@@ -109,9 +109,9 @@ The following is equivalent to the previous example:
 .. code-block:: python
 
     from torch.nn import functional as F
-    labels = torch.tensor([1,0]).unsqueeze(0)
+    labels = torch.tensor([1,0])
     outputs = model(input_ids, attention_mask=attention_mask)
-    loss = F.cross_entropy(labels, outputs.logitd)
+    loss = F.cross_entropy(outputs.logits, labels)
     loss.backward()
     optimizer.step()
 


### PR DESCRIPTION
# What does this PR do?
The current version caused some errors. The proposed changes fixed it for me. Hope this is helpful!

- [ x] This PR fixes a typo or improves the docs (you can dimiss the other checks if that's the case).


@sgugger 