### PR TITLE
[PretrainedConfig] Fix save pretrained config for edge case 

### DIFF
--- a/src/transformers/configuration_encoder_decoder.py
+++ b/src/transformers/configuration_encoder_decoder.py
@@ -70,6 +70,7 @@ class EncoderDecoderConfig(PretrainedConfig):
         >>> model = EncoderDecoderModel.from_pretrained('my-model', config=encoder_decoder_config)
     """
     model_type = "encoder_decoder"
+    is_composition = True
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/src/transformers/configuration_fsmt.py
+++ b/src/transformers/configuration_fsmt.py
@@ -126,9 +126,9 @@ class FSMTConfig(PretrainedConfig):
     # update the defaults from config file
     def __init__(
         self,
-        langs,
-        src_vocab_size,
-        tgt_vocab_size,
+        langs=["en", "de"],
+        src_vocab_size=42024,
+        tgt_vocab_size=42024,
         activation_function="relu",
         d_model=1024,
         max_length=200,

--- a/src/transformers/configuration_rag.py
+++ b/src/transformers/configuration_rag.py
@@ -77,6 +77,7 @@ RAG_CONFIG_DOC = r"""
 @add_start_docstrings(RAG_CONFIG_DOC)
 class RagConfig(PretrainedConfig):
     model_type = "rag"
