### PR TITLE
tf_bart typo - self.self.activation_dropout

### DIFF
--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -267,7 +267,7 @@ class TFEncoderLayer(Layer):
         if self.normalize_before:
             x = self.final_layer_norm(x)
         x = self.activation_fn(self.fc1(x))
-        x = tf.nn.dropout(x, rate=self.self.activation_dropout if training else 0)
+        x = tf.nn.dropout(x, rate=self.activation_dropout if training else 0)
         x = self.fc2(x)
         x = tf.nn.dropout(x, rate=self.dropout if training else 0)
         x = residual + x


### PR DESCRIPTION
# What does this PR do?
Fix one line typo in `modeling_tf_bart` :

`self.self.activation_dropout` -> `self.activation_dropout`

BTW, there's no error in forward pass. 
I met the error when I played around with `model.fit()` :)

## Who can review ?
@sshleifer 