### PR TITLE
[testing] slow tests should be marked as slow

### DIFF
--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -782,7 +782,7 @@ If the test is focused on one of the library's internal components (e.g., modeli
 * All tests that need to download a heavy set of weights (e.g., model or tokenizer integration tests, pipeline integration tests) should be set to slow. If you're adding a new model, you should create and upload to the hub a tiny version of it (with random weights) for integration tests. This is discussed in the following paragraphs.
 * All tests that need to do a training not specifically optimized to be fast should be set to slow.
 * We can introduce exceptions if some of these should-be-non-slow tests are excruciatingly slow, and set them to ``@slow``. Auto-modeling tests, which save and load large files to disk, are a good example of tests that are marked as ``@slow``.
- * If a test completes under 1 second on CI (including downloads if any) then it should be a normal test regardless.
+* If a test completes under 1 second on CI (including downloads if any) then it should be a normal test regardless.
 
 Collectively, all the non-slow tests need to cover entirely the different internals, while remaining fast.
 For example, a significant coverage can be achieved by testing with specially created tiny models with random weights. Such models have the very minimal number of layers (e.g., 2), vocab size (e.g., 1000), etc.

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -751,7 +751,7 @@ More details, example and ways are `here <https://docs.pytest.org/en/latest/skip
 Slow tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The library of tests is ever-growing, and some of the tests take minutes to run, therefore we can't afford waiting for an hour for the test suite to complete on CI. Therefore, with some exceptions, most very slow tests should be marked as in the example below:
+The library of tests is ever-growing, and some of the tests take minutes to run, therefore we can't afford waiting for an hour for the test suite to complete on CI. Therefore, with some exceptions for essential tests, slow tests should be marked as in the example below:
 
 .. code-block:: python
 
@@ -779,8 +779,8 @@ Here is a rough decision making mechanism for choosing which tests should be mar
 
 If the test is focused on one of the library's internal components (e.g., modeling files, tokenization files, pipelines), then we should run that test in the non-slow test suite. If it's focused on an other aspect of the library, such as the documentation or the examples, then we should run these tests in the slow test suite. And then, to refine this approach we should have exceptions:
 
-* All tests that need a specific set of weights (e.g., model or tokenizer integration tests, pipeline integration tests) should be set to slow.
-* All tests that need to do a training (e.g, trainer integration tests) should be set to slow.
+* All tests that need to download a heavy set of weights (e.g., model or tokenizer integration tests, pipeline integration tests) should be set to slow. If you're adding a new model, you should create and upload to the hub a tiny version of it (with random weights) for integration tests. 
+* All tests that need to do a training not specifically optimized to be fast should be set to slow.
 * We can introduce exceptions if some of these should-be-non-slow tests are excruciatingly slow, and set them to ``@slow``. Auto-modeling tests, which save and load large files to disk, are a good example of tests that are marked as ``@slow``.
 
 Collectively, all the non-slow tests need to cover entirely the different internals, while remaining fast.

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -753,7 +753,7 @@ Custom markers
 
 * Slow tests
 
-Tests that are too slow (e.g. once downloading huge model files) are marked with:
+The library of tests is ever-growing, and some of the tests take minutes to run, therefore we can't afford waiting for an hour for the test suite to complete on CI. Therefore any slow tests should be marked as in the example below:
 
 .. code-block:: python
 
@@ -761,13 +761,22 @@ Tests that are too slow (e.g. once downloading huge model files) are marked with
     @slow
     def test_integration_foo():
 
-To run such tests set ``RUN_SLOW=1`` env var, e.g.:
+As explained at the beginning of this document, slow tests run on a scheduled basis, rather than in PRs. So it's possible that some problem will be missed during PR submission, but it'll get caught during the next scheduled CI job.
+
+Here is the gold standard:
+
+1. if the test runs longer than 5 seconds on CI (including model download if any) - it should be marked as slow
+2. For common tests to be marked slow, the slowest iteration of that common test must be > 15s.
+
+It's easy to measure the run-time incorrectly if for example there is an overheard of downloading a huge model, but if you test it locally it'd be cached and thus not measured. Hence check the execution speed report in CI logs instead (the output of ``pytest --durations=0 tests``).
+
+Once a test is marked as ``@slow``, to run such tests set ``RUN_SLOW=1`` env var, e.g.:
 
 .. code-block:: bash
 
     RUN_SLOW=1 pytest tests
     
-Some decorators like ``@parametrized`` rewrite test names, therefore ``@slow`` and the rest of the skip decorators ``@require_*`` have to be listed last for them to work correctly. Here is an example of the correct usage:
+Some decorators like ``@parameterized`` rewrite test names, therefore ``@slow`` and the rest of the skip decorators ``@require_*`` have to be listed last for them to work correctly. Here is an example of the correct usage:
 
 .. code-block:: python
 

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -748,28 +748,16 @@ or skip the whole module:
 
 More details, example and ways are `here <https://docs.pytest.org/en/latest/skipping.html>`__.
 
