### PR TITLE
Model versioning

### DIFF
--- a/model_cards/t5-11b-README.md
+++ b/model_cards/t5-11b-README.md
@@ -12,8 +12,8 @@ inference: false
 
 ## Disclaimer
 
-Due do it's immense size, `t5-11b` requires some special treatment. 
-First, `t5-11b` should be loaded with flag `use_cdn` set to `False` as follows:
+**Before `transformers` v3.5.0**, due do its immense size, `t5-11b` required some special treatment. 
+If you're using transformers `<= v3.4.0`, `t5-11b` should be loaded with flag `use_cdn` set to `False` as follows:
 
 ```python
 t5 = transformers.T5ForConditionalGeneration.from_pretrained('t5-11b', use_cdn = False)

--- a/scripts/fsmt/convert-allenai-wmt16.sh
+++ b/scripts/fsmt/convert-allenai-wmt16.sh
@@ -56,7 +56,3 @@ cd -
 perl -le 'for $f (@ARGV) { print qq[transformers-cli upload -y $_/$f --filename $_/$f] for ("wmt16-en-de-dist-12-1", "wmt16-en-de-dist-6-1", "wmt16-en-de-12-1")}' vocab-src.json vocab-tgt.json tokenizer_config.json config.json
 # add/remove files as needed
 
-# Caching note: Unfortunately due to CDN caching the uploaded model may be unavailable for up to 24hs after upload
-# So the only way to start using the new model sooner is either:
-# 1. download it to a local path and use that path as model_name
-# 2. make sure you use: from_pretrained(..., use_cdn=False) everywhere

--- a/scripts/fsmt/convert-allenai-wmt19.sh
+++ b/scripts/fsmt/convert-allenai-wmt19.sh
@@ -44,7 +44,3 @@ cd -
 perl -le 'for $f (@ARGV) { print qq[transformers-cli upload -y $_/$f --filename $_/$f] for ("wmt19-de-en-6-6-base", "wmt19-de-en-6-6-big")}' vocab-src.json vocab-tgt.json tokenizer_config.json config.json
 # add/remove files as needed
 
-# Caching note: Unfortunately due to CDN caching the uploaded model may be unavailable for up to 24hs after upload
-# So the only way to start using the new model sooner is either:
-# 1. download it to a local path and use that path as model_name
-# 2. make sure you use: from_pretrained(..., use_cdn=False) everywhere

--- a/scripts/fsmt/convert-facebook-wmt19.sh
+++ b/scripts/fsmt/convert-facebook-wmt19.sh
@@ -55,7 +55,3 @@ cd -
 perl -le 'for $f (@ARGV) { print qq[transformers-cli upload -y $_/$f --filename $_/$f] for map { "wmt19-$_" } ("en-ru", "ru-en", "de-en", "en-de")}' vocab-src.json vocab-tgt.json tokenizer_config.json config.json
 # add/remove files as needed
 
-# Caching note: Unfortunately due to CDN caching the uploaded model may be unavailable for up to 24hs after upload
-# So the only way to start using the new model sooner is either:
-# 1. download it to a local path and use that path as model_name
-# 2. make sure you use: from_pretrained(..., use_cdn=False) everywhere

--- a/src/transformers/commands/user.py
+++ b/src/transformers/commands/user.py
@@ -1,9 +1,9 @@
 import os
+import subprocess
 import sys
 from argparse import ArgumentParser
 from getpass import getpass
 from typing import List, Union
-import subprocess
 
 from requests.exceptions import HTTPError
 from transformers.commands import BaseTransformersCLICommand
@@ -23,7 +23,9 @@ class UserCommands(BaseTransformersCLICommand):
         logout_parser = parser.add_parser("logout", help="Log out")
         logout_parser.set_defaults(func=lambda args: LogoutCommand(args))
         # s3_datasets (s3-based system)
-        s3_parser = parser.add_parser("s3_datasets", help="{ls, rm} Commands to interact with the files you upload on S3.")
+        s3_parser = parser.add_parser(
+            "s3_datasets", help="{ls, rm} Commands to interact with the files you upload on S3."
+        )
         s3_subparsers = s3_parser.add_subparsers(help="s3 related commands")
         ls_parser = s3_subparsers.add_parser("ls")
         ls_parser.add_argument("--organization", type=str, help="Optional: organization namespace.")
@@ -33,9 +35,7 @@ class UserCommands(BaseTransformersCLICommand):
         rm_parser.add_argument("--organization", type=str, help="Optional: organization namespace.")
         rm_parser.set_defaults(func=lambda args: DeleteObjCommand(args))
         upload_parser = s3_subparsers.add_parser("upload", help="Upload a file to S3.")
-        upload_parser.add_argument(
-            "path", type=str, help="Local path of the folder or individual file to upload."
-        )
+        upload_parser.add_argument("path", type=str, help="Local path of the folder or individual file to upload.")
         upload_parser.add_argument("--organization", type=str, help="Optional: organization namespace.")
         upload_parser.add_argument(
             "--filename", type=str, default=None, help="Optional: override individual object filename on S3."
@@ -43,22 +43,29 @@ class UserCommands(BaseTransformersCLICommand):
         upload_parser.add_argument("-y", "--yes", action="store_true", help="Optional: answer Yes to the prompt")
         upload_parser.set_defaults(func=lambda args: UploadCommand(args))
         # deprecated model upload
-        upload_parser = parser.add_parser("upload", help=(
-            "Deprecated: used to be the way to upload a model to S3."
-            " We now use a git-based system for storing models and other artifacts."
-            " Use the `repo create` command instead."
-        ))
+        upload_parser = parser.add_parser(
+            "upload",
+            help=(
+                "Deprecated: used to be the way to upload a model to S3."
+                " We now use a git-based system for storing models and other artifacts."
+                " Use the `repo create` command instead."
+            ),
+        )
         upload_parser.set_defaults(func=lambda args: DeprecatedUploadCommand(args))
 
         # new system: git-based repo system
-        repo_parser = parser.add_parser("repo", help="{create, ls-files} Commands to interact with your huggingface.co repos.")
+        repo_parser = parser.add_parser(
+            "repo", help="{create, ls-files} Commands to interact with your huggingface.co repos."
+        )
         repo_subparsers = repo_parser.add_subparsers(help="huggingface.co repos related commands")
         ls_parser = repo_subparsers.add_parser("ls-files", help="List all your files on huggingface.co")
         ls_parser.add_argument("--organization", type=str, help="Optional: organization namespace.")
         ls_parser.set_defaults(func=lambda args: ListReposObjsCommand(args))
         repo_create_parser = repo_subparsers.add_parser("create", help="Create a new repo on huggingface.co")
         repo_create_parser.add_argument(
-            "name", type=str, help="Name for your model's repo. Will be namespaced under your username to build the model id."
+            "name",
+            type=str,
+            help="Name for your model's repo. Will be namespaced under your username to build the model id.",
         )
         repo_create_parser.add_argument("--organization", type=str, help="Optional: organization namespace.")
         repo_create_parser.add_argument("-y", "--yes", action="store_true", help="Optional: answer Yes to the prompt")
@@ -103,7 +110,6 @@ def tabulate(rows: List[List[Union[str, int]]], headers: List[str]) -> str:
     for row in rows:
         lines.append(row_format.format(*row))
     return "\n".join(lines)
-
 
 
 class BaseUserCommand:
@@ -165,7 +171,6 @@ class LogoutCommand(BaseUserCommand):
         HfFolder.delete_token()
         self._api.logout(token)
         print("Successfully logged out.")
-
 
 
 class ListObjsCommand(BaseUserCommand):
@@ -237,21 +242,19 @@ class RepoCreateCommand(BaseUserCommand):
             stdout = subprocess.run(["git-lfs", "--version"], capture_output=True).stdout.decode("utf-8")
             print(ANSI.gray(stdout.strip()))
         except FileNotFoundError:
-            print(ANSI.red(
-                "Looks like you do not have git-lfs installed, please install."
-                " You can install from https://git-lfs.github.com/."
-                " Then run `git lfs install` (you only have to do this once)."
-            ))
+            print(
+                ANSI.red(
+                    "Looks like you do not have git-lfs installed, please install."
+                    " You can install from https://git-lfs.github.com/."
+                    " Then run `git lfs install` (you only have to do this once)."
+                )
+            )
         print("")
-        
+
         user, _ = self._api.whoami(token)
         namespace = self.args.organization if self.args.organization is not None else user
 
-        print(
-            "You are about to create {}".format(
-                ANSI.bold(namespace + "/" + self.args.name)
-            )
-        )
+        print("You are about to create {}".format(ANSI.bold(namespace + "/" + self.args.name)))
 
         if not self.args.yes:
             choice = input("Proceed? [Y/n] ").lower()
@@ -266,10 +269,7 @@ class RepoCreateCommand(BaseUserCommand):
             exit(1)
         print("\nYour repo now lives at:")
         print("  {}".format(ANSI.bold(url)))
-        print(
-            "\nYou can clone it locally with the command below,"
-            " and commit/push as usual."
-        )
+        print("\nYou can clone it locally with the command below," " and commit/push as usual.")
         print(f"\n  git clone {url}")
         print("")
 
@@ -278,9 +278,9 @@ class DeprecatedUploadCommand(BaseUserCommand):
     def run(self):
         print(
             ANSI.red(
-            "Deprecated: used to be the way to upload a model to S3."
-            " We now use a git-based system for storing models and other artifacts."
-            " Use the `repo create` command instead."
+                "Deprecated: used to be the way to upload a model to S3."
+                " We now use a git-based system for storing models and other artifacts."
+                " Use the `repo create` command instead."
             )
         )
         exit(1)

--- a/src/transformers/commands/user.py
+++ b/src/transformers/commands/user.py
@@ -233,13 +233,13 @@ class RepoCreateCommand(BaseUserCommand):
             print("Not logged in")
             exit(1)
         try:
-            stdout = subprocess.run(["git", "--version"], capture_output=True).stdout.decode("utf-8")
+            stdout = subprocess.check_output(["git", "--version"]).decode("utf-8")
             print(ANSI.gray(stdout.strip()))
         except FileNotFoundError:
             print("Looks like you do not have git installed, please install.")
 
         try:
-            stdout = subprocess.run(["git-lfs", "--version"], capture_output=True).stdout.decode("utf-8")
+            stdout = subprocess.check_output(["git-lfs", "--version"]).decode("utf-8")
             print(ANSI.gray(stdout.strip()))
         except FileNotFoundError:
             print(

--- a/src/transformers/commands/user.py
+++ b/src/transformers/commands/user.py
@@ -3,6 +3,7 @@ import sys
 from argparse import ArgumentParser
 from getpass import getpass
 from typing import List, Union
+import subprocess
 
 from requests.exceptions import HTTPError
 from transformers.commands import BaseTransformersCLICommand
@@ -21,8 +22,8 @@ class UserCommands(BaseTransformersCLICommand):
         whoami_parser.set_defaults(func=lambda args: WhoamiCommand(args))
         logout_parser = parser.add_parser("logout", help="Log out")
         logout_parser.set_defaults(func=lambda args: LogoutCommand(args))
-        # s3
-        s3_parser = parser.add_parser("s3", help="{ls, rm} Commands to interact with the files you upload on S3.")
+        # s3_datasets (s3-based system)
+        s3_parser = parser.add_parser("s3_datasets", help="{ls, rm} Commands to interact with the files you upload on S3.")
         s3_subparsers = s3_parser.add_subparsers(help="s3 related commands")
         ls_parser = s3_subparsers.add_parser("ls")
         ls_parser.add_argument("--organization", type=str, help="Optional: organization namespace.")
@@ -31,10 +32,9 @@ class UserCommands(BaseTransformersCLICommand):
         rm_parser.add_argument("filename", type=str, help="individual object filename to delete from S3.")
         rm_parser.add_argument("--organization", type=str, help="Optional: organization namespace.")
         rm_parser.set_defaults(func=lambda args: DeleteObjCommand(args))
-        # upload
-        upload_parser = parser.add_parser("upload", help="Upload a model to S3.")
+        upload_parser = s3_subparsers.add_parser("upload", help="Upload a file to S3.")
         upload_parser.add_argument(
-            "path", type=str, help="Local path of the model folder or individual file to upload."
+            "path", type=str, help="Local path of the folder or individual file to upload."
         )
         upload_parser.add_argument("--organization", type=str, help="Optional: organization namespace.")
         upload_parser.add_argument(
@@ -42,6 +42,27 @@ class UserCommands(BaseTransformersCLICommand):
         )
         upload_parser.add_argument("-y", "--yes", action="store_true", help="Optional: answer Yes to the prompt")
         upload_parser.set_defaults(func=lambda args: UploadCommand(args))
+        # deprecated model upload
+        upload_parser = parser.add_parser("upload", help=(
+            "Deprecated: used to be the way to upload a model to S3."
+            " We now use a git-based system for storing models and other artifacts."
+            " Use the `repo create` command instead."
+        ))
+        upload_parser.set_defaults(func=lambda args: DeprecatedUploadCommand(args))
+
+        # new system: git-based repo system
+        repo_parser = parser.add_parser("repo", help="{create, ls-files} Commands to interact with your huggingface.co repos.")
+        repo_subparsers = repo_parser.add_subparsers(help="huggingface.co repos related commands")
+        ls_parser = repo_subparsers.add_parser("ls-files", help="List all your files on huggingface.co")
+        ls_parser.add_argument("--organization", type=str, help="Optional: organization namespace.")
+        ls_parser.set_defaults(func=lambda args: ListReposObjsCommand(args))
+        repo_create_parser = repo_subparsers.add_parser("create", help="Create a new repo on huggingface.co")
+        repo_create_parser.add_argument(
+            "name", type=str, help="Name for your model's repo. Will be namespaced under your username to build the model id."
+        )
+        repo_create_parser.add_argument("--organization", type=str, help="Optional: organization namespace.")
+        repo_create_parser.add_argument("-y", "--yes", action="store_true", help="Optional: answer Yes to the prompt")
+        repo_create_parser.set_defaults(func=lambda args: RepoCreateCommand(args))
 
 
 class ANSI:
@@ -51,6 +72,7 @@ class ANSI:
 
     _bold = "\u001b[1m"
     _red = "\u001b[31m"
+    _gray = "\u001b[90m"
     _reset = "\u001b[0m"
 
     @classmethod
@@ -60,6 +82,28 @@ class ANSI:
     @classmethod
     def red(cls, s):
         return "{}{}{}".format(cls._bold + cls._red, s, cls._reset)
+
+    @classmethod
+    def gray(cls, s):
+        return "{}{}{}".format(cls._gray, s, cls._reset)
+
+
+def tabulate(rows: List[List[Union[str, int]]], headers: List[str]) -> str:
+    """
+    Inspired by:
+
+    - stackoverflow.com/a/8356620/593036
+    - stackoverflow.com/questions/9535954/printing-lists-as-tabular-data
+    """
+    col_widths = [max(len(str(x)) for x in col) for col in zip(*rows, headers)]
+    row_format = ("{{:{}}} " * len(headers)).format(*col_widths)
+    lines = []
+    lines.append(row_format.format(*headers))
+    lines.append(row_format.format(*["-" * w for w in col_widths]))
+    for row in rows:
+        lines.append(row_format.format(*row))
+    return "\n".join(lines)
+
 
 
 class BaseUserCommand:
@@ -123,23 +167,8 @@ class LogoutCommand(BaseUserCommand):
         print("Successfully logged out.")
 
 
+
 class ListObjsCommand(BaseUserCommand):
-    def tabulate(self, rows: List[List[Union[str, int]]], headers: List[str]) -> str:
-        """
-        Inspired by:
-
-        - stackoverflow.com/a/8356620/593036
-        - stackoverflow.com/questions/9535954/printing-lists-as-tabular-data
-        """
-        col_widths = [max(len(str(x)) for x in col) for col in zip(*rows, headers)]
-        row_format = ("{{:{}}} " * len(headers)).format(*col_widths)
-        lines = []
-        lines.append(row_format.format(*headers))
-        lines.append(row_format.format(*["-" * w for w in col_widths]))
-        for row in rows:
-            lines.append(row_format.format(*row))
-        return "\n".join(lines)
-
     def run(self):
         token = HfFolder.get_token()
         if token is None:
@@ -155,7 +184,7 @@ class ListObjsCommand(BaseUserCommand):
             print("No shared file yet")
             exit()
         rows = [[obj.filename, obj.LastModified, obj.ETag, obj.Size] for obj in objs]
-        print(self.tabulate(rows, headers=["Filename", "LastModified", "ETag", "Size"]))
+        print(tabulate(rows, headers=["Filename", "LastModified", "ETag", "Size"]))
 
 
 class DeleteObjCommand(BaseUserCommand):
@@ -171,6 +200,90 @@ class DeleteObjCommand(BaseUserCommand):
             print(ANSI.red(e.response.text))
             exit(1)
         print("Done")
+
+
+class ListReposObjsCommand(BaseUserCommand):
+    def run(self):
+        token = HfFolder.get_token()
+        if token is None:
+            print("Not logged in")
+            exit(1)
+        try:
+            objs = self._api.list_repos_objs(token, organization=self.args.organization)
+        except HTTPError as e:
+            print(e)
+            print(ANSI.red(e.response.text))
+            exit(1)
+        if len(objs) == 0:
+            print("No shared file yet")
+            exit()
+        rows = [[obj.filename, obj.lastModified, obj.commit, obj.size] for obj in objs]
+        print(tabulate(rows, headers=["Filename", "LastModified", "Commit-Sha", "Size"]))
+
+
+class RepoCreateCommand(BaseUserCommand):
+    def run(self):
+        token = HfFolder.get_token()
+        if token is None:
+            print("Not logged in")
+            exit(1)
+        try:
+            stdout = subprocess.run(["git", "--version"], capture_output=True).stdout.decode("utf-8")
+            print(ANSI.gray(stdout.strip()))
+        except FileNotFoundError:
+            print("Looks like you do not have git installed, please install.")
+
+        try:
+            stdout = subprocess.run(["git-lfs", "--version"], capture_output=True).stdout.decode("utf-8")
+            print(ANSI.gray(stdout.strip()))
+        except FileNotFoundError:
+            print(ANSI.red(
+                "Looks like you do not have git-lfs installed, please install."
+                " You can install from https://git-lfs.github.com/."
+                " Then run `git lfs install` (you only have to do this once)."
+            ))
+        print("")
+        
+        user, _ = self._api.whoami(token)
+        namespace = self.args.organization if self.args.organization is not None else user
+
+        print(
+            "You are about to create {}".format(
+                ANSI.bold(namespace + "/" + self.args.name)
+            )
+        )
+
+        if not self.args.yes:
+            choice = input("Proceed? [Y/n] ").lower()
+            if not (choice == "" or choice == "y" or choice == "yes"):
+                print("Abort")
+                exit()
+        try:
+            url = self._api.create_repo(token, name=self.args.name, organization=self.args.organization)
+        except HTTPError as e:
+            print(e)
+            print(ANSI.red(e.response.text))
+            exit(1)
+        print("\nYour repo now lives at:")
+        print("  {}".format(ANSI.bold(url)))
+        print(
+            "\nYou can clone it locally with the command below,"
+            " and commit/push as usual."
+        )
+        print(f"\n  git clone {url}")
+        print("")
+
+
+class DeprecatedUploadCommand(BaseUserCommand):
+    def run(self):
+        print(
+            ANSI.red(
+            "Deprecated: used to be the way to upload a model to S3."
+            " We now use a git-based system for storing models and other artifacts."
+            " Use the `repo create` command instead."
+            )
+        )
+        exit(1)
 
 
 class UploadCommand(BaseUserCommand):

--- a/src/transformers/configuration_auto.py
+++ b/src/transformers/configuration_auto.py
@@ -289,6 +289,10 @@ class AutoConfig:
             proxies (:obj:`Dict[str, str]`, `optional`):
                 A dictionary of proxy servers to use by protocol or endpoint, e.g., :obj:`{'http': 'foo.bar:3128',
                 'http://hostname': 'foo.bar:4012'}`. The proxies are used on each request.
+            revision(:obj:`str`, `optional`, defaults to :obj:`"main"`):
+                The specific model version to use. It can be a branch name, a tag name, or a commit id, since we use a
+                git-based system for storing models and other artifacts on huggingface.co, so ``revision`` can be any
+                identifier allowed by git.
             return_unused_kwargs (:obj:`bool`, `optional`, defaults to :obj:`False`):
                 If :obj:`False`, then this function returns just the final configuration object.
 

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -384,11 +384,10 @@ class PretrainedConfig(object):
                 local_files_only=local_files_only,
             )
             # Load config dict
-            if resolved_config_file is None:
-                raise EnvironmentError
             config_dict = cls._dict_from_json_file(resolved_config_file)
 
-        except EnvironmentError:
+        except EnvironmentError as err:
+            logger.error(err)
             msg = (
                 f"Can't load config for '{pretrained_model_name_or_path}'. Make sure that:\n\n"
                 f"- '{pretrained_model_name_or_path}' is a correct model identifier listed on 'https://huggingface.co/models'\n\n"

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -362,6 +362,7 @@ class PretrainedConfig(object):
         resume_download = kwargs.pop("resume_download", False)
         proxies = kwargs.pop("proxies", None)
         local_files_only = kwargs.pop("local_files_only", False)
+        revision = kwargs.pop("revision", None)
 
         if os.path.isdir(pretrained_model_name_or_path):
             config_file = os.path.join(pretrained_model_name_or_path, CONFIG_NAME)
@@ -369,7 +370,7 @@ class PretrainedConfig(object):
             config_file = pretrained_model_name_or_path
         else:
             config_file = hf_bucket_url(
-                pretrained_model_name_or_path, filename=CONFIG_NAME, use_cdn=False, mirror=None
+                pretrained_model_name_or_path, filename=CONFIG_NAME, revision=revision, mirror=None
             )
 
         try:

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -311,6 +311,10 @@ class PretrainedConfig(object):
             proxies (:obj:`Dict[str, str]`, `optional`):
                 A dictionary of proxy servers to use by protocol or endpoint, e.g., :obj:`{'http': 'foo.bar:3128',
                 'http://hostname': 'foo.bar:4012'}.` The proxies are used on each request.
+            revision(:obj:`str`, `optional`, defaults to :obj:`"main"`):
+                The specific model version to use. It can be a branch name, a tag name, or a commit id, since we use a
+                git-based system for storing models and other artifacts on huggingface.co, so ``revision`` can be any
+                identifier allowed by git.
             return_unused_kwargs (:obj:`bool`, `optional`, defaults to :obj:`False`):
                 If :obj:`False`, then this function returns just the final configuration object.
 

--- a/src/transformers/convert_fsmt_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/convert_fsmt_original_pytorch_checkpoint_to_pytorch.py
@@ -248,10 +248,6 @@ def convert_fsmt_checkpoint_to_pytorch(fsmt_checkpoint_path, pytorch_dump_folder
     print("\nLast step is to upload the files to s3")
     print(f"cd {data_root}")
     print(f"transformers-cli upload {model_dir}")
-    print(
-        "Note: CDN caches files for up to 24h, so either use a local model path "
-        "or use `from_pretrained(mname, use_cdn=False)` to use the non-cached version."
-    )
 
 
 if __name__ == "__main__":

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -218,8 +218,8 @@ DUMMY_MASK = [[1, 1, 1, 1, 1], [1, 1, 1, 0, 0], [0, 0, 0, 1, 1]]
 
 S3_BUCKET_PREFIX = "https://s3.amazonaws.com/models.huggingface.co/bert"
 CLOUDFRONT_DISTRIB_PREFIX = "https://cdn.huggingface.co"
-# HUGGINGFACE_CO_PREFIX = "http://huggingface.test/{model_id}/resolve/{revision}/{filename}"
-HUGGINGFACE_CO_PREFIX = "https://moon-preprod.huggingface.co/{model_id}/resolve/{revision}/{filename}"
+HUGGINGFACE_CO_PREFIX = "https://huggingface.co/{model_id}/resolve/{revision}/{filename}"
+
 PRESET_MIRROR_DICT = {
     "tuna": "https://mirrors.tuna.tsinghua.edu.cn/hugging-face-models",
     "bfsu": "https://mirrors.bfsu.edu.cn/hugging-face-models",

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -1109,8 +1109,8 @@ def get_from_cache(
             incomplete_path = cache_path + ".incomplete"
 
             @contextmanager
-            def _resumable_file_manager():
-                with open(incomplete_path, "a+b") as f:
+            def _resumable_file_manager() -> "io.BufferedWriter":
+                with open(incomplete_path, "ab") as f:
                     yield f
 
             temp_file_manager = _resumable_file_manager

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -217,6 +217,8 @@ DUMMY_MASK = [[1, 1, 1, 1, 1], [1, 1, 1, 0, 0], [0, 0, 0, 1, 1]]
 
 S3_BUCKET_PREFIX = "https://s3.amazonaws.com/models.huggingface.co/bert"
 CLOUDFRONT_DISTRIB_PREFIX = "https://cdn.huggingface.co"
+HUGGINGFACE_CO_PREFIX = "http://huggingface.test/{model_id}/resolve/{revision}/{filename}"
+# HUGGINGFACE_CO_PREFIX = "https://moon-preprod.huggingface.co/{model_id}/resolve/{revision}/{filename}"
 PRESET_MIRROR_DICT = {
     "tuna": "https://mirrors.tuna.tsinghua.edu.cn/hugging-face-models",
     "bfsu": "https://mirrors.bfsu.edu.cn/hugging-face-models",
@@ -825,31 +827,31 @@ def is_remote_url(url_or_filename):
     return parsed.scheme in ("http", "https")
 
 
-def hf_bucket_url(model_id: str, filename: str, use_cdn=True, mirror=None) -> str:
+def hf_bucket_url(model_id: str, filename: str, revision="main", mirror=None) -> str:
     """
-    Resolve a model identifier, and a file name, to a HF-hosted url on either S3 or Cloudfront (a Content Delivery
-    Network, or CDN).
+    Resolve a model identifier, and a file name, to a huggingface.co-hosted url, potentially redirecting to Cloudfront
+    (a Content Delivery Network, or CDN).
 
     Cloudfront is replicated over the globe so downloads are way faster for the end user (and it also lowers our
     bandwidth costs). However, it is more aggressively cached by default, so may not always reflect the latest changes
     to the underlying file (default TTL is 24 hours).
 
-    In terms of client-side caching from this library, even though Cloudfront relays the ETags from S3, using one or
+    This is not an issue here however, because since migrating to git-based model versioning on huggingface.co,
+    we now store the files on S3/Cloudfront in a content-addressable way (i.e., the file name is its hash).
+
+    TODO(update) In terms of client-side caching from this library, even though Cloudfront relays the ETags from S3, using one or
     the other (or switching from one to the other) will affect caching: cached files are not shared between the two
     because the cached file's name contains a hash of the url.
     """
-    endpoint = (
-        PRESET_MIRROR_DICT.get(mirror, mirror)
-        if mirror
-        else CLOUDFRONT_DISTRIB_PREFIX
-        if use_cdn
-        else S3_BUCKET_PREFIX
-    )
-    legacy_format = "/" not in model_id
-    if legacy_format:
-        return f"{endpoint}/{model_id}-{filename}"
-    else:
-        return f"{endpoint}/{model_id}/{filename}"
+    if mirror:
+        endpoint = PRESET_MIRROR_DICT.get(mirror, mirror)
+        legacy_format = "/" not in model_id
+        if legacy_format:
+            return f"{endpoint}/{model_id}-{filename}"
+        else:
+            return f"{endpoint}/{model_id}/{filename}"
+
+    return HUGGINGFACE_CO_PREFIX.format(model_id=model_id, revision=revision, filename=filename)
 
 
 def url_to_filename(url, etag=None):

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -1087,7 +1087,7 @@ def get_from_cache(
             # between the HEAD and the GET (unlikely, but hey).
             if 300 <= r.status_code <= 399:
                 url_to_download = r.headers["Location"]
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as err:
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             # etag is already None
             pass
 

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -1119,7 +1119,7 @@ def get_from_cache(
             else:
                 resume_size = 0
         else:
-            temp_file_manager = partial(tempfile.NamedTemporaryFile, dir=cache_dir, delete=False)
+            temp_file_manager = partial(tempfile.NamedTemporaryFile, mode="wb", dir=cache_dir, delete=False)
             resume_size = 0
 
         # Download to temporary file, then copy to cache dir once finished.

--- a/src/transformers/hf_api.py
+++ b/src/transformers/hf_api.py
@@ -24,9 +24,7 @@ from tqdm import tqdm
 import requests
 
 
-# ENDPOINT = "https://huggingface.co"
-# ENDPOINT = "http://huggingface.test"
-ENDPOINT = "https://moon-preprod.huggingface.co"
+ENDPOINT = "https://huggingface.co"
 
 
 class RepoObj:

--- a/src/transformers/hf_api.py
+++ b/src/transformers/hf_api.py
@@ -24,12 +24,26 @@ from tqdm import tqdm
 import requests
 
 
-ENDPOINT = "https://huggingface.co"
+# ENDPOINT = "https://huggingface.co"
+# ENDPOINT = "http://huggingface.test"
+ENDPOINT = "https://moon-preprod.huggingface.co"
+
+
+class RepoObj:
+    """
+    HuggingFace git-based system, data structure that represents a file belonging to the current user.
+    """
+
+    def __init__(self, filename: str, lastModified: str, commit: str, size: int, **kwargs):
+        self.filename = filename
+        self.lastModified = lastModified
+        self.commit = commit
+        self.size = size
 
 
 class S3Obj:
     """
-    Data structure that represents a file belonging to the current user.
+    HuggingFace S3-based system, data structure that represents a file belonging to the current user.
     """
 
     def __init__(self, filename: str, LastModified: str, ETag: str, Size: int, **kwargs):
@@ -46,38 +60,25 @@ class PresignedUrl:
         self.type = type  # mime-type to send to S3.
 
 
-class S3Object:
+class ModelSibling:
     """
-    Data structure that represents a public file accessible on our S3.
+    Data structure that represents a public file inside a model, accessible from huggingface.co
     """
 
-    def __init__(
-        self,
-        key: str,  # S3 object key
-        etag: str,
-        lastModified: str,
-        size: int,
-        rfilename: str,  # filename relative to config.json
-        **kwargs
-    ):
-        self.key = key
-        self.etag = etag
-        self.lastModified = lastModified
-        self.size = size
-        self.rfilename = rfilename
+    def __init__(self, rfilename: str, **kwargs):
+        self.rfilename = rfilename  # filename relative to the model root
         for k, v in kwargs.items():
             setattr(self, k, v)
 
 
 class ModelInfo:
     """
-    Info about a public model accessible from our S3.
+    Info about a public model accessible from huggingface.co
     """
 
     def __init__(
         self,
-        modelId: str,  # id of model
-        key: str,  # S3 object key of config.json
+        modelId: Optional[str] = None,  # id of model
         author: Optional[str] = None,
         downloads: Optional[int] = None,
         tags: List[str] = [],
@@ -86,12 +87,11 @@ class ModelInfo:
         **kwargs
     ):
         self.modelId = modelId
-        self.key = key
         self.author = author
         self.downloads = downloads
         self.tags = tags
         self.pipeline_tag = pipeline_tag
-        self.siblings = [S3Object(**x) for x in siblings] if siblings is not None else None
+        self.siblings = [ModelSibling(**x) for x in siblings] if siblings is not None else None
         for k, v in kwargs.items():
             setattr(self, k, v)
 
@@ -134,9 +134,11 @@ class HfApi:
 
     def presign(self, token: str, filename: str, organization: Optional[str] = None) -> PresignedUrl:
         """
+        HuggingFace S3-based system, used for datasets and metrics.
+
         Call HF API to get a presigned url to upload `filename` to S3.
         """
-        path = "{}/api/presign".format(self.endpoint)
+        path = "{}/api/datasets/presign".format(self.endpoint)
         r = requests.post(
             path,
             headers={"authorization": "Bearer {}".format(token)},
@@ -148,6 +150,8 @@ class HfApi:
 
     def presign_and_upload(self, token: str, filename: str, filepath: str, organization: Optional[str] = None) -> str:
         """
+        HuggingFace S3-based system, used for datasets and metrics.
+
         Get a presigned url, then upload file to S3.
 
         Outputs: url: Read-only url for the stored file on S3.
@@ -169,9 +173,11 @@ class HfApi:
 
     def list_objs(self, token: str, organization: Optional[str] = None) -> List[S3Obj]:
         """
+        HuggingFace S3-based system, used for datasets and metrics.
+
         Call HF API to list all stored files for user (or one of their organizations).
         """
-        path = "{}/api/listObjs".format(self.endpoint)
+        path = "{}/api/datasets/listObjs".format(self.endpoint)
         params = {"organization": organization} if organization is not None else None
         r = requests.get(path, params=params, headers={"authorization": "Bearer {}".format(token)})
         r.raise_for_status()
@@ -180,9 +186,11 @@ class HfApi:
 
     def delete_obj(self, token: str, filename: str, organization: Optional[str] = None):
         """
+        HuggingFace S3-based system, used for datasets and metrics.
+
         Call HF API to delete a file stored by user
         """
-        path = "{}/api/deleteObj".format(self.endpoint)
+        path = "{}/api/datasets/deleteObj".format(self.endpoint)
         r = requests.delete(
             path,
             headers={"authorization": "Bearer {}".format(token)},
@@ -199,6 +207,51 @@ class HfApi:
         r.raise_for_status()
         d = r.json()
         return [ModelInfo(**x) for x in d]
+
+    def list_repos_objs(self, token: str, organization: Optional[str] = None) -> List[S3Obj]:
+        """
+        HuggingFace git-based system, used for models.
+
+        Call HF API to list all stored files for user (or one of their organizations).
+        """
+        path = "{}/api/repos/ls".format(self.endpoint)
+        params = {"organization": organization} if organization is not None else None
+        r = requests.get(path, params=params, headers={"authorization": "Bearer {}".format(token)})
+        r.raise_for_status()
+        d = r.json()
+        return [RepoObj(**x) for x in d]
+
+    def create_repo(self, token: str, name: str, organization: Optional[str] = None) -> str:
+        """
+        HuggingFace git-based system, used for models.
+
+        Call HF API to create a whole repo.
+        """
+        path = "{}/api/repos/create".format(self.endpoint)
+        r = requests.post(
+            path,
+            headers={"authorization": "Bearer {}".format(token)},
+            json={"name": name, "organization": organization},
+        )
+        r.raise_for_status()
+        d = r.json()
+        return d["url"]
+
+    def delete_repo(self, token: str, name: str, organization: Optional[str] = None):
+        """
+        HuggingFace git-based system, used for models.
+
+        Call HF API to delete a whole repo.
+
+        CAUTION(this is irreversible).
+        """
+        path = "{}/api/repos/delete".format(self.endpoint)
+        r = requests.delete(
+            path,
+            headers={"authorization": "Bearer {}".format(token)},
+            json={"name": name, "organization": organization},
+        )
+        r.raise_for_status()
 
 
 class TqdmProgressFileReader:

--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -144,9 +144,7 @@ class ModelCard:
         elif os.path.isfile(pretrained_model_name_or_path) or is_remote_url(pretrained_model_name_or_path):
             model_card_file = pretrained_model_name_or_path
         else:
-            model_card_file = hf_bucket_url(
-                pretrained_model_name_or_path, filename=MODEL_CARD_NAME, mirror=None
-            )
+            model_card_file = hf_bucket_url(pretrained_model_name_or_path, filename=MODEL_CARD_NAME, mirror=None)
 
         if find_from_standard_name or pretrained_model_name_or_path in ALL_PRETRAINED_CONFIG_ARCHIVE_MAP:
             model_card_file = model_card_file.replace(CONFIG_NAME, MODEL_CARD_NAME)
@@ -156,8 +154,6 @@ class ModelCard:
         try:
             # Load from URL or cache if already cached
             resolved_model_card_file = cached_path(model_card_file, cache_dir=cache_dir, proxies=proxies)
-            if resolved_model_card_file is None:
-                raise EnvironmentError
             if resolved_model_card_file == model_card_file:
                 logger.info("loading model card file {}".format(model_card_file))
             else:

--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -145,7 +145,7 @@ class ModelCard:
             model_card_file = pretrained_model_name_or_path
         else:
             model_card_file = hf_bucket_url(
-                pretrained_model_name_or_path, filename=MODEL_CARD_NAME, use_cdn=False, mirror=None
+                pretrained_model_name_or_path, filename=MODEL_CARD_NAME, mirror=None
             )
 
         if find_from_standard_name or pretrained_model_name_or_path in ALL_PRETRAINED_CONFIG_ARCHIVE_MAP:

--- a/src/transformers/modeling_auto.py
+++ b/src/transformers/modeling_auto.py
@@ -525,7 +525,7 @@ AUTO_MODEL_PRETRAINED_DOCSTRING = r"""
                 Whether or not to only look at local files (e.g., not try downloading the model).
             revision(:obj:`str`, `optional`, defaults to :obj:`"main"`):
                 The specific model version to use. It can be a branch name, a tag name, or a commit id, since we use a
-                git-based format for storing models and other artifacts on huggingface.co, so ``revision`` can be any
+                git-based system for storing models and other artifacts on huggingface.co, so ``revision`` can be any
                 identifier allowed by git.
             kwargs (additional keyword arguments, `optional`):
                 Can be used to update the configuration object (after it being loaded) and initiate the model (e.g.,

--- a/src/transformers/modeling_auto.py
+++ b/src/transformers/modeling_auto.py
@@ -524,10 +524,9 @@ AUTO_MODEL_PRETRAINED_DOCSTRING = r"""
             local_files_only(:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to only look at local files (e.g., not try downloading the model).
             revision(:obj:`str`, `optional`, defaults to :obj:`main`):
-                Whether to pin to a specific model version (can be a branch name, a tag name, or a commit id).
-                We use a git-based model for storing models and other artefacts on huggingface.co, so ``revision``
-                is any identifier allowed by git.
-                TODO(if agreed upon, duplicate this doc elsewhere.)
+                Whether to pin to a specific model version (can be a branch name, a tag name, or a commit id). We use a
+                git-based model for storing models and other artefacts on huggingface.co, so ``revision`` is any
+                identifier allowed by git. TODO(if agreed upon, duplicate this doc elsewhere.)
             kwargs (additional keyword arguments, `optional`):
                 Can be used to update the configuration object (after it being loaded) and initiate the model (e.g.,
                 :obj:`output_attentions=True`). Behaves differently depending on whether a ``config`` is provided or

--- a/src/transformers/modeling_auto.py
+++ b/src/transformers/modeling_auto.py
@@ -523,10 +523,10 @@ AUTO_MODEL_PRETRAINED_DOCSTRING = r"""
                 Whether ot not to also return a dictionary containing missing keys, unexpected keys and error messages.
             local_files_only(:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to only look at local files (e.g., not try downloading the model).
-            revision(:obj:`str`, `optional`, defaults to :obj:`main`):
-                Whether to pin to a specific model version (can be a branch name, a tag name, or a commit id). We use a
-                git-based model for storing models and other artefacts on huggingface.co, so ``revision`` is any
-                identifier allowed by git. TODO(if agreed upon, duplicate this doc elsewhere.)
+            revision(:obj:`str`, `optional`, defaults to :obj:`"main"`):
+                The specific model version to use. It can be a branch name, a tag name, or a commit id, since we use a
+                git-based format for storing models and other artifacts on huggingface.co, so ``revision`` can be any
+                identifier allowed by git.
             kwargs (additional keyword arguments, `optional`):
                 Can be used to update the configuration object (after it being loaded) and initiate the model (e.g.,
                 :obj:`output_attentions=True`). Behaves differently depending on whether a ``config`` is provided or

--- a/src/transformers/modeling_auto.py
+++ b/src/transformers/modeling_auto.py
@@ -523,9 +523,11 @@ AUTO_MODEL_PRETRAINED_DOCSTRING = r"""
                 Whether ot not to also return a dictionary containing missing keys, unexpected keys and error messages.
             local_files_only(:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to only look at local files (e.g., not try downloading the model).
-            use_cdn(:obj:`bool`, `optional`, defaults to :obj:`True`):
-                Whether or not to use Cloudfront (a Content Delivery Network, or CDN) when searching for the model on
-                our S3 (faster). Should be set to :obj:`False` for checkpoints larger than 20GB.
+            revision(:obj:`str`, `optional`, defaults to :obj:`main`):
+                Whether to pin to a specific model version (can be a branch name, a tag name, or a commit id).
+                We use a git-based model for storing models and other artefacts on huggingface.co, so ``revision``
+                is any identifier allowed by git.
+                TODO(if agreed upon, duplicate this doc elsewhere.)
             kwargs (additional keyword arguments, `optional`):
                 Can be used to update the configuration object (after it being loaded) and initiate the model (e.g.,
                 :obj:`output_attentions=True`). Behaves differently depending on whether a ``config`` is provided or

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -107,6 +107,7 @@ class FlaxPreTrainedModel(ABC):
         proxies = kwargs.pop("proxies", None)
         # output_loading_info = kwargs.pop("output_loading_info", False)
         local_files_only = kwargs.pop("local_files_only", False)
+        revision = kwargs.pop("revision", None)
 
         # Load config if we don't provide a configuration
         if not isinstance(config, PretrainedConfig):
@@ -120,6 +121,7 @@ class FlaxPreTrainedModel(ABC):
                 resume_download=resume_download,
                 proxies=proxies,
                 local_files_only=local_files_only,
+                revision=revision,
                 **kwargs,
             )
         else:
@@ -130,7 +132,7 @@ class FlaxPreTrainedModel(ABC):
             if os.path.isfile(pretrained_model_name_or_path) or is_remote_url(pretrained_model_name_or_path):
                 archive_file = pretrained_model_name_or_path
             else:
-                archive_file = hf_bucket_url(pretrained_model_name_or_path, filename=WEIGHTS_NAME)
+                archive_file = hf_bucket_url(pretrained_model_name_or_path, filename=WEIGHTS_NAME, revision=revision)
 
             # redirect to the cache, if necessary
             try:
@@ -142,16 +144,13 @@ class FlaxPreTrainedModel(ABC):
                     resume_download=resume_download,
                     local_files_only=local_files_only,
                 )
-            except EnvironmentError:
-                if pretrained_model_name_or_path in cls.pretrained_model_archive_map:
-                    msg = f"Couldn't reach server at '{archive_file}' to download pretrained weights."
-                else:
-                    msg = (
-                        f"Model name '{pretrained_model_name_or_path}' "
-                        f"was not found in model name list ({', '.join(cls.pretrained_model_archive_map.keys())}). "
-                        f"We assumed '{archive_file}' was a path or url to model weight files but "
-                        "couldn't find any such file at this path or url."
-                    )
+            except EnvironmentError as err:
+                logger.error(err)
+                msg = (
+                    f"Can't load weights for '{pretrained_model_name_or_path}'. Make sure that:\n\n"
+                    f"- '{pretrained_model_name_or_path}' is a correct model identifier listed on 'https://huggingface.co/models'\n\n"
+                    f"- or '{pretrained_model_name_or_path}' is the correct path to a directory containing a file named one of {TF2_WEIGHTS_NAME}, {WEIGHTS_NAME}.\n\n"
+                )
                 raise EnvironmentError(msg)
 
             if resolved_archive_file == archive_file:

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -149,7 +149,7 @@ class FlaxPreTrainedModel(ABC):
                 msg = (
                     f"Can't load weights for '{pretrained_model_name_or_path}'. Make sure that:\n\n"
                     f"- '{pretrained_model_name_or_path}' is a correct model identifier listed on 'https://huggingface.co/models'\n\n"
-                    f"- or '{pretrained_model_name_or_path}' is the correct path to a directory containing a file named one of {TF2_WEIGHTS_NAME}, {WEIGHTS_NAME}.\n\n"
+                    f"- or '{pretrained_model_name_or_path}' is the correct path to a directory containing a file named {WEIGHTS_NAME}.\n\n"
                 )
                 raise EnvironmentError(msg)
 

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -107,7 +107,6 @@ class FlaxPreTrainedModel(ABC):
         proxies = kwargs.pop("proxies", None)
         # output_loading_info = kwargs.pop("output_loading_info", False)
         local_files_only = kwargs.pop("local_files_only", False)
-        use_cdn = kwargs.pop("use_cdn", True)
 
         # Load config if we don't provide a configuration
         if not isinstance(config, PretrainedConfig):
@@ -131,7 +130,7 @@ class FlaxPreTrainedModel(ABC):
             if os.path.isfile(pretrained_model_name_or_path) or is_remote_url(pretrained_model_name_or_path):
                 archive_file = pretrained_model_name_or_path
             else:
-                archive_file = hf_bucket_url(pretrained_model_name_or_path, filename=WEIGHTS_NAME, use_cdn=use_cdn)
+                archive_file = hf_bucket_url(pretrained_model_name_or_path, filename=WEIGHTS_NAME)
 
             # redirect to the cache, if necessary
             try:

--- a/src/transformers/modeling_tf_auto.py
+++ b/src/transformers/modeling_tf_auto.py
@@ -416,9 +416,6 @@ TF_AUTO_MODEL_PRETRAINED_DOCSTRING = r"""
                 Whether ot not to also return a dictionary containing missing keys, unexpected keys and error messages.
             local_files_only(:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to only look at local files (e.g., not try downloading the model).
-            use_cdn(:obj:`bool`, `optional`, defaults to :obj:`True`):
-                Whether or not to use Cloudfront (a Content Delivery Network, or CDN) when searching for the model on
-                our S3 (faster). Should be set to :obj:`False` for checkpoints larger than 20GB.
             kwargs (additional keyword arguments, `optional`):
                 Can be used to update the configuration object (after it being loaded) and initiate the model (e.g.,
                 :obj:`output_attentions=True`). Behaves differently depending on whether a ``config`` is provided or

--- a/src/transformers/modeling_tf_auto.py
+++ b/src/transformers/modeling_tf_auto.py
@@ -416,6 +416,10 @@ TF_AUTO_MODEL_PRETRAINED_DOCSTRING = r"""
                 Whether ot not to also return a dictionary containing missing keys, unexpected keys and error messages.
             local_files_only(:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to only look at local files (e.g., not try downloading the model).
+            revision(:obj:`str`, `optional`, defaults to :obj:`"main"`):
+                The specific model version to use. It can be a branch name, a tag name, or a commit id, since we use a
+                git-based system for storing models and other artifacts on huggingface.co, so ``revision`` can be any
+                identifier allowed by git.
             kwargs (additional keyword arguments, `optional`):
                 Can be used to update the configuration object (after it being loaded) and initiate the model (e.g.,
                 :obj:`output_attentions=True`). Behaves differently depending on whether a ``config`` is provided or

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -572,9 +572,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
                 Whether ot not to also return a dictionary containing missing keys, unexpected keys and error messages.
             local_files_only(:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to only look at local files (e.g., not try doanloading the model).
-            use_cdn(:obj:`bool`, `optional`, defaults to :obj:`True`):
-                Whether or not to use Cloudfront (a Content Delivery Network, or CDN) when searching for the model on
-                our S3 (faster). Should be set to :obj:`False` for checkpoints larger than 20GB.
             mirror(:obj:`str`, `optional`, defaults to :obj:`None`):
                 Mirror source to accelerate downloads in China. If you are from China and have an accessibility
                 problem, you can set this option to resolve it. Note that we do not guarantee the timeliness or safety.
@@ -616,7 +613,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
         proxies = kwargs.pop("proxies", None)
         output_loading_info = kwargs.pop("output_loading_info", False)
         local_files_only = kwargs.pop("local_files_only", False)
-        use_cdn = kwargs.pop("use_cdn", True)
         mirror = kwargs.pop("mirror", None)
 
         # Load config if we don't provide a configuration
@@ -659,7 +655,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
                 archive_file = hf_bucket_url(
                     pretrained_model_name_or_path,
                     filename=(WEIGHTS_NAME if from_pt else TF2_WEIGHTS_NAME),
-                    use_cdn=use_cdn,
                     mirror=mirror,
                 )
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -668,9 +668,8 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
                     resume_download=resume_download,
                     local_files_only=local_files_only,
                 )
-                if resolved_archive_file is None:
-                    raise EnvironmentError
-            except EnvironmentError:
+            except EnvironmentError as err:
+                logger.error(err)
                 msg = (
                     f"Can't load weights for '{pretrained_model_name_or_path}'. Make sure that:\n\n"
                     f"- '{pretrained_model_name_or_path}' is a correct model identifier listed on 'https://huggingface.co/models'\n\n"

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -572,6 +572,10 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
                 Whether ot not to also return a dictionary containing missing keys, unexpected keys and error messages.
             local_files_only(:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to only look at local files (e.g., not try doanloading the model).
+            revision(:obj:`str`, `optional`, defaults to :obj:`"main"`):
+                The specific model version to use. It can be a branch name, a tag name, or a commit id, since we use a
+                git-based system for storing models and other artifacts on huggingface.co, so ``revision`` can be any
+                identifier allowed by git.
             mirror(:obj:`str`, `optional`, defaults to :obj:`None`):
                 Mirror source to accelerate downloads in China. If you are from China and have an accessibility
                 problem, you can set this option to resolve it. Note that we do not guarantee the timeliness or safety.
@@ -613,6 +617,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
         proxies = kwargs.pop("proxies", None)
         output_loading_info = kwargs.pop("output_loading_info", False)
         local_files_only = kwargs.pop("local_files_only", False)
+        revision = kwargs.pop("revision", None)
         mirror = kwargs.pop("mirror", None)
 
         # Load config if we don't provide a configuration
@@ -627,6 +632,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
                 resume_download=resume_download,
                 proxies=proxies,
                 local_files_only=local_files_only,
+                revision=revision,
                 **kwargs,
             )
         else:
@@ -655,6 +661,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
                 archive_file = hf_bucket_url(
                     pretrained_model_name_or_path,
                     filename=(WEIGHTS_NAME if from_pt else TF2_WEIGHTS_NAME),
+                    revision=revision,
                     mirror=mirror,
                 )
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -920,9 +920,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
                     resume_download=resume_download,
                     local_files_only=local_files_only,
                 )
-                if resolved_archive_file is None:
-                    raise EnvironmentError
-            except EnvironmentError:
+            except EnvironmentError as err:
+                logger.error(err)
                 msg = (
                     f"Can't load weights for '{pretrained_model_name_or_path}'. Make sure that:\n\n"
                     f"- '{pretrained_model_name_or_path}' is a correct model identifier listed on 'https://huggingface.co/models'\n\n"

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -813,6 +813,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
                 Whether ot not to also return a dictionary containing missing keys, unexpected keys and error messages.
             local_files_only(:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to only look at local files (e.g., not try doanloading the model).
+            revision(:obj:`str`, `optional`, defaults to :obj:`"main"`):
+                The specific model version to use. It can be a branch name, a tag name, or a commit id, since we use a
+                git-based system for storing models and other artifacts on huggingface.co, so ``revision`` can be any
+                identifier allowed by git.
             mirror(:obj:`str`, `optional`, defaults to :obj:`None`):
                 Mirror source to accelerate downloads in China. If you are from China and have an accessibility
                 problem, you can set this option to resolve it. Note that we do not guarantee the timeliness or safety.
@@ -869,6 +873,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
                 resume_download=resume_download,
                 proxies=proxies,
                 local_files_only=local_files_only,
+                revision=revision,
                 **kwargs,
             )
         else:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -813,9 +813,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
                 Whether ot not to also return a dictionary containing missing keys, unexpected keys and error messages.
             local_files_only(:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to only look at local files (e.g., not try doanloading the model).
-            use_cdn(:obj:`bool`, `optional`, defaults to :obj:`True`):
-                Whether or not to use Cloudfront (a Content Delivery Network, or CDN) when searching for the model on
-                our S3 (faster). Should be set to :obj:`False` for checkpoints larger than 20GB.
             mirror(:obj:`str`, `optional`, defaults to :obj:`None`):
                 Mirror source to accelerate downloads in China. If you are from China and have an accessibility
                 problem, you can set this option to resolve it. Note that we do not guarantee the timeliness or safety.
@@ -857,7 +854,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
         proxies = kwargs.pop("proxies", None)
         output_loading_info = kwargs.pop("output_loading_info", False)
         local_files_only = kwargs.pop("local_files_only", False)
-        use_cdn = kwargs.pop("use_cdn", True)
+        revision = kwargs.pop("revision", None)
         mirror = kwargs.pop("mirror", None)
 
         # Load config if we don't provide a configuration
@@ -909,7 +906,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin):
                 archive_file = hf_bucket_url(
                     pretrained_model_name_or_path,
                     filename=(TF2_WEIGHTS_NAME if from_tf else WEIGHTS_NAME),
-                    use_cdn=use_cdn,
+                    revision=revision,
                     mirror=mirror,
                 )
 

--- a/src/transformers/retrieval_rag.py
+++ b/src/transformers/retrieval_rag.py
@@ -125,8 +125,6 @@ class LegacyIndex(Index):
         try:
             # Load from URL or cache if already cached
             resolved_archive_file = cached_path(archive_file)
-            if resolved_archive_file is None:
-                raise EnvironmentError
         except EnvironmentError:
             msg = (
                 f"Can't load '{archive_file}'. Make sure that:\n\n"

--- a/src/transformers/tokenization_auto.py
+++ b/src/transformers/tokenization_auto.py
@@ -276,6 +276,10 @@ class AutoTokenizer:
             proxies (:obj:`Dict[str, str]`, `optional`):
                 A dictionary of proxy servers to use by protocol or endpoint, e.g., :obj:`{'http': 'foo.bar:3128',
                 'http://hostname': 'foo.bar:4012'}`. The proxies are used on each request.
+            revision(:obj:`str`, `optional`, defaults to :obj:`"main"`):
+                The specific model version to use. It can be a branch name, a tag name, or a commit id, since we use a
+                git-based system for storing models and other artifacts on huggingface.co, so ``revision`` can be any
+                identifier allowed by git.
             use_fast (:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to try to load the fast version of the tokenizer.
             kwargs (additional keyword arguments, `optional`):

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1517,6 +1517,10 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
             proxies (:obj:`Dict[str, str], `optional`):
                 A dictionary of proxy servers to use by protocol or endpoint, e.g., :obj:`{'http': 'foo.bar:3128',
                 'http://hostname': 'foo.bar:4012'}`. The proxies are used on each request.
