### PR TITLE
Modelling Encoder-Decoder | Error :- `decoder_config` used before intialisation

### DIFF
--- a/src/transformers/modeling_encoder_decoder.py
+++ b/src/transformers/modeling_encoder_decoder.py
@@ -327,7 +327,7 @@ class EncoderDecoderModel(PreTrainedModel):
 
                 kwargs_decoder["config"] = decoder_config
 
-            if kwargs_decoder["config"].is_decoder is False or decoder_config.add_cross_attention is False:
+            if kwargs_decoder["config"].is_decoder is False or kwargs_decoder["config"].add_cross_attention is False:
                 logger.warning(
                     f"Decoder model {decoder_pretrained_model_name_or_path} is not initialized as a decoder. In order to initialize {decoder_pretrained_model_name_or_path} as a decoder, make sure that the attributes `is_decoder` and `add_cross_attention` of `decoder_config` passed to `.from_encoder_decoder_pretrained(...)` are set to `True` or do not pass a `decoder_config` to `.from_encoder_decoder_pretrained(...)`"
                 )


### PR DESCRIPTION
Getting error when sending `decoder_config` as a parameter while initializing an encoder-decoder model from pretrained. 

# What does this PR do?
fixes "UnboundLocalError: local variable 'decoder_config' referenced before assignment"

## Who can review?
@patrickvonplaten @sgugger