-Custom markers
+Slow tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Slow tests
-
-The library of tests is ever-growing, and some of the tests take minutes to run, therefore we can't afford waiting for an hour for the test suite to complete on CI. Therefore any slow tests should be marked as in the example below:
+The library of tests is ever-growing, and some of the tests take minutes to run, therefore we can't afford waiting for an hour for the test suite to complete on CI. Therefore, with some exceptions, most very slow tests should be marked as in the example below:
 
 .. code-block:: python
 
     from transformers.testing_utils import slow
     @slow
     def test_integration_foo():
-
-As explained at the beginning of this document, slow tests run on a scheduled basis, rather than in PRs. So it's possible that some problem will be missed during PR submission, but it'll get caught during the next scheduled CI job.
-
-Here is the gold standard:
-
-1. if the test runs longer than 5 seconds on CI (including model download if any) - it should be marked as slow
-2. For common tests to be marked slow, the slowest iteration of that common test must be > 15s.
-3. If an exception is made and a slow test isn't marked as such a note should be placed explaining why
-   
-It's easy to measure the run-time incorrectly if for example there is an overheard of downloading a huge model, but if you test it locally it'd be cached and thus not measured. Hence check the execution speed report in CI logs instead (the output of ``pytest --durations=0 tests``).
 
 Once a test is marked as ``@slow``, to run such tests set ``RUN_SLOW=1`` env var, e.g.:
 
@@ -784,6 +772,31 @@ Some decorators like ``@parameterized`` rewrite test names, therefore ``@slow`` 
     @parameterized.expand(...)
     @slow
     def test_integration_foo():
