### PR TITLE
Fix TensorBoardCallback for older versions of PyTorch

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -282,7 +282,9 @@ class TensorBoardCallback(TrainerCallback):
                 if hasattr(model, "config") and model.config is not None:
                     model_config_json = model.config.to_json_string()
                     self.tb_writer.add_text("model_config", model_config_json)
-            self.tb_writer.add_hparams(args.to_sanitized_dict(), metric_dict={})
+            # Version of TensorBoard coming from tensorboardX does not have this method.
+            if hasattr(self.tb_writer, "add_hparams"):
+                self.tb_writer.add_hparams(args.to_sanitized_dict(), metric_dict={})
 
     def on_log(self, args, state, control, logs=None, **kwargs):
         if state.is_world_process_zero:


### PR DESCRIPTION
# What does this PR do?

It looks like the olad `SummaryWriter` class from `tensorboardX` does not have all the methods of the more recent class in PyTorch, this PR just checks the method is there before using it.

Fixes #8202