+            revision(:obj:`str`, `optional`, defaults to :obj:`"main"`):
+                The specific model version to use. It can be a branch name, a tag name, or a commit id, since we use a
+                git-based system for storing models and other artifacts on huggingface.co, so ``revision`` can be any
+                identifier allowed by git.
             inputs (additional positional arguments, `optional`):
                 Will be passed along to the Tokenizer ``__init__`` method.
             kwargs (additional keyword arguments, `optional`):
@@ -1551,6 +1555,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
         resume_download = kwargs.pop("resume_download", False)
         proxies = kwargs.pop("proxies", None)
         local_files_only = kwargs.pop("local_files_only", False)
+        revision = kwargs.pop("revision", None)
 
         s3_models = list(cls.max_model_input_sizes.keys())
         vocab_files = {}
@@ -1602,7 +1607,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
                             logger.info("Didn't find file {}. We won't load it.".format(full_file_name))
                             full_file_name = None
                     else:
-                        full_file_name = hf_bucket_url(pretrained_model_name_or_path, filename=file_name, mirror=None)
+                        full_file_name = hf_bucket_url(
+                            pretrained_model_name_or_path, filename=file_name, revision=revision, mirror=None
+                        )
 
                     vocab_files[file_id] = full_file_name
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1624,6 +1624,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
                 except requests.exceptions.HTTPError as err:
                     if "404 Client Error" in str(err):
                         logger.debug(err)
