### PR TITLE
support relative path for best_model_checkpoint

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1219,7 +1219,7 @@ class Trainer:
         checkpoints_sorted = [checkpoint[1] for checkpoint in checkpoints_sorted]
         # Make sure we don't delete the best model.
         if self.state.best_model_checkpoint is not None:
-            best_model_index = checkpoints_sorted.index(self.state.best_model_checkpoint)
+            best_model_index = checkpoints_sorted.index(str(Path(self.state.best_model_checkpoint)))
             checkpoints_sorted[best_model_index], checkpoints_sorted[-1] = (
                 checkpoints_sorted[-1],
                 checkpoints_sorted[best_model_index],


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #7431

When I give a relative path to `output_dir`, it raises some error at line 1222.
https://github.com/huggingface/transformers/blob/83481056921296fadbdc86cd51c157a9a9327946/src/transformers/trainer.py#L1205-L1227

If I give './path1/path2' to `output_dir`, `checkpoints_sorted` becomes 'path1/path2' by Path library on line 1208.
But `self.state.best_model_checkpoint` is still './path1/path2'.
So it will raise error as below.
```
Traceback (most recent call last):
  File "../finetune.py", line 369, in <module>
    main(**vars(args))
  File "../finetune.py", line 315, in main
    device)
  File "../finetune.py", line 120, in train
    trainer.train(optim_pretrained_path)
  File "/usr/local/lib/python3.6/dist-packages/transformers/trainer.py", line 803, in train
    self._maybe_log_save_evaluate(tr_loss, model, trial, epoch)
  File "/usr/local/lib/python3.6/dist-packages/transformers/trainer.py", line 860, in _maybe_log_save_evaluate
    self._save_checkpoint(model, trial, metrics=metrics)
  File "/usr/local/lib/python3.6/dist-packages/transformers/trainer.py", line 918, in _save_checkpoint
    self._rotate_checkpoints(use_mtime=True)
  File "/usr/local/lib/python3.6/dist-packages/transformers/trainer.py", line 1235, in _rotate_checkpoints
    checkpoints_sorted = self._sorted_checkpoints(use_mtime=use_mtime)
  File "/usr/local/lib/python3.6/dist-packages/transformers/trainer.py", line 1223, in _sorted_checkpoints
    best_model_index = checkpoints_sorted.index(self.state.best_model_checkpoint)
ValueError: './results/use_pretrained_test/checkpoint-1162' is not in list
```

So I resolve this error by using Path for `self.state.best_model_checkpoint`.
Any other idea is also welcome. please check it
