### PR TITLE
Support serialized tokenizer in AutoTokenizer

### DIFF
--- a/src/transformers/configuration_auto.py
+++ b/src/transformers/configuration_auto.py
@@ -227,6 +227,16 @@ def replace_list_option_in_docstrings(config_to_class=None, use_model_types=True
     return docstring_decorator
 
 
+def config_class_by_path(searched_path: str):
+    """
+    Using pattern matching on the searched_path to determine config class.
+    """
+    for pattern, config_class in CONFIG_MAPPING.items():
+        if pattern in searched_path:
+            return config_class
+    return None
+
+
 class AutoConfig:
     r"""
     This is a generic configuration class that will be instantiated as one of the configuration classes of the library
@@ -333,9 +343,9 @@ class AutoConfig:
             return config_class.from_dict(config_dict, **kwargs)
         else:
             # Fallback: use pattern matching on the string.
-            for pattern, config_class in CONFIG_MAPPING.items():
-                if pattern in pretrained_model_name_or_path:
-                    return config_class.from_dict(config_dict, **kwargs)
+            config_class = config_class_by_path(pretrained_model_name_or_path)
+            if config_class:
+                return config_class.from_dict(config_dict, **kwargs)
 
         raise ValueError(
             "Unrecognized model in {}. "


### PR DESCRIPTION
# What does this PR do?

Addresses issue: https://github.com/huggingface/transformers/issues/7293

With these changes, the `AutoTokenizer.from_pretrained()` supports also loading a tokenizer, which was saved with [🤗 Tokenizers](https://github.com/huggingface/tokenizers) library.
Example:
```python
from tokenizers import CharBPETokenizer
tokenizer = CharBPETokenizer()
tokenizer.save('./char-bpe.json')

from transformers import AutoTokenizer
my_tokenizer = AutoTokenizer.from_pretrained('./char-bpe.json', use_fast=True)
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to the it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. 
Also: @mfuntowicz (tokenizers), @thomwolf (due to https://github.com/huggingface/transformers/pull/7659)