### PR TITLE
Attempt at a temporary fix on `model_max_length` for roberta and Camembert variants

### DIFF
--- a/src/transformers/tokenization_camembert.py
+++ b/src/transformers/tokenization_camembert.py
@@ -113,6 +113,9 @@ class CamembertTokenizer(PreTrainedTokenizer):
         pad_token="<pad>",
         mask_token="<mask>",
         additional_special_tokens=["<s>NOTUSED", "</s>NOTUSED"],
+        # XXX: More discussion is necessary to remove this hard coded value
+        # more info here: https://github.com/huggingface/transformers/issues/8117
+        model_max_length=512,
         **kwargs
     ):
         super().__init__(
@@ -124,6 +127,7 @@ class CamembertTokenizer(PreTrainedTokenizer):
             pad_token=pad_token,
             mask_token=mask_token,
             additional_special_tokens=additional_special_tokens,
+            model_max_length=model_max_length,
             **kwargs,
         )
         self.sp_model = spm.SentencePieceProcessor()

--- a/src/transformers/tokenization_camembert_fast.py
+++ b/src/transformers/tokenization_camembert_fast.py
@@ -14,7 +14,6 @@
 # limitations under the License
 """ Fast tokenization classes for Camembert model."""
 
-
 import os
 from shutil import copyfile
 from typing import List, Optional, Tuple
@@ -125,6 +124,9 @@ class CamembertTokenizerFast(PreTrainedTokenizerFast):
         pad_token="<pad>",
         mask_token="<mask>",
         additional_special_tokens=["<s>NOTUSED", "</s>NOTUSED"],
+        # XXX: More discussion is necessary to remove this hard coded value
+        # more info here: https://github.com/huggingface/transformers/issues/8117
+        # model_max_length=512,
         **kwargs
     ):
         super().__init__(
@@ -138,6 +140,7 @@ class CamembertTokenizerFast(PreTrainedTokenizerFast):
             pad_token=pad_token,
             mask_token=mask_token,
             additional_special_tokens=additional_special_tokens,
+            # model_max_length=model_max_length,
             **kwargs,
         )
 

--- a/src/transformers/tokenization_camembert_fast.py
+++ b/src/transformers/tokenization_camembert_fast.py
@@ -126,7 +126,7 @@ class CamembertTokenizerFast(PreTrainedTokenizerFast):
         additional_special_tokens=["<s>NOTUSED", "</s>NOTUSED"],
         # XXX: More discussion is necessary to remove this hard coded value
         # more info here: https://github.com/huggingface/transformers/issues/8117
-        # model_max_length=512,
+        model_max_length=512,
         **kwargs
     ):
         super().__init__(
@@ -140,7 +140,7 @@ class CamembertTokenizerFast(PreTrainedTokenizerFast):
             pad_token=pad_token,
             mask_token=mask_token,
             additional_special_tokens=additional_special_tokens,
-            # model_max_length=model_max_length,
+            model_max_length=model_max_length,
             **kwargs,
         )
 

--- a/src/transformers/tokenization_roberta.py
+++ b/src/transformers/tokenization_roberta.py
@@ -145,6 +145,9 @@ class RobertaTokenizer(GPT2Tokenizer):
         pad_token="<pad>",
         mask_token="<mask>",
         add_prefix_space=False,
+        # XXX: More discussion is necessary to remove this hard coded value
+        # more info here: https://github.com/huggingface/transformers/issues/8117
+        model_max_length=512,
         **kwargs
     ):
         bos_token = AddedToken(bos_token, lstrip=False, rstrip=False) if isinstance(bos_token, str) else bos_token
@@ -169,6 +172,7 @@ class RobertaTokenizer(GPT2Tokenizer):
             pad_token=pad_token,
             mask_token=mask_token,
             add_prefix_space=add_prefix_space,
+            model_max_length=model_max_length,
             **kwargs,
         )
 

--- a/src/transformers/tokenization_roberta_fast.py
+++ b/src/transformers/tokenization_roberta_fast.py
@@ -154,6 +154,9 @@ class RobertaTokenizerFast(GPT2TokenizerFast):
         pad_token="<pad>",
         mask_token="<mask>",
         add_prefix_space=False,
+        # XXX: More discussion is necessary to remove this hard coded value
+        # more info here: https://github.com/huggingface/transformers/issues/8117
+        model_max_length=512,
         **kwargs
     ):
         super().__init__(
@@ -169,6 +172,7 @@ class RobertaTokenizerFast(GPT2TokenizerFast):
             pad_token=pad_token,
             mask_token=mask_token,
             add_prefix_space=add_prefix_space,
+            model_max_length=model_max_length,
             **kwargs,
         )
 

--- a/tests/test_tokenization_camembert.py
+++ b/tests/test_tokenization_camembert.py
@@ -50,6 +50,9 @@ class CamembertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokenizer = self.get_tokenizer()
         rust_tokenizer = self.get_rust_tokenizer()
 
+        self.assertEqual(tokenizer.model_max_length, 512)
+        self.assertEqual(rust_tokenizer.model_max_length, 512)
+
         sequence = "I was born in 92000, and this is falsé."
 
         tokens = tokenizer.tokenize(sequence)

--- a/tests/test_tokenization_roberta.py
+++ b/tests/test_tokenization_roberta.py
@@ -102,6 +102,21 @@ class RobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             [0, 31414, 232, 328, 740, 1140, 12695, 69, 46078, 1588, 2],
         )
 
+    def test_model_max_length_by_default(self):
+        tokenizer = self.get_tokenizer()
+        self.assertEqual(tokenizer.model_max_length, 512)
+
+        rust_tokenizer = self.tokenizer_class.from_pretrained("roberta-base", use_fast=True)
+        self.assertEqual(rust_tokenizer.model_max_length, 512)
+
+    @slow
+    def test_model_max_length(self):
+        tokenizer = self.tokenizer_class.from_pretrained("roberta-base")
+        self.assertEqual(tokenizer.model_max_length, 512)
+
+        rust_tokenizer = self.tokenizer_class.from_pretrained("roberta-base", use_fast=True)
+        self.assertEqual(rust_tokenizer.model_max_length, 512)
+
     @slow
     def test_sequence_builders(self):
         tokenizer = self.tokenizer_class.from_pretrained("roberta-base")


### PR DESCRIPTION
- The issue is that this information is not contained in the
`tokenizer` config file.
- It used to be harcoded already (with 512 value too).
- It is unclear right now how to "properly" fix it.


# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #8117  (tentatively) (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to the it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@LysandreJik

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors which may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

 albert, bert, XLM: @LysandreJik
 GPT2: @LysandreJik, @patrickvonplaten
 tokenizers: @mfuntowicz
 Trainer: @sgugger
 Benchmarks: @patrickvonplaten
 Model Cards: @julien-c
 Translation: @sshleifer
 Summarization: @sshleifer
 examples/distillation: @VictorSanh
 nlp datasets: [different repo](https://github.com/huggingface/nlp)
 rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
 Text Generation: @patrickvonplaten, @TevenLeScao
 Blenderbot, Bart, Marian, Pegasus: @sshleifer
 T5: @patrickvonplaten
 Rag: @patrickvonplaten, @lhoestq
 EncoderDecoder: @patrickvonplaten
 Longformer, Reformer: @patrickvonplaten
 TransfoXL, XLNet: @TevenLeScao, @patrickvonplaten
 examples/seq2seq: @sshleifer
 examples/bert-loses-patience: @JetRunner
 tensorflow: @jplu
 examples/token-classification: @stefan-it
 documentation: @sgugger
 -->