### PR TITLE
[DOC] Improve pipeline() docstrings for config and tokenizer

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -2734,9 +2734,9 @@ def pipeline(
             identifier or an actual pretrained model configuration inheriting from
             :class:`~transformers.PretrainedConfig`.
 
-            If not provided, the default configuration file for the requested model will be used: either the given
-            :obj:`model`'s configuration, or - if no :obj:`model` was given - this :obj:`task`'s default model's
-            config.
+            If not provided, the default configuration file for the requested model will be used. That means that if
+            :obj:`model` is given, its default configuration will be used. However, if :obj:`model` is not supplied,
+            this :obj:`task`'s default model's config is used instead.
         tokenizer (:obj:`str` or :obj:`~transformers.PreTrainedTokenizer`, `optional`):
             The tokenizer that will be used by the pipeline to encode data for the model. This can be a model
             identifier or an actual pretrained tokenizer inheriting from :class:`~transformers.PreTrainedTokenizer`.

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -2734,12 +2734,17 @@ def pipeline(
             identifier or an actual pretrained model configuration inheriting from
             :class:`~transformers.PretrainedConfig`.
 
-            If not provided, the default for the :obj:`task` will be loaded.
+            If not provided, the default configuration file for the requested model will be used: either the given 
+            :obj:`model`'s configuration, or - if no :obj:`model` was given - this :obj:`task`'s default model's 
+            config.
         tokenizer (:obj:`str` or :obj:`~transformers.PreTrainedTokenizer`, `optional`):
             The tokenizer that will be used by the pipeline to encode data for the model. This can be a model
             identifier or an actual pretrained tokenizer inheriting from :class:`~transformers.PreTrainedTokenizer`.
 
-            If not provided, the default for the :obj:`task` will be loaded.
+            If not provided, the default tokenizer for the given :obj:`model` will be loaded (if it is a string).
+            If :obj:`model` is not specified or not a string, then the default tokenizer for :obj:`config` is loaded
+            (if it is a string). However, if :obj:`config` is also not given or not a string, then the default
+            tokenizer for the given :obj:`task` will be loaded.
         framework (:obj:`str`, `optional`):
             The framework to use, either :obj:`"pt"` for PyTorch or :obj:`"tf"` for TensorFlow. The specified framework
             must be installed.

--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -2734,17 +2734,17 @@ def pipeline(
             identifier or an actual pretrained model configuration inheriting from
             :class:`~transformers.PretrainedConfig`.
 
-            If not provided, the default configuration file for the requested model will be used: either the given 
-            :obj:`model`'s configuration, or - if no :obj:`model` was given - this :obj:`task`'s default model's 
+            If not provided, the default configuration file for the requested model will be used: either the given
+            :obj:`model`'s configuration, or - if no :obj:`model` was given - this :obj:`task`'s default model's
             config.
         tokenizer (:obj:`str` or :obj:`~transformers.PreTrainedTokenizer`, `optional`):
             The tokenizer that will be used by the pipeline to encode data for the model. This can be a model
             identifier or an actual pretrained tokenizer inheriting from :class:`~transformers.PreTrainedTokenizer`.
 
-            If not provided, the default tokenizer for the given :obj:`model` will be loaded (if it is a string).
-            If :obj:`model` is not specified or not a string, then the default tokenizer for :obj:`config` is loaded
-            (if it is a string). However, if :obj:`config` is also not given or not a string, then the default
-            tokenizer for the given :obj:`task` will be loaded.
+            If not provided, the default tokenizer for the given :obj:`model` will be loaded (if it is a string). If
+            :obj:`model` is not specified or not a string, then the default tokenizer for :obj:`config` is loaded (if
+            it is a string). However, if :obj:`config` is also not given or not a string, then the default tokenizer
+            for the given :obj:`task` will be loaded.
         framework (:obj:`str`, `optional`):
             The framework to use, either :obj:`"pt"` for PyTorch or :obj:`"tf"` for TensorFlow. The specified framework
             must be installed.


### PR DESCRIPTION
As currently written, it was not clear to me which arguments were needed when using a non-default model in `pipeline()`. It seemed that when you provided a non-default `model`, that you still needed to manually change the `config` and `tokenizer` because otherwise the "task's default will be used". In practice, though, the pipeline is smart enough to automatically choose the right config/tokenizer for the given model. This PR clarifies that a bit in the docstrings/documentation, by explaining exactly which priorities are used when loading the tokenizer. A small change was made for `config`, too.

Admittedly, the wording for the tokenizer part is a bit off (programmatical, even), but I think it should make clear how the right tokenizer is loaded.

cc @sgugger 