### PR TITLE
[gh actions] run artifacts job always

### DIFF
--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -84,6 +84,7 @@ jobs:
           python -m pytest -n 1 --dist=loadfile -s -m is_pipeline_test --make_reports=tests_pipeline tests 
 
       - name: test suite reports artifacts
+        if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: test_reports


### PR DESCRIPTION
I see that the recently added artifacts job won't run if the test job failed, which defeats the purpose. ([example](https://github.com/huggingface/transformers/runs/1317972448?check_suite_focus=true))

After some research it appears that adding `if: always()` may do the trick. Supposedly such a job should always be run regardless of the outcome of the previous jobs. Found it [here](https://github.community/t/continue-on-error-allow-failure-ui-indication/16773/2?u=stas00), documented [here](https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#always).

Let's merge and see if it fixes the issue.

@LysandreJik, @sgugger, @sshleifer 