### PR TITLE
[s2s] fix finetune.py to adjust for #8530 changes

### DIFF
--- a/examples/seq2seq/finetune.py
+++ b/examples/seq2seq/finetune.py
@@ -148,7 +148,7 @@ class SummarizationModule(BaseTransformer):
             self.save_readable_batch(batch)
 
         outputs = self(src_ids, attention_mask=src_mask, decoder_input_ids=decoder_input_ids, use_cache=False)
-        lm_logits = outputs[0]
+        lm_logits = outputs["logits"]
         if self.hparams.label_smoothing == 0:
             # Same behavior as modeling_bart.py, besides ignoring pad_token_id
             ce_loss_fct = torch.nn.CrossEntropyLoss(ignore_index=pad_token_id)


### PR DESCRIPTION
Making the script work again after https://github.com/huggingface/transformers/pull/8530 change.

As mentioned in https://github.com/huggingface/transformers/pull/8612 `.logits` doesn't seem to work with apex/PL. No idea why.
So `distillation.py` is probably a problem too since it uses `.logits`. I haven't checked it.

I don't think any tests use apex.
```
RUN_SLOW=1 pyt -sv test_bash_script.py::TestMbartCc25Enro::test_train_mbart_cc25_enro_script
```
tests finetune with fp16, but it runs it in a different way.

@sgugger, @LysandreJik 