### PR TITLE
comet_ml init weirdness

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -14,7 +14,7 @@ try:
     # Comet needs to be imported before any ML frameworks
     import comet_ml  # noqa: F401
 
-    if comet_ml.config.get_config("comet.api_key"):
+    if hasattr(comet_ml, "config") and comet_ml.config.get_config("comet.api_key"):
         _has_comet = True
     else:
         if os.getenv("COMET_MODE", "").upper() != "DISABLED":


### PR DESCRIPTION
Using a slightly bogus invocation of the following
```
cd examples/seq2seq
PYTHONPATH="../../src" BS=2 python finetune.py --data_dir cnn_dm --do_predict --do_train --eval_batch_size $BS --fp16 --fp16_opt_level O1--freeze_embeds --freeze_encoder --gpus 1 --gradient_accumulation_steps 1 --learning_rate 3e-5 --max_target_length 142 --model_name_or_path sshleifer/student_cnn_12_6 --n_val 500 --num_train_epochs 2 --output_dir distilbart-cnn-12-6 --tokenizer_name facebook/bart-large --train_batch_size $BS --val_check_interval 0.25 --val_max_target_length 142 --warmup_steps 500
```
I get:
```
Traceback (most recent call last):
  File "finetune.py", line 18, in <module>
    from callbacks import Seq2SeqLoggingCallback, get_checkpoint_callback, get_early_stopping_callback
  File "/mnt/nvme1/code/huggingface/transformers-comet_ml/examples/seq2seq/callbacks.py", line 11, in <module>
    from utils import save_json
  File "/mnt/nvme1/code/huggingface/transformers-comet_ml/examples/seq2seq/utils.py", line 22, in <module>
    from transformers import BartTokenizer, EvalPrediction, PreTrainedTokenizer, T5Tokenizer
  File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/__init__.py", line 22, in <module>
    from .integrations import (  # isort:skip
  File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/integrations.py", line 17, in <module>
    if comet_ml.config.get_config("comet.api_key"):
AttributeError: module 'comet_ml' has no attribute 'config'
```
no idea why this happens. this PR adds a band-aid - and then once I apply it - the real error shows up `$BS` wasn't defined - i.e. my args had an issue. But I need to see the real error and not some totally unrelated `comet_ml` error.

perhaps something else needs to be fixed.

While we are at it, once again I ended up with `comet_ml` w/o explicitly installing it.

So I again get to enjoy the incessant:
```
comet_ml is installed but `COMET_API_KEY` is not set.
```
:(

```
pipdeptree --reverse --packages comet_ml
```
doesn't give me the parent who pulled it in which is very odd, since it works for other packages.

Is there a different way to trace what pulled in a certain package?

If I install/update it explicitly it appears I already have the latest version:
```
pip install comet_ml -U
Requirement already up-to-date: comet_ml in /mnt/nvme1/anaconda3/envs/main-38/lib/python3.8/site-packages (3.2.5)
```

@sgugger, @dsblank 
