### PR TITLE
[docs] remove sshleifer from issue-template :(

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -30,22 +30,22 @@ assignees: ''
  Trainer: @sgugger
  Speed and Memory Benchmarks: @patrickvonplaten
  Model Cards: @julien-c
- Translation: @sshleifer
- Summarization: @sshleifer
  TextGeneration: @TevenLeScao 
  examples/distillation: @VictorSanh
  nlp datasets: [different repo](https://github.com/huggingface/nlp)
  rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
  Text Generation: @patrickvonplaten @TevenLeScao
- blenderbot: @mariamabarham
- Bart: @sshleifer
- Marian: @sshleifer
+ Blenderbot: @patrickvonplaten
+ Bart: @patrickvonplaten
+ Marian: @patrickvonplaten
+ Pegasus: @patrickvonplaten
+ mBART: @patrickvonplaten
  T5: @patrickvonplaten
  Longformer/Reformer: @patrickvonplaten
  TransfoXL/XLNet: @TevenLeScao
  RAG: @patrickvonplaten, @lhoestq
- FSTM: @stas00
- examples/seq2seq: @sshleifer
+ FSMT: @stas00
+ examples/seq2seq: @patil-suraj
  examples/bert-loses-patience: @JetRunner
  tensorflow: @jplu
  examples/token-classification: @stefan-it

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -43,19 +43,17 @@ members/contributors which may be interested in your PR.
  Trainer: @sgugger
  Benchmarks: @patrickvonplaten
  Model Cards: @julien-c
- Translation: @sshleifer
- Summarization: @sshleifer
  examples/distillation: @VictorSanh
  nlp datasets: [different repo](https://github.com/huggingface/nlp)
  rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
  Text Generation: @patrickvonplaten, @TevenLeScao
- Blenderbot, Bart, Marian, Pegasus: @sshleifer
+ Blenderbot, Bart, Marian, Pegasus: @patrickvonplaten
  T5: @patrickvonplaten
  Rag: @patrickvonplaten, @lhoestq
  EncoderDecoder: @patrickvonplaten
  Longformer, Reformer: @patrickvonplaten
  TransfoXL, XLNet: @TevenLeScao, @patrickvonplaten
- examples/seq2seq: @sshleifer
+ examples/seq2seq: @patil-suraj
  examples/bert-loses-patience: @JetRunner
  tensorflow: @jplu
  examples/token-classification: @stefan-it

--- a/docs/source/model_doc/bart.rst
+++ b/docs/source/model_doc/bart.rst
@@ -3,7 +3,7 @@ BART
 
 **DISCLAIMER:** If you see something strange, file a `Github Issue
 <https://github.com/huggingface/transformers/issues/new?assignees=&labels=&template=bug-report.md&title>`__ and assign
-@sshleifer
+@patrickvonplaten
 
 Overview
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/model_doc/marian.rst
+++ b/docs/source/model_doc/marian.rst
@@ -3,7 +3,7 @@ MarianMT
 
 **Bugs:** If you see something strange, file a `Github Issue
 <https://github.com/huggingface/transformers/issues/new?assignees=sshleifer&labels=&template=bug-report.md&title>`__
-and assign @sshleifer.
+and assign  @patrickvonplaten.
 
 Translations should be similar, but not identical to, output in the test set linked to in each model card.
 

--- a/docs/source/model_doc/marian.rst
+++ b/docs/source/model_doc/marian.rst
@@ -3,7 +3,7 @@ MarianMT
 
 **Bugs:** If you see something strange, file a `Github Issue
 <https://github.com/huggingface/transformers/issues/new?assignees=sshleifer&labels=&template=bug-report.md&title>`__
-and assign  @patrickvonplaten.
+and assign @patrickvonplaten.
 
 Translations should be similar, but not identical to, output in the test set linked to in each model card.
 

--- a/docs/source/model_doc/mbart.rst
+++ b/docs/source/model_doc/mbart.rst
@@ -3,7 +3,7 @@ MBart
 
 **DISCLAIMER:** If you see something strange, file a `Github Issue
 <https://github.com/huggingface/transformers/issues/new?assignees=&labels=&template=bug-report.md&title>`__ and assign
- @patrickvonplaten
+@patrickvonplaten
 
 Overview
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/model_doc/mbart.rst
+++ b/docs/source/model_doc/mbart.rst
@@ -3,7 +3,7 @@ MBart
 
 **DISCLAIMER:** If you see something strange, file a `Github Issue
 <https://github.com/huggingface/transformers/issues/new?assignees=&labels=&template=bug-report.md&title>`__ and assign
-@sshleifer
+ @patrickvonplaten
 
 Overview
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/model_doc/pegasus.rst
+++ b/docs/source/model_doc/pegasus.rst
@@ -3,7 +3,7 @@ Pegasus
 
 **DISCLAIMER:** If you see something strange, file a `Github Issue
 <https://github.com/huggingface/transformers/issues/new?assignees=sshleifer&labels=&template=bug-report.md&title>`__
-and assign  @patrickvonplaten.
+and assign @patrickvonplaten.
 
 
 Overview

--- a/docs/source/model_doc/pegasus.rst
+++ b/docs/source/model_doc/pegasus.rst
@@ -3,7 +3,7 @@ Pegasus
 
 **DISCLAIMER:** If you see something strange, file a `Github Issue
 <https://github.com/huggingface/transformers/issues/new?assignees=sshleifer&labels=&template=bug-report.md&title>`__
-and assign @sshleifer.
+and assign  @patrickvonplaten.
 
 
 Overview


### PR DESCRIPTION
+ Removes sshleifer from issue-templates :( 
+ For previous @sshleifer stuff, if it's in `src/` I put  @patrickvonplaten, if it's `examples/seq2seq` I put @patil-suraj.
+ @stas00 if you want to take over any thing or feel comfortable being the point person for certain things, feel free to suggest.

