### PR TITLE
[s2s test_finetune_trainer] failing multigpu test

### DIFF
--- a/examples/seq2seq/test_finetune_trainer.py
+++ b/examples/seq2seq/test_finetune_trainer.py
@@ -177,7 +177,7 @@ class TestFinetuneTrainer(TestCasePlus):
             --num_train_epochs {str(num_train_epochs)}
             --per_device_train_batch_size 4
             --per_device_eval_batch_size 4
-            --learning_rate 3e-4
+            --learning_rate 3e-3
             --warmup_steps 8
             --evaluate_during_training
             --predict_with_generate


### PR DESCRIPTION
Sam,

On a multigpu machine:
```
RUN_SLOW=1 pytest examples/seq2seq/test_finetune_trainer.py::TestFinetuneTrainer::test_finetune_trainer_slow
```
fails for me - not learning anything. 
```
>       assert first_step_stats["eval_bleu"] < last_step_stats["eval_bleu"]  # model learned nothing
E       AssertionError: assert 0.0 < 0.0
```
Looking at the logs, it gains some >0 bleu score in the first half of the epochs and then drops back to 0.00 in the last ones. On a single gpu it fluctuates between 0 and some small value - this is very fragile.

Changing to lr 3e-3 (this PR) seems to make it slightly more stable, but it could be a card specific thing - this is with rtx3090+rtx1070. So please check on your setup.

I tested that it passes with single gpu (one of each). 

Alternatively the test should compare not the first and last metrics, but perhaps something more flexible? like adding up all blue scores and checking the total >0?

But either way it feels very fragile - depending too much on the hardware type - perhaps a long term approach to make it more resilient is by feeding it more than 8 records.

@sshleifer
