### PR TITLE
New TF loading weights

### DIFF
--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -280,7 +280,7 @@ def load_tf2_checkpoint_in_pytorch_model(pt_model, tf_checkpoint_path, tf_inputs
     if tf_inputs is not None:
         tf_model(tf_inputs, training=False)  # Make sure model is built
 
-    _, _ = load_tf_weights(tf_model, tf_checkpoint_path)
+    load_tf_weights(tf_model, tf_checkpoint_path)
 
     return load_tf2_model_in_pytorch_model(pt_model, tf_model, allow_missing_keys=allow_missing_keys)
 

--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -280,7 +280,7 @@ def load_tf2_checkpoint_in_pytorch_model(pt_model, tf_checkpoint_path, tf_inputs
     if tf_inputs is not None:
         tf_model(tf_inputs, training=False)  # Make sure model is built
 
-    load_tf_weights(tf_model, tf_checkpoint_path)
+    _, _ = load_tf_weights(tf_model, tf_checkpoint_path)
 
     return load_tf2_model_in_pytorch_model(pt_model, tf_model, allow_missing_keys=allow_missing_keys)
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1028,18 +1028,18 @@ class TFSequenceSummary(tf.keras.layers.Layer):
         return output
 
 
-def shape_list(x: tf.Tensor) -> List[int]:
+def shape_list(tensor: tf.Tensor) -> List[int]:
     """
     Deal with dynamic shape in tensorflow cleanly.
 
     Args:
-        x (:obj:`tf.Tensor`): The tensor we want the shape of.
+        tensor (:obj:`tf.Tensor`): The tensor we want the shape of.
 
     Returns:
         :obj:`List[int]`: The shape of the tensor as a list.
     """
-    static = x.shape.as_list()
-    dynamic = tf.shape(x)
+    static = tensor.shape.as_list()
+    dynamic = tf.shape(tensor)
     return [dynamic[i] if s is None else s for i, s in enumerate(static)]
 
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -238,7 +238,7 @@ class TFNextSentencePredictionLoss:
 
 def load_tf_weights(model, resolved_archive_file):
     """
-    Detect missing and unexpected layers
+    Detect missing and unexpected layers and load the TF weights accordingly to their names and shapes.
 
     Args:
         model (:obj:`tf.keras.models.Model`):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -256,7 +256,6 @@ def load_tf_weights(model, resolved_archive_file):
     with h5py.File(resolved_archive_file, "r") as f:
         # Retrieve the name of each layer from the H5 file
         saved_h5_model_layers_name = set(hdf5_format.load_attributes_from_hdf5_group(f, "layer_names"))
-        model_layers_name_value = {}
 
         # Retrieve the name of each layer from the instantiated model
         # make it a dict that looks like {"layer_name": Layer object}

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -238,12 +238,14 @@ class TFNextSentencePredictionLoss:
 
 def load_tf_weights(model, resolved_archive_file):
     """
-    Detect missing and unexpected layers.
+    Detect missing and unexpected layers
+
     Args:
         model (:obj:`tf.keras.models.Model`):
             The model to load the weights into.
         resolved_archive_file (:obj:`str`):
-            The location of the H5 file.
+            The location of the H5 file
+
     Returns:
         Two lists, one for the missing layers, and another one for the unexpected layers.
     """

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -307,7 +307,7 @@ def load_tf_weights(model, resolved_archive_file):
 
                     # Add the updated name to the final list for computing missing/unexpected values
                     symbolic_weights_names.add(symbolic_weight_name)
-                    
+
                     # here we check if the current weight is among the weights from the H5 file
                     # If yes, get the weight_value of the corresponding weight from the H5 file
                     # If not, keep the value to None

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -269,7 +269,7 @@ def load_tf_weights(model, resolved_archive_file):
         # Compute missing and unexpected sub layers
         # Store the weights in list of tuples that looks like [(weight_object, value_of_weight),...]
         for layer in model.layers:
-            # if layer_name from the H5 file belongs to the layers from the instanciated model
+            # if layer_name from the H5 file belongs to the layers from the instantiated model
             if layer.name in saved_h5_model_layers_name:
                 # Get the H5 layer object from its name
                 h5_layer_object = f[layer.name]
@@ -287,7 +287,7 @@ def load_tf_weights(model, resolved_archive_file):
                     # Add the updated name to the final list for computing missing/unexpected values
                     saved_weight_names_set.add(name)
 
-                # Loop over each weights from the instanciated model and compare with the weights from the H5 file
+                # Loop over each weights from the instantiated model and compare with the weights from the H5 file
                 for symbolic_weight in symbolic_weights:
                     # TF names always start with the model name so we ignore it
                     symbolic_weight_name = "/".join(symbolic_weight.name.split("/")[1:])

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -273,15 +273,13 @@ def load_tf_weights(model, resolved_archive_file):
             if layer.name in saved_h5_model_layers_name:
                 # Get the H5 layer object from its name
                 h5_layer_object = f[layer.name]
-                # Get all the weights that are attach to layer_name
-                saved_weight_names = hdf5_format.load_attributes_from_hdf5_group(h5_layer_object, "weight_names")
                 # Get all the weights as a list from the layer object
                 symbolic_weights = layer.trainable_weights + layer.non_trainable_weights
                 saved_weights = {}
 
                 # Create a dict from the H5 saved model that looks like {"weight_name": weight_value}
                 # And a set with only the names
-                for weight_name in saved_weight_names:
+                for weight_name in hdf5_format.load_attributes_from_hdf5_group(h5_layer_object, "weight_names"):
                     # TF names always start with the model name so we ignore it
                     name = "/".join(weight_name.split("/")[1:])
                     saved_weights[name] = np.asarray(h5_layer_object[weight_name])


### PR DESCRIPTION
# What does this PR do?

This PR improves the way we load the TensorFlow weights. Before we had to go through the instantiated model + the checkpoint twice:
- once for loading the weights from the checkpoints into the instantiated model
- once for computing the missing and unexpected keys

Now both are done simultaneously which makes the loading faster.