### PR TITLE
Trainer with Iterable Dataset

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -67,7 +67,7 @@ class RegressionModelConfig(PretrainedConfig):
 
 if is_torch_available():
 
-    class RegressionDataset():
+    class RegressionDataset:
         def __init__(self, a=2, b=3, length=64, seed=42, label_names=None):
             np.random.seed(seed)
             self.label_names = ["labels"] if label_names is None else label_names

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -47,6 +47,24 @@ if is_torch_available():
 PATH_SAMPLE_TEXT = f"{get_tests_dir()}/fixtures/sample_text.txt"
 
 
+class RegressionDataset:
+    def __init__(self, a=2, b=3, length=64, seed=42, label_names=None):
+        np.random.seed(seed)
+        self.label_names = ["labels"] if label_names is None else label_names
+        self.length = length
+        self.x = np.random.normal(size=(length,)).astype(np.float32)
+        self.ys = [a * self.x + b + np.random.normal(scale=0.1, size=(length,)) for _ in self.label_names]
+        self.ys = [y.astype(np.float32) for y in self.ys]
+
+    def __len__(self):
+        return self.length
+
+    def __getitem__(self, i):
+        result = {name: y[i] for name, y in zip(self.label_names, self.ys)}
+        result["input_x"] = self.x[i]
+        return result
+
+
 class AlmostAccuracy:
     def __init__(self, thresh=0.25):
         self.thresh = thresh
@@ -66,23 +84,6 @@ class RegressionModelConfig(PretrainedConfig):
 
 
 if is_torch_available():
-
-    class RegressionDataset:
-        def __init__(self, a=2, b=3, length=64, seed=42, label_names=None):
-            np.random.seed(seed)
-            self.label_names = ["labels"] if label_names is None else label_names
-            self.length = length
-            self.x = np.random.normal(size=(length,)).astype(np.float32)
-            self.ys = [a * self.x + b + np.random.normal(scale=0.1, size=(length,)) for _ in self.label_names]
-            self.ys = [y.astype(np.float32) for y in self.ys]
-
-        def __len__(self):
-            return self.length
-
-        def __getitem__(self, i):
-            result = {name: y[i] for name, y in zip(self.label_names, self.ys)}
-            result["input_x"] = self.x[i]
-            return result
 
     class SampleIterableDataset(IterableDataset):
         """

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -20,7 +20,6 @@ import unittest
 
 import datasets
 import numpy as np
-import pytest
 
 from transformers import AutoTokenizer, PretrainedConfig, TrainingArguments, is_torch_available
 from transformers.file_utils import WEIGHTS_NAME
@@ -129,9 +128,7 @@ if is_torch_available():
             loss = torch.nn.functional.mse_loss(y, labels)
             return (loss, y, y) if self.double_output else (loss, y)
 
-    def get_regression_trainer(
-        a=0, b=0, double_output=False, train_len=64, eval_len=64, pretrained=True, **kwargs
-    ):
+    def get_regression_trainer(a=0, b=0, double_output=False, train_len=64, eval_len=64, pretrained=True, **kwargs):
         label_names = kwargs.get("label_names", None)
         train_dataset = RegressionDataset(length=train_len, label_names=label_names)
         eval_dataset = RegressionDataset(length=eval_len, label_names=label_names)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -48,24 +48,6 @@ if is_torch_available():
 PATH_SAMPLE_TEXT = f"{get_tests_dir()}/fixtures/sample_text.txt"
 
 
-class RegressionDataset(Dataset):
-    def __init__(self, a=2, b=3, length=64, seed=42, label_names=None):
-        np.random.seed(seed)
-        self.label_names = ["labels"] if label_names is None else label_names
-        self.length = length
-        self.x = np.random.normal(size=(length,)).astype(np.float32)
-        self.ys = [a * self.x + b + np.random.normal(scale=0.1, size=(length,)) for _ in self.label_names]
-        self.ys = [y.astype(np.float32) for y in self.ys]
-
-    def __len__(self):
-        return self.length
-
-    def __getitem__(self, i):
-        result = {name: y[i] for name, y in zip(self.label_names, self.ys)}
-        result["input_x"] = self.x[i]
-        return result
-
-
 class AlmostAccuracy:
     def __init__(self, thresh=0.25):
         self.thresh = thresh
@@ -85,6 +67,23 @@ class RegressionModelConfig(PretrainedConfig):
 
 
 if is_torch_available():
+
+    class RegressionDataset(Dataset):
+        def __init__(self, a=2, b=3, length=64, seed=42, label_names=None):
+            np.random.seed(seed)
+            self.label_names = ["labels"] if label_names is None else label_names
+            self.length = length
+            self.x = np.random.normal(size=(length,)).astype(np.float32)
+            self.ys = [a * self.x + b + np.random.normal(scale=0.1, size=(length,)) for _ in self.label_names]
+            self.ys = [y.astype(np.float32) for y in self.ys]
+
+        def __len__(self):
+            return self.length
+
+        def __getitem__(self, i):
+            result = {name: y[i] for name, y in zip(self.label_names, self.ys)}
+            result["input_x"] = self.x[i]
+            return result
 
     class SampleIterableDataset(IterableDataset):
         """

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -28,7 +28,7 @@ from transformers.testing_utils import get_tests_dir, require_torch, slow
 
 if is_torch_available():
     import torch
-    from torch.utils.data import Dataset, IterableDataset
+    from torch.utils.data import IterableDataset
 
     from transformers import (
         AutoModelForMaskedLM,
@@ -67,7 +67,7 @@ class RegressionModelConfig(PretrainedConfig):
 
 if is_torch_available():
 
-    class RegressionDataset(Dataset):
+    class RegressionDataset():
         def __init__(self, a=2, b=3, length=64, seed=42, label_names=None):
             np.random.seed(seed)
             self.label_names = ["labels"] if label_names is None else label_names


### PR DESCRIPTION
# What does this PR do?

Fixes #5990 
Follows #5995 (closed because stale).
Merges all commits from master.

* accomodate iterable dataset without predefined length
* set it as 1 use case: provide max_steps, and NO num_epochs
* Is a merge of master and PR 5995

- [ ] This PR fixes a typo or improves the docs (you can dimiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests), 
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to the it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [X] Did you write any new necessary tests? 


## Who can review?
@sgugger 
