### PR TITLE
Automatically cuts input if the pipeline position_ids can't handle it.

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -707,8 +707,8 @@ class Pipeline(_ScikitCompat):
         Returns:
             Numpy array
         """
-        # Encode for forward
-        if self.model.config.max_position_embeddings:
+        # Check the input is not too long relative for the model.
+        if getattr(self.model.config, "max_position_embeddings", None):
             max_length = self.model.config.max_position_embeddings
             length = inputs.data["input_ids"].shape[1]
             if length > max_length:
@@ -721,6 +721,8 @@ class Pipeline(_ScikitCompat):
                 for key in inputs.data:
                     tensor = inputs.data[key]
                     inputs.data[key] = tensor[:, :max_length]
+
+        # Encode for forward
         with self.device_placement():
             if self.framework == "tf":
                 # TODO trace model

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -88,8 +88,8 @@ def is_pipeline_test(test_case):
     """
     Decorator marking a test as a pipeline test.
 
-    Pipeline tests are skipped by default and we can run only them by setting RUN_PIPELINE_TESTS environment variable to
-    a truthy value and selecting the is_pipeline_test pytest mark.
+    Pipeline tests are skipped by default and we can run only them by setting RUN_PIPELINE_TESTS environment variable
+    to a truthy value and selecting the is_pipeline_test pytest mark.
 
     """
     if not _run_pipeline_tests:

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -88,7 +88,7 @@ def is_pipeline_test(test_case):
     """
     Decorator marking a test as a pipeline test.
 
