### PR TITLE
Bug fix for permutation language modelling

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -579,7 +579,7 @@ class DataCollatorForPermutationLanguageModeling:
             masked_indices.masked_fill_(padding_mask, value=0.0)
 
         # Mask indicating non-functional tokens, where functional tokens are [SEP], [CLS], padding, etc.
-        non_func_mask = ~(padding_mask & special_tokens_mask)
+        non_func_mask = ~(padding_mask | special_tokens_mask)
 
         inputs[masked_indices] = self.tokenizer.mask_token_id
         labels[~masked_indices] = -100  # We only compute loss on masked tokens


### PR DESCRIPTION
Addresses a bug in permutation language modelling data collator, where `&` is used instead of `|` to compute the non-functional token mask (tokens excluding [PAD], [SEP], [CLS]). For verification, may refer to original XLNet code (https://github.com/zihangdai/xlnet/blob/master/data_utils.py#L602).

Addresses #6812 (further investigation needed, however)
 
@patrickvonplaten @LysandreJik 