+                        resolved_vocab_files[file_id] = None
                     else:
                         raise err
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1601,7 +1601,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
                             full_file_name = None
                     else:
                         full_file_name = hf_bucket_url(
-                            pretrained_model_name_or_path, filename=file_name, use_cdn=False, mirror=None
+                            pretrained_model_name_or_path, filename=file_name, mirror=None
                         )
 
                     vocab_files[file_id] = full_file_name

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,0 +1,38 @@
+import unittest
+
+import requests
+from transformers.file_utils import CONFIG_NAME, WEIGHTS_NAME, filename_to_url, get_from_cache, hf_bucket_url
+from transformers.testing_utils import DUMMY_UNKWOWN_IDENTIFIER
+
+
+MODEL_ID = DUMMY_UNKWOWN_IDENTIFIER
+REVISION_ID = "main"
+PINNED_SHA1 = "d9e9f15bc825e4b2c9249e9578f884bbcb5e3684"
+PINNED_SHA256 = "4b243c475af8d0a7754e87d7d096c92e5199ec2fe168a2ee7998e3b8e9bcb1d3"
+
+
+class GetFromCacheTests(unittest.TestCase):
+    def test_bogus_url(self):
+        # This lets us simulate no connection
+        # as the error raised is the same
+        # `ConnectionError`
+        url = "https://bogus"
+        with self.assertRaisesRegex(ValueError, "Connection error"):
+            _ = get_from_cache(url)
+
+    def test_not_found(self):
+        url = hf_bucket_url(MODEL_ID, filename="missing.bin")
+        with self.assertRaisesRegex(requests.exceptions.HTTPError, "404 Client Error"):
+            _ = get_from_cache(url)
+
+    def test_standard_object(self):
+        url = hf_bucket_url(MODEL_ID, filename=CONFIG_NAME, revision=REVISION_ID)
+        filepath = get_from_cache(url, force_download=True)
+        metadata = filename_to_url(filepath)
+        self.assertEqual(metadata, (url, f'"{PINNED_SHA1}"'))
+
+    def test_lfs_object(self):
+        url = hf_bucket_url(MODEL_ID, filename=WEIGHTS_NAME, revision=REVISION_ID)
+        filepath = get_from_cache(url, force_download=True)
+        metadata = filename_to_url(filepath)
+        self.assertEqual(metadata, (url, f'"{PINNED_SHA256}"'))

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -48,7 +48,7 @@ class GetFromCacheTests(unittest.TestCase):
         metadata = filename_to_url(filepath)
         self.assertEqual(metadata, (url, f'"{PINNED_SHA1}"'))
 
