### PR TITLE
[testing utils] get_auto_remove_tmp_dir more intuitive behavior

### DIFF
--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -720,32 +720,32 @@ Here is an example of its usage:
 
 This code creates a unique temporary directory, and sets :obj:`tmp_dir` to its location.
 
-In this and all the following scenarios the temporary directory will be auto-removed at the end of test, unless
-``after=False`` is passed to the helper function.
-
-* Create a temporary directory of my choice and delete it at the end - useful for debugging when you want to monitor a
-  specific directory:
+* Create a unique temporary dir:
 
 .. code-block:: python
 
     def test_whatever(self):
-        tmp_dir = self.get_auto_remove_tmp_dir(tmp_dir="./tmp/run/test")
+        tmp_dir = self.get_auto_remove_tmp_dir()
 
-* Create a temporary directory of my choice and do not delete it at the end---useful for when you want to look at the
-  temp results:
+    ``tmp_dir`` will contain the path to the created temp dir. It will be automatically removed at the end of the test.
+
+* Create a temporary dir of my choice, ensure it's empty before the test starts and don't empty it after the test.
 
 .. code-block:: python
 
     def test_whatever(self):
-        tmp_dir = self.get_auto_remove_tmp_dir(tmp_dir="./tmp/run/test", after=False)
+        tmp_dir = self.get_auto_remove_tmp_dir("./xxx")
 
-* Create a temporary directory of my choice and ensure to delete it right away---useful for when you disabled deletion
-  in the previous test run and want to make sure the that temporary directory is empty before the new test is run:
 
-.. code-block:: python
+    This is useful for debug when you want to monitor a specific directory and want to make sure the previous tests didn't leave any data in there.
 
-   def test_whatever(self):
-        tmp_dir = self.get_auto_remove_tmp_dir(tmp_dir="./tmp/run/test", before=True)
+* You can override the first two options by directly overriding the ``before`` and ``after`` args, leading to the
+  following behavior:
+
+    - ``before=True``: the temporary dir will always be cleared at the beginning of the test.
+    - ``before=False``: if the temporary dir already existed, any existing files will remain there.
+    - ``after=True``: the temporary dir will always be deleted at the end of the test.
+    - ``after=False``: the temporary dir will always be left intact at the end of the test.
 
 .. note::
    In order to run the equivalent of ``rm -r`` safely, only subdirs of the project repository checkout are allowed if

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -736,10 +736,11 @@ This code creates a unique temporary directory, and sets :obj:`tmp_dir` to its l
     def test_whatever(self):
         tmp_dir = self.get_auto_remove_tmp_dir("./xxx")
 
-This is useful for debug when you want to monitor a specific directory and want to make sure the previous tests didn't leave any data in there.
+This is useful for debug when you want to monitor a specific directory and want to make sure the previous tests didn't
+leave any data in there.
 
