### PR TITLE
Only log total_flos at the end of training

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -830,11 +830,11 @@ class Trainer:
                 state_dict = torch.load(os.path.join(self.state.best_model_checkpoint, WEIGHTS_NAME))
                 self.model.load_state_dict(state_dict)
 
-        self.control = self.callback_handler.on_train_end(self.args, self.state, self.control)
-
         if self._total_flos is not None:
             self.store_flos()
             self.log({"total_flos": self.state.total_flos})
+
+        self.control = self.callback_handler.on_train_end(self.args, self.state, self.control)
 
         return TrainOutput(self.state.global_step, tr_loss.item() / self.state.global_step)
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -832,6 +832,10 @@ class Trainer:
 
         self.control = self.callback_handler.on_train_end(self.args, self.state, self.control)
 
+        if self._total_flos is not None:
+            self.store_flos()
+            self.log({"total_flos": self.state.total_flos})
+
         return TrainOutput(self.state.global_step, tr_loss.item() / self.state.global_step)
 
     def _maybe_log_save_evaluate(self, tr_loss, model, trial, epoch):
@@ -1015,9 +1019,6 @@ class Trainer:
             return self._log(logs)
         if self.state.epoch is not None:
             logs["epoch"] = self.state.epoch
-        if self._total_flos is not None:
-            self.store_flos()
-            logs["total_flos"] = self.state.total_flos
 
         self.control = self.callback_handler.on_log(self.args, self.state, self.control, logs)
         output = {**logs, **{"step": self.state.global_step}}

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -114,12 +114,7 @@ def default_compute_objective(metrics: Dict[str, float]) -> float:
     metrics = copy.deepcopy(metrics)
     loss = metrics.pop("eval_loss", None)
     _ = metrics.pop("epoch", None)
-    _ = metrics.pop("total_flos", None)
-    if len(metrics) != 0:
-        raise RuntimeError(
-            "Metrics contains more entries than just 'eval_loss', 'epoch' and 'total_flos', please provide your own compute_objective function."
-        )
-    return loss
+    return loss if len(metrics) == 0 else sum(metrics.values())
 
 
 def default_hp_space_optuna(trial) -> Dict[str, float]:

--- a/tests/test_trainer_callback.py
+++ b/tests/test_trainer_callback.py
@@ -125,7 +125,7 @@ class TrainerCallbackTest(unittest.TestCase):
             expected_events.append("on_epoch_end")
             if trainer.args.evaluation_strategy == EvaluationStrategy.EPOCH:
                 expected_events += evaluation_events.copy()
-        expected_events.append("on_train_end")
+        expected_events += ["on_log", "on_train_end"]
         return expected_events
 
     def test_init_callback(self):


### PR DESCRIPTION
# What does this PR do?

This PR removes the addition of `total_flos` at each (and every) log, since this kind of pollutes them, and only logs it once and for all at the end of training. Users can still define their own callbacks and do more with that value if they really want to, but from what I understood. @TevenLeScao, that value is mainly necessary at the end.

Also, now that it's not in the metrics anymore, I've reverted the default compute metrics to its previous behavior (sum of all metrics) since it's the documented behavior. (cc @madlag) If we want to really change it, we need to put more examples out there.