### PR TITLE
[CIs] report slow tests add --durations=0 to some pytest jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
                 key: v0.3-{{ checksum "setup.py" }}
                 paths:
                     - '~/.cache/pip'
-            - run: python -m pytest -n 8 --dist=loadfile -rA -s ./tests/ --cov  | tee output.txt
+            - run: python -m pytest -n 8 --dist=loadfile -rA -s ./tests/ --cov --durations=50 | tee output.txt
             - run: codecov
             - store_artifacts:
                   path: ~/transformers/output.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
                 key: v0.3-{{ checksum "setup.py" }}
                 paths:
                     - '~/.cache/pip'
-            - run: python -m pytest -n 8 --dist=loadfile -rA -s ./tests/ --cov --durations=50 | tee output.txt
+            - run: python -m pytest -n 8 --dist=loadfile -rA -s ./tests/ --cov --durations=0 | tee output.txt
             - run: codecov
             - store_artifacts:
                   path: ~/transformers/output.txt

--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -60,7 +60,7 @@ jobs:
         USE_CUDA: yes
       run: |
         source .env/bin/activate
-        python -m pytest -n 1 --dist=loadfile -s ./tests/
+        python -m pytest -n 1 --dist=loadfile -s ./tests/ --durations=50
 
     - name: Run examples tests on GPU
       env:
@@ -71,7 +71,7 @@ jobs:
       run: |
         source .env/bin/activate
         pip install -r examples/requirements.txt
-        python -m pytest -n 1 --dist=loadfile -s examples
+        python -m pytest -n 1 --dist=loadfile -s examples --durations=50
 
   run_all_tests_torch_and_tf_multiple_gpu:
     runs-on: [self-hosted, multi-gpu]
@@ -123,7 +123,7 @@ jobs:
           USE_CUDA: yes
         run: |
           source .env/bin/activate
-          python -m pytest -n 1 --dist=loadfile -s ./tests/
+          python -m pytest -n 1 --dist=loadfile -s ./tests/ --durations=50
 
       - name: Run examples tests on GPU
         env:
@@ -134,4 +134,4 @@ jobs:
         run: |
           source .env/bin/activate
           pip install -r examples/requirements.txt
-          python -m pytest -n 1 --dist=loadfile -s examples
+          python -m pytest -n 1 --dist=loadfile -s examples --durations=50

--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -60,7 +60,7 @@ jobs:
         USE_CUDA: yes
       run: |
         source .env/bin/activate
-        python -m pytest -n 1 --dist=loadfile -s ./tests/ --durations=50
+        python -m pytest -n 1 --dist=loadfile -s ./tests/ --durations=0
 
     - name: Run examples tests on GPU
       env:
@@ -71,7 +71,7 @@ jobs:
       run: |
         source .env/bin/activate
         pip install -r examples/requirements.txt
-        python -m pytest -n 1 --dist=loadfile -s examples --durations=50
+        python -m pytest -n 1 --dist=loadfile -s examples --durations=0
 
   run_all_tests_torch_and_tf_multiple_gpu:
     runs-on: [self-hosted, multi-gpu]
@@ -123,7 +123,7 @@ jobs:
           USE_CUDA: yes
         run: |
           source .env/bin/activate
-          python -m pytest -n 1 --dist=loadfile -s ./tests/ --durations=50
+          python -m pytest -n 1 --dist=loadfile -s ./tests/ --durations=0
 
       - name: Run examples tests on GPU
         env:
@@ -134,4 +134,4 @@ jobs:
         run: |
           source .env/bin/activate
           pip install -r examples/requirements.txt
-          python -m pytest -n 1 --dist=loadfile -s examples --durations=50
+          python -m pytest -n 1 --dist=loadfile -s examples --durations=0


### PR DESCRIPTION
It appears that over the last 10 days or so the CIs have gone 4-5 times slower. From 2-3 minutes to 10-11 minutes for `run_tests_torch`.

This PR adds a report, generated by `pytest`, that lists the slowest tests so that we could quickly detect such regressions in our test suite's performance.

As suggested by @sshleifer, pytest can do the diagnostics using `--durations=` flag. I'm not sure what the best number to set it to - let's try with 50:

I propose adding this to:
* `run_tests_torch_and_tf` job - as it runs all non-slow tests in "real-time"
* all scheduled jobs that run slow tests

**edit**: Several fixes have been merged since this slowdown was found, so we are much better off and there is an effort to perform a major clean up here https://github.com/huggingface/transformers/pull/7895 so support this effort let's start with reporting the runtime of all tests, that is `--durations=0` (`pytest` currently doesn't have an option to report only tests slower than a certain run time) and once the clean up has been done, then we dial down to `--durations=50` to only monitor any new outliers.

@sshleifer, @sgugger, @LysandreJik 