### PR TITLE
[seq2seq] get_git_info fails gracefully

### DIFF
--- a/examples/seq2seq/utils.py
+++ b/examples/seq2seq/utils.py
@@ -466,7 +466,7 @@ def get_git_info():
             "hostname": str(socket.gethostname()),
         }
         return repo_infos
-    except (TypeError):
+    except TypeError:
         return {
             "repo_id": None,
             "repo_sha": None,

--- a/examples/seq2seq/utils.py
+++ b/examples/seq2seq/utils.py
@@ -457,14 +457,23 @@ def load_json(path):
 
 
 def get_git_info():
-    repo = git.Repo(search_parent_directories=True)
-    repo_infos = {
-        "repo_id": str(repo),
-        "repo_sha": str(repo.head.object.hexsha),
-        "repo_branch": str(repo.active_branch),
-        "hostname": str(socket.gethostname()),
-    }
-    return repo_infos
+    try: 
+        # XXX: workaround for https://github.com/gitpython-developers/GitPython/issues/633
+        repo = git.Repo(search_parent_directories=True)
+        repo_infos = {
+            "repo_id": str(repo),
+            "repo_sha": str(repo.head.object.hexsha),
+            "repo_branch": str(repo.active_branch),
+            "hostname": str(socket.gethostname()),
+        }
+        return repo_infos
+    except (TypeError):
+        return {
+            "repo_id": None,
+            "repo_sha": None,
+            "repo_branch": None,
+            "hostname": None,
+        }
 
 
 ROUGE_KEYS = ["rouge1", "rouge2", "rougeL", "rougeLsum"]

--- a/examples/seq2seq/utils.py
+++ b/examples/seq2seq/utils.py
@@ -457,8 +457,7 @@ def load_json(path):
 
 
 def get_git_info():
-    try: 
-        # XXX: workaround for https://github.com/gitpython-developers/GitPython/issues/633
+    try:
         repo = git.Repo(search_parent_directories=True)
         repo_infos = {
             "repo_id": str(repo),


### PR DESCRIPTION
It looks like gitpython is broken when one tries to use it from `git checkout hash`, see: https://github.com/gitpython-developers/GitPython/issues/633

While debugging/bisecting we need to be able to step through different commits and for the code to still work. 

Currently if I do:
```
git checkout fb94b8f1e16eb
```
and run an examples test, like `examples/seq2seq/test_seq2seq_examples_multi_gpu.py` (soon to be merged) it fails with:
```
ERR:   File "./examples/seq2seq/distillation.py", line 504, in <module>
ERR:     distill_main(args)
ERR:   File "./examples/seq2seq/distillation.py", line 494, in distill_main
ERR:     model = create_module(args)
ERR:   File "./examples/seq2seq/distillation.py", line 411, in create_module
ERR:     model = module_cls(args)
ERR:   File "/mnt/nvme1/code/huggingface/transformers-multigpu/examples/seq2seq/finetune.py", line 58, in __init__
ERR:     save_git_info(self.hparams.output_dir)
ERR:   File "/mnt/nvme1/code/huggingface/transformers-multigpu/examples/seq2seq/utils.py", line 355, in save_git_info
ERR:     repo_infos = get_git_info()
ERR:   File "/mnt/nvme1/code/huggingface/transformers-multigpu/examples/seq2seq/utils.py", line 374, in get_git_info
ERR:     "repo_branch": str(repo.active_branch),
ERR:   File "/home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/git/repo/base.py", line 705, in active_branch
ERR:     return self.head.reference
ERR:   File "/home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/git/refs/symbolic.py", line 272, in _get_reference
ERR:     raise TypeError("%s is a detached symbolic reference as it points to %r" % (self, sha))
ERR: TypeError: HEAD is a detached symbolic reference as it points to 'fb94b8f1e16eb21d166174f52e3e49e669ef0ac4'
```

The odd leading `ERR` string is just a replay of stderr from the sub-process - please ignore this nuance.

This PR provides a workaround.

@sshleifer
