### PR TITLE
[testing] disable FutureWarning in examples tests

### DIFF
--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -9,3 +9,7 @@ from os.path import abspath, dirname, join
 # 'pip install -e .[dev]' when switching between checkouts and running tests.
 git_repo_path = abspath(join(dirname(dirname(__file__)), "src"))
 sys.path.insert(1, git_repo_path)
+
+# silence FutureWarning warnings in tests since often we can't act on them until
+# they become normal warnings - i.e. the tests still need to test the current functionality
+warnings.simplefilter(action="ignore", category=FutureWarning)

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -2,6 +2,7 @@
 # by pytest before any tests are run
 
 import sys
+import warnings
 from os.path import abspath, dirname, join
 
 


### PR DESCRIPTION
same as tests/conftest.py, we can't resolve those warning, so turn the noise off.

same as PR: https://github.com/huggingface/transformers/pull/7079