### PR TITLE
[distributed testing] forward the worker stderr to the parent process

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -896,8 +896,10 @@ def execute_subprocess_async(cmd, env=None, stdin=None, timeout=180, quiet=False
 
     cmd_str = " ".join(cmd)
     if result.returncode > 0:
+        stderr = "\n".join(result.stderr)
         raise RuntimeError(
-            f"'{cmd_str}' failed with returncode {result.returncode} - see the `stderr:` messages from above for details."
+            f"'{cmd_str}' failed with returncode {result.returncode}\n\n"
+            f"The combined stderr from workers follows:\n{stderr}"
         )
 
     # check that the subprocess actually did run and produced some output, should the test rely on


### PR DESCRIPTION
As discussed on slack, this PR:

* on distributed failure reproduces the combined `stderr` of the worker processes in the exception of the test invoking the distributed process 

This is so that the CI's new optimized reports will include the full error message.

@sgugger 