-    def test_standard_object(self):
+    def test_standard_object_rev(self):
         # Same object, but different revision
         url = hf_bucket_url(MODEL_ID, filename=CONFIG_NAME, revision=REVISION_ID_ONE_SPECIFIC_COMMIT)
         filepath = get_from_cache(url, force_download=True)

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -10,8 +10,8 @@ MODEL_ID = DUMMY_UNKWOWN_IDENTIFIER
 
 REVISION_ID_DEFAULT = "main"
 # Default branch name
-REVISION_ID_ONE_SPECIFIC_COMMIT = "432fec7515a022825ab3b79096838778e30aac17"
-# One particular commit
+REVISION_ID_ONE_SPECIFIC_COMMIT = "f2c752cfc5c0ab6f4bdec59acea69eefbee381c2"
+# One particular commit (not the top of `main`)
 REVISION_ID_INVALID = "aaaaaaa"
 # This commit does not exist, so we should 404.
 

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -6,9 +6,19 @@ from transformers.testing_utils import DUMMY_UNKWOWN_IDENTIFIER
 
 
 MODEL_ID = DUMMY_UNKWOWN_IDENTIFIER
-REVISION_ID = "main"
+# An actual model hosted on huggingface.co
+
+REVISION_ID_DEFAULT = "main"
+# Default branch name
+REVISION_ID_ONE_SPECIFIC_COMMIT = "432fec7515a022825ab3b79096838778e30aac17"
+# One particular commit
+REVISION_ID_INVALID = "aaaaaaa"
+# This commit does not exist, so we should 404.
+
 PINNED_SHA1 = "d9e9f15bc825e4b2c9249e9578f884bbcb5e3684"
