### PR TITLE
Updated Reformer to use caching during generation

### DIFF
--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -567,6 +567,8 @@ class GenerationMixin:
                 past = outputs.past_key_values
             elif "mems" in outputs:
                 past = outputs.mems
+            elif "past_buckets_states" in outputs:
+                past = outputs.past_buckets_states
 
             if do_sample:
                 # Temperature (higher temperature => more likely to sample low probability tokens)


### PR DESCRIPTION
# What does this PR do?

The current reformer implementation supports caching of buckets and states, but this is not used during generation. Running a generation example in debugging mode, such as 
```python
from transformers import ReformerModelWithLMHead, ReformerTokenizer

model = ReformerModelWithLMHead.from_pretrained("google/reformer-crime-and-punishment").cuda()
tok = ReformerTokenizer.from_pretrained("google/reformer-crime-and-punishment")
output = tok.decode(
    model.generate(tok.encode("Notwithstanding", return_tensors="pt").cuda(),
                   do_sample=True,
                   temperature=0.7,
                   max_length=100,
                   use_cache=True)[0])
```
One can see that the `past_buckets_states` passed to the attention are always `None` (at https://github.com/huggingface/transformers/blob/504ff7bb1234991eb07595c123b264a8a1064bd3/src/transformers/modeling_reformer.py#L365)

This is because the name of the past states for the reformer are neither `past_key_values` or `mems`.
This PR adds the name of the past states to the generation `past` allocation.

Generally, it may make sense to harmonize the `past` value for all models, so that the `generate` function generalizes better 

## Who can review?

Text Generation: @patrickvonplaten, @TevenLeScao
Reformer: @patrickvonplaten
