### PR TITLE
Raise error when using AMP on non-CUDA device

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -350,6 +350,9 @@ class TrainingArguments:
             self.greater_is_better = self.metric_for_best_model not in ["loss", "eval_loss"]
         if self.run_name is None:
             self.run_name = self.output_dir
+        
+        if self.device.type != "cuda" and self.fp16:
+            raise ValueError("AMP (`--fp16`) can only be used on CUDA devices.")
 
     @property
     def train_batch_size(self) -> int:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -191,16 +191,13 @@ class TrainingArguments:
     do_eval: bool = field(default=None, metadata={"help": "Whether to run eval on the dev set."})
     do_predict: bool = field(default=False, metadata={"help": "Whether to run predictions on the test set."})
     evaluate_during_training: bool = field(
-        default=False,
-        metadata={"help": "Run evaluation during training at each logging step."},
+        default=False, metadata={"help": "Run evaluation during training at each logging step."},
     )
     evaluation_strategy: EvaluationStrategy = field(
-        default="no",
-        metadata={"help": "Run evaluation during training at each logging step."},
+        default="no", metadata={"help": "Run evaluation during training at each logging step."},
     )
     prediction_loss_only: bool = field(
-        default=False,
-        metadata={"help": "When performing evaluation and predictions, only returns the loss."},
+        default=False, metadata={"help": "When performing evaluation and predictions, only returns the loss."},
     )
 
     per_device_train_batch_size: int = field(
@@ -350,7 +347,7 @@ class TrainingArguments:
             self.greater_is_better = self.metric_for_best_model not in ["loss", "eval_loss"]
         if self.run_name is None:
             self.run_name = self.output_dir
-        
+
         if self.device.type != "cuda" and self.fp16:
             raise ValueError("AMP (`--fp16`) can only be used on CUDA devices.")
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -191,13 +191,16 @@ class TrainingArguments:
     do_eval: bool = field(default=None, metadata={"help": "Whether to run eval on the dev set."})
     do_predict: bool = field(default=False, metadata={"help": "Whether to run predictions on the test set."})
     evaluate_during_training: bool = field(
-        default=False, metadata={"help": "Run evaluation during training at each logging step."},
+        default=False,
+        metadata={"help": "Run evaluation during training at each logging step."},
     )
     evaluation_strategy: EvaluationStrategy = field(
-        default="no", metadata={"help": "Run evaluation during training at each logging step."},
+        default="no",
+        metadata={"help": "Run evaluation during training at each logging step."},
     )
     prediction_loss_only: bool = field(
-        default=False, metadata={"help": "When performing evaluation and predictions, only returns the loss."},
+        default=False,
+        metadata={"help": "When performing evaluation and predictions, only returns the loss."},
     )
 
     per_device_train_batch_size: int = field(


### PR DESCRIPTION
The trainer currently implements native AMP in such a way that a GradScaler is always used. AFAIK, and as supported by [this post](https://github.com/pytorch/pytorch/issues/36169#issuecomment-611261781) and [this report on the forums](https://discuss.huggingface.co/t/training-gpt2-on-cpus/1603), this will only work on CUDA devices. Therefore, an error should probably be thrown when a user tries to use `--fp16` alongside a non-CUDA device.

This PR is currently very brief because I am uncertain about a few things:

- I am not sure if the current implementation of `--fp16` in the trainer works with TPUs;
- I am not sure about differences in behaviour between using `apex` and native AMP in this respect;
- I am not entirely sure whether `_post_init` is the right place to do an argument sanity check. Particularly because I am now calling `self.device` which will set the device through `_set_devices`, even though you may (?) want to delay that as long as possible until the arguments are used in the trainer.

cc @sgugger 