### PR TITLE
Move style_doc to extra_quality_checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ modified_only_fixup:
 		black $(modified_py_files); \
 		isort $(modified_py_files); \
 		flake8 $(modified_py_files); \
-		python utils/style_doc.py $(modified_py_files) --max_len 119; \
 	else \
 		echo "No library .py files were modified"; \
 	fi
@@ -26,6 +25,7 @@ extra_quality_checks:
 	python utils/check_copies.py
 	python utils/check_dummies.py
 	python utils/check_repo.py
+	python utils/style_doc.py src/transformers docs/source --max_len 119
 
 # this target runs checks on all files
 quality:


### PR DESCRIPTION
Previously, if you have a doc style error in a .rst file,
```bash
python utils/style_doc.py $(modified_py_files) --max_len 119;
```
 wouldn't catch it