+# Sha-1 of config.json on the top of `main`, for checking purposes
 PINNED_SHA256 = "4b243c475af8d0a7754e87d7d096c92e5199ec2fe168a2ee7998e3b8e9bcb1d3"
+# Sha-256 of pytorch_model.bin on the top of `main`, for checking purposes
 
 
 class GetFromCacheTests(unittest.TestCase):
@@ -20,19 +30,34 @@ class GetFromCacheTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Connection error"):
             _ = get_from_cache(url)
 
-    def test_not_found(self):
+    def test_file_not_found(self):
+        # Valid revision (None) but missing file.
         url = hf_bucket_url(MODEL_ID, filename="missing.bin")
         with self.assertRaisesRegex(requests.exceptions.HTTPError, "404 Client Error"):
             _ = get_from_cache(url)
 
+    def test_revision_not_found(self):
+        # Valid file but missing revision
+        url = hf_bucket_url(MODEL_ID, filename=CONFIG_NAME, revision=REVISION_ID_INVALID)
+        with self.assertRaisesRegex(requests.exceptions.HTTPError, "404 Client Error"):
+            _ = get_from_cache(url)
+
     def test_standard_object(self):
-        url = hf_bucket_url(MODEL_ID, filename=CONFIG_NAME, revision=REVISION_ID)
+        url = hf_bucket_url(MODEL_ID, filename=CONFIG_NAME, revision=REVISION_ID_DEFAULT)
         filepath = get_from_cache(url, force_download=True)
         metadata = filename_to_url(filepath)
         self.assertEqual(metadata, (url, f'"{PINNED_SHA1}"'))
 
