### PR TITLE
Fix TF training arguments instantiation

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -351,7 +351,7 @@ class TrainingArguments:
         if self.run_name is None:
             self.run_name = self.output_dir
 
-        if self.device.type != "cuda" and self.fp16:
+        if is_torch_available() and self.device.type != "cuda" and self.fp16:
             raise ValueError("AMP (`--fp16`) can only be used on CUDA devices.")
 
     @property


### PR DESCRIPTION
Check that pytorch is installed before checking the device type.