### PR TITLE
[Bug fix] Fixed value for BlenderBot pad token

### DIFF
--- a/src/transformers/tokenization_blenderbot.py
+++ b/src/transformers/tokenization_blenderbot.py
@@ -134,7 +134,7 @@ class BlenderbotSmallTokenizer(PreTrainedTokenizer):
         bos_token="__start__",
         eos_token="__end__",
         unk_token="__unk__",
-        pad_token="__null",
+        pad_token="__null__",
         **kwargs
     ):
         super().__init__(unk_token=unk_token, bos_token=bos_token, eos_token=eos_token, pad_token=pad_token, **kwargs)


### PR DESCRIPTION
# What does this PR do?

The current `BlenderbotSmallTokenizer` has an incorrect (probably a typo) value for the `pad_token`. This causes the BlenderBot model to crash on padded sequences (currently pads with a value that exceeds the embedding matrix size).

This PR fixes the behaviour and the tokenizer now pads correctly with `0`.

## Who can review?

 Blenderbot, Bart, Marian, Pegasus: @sshleifer