+    def test_standard_object(self):
+        # Same object, but different revision
+        url = hf_bucket_url(MODEL_ID, filename=CONFIG_NAME, revision=REVISION_ID_ONE_SPECIFIC_COMMIT)
+        filepath = get_from_cache(url, force_download=True)
+        metadata = filename_to_url(filepath)
+        self.assertNotEqual(metadata[1], f'"{PINNED_SHA1}"')
+        # Caution: check that the etag is *not* equal to the one from `test_standard_object`
+
     def test_lfs_object(self):
-        url = hf_bucket_url(MODEL_ID, filename=WEIGHTS_NAME, revision=REVISION_ID)
+        url = hf_bucket_url(MODEL_ID, filename=WEIGHTS_NAME, revision=REVISION_ID_DEFAULT)
         filepath = get_from_cache(url, force_download=True)
         metadata = filename_to_url(filepath)
         self.assertEqual(metadata, (url, f'"{PINNED_SHA256}"'))

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -20,7 +20,7 @@ import unittest
 
 import requests
 from requests.exceptions import HTTPError
-from transformers.hf_api import HfApi, HfFolder, ModelInfo, PresignedUrl, S3Obj
+from transformers.hf_api import HfApi, HfFolder, ModelInfo, PresignedUrl, RepoObj, S3Obj
 
 
 USER = "__DUMMY_TRANSFORMERS_USER__"