-    Pipeline tests are skipped by default and we can run only them by setting RUN_PIPELINE_TEST environment variable to
+    Pipeline tests are skipped by default and we can run only them by setting RUN_PIPELINE_TESTS environment variable to
     a truthy value and selecting the is_pipeline_test pytest mark.
 
     """

--- a/tests/test_pipelines_sentiment_analysis.py
+++ b/tests/test_pipelines_sentiment_analysis.py
@@ -1,5 +1,11 @@
 import unittest
 
+import pytest
+
+from transformers import pipeline
+from transformers.pipelines import PipelineWarning
+from transformers.testing_utils import require_torch
+
 from .test_pipelines_common import MonoInputPipelineCommonMixin
 
 
@@ -10,3 +16,23 @@ class SentimentAnalysisPipelineTests(MonoInputPipelineCommonMixin, unittest.Test
     ]  # Default model - Models tested without the @slow decorator
     large_models = [None]  # Models tested with the @slow decorator
     mandatory_keys = {"label", "score"}  # Keys which should be in the output
+
+    @require_torch
+    def test_input_too_long(self):
+        model = self.small_models[0]
+        pipe = pipeline(self.pipeline_task, model=model)
+
+        with pytest.warns(PipelineWarning, match=r".*truncated.*"):
+            pipe(
+                """
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. At ultrices mi tempus imperdiet nulla malesuada. Nam libero justo laoreet sit amet cursus. Libero volutpat sed cras ornare arcu dui. Nunc aliquet bibendum enim facilisis gravida neque convallis. Odio pellentesque diam volutpat commodo sed egestas. Malesuada nunc vel risus commodo viverra maecenas accumsan. Id semper risus in hendrerit gravida. Habitant morbi tristique senectus et netus. Habitant morbi tristique senectus et netus. Id semper risus in hendrerit gravida rutrum quisque non. Faucibus vitae aliquet nec ullamcorper sit amet risus nullam eget. Non pulvinar neque laoreet suspendisse interdum consectetur libero id. Quis commodo odio aenean sed adipiscing diam. Ut diam quam nulla porttitor massa id. Posuere lorem ipsum dolor sit amet consectetur. Sollicitudin nibh sit amet commodo nulla facilisi nullam vehicula. Mattis rhoncus urna neque viverra justo nec. Odio ut sem nulla pharetra diam sit amet.
+
+Magna fringilla urna porttitor rhoncus dolor. Lorem ipsum dolor sit amet consectetur adipiscing elit duis tristique. Sit amet consectetur adipiscing elit. Auctor elit sed vulputate mi sit. Ac turpis egestas sed tempus. Ut aliquam purus sit amet. Id semper risus in hendrerit gravida rutrum. A diam sollicitudin tempor id eu. Lorem ipsum dolor sit amet. Enim neque volutpat ac tincidunt. Dictum sit amet justo donec enim diam. Sapien faucibus et molestie ac. Dictum sit amet justo donec enim diam vulputate ut pharetra. Porttitor eget dolor morbi non arcu risus. Viverra nam libero justo laoreet. Consectetur purus ut faucibus pulvinar. Nunc mi ipsum faucibus vitae aliquet nec ullamcorper sit amet. Auctor eu augue ut lectus arcu. Ultricies mi eget mauris pharetra et ultrices. Volutpat diam ut venenatis tellus.
+
+Tortor at auctor urna nunc id cursus. Massa eget egestas purus viverra accumsan in nisl. Sed lectus vestibulum mattis ullamcorper velit sed ullamcorper. Morbi tincidunt ornare massa eget egestas. Tincidunt vitae semper quis lectus nulla at. Viverra nam libero justo laoreet sit amet cursus sit. A iaculis at erat pellentesque. A pellentesque sit amet porttitor eget dolor morbi non. Massa sed elementum tempus egestas sed sed risus pretium quam. Ac turpis egestas maecenas pharetra convallis. Nisi quis eleifend quam adipiscing vitae proin.
+
+Morbi enim nunc faucibus a. Vel quam elementum pulvinar etiam non quam. Egestas dui id ornare arcu odio ut. Ut ornare lectus sit amet est placerat in. Ut pharetra sit amet aliquam id diam. Arcu ac tortor dignissim convallis aenean et tortor at risus. Phasellus faucibus scelerisque eleifend donec pretium vulputate sapien nec sagittis. Vestibulum rhoncus est pellentesque elit ullamcorper dignissim. Eros in cursus turpis massa tincidunt. Non sodales neque sodales ut etiam sit. Ultricies lacus sed turpis tincidunt id aliquet. In nisl nisi scelerisque eu ultrices vitae auctor. Eget mi proin sed libero enim sed faucibus. Orci dapibus ultrices in iaculis nunc sed augue lacus. Commodo elit at imperdiet dui accumsan sit amet. Ac odio tempor orci dapibus. Ullamcorper morbi tincidunt ornare massa eget. Sed euismod nisi porta lorem mollis aliquam.
+
+Dictumst vestibulum rhoncus est pellentesque elit ullamcorper dignissim cras tincidunt. Viverra suspendisse potenti nullam ac tortor vitae purus. Ornare massa eget egestas purus. Parturient montes nascetur ridiculus mus mauris vitae ultricies. Maecenas accumsan lacus vel facilisis. Consectetur lorem donec massa sapien faucibus et molestie. Elit ut aliquam purus sit amet luctus. Quis auctor elit sed vulputate mi sit amet mauris. Id leo in vitae turpis massa sed. Consequat ac felis donec et odio pellentesque diam volutpat commodo. Platea dictumst vestibulum rhoncus est pellentesque elit ullamcorper dignissim. Nec ultrices dui sapien eget mi proin sed libero. Quisque non tellus orci ac auctor augue.
+"""
+            )

--- a/tests/test_pipelines_sentiment_analysis.py
+++ b/tests/test_pipelines_sentiment_analysis.py
@@ -4,7 +4,7 @@ import pytest
 
 from transformers import pipeline
 from transformers.pipelines import PipelineWarning
-from transformers.testing_utils import require_torch
+from transformers.testing_utils import require_torch, slow
 
 from .test_pipelines_common import MonoInputPipelineCommonMixin
 
@@ -20,6 +20,27 @@ class SentimentAnalysisPipelineTests(MonoInputPipelineCommonMixin, unittest.Test
     @require_torch
     def test_input_too_long(self):
         model = self.small_models[0]
+        pipe = pipeline(self.pipeline_task, model=model)
+
+        with pytest.warns(PipelineWarning, match=r".*truncated.*"):
+            pipe(
+                """
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. At ultrices mi tempus imperdiet nulla malesuada. Nam libero justo laoreet sit amet cursus. Libero volutpat sed cras ornare arcu dui. Nunc aliquet bibendum enim facilisis gravida neque convallis. Odio pellentesque diam volutpat commodo sed egestas. Malesuada nunc vel risus commodo viverra maecenas accumsan. Id semper risus in hendrerit gravida. Habitant morbi tristique senectus et netus. Habitant morbi tristique senectus et netus. Id semper risus in hendrerit gravida rutrum quisque non. Faucibus vitae aliquet nec ullamcorper sit amet risus nullam eget. Non pulvinar neque laoreet suspendisse interdum consectetur libero id. Quis commodo odio aenean sed adipiscing diam. Ut diam quam nulla porttitor massa id. Posuere lorem ipsum dolor sit amet consectetur. Sollicitudin nibh sit amet commodo nulla facilisi nullam vehicula. Mattis rhoncus urna neque viverra justo nec. Odio ut sem nulla pharetra diam sit amet.
+
+Magna fringilla urna porttitor rhoncus dolor. Lorem ipsum dolor sit amet consectetur adipiscing elit duis tristique. Sit amet consectetur adipiscing elit. Auctor elit sed vulputate mi sit. Ac turpis egestas sed tempus. Ut aliquam purus sit amet. Id semper risus in hendrerit gravida rutrum. A diam sollicitudin tempor id eu. Lorem ipsum dolor sit amet. Enim neque volutpat ac tincidunt. Dictum sit amet justo donec enim diam. Sapien faucibus et molestie ac. Dictum sit amet justo donec enim diam vulputate ut pharetra. Porttitor eget dolor morbi non arcu risus. Viverra nam libero justo laoreet. Consectetur purus ut faucibus pulvinar. Nunc mi ipsum faucibus vitae aliquet nec ullamcorper sit amet. Auctor eu augue ut lectus arcu. Ultricies mi eget mauris pharetra et ultrices. Volutpat diam ut venenatis tellus.
+
+Tortor at auctor urna nunc id cursus. Massa eget egestas purus viverra accumsan in nisl. Sed lectus vestibulum mattis ullamcorper velit sed ullamcorper. Morbi tincidunt ornare massa eget egestas. Tincidunt vitae semper quis lectus nulla at. Viverra nam libero justo laoreet sit amet cursus sit. A iaculis at erat pellentesque. A pellentesque sit amet porttitor eget dolor morbi non. Massa sed elementum tempus egestas sed sed risus pretium quam. Ac turpis egestas maecenas pharetra convallis. Nisi quis eleifend quam adipiscing vitae proin.
+
+Morbi enim nunc faucibus a. Vel quam elementum pulvinar etiam non quam. Egestas dui id ornare arcu odio ut. Ut ornare lectus sit amet est placerat in. Ut pharetra sit amet aliquam id diam. Arcu ac tortor dignissim convallis aenean et tortor at risus. Phasellus faucibus scelerisque eleifend donec pretium vulputate sapien nec sagittis. Vestibulum rhoncus est pellentesque elit ullamcorper dignissim. Eros in cursus turpis massa tincidunt. Non sodales neque sodales ut etiam sit. Ultricies lacus sed turpis tincidunt id aliquet. In nisl nisi scelerisque eu ultrices vitae auctor. Eget mi proin sed libero enim sed faucibus. Orci dapibus ultrices in iaculis nunc sed augue lacus. Commodo elit at imperdiet dui accumsan sit amet. Ac odio tempor orci dapibus. Ullamcorper morbi tincidunt ornare massa eget. Sed euismod nisi porta lorem mollis aliquam.
+
+Dictumst vestibulum rhoncus est pellentesque elit ullamcorper dignissim cras tincidunt. Viverra suspendisse potenti nullam ac tortor vitae purus. Ornare massa eget egestas purus. Parturient montes nascetur ridiculus mus mauris vitae ultricies. Maecenas accumsan lacus vel facilisis. Consectetur lorem donec massa sapien faucibus et molestie. Elit ut aliquam purus sit amet luctus. Quis auctor elit sed vulputate mi sit amet mauris. Id leo in vitae turpis massa sed. Consequat ac felis donec et odio pellentesque diam volutpat commodo. Platea dictumst vestibulum rhoncus est pellentesque elit ullamcorper dignissim. Nec ultrices dui sapien eget mi proin sed libero. Quisque non tellus orci ac auctor augue.
+"""
+            )
+
+    @require_torch
+    @slow
+    def test_input_too_long_roberta_openai_detector(self):
+        model = "roberta-base-openai-detector"
         pipe = pipeline(self.pipeline_task, model=model)
 
         with pytest.warns(PipelineWarning, match=r".*truncated.*"):

--- a/tests/test_pipelines_translation.py
+++ b/tests/test_pipelines_translation.py
@@ -3,6 +3,7 @@ import unittest
 import pytest
 
 from transformers import pipeline
+from transformers.pipelines import PipelineWarning
 from transformers.testing_utils import is_pipeline_test, require_torch, slow
 
 from .test_pipelines_common import MonoInputPipelineCommonMixin
@@ -44,7 +45,7 @@ class TranslationNewFormatPipelineTests(unittest.TestCase):
     @require_torch
     def test_translation_default_language_selection(self):
         model = "patrickvonplaten/t5-tiny-random"
-        with pytest.warns(UserWarning, match=r".*translation_en_to_de.*"):
+        with pytest.warns(PipelineWarning, match=r".*translation_en_to_de.*"):
             nlp = pipeline(task="translation", model=model)
         self.assertEqual(nlp.task, "translation_en_to_de")
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Currently the failure is `index out of range in self`.  (it fails in pytorch position_embeddings call).
The current PR aims to simply cut the input to the pipeline if the pipeline can't handle it with a warning to the user.

It feels better than the bad error message. As for triggering an error, it seems correct for the underlying model (it can't handle
the input). But, it seems a bit off to trigger the error for the pipeline as there is no way of knowing how to trim the input
for the user as he does not inputs tokens himself. Automatically cutting with a warning seems a bit better from
a usage standpoint.

This PR also improve a docstring which had a typo.
It also adds a new `PipelineWarning` because there are now 2 instances of such warnings and there should be more in the
future so enabling users to catch those warnings seems like a good idea.



## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to the it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors which may be interested in your PR.

@patrickvonplaten
@lhoestq

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

 albert, bert, XLM: @LysandreJik
 GPT2: @LysandreJik, @patrickvonplaten
 tokenizers: @mfuntowicz
 Trainer: @sgugger
 Benchmarks: @patrickvonplaten
 Model Cards: @julien-c
 Translation: @sshleifer
 Summarization: @sshleifer
 examples/distillation: @VictorSanh
 nlp datasets: [different repo](https://github.com/huggingface/nlp)
 rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
 Text Generation: @patrickvonplaten, @TevenLeScao
 Blenderbot, Bart, Marian, Pegasus: @sshleifer
 T5: @patrickvonplaten
 Rag: @patrickvonplaten, @lhoestq
 EncoderDecoder: @patrickvonplaten
 Longformer, Reformer: @patrickvonplaten
 TransfoXL, XLNet: @TevenLeScao, @patrickvonplaten
 examples/seq2seq: @sshleifer
 examples/bert-loses-patience: @JetRunner
 tensorflow: @jplu
 examples/token-classification: @stefan-it
 documentation: @sgugger
 -->