### PR TITLE
pipelines: Tentative fix for AutoModel for PegasusConfig.

### DIFF
--- a/src/transformers/modeling_auto.py
+++ b/src/transformers/modeling_auto.py
@@ -233,6 +233,7 @@ MODEL_MAPPING = OrderedDict(
         (AlbertConfig, AlbertModel),
         (CamembertConfig, CamembertModel),
         (XLMRobertaConfig, XLMRobertaModel),
+        (PegasusConfig, PegasusForConditionalGeneration),
         (BartConfig, BartModel),
         (LongformerConfig, LongformerModel),
         (RobertaConfig, RobertaModel),

--- a/tests/test_pipelines_summarization.py
+++ b/tests/test_pipelines_summarization.py
@@ -28,3 +28,8 @@ class SummarizationPipelineTests(MonoInputPipelineCommonMixin, unittest.TestCase
         expected_cnn_summary = " The Palestinian Authority becomes the 123rd member of the International Criminal Court . The move gives the court jurisdiction over alleged crimes in Palestinian territories . Israel and the United States opposed the Palestinians' efforts to join the court . Rights group Human Rights Watch welcomes the move, says governments seeking to penalize Palestine should end pressure ."
         result = nlp(cnn_article)
         self.assertEqual(result[0]["summary_text"], expected_cnn_summary)
+
+    @require_torch
+    @slow
+    def test_integration_torch_summarization_pegasus(self):
+        pipeline(task="summarization", model="google/pegasus-xsum")


### PR DESCRIPTION
# What does this PR do?

Original error lies in `pipeline(task='summarization',
model='google/pegasus-xsum')`.
 - Code fails while trying to infer framework from model_name (str).
 - It attempts to determine framework by running `AutoModel.from_pretrained(..)` then  `TFAutoModel.from_pretrained(...)` and decides by seeing whichever works first.


Proposed fix by:
-  implementing `AutoModel.from_pretrained('google/pegasus-xsum')` that is a
`PegasusConfig`. and returning a `PegasusForConditionalGeneration`.

Not sure if that's desirable as we are loading a
`ForConditionalGeneration` model by default (but it's the only available
anyway).

Other options that are available:

- load `BartModel` (Pegasus inherits from BartForConditionalGeneration)
from `PegasusConfig`, but unsure about side effects and odd to load
`Bart` from `Pegasus`.
- Change `get_framework` function from pipeline. That was my initial
choice but it seems understanding if a config is for a TF or Pytorch
model would require replicating some of `AutoModel` logic anyway
so doing that would lead to a discrepancy between the 2 code paths just
for Pegasus (and maybe BartConfig which also suffers some issues, but
that will be in a follow-up PR).



<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to the it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@LysandreJik
@sshleifer

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors which may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

 albert, bert, XLM: @LysandreJik
 GPT2: @LysandreJik, @patrickvonplaten
 tokenizers: @mfuntowicz
 Trainer: @sgugger
 Benchmarks: @patrickvonplaten
 Model Cards: @julien-c
 Translation: @sshleifer
 Summarization: @sshleifer
 examples/distillation: @VictorSanh
 nlp datasets: [different repo](https://github.com/huggingface/nlp)
 rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
 Text Generation: @patrickvonplaten, @TevenLeScao
 Blenderbot, Bart, Marian, Pegasus: @sshleifer
 T5: @patrickvonplaten
 Rag: @patrickvonplaten, @lhoestq
 EncoderDecoder: @patrickvonplaten
 Longformer, Reformer: @patrickvonplaten
 TransfoXL, XLNet: @TevenLeScao, @patrickvonplaten
 examples/seq2seq: @sshleifer
 examples/bert-loses-patience: @JetRunner
 tensorflow: @jplu
 examples/token-classification: @stefan-it
 documentation: @sgugger
 -->