### PR TITLE
[examples/seq2seq] fix PL deprecation warning

### DIFF
--- a/examples/seq2seq/callbacks.py
+++ b/examples/seq2seq/callbacks.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from pathlib import Path
 
 import numpy as np

--- a/examples/seq2seq/callbacks.py
+++ b/examples/seq2seq/callbacks.py
@@ -98,7 +98,8 @@ def get_checkpoint_callback(output_dir, metric, save_top_k=1, lower_is_better=Fa
         )
 
     checkpoint_callback = ModelCheckpoint(
-        filepath=os.path.join(output_dir, exp),
+        dirpath=output_dir,
+        filename=exp,
         monitor=f"val_{metric}",
         mode="min" if "loss" in metric else "max",
         save_top_k=save_top_k,


### PR DESCRIPTION
This PR fixes a PL deprecation warning, since we require PL-1.0.4 this is a safe switch.

Reference: https://pytorch-lightning.readthedocs.io/en/latest/generated/pytorch_lightning.callbacks.ModelCheckpoint.html#pytorch_lightning.callbacks.ModelCheckpoint.params.filepath

@patrickvonplaten