### PR TITLE
Fix BatchEncoding.word_to_tokens for removed tokens

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -347,7 +347,7 @@ class BatchEncoding(UserDict):
             token_index = self._seq_len + token_index
         return self._encodings[batch_index].token_to_word(token_index)
 
-    def word_to_tokens(self, batch_or_word_index: int, word_index: Optional[int] = None) -> TokenSpan:
+    def word_to_tokens(self, batch_or_word_index: int, word_index: Optional[int] = None) -> Optional[TokenSpan]:
         """
         Get the encoded token span corresponding to a word in the sequence of the batch.
 
@@ -374,8 +374,9 @@ class BatchEncoding(UserDict):
                 of the word in the sequence.
 
         Returns:
-            :class:`~transformers.tokenization_utils_base.TokenSpan`
-            Span of tokens in the encoded sequence.
+            Optional :class:`~transformers.tokenization_utils_base.TokenSpan`
+            Span of tokens in the encoded sequence. Returns :obj:`None` if no tokens correspond
+            to the word.
         """
 
         if not self._encodings:
@@ -389,7 +390,8 @@ class BatchEncoding(UserDict):
             batch_index = self._batch_size + batch_index
         if word_index < 0:
             word_index = self._seq_len + word_index
-        return TokenSpan(*(self._encodings[batch_index].word_to_tokens(word_index)))
+        span = self._encodings[batch_index].word_to_tokens(word_index)
+        return TokenSpan(*span) if span is not None else None
 
     def token_to_chars(self, batch_or_token_index: int, token_index: Optional[int] = None) -> CharSpan:
         """

--- a/tests/test_tokenization_utils.py
+++ b/tests/test_tokenization_utils.py
@@ -18,7 +18,7 @@ from typing import Callable, Optional
 
 import numpy as np
 
-from transformers import BatchEncoding, BertTokenizer, BertTokenizerFast, PreTrainedTokenizer, TensorType
+from transformers import BatchEncoding, BertTokenizer, BertTokenizerFast, PreTrainedTokenizer, TensorType, TokenSpan
 from transformers.testing_utils import require_tf, require_tokenizers, require_torch, slow
 from transformers.tokenization_gpt2 import GPT2Tokenizer
 
@@ -141,6 +141,15 @@ class TokenizerUtilsTest(unittest.TestCase):
 
         with self.subTest("Rust Tokenizer"):
             self.assertTrue(tokenizer_r("Small example to_encode").is_fast)
+
+    @require_tokenizers
+    def test_batch_encoding_word_to_tokens(self):
+        tokenizer_r = BertTokenizerFast.from_pretrained("bert-base-cased")
+        encoded = tokenizer_r(["Test", "\xad", "test"], is_split_into_words=True)
+
+        self.assertEqual(encoded.word_to_tokens(0), TokenSpan(start=1, end=2))
+        self.assertEqual(encoded.word_to_tokens(1), None)
+        self.assertEqual(encoded.word_to_tokens(2), TokenSpan(start=2, end=3))
 
     def test_batch_encoding_with_labels(self):
         batch = BatchEncoding({"inputs": [[1, 2, 3], [4, 5, 6]], "labels": [0, 1]})


### PR DESCRIPTION
Fixes https://github.com/huggingface/tokenizers/issues/343

Copied from issue on `tokenizers` repo:

> I'm working with pre-tokenized data (UD-Treebanks) for a sequence-tagging task, since I don't want to inflate the importance of a training example based on the number of word-pieces the token gets split into, I need to map the labels to only the first word-piece of a token.
>
> To achieve this, I was iterating over the words in the original sentence as taken from the treebank and used the word_to_tokens method with the offset of the word in the sentence to get the corresponding token span. If words simply vanish from the sentence, then at first the offsets become invalid and at the final word of the sequence an exception is raised because there's no offset for disappearing words in the sequence. 

This notebook demontrates the issue: 

https://colab.research.google.com/drive/139mVXMQ7jZBBoTpgkribgVpOu6W1u8e9?usp=sharing

~~~Py
import transformers
import torch
tokenizer = transformers.AutoTokenizer.from_pretrained("bert-base-multilingual-cased", use_fast=True)
batch = [["Test", "\xad", "test"]]
encoded_batch = tokenizer.batch_encode_plus(
    batch,
    padding=True,
    is_pretokenized=True,
    return_tensors='pt',
    truncation=True)
first_pieces = torch.zeros_like(encoded_batch.attention_mask, dtype=torch.bool)

for row, sentence in enumerate(batch):
    for col, token in enumerate(sentence):
        idx = encoded_batch.word_to_tokens(row, col)[0] # this method raises the exception
        first_pieces[row, idx] = True
~~~