### PR TITLE
Name or path should be added on configuration as well

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -361,6 +361,9 @@ class PretrainedConfig(object):
         proxies = kwargs.pop("proxies", None)
         local_files_only = kwargs.pop("local_files_only", False)
 
+        if "pretrained_model_name_or_path" not in kwargs:
+            kwargs["pretrained_model_name_or_path"] = pretrained_model_name_or_path
+
         if os.path.isdir(pretrained_model_name_or_path):
             config_file = os.path.join(pretrained_model_name_or_path, CONFIG_NAME)
         elif os.path.isfile(pretrained_model_name_or_path) or is_remote_url(pretrained_model_name_or_path):
@@ -430,6 +433,9 @@ class PretrainedConfig(object):
 
         if hasattr(config, "pruned_heads"):
             config.pruned_heads = dict((int(key), value) for key, value in config.pruned_heads.items())
+
+        if "pretrained_model_name_or_path" in kwargs:
+            config.name_or_path = kwargs.pop("pretrained_model_name_or_path")
 
         # Update config with kwargs if needed
         to_remove = []

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -618,6 +618,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
         local_files_only = kwargs.pop("local_files_only", False)
         use_cdn = kwargs.pop("use_cdn", True)
         mirror = kwargs.pop("mirror", None)
+        kwargs["pretrained_model_name_or_path"] = pretrained_model_name_or_path
 
         # Load config if we don't provide a configuration
         if not isinstance(config, PretrainedConfig):
@@ -635,6 +636,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
             )
         else:
             model_kwargs = kwargs
+            config.name_or_path = kwargs.pop("pretrained_model_name_or_path")
 
         # Load model
         if pretrained_model_name_or_path is not None:
@@ -688,8 +690,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
                 logger.info("loading weights file {} from cache at {}".format(archive_file, resolved_archive_file))
         else:
             resolved_archive_file = None
-
-        config.name_or_path = pretrained_model_name_or_path
 
         # Instantiate model.
         model = cls(config, *model_args, **model_kwargs)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -859,6 +859,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
         local_files_only = kwargs.pop("local_files_only", False)
         use_cdn = kwargs.pop("use_cdn", True)
         mirror = kwargs.pop("mirror", None)
+        kwargs["pretrained_model_name_or_path"] = pretrained_model_name_or_path
 
         # Load config if we don't provide a configuration
         if not isinstance(config, PretrainedConfig):
@@ -876,6 +877,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
             )
         else:
             model_kwargs = kwargs
+            config.name_or_path = kwargs.pop("pretrained_model_name_or_path")
 
         # Load model
         if pretrained_model_name_or_path is not None:
@@ -939,8 +941,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
                 logger.info("loading weights file {} from cache at {}".format(archive_file, resolved_archive_file))
         else:
             resolved_archive_file = None
-
-        config.name_or_path = pretrained_model_name_or_path
 
         # Instantiate model.
         model = cls(config, *model_args, **model_kwargs)


### PR DESCRIPTION
Close https://github.com/huggingface/transformers/issues/8035

Currently a configuration initialized with 
```
config = BertConfig.from_pretrained(model_name)
```
does not have the `_model_name_or_path` attribute, whereas a configuration intialized from a model with 
```py
model = BertModel.from_pretrained(model_name)
``` 
does.

This fixes the discrepancy and fixes the failing test in the process.