### PR TITLE
Return raw outputs in TextClassificationPipeline

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -288,7 +288,7 @@ class PretrainedConfig(PushToHubMixin):
         allowed_problem_types = ("regression", "single_label_classification", "multi_label_classification")
         if self.problem_type is not None and self.problem_type not in allowed_problem_types:
             raise ValueError(
-                f"The config parameter `problem_type` wasnot understood: received {self.problem_type}"
+                f"The config parameter `problem_type` was not understood: received {self.problem_type}"
                 "but only 'regression', 'single_label_classification' and 'multi_label_classification' are valid."
             )
 

--- a/src/transformers/pipelines/text_classification.py
+++ b/src/transformers/pipelines/text_classification.py
@@ -95,6 +95,12 @@ class TextClassificationPipeline(Pipeline):
         return_all_scores = return_all_scores if return_all_scores is not None else self.return_all_scores
         function_to_apply = function_to_apply if function_to_apply is not None else self.function_to_apply
 
+        if function_to_apply is None and self.model.config.problem_type is not None:
+            if self.model.config.problem_type == "multi_label_classification":
+                self.function_to_apply = "sigmoid"
+            elif self.model.config.problem_type == "single_label_classification":
+                self.function_to_apply = "softmax"
+
         def sigmoid(_outputs):
             return 1.0 / (1.0 + np.exp(-_outputs))
 

--- a/src/transformers/pipelines/text_classification.py
+++ b/src/transformers/pipelines/text_classification.py
@@ -105,7 +105,9 @@ class TextClassificationPipeline(Pipeline):
             return 1.0 / (1.0 + np.exp(-_outputs))
 
         def softmax(_outputs):
-            return np.exp(_outputs) / np.exp(_outputs).sum(-1, keepdims=True)
+            maxes = np.max(_outputs, axis=-1, keepdims=True)
+            shifted_exp = np.exp(_outputs - maxes)
+            return shifted_exp / shifted_exp.sum(axis=-1, keepdims=True)
 
         if function_to_apply == "default":
             if self.model.config.num_labels == 1:

--- a/tests/test_pipelines_text_classification.py
+++ b/tests/test_pipelines_text_classification.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+import numpy as np
 
 from transformers import (
     MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING,

--- a/tests/test_pipelines_text_classification.py
+++ b/tests/test_pipelines_text_classification.py
@@ -14,8 +14,6 @@
 
 import unittest
 
-import numpy as np
-
 from transformers import (
     MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING,
     TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING,
@@ -26,7 +24,6 @@ from transformers.testing_utils import is_pipeline_test, nested_simplify, requir
 
 from .test_pipelines_common import ANY, PipelineTestCaseMeta
 
-from .test_pipelines_common import MonoInputPipelineCommonMixin
 
 @is_pipeline_test
 class TextClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta):

--- a/tests/test_pipelines_text_classification.py
+++ b/tests/test_pipelines_text_classification.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+
 import numpy as np
 
 from transformers import (
@@ -25,6 +26,7 @@ from transformers.testing_utils import is_pipeline_test, nested_simplify, requir
 
 from .test_pipelines_common import ANY, PipelineTestCaseMeta
 
+from .test_pipelines_common import MonoInputPipelineCommonMixin
 
 @is_pipeline_test
 class TextClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta):


### PR DESCRIPTION
Currently the `TextClassificationPipeline` does a softmax over the output values when `num_labels > 1`, and does a sigmoid over the output when `num_labels == 1`.

As seen in https://github.com/huggingface/transformers/issues/8259, this may be problematic when systems depend on a different output range.

Adding a flag `return_raw_outputs` that will not apply the sigmoid or softmax in that case.

closes #8259