### PR TITLE
# Add whole word mask support for lm fine-tune

### DIFF
--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -45,7 +45,7 @@ slightly slower (over-fitting takes more epochs).
 
 We use the `--mlm` flag so that the script may change its loss function.
 
-If use whole-word masking, use both `--mlm` and `--wwm` flag(for English Model).
+If using whole-word masking, use both the`--mlm` and `--wwm` flags.
 
 ```bash
 export TRAIN_FILE=/path/to/dataset/wiki.train.raw

--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -45,6 +45,8 @@ slightly slower (over-fitting takes more epochs).
 
 We use the `--mlm` flag so that the script may change its loss function.
 
+If use whole-word masking, use both `--mlm` and `--wwm` flag(for English Model).
+
 ```bash
 export TRAIN_FILE=/path/to/dataset/wiki.train.raw
 export TEST_FILE=/path/to/dataset/wiki.test.raw
@@ -57,7 +59,43 @@ python run_language_modeling.py \
     --train_data_file=$TRAIN_FILE \
     --do_eval \
     --eval_data_file=$TEST_FILE \
-    --mlm
+    --mlm \
+    --wwm
+```
+
+For Chinese Model, we need to generate ref files, case it's char level.
+
+```bash
+export TRAIN_FILE=/path/to/dataset/wiki.train.raw
+export LTP_RESOURCE=/path/to/ltp/tokenizer
+export BERT_RESOURCE=/path/to/bert/tokenizer
+export SAVE_PATH=/path/to/data/ref.txt
+
+python chinese_ref.py \
+    --file_name=$TRAIN_FILE \
+    --ltp=$LTP_RESOURCE
+    --bert=$BERT_RESOURCE \
+    --save_path=$SAVE_PATH 
+```
+Then: 
+
+
+```bash
+export TRAIN_FILE=/path/to/dataset/wiki.train.raw
+export TEST_FILE=/path/to/dataset/wiki.test.raw
+export REF_FILE=/path/to/ref.txt
+
+python run_language_modeling.py \
+    --output_dir=output \
+    --model_type=roberta \
+    --model_name_or_path=roberta-base \
+    --do_train \
+    --train_data_file=$TRAIN_FILE \
+    --chinese_ref_file=$REF_FILE \
+    --do_eval \
+    --eval_data_file=$TEST_FILE \
+    --mlm \
+    --wwm
 ```
 
 ### XLNet and permutation language modeling

--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -73,7 +73,7 @@ So we need a ref file to tell model which pos of BERT original token should be a
 
 **Q :** Why LTP ?
 
-**A :** Cause the best known Chinese WWM BERT is [Chinese-BERT-wwm](https://github.com/ymcui/Chinese-BERT-wwm). It works well on so many Chines Task like CLUE (Chinese GLUE).
+**A :** Cause the best known Chinese WWM BERT is [Chinese-BERT-wwm](https://github.com/ymcui/Chinese-BERT-wwm) by HIT. It works well on so many Chines Task like CLUE (Chinese GLUE).
 They use LTP, so if we want to fine-tune their model, we need LTP.
 
 ```bash

--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -65,6 +65,17 @@ python run_language_modeling.py \
 
 For Chinese models, it's same with English model with only --mlm`. If using whole-word masking, we need to generate a reference files, case it's char level.
 
