### PR TITLE
[bart] 2 SinusoidalPositionalEmbedding fixes

### DIFF
--- a/tests/test_modeling_bart.py
+++ b/tests/test_modeling_bart.py
@@ -620,8 +620,8 @@ class TestSinusoidalPositionalEmbeddings(unittest.TestCase):
         self.assertListEqual(no_cache[-1].tolist(), yes_cache[0][0].tolist())
 
     def test_odd_embed_dim(self):
-        with self.assertRaises(NotImplementedError):
-            SinusoidalPositionalEmbedding(num_positions=4, embedding_dim=5, padding_idx=0).to(torch_device)
+        # odd embedding_dim is allowed
+        SinusoidalPositionalEmbedding(num_positions=4, embedding_dim=5, padding_idx=0).to(torch_device)
 
         # odd num_positions is allowed
         SinusoidalPositionalEmbedding(num_positions=5, embedding_dim=4, padding_idx=0).to(torch_device)


### PR DESCRIPTION
This PR:
* `embedding_dim` param for `SinusoidalPositionalEmbedding` can now be odd.
* fixes a bug "RuntimeError: a view of a leaf Variable that requires grad is being used in an in-place operation" appearing in pytorch-1.8+ (this var requires no grad, so make it so before we do anything grad-related with it).

Fixes: #8021

@sshleifer, @LysandreJik 