### PR TITLE
[s2s] multigpu skip

### DIFF
--- a/examples/seq2seq/test_finetune_trainer.py
+++ b/examples/seq2seq/test_finetune_trainer.py
@@ -4,7 +4,13 @@ from unittest.mock import patch
 
 from transformers import BertTokenizer, EncoderDecoderModel
 from transformers.file_utils import is_datasets_available
-from transformers.testing_utils import TestCasePlus, execute_subprocess_async, get_gpu_count, slow
+from transformers.testing_utils import (
+    TestCasePlus,
+    execute_subprocess_async,
+    get_gpu_count,
+    require_torch_non_multi_gpu_but_fix_me,
+    slow,
+)
 from transformers.trainer_callback import TrainerState
 from transformers.trainer_utils import set_seed
 
@@ -46,6 +52,7 @@ class TestFinetuneTrainer(TestCasePlus):
         assert "test_results.json" in contents
 
     @slow
+    @require_torch_non_multi_gpu_but_fix_me
     def test_finetune_bert2bert(self):
         if not is_datasets_available():
             return


### PR DESCRIPTION
I have a hard time remembering whether this test worked on multi-gpu or not, it currently fails there, but work on a single gpu. So putting a band-aid `require_torch_non_multi_gpu_but_fix_me` skip for now, unless someone wants to work on it. For some reason I thought it was fine - I think it used to be fine.

The error:

```
CUDA_VISIBLE_DEVICES=0,1 RUN_SLOW=1 pyt test_finetune_trainer.py::TestFinetuneTrainer::test_finetune_bert2bert
...

test_finetune_trainer.py:159: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../src/transformers/trainer.py:774: in train
    self._maybe_log_save_evaluate(tr_loss, model, trial, epoch)
../../src/transformers/trainer.py:838: in _maybe_log_save_evaluate
    metrics = self.evaluate()
../../src/transformers/trainer.py:1241: in evaluate
    output = self.prediction_loop(
../../src/transformers/trainer.py:1343: in prediction_loop
    loss, logits, labels = self.prediction_step(model, inputs, prediction_loss_only)
seq2seq_trainer.py:188: in prediction_step
    generated_tokens = model.generate(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = DataParallel(
  (module): EncoderDecoderModel(
    (encoder): BertModel(
      (embeddings): BertEmbeddings(
        (...)
          )
          (decoder): Linear(in_features=128, out_features=30522, bias=True)
        )
      )
    )
  )
)
name = 'generate'

    def __getattr__(self, name: str) -> Union[Tensor, 'Module']:
        if '_parameters' in self.__dict__:
            _parameters = self.__dict__['_parameters']
            if name in _parameters:
                return _parameters[name]
        if '_buffers' in self.__dict__:
            _buffers = self.__dict__['_buffers']
            if name in _buffers:
                return _buffers[name]
        if '_modules' in self.__dict__:
            modules = self.__dict__['_modules']
            if name in modules:
                return modules[name]
>       raise ModuleAttributeError("'{}' object has no attribute '{}'".format(
            type(self).__name__, name))
E       torch.nn.modules.module.ModuleAttributeError: 'DataParallel' object has no attribute 'generate'

/home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/torch/nn/modules/module.py:795: ModuleAttributeError
```

@patrickvonplaten, @LysandreJik 