### PR TITLE
Make BART more ONNX friendly

### DIFF
--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -1199,7 +1199,7 @@ class BartForSequenceClassification(PretrainedBartModel):
         )
         x = outputs[0]  # last hidden state
         eos_mask = input_ids.eq(self.config.eos_token_id)
-        if len(torch.unique(eos_mask.sum(1))) > 1:
+        if torch.unique(eos_mask.sum(1)).size(-1) > 1:
             raise ValueError("All examples must have the same number of <eos> tokens.")
         sentence_representation = x[eos_mask, :].view(x.size(0), -1, x.size(-1))[:, -1, :]
         logits = self.classification_head(sentence_representation)

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -1204,7 +1204,7 @@ class BartForSequenceClassification(PretrainedBartModel):
 
         # Attempt to gather the latest eos_token representation in an ONNX compatible way
         # (-1: remove the batch indexes from the vector, -1: Take the last occurrence of eos_token)
-        sentence_representation = torch.index_select(x, 1, eos_mask.nonzero().t()[-1, -1])
+        sentence_representation = torch.index_select(x, 1, eos_mask.nonzero(as_tuple=False).t()[-1, -1])
         logits = self.classification_head(sentence_representation).squeeze(1)
 
         loss = None

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -1204,7 +1204,7 @@ class BartForSequenceClassification(PretrainedBartModel):
 
         # Attempt to gather the latest eos_token representation in an ONNX compatible way
         # (-1: remove the batch indexes from the vector, -1: Take the last occurrence of eos_token)
-        sentence_representation = torch.index_select(x, 1, eos_mask.nonzero().T[-1, -1])
+        sentence_representation = torch.index_select(x, 1, eos_mask.nonzero().t()[-1, -1])
         logits = self.classification_head(sentence_representation).squeeze(1)
 
         loss = None

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -1205,7 +1205,7 @@ class BartForSequenceClassification(PretrainedBartModel):
         # Attempt to gather the latest eos_token representation in an ONNX compatible way
         # (-1: remove the batch indexes from the vector, -1: Take the last occurrence of eos_token)
         sentence_representation = torch.index_select(x, 1, eos_mask.nonzero().T[-1, -1])
-        logits = self.classification_head(sentence_representation)
+        logits = self.classification_head(sentence_representation).squeeze(1)
 
         loss = None
         if labels is not None:

--- a/src/transformers/modeling_bart.py
+++ b/src/transformers/modeling_bart.py
@@ -1199,7 +1199,7 @@ class BartForSequenceClassification(PretrainedBartModel):
         )
         x = outputs[0]  # last hidden state
         eos_mask = input_ids.eq(self.config.eos_token_id)
-        if torch.unique(eos_mask.sum(1)).item() > 1:
+        if torch.unique(eos_mask.sum(1)).size(-1) > 1:
             raise ValueError("All examples must have the same number of <eos> tokens.")
 
         # Attempt to gather the latest eos_token representation in an ONNX compatible way


### PR DESCRIPTION
**Major concerns:** 
1. ONNX complains about Python raw integer usage.
2. ONNX doesn't support boolean indexing with something else than vector. The code was using 2D Tensor indices (batch, token). 

**PR workarounds:**
1. Remove the call to `len(..)` and prefer the use of `.size(-1)`
2. Attempt to index the output tensors to retrieve only the **last** EOS token over the sequence axis through `.index_select(..)`