### PR TITLE
RoBERTa convert-script modified to support mapping of bpe tokens

### DIFF
--- a/src/transformers/convert_roberta_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/convert_roberta_original_pytorch_checkpoint_to_pytorch.py
@@ -39,9 +39,7 @@ logger = logging.get_logger(__name__)
 SAMPLE_TEXT = "Hello world! cécé herlolip"
 
 
-def map_roberta_embedding(
-    dictionary: fairseq.data.Dictionary, emb: torch.Tensor, shape: tuple
-):
+def map_roberta_embedding(dictionary: fairseq.data.Dictionary, emb: torch.Tensor, shape: tuple):
     """
     Convert RoBERTa embedding weights using dict.txt to remove need for gpt2 bpe vocab
     exercises further down the pipeline.
@@ -67,7 +65,7 @@ def map_roberta_embedding(
     # Simple hack since vocab is always biggest
 
     vocab_size = max(shape)
-    
+
     for i in range(hf_mask_idx + 1, vocab_size):
         if i < symb_count and dictionary.symbols[i].isnumeric():
             new_emb[int(dictionary.symbols[i])] = emb[i]
@@ -117,9 +115,7 @@ def convert_roberta_checkpoint_to_pytorch(
     # Embeddings
     if roberta_dict:
         word_emb = map_roberta_embedding(
-            roberta_dict,
-            roberta_sent_encoder.embed_tokens.weight,
-            (vocab_size, roberta.args.encoder_embed_dim)
+            roberta_dict, roberta_sent_encoder.embed_tokens.weight, (vocab_size, roberta.args.encoder_embed_dim)
         )
     else:
         word_emb = roberta_sent_encoder.embed_tokens.weight
@@ -184,14 +180,14 @@ def convert_roberta_checkpoint_to_pytorch(
             model.classifier.out_proj.weight = map_roberta_embedding(
                 roberta_dict,
                 roberta.model.classification_heads["mnli"].out_proj.weight,
-                (vocab_size, config.num_labels)
+                (vocab_size, config.num_labels),
             )
         else:
             model.classifier.out_proj.weight = roberta.model.classification_heads["mnli"].out_proj.weight
         model.classifier.out_proj.bias = roberta.model.classification_heads["mnli"].out_proj.bias
     else:
         # LM Head
-        
+
         model.lm_head.dense.weight = roberta.model.encoder.lm_head.dense.weight
         model.lm_head.dense.bias = roberta.model.encoder.lm_head.dense.bias
         model.lm_head.layer_norm.weight = roberta.model.encoder.lm_head.layer_norm.weight
@@ -199,14 +195,10 @@ def convert_roberta_checkpoint_to_pytorch(
 
         if roberta_dict:
             model.lm_head.decoder.weight = map_roberta_embedding(
-                roberta_dict,
-                roberta.model.encoder.lm_head.weight,
-                (vocab_size, roberta.args.encoder_embed_dim)
+                roberta_dict, roberta.model.encoder.lm_head.weight, (vocab_size, roberta.args.encoder_embed_dim)
             )
             model.lm_head.decoder.bias = map_roberta_embedding(
-                roberta_dict,
-                roberta.model.encoder.lm_head.bias,
-                (vocab_size, )
+                roberta_dict, roberta.model.encoder.lm_head.bias, (vocab_size,)
             )
         else:
             model.lm_head.decoder.weight = roberta.model.encoder.lm_head.weight
@@ -246,9 +238,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--pytorch_dump_folder_path", default=None, type=str, required=True, help="Path to the output PyTorch model."
     )
-    parser.add_argument(
-        "--roberta_dict", action="store_true", help="Whether to use fairseq preprocessing dict."
-    )
+    parser.add_argument("--roberta_dict", action="store_true", help="Whether to use fairseq preprocessing dict.")
     parser.add_argument(
         "--classification_head", action="store_true", help="Whether to convert a final classification head."
     )
@@ -256,6 +246,3 @@ if __name__ == "__main__":
     convert_roberta_checkpoint_to_pytorch(
         args.roberta_checkpoint_path, args.pytorch_dump_folder_path, args.roberta_dict, args.classification_head
     )
-
-
-


### PR DESCRIPTION
# Reordering of embeddings possible when converting roberta with dict file

When RoBERTa is trained using fairseq the preprocessing pipeline bpe encodes tokens and stores a mapping of token ids to bpe-token ids in a dict.txt file. This is mostly just a re-ordering of the tokens (potentially with a few missing ones if they were not found in the training data). The earlier version of the conversion script maps the fairseq model directly creating a need for downstream processing to recover the original tokens, this removes that need by allowing a shuffling of the embedding tensors using the dict.txt file. This enables e.g. the "fill-mask" pipeline out of the box on a converted model.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to the it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests? 


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors which may be interested in your PR.

@julien-c (since prominent in blame)
 