### PR TITLE
[QA examples] fix inconsistent tokenization in _improve_answer_span 

### DIFF
--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -37,16 +37,16 @@ logger = logging.get_logger(__name__)
 
 def _improve_answer_span(doc_tokens, input_start, input_end, tokenizer, orig_answer_text):
     """Returns tokenized answer spans that better match the annotated answer."""
+
+    candidate_cleaned_forms = []
+    candidate_cleaned_forms.append(" ".join(tokenizer.tokenize(orig_answer_text)))
     if tokenizer.__class__.__name__ in NEED_PREFIX_SPACE_TOKENIZERS_SET:
-        sub_tokens = tokenizer.tokenize(orig_answer_text, add_prefix_space=True)
-    else:
-        sub_tokens = tokenizer.tokenize(orig_answer_text)
-    tok_answer_text = " ".join(sub_tokens)
+        candidate_cleaned_forms.append(" ".join(tokenizer.tokenize(orig_answer_text, add_prefix_space=True)))
 
     for new_start in range(input_start, input_end + 1):
         for new_end in range(input_end, new_start - 1, -1):
             text_span = " ".join(doc_tokens[new_start : (new_end + 1)])
-            if text_span == tok_answer_text:
+            if text_span in candidate_cleaned_forms:
                 return (new_start, new_end)
 
     return (input_start, input_end)


### PR DESCRIPTION
Basically, I am trying to fix the QA preprocessing steps when using BPE-based tokenizers (Roberta, Bart, Longformer)

The prior _improve_answer_span has a bug because the way it tokenizes the answer_text is different from the way context is handled. So when the original context is '1987', and the old input ans_span is ['Ġ1987', ','], then the ',' won't be removed.

To fix these cases I use two cleaned forms built by either including prefix_space or not. If a sub_answer_span matches either one of them we'll improve the answer_span. The first form [line 42] is used to handle things with leading punctuations, e.g., orig_answer_context=="73 million" and ans_span is ["Ġ$", "73", "Ġmillion"] (should be cleaned to  ["73", "Ġmillion"] ). The second form is used to handle things with ending punctuations, e.g., the '1987' example mentioned above.
