### PR TITLE
Fix bad import with PyTorch <= 1.4.1

### DIFF
--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -23,7 +23,7 @@ from typing import List, Optional, Union
 
 import numpy as np
 import torch
-from torch.optim.lr_scheduler import SAVE_STATE_WARNING
+from packaging import version
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data.sampler import RandomSampler, Sampler
 
@@ -33,6 +33,11 @@ from .utils import logging
 
 if is_torch_tpu_available():
     import torch_xla.core.xla_model as xm
+
+if version.parse(torch.__version__) <= version.parse("1.4.1"):
+    SAVE_STATE_WARNING = ""
+else:
+    from torch.optim.lr_scheduler import SAVE_STATE_WARNING
 
 logger = logging.get_logger(__name__)
 


### PR DESCRIPTION
# What does this PR do?

`trainer_pt_utils` imports `SAVE_STATE_WARNING` from PyTorch, which only exists in 1.5.0 or later. This fixes that problem.

Fixes #8232