### PR TITLE
[examples] minimal version requirement run-time check in PL

### DIFF
--- a/examples/lightning_base.py
+++ b/examples/lightning_base.py
@@ -33,7 +33,6 @@ from transformers.optimization import (
 
 logger = logging.getLogger(__name__)
 
-# remember to update along with ./requirements.txt when there are breaking changes
 try:
     pkg = "pytorch_lightning"
     min_ver = "1.0.4"

--- a/examples/lightning_base.py
+++ b/examples/lightning_base.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 import pytorch_lightning as pl
 from pytorch_lightning.utilities import rank_zero_info
 
+import pkg_resources
 from transformers import (
     AdamW,
     AutoConfig,
@@ -31,6 +32,16 @@ from transformers.optimization import (
 
 
 logger = logging.getLogger(__name__)
+
+# remember to update along with ./requirements.txt when there are breaking changes
+try:
+    pkg = "pytorch_lightning"
+    min_ver = "1.0.4"
+    pkg_resources.require(f"{pkg}>={min_ver}")
+except pkg_resources.VersionConflict:
+    logger.warning(
+        f"{pkg}>={min_ver} is required for a normal functioning of this module, but found {pkg}=={pkg_resources.get_distribution(pkg).version}."
+    )
 
 
 MODEL_MODES = {

--- a/examples/lightning_base.py
+++ b/examples/lightning_base.py
@@ -39,7 +39,7 @@ try:
     pkg_resources.require(f"{pkg}>={min_ver}")
 except pkg_resources.VersionConflict:
     logger.warning(
-        f"{pkg}>={min_ver} is required for a normal functioning of this module, but found {pkg}=={pkg_resources.get_distribution(pkg).version}."
+        f"{pkg}>={min_ver} is required for a normal functioning of this module, but found {pkg}=={pkg_resources.get_distribution(pkg).version}. Try pip install -r examples/requirements.txt"
     )
 
 


### PR DESCRIPTION
This PR adds a run-time version check for PL. Via the warning for now. This is a follow up to https://github.com/huggingface/transformers/pull/7852#issuecomment-718144095

In the nature of development we don't constantly re-run `pip install -r requirements.txt` so often when a breaking change is introduced we have to signal to each other - hey, upgrade your PL or so. It'd be much simpler to let the program do this automatically for us.

for now one needs to update requirements.txt and the relevant .py files, but we could automate this to have one source to maintain - parse `requirements.txt` and pull the important min-version from there...

for now this is just a hardcoded plain check.

**My only suggestion is to make it an error** - there are too too many warnings in the test suite for someone to notice this yet another one - so I vote for making it an error.

@sshleifer, @sgugger, @LysandreJik 