+
+As explained at the beginning of this document, slow tests get to run on a scheduled basis, rather than in PRs CI checks. So it's possible that some problems will be missed during a PR submission and get merged. Such problems will get caught during the next scheduled CI job. But it also means that it's important to run the slow tests on your machine before submitting the PR.
+
+Here is a rough decision making mechanism for choosing which tests should be marked as slow:
+
+If the test is focused on one of the library's internal components (e.g., modeling files, tokenization files, pipelines), then we should run that test in the non-slow test suite. If it's focused on an other aspect of the library, such as the documentation or the examples, then we should run these tests in the slow test suite. And then, to refine this approach we should have exceptions:
+
+* All tests that need a specific set of weights (e.g., model or tokenizer integration tests, pipeline integration tests) should be set to slow.
+* All tests that need to do a training (e.g, trainer integration tests) should be set to slow.
+* We can introduce exceptions if some of these should-be-non-slow tests are excruciatingly slow, and set them to ``@slow``. Auto-modeling tests, which save and load large files to disk, are a good example of tests that are marked as ``@slow``.
+
+Collectively, all the non-slow tests need to cover entirely the different internals, while remaining fast.
+For example, a significant coverage can be achieved by testing with specially created tiny models with random weights. Such models have the very minimal number of layers (e.g., 2), vocab size (e.g., 1000), etc.
+Then the ``@slow`` tests can use large slow models to do qualitative testing. To see the use of these simply look for *tiny* models with:
+
+.. code-block:: bash
+
+    grep tiny tests examples
+
+If you need to create such tiny model, here is a [script](https://github.com/huggingface/transformers/blob/master/scripts/fsmt/fsmt-make-tiny-model.py) that created the tiny model [stas/tiny-wmt19-en-de](https://huggingface.co/stas/tiny-wmt19-en-de). You can easily adjust it to your specific model's architecture.
+
+It's easy to measure the run-time incorrectly if for example there is an overheard of downloading a huge model, but if you test it locally the downloaded files would be cached and thus the download time not measured. Hence check the execution speed report in CI logs instead (the output of ``pytest --durations=0 tests``).
+
+That report is also useful to find slow outliers that aren't marked as such, or which need to be re-written to be fast. If you notice that the test suite starts getting slow on CI, the top listing of this report will show the slowest tests.
+
 
 Testing the stdout/stderr output
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -779,7 +779,7 @@ Here is a rough decision making mechanism for choosing which tests should be mar
 
 If the test is focused on one of the library's internal components (e.g., modeling files, tokenization files, pipelines), then we should run that test in the non-slow test suite. If it's focused on an other aspect of the library, such as the documentation or the examples, then we should run these tests in the slow test suite. And then, to refine this approach we should have exceptions:
 
-* All tests that need to download a heavy set of weights (e.g., model or tokenizer integration tests, pipeline integration tests) should be set to slow. If you're adding a new model, you should create and upload to the hub a tiny version of it (with random weights) for integration tests. 
+* All tests that need to download a heavy set of weights (e.g., model or tokenizer integration tests, pipeline integration tests) should be set to slow. If you're adding a new model, you should create and upload to the hub a tiny version of it (with random weights) for integration tests. This is discussed in the following paragraphs.
 * All tests that need to do a training not specifically optimized to be fast should be set to slow.
 * We can introduce exceptions if some of these should-be-non-slow tests are excruciatingly slow, and set them to ``@slow``. Auto-modeling tests, which save and load large files to disk, are a good example of tests that are marked as ``@slow``.
 

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -791,7 +791,7 @@ Then the ``@slow`` tests can use large slow models to do qualitative testing. To
 
     grep tiny tests examples
 
-If you need to create such tiny model, here is a [script](https://github.com/huggingface/transformers/blob/master/scripts/fsmt/fsmt-make-tiny-model.py) that created the tiny model [stas/tiny-wmt19-en-de](https://huggingface.co/stas/tiny-wmt19-en-de). You can easily adjust it to your specific model's architecture.
+Here is a an example of a `script <https://github.com/huggingface/transformers/blob/master/scripts/fsmt/fsmt-make-tiny-model.py>`__ that created the tiny model `stas/tiny-wmt19-en-de <https://huggingface.co/stas/tiny-wmt19-en-de>`__. You can easily adjust it to your specific model's architecture.
 
 It's easy to measure the run-time incorrectly if for example there is an overheard of downloading a huge model, but if you test it locally the downloaded files would be cached and thus the download time not measured. Hence check the execution speed report in CI logs instead (the output of ``pytest --durations=0 tests``).
 

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -782,6 +782,7 @@ If the test is focused on one of the library's internal components (e.g., modeli
 * All tests that need to download a heavy set of weights (e.g., model or tokenizer integration tests, pipeline integration tests) should be set to slow. If you're adding a new model, you should create and upload to the hub a tiny version of it (with random weights) for integration tests. This is discussed in the following paragraphs.
 * All tests that need to do a training not specifically optimized to be fast should be set to slow.
 * We can introduce exceptions if some of these should-be-non-slow tests are excruciatingly slow, and set them to ``@slow``. Auto-modeling tests, which save and load large files to disk, are a good example of tests that are marked as ``@slow``.
+ * If a test completes under 1 second on CI (including downloads if any) then it should be a normal test regardless.
 
 Collectively, all the non-slow tests need to cover entirely the different internals, while remaining fast.
 For example, a significant coverage can be achieved by testing with specially created tiny models with random weights. Such models have the very minimal number of layers (e.g., 2), vocab size (e.g., 1000), etc.

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -767,7 +767,8 @@ Here is the gold standard:
 
 1. if the test runs longer than 5 seconds on CI (including model download if any) - it should be marked as slow
 2. For common tests to be marked slow, the slowest iteration of that common test must be > 15s.
-
+3. If an exception is made and a slow test isn't marked as such a note should be placed explaining why
+   
 It's easy to measure the run-time incorrectly if for example there is an overheard of downloading a huge model, but if you test it locally it'd be cached and thus not measured. Hence check the execution speed report in CI logs instead (the output of ``pytest --durations=0 tests``).
 
 Once a test is marked as ``@slow``, to run such tests set ``RUN_SLOW=1`` env var, e.g.:

--- a/tests/test_modeling_marian.py
+++ b/tests/test_modeling_marian.py
@@ -263,6 +263,7 @@ class TestMarian_en_ROMANCE(MarianIntegrationTest):
         with self.assertRaises(ValueError):
             self.tokenizer.prepare_seq2seq_batch([""])
 
+    @slow
     def test_pipeline(self):
         device = 0 if torch_device == "cuda" else -1
         pipeline = TranslationPipeline(self.model, self.tokenizer, framework="pt", device=device)

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -379,6 +379,7 @@ class MonoColumnInputTestCase(unittest.TestCase):
 
     @require_torch
     @require_tokenizers
+    @slow
     def test_torch_translation(self):
         invalid_inputs = [4, "<mask>"]
         mandatory_keys = ["translation_text"]

--- a/tests/test_tokenization_auto.py
+++ b/tests/test_tokenization_auto.py
@@ -34,6 +34,7 @@ from transformers.testing_utils import (
     DUMMY_UNKWOWN_IDENTIFIER,
     SMALL_MODEL_IDENTIFIER,
     require_tokenizers,
+    slow,
 )
 from transformers.tokenization_auto import TOKENIZER_MAPPING
 

--- a/tests/test_tokenization_auto.py
+++ b/tests/test_tokenization_auto.py
@@ -39,7 +39,7 @@ from transformers.tokenization_auto import TOKENIZER_MAPPING
 
 
 class AutoTokenizerTest(unittest.TestCase):
-    # @slow
+    @slow
     def test_tokenizer_from_pretrained(self):
         for model_name in (x for x in BERT_PRETRAINED_CONFIG_ARCHIVE_MAP.keys() if "japanese" not in x):
             tokenizer = AutoTokenizer.from_pretrained(model_name)


### PR DESCRIPTION
As discussed in https://github.com/huggingface/transformers/issues/7885 this is an effort to make the test suite manageable execution time-wise, as the number of tests is growing and it takes much longer to complete the tests on CI.

* [x] document and set a standard for when a test needs to be marked as `@slow`
* [x] Marks slow the following tests:
- tests/test_tokenization_auto.py::AutoTokenizerTest::test_tokenizer_from_pretrained (23s)
- tests/test_pipelines.py::MonoColumnInputTestCase::test_torch_translation (17s)
- tests/test_modeling_marian.py::TestMarian_en_ROMANCE::test_pipeline (35s)

Fixes: https://github.com/huggingface/transformers/issues/7885

 @LysandreJik, @sgugger, @sshleifer 