@@ -35,7 +35,10 @@ FILES = [
         os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures/empty.txt"),
     ),
 ]
-ENDPOINT_STAGING = "https://moon-staging.huggingface.co"
+REPO_NAME = "my-model-{}".format(int(time.time()))
+# ENDPOINT_STAGING = "https://moon-staging.huggingface.co"
+ENDPOINT_STAGING = "https://moon-preprod.huggingface.co"
+# ENDPOINT_STAGING = "http://huggingface.test"
 
 
 class HfApiCommonTest(unittest.TestCase):
@@ -78,15 +81,6 @@ class HfApiEndpointsTest(HfApiCommonTest):
         urls = self._api.presign(token=self._token, filename="nested/valid_org.txt", organization="valid_org")
         self.assertIsInstance(urls, PresignedUrl)
 
-    def test_presign_invalid(self):
-        try:
-            _ = self._api.presign(token=self._token, filename="non_nested.json")
-        except HTTPError as e:
-            self.assertIsNotNone(e.response.text)
-            self.assertTrue("Filename invalid" in e.response.text)
-        else:
-            self.fail("Expected an exception")
-
     def test_presign(self):
         for FILE_KEY, FILE_PATH in FILES:
             urls = self._api.presign(token=self._token, filename=FILE_KEY)