-* You can override the first two options by directly overriding the ``before`` and ``after`` args, leading to the
-  following behavior:
+* You can override the default behavior by directly overriding the ``before`` and ``after`` args, leading to one of the
+  following behaviors:
 
     - ``before=True``: the temporary dir will always be cleared at the beginning of the test.
     - ``before=False``: if the temporary dir already existed, any existing files will remain there.

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -727,7 +727,7 @@ This code creates a unique temporary directory, and sets :obj:`tmp_dir` to its l
     def test_whatever(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
 
-    ``tmp_dir`` will contain the path to the created temp dir. It will be automatically removed at the end of the test.
+``tmp_dir`` will contain the path to the created temp dir. It will be automatically removed at the end of the test.
 
 * Create a temporary dir of my choice, ensure it's empty before the test starts and don't empty it after the test.
 
@@ -736,8 +736,7 @@ This code creates a unique temporary directory, and sets :obj:`tmp_dir` to its l
     def test_whatever(self):
         tmp_dir = self.get_auto_remove_tmp_dir("./xxx")
 
-
-    This is useful for debug when you want to monitor a specific directory and want to make sure the previous tests didn't leave any data in there.
+This is useful for debug when you want to monitor a specific directory and want to make sure the previous tests didn't leave any data in there.
 
 * You can override the first two options by directly overriding the ``before`` and ``after`` args, leading to the
   following behavior:
@@ -799,7 +798,7 @@ or the ``xfail`` way:
     @pytest.mark.xfail
     def test_feature_x():
 
-Here is how to skip a test based on some internal check inside the test:
+- Here is how to skip a test based on some internal check inside the test:
 
 .. code-block:: python
 
@@ -822,7 +821,7 @@ or the ``xfail`` way:
     def test_feature_x():
         pytest.xfail("expected to fail until bug XYZ is fixed")
 
-Here is how to skip all tests in a module if some import is missing:
+- Here is how to skip all tests in a module if some import is missing:
 
 .. code-block:: python
 

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -700,11 +700,11 @@ Temporary files and directories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Using unique temporary files and directories are essential for parallel test running, so that the tests won't overwrite
-each other's data. Also we want to get the temp files and directories removed at the end of each test that created
+each other's data. Also we want to get the temporary files and directories removed at the end of each test that created
 them. Therefore, using packages like ``tempfile``, which address these needs is essential.
 
-However, when debugging tests, you need to be able to see what goes into the temp file or directory and you want to
-know it's exact path and not having it randomized on every test re-run.
+However, when debugging tests, you need to be able to see what goes into the temporary file or directory and you want
+to know it's exact path and not having it randomized on every test re-run.
 
 A helper class :obj:`transformers.test_utils.TestCasePlus` is best used for such purposes. It's a sub-class of
 :obj:`unittest.TestCase`, so we can easily inherit from it in the test modules.
@@ -727,7 +727,8 @@ This code creates a unique temporary directory, and sets :obj:`tmp_dir` to its l
     def test_whatever(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
 
-``tmp_dir`` will contain the path to the created temp dir. It will be automatically removed at the end of the test.
+``tmp_dir`` will contain the path to the created temporary dir. It will be automatically removed at the end of the
+test.
 
 * Create a temporary dir of my choice, ensure it's empty before the test starts and don't empty it after the test.
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -668,7 +668,7 @@ class TestCasePlus(unittest.TestCase):
                    - sets ``after=True`` if ``after`` is :obj:`None`
                 else:
 
-                   - a unique temporary path will be chosen and created
+                   - :obj:`tmp_dir` will be created
                    - sets ``before=True`` if ``before`` is :obj:`None`
                    - sets ``after=False`` if ``after`` is :obj:`None`
             before (:obj:`bool`, `optional`):
@@ -679,7 +679,7 @@ class TestCasePlus(unittest.TestCase):
                 :obj:`tmp_dir` and its contents intact at the end of the test.
 
         Returns:
-            tmp_dir(:obj:`string`): either the same value as passed via `tmp_dir` or the path to the auto-created tmp
+            tmp_dir(:obj:`string`): either the same value as passed via `tmp_dir` or the path to the auto-selected tmp
             dir
         """
         if tmp_dir is not None:

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -539,16 +539,16 @@ class TestCasePlus(unittest.TestCase):
     This is useful for debug when you want to monitor a specific directory and want to make sure the previous tests
     didn't leave any data in there.
 
-    3. You can override the first two options by directly overriding the ``before`` and ``after`` args.
+    3. You can override the first two options by directly overriding the ``before`` and ``after`` args, leading to the
+       following behavior:
 
-    When ``before=True`` is passed the temporary dir will always be cleared at the beginning of the test.
+    ``before=True``: the temporary dir will always be cleared at the beginning of the test.
 
-    With ``before=False``if the temporary dir already existed and contained some files they will remain there.
+    ``before=False``: if the temporary dir already existed, any existing files will remain there.
 
-    When ``after=True`` is passed the temporary dir will always be deleted at the end of the test.
+    ``after=True``: the temporary dir will always be deleted at the end of the test.
 
-    When ``after=False`` is passed the temporary dir will always be left intact at the end of the test.
-
+    ``after=False``: the temporary dir will always be left intact at the end of the test.
 
     Note 1: In order to run the equivalent of ``rm -r`` safely, only subdirs of the project repository checkout are
     allowed if an explicit ``tmp_dir`` is used, so that by mistake no ``/tmp`` or similar important part of the

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -660,19 +660,21 @@ class TestCasePlus(unittest.TestCase):
         Args:
             tmp_dir (:obj:`string`, `optional`):
                 if :obj:`None`:
+
                    - a unique tmp path will be created
                    - sets ``before=True`` if ``before`` is :obj:`None`
                    - sets ``after=True`` if ``after`` is :obj:`None`
                 else:
+
                    - a unique tmp path will be chosen and created
                    - sets ``before=True`` if ``before`` is :obj:`None`
                    - sets ``after=False`` if ``after`` is :obj:`None`
             before (:obj:`bool`, `optional`):
-                if :obj:`True` and the tmp dir already exists, make sure to empty it right away
-                if :obj:`False` and the tmp dir already exists, any existing files will remain there.
+                if :obj:`True` and the tmp dir already exists, make sure to empty it right away if :obj:`False` and the
+                tmp dir already exists, any existing files will remain there.
             after (:obj:`bool`, `optional`):
-                if :obj:`True`, delete the tmp dir at the end of the test
-                if :obj:`False`, leave the tmp dir and its contents intact at the end of the test
+                if :obj:`True`, delete the tmp dir at the end of the test if :obj:`False`, leave the tmp dir and its
+                contents intact at the end of the test
 
         Returns:
             tmp_dir(:obj:`string`): either the same value as passed via `tmp_dir` or the path to the auto-created tmp

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -660,7 +660,7 @@ class TestCasePlus(unittest.TestCase):
         Args:
             tmp_dir (:obj:`string`, `optional`):
                 if not :obj:`None` use this path, otherwise, use a unique tmp path will be created
-            before (:obj:`bool`, `optional`, defaults to :obj:`None`):
+            before (:obj:`bool`, `optional`):
                 if :obj:`True` and the tmp dir already exists make sure to empty it right away
             after (:obj:`bool`, `optional`, defaults to :obj:`None`):
                 if :obj:`True` delete the tmp dir at the end of the test

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -516,7 +516,7 @@ class TestCasePlus(unittest.TestCase):
        - ``repo_root_dir_str``
        - ``src_dir_str``
 
-    Feature 2: Flexible auto-removable temp dirs which are guaranteed to get removed at the end of test.
+    Feature 2: Flexible auto-removable temporary dirs which are guaranteed to get removed at the end of test.
 
     1. Create a unique temporary dir:
 
@@ -525,7 +525,8 @@ class TestCasePlus(unittest.TestCase):
         def test_whatever(self):
             tmp_dir = self.get_auto_remove_tmp_dir()
 
-    ``tmp_dir`` will contain the path to the created temp dir. It will be automatically removed at the end of the test.
+    ``tmp_dir`` will contain the path to the created temporary dir. It will be automatically removed at the end of the
+    test.
 
 
     2. Create a temporary dir of my choice, ensure it's empty before the test starts and don't
@@ -554,7 +555,8 @@ class TestCasePlus(unittest.TestCase):
     allowed if an explicit ``tmp_dir`` is used, so that by mistake no ``/tmp`` or similar important part of the
     filesystem will get nuked. i.e. please always pass paths that start with ``./``
 
-    Note 2: Each test can register multiple temp dirs and they all will get auto-removed, unless requested otherwise.
+    Note 2: Each test can register multiple temporary dirs and they all will get auto-removed, unless requested
+    otherwise.
 
     Feature 3: Get a copy of the ``os.environ`` object that sets up ``PYTHONPATH`` specific to the current test suite.
     This is useful for invoking external programs from the test suite - e.g. distributed training.
@@ -661,20 +663,20 @@ class TestCasePlus(unittest.TestCase):
             tmp_dir (:obj:`string`, `optional`):
                 if :obj:`None`:
 
-                   - a unique tmp path will be created
+                   - a unique temporary path will be created
                    - sets ``before=True`` if ``before`` is :obj:`None`
                    - sets ``after=True`` if ``after`` is :obj:`None`
                 else:
 
-                   - a unique tmp path will be chosen and created
+                   - a unique temporary path will be chosen and created
                    - sets ``before=True`` if ``before`` is :obj:`None`
                    - sets ``after=False`` if ``after`` is :obj:`None`
             before (:obj:`bool`, `optional`):
-                If :obj:`True` and the :obj:`tmp_dir` already exists, make sure to empty it right away if :obj:`False` and the
-                :obj:`tmp_dir` already exists, any existing files will remain there.
+                If :obj:`True` and the :obj:`tmp_dir` already exists, make sure to empty it right away if :obj:`False`
+                and the :obj:`tmp_dir` already exists, any existing files will remain there.
             after (:obj:`bool`, `optional`):
-                If :obj:`True`, delete the :obj:`tmp_dir` at the end of the test if :obj:`False`, leave the :obj:`tmp_dir` and its
-                contents intact at the end of the test.
+                If :obj:`True`, delete the :obj:`tmp_dir` at the end of the test if :obj:`False`, leave the
+                :obj:`tmp_dir` and its contents intact at the end of the test.
 
         Returns:
             tmp_dir(:obj:`string`): either the same value as passed via `tmp_dir` or the path to the auto-created tmp

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -670,11 +670,11 @@ class TestCasePlus(unittest.TestCase):
                    - sets ``before=True`` if ``before`` is :obj:`None`
                    - sets ``after=False`` if ``after`` is :obj:`None`
             before (:obj:`bool`, `optional`):
-                if :obj:`True` and the tmp dir already exists, make sure to empty it right away if :obj:`False` and the
-                tmp dir already exists, any existing files will remain there.
+                If :obj:`True` and the :obj:`tmp_dir` already exists, make sure to empty it right away if :obj:`False` and the
+                :obj:`tmp_dir` already exists, any existing files will remain there.
             after (:obj:`bool`, `optional`):
-                if :obj:`True`, delete the tmp dir at the end of the test if :obj:`False`, leave the tmp dir and its
-                contents intact at the end of the test
+                If :obj:`True`, delete the :obj:`tmp_dir` at the end of the test if :obj:`False`, leave the :obj:`tmp_dir` and its
+                contents intact at the end of the test.
 
         Returns:
             tmp_dir(:obj:`string`): either the same value as passed via `tmp_dir` or the path to the auto-created tmp

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -518,16 +518,17 @@ class TestCasePlus(unittest.TestCase):
 
     Feature 2: Flexible auto-removable temp dirs which are guaranteed to get removed at the end of test.
 
-    In all the following scenarios the temp dir will be auto-removed at the end of test, unless `after=False`.
+    In all the following scenarios the temp dir will be cleared out at the beginning of the test (unless `before=False`) 
+    and auto-removed at the end of test (unless `after=False`).
 
-    # 1. create a unique temp dir, `tmp_dir` will contain the path to the created temp dir
+    1. create a unique temp dir, `tmp_dir` will contain the path to the created temp dir
 
     ::
 
         def test_whatever(self):
             tmp_dir = self.get_auto_remove_tmp_dir()
 
-    # 2. create a temp dir of my choice and delete it at the end - useful for debug when you want to # monitor a
+    2. create a temp dir of my choice and delete it at the end - useful for debug when you want to monitor a
     specific directory
 
     ::
@@ -535,20 +536,19 @@ class TestCasePlus(unittest.TestCase):
         def test_whatever(self):
             tmp_dir = self.get_auto_remove_tmp_dir(tmp_dir="./tmp/run/test")
 
-    # 3. create a temp dir of my choice and do not delete it at the end - useful for when you want # to look at the
+    3. create a temp dir of my choice and do not delete it at the end - useful for when you want to look at the
     temp results
 
     ::
         def test_whatever(self):
             tmp_dir = self.get_auto_remove_tmp_dir(tmp_dir="./tmp/run/test", after=False)
 
-    # 4. create a temp dir of my choice and ensure to delete it right away - useful for when you # disabled deletion in
-    the previous test run and want to make sure the that tmp dir is empty # before the new test is run
+    4. create a temp dir of my choice, but if it already exists leave its contents as they are
 
     ::
 
         def test_whatever(self):
-            tmp_dir = self.get_auto_remove_tmp_dir(tmp_dir="./tmp/run/test", before=True)
+            tmp_dir = self.get_auto_remove_tmp_dir(tmp_dir="./tmp/run/test", before=False)
 
     Note 1: In order to run the equivalent of `rm -r` safely, only subdirs of the project repository checkout are
     allowed if an explicit `tmp_dir` is used, so that by mistake no `/tmp` or similar important part of the filesystem
@@ -654,15 +654,15 @@ class TestCasePlus(unittest.TestCase):
         env["PYTHONPATH"] = ":".join(paths)
         return env
 
-    def get_auto_remove_tmp_dir(self, tmp_dir=None, after=True, before=False):
+    def get_auto_remove_tmp_dir(self, tmp_dir=None, after=True, before=True):
         """
         Args:
             tmp_dir (:obj:`string`, `optional`):
                 use this path, if None a unique path will be assigned
-            before (:obj:`bool`, `optional`, defaults to :obj:`False`):
+            before (:obj:`bool`, `optional`, defaults to :obj:`True`):
                 if `True` and tmp dir already exists make sure to empty it right away
             after (:obj:`bool`, `optional`, defaults to :obj:`True`):
-                delete the tmp dir at the end of the test
+                if `True` delete the tmp dir at the end of the test
 
         Returns:
             tmp_dir(:obj:`string`): either the same value as passed via `tmp_dir` or the path to the auto-created tmp

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -659,11 +659,20 @@ class TestCasePlus(unittest.TestCase):
         """
         Args:
             tmp_dir (:obj:`string`, `optional`):
-                if not :obj:`None` use this path, otherwise, use a unique tmp path will be created
+                if :obj:`None`:
+                   - a unique tmp path will be created
+                   - sets ``before=True`` if ``before`` is :obj:`None`
+                   - sets ``after=True`` if ``after`` is :obj:`None`
+                else:
+                   - a unique tmp path will be chosen and created
+                   - sets ``before=True`` if ``before`` is :obj:`None`
+                   - sets ``after=False`` if ``after`` is :obj:`None`
             before (:obj:`bool`, `optional`):
-                if :obj:`True` and the tmp dir already exists make sure to empty it right away
-            after (:obj:`bool`, `optional`, defaults to :obj:`None`):
-                if :obj:`True` delete the tmp dir at the end of the test
+                if :obj:`True` and the tmp dir already exists, make sure to empty it right away
+                if :obj:`False` and the tmp dir already exists, any existing files will remain there.
+            after (:obj:`bool`, `optional`):
+                if :obj:`True`, delete the tmp dir at the end of the test
+                if :obj:`False`, leave the tmp dir and its contents intact at the end of the test
 
         Returns:
             tmp_dir(:obj:`string`): either the same value as passed via `tmp_dir` or the path to the auto-created tmp


### PR DESCRIPTION
Now that I have been heavily using `get_auto_remove_tmp_dir` for a while, I realized that one of the defaults isn't most optimal and we had to type too much for what we need most of the time.

tldr: 99% of the time when debugging we want the tmp dir 
1. to be empty at the beginning of the test 
2. to be left alone after the test

This PR changes the behavior of `get_auto_remove_tmp_dir` to simplify things greatly and require much less typing.

Before this PR  when debugging a test we had to do this:
```
-        output_dir = self.get_auto_remove_tmp_dir()
+        output_dir = self.get_auto_remove_tmp_dir("./xxx", before=True, after=False)
```
Now, all you need to do is:
```
-        output_dir = self.get_auto_remove_tmp_dir()
+        output_dir = self.get_auto_remove_tmp_dir("./xxx")
```

You can still override `before` and `after` should you need to, but the main change is that if you pass a hardcoded path - you are most likely wanting to debug and see the results of the test in an easily locatable and repeatable location, and ensuring that dir is empty before the test.

Done!

@LysandreJik, @sgugger 