### PR TITLE
Mlflow integration callback

### DIFF
--- a/docs/source/main_classes/callback.rst
+++ b/docs/source/main_classes/callback.rst
@@ -20,6 +20,7 @@ By default a :class:`~transformers.Trainer` will use the following callbacks:
   or tensorboardX).
 - :class:`~transformers.integrations.WandbCallback` if `wandb <https://www.wandb.com/>`__ is installed.
 - :class:`~transformers.integrations.CometCallback` if `comet_ml <https://www.comet.ml/site/>`__ is installed.
+- :class:`~transformers.integrations.MLflowCallback` if `mlflow <https://www.mlflow.org/>`__ is installed.
 
 The main class that implements callbacks is :class:`~transformers.TrainerCallback`. It gets the
 :class:`~transformers.TrainingArguments` used to instantiate the :class:`~transformers.Trainer`, can access that
@@ -44,6 +45,9 @@ Here is the list of the available :class:`~transformers.TrainerCallback` in the 
 .. autoclass:: transformers.integrations.TensorBoardCallback
 
 .. autoclass:: transformers.integrations.WandbCallback
+    :members: setup
+
+.. autoclass:: transformers.integrations.MLflowCallback
     :members: setup
 
 

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -92,8 +92,10 @@ def is_optuna_available():
 def is_ray_available():
     return _has_ray
 
+
 def is_mlflow_available():
     return _has_mlflow
+
 
 def hp_params(trial):
     if is_optuna_available():
@@ -425,6 +427,7 @@ class MLflowCallback(TrainerCallback):
     A :class:`~transformers.TrainerCallback` that sends the logs to `MLflow
     <https://www.mlflow.org/>`__.
     """
+
     MAX_LOG_SIZE = 100
 
     def __init__(self):
@@ -457,7 +460,7 @@ class MLflowCallback(TrainerCallback):
             # MLflow cannot log more than 100 values in one go, so we have to split it
             combined_dict_items = list(combined_dict.items())
             for i in range(0, len(combined_dict_items), MLflowCallback.MAX_LOG_SIZE):
-                mlflow.log_params(dict(combined_dict_items[i:i + MLflowCallback.MAX_LOG_SIZE]))
+                mlflow.log_params(dict(combined_dict_items[i : i + MLflowCallback.MAX_LOG_SIZE]))
         self._initialized = True
 
     def on_train_begin(self, args, state, control, model=None, **kwargs):

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -491,3 +491,9 @@ class MLflowCallback(TrainerCallback):
                 logger.info("Logging artifacts. This may take time.")
                 mlflow.log_artifacts(args.output_dir)
             mlflow.end_run()
+
+    def __del__(self):
+        # if the previous run is not terminated correctly, the fluent API will
+        # not let you start a new run before the previous one is killed
+        if mlflow.active_run is not None:
+            mlflow.end_run(status="KILLED")

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -45,6 +45,7 @@ from .integrations import (
     is_ray_available,
     is_tensorboard_available,
     is_wandb_available,
+    is_mlflow_available,
     run_hp_search_optuna,
     run_hp_search_ray,
 )
@@ -138,6 +139,11 @@ if is_comet_available():
     from .integrations import CometCallback
 
     DEFAULT_CALLBACKS.append(CometCallback)
+
+if is_mlflow_available():
+    from .integrations import MLflowCallback
+
+    DEFAULT_CALLBACKS.append(MLflowCallback)
 
 if is_optuna_available():
     import optuna

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -41,11 +41,11 @@ from .integrations import (
     default_hp_search_backend,
     hp_params,
     is_comet_available,
+    is_mlflow_available,
     is_optuna_available,
     is_ray_available,
     is_tensorboard_available,
     is_wandb_available,
-    is_mlflow_available,
     run_hp_search_optuna,
     run_hp_search_ray,
 )


### PR DESCRIPTION
# What does this PR do?

This PR adds Trainer integration with [MLflow](https://mlflow.org/). 

It is implemented in roughly the same way as other integration callbacks (CometML, wandb) and gets added to the list of Trainer callbacks automatically when mlflow is installed. All the mlflow parameters are configured with env variables, as described in the library documentation. This PR adds an additional environment variable, `HF_MLFLOW_LOG_ARTIFACTS`, which controls whether to use mlflow artifact logging facility to save artifacts generated after training (it doesn't make much sense if mlflow is used locally).  

Fixes #7698


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to the it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sgugger
