### PR TITLE
improve documentation of training_args.py

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -48,12 +48,22 @@ class TrainingArguments:
             If :obj:`True`, overwrite the content of the output directory. Use this to continue training if
             :obj:`output_dir` points to a checkpoint directory.
         do_train (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            Whether to run training or not.
+            Whether to run training or not. This argument is not directly used by :class:`~transformers.Trainer`,
+            it's intended to be used by your training/evaluation scripts instead.
+            See the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`___
+            for more details.
         do_eval (:obj:`bool`, `optional`):
-            Whether to run evaluation on the dev set or not. Will default to :obj:`evaluation_strategy` different from
-            :obj:`"no"`.
+            Whether to run evaluation on the dev set or not. Will be set to :obj:`True` if :obj:`evaluation_strategy`
+            is different from :obj:`"no"`.
+            This argument is not directly used by :class:`~transformers.Trainer`,
+            it's intended to be used by your training/evaluation scripts instead.
+            See the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`___
+            for more details.
         do_predict (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            Whether to run predictions on the test set or not.
+            Whether to run predictions on the test set or not. This argument is not directly used by :class:`~transformers.Trainer`,
+            it's intended to be used by your training/evaluation scripts instead.
+            See the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`___
+            for more details.
         evaluation_strategy (:obj:`str` or :class:`~transformers.trainer_utils.EvaluationStrategy`, `optional`, defaults to :obj:`"no"`):
             The evaluation strategy to adopt during training. Possible values are:
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -48,23 +48,19 @@ class TrainingArguments:
             If :obj:`True`, overwrite the content of the output directory. Use this to continue training if
             :obj:`output_dir` points to a checkpoint directory.
         do_train (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            Whether to run training or not. This argument is not directly used by :class:`~transformers.Trainer`,
-            it's intended to be used by your training/evaluation scripts instead.
-            See the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`__
-            for more details.
+            Whether to run training or not. This argument is not directly used by :class:`~transformers.Trainer`, it's
+            intended to be used by your training/evaluation scripts instead. See the `example scripts
+            <https://github.com/huggingface/transformers/tree/master/examples>`__ for more details.
         do_eval (:obj:`bool`, `optional`):
             Whether to run evaluation on the dev set or not. Will be set to :obj:`True` if :obj:`evaluation_strategy`
-            is different from :obj:`"no"`.
-            This argument is not directly used by :class:`~transformers.Trainer`,
-            it's intended to be used by your training/evaluation scripts instead.
-            See the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`__
-            for more details.
+            is different from :obj:`"no"`. This argument is not directly used by :class:`~transformers.Trainer`, it's
+            intended to be used by your training/evaluation scripts instead. See the `example scripts
+            <https://github.com/huggingface/transformers/tree/master/examples>`__ for more details.
         do_predict (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            Whether to run predictions on the test set or not.
-            This argument is not directly used by :class:`~transformers.Trainer`,
-            it's intended to be used by your training/evaluation scripts instead.
-            See the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`__
-            for more details.
+            Whether to run predictions on the test set or not. This argument is not directly used by
+            :class:`~transformers.Trainer`, it's intended to be used by your training/evaluation scripts instead. See
+            the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`__ for more
+            details.
         evaluation_strategy (:obj:`str` or :class:`~transformers.trainer_utils.EvaluationStrategy`, `optional`, defaults to :obj:`"no"`):
             The evaluation strategy to adopt during training. Possible values are:
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -63,7 +63,7 @@ class TrainingArguments:
             Whether to run predictions on the test set or not.
             This argument is not directly used by :class:`~transformers.Trainer`,
             it's intended to be used by your training/evaluation scripts instead.
-            See the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`___
+            See the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`__
             for more details.
         evaluation_strategy (:obj:`str` or :class:`~transformers.trainer_utils.EvaluationStrategy`, `optional`, defaults to :obj:`"no"`):
             The evaluation strategy to adopt during training. Possible values are:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -203,16 +203,13 @@ class TrainingArguments:
     do_eval: bool = field(default=None, metadata={"help": "Whether to run eval on the dev set."})
     do_predict: bool = field(default=False, metadata={"help": "Whether to run predictions on the test set."})
     evaluate_during_training: bool = field(
-        default=False,
-        metadata={"help": "Run evaluation during training at each logging step."},
+        default=False, metadata={"help": "Run evaluation during training at each logging step."},
     )
     evaluation_strategy: EvaluationStrategy = field(
-        default="no",
-        metadata={"help": "Run evaluation during training at each logging step."},
+        default="no", metadata={"help": "Run evaluation during training at each logging step."},
     )
     prediction_loss_only: bool = field(
-        default=False,
-        metadata={"help": "When performing evaluation and predictions, only returns the loss."},
+        default=False, metadata={"help": "When performing evaluation and predictions, only returns the loss."},
     )
 
     per_device_train_batch_size: int = field(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -57,7 +57,7 @@ class TrainingArguments:
             is different from :obj:`"no"`.
             This argument is not directly used by :class:`~transformers.Trainer`,
             it's intended to be used by your training/evaluation scripts instead.
-            See the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`___
+            See the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`__
             for more details.
         do_predict (:obj:`bool`, `optional`, defaults to :obj:`False`):
             Whether to run predictions on the test set or not.

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -50,7 +50,7 @@ class TrainingArguments:
         do_train (:obj:`bool`, `optional`, defaults to :obj:`False`):
             Whether to run training or not. This argument is not directly used by :class:`~transformers.Trainer`,
             it's intended to be used by your training/evaluation scripts instead.
-            See the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`___
+            See the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`__
             for more details.
         do_eval (:obj:`bool`, `optional`):
             Whether to run evaluation on the dev set or not. Will be set to :obj:`True` if :obj:`evaluation_strategy`

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -199,13 +199,16 @@ class TrainingArguments:
     do_eval: bool = field(default=None, metadata={"help": "Whether to run eval on the dev set."})
     do_predict: bool = field(default=False, metadata={"help": "Whether to run predictions on the test set."})
     evaluate_during_training: bool = field(
-        default=False, metadata={"help": "Run evaluation during training at each logging step."},
+        default=False,
+        metadata={"help": "Run evaluation during training at each logging step."},
     )
     evaluation_strategy: EvaluationStrategy = field(
-        default="no", metadata={"help": "Run evaluation during training at each logging step."},
+        default="no",
+        metadata={"help": "Run evaluation during training at each logging step."},
     )
     prediction_loss_only: bool = field(
-        default=False, metadata={"help": "When performing evaluation and predictions, only returns the loss."},
+        default=False,
+        metadata={"help": "When performing evaluation and predictions, only returns the loss."},
     )
 
     per_device_train_batch_size: int = field(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -60,7 +60,8 @@ class TrainingArguments:
             See the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`___
             for more details.
         do_predict (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            Whether to run predictions on the test set or not. This argument is not directly used by :class:`~transformers.Trainer`,
+            Whether to run predictions on the test set or not.
+            This argument is not directly used by :class:`~transformers.Trainer`,
             it's intended to be used by your training/evaluation scripts instead.
             See the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`___
             for more details.


### PR DESCRIPTION
Documentation for the following fields has been improved:

- do_train
- do_eval
- do_predict

Also see #8179