### PR TITLE
Better regex expression for extracting language code in tokenization_marian.py

### DIFF
--- a/src/transformers/tokenization_marian.py
+++ b/src/transformers/tokenization_marian.py
@@ -80,7 +80,7 @@ class MarianTokenizer(PreTrainedTokenizer):
     pretrained_init_configuration = PRETRAINED_INIT_CONFIGURATION
     max_model_input_sizes = PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES
     model_input_names = ["attention_mask"]
-    language_code_re = re.compile("">>.{3}<<|>>.{3}\_.{4}<<"")  # type: re.Pattern
+    language_code_re = re.compile(">>.{3}<<|>>.{3}\_.{4}<<")  # type: re.Pattern
 
     def __init__(
         self,

--- a/src/transformers/tokenization_marian.py
+++ b/src/transformers/tokenization_marian.py
@@ -80,7 +80,7 @@ class MarianTokenizer(PreTrainedTokenizer):
     pretrained_init_configuration = PRETRAINED_INIT_CONFIGURATION
     max_model_input_sizes = PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES
     model_input_names = ["attention_mask"]
-    language_code_re = re.compile(">>.+<<")  # type: re.Pattern
+    language_code_re = re.compile("">>.{3}<<|>>.{3}\_.{4}<<"")  # type: re.Pattern
 
     def __init__(
         self,


### PR DESCRIPTION
# Better regex expression for extracting language code in tokenization_marian.py

In `tokenization_marian.py`, the regex `>>.+<<` is used to extract the language token from the sentences leading to the following incorrect tokenization.

```
Example Sentence:
>>hin<< We use cout<< function to print a line in C++.

Current Tokenizer gives:
['<unk>', '▁function', '▁to', '▁print', '▁a', '▁line', '▁in', '▁C', '++', '.', '</s>']

Expected Tokenization:
['>>hin<<', '▁We', '▁use', '▁c', 'out', '<', '<', '▁function', '▁to', '▁print', '▁a', '▁line', '▁in', '▁C', '++', '.', '</s>']
```

This pull request changes the regex to `>>.{3}<<|>>.{3}\_.{4}<<` which covers the 194 language tags in the en-mul model.

@sshleifer 