### PR TITLE
Add mixed precision evaluation

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1466,7 +1466,7 @@ class Trainer:
         inputs = self._prepare_inputs(inputs)
 
         with torch.no_grad():
-            if self.args.fp16_eval and _use_native_amp:
+            if self.args.fp16 and _use_native_amp:
                 with autocast():
                     outputs = model(**inputs)
             else:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1466,7 +1466,11 @@ class Trainer:
         inputs = self._prepare_inputs(inputs)
 
         with torch.no_grad():
-            outputs = model(**inputs)
+            if self.args.fp16_eval and _use_native_amp:
+                with autocast():
+                    outputs = model(**inputs)
+            else:
+                outputs = model(**inputs)
             if has_labels:
                 loss = outputs[0].mean().detach()
                 logits = outputs[1:]

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -268,6 +268,10 @@ class TrainingArguments:
         default=False,
         metadata={"help": "Whether to use 16-bit (mixed) precision (through NVIDIA apex) instead of 32-bit"},
     )
+    fp16_eval: bool = field(
+        default=False,
+        metadata={"help": "Whether to use 16-bit (mixed) precision in evaluation"},
+    )
     fp16_opt_level: str = field(
         default="O1",
         metadata={

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -268,10 +268,6 @@ class TrainingArguments:
         default=False,
         metadata={"help": "Whether to use 16-bit (mixed) precision (through NVIDIA apex) instead of 32-bit"},
     )
-    fp16_eval: bool = field(
-        default=False,
-        metadata={"help": "Whether to use 16-bit (mixed) precision in evaluation"},
-    )
     fp16_opt_level: str = field(
         default="O1",
         metadata={


### PR DESCRIPTION
# What does this PR do?

Add flag and code to do mixed precision forward in trainer's `prediction_step` function. 
Let evaluation (and prediction) to run faster.


## Who can review?

@sgugger
