### PR TITLE
[wip] [fsmt] possible support of iwslt14 in fsmt

### DIFF
--- a/src/transformers/convert_fsmt_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/convert_fsmt_original_pytorch_checkpoint_to_pytorch.py
@@ -115,8 +115,8 @@ def convert_fsmt_checkpoint_to_pytorch(fsmt_checkpoint_path, pytorch_dump_folder
 
     args = dict(vars(chkpt["args"]))
 
-    src_lang = args["source_lang"]
-    tgt_lang = args["target_lang"]
+    src_lang = "en" # args["source_lang"]
+    tgt_lang = "el" # args["target_lang"]
 
     data_root = dirname(pytorch_dump_folder_path)
     model_dir = basename(pytorch_dump_folder_path)
@@ -143,7 +143,7 @@ def convert_fsmt_checkpoint_to_pytorch(fsmt_checkpoint_path, pytorch_dump_folder
 
     # merges_file (bpecodes)
     merges_file = os.path.join(pytorch_dump_folder_path, VOCAB_FILES_NAMES["merges_file"])
-    fsmt_merges_file = os.path.join(fsmt_folder_path, "bpecodes")
+    fsmt_merges_file = os.path.join(fsmt_folder_path, "code")
     with open(fsmt_merges_file, encoding="utf-8") as fin:
         merges = fin.read()
     merges = re.sub(r" \d+$", "", merges, 0, re.M)  # remove frequency number
@@ -154,10 +154,32 @@ def convert_fsmt_checkpoint_to_pytorch(fsmt_checkpoint_path, pytorch_dump_folder
     # model config
     fsmt_model_config_file = os.path.join(pytorch_dump_folder_path, "config.json")
 
+    args = {
+      "activation_dropout": 0.0,
+      "attention_dropout": 0.0,
+      "decoder_embed_dim": 512,
+      "dropout": 0.1,
+      "max_source_positions": 1024,
+      "encoder_layers": 6,
+      "encoder_attention_heads": 16,
+      "encoder_ffn_embed_dim": 1024,
+      "encoder_layerdrop": 0,
+      "encoder_layers": 6,
+      "decoder_attention_heads": 16,
+      "decoder_ffn_embed_dim": 1024,
+      "decoder_layerdrop": 0,
+      "decoder_layers": 6,
+      "bos_token_id": 0,
+      "pad_token_id": 1,
+      "eos_token_id": 2,
+      "no_scale_embedding": False,
+      "share_all_embeddings": True,
+    }
+    
     # validate bpe/tokenizer config, as currently it's hardcoded to moses+fastbpe -
     # may have to modify the tokenizer if a different type is used by a future model
-    assert args["bpe"] == "fastbpe", f"need to extend tokenizer to support bpe={args['bpe']}"
-    assert args["tokenizer"] == "moses", f"need to extend tokenizer to support bpe={args['tokenizer']}"
+    #assert args["bpe"] == "fastbpe", f"need to extend tokenizer to support bpe={args['bpe']}"
+    #assert args["tokenizer"] == "moses", f"need to extend tokenizer to support bpe={args['tokenizer']}"
 
     model_conf = {
         "architectures": ["FSMTForConditionalGeneration"],


### PR DESCRIPTION
This is an attempt to see whether fsmt can support older fairseq archs, based on this request: https://github.com/huggingface/transformers/issues/8233

Currently it's just changing the conversion code directly to see if it can be converted.
```
python src/transformers/convert_fsmt_original_pytorch_checkpoint_to_pytorch.py --fsmt_checkpoint_path ./fairseq-en-el-model/checkpoint_best.pt --pytorch_dump_folder_path ./model-data
```

@lighteternal, please have a look.

I made the model configuration `args` based on the arch configuration. The only issue at the moment is sizes of encoder decoder - for some reason the vocab size seems to be reversed?

```
$wc -l fairseq-en-el-model/*txt
 12892 fairseq-en-el-model/dict.el.txt
  9932 fairseq-en-el-model/dict.en.txt
```
So this is English to Greek, correct?  And not the other way around, correct? So the source is `9932` and target is `12892`-long.

Your issue mentioned "Greek<->English", but this model must be one way - which is it?

When I run the script:
```
        size mismatch for model.encoder.embed_tokens.weight: copying a param with shape torch.Size([12896, 512]) from checkpoint, the shape in current model is torch.Size([9936, 512]).
        size mismatch for model.decoder.output_projection.weight: copying a param with shape torch.Size([9936, 512]) from checkpoint, the shape in current model is torch.Size([12896, 512]).
```

So it suggests that the encoder is `12896`- long, which should be the other way around, no? Unless it was trained on Greek to English.

Well, you can also experiment with the conversion.
