### PR TITLE
Fix some tooling for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,8 @@
 check_dirs := examples tests src utils
 
 modified_only_fixup:
-<<<<<<< HEAD
 	$(eval modified_py_files := $(shell python utils/get_modified_files.py $(check_dirs)))
 	@if test -n "$(modified_py_files)"; then \
-=======
-	# get modified files since the branch was made
-	fork_point_sha := $(shell git merge-base --fork-point master)
-	joined_dirs := $(shell echo $(check_dirs) | tr " " "|")
-	modified_py_files := $(shell git diff --name-only $(fork_point_sha) | egrep '^($(joined_dirs))' | egrep '\.py$$')
-	#$(info modified files are: $(modified_py_files))
-	@if [ -n "$(modified_py_files)" ]; then \
->>>>>>> 68499866... Fix some tooling for windows
 		echo "Checking/fixing $(modified_py_files)"; \
 		black $(modified_py_files); \
 		isort $(modified_py_files); \

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,17 @@
 check_dirs := examples tests src utils
 
 modified_only_fixup:
+<<<<<<< HEAD
 	$(eval modified_py_files := $(shell python utils/get_modified_files.py $(check_dirs)))
 	@if test -n "$(modified_py_files)"; then \
+=======
+	# get modified files since the branch was made
+	fork_point_sha := $(shell git merge-base --fork-point master)
+	joined_dirs := $(shell echo $(check_dirs) | tr " " "|")
+	modified_py_files := $(shell git diff --name-only $(fork_point_sha) | egrep '^($(joined_dirs))' | egrep '\.py$$')
+	#$(info modified files are: $(modified_py_files))
+	@if [ -n "$(modified_py_files)" ]; then \
+>>>>>>> 68499866... Fix some tooling for windows
 		echo "Checking/fixing $(modified_py_files)"; \
 		black $(modified_py_files); \
 		isort $(modified_py_files); \

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -163,7 +163,7 @@ def get_model_doc_files():
 def find_tested_models(test_file):
     """ Parse the content of test_file to detect what's in all_model_classes"""
     # This is a bit hacky but I didn't find a way to import the test_file as a module and read inside the class
-    with open(os.path.join(PATH_TO_TESTS, test_file)) as f:
+    with open(os.path.join(PATH_TO_TESTS, test_file), "r", encoding="utf-8") as f:
         content = f.read()
     all_models = re.findall(r"all_model_classes\s+=\s+\(\s*\(([^\)]*)\)", content)
     # Check with one less parenthesis
@@ -221,7 +221,7 @@ def check_all_models_are_tested():
 
 def find_documented_classes(doc_file):
     """ Parse the content of doc_file to detect which classes it documents"""
-    with open(os.path.join(PATH_TO_DOC, doc_file)) as f:
+    with open(os.path.join(PATH_TO_DOC, doc_file), "r", encoding="utf-8") as f:
         content = f.read()
     return re.findall(r"autoclass:: transformers.(\S+)\s+", content)
 


### PR DESCRIPTION
# What does this PR do?
This PR fixes a small issue on the `check_repo.py` script with the encodings. I have also updated the `Makefile` to move the creation of the variables `fork_point_sha`, `joined_dirs` and `modified_py_files` in the `modified_only_fixup` target because they are used only there.

The makefile raises an error on Windows environment when creating the `modified_py_files` variable:
```
'tests' is not recognized as an internal or external command, operable program or batch file
```

ping @stas00 and @sgugger 