### PR TITLE
[make] rewrite modified_py_files in python to be cross-platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ check_dirs := examples tests src utils
 
 modified_only_fixup:
 	$(eval modified_py_files := $(shell python utils/get_modified_files.py $(check_dirs)))
-	@if [ -n "$(modified_py_files)" ]; then \
+	@if test -n "$(modified_py_files)"; then \
 		echo "Checking/fixing $(modified_py_files)"; \
 		black $(modified_py_files); \
 		isort $(modified_py_files); \

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,8 @@
 
 check_dirs := examples tests src utils
 
-# get modified files since the branch was made
-fork_point_sha := $(shell git merge-base --fork-point master)
-joined_dirs := $(shell echo $(check_dirs) | tr " " "|")
-modified_py_files := $(shell git diff --name-only $(fork_point_sha) | egrep '^($(joined_dirs))' | egrep '\.py$$')
-#$(info modified files are: $(modified_py_files))
-
 modified_only_fixup:
+	$(eval modified_py_files := $(shell python utils/get_modified_files.py $(check_dirs)))
 	@if [ -n "$(modified_py_files)" ]; then \
 		echo "Checking/fixing $(modified_py_files)"; \
 		black $(modified_py_files); \

--- a/utils/get_modified_files.py
+++ b/utils/get_modified_files.py
@@ -17,7 +17,7 @@
 #   python ./utils/get_modified_files.py utils src tests examples
 #
 # it uses git to find the forking point and which files were modified - i.e. files not under git won't be considered
-# since it is used to be fed into Makefile commands it doesn't print a newline
+# since the output of this script is fed into Makefile commands it doesn't print a newline after the results
 
 import re
 import subprocess

--- a/utils/get_modified_files.py
+++ b/utils/get_modified_files.py
@@ -1,0 +1,34 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# this script reports modified .py files under the desired list of top-level sub-dirs passed as a list of arguments, e.g.:
+#   python ./utils/get_modified_files.py utils src tests examples
+#
+# it uses git to find the forking point and which files were modified - i.e. files not under git won't be considered
+# since it is used to be fed into Makefile commands it doesn't print a newline
+
+import re
+import subprocess
+import sys
+
+
+fork_point_sha = subprocess.check_output("git merge-base --fork-point master".split()).decode("utf-8")
+modified_files = subprocess.check_output(f"git diff --name-only {fork_point_sha}".split()).decode("utf-8").split()
+
+joined_dirs = "|".join(sys.argv[1:])
+regex = re.compile(fr"^({joined_dirs}).*?\.py$")
+
+relevant_modified_files = [x for x in modified_files if regex.match(x)]
+print(" ".join(relevant_modified_files), end="")


### PR DESCRIPTION
As it can be seen here https://github.com/huggingface/transformers/pull/8359 some windows setups don't do well with the few lines of unix code that derive which files were modified, when called from `Makefile` so it looked like the best solution was to rewrite that logic in python which this PR does.

**status update:** If I understand correctly this PR works on windows @sgugger uses, but not for @jplu, but it should be merged regardless as it removes the hurdle reported in https://github.com/huggingface/transformers/pull/8359, which was preventing @jplu from using any `make` targets. Since `fixup` is an optional target and isn't a show stopper I recommend we merge this and then move the remaining issue into a separate issue and then find a windows expert to help make this target work for all windows users.

The rest of the post is the original request to validate that the PR works on windows.

----------------------------

@jplu  - please kindly validate that this works on windows. test it with:
1. no changes to any files under src utils tests examples


```
make fixup
```
this one should not fail but not do much either, my output is:
```
No library .py files were modified
python utils/check_copies.py
python utils/check_dummies.py
python utils/check_repo.py
Checking all models are properly tested.
Checking all models are properly documented.
python utils/style_doc.py src/transformers docs/source --max_len 119
```


2. with 1 change in some .py file under 2 of the above dirs, by hand or via `echo` if it works on windows:
```
echo -n "#" >> tests/conftest.py 
echo -n "#" >> examples/README.md 
echo -n "#" >> src/transformers/testing_utils.py
make fixup
```
this time I get:
```
Checking/fixing src/transformers/testing_utils.py tests/conftest.py
reformatted /mnt/nvme1/code/huggingface/transformers-fixup-python/tests/conftest.py
reformatted /mnt/nvme1/code/huggingface/transformers-fixup-python/src/transformers/testing_utils.py
All done! ✨ 🍰 ✨
2 files reformatted
python utils/check_copies.py
python utils/check_dummies.py
python utils/check_repo.py
Checking all models are properly tested.
Checking all models are properly documented.
python utils/style_doc.py src/transformers docs/source --max_len 119
```

If all is good you should get the same output as mine, sans different base path.

The key is to see:
```
Checking/fixing src/transformers/testing_utils.py tests/conftest.py
```
it may include `utils/get_modified_files.py` if you're checking out this PR as it's under git too, it doesn't matter. What we want to ensure is that out of 3 intentionally modified files 2 gets looked at as they are ending with `.py`.

Just in case you don't know how to checkout a pr, you can for example use `gh` https://github.com/cli/cli:
```
gh pr checkout 8371
```
but there are many other ways to do it.

Thank you!

@LysandreJik, @sgugger 