### PR TITLE
Fixed emmental example.

### DIFF
--- a/examples/movement-pruning/README.md
+++ b/examples/movement-pruning/README.md
@@ -49,8 +49,16 @@ Below, we detail how to reproduce the results reported in the paper. We use SQuA
 The following command fine-prunes a pre-trained `BERT-base` on SQuAD using movement pruning towards 15% of remaining weights (85% sparsity). Note that we freeze all the embeddings modules (from their pre-trained value) and only prune the Fully Connected layers in the encoder (12 layers of Transformer Block).
 
 ```bash
+
 SERIALIZATION_DIR=<OUTPUT_DIR>
-SQUAD_DATA=<SQUAD_DATA>
+SQUAD_DATA=squad_data
+
+mkdir $SQUAD_DATA
+cd $SQUAD_DATA
+wget -q https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v1.1.json
+wget -q https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v1.1.json
+cd ..
+
 
 python examples/movement-pruning/masked_run_squad.py \
     --output_dir $SERIALIZATION_DIR \

--- a/examples/movement-pruning/emmental/modeling_bert_masked.py
+++ b/examples/movement-pruning/emmental/modeling_bert_masked.py
@@ -29,9 +29,10 @@ from torch.nn import CrossEntropyLoss, MSELoss
 from emmental import MaskedBertConfig
 from emmental.modules import MaskedLinear
 from transformers.file_utils import add_start_docstrings, add_start_docstrings_to_model_forward
-from transformers.modeling_bert import ACT2FN, BertLayerNorm, load_tf_weights_in_bert
+from transformers.modeling_bert import ACT2FN, load_tf_weights_in_bert
 from transformers.modeling_utils import PreTrainedModel, prune_linear_layer
 
+BertLayerNorm = torch.nn.LayerNorm
 
 logger = logging.getLogger(__name__)
 

--- a/examples/movement-pruning/emmental/modeling_bert_masked.py
+++ b/examples/movement-pruning/emmental/modeling_bert_masked.py
@@ -32,6 +32,7 @@ from transformers.file_utils import add_start_docstrings, add_start_docstrings_t
 from transformers.modeling_bert import ACT2FN, load_tf_weights_in_bert
 from transformers.modeling_utils import PreTrainedModel, prune_linear_layer
 
+
 BertLayerNorm = torch.nn.LayerNorm
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Added information about loading of squad data in README.
Fixed BertLayerNorm which disappeared some time ago, replace with torch.nn.LayerNorm (which was buggy long time ago it seems).
