### PR TITLE
[flax] fix repo_check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,7 +264,7 @@ jobs:
                       - v0.3-{{ checksum "setup.py" }}
             - run: pip install --upgrade pip
             - run: pip install isort
-            - run: pip install .[tf,torch,quality]
+            - run: pip install .[tf,torch,flax,quality]
             - save_cache:
                   key: v0.3-code_quality-{{ checksum "setup.py" }}
                   paths:

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -85,6 +85,7 @@ def get_model_modules():
         "modeling_encoder_decoder",
         "modeling_marian",
         "modeling_mmbt",
+        "modeling_flax_utils",
         "modeling_outputs",
         "modeling_retribert",
         "modeling_utils",

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -41,12 +41,14 @@ IGNORE_NON_TESTED = [
 # trigger the common tests.
 TEST_FILES_WITH_NO_COMMON_TESTS = [
     "test_modeling_camembert.py",
+    "test_modeling_flax_bert.py",
+    "test_modeling_flax_roberta.py",
+    "test_modeling_mbart.py",
+    "test_modeling_pegasus.py",
     "test_modeling_tf_camembert.py",
     "test_modeling_tf_xlm_roberta.py",
     "test_modeling_xlm_prophetnet.py",
     "test_modeling_xlm_roberta.py",
-    "test_modeling_pegasus.py",
-    "test_modeling_mbart.py",
 ]
 
 # Update this list for models that are not documented with a comment explaining the reason it should not be.
@@ -85,10 +87,10 @@ def get_model_modules():
         "modeling_encoder_decoder",
         "modeling_marian",
         "modeling_mmbt",
-        "modeling_flax_utils",
         "modeling_outputs",
         "modeling_retribert",
         "modeling_utils",
+        "modeling_flax_utils",
         "modeling_transfo_xl_utilities",
         "modeling_tf_auto",
         "modeling_tf_outputs",


### PR DESCRIPTION
Unless, this is actually a problem, this PR adds `modeling_flax_utils` to ignore list. otherwise currently it expects to have  `tests/test_modeling_flax_utils.py` for this module.

It also adds the 2 new tests that don't run common tests to `TEST_FILES_WITH_NO_COMMON_TESTS`

For context please see: https://github.com/huggingface/transformers/pull/3722#issuecomment-712360415

now check_repo is happy.

@sgugger 