### PR TITLE
[s2s] test_bash_script.py - actually learn something

### DIFF
--- a/examples/seq2seq/test_bash_script.py
+++ b/examples/seq2seq/test_bash_script.py
@@ -3,19 +3,17 @@
 import argparse
 import os
 import sys
-from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 import pytorch_lightning as pl
 import timeout_decorator
 import torch
 
 from distillation import BartSummarizationDistiller, distill_main
 from finetune import SummarizationModule, main
-from test_seq2seq_examples import CUDA_AVAILABLE, MBART_TINY
+from test_seq2seq_examples import MBART_TINY
 from transformers import BartForConditionalGeneration, MarianMTModel
-from transformers.testing_utils import TestCasePlus, slow, require_torch_gpu
+from transformers.testing_utils import TestCasePlus, require_torch_gpu, slow
 from utils import load_json
 
 
@@ -35,7 +33,7 @@ class TestAll(TestCasePlus):
     @slow
     @require_torch_gpu
     def test_train_mbart_cc25_enro_script(self):
-        data_dir = "examples/seq2seq/test_data/wmt_en_ro"
+        data_dir = f"{self.test_file_dir_str}/test_data/wmt_en_ro"
         env_vars_to_replace = {
             "--fp16_opt_level=O1": "",
             "$MAX_LEN": 128,
@@ -48,7 +46,7 @@ class TestAll(TestCasePlus):
         }
 
         # Clean up bash script
-        bash_script = Path("examples/seq2seq/train_mbart_cc25_enro.sh").open().read().split("finetune.py")[1].strip()
+        bash_script = (self.test_file_dir / "train_mbart_cc25_enro.sh").open().read().split("finetune.py")[1].strip()
         bash_script = bash_script.replace("\\\n", "").strip().replace('"$@"', "")
         for k, v in env_vars_to_replace.items():
             bash_script = bash_script.replace(k, str(v))
@@ -111,7 +109,7 @@ class TestAll(TestCasePlus):
     @slow
     @require_torch_gpu
     def test_opus_mt_distill_script(self):
