### PR TITLE
Fix a bug for `CallbackHandler.callback_list`

### DIFF
--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -325,7 +325,7 @@ class CallbackHandler(TrainerCallback):
 
     @property
     def callback_list(self):
-        return "\n".join(self.callbacks)
+        return "\n".join(cb.__class__.__name__ for cb in self.callbacks)
 
     def on_init_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
         return self.call_event("on_init_end", args, state, control)

--- a/tests/test_trainer_callback.py
+++ b/tests/test_trainer_callback.py
@@ -227,4 +227,4 @@ class TrainerCallbackTest(unittest.TestCase):
             trainer = self.get_trainer(
                 callbacks=[MyTestTrainerCallback, MyTestTrainerCallback],
             )
-            assert str(MyTestTrainerCallback) in warn_mock.call_args.args[0]
+            assert str(MyTestTrainerCallback) in warn_mock.call_args[0][0]

--- a/tests/test_trainer_callback.py
+++ b/tests/test_trainer_callback.py
@@ -221,3 +221,10 @@ class TrainerCallbackTest(unittest.TestCase):
         trainer.train()
         events = trainer.callback_handler.callbacks[-2].events
         self.assertEqual(events, self.get_expected_events(trainer))
+
+        # warning should be emitted for duplicated callbacks
+        with unittest.mock.patch("transformers.trainer_callback.logger.warn") as warn_mock:
+            trainer = self.get_trainer(
+                callbacks=[MyTestTrainerCallback, MyTestTrainerCallback],
+            )
+            assert str(MyTestTrainerCallback) in warn_mock.call_args.args[0]


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fix a bug where `CallbackHandler.callback_list` fails when given callbacks are duplicated:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-40-9605b122f4d1> in <module>()
      2 from transformers.trainer import DEFAULT_CALLBACKS
      3 
----> 4 CallbackHandler(DEFAULT_CALLBACKS + [MLflowCallback], "model", "optimizer", "lr_scheduler")

2 frames
/usr/local/lib/python3.6/dist-packages/transformers/trainer_callback.py in __init__(self, callbacks, model, optimizer, lr_scheduler)
    277         self.callbacks = []
    278         for cb in callbacks:
--> 279             self.add_callback(cb)
    280         self.model = model
    281         self.optimizer = optimizer

/usr/local/lib/python3.6/dist-packages/transformers/trainer_callback.py in add_callback(self, callback)
    299                 f"You are adding a {cb_class} to the callbacks of this Trainer, but there is already one. The current"
    300                 + "list of callbacks is\n:"
--> 301                 + self.callback_list
    302             )
    303         self.callbacks.append(cb)

/usr/local/lib/python3.6/dist-packages/transformers/trainer_callback.py in callback_list(self)
    326     @property
    327     def callback_list(self):
--> 328         return "\n".join(self.callbacks)
    329 
    330     def on_init_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):

TypeError: sequence item 0: expected str instance, DefaultFlowCallback found
```

Code to reproduce the bug:

```python
from transformers.trainer_callback import CallbackHandler
from transformers.trainer import DEFAULT_CALLBACKS

CallbackHandler(DEFAULT_CALLBACKS + [MLflowCallback], "model", "optimizer", "lr_scheduler")
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to the it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sgugger

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors which may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

 albert, bert, XLM: @LysandreJik
 GPT2: @LysandreJik, @patrickvonplaten
 tokenizers: @mfuntowicz
 Trainer: @sgugger
 Benchmarks: @patrickvonplaten
 Model Cards: @julien-c
 Translation: @sshleifer
 Summarization: @sshleifer
 examples/distillation: @VictorSanh
 nlp datasets: [different repo](https://github.com/huggingface/nlp)
 rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
 Text Generation: @patrickvonplaten, @TevenLeScao
 Blenderbot, Bart, Marian, Pegasus: @sshleifer
 T5: @patrickvonplaten
 Rag: @patrickvonplaten, @lhoestq
 EncoderDecoder: @patrickvonplaten
 Longformer, Reformer: @patrickvonplaten
 TransfoXL, XLNet: @TevenLeScao, @patrickvonplaten
 examples/seq2seq: @sshleifer
 examples/bert-loses-patience: @JetRunner
 tensorflow: @jplu
 examples/token-classification: @stefan-it
 documentation: @sgugger
 -->
