### PR TITLE
Fix + Test

### DIFF
--- a/src/transformers/tokenization_blenderbot.py
+++ b/src/transformers/tokenization_blenderbot.py
@@ -166,6 +166,9 @@ class BlenderbotSmallTokenizer(PreTrainedTokenizer):
         tokens = token.split(" ")
         words = []
         for token in tokens:
+            if not len(token):
+                continue
+
             token = token.lower()
             word = tuple(token)
             word = tuple(list(word[:-1]) + [word[-1] + "</w>"])

--- a/tests/test_tokenization_blenderbot.py
+++ b/tests/test_tokenization_blenderbot.py
@@ -75,6 +75,15 @@ class BlenderbotSmallTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         assert src_text != decoded  # I wish it did!
         assert decoded == "i am a small frog ."
 
+    def test_empty_word_small_tok(self):
+        tok = BlenderbotSmallTokenizer.from_pretrained("facebook/blenderbot-90M")
+        src_text = "I am a small frog ."
+        src_text_dot = "."
+        encoded = tok(src_text)["input_ids"]
+        encoded_dot = tok(src_text_dot)["input_ids"]
+
+        assert encoded[-1] == encoded_dot[0]
+
 
 class Blenderbot3BTokenizerTests(unittest.TestCase):
     @cached_property


### PR DESCRIPTION
Fix an edge case of the blenderbot-90 tokenizer.

Closes #8029 

# Context

If the blenderbot-90 tokenizer is used to tokenize the following sequence:
```py
sequence = "Ok ."
```
It will split it in two tokens at first:
https://github.com/huggingface/transformers/blob/8bbe8247f13057b7df1b2c9abbfacb05b30020bf/src/transformers/tokenization_blenderbot.py#L221

Those two tokens will be `['Ok', '.']`

The issue is that, when passed the second token, the `bpe` method will convert it from `'.'` to `' .'` here:
https://github.com/huggingface/transformers/blob/8bbe8247f13057b7df1b2c9abbfacb05b30020bf/src/transformers/tokenization_blenderbot.py#L160

This then gets split on spaces here:
https://github.com/huggingface/transformers/blob/8bbe8247f13057b7df1b2c9abbfacb05b30020bf/src/transformers/tokenization_blenderbot.py#L166

This is where the issue lies, as it creates two strings: `["", "."]`, the first one being empty.

It then crashes a bit further as we try to index the empty string:
https://github.com/huggingface/transformers/blob/8bbe8247f13057b7df1b2c9abbfacb05b30020bf/src/transformers/tokenization_blenderbot.py#L171

## Proposal

Ensure that the token has a length > 0 before trying to manage it, otherwise ignore that token.

Added a test.


