### PR TITLE
GPT2 - Remove else branch adding 0 to the hidden state if token_type_embeds is None.

### DIFF
--- a/src/transformers/modeling_gpt2.py
+++ b/src/transformers/modeling_gpt2.py
@@ -607,11 +607,12 @@ class GPT2Model(GPT2PreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.wte(input_ids)
         position_embeds = self.wpe(position_ids)
+        hidden_states = inputs_embeds + position_embeds
+
         if token_type_ids is not None:
             token_type_embeds = self.wte(token_type_ids)
-        else:
-            token_type_embeds = 0
-        hidden_states = inputs_embeds + position_embeds + token_type_embeds
+            hidden_states = hidden_states + token_type_embeds
+
         hidden_states = self.drop(hidden_states)
 
         output_shape = input_shape + (hidden_states.size(-1),)


### PR DESCRIPTION
Currently, when `token_type_embeds` is `None` we set its value to `0` and add it to the triplet `inputs_embeds + position_embeds + token_type_embeds`.

This can be simplified to: 
- avoid summing 0 over many elements
- avoid using raw Python scalar value which cannot be traced by TorchScript / ONNX when exporting.

Leading to: 

> [ONNXRuntimeError] : 1 : FAIL : TensorRT input: 200 has no shape specified. Please run shape inference on the onnx model first.

Signed-off-by: Morgan Funtowicz <funtowiczmo@gmail.com>