### PR TITLE
Fix label name in DataCollatorForNextSentencePrediction test

### DIFF
--- a/tests/test_data_collator.py
+++ b/tests/test_data_collator.py
@@ -175,7 +175,7 @@ class DataCollatorIntegrationTest(unittest.TestCase):
         total_samples = batch["input_ids"].shape[0]
         self.assertEqual(batch["input_ids"].shape, torch.Size((total_samples, 512)))
         self.assertEqual(batch["token_type_ids"].shape, torch.Size((total_samples, 512)))
-        self.assertEqual(batch["masked_lm_labels"].shape, torch.Size((total_samples, 512)))
+        self.assertEqual(batch["labels"].shape, torch.Size((total_samples, 512)))
         self.assertEqual(batch["next_sentence_label"].shape, torch.Size((total_samples,)))
 
     @slow


### PR DESCRIPTION
# What does this PR do?

Labels have been renamed in `DataCollatorForNextSentencePrediction` to go with the fact `masked_lm_labels` is a deprecated argument, but the corresponding test was not adjusted accordingly, this PR fixes that.

Fixes #8034