### PR TITLE
[QOL] PretrainedConfig.to_diff_dict(other_config)

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -467,19 +467,26 @@ class PretrainedConfig(object):
     def __repr__(self):
         return "{} {}".format(self.__class__.__name__, self.to_json_string())
 
-    def to_diff_dict(self) -> Dict[str, Any]:
+    def to_diff_dict(self, default_config_dict=None) -> Dict[str, Any]:
         """
         Removes all attributes from config which correspond to the default
         config attributes for better readability and serializes to a Python
         dictionary.
+        Args:
+            default_config_dict: (:obj:`Union[PretrainedConfig, Dict]`, `optional`):
+                The config (or dictionary) that this object should should be compared to.
+                By default the instance is compared to :obj:`PretrainedConfig` defaults
 
         Returns:
-            :obj:`Dict[str, Any]`: Dictionary of all the attributes that make up this configuration instance,
+            :obj:`Dict[str, Any]`: Dictionary of all configuration values that differ from the default.
+
         """
         config_dict = self.to_dict()
-
-        # get the default config dict
-        default_config_dict = PretrainedConfig().to_dict()
+        if default_config_dict is None:
+            # get the default config dict
+            default_config_dict = PretrainedConfig().to_dict()
+        elif isinstance(default_config_dict, PretrainedConfig):
+            default_config_dict = default_config_dict.to_dict()
 
         # get class specific config dict
         class_config_dict = self.__class__().to_dict() if not self.is_composition else {}

--- a/tests/test_configuration_auto.py
+++ b/tests/test_configuration_auto.py
@@ -51,3 +51,14 @@ class AutoConfigTest(unittest.TestCase):
         keys = list(CONFIG_MAPPING.keys())
         for i, key in enumerate(keys):
             self.assertFalse(any(key in later_key for later_key in keys[i + 1 :]))
+
+    def test_pretrained_config_to_diff_dict(self):
+        """Test that PretrainedConfig.to_diff_dict() supports a default_config_dct argument."""
+        bart_base = AutoConfig.from_pretrained("facebook/bart-base")
+        bert_uncased = AutoConfig.from_pretrained("bert-base-uncased", vocab_size=bart_base.vocab_size)
+        bart_diff = bart_base.to_diff_dict()
+        assert "vocab_size" in bart_diff
+        bart_vs_bert = bart_base.to_diff_dict(bert_uncased)
+        assert "vocab_size" not in bart_vs_bert
+        # Check dict support
+        assert bart_vs_bert == bart_base.to_diff_dict(bert_uncased.to_dict())


### PR DESCRIPTION
This PR allows users to compare two configs in a backwards compatible way. 
### Solution
The following calls work:
```python
bart_large_config = BartConfig.from_pretrained('facebook/bart-large')
bart_base_config = BartConfig.from_pretrained('facebook/bart-base')
t5_config = T5Config.from_pretrained('t5-small')
bart_large_config.to_diff_dict() # unchanged
bart_large_config.to_diff_dict(bart_base_config) # compares configs
bart_large_config.to_diff_dict(t5_config) # can be across subtypes
bart_large_config.to_diff_dict(bart_base_config.to_dict()) # can be against dict
```

Adds test that outputs are reasonable.
### Problem
Current best way to compare configs is to define your own function. Here is the one I use. Also good for debugging conversion scripts:

```python
def dct_differences(dct_a, dct_b):
    SENTINEL = '__MissingKey'
    k1, k2 = set(dct_a), set(dct_b) # just the keys
    deltas = []
    for k in k1.union(k2):
        vala, valb = dct_a.get(k, SENTINEL), dct_b.get(k, SENTINEL)
        # TODO(SS): nested dicts? Maybe better to dump to json and compare (after sorting keys!)
        if vala == valb:
            if (vala == SENTINEL and valb == SENTINEL): raise AssertionError('Adversarial Sentinel Input!')
        else:
            deltas.append((k, vala, valb))
    return deltas
bart_large_config = BartConfig.from_pretrained('facebook/bart-large')
bart_base_config = BartConfig.from_pretrained('facebook/bart-base')
delta =  dct_differences(bart_large_config.to_dict(), bart_base_config.to_dict())
```
this implementation is almost as useful without breaking backwards compatibility.