### PR TITLE
Fixed Trainer default labels for QA Model

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -328,7 +328,7 @@ class Trainer:
         self.hp_search_backend = None
         self.use_tune_checkpoints = False
         default_label_names = (
-            ["start_positions, end_positions"]
+            ["start_positions", "end_positions"]
             if type(self.model) in MODEL_FOR_QUESTION_ANSWERING_MAPPING.values()
             else ["labels"]
         )


### PR DESCRIPTION
PR https://github.com/huggingface/transformers/pull/7191 added default labels for models. However, for QA Models it sets the default labels to ["start_positions, end_positions"] instead of ["start_positions", "end_positions"], which was the intention based on the PR description. This PR is a simple fix to this.

Fixes #8390 

@sgugger 