### PR TITLE
Add model_max_length property on fast tokenizers

### DIFF
--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -40,7 +40,7 @@ from .tokenization_utils_base import (
     PreTrainedTokenizerBase,
     TextInput,
     TextInputPair,
-    TruncationStrategy,
+    TruncationStrategy, VERY_LARGE_INTEGER,
 )
 from .utils import logging
 
@@ -81,6 +81,10 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
     def __init__(self, *args, **kwargs):
         slow_tokenizer = kwargs.pop("__slow_tokenizer", None)
         fast_tokenizer_file = kwargs.pop("tokenizer_file", None)
+
+        # For backward compatibility we fallback to set model_max_length from max_len if provided
+        model_max_length = kwargs.pop("model_max_length", kwargs.pop("max_len", None))
+        self.model_max_length = model_max_length if model_max_length is not None else VERY_LARGE_INTEGER
 
         if fast_tokenizer_file is not None:
             # We have a serialization from tokenizers which let us directly build the backend

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -2537,3 +2537,12 @@ class TokenizerTesterMixin:
                 )
                 for key in python_output:
                     self.assertEqual(python_output[key], rust_output[key])
+
+    def test_model_max_length(self):
+        for tokenizer, pretrained_name, kwargs in self.tokenizers_list:
+            with self.subTest("{}.model_max_length ({})".format(tokenizer.__class__.__name__, pretrained_name)):
+                tokenizer_r = self.rust_tokenizer_class.from_pretrained(pretrained_name, **kwargs)
+                tokenizer_p = self.tokenizer_class.from_pretrained(pretrained_name, **kwargs)
+                self.assertTrue(hasattr(tokenizer_p, "model_max_length"))
+                self.assertTrue(hasattr(tokenizer_r, "model_max_length"))
+


### PR DESCRIPTION
Fast tokenizers doesn't have model_max_length property as their "slow" counterpart.

```python
>>> t.model_max_len
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'BertTokenizerFast' object has no attribute 'model_max_len'
```



Signed-off-by: Morgan Funtowicz <morgan@huggingface.co>