### PR TITLE
invalid argument wwm passed to the run_language_modeling.py file

### DIFF
--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -60,7 +60,7 @@ python run_language_modeling.py \
     --do_eval \
     --eval_data_file=$TEST_FILE \
     --mlm \
-    --wwm
+    --whole_word_mask
 ```
 
 For Chinese models, it's same with English model with only --mlm`. If using whole-word masking, we need to generate a reference files, case it's char level.
@@ -107,7 +107,7 @@ python run_language_modeling.py \
     --eval_data_file=$TEST_FILE \
     --mlm \
     --line_by_line \
-    --wwm
+    --whole_word_mask
 ```
 
 ### XLNet and permutation language modeling


### PR DESCRIPTION


# What does this PR do?
--wwm cant be used as an argument given run_language_modeling.py and should be changed to --whole_word_mask
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->




## Before submitting
- [x ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

@stefan-it