### PR TITLE
[s2s examples test] fix data path

### DIFF
--- a/examples/seq2seq/test_seq2seq_examples_multi_gpu.py
+++ b/examples/seq2seq/test_seq2seq_examples_multi_gpu.py
@@ -95,7 +95,7 @@ class TestSummarizationDistillerMultiGPU(TestCasePlus):
         args = f"""
             --model_name Helsinki-NLP/opus-mt-en-ro
             --save_dir {output_dir}
-            --data_dir test_data/wmt_en_ro
+            --data_dir {self.test_file_dir_str}/test_data/wmt_en_ro
             --num_beams 2
             --task translation
         """.split()


### PR DESCRIPTION
This PR fixes a relative path in a test that should be a resolved full path instead - I forgot to test from the top of the repo in the previous PR and therefore missed this.

@sshleifer 