### PR TITLE
Smarter prediction loop and no- -> no_ in console args

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -147,7 +147,6 @@ class ExamplesTests(TestCasePlus):
             --num_train_epochs 2
             --output_dir {tmp_dir}
             --overwrite_output_dir
-            --prediction_loss_only
             """.split()
 
         if torch.cuda.device_count() > 1:

--- a/src/transformers/benchmark/benchmark_args.py
+++ b/src/transformers/benchmark/benchmark_args.py
@@ -55,7 +55,7 @@ class PyTorchBenchmarkArguments(BenchmarkArguments):
                 positive_arg = deprecated_arg[3:]
                 setattr(self, positive_arg, not kwargs.pop(deprecated_arg))
                 logger.warning(
-                    f"{deprecated_arg} is depreciated. Please use --no-{positive_arg} or {positive_arg}={kwargs[positive_arg]}"
+                    f"{deprecated_arg} is depreciated. Please use --no_{positive_arg} or {positive_arg}={kwargs[positive_arg]}"
                 )
 
         self.torchscript = kwargs.pop("torchscript", self.torchscript)

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -66,7 +66,7 @@ class HfArgumentParser(ArgumentParser):
                 if field.type is bool or (field.default is not None and field.default is not dataclasses.MISSING):
                     kwargs["action"] = "store_false" if field.default is True else "store_true"
                 if field.default is True:
-                    field_name = f"--no-{field.name}"
+                    field_name = f"--no_{field.name}"
                     kwargs["dest"] = field.name
             elif hasattr(field.type, "__origin__") and issubclass(field.type.__origin__, List):
                 kwargs["nargs"] = "+"

--- a/tests/test_hf_argparser.py
+++ b/tests/test_hf_argparser.py
@@ -93,13 +93,13 @@ class HfArgumentParserTest(unittest.TestCase):
 
         expected = argparse.ArgumentParser()
         expected.add_argument("--foo", action="store_true")
-        expected.add_argument("--no-baz", action="store_false", dest="baz")
+        expected.add_argument("--no_baz", action="store_false", dest="baz")
         self.argparsersEqual(parser, expected)
 
         args = parser.parse_args([])
         self.assertEqual(args, Namespace(foo=False, baz=True))
 
-        args = parser.parse_args(["--foo", "--no-baz"])
+        args = parser.parse_args(["--foo", "--no_baz"])
         self.assertEqual(args, Namespace(foo=True, baz=False))
 
     def test_with_enum(self):


### PR DESCRIPTION
# What does this PR do?

This PR does two things:
- the first one is to replace `no-` to `no_` in the `HFArgumentParser` so that arguments get a more consistent name: for instance `use_tokenizer_fast` in the new examples script give an argument `no-use_tokenizer_fast` and the inconsistency between - and _ makes it hard to find.
- the second one is to avoid computing the predictions and labels (and storing them) in the evaluation of a `Trainer` when there is no `compute_metrics` function.