-        data_dir = "examples/seq2seq/test_data/wmt_en_ro"
+        data_dir = f"{self.test_file_dir_str}/test_data/wmt_en_ro"
         env_vars_to_replace = {
             "--fp16_opt_level=O1": "",
             "$MAX_LEN": 128,
@@ -124,7 +122,7 @@ class TestAll(TestCasePlus):
 
         # Clean up bash script
         bash_script = (
-            Path("examples/seq2seq/distil_marian_no_teacher.sh").open().read().split("distillation.py")[1].strip()
+            (self.test_file_dir / "distil_marian_no_teacher.sh").open().read().split("distillation.py")[1].strip()
         )
         bash_script = bash_script.replace("\\\n", "").strip().replace('"$@"', "")
         bash_script = bash_script.replace("--fp16 ", " ")

--- a/examples/seq2seq/test_bash_script.py
+++ b/examples/seq2seq/test_bash_script.py
@@ -15,7 +15,7 @@ from distillation import BartSummarizationDistiller, distill_main
 from finetune import SummarizationModule, main
 from test_seq2seq_examples import CUDA_AVAILABLE, MBART_TINY
 from transformers import BartForConditionalGeneration, MarianMTModel
-from transformers.testing_utils import TestCasePlus, slow
+from transformers.testing_utils import TestCasePlus, slow, require_torch_gpu
 from utils import load_json
 
 
@@ -25,7 +25,7 @@ MARIAN_MODEL = "sshleifer/student_marian_en_ro_6_1"
 
 class TestAll(TestCasePlus):
     @slow
-    @pytest.mark.skipif(not CUDA_AVAILABLE, reason="too slow to run on CPU")
+    @require_torch_gpu
     def test_model_download(self):
         """This warms up the cache so that we can time the next test without including download time, which varies between machines."""
         BartForConditionalGeneration.from_pretrained(MODEL_NAME)
@@ -33,7 +33,7 @@ class TestAll(TestCasePlus):
 
     @timeout_decorator.timeout(120)
     @slow
-    @pytest.mark.skipif(not CUDA_AVAILABLE, reason="too slow to run on CPU")
+    @require_torch_gpu
     def test_train_mbart_cc25_enro_script(self):
         data_dir = "examples/seq2seq/test_data/wmt_en_ro"
         env_vars_to_replace = {
@@ -109,7 +109,7 @@ class TestAll(TestCasePlus):
 
     @timeout_decorator.timeout(600)
     @slow
-    @pytest.mark.skipif(not CUDA_AVAILABLE, reason="too slow to run on CPU")
+    @require_torch_gpu
     def test_opus_mt_distill_script(self):
         data_dir = "examples/seq2seq/test_data/wmt_en_ro"
         env_vars_to_replace = {

--- a/examples/seq2seq/test_bash_script.py
+++ b/examples/seq2seq/test_bash_script.py
@@ -45,7 +45,7 @@ class TestAll(TestCasePlus):
         data_dir = self.data_dir
         env_vars_to_replace = {
             "--fp16_opt_level=O1": "",
-            "$MAX_LEN": 128,
+            "$MAX_LEN": 64,
             "$BS": 64,
             "$GAS": 1,
             "$ENRO_DIR": data_dir,

--- a/examples/seq2seq/test_bash_script.py
+++ b/examples/seq2seq/test_bash_script.py
@@ -51,7 +51,7 @@ class TestAll(TestCasePlus):
             "$ENRO_DIR": data_dir,
             "facebook/mbart-large-cc25": MARIAN_MODEL,
             # "val_check_interval=0.25": "val_check_interval=1.0",
-            "--learning_rate=3e-5": "--learning_rate=3e-4",
+            "--learning_rate=3e-5": "--learning_rate 3e-4",
             "--num_train_epochs 6": "--num_train_epochs 1",
         }
 
@@ -66,18 +66,18 @@ class TestAll(TestCasePlus):
 
         # bash_script = bash_script.replace("--fp16 ", "")
         args = f"""
-            --output_dir={output_dir}
-            --gpus=1
-            --freeze_encoder
-            --learning_rate=3e-4
+            --output_dir {output_dir}
             --tokenizer_name Helsinki-NLP/opus-mt-en-ro
+            --sortish_sampler
+            --do_predict
+            --gpus 1
+            --freeze_encoder
             --n_train 100000
             --n_val 500
             --n_test 500
-            --fp16_opt_level=O1
-            --num_sanity_val_steps=0
-            --sortish_sampler
-            --do_predict
+            --fp16_opt_level O1
+            --num_sanity_val_steps 0
+            --eval_beams 2
         """.split()
         # XXX: args.gpus > 1 : handle multigpu in the future
 


### PR DESCRIPTION
As discussed in https://github.com/huggingface/transformers/issues/6049 this PR replaces the original `test_train_mbart_cc25_enro_script` test with mostly new guts doing the following:

* [x] switches to downloading and caching a bigger custom dataset, which is a subset of the full wmt_en_ro.  I created https://cdn-datasets.huggingface.co/translation/wmt_en_ro-tr40k-va0.5k-te0.5k.tar.gz - hope the name is intuitive - self-documenting. It's just 3.6M (vs 56M original). I made it using this script: https://github.com/stas00/porting/blob/master/transformers/translation/make-wmt_en_ro-subset.md

* [x] performs qualitative checks on the eval/test results:
   - Minimum learning requirement 1: BLEU improves over the course of training by more than 2 pts
   - Minimum learning requirement 2: BLEU finishes above 17
   - Minimum learning requirement 3: test bleu and val bleu within ~1 pt. 

also makes some extra improvements:
* [x] uses `require_torch_gpu` decorator
* [x] removes hardcoded paths

Runtime is about ~2min on unoptimized rtx-3090.

Fixes: #6049

@sshleifer 