### PR TITLE
[testing] fixing crash in deberta

### DIFF
--- a/src/transformers/modeling_deberta.py
+++ b/src/transformers/modeling_deberta.py
@@ -571,8 +571,8 @@ class DisentangledSelfAttention(torch.nn.Module):
             k, v = [linear(qkvw[i], qkvb[i], hidden_states) for i in range(1, 3)]
             query_layer, key_layer, value_layer = [self.transpose_for_scores(x) for x in [q, k, v]]
 
-        query_layer += self.transpose_for_scores(self.q_bias[None, None, :])
-        value_layer += self.transpose_for_scores(self.v_bias[None, None, :])
+        query_layer = query_layer + self.transpose_for_scores(self.q_bias[None, None, :])
+        value_layer = value_layer + self.transpose_for_scores(self.v_bias[None, None, :])
 
         rel_att = None
         # Take the dot product between "query" and "key" to get the raw attention scores.


### PR DESCRIPTION
This PR fixes a crash in deberta tests w/ pytorch-1.7+:
```
RuntimeError: diff_view_meta->output_nr_ == 0 INTERNAL ASSERT FAILED at "/opt/conda/conda- \ 
bld/pytorch_1603436966316/work/torch/csrc/autograd/variable.cpp":363, please report a bug to PyTorch.
```

All credits go to @gchanan, thank you! For details of why please see https://github.com/huggingface/transformers/issues/8022#issuecomment-716252599

Fixes: #8022