### PR TITLE
tokenization_bart.py: return_tensors default should be "pt"

### DIFF
--- a/src/transformers/tokenization_bart.py
+++ b/src/transformers/tokenization_bart.py
@@ -61,7 +61,7 @@ class BartTokenizer(RobertaTokenizer):
         max_length: Optional[int] = None,
         max_target_length: Optional[int] = None,
         padding: str = "longest",
-        return_tensors: str = "None",
+        return_tensors: str = "pt",
         truncation=True,
         **kwargs,
     ) -> BatchEncoding:


### PR DESCRIPTION
return_tensors default should be "pt" in bart's `prepare_seq2seq_batch`.