### PR TITLE
Bump tokenizers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ setup(
     packages=find_packages("src"),
     install_requires=[
         "numpy",
-        "tokenizers == 0.9.2",
+        "tokenizers == 0.9.3",
         # dataclasses for Python versions that don't have it
         "dataclasses;python_version<'3.7'",
         # utilities from PyPA to e.g. compare versions


### PR DESCRIPTION
# What does this PR do?

Bump the version of tokenizers to the last release. This fixes some bugs in `XLNetTokenizerFast`.