### PR TITLE
Add labels padding in tokenization_utils_base.py

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2916,6 +2916,8 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
                     encoded_inputs["token_type_ids"] = (
                         encoded_inputs["token_type_ids"] + [self.pad_token_type_id] * difference
                     )
+                if "labels" in encoded_inputs:
+                    encoded_inputs["labels"] = encoded_inputs["labels"] + [-100] * difference
                 if "special_tokens_mask" in encoded_inputs:
                     encoded_inputs["special_tokens_mask"] = encoded_inputs["special_tokens_mask"] + [1] * difference
                 encoded_inputs["input_ids"] = encoded_inputs["input_ids"] + [self.pad_token_id] * difference
@@ -2926,6 +2928,8 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
                     encoded_inputs["token_type_ids"] = [self.pad_token_type_id] * difference + encoded_inputs[
                         "token_type_ids"
                     ]
+                if "labels" in encoded_inputs:
+                    encoded_inputs["labels"] = [-100] * difference + encoded_inputs["labels"]
                 if "special_tokens_mask" in encoded_inputs:
                     encoded_inputs["special_tokens_mask"] = [1] * difference + encoded_inputs["special_tokens_mask"]
                 encoded_inputs["input_ids"] = [self.pad_token_id] * difference + encoded_inputs["input_ids"]


### PR DESCRIPTION
# What does this PR do?

This PR makes `tokenizer.pad()` also pad `'labels'`.

I tried to use this:
https://github.com/huggingface/transformers/blob/8065fea87007fbf7542fc060ff8ddd0b5df567da/src/transformers/data/data_collator.py#L69 

But since labels is not padded, the result cannot turn into a tensor. `ValueError: Unable to create tensor, you should probably activate truncation and/or padding with 'padding=True' 'truncation=True' to have batched tensors with the same lengt
h.
`
This patch solves the problem.

It seems logical to me that `tokenizer.pad()` should also pad `'labels'`. 



This portion of code is last changed in #4015 @n1t0 @thomwolf @LysandreJik 