### PR TITLE
Docs bart training ref

### DIFF
--- a/docs/source/model_doc/bart.rst
+++ b/docs/source/model_doc/bart.rst
@@ -23,9 +23,19 @@ According to the abstract,
   state-of-the-art results on a range of abstractive dialogue, question answering, and summarization tasks, with gains
   of up to 6 ROUGE.
 
-The Authors' code can be found `here <https://github.com/pytorch/fairseq/tree/master/examples/bart>`__. An example
-of how to train Bart for conditional generation such as summarisation can be found in `this 
+The Authors' code can be found `here <https://github.com/pytorch/fairseq/tree/master/examples/bart>`__. An example of
+how to train Bart for conditional generation such as summarisation can be found in `this
 <https://discuss.huggingface.co/t/train-bart-for-conditional-generation-e-g-summarization/1904>`__ forum discussion.
+
+
+Examples
+_______________________________________________________________________________________________________________________
+
+- Examples and scripts for fine-tuning BART and other models for sequence to sequence tasks can be found in
+  `examples/seq2seq/ <https://github.com/huggingface/transformers/blob/master/examples/seq2seq/README.md>`__.
+- An example of how to train :class:`~transformers.BartForConditionalGeneration` with a Hugging Face :obj:`datasets` object
+  can be found in this
+  `forum discussion <https://discuss.huggingface.co/t/train-bart-for-conditional-generation-e-g-summarization/1904>`__.
 
 
 Implementation Notes

--- a/docs/source/model_doc/bart.rst
+++ b/docs/source/model_doc/bart.rst
@@ -23,7 +23,9 @@ According to the abstract,
   state-of-the-art results on a range of abstractive dialogue, question answering, and summarization tasks, with gains
   of up to 6 ROUGE.
 
-The Authors' code can be found `here <https://github.com/pytorch/fairseq/tree/master/examples/bart>`__.
+The Authors' code can be found `here <https://github.com/pytorch/fairseq/tree/master/examples/bart>`__. An example
+of how to train Bart conditional generation such as summarisation can be found in `this 
+<https://discuss.huggingface.co/t/train-bart-for-conditional-generation-e-g-summarization/1904>`__ forum topic.
 
 
 Implementation Notes

--- a/docs/source/model_doc/bart.rst
+++ b/docs/source/model_doc/bart.rst
@@ -23,9 +23,7 @@ According to the abstract,
   state-of-the-art results on a range of abstractive dialogue, question answering, and summarization tasks, with gains
   of up to 6 ROUGE.
 
-The Authors' code can be found `here <https://github.com/pytorch/fairseq/tree/master/examples/bart>`__. An example of
-how to train Bart for conditional generation such as summarisation can be found in `this
-<https://discuss.huggingface.co/t/train-bart-for-conditional-generation-e-g-summarization/1904>`__ forum discussion.
+The Authors' code can be found `here <https://github.com/pytorch/fairseq/tree/master/examples/bart>`__.
 
 
 Examples

--- a/docs/source/model_doc/bart.rst
+++ b/docs/source/model_doc/bart.rst
@@ -24,8 +24,8 @@ According to the abstract,
   of up to 6 ROUGE.
 
 The Authors' code can be found `here <https://github.com/pytorch/fairseq/tree/master/examples/bart>`__. An example
-of how to train Bart conditional generation such as summarisation can be found in `this 
-<https://discuss.huggingface.co/t/train-bart-for-conditional-generation-e-g-summarization/1904>`__ forum topic.
+of how to train Bart for conditional generation such as summarisation can be found in `this 
+<https://discuss.huggingface.co/t/train-bart-for-conditional-generation-e-g-summarization/1904>`__ forum discussion.
 
 
 Implementation Notes

--- a/docs/source/model_doc/bart.rst
+++ b/docs/source/model_doc/bart.rst
@@ -33,9 +33,9 @@ ________________________________________________________________________________
 
 - Examples and scripts for fine-tuning BART and other models for sequence to sequence tasks can be found in
   `examples/seq2seq/ <https://github.com/huggingface/transformers/blob/master/examples/seq2seq/README.md>`__.
-- An example of how to train :class:`~transformers.BartForConditionalGeneration` with a Hugging Face :obj:`datasets` object
-  can be found in this
-  `forum discussion <https://discuss.huggingface.co/t/train-bart-for-conditional-generation-e-g-summarization/1904>`__.
+- An example of how to train :class:`~transformers.BartForConditionalGeneration` with a Hugging Face :obj:`datasets`
+  object can be found in this `forum discussion
+  <https://discuss.huggingface.co/t/train-bart-for-conditional-generation-e-g-summarization/1904>`__.
 
 
 Implementation Notes

--- a/examples/seq2seq/README.md
+++ b/examples/seq2seq/README.md
@@ -1,7 +1,7 @@
 ## Sequence to Sequence Training and Evaluation
 
 This directory contains examples for finetuning and evaluating transformers on summarization and translation tasks.
-Please tag @sshleifer with any issues/unexpected behaviors, or send a PR!
+Please tag @patil-suraj with any issues/unexpected behaviors, or send a PR!
 For deprecated `bertabs` instructions, see [`bertabs/README.md`](bertabs/README.md).
 
 ### Supported Architectures


### PR DESCRIPTION
# What does this PR do?
Following the discussion on #7828 with @sshleifer and others I created a minimal example on the forum and added a reference to the Bart documentation. Let me know if this works for you.