@@ -108,6 +102,17 @@ class HfApiEndpointsTest(HfApiCommonTest):
         if len(objs) > 0:
             o = objs[-1]
             self.assertIsInstance(o, S3Obj)
+
+    def test_list_repos_objs(self):
+        objs = self._api.list_repos_objs(token=self._token)
+        self.assertIsInstance(objs, list)
+        if len(objs) > 0:
+            o = objs[-1]
+            self.assertIsInstance(o, RepoObj)
+
+    def test_create_and_delete_repo(self):
+        self._api.create_repo(token=self._token, name=REPO_NAME)
+        self._api.delete_repo(token=self._token, name=REPO_NAME)
 
 
 class HfApiPublicTest(unittest.TestCase):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -36,9 +36,7 @@ FILES = [
     ),
 ]
 REPO_NAME = "my-model-{}".format(int(time.time()))
-# ENDPOINT_STAGING = "https://moon-staging.huggingface.co"
-ENDPOINT_STAGING = "https://moon-preprod.huggingface.co"
-# ENDPOINT_STAGING = "http://huggingface.test"
+ENDPOINT_STAGING = "https://moon-staging.huggingface.co"
 
 
 class HfApiCommonTest(unittest.TestCase):

--- a/tests/test_modeling_tf_bert.py
+++ b/tests/test_modeling_tf_bert.py
@@ -323,7 +323,7 @@ class TFBertModelTest(TFModelTesterMixin, unittest.TestCase):
 
     def test_custom_load_tf_weights(self):
         model, output_loading_info = TFBertForTokenClassification.from_pretrained(
-            "jplu/tiny-tf-bert-random", use_cdn=False, output_loading_info=True
+            "jplu/tiny-tf-bert-random", output_loading_info=True
         )
         self.assertEqual(sorted(output_loading_info["unexpected_keys"]), ["mlm___cls", "nsp___cls"])
         for layer in output_loading_info["missing_keys"]:

--- a/tests/test_modeling_tf_longformer.py
+++ b/tests/test_modeling_tf_longformer.py
@@ -436,7 +436,7 @@ class TFLongformerModelIntegrationTest(unittest.TestCase):
         tf.debugging.assert_near(chunked_hidden_states[0, 0, :, 0], expected_slice_along_chunk, rtol=1e-3)
 
     def test_layer_local_attn(self):
-        model = TFLongformerModel.from_pretrained("patrickvonplaten/longformer-random-tiny", use_cdn=False)
+        model = TFLongformerModel.from_pretrained("patrickvonplaten/longformer-random-tiny")
         layer = model.longformer.encoder.layer[0].attention.self_attention
         hidden_states = self._get_hidden_states()
         batch_size, seq_length, hidden_size = hidden_states.shape
@@ -460,7 +460,7 @@ class TFLongformerModelIntegrationTest(unittest.TestCase):
         tf.debugging.assert_near(output_hidden_states[0, 1], expected_slice, rtol=1e-3)
 
     def test_layer_global_attn(self):
-        model = TFLongformerModel.from_pretrained("patrickvonplaten/longformer-random-tiny", use_cdn=False)
+        model = TFLongformerModel.from_pretrained("patrickvonplaten/longformer-random-tiny")
         layer = model.longformer.encoder.layer[0].attention.self_attention
         hidden_states = self._get_hidden_states()
 

--- a/utils/check_dummies.py
+++ b/utils/check_dummies.py
@@ -165,7 +165,7 @@ DUMMY_FUNCTION = {
 
 
 def read_init():
-    """ Read the init and exctracts PyTorch, TensorFlow, SentencePiece and Tokenizers objects. """
+    """ Read the init and extracts PyTorch, TensorFlow, SentencePiece and Tokenizers objects. """
     with open(os.path.join(PATH_TO_TRANSFORMERS, "__init__.py"), "r", encoding="utf-8") as f:
         lines = f.readlines()
 


### PR DESCRIPTION
**Write-up about the context for this change, and the enabled features is at https://discuss.huggingface.co/t/announcement-model-versioning-upcoming-changes-to-the-model-hub/1914**

In short:

1. changes to the file downloading code used in `from_pretrained()` methods to use the new file URLs backed by huggingface-hosted git repos.
2. changes to the model upload CLI to create a model repo then be able to git clone and git push to it.
