### PR TITLE
Fix TF next sentence output

### DIFF
--- a/src/transformers/modeling_tf_outputs.py
+++ b/src/transformers/modeling_tf_outputs.py
@@ -325,7 +325,7 @@ class TFNextSentencePredictorOutput(ModelOutput):
             heads.
     """
 
-    loss: tf.Tensor = None
+    loss: Optional[tf.Tensor] = None
     logits: tf.Tensor = None
     hidden_states: Optional[Tuple[tf.Tensor]] = None
     attentions: Optional[Tuple[tf.Tensor]] = None


### PR DESCRIPTION
# What does this PR do?

Make the loss optional in the TF next sentence prediction output.