+    is_composition = True
 
     def __init__(
         self,

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -41,7 +41,9 @@ class PretrainedConfig(object):
     Class attributes (overridden by derived classes)
         - **model_type** (:obj:`str`): An identifier for the model type, serialized into the JSON file, and used to
           recreate the correct object in :class:`~transformers.AutoConfig`.
-        - **is_composition** (:obj:`bool`): Whether the config class is composed of multiple sub-configs. In this case the config has to be initialized from two or more configs of type :class:`~transformers.PretrainedConfig`, *e.g.*: `EncoderDecoderConfig`, `RagConfig`.
+        - **is_composition** (:obj:`bool`): Whether the config class is composed of multiple
+          sub-configs. In this case the config has to be initialized from two or more configs of
+          type :class:`~transformers.PretrainedConfig`, *e.g.*: `EncoderDecoderConfig`, `RagConfig`.
 
     Args:
         name_or_path (:obj:`str`, `optional`, defaults to :obj:`""`):

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -43,7 +43,8 @@ class PretrainedConfig(object):
           recreate the correct object in :class:`~transformers.AutoConfig`.
         - **is_composition** (:obj:`bool`): Whether the config class is composed of multiple
           sub-configs. In this case the config has to be initialized from two or more configs of
-          type :class:`~transformers.PretrainedConfig`, *e.g.*: `EncoderDecoderConfig`, `RagConfig`.
+          type :class:`~transformers.PretrainedConfig` like: :class:`~transformers.EncoderDecoderConfig` or
+          :class:`~RagConfig`.
 
     Args:
         name_or_path (:obj:`str`, `optional`, defaults to :obj:`""`):

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -41,6 +41,7 @@ class PretrainedConfig(object):
     Class attributes (overridden by derived classes)
         - **model_type** (:obj:`str`): An identifier for the model type, serialized into the JSON file, and used to
           recreate the correct object in :class:`~transformers.AutoConfig`.
+        - **is_composition** (:obj:`bool`): Whether the config class is composed of multiple sub-configs. In this case the config has to be initialized from two or more configs of type :class:`~transformers.PretrainedConfig`, *e.g.*: `EncoderDecoderConfig`, `RagConfig`.
 
     Args:
         name_or_path (:obj:`str`, `optional`, defaults to :obj:`""`):
@@ -145,6 +146,7 @@ class PretrainedConfig(object):
           use BFloat16 scalars (only used by some TensorFlow models).
     """
     model_type: str = ""
+    is_composition: bool = False
 
     def __init__(self, **kwargs):
         # Attributes with defaults
@@ -477,7 +479,7 @@ class PretrainedConfig(object):
         default_config_dict = PretrainedConfig().to_dict()
 
         # get class specific config dict
-        class_config_dict = self.__class__().to_dict()
+        class_config_dict = self.__class__().to_dict() if not self.is_composition else {}
 
         serializable_config_dict = {}
 

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -476,11 +476,18 @@ class PretrainedConfig(object):
         # get the default config dict
         default_config_dict = PretrainedConfig().to_dict()
 
+        # get class specific config dict
+        class_config_dict = self.__class__().to_dict()
+
         serializable_config_dict = {}
 
         # only serialize values that differ from the default config
         for key, value in config_dict.items():
-            if key not in default_config_dict or value != default_config_dict[key]:
+            if (
+                key not in default_config_dict
+                or value != default_config_dict[key]
+                or (key in class_config_dict and value != class_config_dict[key])
+            ):
                 serializable_config_dict[key] = value
 
         return serializable_config_dict

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -66,9 +66,16 @@ class ConfigTester(object):
         self.parent.assertEqual(len(config.id2label), 3)
         self.parent.assertEqual(len(config.label2id), 3)
 
+    def check_config_can_be_init_without_params(self):
+        if self.config_class.needs_sub_configs:
+            return
+        config = self.config_class()
+        self.parent.assertIsNone(config)
+
     def run_common_tests(self):
         self.create_and_test_config_common_properties()
         self.create_and_test_config_to_json_string()
         self.create_and_test_config_to_json_file()
         self.create_and_test_config_from_and_save_pretrained()
         self.create_and_test_config_with_num_labels()
+        self.check_config_can_be_init_without_params()

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -70,7 +70,7 @@ class ConfigTester(object):
         if self.config_class.is_composition:
             return
         config = self.config_class()
-        self.parent.assertIsNone(config)
+        self.parent.assertIsNotNone(config)
 
     def run_common_tests(self):
         self.create_and_test_config_common_properties()

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -67,7 +67,7 @@ class ConfigTester(object):
         self.parent.assertEqual(len(config.label2id), 3)
 
     def check_config_can_be_init_without_params(self):
-        if self.config_class.needs_sub_configs:
+        if self.config_class.is_composition:
             return
         config = self.config_class()
         self.parent.assertIsNone(config)

--- a/tests/test_modeling_prophetnet.py
+++ b/tests/test_modeling_prophetnet.py
@@ -901,6 +901,15 @@ class ProphetNetModelTest(ModelTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.check_model_with_attn_mask(*config_and_inputs)
 
+    def test_config_save(self):
+        config = self.model_tester.prepare_config_and_inputs()[0]
+        config.add_cross_attention = False
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            config.save_pretrained(tmp_dirname)
+            config = ProphetNetConfig.from_pretrained(tmp_dirname)
+
+        self.assertFalse(config.add_cross_attention)
+
     @unittest.skipIf(torch_device == "cpu", "Cant do half precision")
     def test_fp16_forward(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()


### PR DESCRIPTION
# What does this PR do?

There is an edge case for which the "diff" save method for `PretrainedConfig` fails. We decided a while ago in this PR: https://github.com/huggingface/transformers/pull/3797 that we wanted to have more readable configs and thus tweaked the `save_pretrained()` method so that only parameters that are different to the default **PretrainedConfig** class are serialized. 

There was an edge case we did not consider:

If a parameter, like `add_cross_attention` defaults to `True` in `ProphetNetConfig`, but is by default `False` in `PretrainedConfig` a problem can arise when a user wants to save `add_cross_attention=False` in his `ProphetNetConfig`. Because `add_cross_attention=False` corresponds to the `PretrainedConfig` default case, this parameter will not be serialized and thus when reloading the config, the parameter defaults to `ProphetNetConfig` which is `True` and which is then an error.

This PR fixes this behavior by simply making sure that a parameter is only **not** saved if it is equal to both `PretrainedConfig` and `ProphetNetConfig`. 

This feature requires configs to be instantiated without providing any parameters. This is currently not possible for the `EncoderDecoderModelConfig` and `RagConfig` because those configs are composed of multiple sub-configs which have to be provided. => A new class attribute `is_composition` is added to correctly handle these classes.

Two tests are added.

Also cc @stas00 for FSTM config.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to the it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?


