### PR TITLE
[Seq2Seq Trainer] Make sure padding is implemented for models without pad_token

### DIFF
--- a/all_results.json
+++ b/all_results.json
@@ -1,9 +1,0 @@
-{
-    "eval_loss": 4568.46875,
-    "eval_bleu": 0.3241,
-    "eval_gen_len": 74.1,
-    "epoch": 10.0,
-    "test_loss": 4455.72705078125,
-    "test_bleu": 0.0588,
-    "test_gen_len": 80.1
-}

--- a/all_results.json
+++ b/all_results.json
@@ -1,9 +1,0 @@
-{
-    "eval_loss": 596.3809814453125,
-    "eval_bleu": 0.0,
-    "eval_gen_len": 12.0,
-    "epoch": 1.0,
-    "test_loss": 572.8933715820312,
-    "test_bleu": 0.0,
-    "test_gen_len": 12.0
-}

--- a/all_results.json
+++ b/all_results.json
@@ -1,0 +1,9 @@
+{
+    "eval_loss": 596.3809814453125,
+    "eval_bleu": 0.0,
+    "eval_gen_len": 12.0,
+    "epoch": 1.0,
+    "test_loss": 572.8933715820312,
+    "test_bleu": 0.0,
+    "test_gen_len": 12.0
+}

--- a/all_results.json
+++ b/all_results.json
@@ -1,0 +1,9 @@
+{
+    "eval_loss": 4568.46875,
+    "eval_bleu": 0.3241,
+    "eval_gen_len": 74.1,
+    "epoch": 10.0,
+    "test_loss": 4455.72705078125,
+    "test_bleu": 0.0588,
+    "test_gen_len": 80.1
+}

--- a/examples/seq2seq/seq2seq_trainer.py
+++ b/examples/seq2seq/seq2seq_trainer.py
@@ -60,6 +60,11 @@ class Seq2SeqTrainer(Trainer):
                 self.config.pad_token_id is not None
             ), "Make sure that `config.pad_token_id` is correcly defined when ignoring `pad_token` for loss calculation or doing label smoothing."
 
+        if self.config.pad_token_id is None and self.config.eos_token_id is not None:
+            logger.warn(
+                f"The `config.pad_token_id` is `None`. Use `config.eos_token_id` = {self.config.eos_token_id} for padding."
+            )
+
     def create_optimizer_and_scheduler(self, num_training_steps: int):
         """
         Setup the optimizer and the learning rate scheduler.

--- a/examples/seq2seq/seq2seq_trainer.py
+++ b/examples/seq2seq/seq2seq_trainer.py
@@ -62,7 +62,7 @@ class Seq2SeqTrainer(Trainer):
 
         if self.config.pad_token_id is None and self.config.eos_token_id is not None:
             logger.warn(
-                f"The `config.pad_token_id` is `None`. Use `config.eos_token_id` = {self.config.eos_token_id} for padding."
+                f"The `config.pad_token_id` is `None`. Using `config.eos_token_id` = {self.config.eos_token_id} for padding.."
             )
 
     def create_optimizer_and_scheduler(self, num_training_steps: int):

--- a/examples/seq2seq/seq2seq_trainer.py
+++ b/examples/seq2seq/seq2seq_trainer.py
@@ -180,7 +180,7 @@ class Seq2SeqTrainer(Trainer):
         """
         inputs = self._prepare_inputs(inputs)
 
-        pred_kwargs = {
+        gen_kwargs = {
             "max_length": self.data_args.val_max_target_length
             if self.data_args is not None
             else self.config.max_length,
@@ -191,11 +191,11 @@ class Seq2SeqTrainer(Trainer):
             generated_tokens = model.generate(
                 inputs["input_ids"],
                 attention_mask=inputs["attention_mask"],
-                **pred_kwargs,
+                **gen_kwargs,
             )
             # in case the batch is shorter than max length, the output should be padded
-            if generated_tokens.shape[-1] < pred_kwargs["max_length"]:
-                generated_tokens = self._pad_tensors_to_max_len(generated_tokens, pred_kwargs["max_length"])
+            if generated_tokens.shape[-1] < gen_kwargs["max_length"]:
+                generated_tokens = self._pad_tensors_to_max_len(generated_tokens, gen_kwargs["max_length"])
 
         labels = inputs.pop("labels")
         with torch.no_grad():
@@ -208,8 +208,8 @@ class Seq2SeqTrainer(Trainer):
 
         logits = generated_tokens if self.args.predict_with_generate else logits
 
-        if labels.shape[-1] < pred_kwargs["max_length"]:
-            labels = self._pad_tensors_to_max_len(labels, pred_kwargs["max_length"])
+        if labels.shape[-1] < gen_kwargs["max_length"]:
+            labels = self._pad_tensors_to_max_len(labels, gen_kwargs["max_length"])
 
         return (loss, logits, labels)
 

--- a/examples/seq2seq/seq2seq_trainer.py
+++ b/examples/seq2seq/seq2seq_trainer.py
@@ -1,4 +1,3 @@
-import copy
 from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
@@ -132,21 +131,19 @@ class Seq2SeqTrainer(Trainer):
             )
 
     def _compute_loss(self, model, inputs):
-        inputs = copy.deepcopy(inputs)
+        labels = inputs.pop("labels")
         if self.args.label_smoothing == 0:
             if self.data_args is not None and self.data_args.ignore_pad_token_for_loss:
                 # force training to ignore pad token
-                labels = inputs.pop("labels")
                 logits = model(**inputs, use_cache=False)[0]
 
                 loss_fct = torch.nn.CrossEntropyLoss(ignore_index=self.config.pad_token_id)
                 loss = loss_fct(logits.view(-1, logits.shape[-1]), labels.view(-1))
             else:
                 # compute usual loss via models
-                loss, logits = model(**inputs, use_cache=False)[:2]
+                loss, logits = model(**inputs, labels=labels, use_cache=False)[:2]
         else:
             # compute label smoothed loss
-            labels = inputs.pop("labels")
             logits = model(**inputs, use_cache=False)[0]
             lprobs = torch.nn.functional.log_softmax(logits, dim=-1)
             loss, _ = label_smoothed_nll_loss(

--- a/examples/seq2seq/test_finetune_trainer.py
+++ b/examples/seq2seq/test_finetune_trainer.py
@@ -63,7 +63,9 @@ class TestFinetuneTrainer(TestCasePlus):
         tokenizer = BertTokenizer.from_pretrained("bert-base-uncased")
 
         bert2bert.config.vocab_size = bert2bert.config.encoder.vocab_size
+        bert2bert.config.eos_token_id = tokenizer.sep_token_id
         bert2bert.config.decoder_start_token_id = tokenizer.cls_token_id
+        bert2bert.config.max_length = 128
 
         train_dataset = datasets.load_dataset("cnn_dailymail", "3.0.0", split="train[:1%]")
         val_dataset = datasets.load_dataset("cnn_dailymail", "3.0.0", split="validation[:1%]")


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR adds padding for models without padding token as well. The logic is the following:

1) If model predicts `targets` < `max_length` => model has to have at least an `eos_token_id`. If model has no `config.pad_token_id` defined than the model simply uses the `config.eos_token_id` for padding.

2) If the model has no `config.eos_token_id`, => model cannot generate predictions shorter than `max_length`. In this case padding will never happen.

@sshleifer @patil-suraj - you guys were right -> the `Trainer` requires padding in any case (also if model has no padding token).
Could you guys review this PR and see if these fixes in Seq2Seq Trainer are ok for you?