+**Q :** Why ref file ?
+
+**A :** Suppose we have a Chinese sentence like : `我喜欢你。` The original Chinese-BERT will tokenize it as `['我','喜','欢','你']` in char level.
+Actually, `喜欢` is a whole word. For whole word mask proxy, We need res like `['我','喜','##欢','你']`.
+So we need a ref file to tell model which pos of BERT original token should be added `##`.
+
+**Q :** Why LTP ?
+
+**A :** Cause the best known Chinese WWM BERT is [https://github.com/ymcui/Chinese-BERT-wwm](https://github.com/ymcui/Chinese-BERT-wwm). It works well on so many Chines Task like CLUE (Chinese GLUE).
+They use LTP, so if we want to fine-tune their model, we need LTP.
+
 ```bash
 export TRAIN_FILE=/path/to/dataset/wiki.train.raw
 export LTP_RESOURCE=/path/to/ltp/tokenizer

--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -88,7 +88,7 @@ python chinese_ref.py \
     --bert=$BERT_RESOURCE \
     --save_path=$SAVE_PATH 
 ```
-Then: 
+Now Chinese Ref is only supported by `LineByLineWithRefDataset` Class, so we need add `line_by_line` flag: 
 
 
 ```bash
@@ -106,6 +106,7 @@ python run_language_modeling.py \
     --do_eval \
     --eval_data_file=$TEST_FILE \
     --mlm \
+    --line_by_line \
     --wwm
 ```
 

--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -63,7 +63,7 @@ python run_language_modeling.py \
     --wwm
 ```
 
-For Chinese models, we need to generate a reference files, case it's char level.
+For Chinese models, it's same with English model with only --mlm`. If using whole-word masking, we need to generate a reference files, case it's char level.
 
 ```bash
 export TRAIN_FILE=/path/to/dataset/wiki.train.raw

--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -67,13 +67,13 @@ For Chinese models, it's same with English model with only --mlm`. If using whol
 
 **Q :** Why ref file ?
 
-**A :** Suppose we have a Chinese sentence like : `我喜欢你。` The original Chinese-BERT will tokenize it as `['我','喜','欢','你']` in char level.
+**A :** Suppose we have a Chinese sentence like : `我喜欢你` The original Chinese-BERT will tokenize it as `['我','喜','欢','你']` in char level.
 Actually, `喜欢` is a whole word. For whole word mask proxy, We need res like `['我','喜','##欢','你']`.
 So we need a ref file to tell model which pos of BERT original token should be added `##`.
 
 **Q :** Why LTP ?
 
-**A :** Cause the best known Chinese WWM BERT is [https://github.com/ymcui/Chinese-BERT-wwm](https://github.com/ymcui/Chinese-BERT-wwm). It works well on so many Chines Task like CLUE (Chinese GLUE).
+**A :** Cause the best known Chinese WWM BERT is [Chinese-BERT-wwm](https://github.com/ymcui/Chinese-BERT-wwm). It works well on so many Chines Task like CLUE (Chinese GLUE).
 They use LTP, so if we want to fine-tune their model, we need LTP.
 
 ```bash

--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -63,7 +63,7 @@ python run_language_modeling.py \
     --wwm
 ```
 
-For Chinese Model, we need to generate ref files, case it's char level.
+For Chinese models, we need to generate a reference files, case it's char level.
 
 ```bash
 export TRAIN_FILE=/path/to/dataset/wiki.train.raw

--- a/examples/language-modeling/chinese_ref.py
+++ b/examples/language-modeling/chinese_ref.py
@@ -1,10 +1,9 @@
-import json
-import random
 import argparse
+import json
+from typing import List
+
 from ltp import LTP
 from transformers.tokenization_bert import BertTokenizer
-
-from typing import List
 
 
 def _is_chinese_char(cp):

--- a/examples/language-modeling/chinese_ref.py
+++ b/examples/language-modeling/chinese_ref.py
@@ -1,0 +1,143 @@
+import json
+import random
+import argparse
+from ltp import LTP
+from transformers.tokenization_bert import BertTokenizer
+
+from typing import List
+
+
+def _is_chinese_char(cp):
+    """Checks whether CP is the codepoint of a CJK character."""
+    # This defines a "chinese character" as anything in the CJK Unicode block:
+    #   https://en.wikipedia.org/wiki/CJK_Unified_Ideographs_(Unicode_block)
+    #
+    # Note that the CJK Unicode block is NOT all Japanese and Korean characters,
+    # despite its name. The modern Korean Hangul alphabet is a different block,
+    # as is Japanese Hiragana and Katakana. Those alphabets are used to write
+    # space-separated words, so they are not treated specially and handled
+    # like the all of the other languages.
+    if (
+            (cp >= 0x4E00 and cp <= 0x9FFF)
+            or (cp >= 0x3400 and cp <= 0x4DBF)  #
+            or (cp >= 0x20000 and cp <= 0x2A6DF)  #
+            or (cp >= 0x2A700 and cp <= 0x2B73F)  #
+            or (cp >= 0x2B740 and cp <= 0x2B81F)  #
+            or (cp >= 0x2B820 and cp <= 0x2CEAF)  #
+            or (cp >= 0xF900 and cp <= 0xFAFF)
+            or (cp >= 0x2F800 and cp <= 0x2FA1F)  #
+    ):  #
+        return True
+
+    return False
+
+
+def is_chinese(word: str):
+    # word like '180' or '身高' or '神'
+    for char in word:
+        char = ord(char)
+        if not _is_chinese_char(char):
+            return 0
+    return 1
+
+
+def get_chinese_word(tokens: List[str]):
+    word_set = set()
+
+    for token in tokens:
+        chinese_word = len(token) > 1 and is_chinese(token)
+        if chinese_word:
+            word_set.add(token)
+    word_list = list(word_set)
+    return word_list
+
+
+def add_sub_symbol(bert_tokens: List[str], chinese_word_set: set()):
+    if not chinese_word_set:
+        return bert_tokens
+    max_word_len = max([len(w) for w in chinese_word_set])
+
+    bert_word = bert_tokens
+    start, end = 0, len(bert_word)
+    while start < end:
+        single_word = True
+        if is_chinese(bert_word[start]):
+            l = min(end - start, max_word_len)
+            for i in range(l, 1, -1):
+                whole_word = ''.join(bert_word[start:start + i])
+                if whole_word in chinese_word_set:
+                    for j in range(start + 1, start + i):
+                        bert_word[j] = '##' + bert_word[j]
+                    start = start + i
+                    single_word = False
+                    break
+        if single_word:
+            start += 1
+    return bert_word
+
+
+def prepare_ref(lines: List[str], ltp_tokenizer: LTP, bert_tokenizer: BertTokenizer):
+    ltp_res = []
+
+    for i in range(0, len(lines), 100):
+        res = ltp_tokenizer.seg(lines[i:i + 100])[0]
+        res = [get_chinese_word(r) for r in res]
+        ltp_res.extend(res)
+    assert len(ltp_res) == len(lines)
+
+    bert_res = []
+    for i in range(0, len(lines), 100):
+        res = bert_tokenizer(lines[i:i + 100], add_special_tokens=True, truncation=True, max_length=512)
+        bert_res.extend(res['input_ids'])
+    assert len(bert_res) == len(lines)
+
+    ref_ids = []
+    for input_ids, chinese_word in zip(bert_res, ltp_res):
+
+        input_tokens = []
+        for id in input_ids:
+            token = bert_tokenizer._convert_id_to_token(id)
+            input_tokens.append(token)
+        input_tokens = add_sub_symbol(input_tokens, chinese_word)
+        ref_id = []
+        # We only save pos of chinese subwords start with ##, which mean is part of a whole word.
+        for i, token in enumerate(input_tokens):
+            if token[:2] == '##':
+                clean_token = token[2:]
+                # save chinese tokens' pos
+                if len(clean_token) == 1 and _is_chinese_char(ord(clean_token)):
+                    ref_id.append(i)
+        ref_ids.append(ref_id)
+
+    assert len(ref_ids) == len(bert_res)
+
+    return ref_ids
+
+
+def main(args):
+    # For Chinese (Ro)Bert, the best result is from : RoBERTa-wwm-ext (https://github.com/ymcui/Chinese-BERT-wwm)
+    # If we want to fine-tune these model, we have to use same tokenizer : LTP (https://github.com/HIT-SCIR/ltp)
+    with open(args.file_name, 'r', encoding='utf-8') as f:
+        data = f.readlines()
+
+    ltp_tokenizer = LTP(args.ltp)  # faster in GPU device
+    bert_tokenizer = BertTokenizer.from_pretrained(args.bert)
+
+    ref_ids = prepare_ref(data, ltp_tokenizer, bert_tokenizer)
+
+    with open(args.save_path, 'w', encoding='utf-8') as f:
+        data = [json.dumps(ref) + '\n' for ref in ref_ids]
+        f.writelines(data)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='prepare_chinese_ref')
+    parser.add_argument('--file_name', type=str, default='./resources/chinese-demo.txt',
+                        help='file need process, same as training data in lm')
+    parser.add_argument('--ltp', type=str, default='./resources/ltp',
+                        help='resources for LTP tokenizer, usually a path')
+    parser.add_argument('--bert', type=str, default='./resources/robert', help='resources for Bert tokenizer')
+    parser.add_argument('--save_path', type=str, default='./resources/ref.txt', help='path to save res')
+
+    args = parser.parse_args()
+    main(args)

--- a/examples/language-modeling/chinese_ref.py
+++ b/examples/language-modeling/chinese_ref.py
@@ -18,14 +18,14 @@ def _is_chinese_char(cp):
     # space-separated words, so they are not treated specially and handled
     # like the all of the other languages.
     if (
-            (cp >= 0x4E00 and cp <= 0x9FFF)
-            or (cp >= 0x3400 and cp <= 0x4DBF)  #
-            or (cp >= 0x20000 and cp <= 0x2A6DF)  #
-            or (cp >= 0x2A700 and cp <= 0x2B73F)  #
-            or (cp >= 0x2B740 and cp <= 0x2B81F)  #
-            or (cp >= 0x2B820 and cp <= 0x2CEAF)  #
-            or (cp >= 0xF900 and cp <= 0xFAFF)
-            or (cp >= 0x2F800 and cp <= 0x2FA1F)  #
+        (cp >= 0x4E00 and cp <= 0x9FFF)
+        or (cp >= 0x3400 and cp <= 0x4DBF)  #
+        or (cp >= 0x20000 and cp <= 0x2A6DF)  #
+        or (cp >= 0x2A700 and cp <= 0x2B73F)  #
+        or (cp >= 0x2B740 and cp <= 0x2B81F)  #
+        or (cp >= 0x2B820 and cp <= 0x2CEAF)  #
+        or (cp >= 0xF900 and cp <= 0xFAFF)
+        or (cp >= 0x2F800 and cp <= 0x2FA1F)  #
     ):  #
         return True
 
@@ -64,10 +64,10 @@ def add_sub_symbol(bert_tokens: List[str], chinese_word_set: set()):
         if is_chinese(bert_word[start]):
             l = min(end - start, max_word_len)
             for i in range(l, 1, -1):
-                whole_word = ''.join(bert_word[start:start + i])
+                whole_word = "".join(bert_word[start : start + i])
                 if whole_word in chinese_word_set:
                     for j in range(start + 1, start + i):
-                        bert_word[j] = '##' + bert_word[j]
+                        bert_word[j] = "##" + bert_word[j]
                     start = start + i
                     single_word = False
                     break
@@ -80,15 +80,15 @@ def prepare_ref(lines: List[str], ltp_tokenizer: LTP, bert_tokenizer: BertTokeni
     ltp_res = []
 
     for i in range(0, len(lines), 100):
-        res = ltp_tokenizer.seg(lines[i:i + 100])[0]
+        res = ltp_tokenizer.seg(lines[i : i + 100])[0]
         res = [get_chinese_word(r) for r in res]
         ltp_res.extend(res)
     assert len(ltp_res) == len(lines)
 
     bert_res = []
     for i in range(0, len(lines), 100):
-        res = bert_tokenizer(lines[i:i + 100], add_special_tokens=True, truncation=True, max_length=512)
-        bert_res.extend(res['input_ids'])
+        res = bert_tokenizer(lines[i : i + 100], add_special_tokens=True, truncation=True, max_length=512)
+        bert_res.extend(res["input_ids"])
     assert len(bert_res) == len(lines)
 
     ref_ids = []
@@ -102,7 +102,7 @@ def prepare_ref(lines: List[str], ltp_tokenizer: LTP, bert_tokenizer: BertTokeni
         ref_id = []
         # We only save pos of chinese subwords start with ##, which mean is part of a whole word.
         for i, token in enumerate(input_tokens):
-            if token[:2] == '##':
+            if token[:2] == "##":
                 clean_token = token[2:]
                 # save chinese tokens' pos
                 if len(clean_token) == 1 and _is_chinese_char(ord(clean_token)):
@@ -117,7 +117,7 @@ def prepare_ref(lines: List[str], ltp_tokenizer: LTP, bert_tokenizer: BertTokeni
 def main(args):
     # For Chinese (Ro)Bert, the best result is from : RoBERTa-wwm-ext (https://github.com/ymcui/Chinese-BERT-wwm)
     # If we want to fine-tune these model, we have to use same tokenizer : LTP (https://github.com/HIT-SCIR/ltp)
-    with open(args.file_name, 'r', encoding='utf-8') as f:
+    with open(args.file_name, "r", encoding="utf-8") as f:
         data = f.readlines()
 
     ltp_tokenizer = LTP(args.ltp)  # faster in GPU device
@@ -125,19 +125,24 @@ def main(args):
 
     ref_ids = prepare_ref(data, ltp_tokenizer, bert_tokenizer)
 
-    with open(args.save_path, 'w', encoding='utf-8') as f:
-        data = [json.dumps(ref) + '\n' for ref in ref_ids]
+    with open(args.save_path, "w", encoding="utf-8") as f:
+        data = [json.dumps(ref) + "\n" for ref in ref_ids]
         f.writelines(data)
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='prepare_chinese_ref')
-    parser.add_argument('--file_name', type=str, default='./resources/chinese-demo.txt',
-                        help='file need process, same as training data in lm')
-    parser.add_argument('--ltp', type=str, default='./resources/ltp',
-                        help='resources for LTP tokenizer, usually a path')
-    parser.add_argument('--bert', type=str, default='./resources/robert', help='resources for Bert tokenizer')
-    parser.add_argument('--save_path', type=str, default='./resources/ref.txt', help='path to save res')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="prepare_chinese_ref")
+    parser.add_argument(
+        "--file_name",
+        type=str,
+        default="./resources/chinese-demo.txt",
+        help="file need process, same as training data in lm",
+    )
+    parser.add_argument(
+        "--ltp", type=str, default="./resources/ltp", help="resources for LTP tokenizer, usually a path"
+    )
+    parser.add_argument("--bert", type=str, default="./resources/robert", help="resources for Bert tokenizer")
+    parser.add_argument("--save_path", type=str, default="./resources/ref.txt", help="path to save res")
 
     args = parser.parse_args()
     main(args)

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -151,7 +151,7 @@ def get_dataset(
         if args.line_by_line:
             if args.chinese_ref_file:
                 if not args.wwm or args.mlm:
-                    raise ValueError("Need set wwm and mlm to true for Chinese Whole Word Mask")
+                    raise ValueError("You need to set world whole masking and mlm to True for Chinese Whole Word Mask")
                 return LineByLineWithRefDataset(
                     tokenizer=tokenizer,
                     file_path=file_path,

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -114,9 +114,7 @@ class DataTrainingArguments:
     mlm: bool = field(
         default=False, metadata={"help": "Train with masked-language modeling loss instead of language modeling."}
     )
-    wwm: bool = field(
-        default=False, metadata={"help": "Use Whole Word Mask."}
-    )
+    wwm: bool = field(default=False, metadata={"help": "Use Whole Word Mask."})
     mlm_probability: float = field(
         default=0.15, metadata={"help": "Ratio of tokens to mask for masked language modeling loss"}
     )
@@ -153,9 +151,7 @@ def get_dataset(
         if args.line_by_line:
             if args.chinese_ref_file:
                 if not args.wwm or args.mlm:
-                    raise ValueError(
-                        "Need set wwm and mlm to true for Chinese Whole Word Mask"
-                    )
+                    raise ValueError("Need set wwm and mlm to true for Chinese Whole Word Mask")
                 return LineByLineWithRefDataset(
                     tokenizer=tokenizer,
                     file_path=file_path,

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -23,12 +23,12 @@ using a masked language modeling (MLM) loss. XLNet is fine-tuned using a permuta
 import logging
 import math
 import os
-from dataclasses import dataclass, field
 from glob import glob
 from typing import Optional
 
 from torch.utils.data import ConcatDataset
 
+from dataclasses import dataclass, field
 from transformers import (
     CONFIG_MAPPING,
     MODEL_WITH_LM_HEAD_MAPPING,
@@ -36,8 +36,8 @@ from transformers import (
     AutoModelWithLMHead,
     AutoTokenizer,
     DataCollatorForLanguageModeling,
-    DataCollatorForWholeWordMask,
     DataCollatorForPermutationLanguageModeling,
+    DataCollatorForWholeWordMask,
     HfArgumentParser,
     LineByLineTextDataset,
     LineByLineWithRefDataset,

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -114,7 +114,7 @@ class DataTrainingArguments:
     mlm: bool = field(
         default=False, metadata={"help": "Train with masked-language modeling loss instead of language modeling."}
     )
-    wwm: bool = field(default=False, metadata={"help": "Use Whole Word Mask."})
+    whole_word_mask: bool = field(default=False, metadata={"help": "Whether ot not to use whole word mask."})
     mlm_probability: float = field(
         default=0.15, metadata={"help": "Ratio of tokens to mask for masked language modeling loss"}
     )

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -104,7 +104,7 @@ class DataTrainingArguments:
         metadata={"help": "An optional input evaluation data file to evaluate the perplexity on (a text file)."},
     )
     chinese_ref_file: Optional[str] = field(
-        default=None, metadata={"help": "An optional input ref data file for whole word mask(wwm) in Chinees."},
+        default=None, metadata={"help": "An optional input ref data file for whole word mask in Chinees."},
     )
     line_by_line: bool = field(
         default=False,

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -103,7 +103,7 @@ class DataTrainingArguments:
         metadata={"help": "An optional input evaluation data file to evaluate the perplexity on (a text file)."},
     )
     chinese_ref_file: Optional[str] = field(
-        default=NoneŒ, metadata={"help": "An optional input ref data file for whole word mask(wwm) in Chinees."},
+        default=None, metadata={"help": "An optional input ref data file for whole word mask(wwm) in Chinees."},
     )
     line_by_line: bool = field(
         default=False,

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -149,7 +149,7 @@ def get_dataset(
 ):
     def _dataset(file_path):
         if args.line_by_line:
-            if args.chinese_ref_file:
+            if args.chinese_ref_file is not None:
                 if not args.wwm or args.mlm:
                     raise ValueError("You need to set world whole masking and mlm to True for Chinese Whole Word Mask")
                 return LineByLineWithRefDataset(

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -103,7 +103,7 @@ class DataTrainingArguments:
         metadata={"help": "An optional input evaluation data file to evaluate the perplexity on (a text file)."},
     )
     chinese_ref_file: Optional[str] = field(
-        default=False,
+        default=NoneŒ,
         metadata={"help": "An optional input ref data file for whole word mask(wwm) in Chinees."},
     )
     line_by_line: bool = field(

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -150,7 +150,7 @@ def get_dataset(
     def _dataset(file_path):
         if args.line_by_line:
             if args.chinese_ref_file is not None:
-                if not args.wwm or args.mlm:
+                if not args.whole_word_mask or not args.mlm:
                     raise ValueError("You need to set world whole masking and mlm to True for Chinese Whole Word Mask")
                 return LineByLineWithRefDataset(
                     tokenizer=tokenizer,
@@ -283,7 +283,7 @@ def main():
             tokenizer=tokenizer, plm_probability=data_args.plm_probability, max_span_length=data_args.max_span_length,
         )
     else:
-        if data_args.mlm and data_args.wwm:
+        if data_args.mlm and data_args.whole_word_mask:
             data_collator = DataCollatorForWholeWordMask(
                 tokenizer=tokenizer, mlm_probability=data_args.mlm_probability
             )

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -23,12 +23,12 @@ using a masked language modeling (MLM) loss. XLNet is fine-tuned using a permuta
 import logging
 import math
 import os
+from dataclasses import dataclass, field
 from glob import glob
 from typing import Optional
 
 from torch.utils.data import ConcatDataset
 
-from dataclasses import dataclass, field
 from transformers import (
     CONFIG_MAPPING,
     MODEL_WITH_LM_HEAD_MAPPING,

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -103,8 +103,7 @@ class DataTrainingArguments:
         metadata={"help": "An optional input evaluation data file to evaluate the perplexity on (a text file)."},
     )
     chinese_ref_file: Optional[str] = field(
-        default=NoneŒ,
-        metadata={"help": "An optional input ref data file for whole word mask(wwm) in Chinees."},
+        default=NoneŒ, metadata={"help": "An optional input ref data file for whole word mask(wwm) in Chinees."},
     )
     line_by_line: bool = field(
         default=False,
@@ -114,9 +113,7 @@ class DataTrainingArguments:
     mlm: bool = field(
         default=False, metadata={"help": "Train with masked-language modeling loss instead of language modeling."}
     )
-    wwm: bool = field(
-        default=False, metadata={"help": "Use Whole Word Mask."}
-    )
+    wwm: bool = field(default=False, metadata={"help": "Use Whole Word Mask."})
     mlm_probability: float = field(
         default=0.15, metadata={"help": "Ratio of tokens to mask for masked language modeling loss"}
     )
@@ -152,8 +149,12 @@ def get_dataset(
     def _dataset(file_path):
         if args.line_by_line:
             if args.chinese_ref_file:
-                return LineByLineWithRefDataset(tokenizer=tokenizer, file_path=file_path, block_size=args.block_size,
-                                             ref_path=args.chinese_ref_file)
+                return LineByLineWithRefDataset(
+                    tokenizer=tokenizer,
+                    file_path=file_path,
+                    block_size=args.block_size,
+                    ref_path=args.chinese_ref_file,
+                )
 
             return LineByLineTextDataset(tokenizer=tokenizer, file_path=file_path, block_size=args.block_size)
         else:
@@ -277,9 +278,7 @@ def main():
     )
     if config.model_type == "xlnet":
         data_collator = DataCollatorForPermutationLanguageModeling(
-            tokenizer=tokenizer,
-            plm_probability=data_args.plm_probability,
-            max_span_length=data_args.max_span_length,
+            tokenizer=tokenizer, plm_probability=data_args.plm_probability, max_span_length=data_args.max_span_length,
         )
     else:
         data_collator = DataCollatorForLanguageModeling(

--- a/examples/language-modeling/run_language_modeling.py
+++ b/examples/language-modeling/run_language_modeling.py
@@ -104,7 +104,8 @@ class DataTrainingArguments:
         metadata={"help": "An optional input evaluation data file to evaluate the perplexity on (a text file)."},
     )
     chinese_ref_file: Optional[str] = field(
-        default=None, metadata={"help": "An optional input ref data file for whole word mask in Chinees."},
+        default=None,
+        metadata={"help": "An optional input ref data file for whole word mask in Chinees."},
     )
     line_by_line: bool = field(
         default=False,
@@ -280,7 +281,9 @@ def main():
     )
     if config.model_type == "xlnet":
         data_collator = DataCollatorForPermutationLanguageModeling(
-            tokenizer=tokenizer, plm_probability=data_args.plm_probability, max_span_length=data_args.max_span_length,
+            tokenizer=tokenizer,
+            plm_probability=data_args.plm_probability,
+            max_span_length=data_args.max_span_length,
         )
     else:
         if data_args.mlm and data_args.whole_word_mask:

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -291,6 +291,7 @@ if is_torch_available():
         GlueDataset,
         GlueDataTrainingArguments,
         LineByLineTextDataset,
+        LineByLineWithRefDataset,
         LineByLineWithSOPTextDataset,
         SquadDataset,
         SquadDataTrainingArguments,

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -281,6 +281,7 @@ if is_torch_available():
     from .data.data_collator import (
         DataCollator,
         DataCollatorForLanguageModeling,
+        DataCollatorForWholeWordMask,
         DataCollatorForNextSentencePrediction,
         DataCollatorForPermutationLanguageModeling,
         DataCollatorForSOP,

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -281,10 +281,10 @@ if is_torch_available():
     from .data.data_collator import (
         DataCollator,
         DataCollatorForLanguageModeling,
-        DataCollatorForWholeWordMask,
         DataCollatorForNextSentencePrediction,
         DataCollatorForPermutationLanguageModeling,
         DataCollatorForSOP,
+        DataCollatorForWholeWordMask,
         DataCollatorWithPadding,
         default_data_collator,
     )

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -113,6 +113,7 @@ class DataCollatorWithPadding:
             del batch["label_ids"]
         return batch
 
+
 @dataclass
 class DataCollatorForLanguageModeling:
     """
@@ -193,6 +194,7 @@ class DataCollatorForLanguageModeling:
         # The rest of the time (10% of the time) we keep the masked input tokens unchanged
         return inputs, labels
 
+
 @dataclass
 class DataCollatorForWholeWordMask(DataCollatorForLanguageModeling):
     """
@@ -202,7 +204,7 @@ class DataCollatorForWholeWordMask(DataCollatorForLanguageModeling):
     """
 
     def __call__(
-            self, examples: List[Union[List[int], torch.Tensor, Dict[str, torch.Tensor]]]
+        self, examples: List[Union[List[int], torch.Tensor, Dict[str, torch.Tensor]]]
     ) -> Dict[str, torch.Tensor]:
         if isinstance(examples[0], (dict, BatchEncoding)):
             input_ids = [e["input_ids"] for e in examples]

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -128,7 +128,7 @@ class DataCollatorForLanguageModeling:
     mlm_probability: float = 0.15
 
     def __call__(
-            self, examples: List[Union[List[int], torch.Tensor, Dict[str, torch.Tensor]]]
+        self, examples: List[Union[List[int], torch.Tensor, Dict[str, torch.Tensor]]]
     ) -> Dict[str, torch.Tensor]:
         if isinstance(examples[0], (dict, BatchEncoding)):
             input_ids = [e["input_ids"] for e in examples]
@@ -207,7 +207,7 @@ class DataCollatorForLanguageModeling:
         return mask_labels
 
     def _tensorize_batch(
-            self, examples: List[Union[List[int], torch.Tensor, Dict[str, torch.Tensor]]]
+        self, examples: List[Union[List[int], torch.Tensor, Dict[str, torch.Tensor]]]
     ) -> torch.Tensor:
         # In order to accept both lists of lists and lists of Tensors
         if isinstance(examples[0], (list, tuple)):

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -134,7 +134,7 @@ class DataCollatorForLanguageModeling:
             input_ids = [e["input_ids"] for e in examples]
         else:
             input_ids = examples
-            examples = [{"input_ids":e} for e in examples]
+            examples = [{"input_ids": e} for e in examples]
 
         batch_input = self._tensorize_batch(input_ids)
 
@@ -143,16 +143,16 @@ class DataCollatorForLanguageModeling:
                 mask_labels = []
                 for e in examples:
                     ref_tokens = []
-                    for id in e['input_ids'].tolist():
+                    for id in e["input_ids"].tolist():
                         token = self.tokenizer._convert_id_to_token(id)
                         ref_tokens.append(token)
 
                     # For Chinese tokens, we need extra inf to mark sub-word, e.g [喜,欢]-> [喜，##欢]
                     if "chinese_ref" in e:
-                        ref_pos = e['chinese_ref'].tolist()
-                        for i in range(e['input_ids'].size(0)):
+                        ref_pos = e["chinese_ref"].tolist()
+                        for i in range(e["input_ids"].size(0)):
                             if i in ref_pos:
-                                ref_tokens[i] = '##' + ref_tokens[i]
+                                ref_tokens[i] = "##" + ref_tokens[i]
                     mask_labels.append(self._whole_word_mask(ref_tokens))
                 batch_mask = self._tensorize_batch(mask_labels)
                 inputs, labels = self.mask_tokens(batch_input, batch_mask)

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -1,8 +1,10 @@
-from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, NewType, Optional, Tuple, Union
 import random
+from typing import Any, Callable, Dict, List, NewType, Optional, Tuple, Union
+
 import torch
 from torch.nn.utils.rnn import pad_sequence
+
+from dataclasses import dataclass
 
 from ..tokenization_utils_base import BatchEncoding, PaddingStrategy, PreTrainedTokenizerBase
 

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -113,7 +113,6 @@ class DataCollatorWithPadding:
             del batch["label_ids"]
         return batch
 
-
 @dataclass
 class DataCollatorForLanguageModeling:
     """
@@ -124,11 +123,86 @@ class DataCollatorForLanguageModeling:
 
     tokenizer: PreTrainedTokenizerBase
     mlm: bool = True
-    wwm: bool = True
     mlm_probability: float = 0.15
 
     def __call__(
         self, examples: List[Union[List[int], torch.Tensor, Dict[str, torch.Tensor]]]
+    ) -> Dict[str, torch.Tensor]:
+        if isinstance(examples[0], (dict, BatchEncoding)):
+            examples = [e["input_ids"] for e in examples]
+        batch = self._tensorize_batch(examples)
+        if self.mlm:
+            inputs, labels = self.mask_tokens(batch)
+            return {"input_ids": inputs, "labels": labels}
+        else:
+            labels = batch.clone().detach()
+            if self.tokenizer.pad_token_id is not None:
+                labels[labels == self.tokenizer.pad_token_id] = -100
+            return {"input_ids": batch, "labels": labels}
+
+    def _tensorize_batch(
+        self, examples: List[Union[List[int], torch.Tensor, Dict[str, torch.Tensor]]]
+    ) -> torch.Tensor:
+        # In order to accept both lists of lists and lists of Tensors
+        if isinstance(examples[0], (list, tuple)):
+            examples = [torch.tensor(e, dtype=torch.long) for e in examples]
+        length_of_first = examples[0].size(0)
+        are_tensors_same_length = all(x.size(0) == length_of_first for x in examples)
+        if are_tensors_same_length:
+            return torch.stack(examples, dim=0)
+        else:
+            if self.tokenizer._pad_token is None:
+                raise ValueError(
+                    "You are attempting to pad samples but the tokenizer you are using"
+                    f" ({self.tokenizer.__class__.__name__}) does not have one."
+                )
+            return pad_sequence(examples, batch_first=True, padding_value=self.tokenizer.pad_token_id)
+
+    def mask_tokens(self, inputs: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Prepare masked tokens inputs/labels for masked language modeling: 80% MASK, 10% random, 10% original.
+        """
+
+        if self.tokenizer.mask_token is None:
+            raise ValueError(
+                "This tokenizer does not have a mask token which is necessary for masked language modeling. Remove the --mlm flag if you want to use this tokenizer."
+            )
+
+        labels = inputs.clone()
+        # We sample a few tokens in each sequence for masked-LM training (with probability args.mlm_probability defaults to 0.15 in Bert/RoBERTa)
+        probability_matrix = torch.full(labels.shape, self.mlm_probability)
+        special_tokens_mask = [
+            self.tokenizer.get_special_tokens_mask(val, already_has_special_tokens=True) for val in labels.tolist()
+        ]
+        probability_matrix.masked_fill_(torch.tensor(special_tokens_mask, dtype=torch.bool), value=0.0)
+        if self.tokenizer._pad_token is not None:
+            padding_mask = labels.eq(self.tokenizer.pad_token_id)
+            probability_matrix.masked_fill_(padding_mask, value=0.0)
+        masked_indices = torch.bernoulli(probability_matrix).bool()
+        labels[~masked_indices] = -100  # We only compute loss on masked tokens
+
+        # 80% of the time, we replace masked input tokens with tokenizer.mask_token ([MASK])
+        indices_replaced = torch.bernoulli(torch.full(labels.shape, 0.8)).bool() & masked_indices
+        inputs[indices_replaced] = self.tokenizer.convert_tokens_to_ids(self.tokenizer.mask_token)
+
+        # 10% of the time, we replace masked input tokens with random word
+        indices_random = torch.bernoulli(torch.full(labels.shape, 0.5)).bool() & masked_indices & ~indices_replaced
+        random_words = torch.randint(len(self.tokenizer), labels.shape, dtype=torch.long)
+        inputs[indices_random] = random_words[indices_random]
+
+        # The rest of the time (10% of the time) we keep the masked input tokens unchanged
+        return inputs, labels
+
+@dataclass
+class DataCollatorForWholeWordMask(DataCollatorForLanguageModeling):
+    """
+    Data collator used for language modeling.
+    - collates batches of tensors, honoring their tokenizer's pad_token
+    - preprocesses batches for masked language modeling
+    """
+
+    def __call__(
+            self, examples: List[Union[List[int], torch.Tensor, Dict[str, torch.Tensor]]]
     ) -> Dict[str, torch.Tensor]:
         if isinstance(examples[0], (dict, BatchEncoding)):
             input_ids = [e["input_ids"] for e in examples]
@@ -138,32 +212,24 @@ class DataCollatorForLanguageModeling:
 
         batch_input = self._tensorize_batch(input_ids)
 
-        if self.mlm:
-            if self.wwm:  # Whole Word Mask
-                mask_labels = []
-                for e in examples:
-                    ref_tokens = []
-                    for id in e["input_ids"].tolist():
-                        token = self.tokenizer._convert_id_to_token(id)
-                        ref_tokens.append(token)
+        mask_labels = []
+        for e in examples:
+            ref_tokens = []
+            for id in e["input_ids"].tolist():
+                token = self.tokenizer._convert_id_to_token(id)
+                ref_tokens.append(token)
 
-                    # For Chinese tokens, we need extra inf to mark sub-word, e.g [喜,欢]-> [喜，##欢]
-                    if "chinese_ref" in e:
-                        ref_pos = e["chinese_ref"].tolist()
-                        for i in range(e["input_ids"].size(0)):
-                            if i in ref_pos:
-                                ref_tokens[i] = "##" + ref_tokens[i]
-                    mask_labels.append(self._whole_word_mask(ref_tokens))
-                batch_mask = self._tensorize_batch(mask_labels)
-                inputs, labels = self.mask_tokens(batch_input, batch_mask)
-            else:
-                inputs, labels = self.mask_tokens(batch_input)
-            return {"input_ids": inputs, "labels": labels}
-        else:
-            labels = batch_input.clone().detach()
-            if self.tokenizer.pad_token_id is not None:
-                labels[labels == self.tokenizer.pad_token_id] = -100
-            return {"input_ids": batch_input, "labels": labels}
+            # For Chinese tokens, we need extra inf to mark sub-word, e.g [喜,欢]-> [喜，##欢]
+            if "chinese_ref" in e:
+                ref_pos = e["chinese_ref"].tolist()
+                len_seq = e["input_ids"].size(0)
+                for i in range(len_seq):
+                    if i in ref_pos:
+                        ref_tokens[i] = "##" + ref_tokens[i]
+            mask_labels.append(self._whole_word_mask(ref_tokens))
+        batch_mask = self._tensorize_batch(mask_labels)
+        inputs, labels = self.mask_tokens(batch_input, batch_mask)
+        return {"input_ids": inputs, "labels": labels}
 
     def _whole_word_mask(self, input_tokens: List[str], max_predictions=512):
         """
@@ -206,25 +272,7 @@ class DataCollatorForLanguageModeling:
         mask_labels = [1 if i in covered_indexes else 0 for i in range(len(input_tokens))]
         return mask_labels
 
-    def _tensorize_batch(
-        self, examples: List[Union[List[int], torch.Tensor, Dict[str, torch.Tensor]]]
-    ) -> torch.Tensor:
-        # In order to accept both lists of lists and lists of Tensors
-        if isinstance(examples[0], (list, tuple)):
-            examples = [torch.tensor(e, dtype=torch.long) for e in examples]
-        length_of_first = examples[0].size(0)
-        are_tensors_same_length = all(x.size(0) == length_of_first for x in examples)
-        if are_tensors_same_length:
-            return torch.stack(examples, dim=0)
-        else:
-            if self.tokenizer._pad_token is None:
-                raise ValueError(
-                    "You are attempting to pad samples but the tokenizer you are using"
-                    f" ({self.tokenizer.__class__.__name__}) does not have one."
-                )
-            return pad_sequence(examples, batch_first=True, padding_value=self.tokenizer.pad_token_id)
-
-    def mask_tokens(self, inputs: torch.Tensor, mask_labels: torch.Tensor = None) -> Tuple[torch.Tensor, torch.Tensor]:
+    def mask_tokens(self, inputs: torch.Tensor, mask_labels: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Prepare masked tokens inputs/labels for masked language modeling: 80% MASK, 10% random, 10% original.
         Set 'mask_labels' means we use whole word mask (wwm), we directly mask idxs according to it's ref.
@@ -236,10 +284,9 @@ class DataCollatorForLanguageModeling:
             )
         labels = inputs.clone()
         # We sample a few tokens in each sequence for masked-LM training (with probability args.mlm_probability defaults to 0.15 in Bert/RoBERTa)
-        if self.wwm and mask_labels is not None:
-            probability_matrix = mask_labels
-        else:
-            probability_matrix = torch.full(labels.shape, self.mlm_probability)
+
+        probability_matrix = mask_labels
+
         special_tokens_mask = [
             self.tokenizer.get_special_tokens_mask(val, already_has_special_tokens=True) for val in labels.tolist()
         ]
@@ -247,10 +294,8 @@ class DataCollatorForLanguageModeling:
         if self.tokenizer._pad_token is not None:
             padding_mask = labels.eq(self.tokenizer.pad_token_id)
             probability_matrix.masked_fill_(padding_mask, value=0.0)
-        if self.wwm:
-            masked_indices = probability_matrix.bool()
-        else:
-            masked_indices = torch.bernoulli(probability_matrix).bool()
+
+        masked_indices = probability_matrix.bool()
         labels[~masked_indices] = -100  # We only compute loss on masked tokens
 
         # 80% of the time, we replace masked input tokens with tokenizer.mask_token ([MASK])

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -1,10 +1,9 @@
 import random
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, NewType, Optional, Tuple, Union
 
 import torch
 from torch.nn.utils.rnn import pad_sequence
-
-from dataclasses import dataclass
 
 from ..tokenization_utils_base import BatchEncoding, PaddingStrategy, PreTrainedTokenizerBase
 

--- a/src/transformers/data/datasets/__init__.py
+++ b/src/transformers/data/datasets/__init__.py
@@ -5,7 +5,7 @@
 from .glue import GlueDataset, GlueDataTrainingArguments
 from .language_modeling import (
     LineByLineTextDataset,
-    LineByLineWithRefDataset,Œ
+    LineByLineWithRefDataset,
     LineByLineWithSOPTextDataset,
     TextDataset,
     TextDatasetForNextSentencePrediction,

--- a/src/transformers/data/datasets/__init__.py
+++ b/src/transformers/data/datasets/__init__.py
@@ -5,6 +5,7 @@
 from .glue import GlueDataset, GlueDataTrainingArguments
 from .language_modeling import (
     LineByLineTextDataset,
+    LineByLineWithRefDataset,Œ
     LineByLineWithSOPTextDataset,
     TextDataset,
     TextDatasetForNextSentencePrediction,

--- a/src/transformers/data/datasets/language_modeling.py
+++ b/src/transformers/data/datasets/language_modeling.py
@@ -3,7 +3,7 @@ import pickle
 import random
 import time
 from typing import Dict, List, Optional
-
+import json
 import torch
 from torch.utils.data.dataset import Dataset
 
@@ -106,12 +106,47 @@ class LineByLineTextDataset(Dataset):
 
         batch_encoding = tokenizer(lines, add_special_tokens=True, truncation=True, max_length=block_size)
         self.examples = batch_encoding["input_ids"]
+        self.examples = [{"input_ids": torch.tensor(e, dtype=torch.long)} for e in self.examples]
 
     def __len__(self):
         return len(self.examples)
 
-    def __getitem__(self, i) -> torch.Tensor:
-        return torch.tensor(self.examples[i], dtype=torch.long)
+    def __getitem__(self, i) -> Dict[str, torch.tensor]:
+        return self.examples[i]
+
+class LineByLineWithRefDataset(Dataset):
+    """
+    This will be superseded by a framework-agnostic approach
+    soon.
+    """
+
+    def __init__(self, tokenizer: PreTrainedTokenizer, file_path: str, block_size: int, ref_path: str):
+        assert os.path.isfile(file_path), f"Input file path {file_path} not found"
+        assert os.path.isfile(ref_path), f"Ref file path {file_path} not found"
+        # Here, we do not cache the features, operating under the assumption
+        # that we will soon use fast multithreaded tokenizers from the
+        # `tokenizers` repo everywhere =)
+        logger.info("Creating features from dataset file at %s", file_path)
+        logger.info("Use ref segment results at %s", ref_path)
+        with open(file_path, encoding="utf-8") as f:
+            data = [line for line in f.read().splitlines() if (len(line) > 0 and not line.isspace())]
+        batch_encoding = tokenizer(data, add_special_tokens=True, truncation=True, max_length=block_size)
+        self.examples = batch_encoding["input_ids"]
+        self.examples = [{"input_ids": torch.tensor(e, dtype=torch.long)} for e in self.examples]
+
+        # Get ref inf from file
+        with open(ref_path, encoding="utf-8") as f:
+            ref = [json.loads(line) for line in f.read().splitlines() if (len(line) > 0 and not line.isspace())]
+        assert len(data) == len(ref)
+        n = len(self.examples)
+        for i in range(n):
+            self.examples[i]['chinese_ref'] = torch.tensor(ref[i], dtype=torch.long)
+
+    def __len__(self):
+        return len(self.examples)
+
+    def __getitem__(self, i) -> Dict[str, torch.tensor]:
+        return self.examples[i]
 
 
 class LineByLineWithSOPTextDataset(Dataset):

--- a/src/transformers/data/datasets/language_modeling.py
+++ b/src/transformers/data/datasets/language_modeling.py
@@ -37,7 +37,11 @@ class TextDataset(Dataset):
         directory, filename = os.path.split(file_path)
         cached_features_file = os.path.join(
             cache_dir if cache_dir is not None else directory,
-            "cached_lm_{}_{}_{}".format(tokenizer.__class__.__name__, str(block_size), filename,),
+            "cached_lm_{}_{}_{}".format(
+                tokenizer.__class__.__name__,
+                str(block_size),
+                filename,
+            ),
         )
 
         # Make sure only the first process in distributed training processes the dataset,
@@ -310,7 +314,12 @@ class TextDatasetForNextSentencePrediction(Dataset):
 
         directory, filename = os.path.split(file_path)
         cached_features_file = os.path.join(
-            directory, "cached_nsp_{}_{}_{}".format(tokenizer.__class__.__name__, str(block_size), filename,),
+            directory,
+            "cached_nsp_{}_{}_{}".format(
+                tokenizer.__class__.__name__,
+                str(block_size),
+                filename,
+            ),
         )
 
         self.tokenizer = tokenizer

--- a/src/transformers/data/datasets/language_modeling.py
+++ b/src/transformers/data/datasets/language_modeling.py
@@ -1,9 +1,10 @@
+import json
 import os
 import pickle
 import random
 import time
 from typing import Dict, List, Optional
-import json
+
 import torch
 from torch.utils.data.dataset import Dataset
 

--- a/src/transformers/data/datasets/language_modeling.py
+++ b/src/transformers/data/datasets/language_modeling.py
@@ -37,11 +37,7 @@ class TextDataset(Dataset):
         directory, filename = os.path.split(file_path)
         cached_features_file = os.path.join(
             cache_dir if cache_dir is not None else directory,
-            "cached_lm_{}_{}_{}".format(
-                tokenizer.__class__.__name__,
-                str(block_size),
-                filename,
-            ),
+            "cached_lm_{}_{}_{}".format(tokenizer.__class__.__name__, str(block_size), filename,),
         )
 
         # Make sure only the first process in distributed training processes the dataset,
@@ -114,6 +110,7 @@ class LineByLineTextDataset(Dataset):
     def __getitem__(self, i) -> Dict[str, torch.tensor]:
         return self.examples[i]
 
+
 class LineByLineWithRefDataset(Dataset):
     """
     This will be superseded by a framework-agnostic approach
@@ -140,7 +137,7 @@ class LineByLineWithRefDataset(Dataset):
         assert len(data) == len(ref)
         n = len(self.examples)
         for i in range(n):
-            self.examples[i]['chinese_ref'] = torch.tensor(ref[i], dtype=torch.long)
+            self.examples[i]["chinese_ref"] = torch.tensor(ref[i], dtype=torch.long)
 
     def __len__(self):
         return len(self.examples)
@@ -313,12 +310,7 @@ class TextDatasetForNextSentencePrediction(Dataset):
 
         directory, filename = os.path.split(file_path)
         cached_features_file = os.path.join(
-            directory,
-            "cached_nsp_{}_{}_{}".format(
-                tokenizer.__class__.__name__,
-                str(block_size),
-                filename,
-            ),
+            directory, "cached_nsp_{}_{}_{}".format(tokenizer.__class__.__name__, str(block_size), filename,),
         )
 
         self.tokenizer = tokenizer

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -45,6 +45,11 @@ class DataCollatorForSOP:
         requires_pytorch(self)
 
 
+class DataCollatorForWholeWordMask:
+    def __init__(self, *args, **kwargs):
+        requires_pytorch(self)
+
+
 class DataCollatorWithPadding:
     def __init__(self, *args, **kwargs):
         requires_pytorch(self)
@@ -65,6 +70,11 @@ class GlueDataTrainingArguments:
 
 
 class LineByLineTextDataset:
+    def __init__(self, *args, **kwargs):
+        requires_pytorch(self)
+
+
+class LineByLineWithRefDataset:
     def __init__(self, *args, **kwargs):
         requires_pytorch(self)
 


### PR DESCRIPTION
This PR add support for **wwm** (whole word mask) proxy when fine-tune BERT like model.
And it can be divided into two part : English Model Support and Chinese Model Support

For English, it's simple. The original tokenizer res contains symbols like '##ing'.
I just use the same mask proxy in [data_collator.py](https://github.com/wlhgtc/transformers/blob/master/src/transformers/data/data_collator.py#L168) by [Google.](https://github.com/google-research/bert/blob/master/create_pretraining_data.py#L342)

For Chinese, it's hard. We need to rely on (word level) tokenizer,  cause BERT is char level in Chinese.
So I do things as follow to get word level tokens:
1.  add get info code in [chinese_ref.py](https://github.com/wlhgtc/transformers/blob/master/examples/language-modeling/chinese_ref.py#L79)
2. create a new dataset to keep ref info [language_model.py](https://github.com/wlhgtc/transformers/blob/master/src/transformers/data/datasets/language_modeling.py#L117)
3. create word level ref according to ref [data_collator.py](https://github.com/wlhgtc/transformers/blob/master/src/transformers/data/data_collator.py#L150)

Then, it's all same to English. 

And I add two parameters (`wwm` and `chinese_ref_path` ) to run lm.
