### PR TITLE
Fix embeddings resizing in TF models

### DIFF
--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -45,19 +45,6 @@ class TFGenerationMixin:
             return False
         return True
 
-    def is_lm_model(self):
-        from .models.auto import (
-            TF_MODEL_FOR_CAUSAL_LM_MAPPING,
-            TF_MODEL_FOR_MASKED_LM_MAPPING,
-            TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
-        )
-
-        list_models = list(TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.values())
-        list_models.extend(list(TF_MODEL_FOR_CAUSAL_LM_MAPPING.values()))
-        list_models.extend(list(TF_MODEL_FOR_MASKED_LM_MAPPING.values()))
-
-        return (type(self) in list_models, [model.__name__ for model in list_models])
-
     def generate(
         self,
         input_ids=None,
@@ -198,10 +185,10 @@ class TFGenerationMixin:
         """
 
         # We cannot generate if the model does not have a LM head
-        is_lm, list_models = self.is_lm_model()
-        if not is_lm:
+        if self.get_output_embeddings() is None:
             raise AttributeError(
-                f"You tried to generate sequences with a model that does not have a LM Head. Please use a model class that belongs to {list_models}."
+                "You tried to generate sequences with a model that does not have a LM Head."
+                "Please use another model class (e.g. `TFOpenAIGPTLMHeadModel`, `TFXLNetLMHeadModel`, `TFGPT2LMHeadModel`, `TFCTRLLMHeadModel`, `TFT5ForConditionalGeneration`, `TFTransfoXLLMHeadModel`)"
             )
 
         max_length = max_length if max_length is not None else self.config.max_length

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -44,12 +44,12 @@ class TFGenerationMixin:
         if hasattr(self.config, "mem_len") and self.config.mem_len == 0:
             return False
         return True
-    
+
     def is_lm_model(self):
         from .models.auto import (
-            TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
             TF_MODEL_FOR_CAUSAL_LM_MAPPING,
             TF_MODEL_FOR_MASKED_LM_MAPPING,
+            TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
         )
 
         list_models = list(TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.values())

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -694,16 +694,17 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
         # todo: initializer range is not always passed in config.
         init_range = getattr(self.config, "initializer_range", 0.02)
         new_embeddings = self.add_weight(
-            "weight",
+            name=word_embeddings.name.split(":")[0],
             shape=[new_num_tokens, old_embedding_dim],
             initializer=get_initializer(init_range),
             dtype=tf.float32,
         )
-        init_weights = new_embeddings.numpy()
+
+        init_weights = tf.make_ndarray(tf.make_tensor_proto(new_embeddings.value()))
 
         # Copy token embeddings from the previous weights
         num_tokens_to_copy = min(old_num_tokens, new_num_tokens)
-        init_weights[:num_tokens_to_copy] = word_embeddings[:num_tokens_to_copy, :]
+        init_weights[:num_tokens_to_copy] = word_embeddings.value()[:num_tokens_to_copy, :]
         new_embeddings.assign(init_weights)
 
         return new_embeddings

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -748,7 +748,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
 
             # initialize bias
             init_bias = np.zeros((new_num_tokens,))
-            init_bias[:num_tokens_to_copy] = tf.make_ndarray(tf.make_tensor_proto(bias_layer.bias.value()))[:num_tokens_to_copy]
+            init_bias[:num_tokens_to_copy] = tf.make_ndarray(tf.make_tensor_proto(bias_layer.bias.value()))[
+                :num_tokens_to_copy
+            ]
 
             bias_layer.bias = self.add_weight(
                 shape=(new_num_tokens,),

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -758,9 +758,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
 
             # initialize bias
             init_bias = np.zeros((new_num_tokens,))
-            init_bias[:num_tokens_to_copy] = tf.make_ndarray(tf.make_tensor_proto(bias_layer.bias.value()))[
-                :num_tokens_to_copy
-            ]
+            init_bias[:num_tokens_to_copy] = bias_layer.bias.value()[:num_tokens_to_copy] # tf.make_ndarray(tf.make_tensor_proto(bias_layer.bias.value()))[:num_tokens_to_copy]
 
             bias_layer.bias = self.add_weight(
                 shape=(new_num_tokens,),
@@ -770,6 +768,18 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
             )
 
             bias_layer.bias.assign(init_bias)
+        
+            if self.get_input_embeddings() != self.get_output_embeddings():
+                init_weights = np.zeros((new_num_tokens, old_embedding_dim))
+                init_weights[:num_tokens_to_copy] = bias_layer.decoder.value()[:num_tokens_to_copy, :]
+
+                bias_layer.decoder = self.add_weight(
+                    shape=(new_num_tokens, old_embedding_dim),
+                    initializer="zeros",
+                    trainable=True,
+                    name=self.get_prefix_bias_name() + "/decoder/weight",
+                )
+                bias_layer.decoder.assign(init_weights)
 
         return new_embeddings
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -776,7 +776,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
         if output_embeddings is not None:
             if self.get_input_embeddings() != output_embeddings:
                 if not hasattr(output_embeddings, "decoder"):
-                    bias_layer.build([])
+                    output_embeddings.build([])
 
                 # Second check in order to be sure the attribute has been properly created
                 if not hasattr(output_embeddings, "decoder"):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -612,15 +612,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
         else:
             raise NotImplementedError
 
-    def get_output_embeddings(self) -> tf.keras.layers.Layer:
-        """
-        Returns the model's output embeddings.
-
-        Returns:
-            :obj:`tf.keras.layers.Layer`: A torch module mapping hidden states to vocabulary.
-        """
-        return None  # Overwrite for models with output embeddings
-
     def resize_token_embeddings(self, new_num_tokens=None) -> tf.Variable:
         """
         Resizes input token embeddings matrix of the model if :obj:`new_num_tokens != config.vocab_size`.

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -770,16 +770,16 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
             )
 
             bias_layer.bias.assign(init_bias)
+        
+        output_embeddings = self.get_output_embeddings()
 
-        if self.get_output_embeddings is not None:
-            if self.get_input_embeddings() != self.get_output_embeddings():
-                output_embeddings = self.get_output_embeddings()
-
-                if not hasattr(bias_layer, "decoder"):
+        if output_embeddings is not None:
+            if self.get_input_embeddings() != output_embeddings:
+                if not hasattr(output_embeddings, "decoder"):
                     bias_layer.build([])
 
                 # Second check in order to be sure the attribute has been properly created
-                if not hasattr(bias_layer, "decoder"):
+                if not hasattr(output_embeddings, "decoder"):
                     raise ValueError("decoder is not defined.")
 
                 # initialize decoder

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -758,7 +758,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
 
             # initialize bias
             init_bias = np.zeros((new_num_tokens,))
-            init_bias[:num_tokens_to_copy] = bias_layer.bias.value()[:num_tokens_to_copy] # tf.make_ndarray(tf.make_tensor_proto(bias_layer.bias.value()))[:num_tokens_to_copy]
+            init_bias[:num_tokens_to_copy] = bias_layer.bias.value()[
+                :num_tokens_to_copy
+            ]  # tf.make_ndarray(tf.make_tensor_proto(bias_layer.bias.value()))[:num_tokens_to_copy]
 
             bias_layer.bias = self.add_weight(
                 shape=(new_num_tokens,),
@@ -768,7 +770,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
             )
 
             bias_layer.bias.assign(init_bias)
-        
+
             if self.get_input_embeddings() != self.get_output_embeddings():
                 init_weights = np.zeros((new_num_tokens, old_embedding_dim))
                 init_weights[:num_tokens_to_copy] = bias_layer.decoder.value()[:num_tokens_to_copy, :]

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -747,17 +747,17 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
                 raise ValueError("bias is not defined.")
 
             # initialize bias
-            new_bias = self.add_weight(
+            init_bias = np.zeros((new_num_tokens,))
+            init_bias[:num_tokens_to_copy] = tf.make_ndarray(tf.make_tensor_proto(bias_layer.bias.value()))[:num_tokens_to_copy]
+
+            bias_layer.bias = self.add_weight(
                 shape=(new_num_tokens,),
                 initializer="zeros",
                 trainable=True,
                 name=self.get_prefix_bias_name() + "/bias",
             )
-            init_bias = tf.make_ndarray(tf.make_tensor_proto(bias_layer.bias.value()))[:num_tokens_to_copy]
 
-            new_bias.assign(init_bias)
-
-            bias_layer.bias = new_bias
+            bias_layer.bias.assign(init_bias)
 
         return new_embeddings
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -770,7 +770,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
             )
 
             bias_layer.bias.assign(init_bias)
-        
+
         output_embeddings = self.get_output_embeddings()
 
         if output_embeddings is not None:

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -611,10 +611,11 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
             base_model.set_input_embeddings(value)
         else:
             raise NotImplementedError
-    
+
     def get_output_embeddings(self) -> tf.keras.layers.Layer:
         """
-        Returns the model's output embeddings.
+        Returns the model's output embeddings
+
         Returns:
             :obj:`tf.keras.layers.Layer`: A torch module mapping hidden states to vocabulary.
         """

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -747,19 +747,17 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
                 raise ValueError("bias is not defined.")
 
             # initialize bias
-            bias_layer.bias = self.add_weight(
+            new_bias = self.add_weight(
                 shape=(new_num_tokens,),
                 initializer="zeros",
                 trainable=True,
                 name=self.get_prefix_bias_name() + "/bias",
             )
-            init_bias = tf.make_ndarray(tf.make_tensor_proto(bias_layer.bias.value()))
+            init_bias = tf.make_ndarray(tf.make_tensor_proto(bias_layer.bias.value()))[:num_tokens_to_copy]
 
-            # Copy bias from the previous one
-            init_bias[:num_tokens_to_copy] = bias_layer.bias.value()[:num_tokens_to_copy]
-            base_layer.vocab_size = num_tokens_to_copy
+            new_bias.assign(init_bias)
 
-            bias_layer.bias.assign(init_bias)
+            bias_layer.bias = new_bias
 
         return new_embeddings
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -612,9 +612,10 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
         else:
             raise NotImplementedError
 
-    def get_bias(self) -> Union[None, tf.keras.layers.Layer]:
+    def get_output_layer_with_bias(self) -> Union[None, tf.keras.layers.Layer]:
         """
-        Get the layer that handles a bias attribute in case the model has an LM head.
+        Get the layer that handles a bias attribute in case the model has an LM head with weights tied to the
+        embeddings.
 
         Return:
             :obj:`tf.keras.layers.Layer`: The layer that handles the bias, None if not an LM model.

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -611,6 +611,14 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
             base_model.set_input_embeddings(value)
         else:
             raise NotImplementedError
+    
+    def get_output_embeddings(self) -> tf.keras.layers.Layer:
+        """
+        Returns the model's output embeddings.
+        Returns:
+            :obj:`tf.keras.layers.Layer`: A torch module mapping hidden states to vocabulary.
+        """
+        return None  # Overwrite for models with output embeddings
 
     def get_output_layer_with_bias(self) -> Union[None, tf.keras.layers.Layer]:
         """
@@ -672,6 +680,8 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
             # TFSharedEmbeddings
             return embeddings.weight
         else:
+            # Here we build the word embeddings weights if not exists.
+            # And then we retry to get the attribute once built.
             embeddings.build([])
             if hasattr(embeddings, "word_embeddings"):
                 # TFBertEmbeddings, TFAlbertEmbeddings, TFElectraEmbeddings

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -26,7 +26,6 @@ import h5py
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.keras import backend as K
-from tensorflow.python.keras.engine import base_layer
 from tensorflow.python.keras.saving import hdf5_format
 
 from .configuration_utils import PretrainedConfig

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -470,21 +470,6 @@ class TFAlbertMLMHead(tf.keras.layers.Layer):
 
         super().build(input_shape)
 
-    def resize_bias(self, new_num_tokens):
-        if new_num_tokens is not None:
-            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
-            init_bias = self.bias.value()[:num_tokens_to_copy]
-            self.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
-            )
-            self.bias.assign(init_bias)
-
-            init_decoder_bias = self.decoder_bias.value()[:num_tokens_to_copy]
-            self.decoder_bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.decoder_bias.name.split(":")[0]
-            )
-            self.decoder_bias.assign(init_decoder_bias)
-
     def call(self, hidden_states):
         hidden_states = self.dense(hidden_states)
         hidden_states = self.activation(hidden_states)
@@ -838,13 +823,31 @@ class TFAlbertForPreTraining(TFAlbertPreTrainedModel):
         self.predictions = TFAlbertMLMHead(config, self.albert.embeddings, name="predictions")
         self.sop_classifier = TFAlbertSOPHead(config, name="sop_classifier")
 
-    def get_output_embeddings(self):
-        return self.albert.embeddings
-
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
-        self.predictions.resize_bias(new_num_tokens)
+        # ALBERT is a special case where there are two bias to update
+        # even though self.bias is not used anywhere and is here
+        # just to make the loading weights from a PT model happy
+        if new_num_tokens is not None:
+            num_tokens_to_copy = min(self.predictions.bias.shape[0], new_num_tokens)
+            init_bias = self.predictions.bias.value()[:num_tokens_to_copy]
+            self.predictions.bias = self.add_weight(
+                shape=(new_num_tokens,),
+                initializer="zeros",
+                trainable=True,
+                name=self.predictions.bias.name.split(":")[0],
+            )
+            self.predictions.bias.assign(init_bias)
+
+            init_decoder_bias = self.predictions.decoder_bias.value()[:num_tokens_to_copy]
+            self.predictions.decoder_bias = self.add_weight(
+                shape=(new_num_tokens,),
+                initializer="zeros",
+                trainable=True,
+                name=self.predictions.decoder_bias.name.split(":")[0],
+            )
+            self.predictions.decoder_bias.assign(init_decoder_bias)
 
     @add_start_docstrings_to_model_forward(ALBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFAlbertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
@@ -951,13 +954,28 @@ class TFAlbertForMaskedLM(TFAlbertPreTrainedModel, TFMaskedLanguageModelingLoss)
         self.albert = TFAlbertMainLayer(config, add_pooling_layer=False, name="albert")
         self.predictions = TFAlbertMLMHead(config, self.albert.embeddings, name="predictions")
 
-    def get_output_embeddings(self):
-        return self.albert.embeddings
-
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
-        self.predictions.resize_bias(new_num_tokens)
+        # ALBERT is a special case where there are two bias to update
+        # even though self.bias is not used anywhere and is here
+        # just to make the loading weights from a PT model happy
+        if new_num_tokens is not None:
+            num_tokens_to_copy = min(self.predictions.bias.shape[0], new_num_tokens)
+            init_bias = self.predictions.bias.value()[:num_tokens_to_copy]
+            name = self.name + "/" + self.predictions + "/bias"
+            self.predictions.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=name
+            )
+            self.predictions.bias.assign(init_bias)
+
+            init_decoder_bias = self.predictions.decoder_bias.value()[:num_tokens_to_copy]
+            name = self.name + "/" + self.predictions + "/decoder_bias"
+            self.predictions.decoder_bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=name
+            )
+            self.predictions.vocab_size = num_tokens_to_copy
+            self.predictions.decoder_bias.assign(init_decoder_bias)
 
     @add_start_docstrings_to_model_forward(ALBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -823,6 +823,9 @@ class TFAlbertForPreTraining(TFAlbertPreTrainedModel):
         self.predictions = TFAlbertMLMHead(config, self.albert.embeddings, name="predictions")
         self.sop_classifier = TFAlbertSOPHead(config, name="sop_classifier")
 
+    def get_output_embeddings(self):
+        return self.albert.embeddings
+
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
@@ -953,6 +956,9 @@ class TFAlbertForMaskedLM(TFAlbertPreTrainedModel, TFMaskedLanguageModelingLoss)
 
         self.albert = TFAlbertMainLayer(config, add_pooling_layer=False, name="albert")
         self.predictions = TFAlbertMLMHead(config, self.albert.embeddings, name="predictions")
+
+    def get_output_embeddings(self):
+        return self.albert.embeddings
 
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -832,21 +832,18 @@ class TFAlbertForPreTraining(TFAlbertPreTrainedModel):
         if new_num_tokens is not None:
             num_tokens_to_copy = min(self.predictions.bias.shape[0], new_num_tokens)
             init_bias = self.predictions.bias.value()[:num_tokens_to_copy]
+            name = self.name + "/" + self.predictions.name + "/bias"
             self.predictions.bias = self.add_weight(
-                shape=(new_num_tokens,),
-                initializer="zeros",
-                trainable=True,
-                name=self.predictions.bias.name.split(":")[0],
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=name
             )
             self.predictions.bias.assign(init_bias)
 
             init_decoder_bias = self.predictions.decoder_bias.value()[:num_tokens_to_copy]
+            name = self.name + "/" + self.predictions.name + "/decoder_bias"
             self.predictions.decoder_bias = self.add_weight(
-                shape=(new_num_tokens,),
-                initializer="zeros",
-                trainable=True,
-                name=self.predictions.decoder_bias.name.split(":")[0],
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=name
             )
+            self.predictions.vocab_size = num_tokens_to_copy
             self.predictions.decoder_bias.assign(init_decoder_bias)
 
     @add_start_docstrings_to_model_forward(ALBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
@@ -963,14 +960,14 @@ class TFAlbertForMaskedLM(TFAlbertPreTrainedModel, TFMaskedLanguageModelingLoss)
         if new_num_tokens is not None:
             num_tokens_to_copy = min(self.predictions.bias.shape[0], new_num_tokens)
             init_bias = self.predictions.bias.value()[:num_tokens_to_copy]
-            name = self.name + "/" + self.predictions + "/bias"
+            name = self.name + "/" + self.predictions.name + "/bias"
             self.predictions.bias = self.add_weight(
                 shape=(new_num_tokens,), initializer="zeros", trainable=True, name=name
             )
             self.predictions.bias.assign(init_bias)
 
             init_decoder_bias = self.predictions.decoder_bias.value()[:num_tokens_to_copy]
-            name = self.name + "/" + self.predictions + "/decoder_bias"
+            name = self.name + "/" + self.predictions.name + "/decoder_bias"
             self.predictions.decoder_bias = self.add_weight(
                 shape=(new_num_tokens,), initializer="zeros", trainable=True, name=name
             )

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -831,19 +831,22 @@ class TFAlbertForPreTraining(TFAlbertPreTrainedModel):
         # just to make the loading weights from a PT model happy
         if new_num_tokens is not None:
             num_tokens_to_copy = min(self.predictions.bias.shape[0], new_num_tokens)
-            init_bias = self.predictions.bias.value()[:num_tokens_to_copy]
+            self.predictions.vocab_size = num_tokens_to_copy
+            init_bias = tf.zeros((new_num_tokens,))
+            init_bias[:num_tokens_to_copy] = self.predictions.bias.value()[:num_tokens_to_copy]
             name = self.name + "/" + self.predictions.name + "/bias"
             self.predictions.bias = self.add_weight(
                 shape=(new_num_tokens,), initializer="zeros", trainable=True, name=name
             )
             self.predictions.bias.assign(init_bias)
 
-            init_decoder_bias = self.predictions.decoder_bias.value()[:num_tokens_to_copy]
+            init_decoder_bias = tf.zeros((new_num_tokens,))
+            init_decoder_bias[:num_tokens_to_copy] = self.predictions.decoder_bias.value()[:num_tokens_to_copy]
             name = self.name + "/" + self.predictions.name + "/decoder_bias"
             self.predictions.decoder_bias = self.add_weight(
                 shape=(new_num_tokens,), initializer="zeros", trainable=True, name=name
             )
-            self.predictions.vocab_size = num_tokens_to_copy
+
             self.predictions.decoder_bias.assign(init_decoder_bias)
 
     @add_start_docstrings_to_model_forward(ALBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -962,19 +962,22 @@ class TFAlbertForMaskedLM(TFAlbertPreTrainedModel, TFMaskedLanguageModelingLoss)
         # just to make the loading weights from a PT model happy
         if new_num_tokens is not None:
             num_tokens_to_copy = min(self.predictions.bias.shape[0], new_num_tokens)
-            init_bias = self.predictions.bias.value()[:num_tokens_to_copy]
+            self.predictions.vocab_size = num_tokens_to_copy
+            init_bias = tf.zeros((new_num_tokens,))
+            init_bias[:num_tokens_to_copy] = self.predictions.bias.value()[:num_tokens_to_copy]
             name = self.name + "/" + self.predictions.name + "/bias"
             self.predictions.bias = self.add_weight(
                 shape=(new_num_tokens,), initializer="zeros", trainable=True, name=name
             )
             self.predictions.bias.assign(init_bias)
 
-            init_decoder_bias = self.predictions.decoder_bias.value()[:num_tokens_to_copy]
+            init_decoder_bias = tf.zeros((new_num_tokens,))
+            init_decoder_bias[:num_tokens_to_copy] = self.predictions.decoder_bias.value()[:num_tokens_to_copy]
             name = self.name + "/" + self.predictions.name + "/decoder_bias"
             self.predictions.decoder_bias = self.add_weight(
                 shape=(new_num_tokens,), initializer="zeros", trainable=True, name=name
             )
-            self.predictions.vocab_size = num_tokens_to_copy
+
             self.predictions.decoder_bias.assign(init_decoder_bias)
 
     @add_start_docstrings_to_model_forward(ALBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -467,7 +467,23 @@ class TFAlbertMLMHead(tf.keras.layers.Layer):
         self.decoder_bias = self.add_weight(
             shape=(self.vocab_size,), initializer="zeros", trainable=True, name="decoder/bias"
         )
+
         super().build(input_shape)
+
+    def resize_bias(self, new_num_tokens):
+        if new_num_tokens is not None:
+            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
+            init_bias = self.bias.value()[:num_tokens_to_copy]
+            self.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
+            )
+            self.bias.assign(init_bias)
+
+            init_decoder_bias = self.decoder_bias.value()[:num_tokens_to_copy]
+            self.decoder_bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.decoder_bias.name.split(":")[0]
+            )
+            self.decoder_bias.assign(init_decoder_bias)
 
     def call(self, hidden_states):
         hidden_states = self.dense(hidden_states)
@@ -828,13 +844,7 @@ class TFAlbertForPreTraining(TFAlbertPreTrainedModel):
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
-        if new_num_tokens is not None:
-            self.predictions.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
-            )
-            self.predictions.decoder_bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
-            )
+        self.predictions.resize_bias(new_num_tokens)
 
     @add_start_docstrings_to_model_forward(ALBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFAlbertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
@@ -947,13 +957,7 @@ class TFAlbertForMaskedLM(TFAlbertPreTrainedModel, TFMaskedLanguageModelingLoss)
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
-        if new_num_tokens is not None:
-            self.predictions.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
-            )
-            self.predictions.decoder_bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
-            )
+        self.predictions.resize_bias(new_num_tokens)
 
     @add_start_docstrings_to_model_forward(ALBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -825,6 +825,17 @@ class TFAlbertForPreTraining(TFAlbertPreTrainedModel):
     def get_output_embeddings(self):
         return self.albert.embeddings
 
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.predictions.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
+            self.predictions.decoder_bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
+
     @add_start_docstrings_to_model_forward(ALBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFAlbertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
     def call(
@@ -932,6 +943,17 @@ class TFAlbertForMaskedLM(TFAlbertPreTrainedModel, TFMaskedLanguageModelingLoss)
 
     def get_output_embeddings(self):
         return self.albert.embeddings
+
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.predictions.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
+            self.predictions.decoder_bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
 
     @add_start_docstrings_to_model_forward(ALBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -1053,9 +1053,15 @@ class TFBartForConditionalGeneration(TFPretrainedBartModel):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
         if new_num_tokens is not None:
+            num_tokens_to_copy = min(self.final_logits_bias.shape[0], new_num_tokens)
+            init_bias = self.final_logits_bias.value()[:num_tokens_to_copy]
             self.final_logits_bias = self.add_weight(
-                shape=(1, new_num_tokens), initializer="zeros", trainable=False, name="bias"
+                shape=(1, new_num_tokens),
+                initializer="zeros",
+                trainable=False,
+                name=self.final_logits_bias.name.split(":")[0],
             )
+            self.final_logits_bias.assign(init_bias)
 
     @add_start_docstrings_to_model_forward(BART_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFSeq2SeqLMOutput, config_class=_CONFIG_FOR_DOC)

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -1052,14 +1052,17 @@ class TFBartForConditionalGeneration(TFPretrainedBartModel):
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
+        # BART is a special case where the bias has two dimensions
+        # and not named just `bias`
         if new_num_tokens is not None:
+            name = self.name + "/final_logits_bias"
             num_tokens_to_copy = min(self.final_logits_bias.shape[0], new_num_tokens)
             init_bias = self.final_logits_bias.value()[:num_tokens_to_copy]
             self.final_logits_bias = self.add_weight(
                 shape=(1, new_num_tokens),
                 initializer="zeros",
                 trainable=False,
-                name=self.final_logits_bias.name.split(":")[0],
+                name=name,
             )
             self.final_logits_bias.assign(init_bias)
 

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -1055,9 +1055,10 @@ class TFBartForConditionalGeneration(TFPretrainedBartModel):
         # BART is a special case where the bias has two dimensions
         # and not named just `bias`
         if new_num_tokens is not None:
-            name = self.name + "/final_logits_bias"
             num_tokens_to_copy = min(self.final_logits_bias.shape[0], new_num_tokens)
-            init_bias = self.final_logits_bias.value()[:num_tokens_to_copy]
+            init_bias = tf.zeros((new_num_tokens,))
+            init_bias[:num_tokens_to_copy] = self.final_logits_bias.value()[:num_tokens_to_copy]
+            name = self.name + "/final_logits_bias"
             self.final_logits_bias = self.add_weight(
                 shape=(1, new_num_tokens),
                 initializer="zeros",

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -1049,6 +1049,14 @@ class TFBartForConditionalGeneration(TFPretrainedBartModel):
             name="/final_logits_bias", shape=[1, config.vocab_size], initializer="zeros", trainable=False
         )
 
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.final_logits_bias = self.add_weight(
+                shape=(1, new_num_tokens), initializer="zeros", trainable=False, name="bias"
+            )
+
     @add_start_docstrings_to_model_forward(BART_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFSeq2SeqLMOutput, config_class=_CONFIG_FOR_DOC)
     def call(

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -893,6 +893,14 @@ class TFBertForPreTraining(TFBertPreTrainedModel, TFBertPreTrainingLoss):
     def get_output_embeddings(self):
         return self.bert.embeddings
 
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.mlm.predictions.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
+
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFBertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
     def call(
@@ -1002,6 +1010,14 @@ class TFBertForMaskedLM(TFBertPreTrainedModel, TFMaskedLanguageModelingLoss):
     def get_output_embeddings(self):
         return self.bert.embeddings
 
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.mlm.predictions.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
+
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,
@@ -1094,6 +1110,14 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
 
     def get_output_embeddings(self):
         return self.bert.embeddings
+
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.mlm.predictions.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
 
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -509,15 +509,6 @@ class TFBertLMPredictionHead(tf.keras.layers.Layer):
 
         super().build(input_shape)
 
-    def resize_bias(self, new_num_tokens):
-        if new_num_tokens is not None:
-            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
-            init_bias = self.bias.value()[:num_tokens_to_copy]
-            self.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
-            )
-            self.bias.assign(init_bias)
-
     def call(self, hidden_states):
         hidden_states = self.transform(hidden_states)
         hidden_states = self.input_embeddings(hidden_states, mode="linear")
@@ -899,13 +890,8 @@ class TFBertForPreTraining(TFBertPreTrainedModel, TFBertPreTrainingLoss):
         self.nsp = TFBertNSPHead(config, name="nsp___cls")
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
-    def get_output_embeddings(self):
-        return self.bert.embeddings
-
-    def resize_token_embeddings(self, new_num_tokens):
-        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
-
-        self.mlm.predictions.resize_bias(new_num_tokens)
+    def get_bias(self):
+        return self.mlm.predictions
 
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFBertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
@@ -1013,13 +999,8 @@ class TFBertForMaskedLM(TFBertPreTrainedModel, TFMaskedLanguageModelingLoss):
         self.bert = TFBertMainLayer(config, add_pooling_layer=False, name="bert")
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
-    def get_output_embeddings(self):
-        return self.bert.embeddings
-
-    def resize_token_embeddings(self, new_num_tokens):
-        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
-
-        self.mlm.predictions.resize_bias(new_num_tokens)
+    def get_bias(self):
+        return self.mlm.predictions
 
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
@@ -1111,13 +1092,8 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
         self.bert = TFBertMainLayer(config, add_pooling_layer=False, name="bert")
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
-    def get_output_embeddings(self):
-        return self.bert.embeddings
-
-    def resize_token_embeddings(self, new_num_tokens):
-        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
-
-        self.mlm.predictions.resize_bias(new_num_tokens)
+    def get_bias(self):
+        return self.mlm.predictions
 
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -890,6 +890,9 @@ class TFBertForPreTraining(TFBertPreTrainedModel, TFBertPreTrainingLoss):
         self.nsp = TFBertNSPHead(config, name="nsp___cls")
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
+    def get_output_embeddings(self):
+        return self.bert.embeddings
+
     def get_output_layer_with_bias(self):
         return self.mlm.predictions
 
@@ -1002,6 +1005,9 @@ class TFBertForMaskedLM(TFBertPreTrainedModel, TFMaskedLanguageModelingLoss):
         self.bert = TFBertMainLayer(config, add_pooling_layer=False, name="bert")
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
+    def get_output_embeddings(self):
+        return self.bert.embeddings
+
     def get_output_layer_with_bias(self):
         return self.mlm.predictions
 
@@ -1098,8 +1104,14 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
         self.bert = TFBertMainLayer(config, add_pooling_layer=False, name="bert")
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
-    def get_bias(self):
+    def get_output_embeddings(self):
+        return self.bert.embeddings
+
+    def get_output_layer_with_bias(self):
         return self.mlm.predictions
+
+    def get_prefix_bias_name(self):
+        return self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name
 
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -509,6 +509,15 @@ class TFBertLMPredictionHead(tf.keras.layers.Layer):
 
         super().build(input_shape)
 
+    def resize_bias(self, new_num_tokens):
+        if new_num_tokens is not None:
+            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
+            init_bias = self.bias.value()[:num_tokens_to_copy]
+            self.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
+            )
+            self.bias.assign(init_bias)
+
     def call(self, hidden_states):
         hidden_states = self.transform(hidden_states)
         hidden_states = self.input_embeddings(hidden_states, mode="linear")
@@ -896,10 +905,7 @@ class TFBertForPreTraining(TFBertPreTrainedModel, TFBertPreTrainingLoss):
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
-        if new_num_tokens is not None:
-            self.mlm.predictions.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
-            )
+        self.mlm.predictions.resize_bias(new_num_tokens)
 
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFBertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
@@ -1013,10 +1019,7 @@ class TFBertForMaskedLM(TFBertPreTrainedModel, TFMaskedLanguageModelingLoss):
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
-        if new_num_tokens is not None:
-            self.mlm.predictions.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
-            )
+        self.mlm.predictions.resize_bias(new_num_tokens)
 
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
@@ -1114,10 +1117,7 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
-        if new_num_tokens is not None:
-            self.mlm.predictions.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
-            )
+        self.mlm.predictions.resize_bias(new_num_tokens)
 
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -890,8 +890,11 @@ class TFBertForPreTraining(TFBertPreTrainedModel, TFBertPreTrainingLoss):
         self.nsp = TFBertNSPHead(config, name="nsp___cls")
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
-    def get_bias(self):
+    def get_output_layer_with_bias(self):
         return self.mlm.predictions
+
+    def get_prefix_bias_name(self):
+        return self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name
 
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFBertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
@@ -999,8 +1002,11 @@ class TFBertForMaskedLM(TFBertPreTrainedModel, TFMaskedLanguageModelingLoss):
         self.bert = TFBertMainLayer(config, add_pooling_layer=False, name="bert")
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
-    def get_bias(self):
+    def get_output_layer_with_bias(self):
         return self.mlm.predictions
+
+    def get_prefix_bias_name(self):
+        return self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name
 
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/ctrl/modeling_tf_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_tf_ctrl.py
@@ -626,6 +626,9 @@ class TFCTRLLMHeadModel(TFCTRLPreTrainedModel, TFCausalLanguageModelingLoss):
 
         self.lm_head = TFCTRLLMHead(config, self.transformer.w, name="lm_head")
 
+    def get_output_embeddings(self):
+        return self.lm_head.input_embeddings
+
     def get_output_layer_with_bias(self):
         return self.lm_head
 

--- a/src/transformers/models/ctrl/modeling_tf_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_tf_ctrl.py
@@ -606,15 +606,6 @@ class TFCTRLLMHead(tf.keras.layers.Layer):
         self.bias = self.add_weight(shape=(self.vocab_size,), initializer="zeros", trainable=True, name="bias")
         super().build(input_shape)
 
-    def resize_bias(self, new_num_tokens):
-        if new_num_tokens is not None:
-            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
-            init_bias = self.bias.value()[:num_tokens_to_copy]
-            self.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
-            )
-            self.bias.assign(init_bias)
-
     def call(self, hidden_states):
         hidden_states = self.input_embeddings(hidden_states, mode="linear")
         hidden_states = hidden_states + self.bias
@@ -635,13 +626,11 @@ class TFCTRLLMHeadModel(TFCTRLPreTrainedModel, TFCausalLanguageModelingLoss):
 
         self.lm_head = TFCTRLLMHead(config, self.transformer.w, name="lm_head")
 
-    def get_output_embeddings(self):
-        return self.lm_head.input_embeddings
+    def get_output_layer_with_bias(self):
+        return self.lm_head
 
-    def resize_token_embeddings(self, new_num_tokens):
-        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
-
-        self.lm_head.resize_bias(new_num_tokens)
+    def get_prefix_bias_name(self):
+        return self.name + "/" + self.lm_head.name
 
     def prepare_inputs_for_generation(self, inputs, past, **kwargs):
         # only last token for inputs_ids if past is defined in kwargs

--- a/src/transformers/models/ctrl/modeling_tf_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_tf_ctrl.py
@@ -606,6 +606,15 @@ class TFCTRLLMHead(tf.keras.layers.Layer):
         self.bias = self.add_weight(shape=(self.vocab_size,), initializer="zeros", trainable=True, name="bias")
         super().build(input_shape)
 
+    def resize_bias(self, new_num_tokens):
+        if new_num_tokens is not None:
+            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
+            init_bias = self.bias.value()[:num_tokens_to_copy]
+            self.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
+            )
+            self.bias.assign(init_bias)
+
     def call(self, hidden_states):
         hidden_states = self.input_embeddings(hidden_states, mode="linear")
         hidden_states = hidden_states + self.bias
@@ -632,10 +641,7 @@ class TFCTRLLMHeadModel(TFCTRLPreTrainedModel, TFCausalLanguageModelingLoss):
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
-        if new_num_tokens is not None:
-            self.lm_head.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
-            )
+        self.lm_head.resize_bias(new_num_tokens)
 
     def prepare_inputs_for_generation(self, inputs, past, **kwargs):
         # only last token for inputs_ids if past is defined in kwargs

--- a/src/transformers/models/ctrl/modeling_tf_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_tf_ctrl.py
@@ -629,6 +629,14 @@ class TFCTRLLMHeadModel(TFCTRLPreTrainedModel, TFCausalLanguageModelingLoss):
     def get_output_embeddings(self):
         return self.lm_head.input_embeddings
 
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.lm_head.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
+
     def prepare_inputs_for_generation(self, inputs, past, **kwargs):
         # only last token for inputs_ids if past is defined in kwargs
         if past:

--- a/src/transformers/models/distilbert/modeling_tf_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_tf_distilbert.py
@@ -629,6 +629,15 @@ class TFDistilBertLMHead(tf.keras.layers.Layer):
         self.bias = self.add_weight(shape=(self.vocab_size,), initializer="zeros", trainable=True, name="bias")
         super().build(input_shape)
 
+    def resize_bias(self, new_num_tokens):
+        if new_num_tokens is not None:
+            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
+            init_bias = self.bias.value()[:num_tokens_to_copy]
+            self.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
+            )
+            self.bias.assign(init_bias)
+
     def call(self, hidden_states):
         hidden_states = self.input_embeddings(hidden_states, mode="linear")
         hidden_states = hidden_states + self.bias
@@ -658,10 +667,7 @@ class TFDistilBertForMaskedLM(TFDistilBertPreTrainedModel, TFMaskedLanguageModel
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
-        if new_num_tokens is not None:
-            self.vocab_projector.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
-            )
+        self.vocab_projector.resize_bias(new_num_tokens)
 
     @add_start_docstrings_to_model_forward(DISTILBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/distilbert/modeling_tf_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_tf_distilbert.py
@@ -655,6 +655,14 @@ class TFDistilBertForMaskedLM(TFDistilBertPreTrainedModel, TFMaskedLanguageModel
     def get_output_embeddings(self):
         return self.vocab_projector.input_embeddings
 
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.vocab_projector.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
+
     @add_start_docstrings_to_model_forward(DISTILBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/src/transformers/models/distilbert/modeling_tf_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_tf_distilbert.py
@@ -652,6 +652,9 @@ class TFDistilBertForMaskedLM(TFDistilBertPreTrainedModel, TFMaskedLanguageModel
         self.vocab_layer_norm = tf.keras.layers.LayerNormalization(epsilon=1e-12, name="vocab_layer_norm")
         self.vocab_projector = TFDistilBertLMHead(config, self.distilbert.embeddings, name="vocab_projector")
 
+    def get_output_embeddings(self):
+        return self.vocab_projector.input_embeddings
+
     def get_output_layer_with_bias(self):
         return self.vocab_projector
 

--- a/src/transformers/models/electra/modeling_tf_electra.py
+++ b/src/transformers/models/electra/modeling_tf_electra.py
@@ -914,7 +914,7 @@ class TFElectraForMaskedLM(TFElectraPreTrainedModel, TFMaskedLanguageModelingLos
         self.generator_lm_head = TFElectraMaskedLMHead(config, self.electra.embeddings, name="generator_lm_head")
 
     def get_output_embeddings(self):
-        return self.generator_lm_head
+        return self.electra.embeddings
 
     def get_output_layer_with_bias(self):
         return self.generator_lm_head

--- a/src/transformers/models/electra/modeling_tf_electra.py
+++ b/src/transformers/models/electra/modeling_tf_electra.py
@@ -913,6 +913,9 @@ class TFElectraForMaskedLM(TFElectraPreTrainedModel, TFMaskedLanguageModelingLos
 
         self.generator_lm_head = TFElectraMaskedLMHead(config, self.electra.embeddings, name="generator_lm_head")
 
+    def get_output_embeddings(self):
+        return self.generator_lm_head
+
     def get_output_layer_with_bias(self):
         return self.generator_lm_head
 

--- a/src/transformers/models/electra/modeling_tf_electra.py
+++ b/src/transformers/models/electra/modeling_tf_electra.py
@@ -882,7 +882,16 @@ class TFElectraMaskedLMHead(tf.keras.layers.Layer):
 
         super().build(input_shape)
 
-    def call(self, hidden_states):
+    def resize_bias(self, new_num_tokens):
+        if new_num_tokens is not None:
+            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
+            init_bias = self.bias.value()[:num_tokens_to_copy]
+            self.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
+            )
+            self.bias.assign(init_bias)
+
+    def call(self, hidden_states, training=False):
         hidden_states = self.input_embeddings(hidden_states, mode="linear")
         hidden_states = hidden_states + self.bias
 
@@ -919,10 +928,7 @@ class TFElectraForMaskedLM(TFElectraPreTrainedModel, TFMaskedLanguageModelingLos
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
-        if new_num_tokens is not None:
-            self.generator_lm_head.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
-            )
+        self.generator_lm_head.resize_bias(new_num_tokens)
 
     @add_start_docstrings_to_model_forward(ELECTRA_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/electra/modeling_tf_electra.py
+++ b/src/transformers/models/electra/modeling_tf_electra.py
@@ -916,6 +916,14 @@ class TFElectraForMaskedLM(TFElectraPreTrainedModel, TFMaskedLanguageModelingLos
     def get_output_embeddings(self):
         return self.generator_lm_head
 
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.generator_lm_head.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
+
     @add_start_docstrings_to_model_forward(ELECTRA_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/src/transformers/models/flaubert/modeling_tf_flaubert.py
+++ b/src/transformers/models/flaubert/modeling_tf_flaubert.py
@@ -766,6 +766,14 @@ class TFFlaubertWithLMHeadModel(TFFlaubertPreTrainedModel):
     def get_output_embeddings(self):
         return self.pred_layer.input_embeddings
 
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.pred_layer.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
+
     def prepare_inputs_for_generation(self, inputs, **kwargs):
         mask_token_id = self.config.mask_token_id
         lang_id = self.config.lang_id

--- a/src/transformers/models/flaubert/modeling_tf_flaubert.py
+++ b/src/transformers/models/flaubert/modeling_tf_flaubert.py
@@ -763,6 +763,9 @@ class TFFlaubertWithLMHeadModel(TFFlaubertPreTrainedModel):
         self.transformer = TFFlaubertMainLayer(config, name="transformer")
         self.pred_layer = TFFlaubertPredLayer(config, self.transformer.embeddings, name="pred_layer_._proj")
 
+    def get_output_embeddings(self):
+        return self.pred_layer.input_embeddings
+
     def get_output_layer_with_bias(self):
         return self.pred_layer
 

--- a/src/transformers/models/flaubert/modeling_tf_flaubert.py
+++ b/src/transformers/models/flaubert/modeling_tf_flaubert.py
@@ -717,6 +717,15 @@ class TFFlaubertPredLayer(tf.keras.layers.Layer):
 
         super().build(input_shape)
 
+    def resize_bias(self, new_num_tokens):
+        if new_num_tokens is not None:
+            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
+            init_bias = self.bias.value()[:num_tokens_to_copy]
+            self.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
+            )
+            self.bias.assign(init_bias)
+
     def call(self, hidden_states):
         hidden_states = self.input_embeddings(hidden_states, mode="linear")
         hidden_states = hidden_states + self.bias
@@ -769,10 +778,7 @@ class TFFlaubertWithLMHeadModel(TFFlaubertPreTrainedModel):
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
-        if new_num_tokens is not None:
-            self.pred_layer.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
-            )
+        self.pred_layer.resize_bias(new_num_tokens)
 
     def prepare_inputs_for_generation(self, inputs, **kwargs):
         mask_token_id = self.config.mask_token_id

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -1320,6 +1320,14 @@ class TFFunnelForMaskedLM(TFFunnelPreTrainedModel, TFMaskedLanguageModelingLoss)
         self.funnel = TFFunnelMainLayer(config, name="funnel")
         self.lm_head = TFFunnelMaskedLMHead(config, self.funnel.embeddings, name="lm_head")
 
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.lm_head.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
+
     @add_start_docstrings_to_model_forward(FUNNEL_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -983,6 +983,15 @@ class TFFunnelMaskedLMHead(tf.keras.layers.Layer):
         self.bias = self.add_weight(shape=(self.vocab_size,), initializer="zeros", trainable=True, name="bias")
         super().build(input_shape)
 
+    def resize_bias(self, new_num_tokens):
+        if new_num_tokens is not None:
+            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
+            init_bias = self.bias.value()[:num_tokens_to_copy]
+            self.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
+            )
+            self.bias.assign(init_bias)
+
     def call(self, hidden_states, training=False):
         hidden_states = self.input_embeddings(hidden_states, mode="linear")
         hidden_states = hidden_states + self.bias
@@ -1323,10 +1332,7 @@ class TFFunnelForMaskedLM(TFFunnelPreTrainedModel, TFMaskedLanguageModelingLoss)
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
-        if new_num_tokens is not None:
-            self.lm_head.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
-            )
+        self.lm_head.resize_bias(new_num_tokens)
 
     @add_start_docstrings_to_model_forward(FUNNEL_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -1320,6 +1320,9 @@ class TFFunnelForMaskedLM(TFFunnelPreTrainedModel, TFMaskedLanguageModelingLoss)
         self.funnel = TFFunnelMainLayer(config, name="funnel")
         self.lm_head = TFFunnelMaskedLMHead(config, self.funnel.embeddings, name="lm_head")
 
+    def get_output_embeddings(self):
+        return self.funnel.embeddings
+
     def get_output_layer_with_bias(self):
         return self.lm_head
 

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -983,15 +983,6 @@ class TFFunnelMaskedLMHead(tf.keras.layers.Layer):
         self.bias = self.add_weight(shape=(self.vocab_size,), initializer="zeros", trainable=True, name="bias")
         super().build(input_shape)
 
-    def resize_bias(self, new_num_tokens):
-        if new_num_tokens is not None:
-            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
-            init_bias = self.bias.value()[:num_tokens_to_copy]
-            self.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
-            )
-            self.bias.assign(init_bias)
-
     def call(self, hidden_states, training=False):
         hidden_states = self.input_embeddings(hidden_states, mode="linear")
         hidden_states = hidden_states + self.bias
@@ -1329,10 +1320,11 @@ class TFFunnelForMaskedLM(TFFunnelPreTrainedModel, TFMaskedLanguageModelingLoss)
         self.funnel = TFFunnelMainLayer(config, name="funnel")
         self.lm_head = TFFunnelMaskedLMHead(config, self.funnel.embeddings, name="lm_head")
 
-    def resize_token_embeddings(self, new_num_tokens):
-        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+    def get_output_layer_with_bias(self):
+        return self.lm_head
 
-        self.lm_head.resize_bias(new_num_tokens)
+    def get_prefix_bias_name(self):
+        return self.name + "/" + self.lm_head.name
 
     @add_start_docstrings_to_model_forward(FUNNEL_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/gpt2/modeling_tf_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_tf_gpt2.py
@@ -742,9 +742,6 @@ class TFGPT2DoubleHeadsModel(TFGPT2PreTrainedModel):
             config, initializer_range=config.initializer_range, name="multiple_choice_head"
         )
 
-    def get_output_embeddings(self):
-        return self.transformer.wte
-
     @add_start_docstrings_to_model_forward(GPT2_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFGPT2DoubleHeadsModelOutput, config_class=_CONFIG_FOR_DOC)
     def call(

--- a/src/transformers/models/gpt2/modeling_tf_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_tf_gpt2.py
@@ -742,6 +742,9 @@ class TFGPT2DoubleHeadsModel(TFGPT2PreTrainedModel):
             config, initializer_range=config.initializer_range, name="multiple_choice_head"
         )
 
+    def get_output_embeddings(self):
+        return self.transformer.wte
+
     @add_start_docstrings_to_model_forward(GPT2_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFGPT2DoubleHeadsModelOutput, config_class=_CONFIG_FOR_DOC)
     def call(

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -2009,6 +2009,14 @@ class TFLongformerForMaskedLM(TFLongformerPreTrainedModel, TFMaskedLanguageModel
     def get_output_embeddings(self):
         return self.lm_head.decoder
 
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.lm_head.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
+
     @add_start_docstrings_to_model_forward(LONGFORMER_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -437,15 +437,6 @@ class TFLongformerLMHead(tf.keras.layers.Layer):
 
         super().build(input_shape)
 
-    def resize_bias(self, new_num_tokens):
-        if new_num_tokens is not None:
-            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
-            init_bias = self.bias.value()[:num_tokens_to_copy]
-            self.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
-            )
-            self.bias.assign(init_bias)
-
     def call(self, hidden_states):
         hidden_states = self.dense(hidden_states)
         hidden_states = self.act(hidden_states)
@@ -2015,13 +2006,11 @@ class TFLongformerForMaskedLM(TFLongformerPreTrainedModel, TFMaskedLanguageModel
         self.longformer = TFLongformerMainLayer(config, add_pooling_layer=False, name="longformer")
         self.lm_head = TFLongformerLMHead(config, self.longformer.embeddings, name="lm_head")
 
-    def get_output_embeddings(self):
-        return self.lm_head.decoder
+    def get_output_layer_with_bias(self):
+        return self.lm_head
 
-    def resize_token_embeddings(self, new_num_tokens):
-        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
-
-        self.lm_head.resize_bias(new_num_tokens)
+    def get_prefix_bias_name(self):
+        return self.name + "/" + self.lm_head.name
 
     @add_start_docstrings_to_model_forward(LONGFORMER_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -2006,6 +2006,9 @@ class TFLongformerForMaskedLM(TFLongformerPreTrainedModel, TFMaskedLanguageModel
         self.longformer = TFLongformerMainLayer(config, add_pooling_layer=False, name="longformer")
         self.lm_head = TFLongformerLMHead(config, self.longformer.embeddings, name="lm_head")
 
+    def get_output_embeddings(self):
+        return self.lm_head.decoder
+
     def get_output_layer_with_bias(self):
         return self.lm_head
 

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -437,6 +437,15 @@ class TFLongformerLMHead(tf.keras.layers.Layer):
 
         super().build(input_shape)
 
+    def resize_bias(self, new_num_tokens):
+        if new_num_tokens is not None:
+            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
+            init_bias = self.bias.value()[:num_tokens_to_copy]
+            self.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
+            )
+            self.bias.assign(init_bias)
+
     def call(self, hidden_states):
         hidden_states = self.dense(hidden_states)
         hidden_states = self.act(hidden_states)
@@ -2012,10 +2021,7 @@ class TFLongformerForMaskedLM(TFLongformerPreTrainedModel, TFMaskedLanguageModel
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
-        if new_num_tokens is not None:
-            self.lm_head.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
-            )
+        self.lm_head.resize_bias(new_num_tokens)
 
     @add_start_docstrings_to_model_forward(LONGFORMER_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/lxmert/modeling_tf_lxmert.py
+++ b/src/transformers/models/lxmert/modeling_tf_lxmert.py
@@ -1257,6 +1257,9 @@ class TFLxmertForPreTraining(TFLxmertPreTrainedModel):
             **({"obj_labels": obj_labels} if self.config.task_obj_predict else {}),
         }
 
+    def get_output_embeddings(self):
+        return self.lxmert.embeddings
+
     def get_output_layer_with_bias(self):
         return self.cls.predictions
 

--- a/src/transformers/models/lxmert/modeling_tf_lxmert.py
+++ b/src/transformers/models/lxmert/modeling_tf_lxmert.py
@@ -1068,15 +1068,6 @@ class TFLxmertLMPredictionHead(tf.keras.layers.Layer):
         self.bias = self.add_weight(shape=(self.vocab_size,), initializer="zeros", trainable=True, name="bias")
         super().build(input_shape)
 
-    def resize_bias(self, new_num_tokens):
-        if new_num_tokens is not None:
-            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
-            init_bias = self.bias.value()[:num_tokens_to_copy]
-            self.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
-            )
-            self.bias.assign(init_bias)
-
     def call(self, hidden_states):
         hidden_states = self.transform(hidden_states)
         hidden_states = self.input_embeddings(hidden_states, mode="linear")
@@ -1266,10 +1257,11 @@ class TFLxmertForPreTraining(TFLxmertPreTrainedModel):
             **({"obj_labels": obj_labels} if self.config.task_obj_predict else {}),
         }
 
-    def resize_token_embeddings(self, new_num_tokens):
-        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+    def get_output_layer_with_bias(self):
+        return self.cls.predictions
 
-        self.cls.predictions.resize_bias(new_num_tokens)
+    def get_prefix_bias_name(self):
+        return self.name + "/" + self.cls.name + "/" + self.cls.predictions.name
 
     @add_start_docstrings_to_model_forward(LXMERT_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFLxmertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)

--- a/src/transformers/models/lxmert/modeling_tf_lxmert.py
+++ b/src/transformers/models/lxmert/modeling_tf_lxmert.py
@@ -1257,6 +1257,14 @@ class TFLxmertForPreTraining(TFLxmertPreTrainedModel):
             **({"obj_labels": obj_labels} if self.config.task_obj_predict else {}),
         }
 
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.cls.predictions.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
+
     @add_start_docstrings_to_model_forward(LXMERT_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFLxmertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
     def call(

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -1026,6 +1026,20 @@ class TFMobileBertForPreTraining(TFMobileBertPreTrainedModel):
     def get_output_embeddings(self):
         return self.mobilebert.embeddings
 
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.predictions.predictions.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
+            self.predictions.predictions.decoder = self.add_weight(
+                shape=(new_num_tokens, self.config.embedding_size),
+                initializer="zeros",
+                trainable=True,
+                name="decoder/weight",
+            )
+
     @add_start_docstrings_to_model_forward(MOBILEBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFMobileBertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
     def call(
@@ -1118,6 +1132,20 @@ class TFMobileBertForMaskedLM(TFMobileBertPreTrainedModel, TFMaskedLanguageModel
 
     def get_output_embeddings(self):
         return self.mobilebert.embeddings
+
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.mlm.predictions.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
+            self.mlm.predictions.decoder = self.add_weight(
+                shape=(new_num_tokens, self.config.embedding_size),
+                initializer="zeros",
+                trainable=True,
+                name="decoder/weight",
+            )
 
     @add_start_docstrings_to_model_forward(MOBILEBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -1029,13 +1029,13 @@ class TFMobileBertForPreTraining(TFMobileBertPreTrainedModel):
 
     def get_output_embeddings(self):
         return self.predictions.predictions
-    
+
     def get_output_layer_with_bias(self):
         return self.predictions.predictions
 
     def get_prefix_bias_name(self):
         return self.name + "/" + self.predictions.name + "/" + self.predictions.predictions.name
-    
+
     @add_start_docstrings_to_model_forward(MOBILEBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFMobileBertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
     def call(
@@ -1128,7 +1128,7 @@ class TFMobileBertForMaskedLM(TFMobileBertPreTrainedModel, TFMaskedLanguageModel
 
     def get_output_embeddings(self):
         return self.mlm.predictions
-    
+
     def get_output_layer_with_bias(self):
         return self.mlm.predictions
 

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -1027,6 +1027,9 @@ class TFMobileBertForPreTraining(TFMobileBertPreTrainedModel):
         self.predictions = TFMobileBertMLMHead(config, name="predictions___cls")
         self.seq_relationship = TFMobileBertOnlyNSPHead(2, name="seq_relationship___cls")
 
+    def get_output_embeddings(self):
+        return self.mobilebert.embeddings
+
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
@@ -1143,6 +1146,9 @@ class TFMobileBertForMaskedLM(TFMobileBertPreTrainedModel, TFMaskedLanguageModel
 
         self.mobilebert = TFMobileBertMainLayer(config, add_pooling_layer=False, name="mobilebert")
         self.mlm = TFMobileBertMLMHead(config, name="mlm___cls")
+
+    def get_output_embeddings(self):
+        return self.mobilebert.embeddings
 
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -701,7 +701,7 @@ class TFMobileBertMainLayer(tf.keras.layers.Layer):
 
     def get_input_embeddings(self):
         return self.embeddings
-    
+
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
         self.embeddings.vocab_size = value.shape[0]
@@ -1033,17 +1033,17 @@ class TFMobileBertForPreTraining(TFMobileBertPreTrainedModel):
         if new_num_tokens is not None:
             num_tokens_to_copy = min(self.predictions.predictions.bias.shape[0], new_num_tokens)
             self.predictions.predictions.vocab_size = num_tokens_to_copy
-            init_bias = self.predictions.predictions.bias.value()[:num_tokens_to_copy]
+            init_bias = tf.zeros((new_num_tokens,))
+            init_bias[:num_tokens_to_copy] = self.predictions.predictions.bias.value()[:num_tokens_to_copy]
             name = self.name + "/" + self.predictions.name + "/" + self.predictions.predictions.name + "/bias"
             self.predictions.predictions.bias = self.add_weight(
                 shape=(new_num_tokens,), initializer="zeros", trainable=True, name=name
             )
             self.predictions.predictions.bias.assign(init_bias)
 
-            init_weights = self.predictions.predictions.decoder.value()[:num_tokens_to_copy]
-            name = (
-                self.name + "/" + self.predictions.name + "/" + self.predictions.predictions.name + "/decoder/weight"
-            )
+            init_weights = tf.zeros((new_num_tokens,))
+            init_weights[:num_tokens_to_copy] = self.predictions.predictions.decoder.value()[:num_tokens_to_copy]
+            name = self.name + "/" + self.predictions.name + "/" + self.predictions.predictions.name + "/decoder/weight"
             self.predictions.predictions.decoder = self.add_weight(
                 shape=(new_num_tokens, self.predictions.predictions.config.embedding_size),
                 initializer="zeros",
@@ -1158,9 +1158,7 @@ class TFMobileBertForMaskedLM(TFMobileBertPreTrainedModel, TFMaskedLanguageModel
 
             init_weights = tf.zeros((new_num_tokens,))
             init_weights[:num_tokens_to_copy] = self.mlm.predictions.decoder.value()[:num_tokens_to_copy]
-            name = (
-                self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name + "/decoder/weight"
-            )
+            name = self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name + "/decoder/weight"
             self.mlm.predictions.decoder = self.add_weight(
                 shape=(new_num_tokens, self.mlm.predictions.config.embedding_size),
                 initializer="zeros",

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -1148,14 +1148,16 @@ class TFMobileBertForMaskedLM(TFMobileBertPreTrainedModel, TFMaskedLanguageModel
         if new_num_tokens is not None:
             num_tokens_to_copy = min(self.mlm.predictions.bias.shape[0], new_num_tokens)
             self.mlm.predictions.vocab_size = num_tokens_to_copy
-            init_bias = self.mlm.predictions.bias.value()[:num_tokens_to_copy]
+            init_bias = tf.zeros((new_num_tokens,))
+            init_bias[:num_tokens_to_copy] = self.mlm.predictions.bias.value()[:num_tokens_to_copy]
             name = self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name + "/bias"
             self.mlm.predictions.bias = self.add_weight(
                 shape=(new_num_tokens,), initializer="zeros", trainable=True, name=name
             )
             self.mlm.predictions.bias.assign(init_bias)
 
-            init_weights = self.mlm.predictions.decoder.value()[:num_tokens_to_copy]
+            init_weights = tf.zeros((new_num_tokens,))
+            init_weights[:num_tokens_to_copy] = self.mlm.predictions.decoder.value()[:num_tokens_to_copy]
             name = (
                 self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name + "/decoder/weight"
             )

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -701,6 +701,10 @@ class TFMobileBertMainLayer(tf.keras.layers.Layer):
 
     def get_input_embeddings(self):
         return self.embeddings
+    
+    def set_input_embeddings(self, value):
+        self.embeddings.word_embeddings = value
+        self.embeddings.vocab_size = value.shape[0]
 
     def _resize_token_embeddings(self, new_num_tokens):
         raise NotImplementedError
@@ -1138,13 +1142,30 @@ class TFMobileBertForMaskedLM(TFMobileBertPreTrainedModel, TFMaskedLanguageModel
         self.mobilebert = TFMobileBertMainLayer(config, add_pooling_layer=False, name="mobilebert")
         self.mlm = TFMobileBertMLMHead(config, name="mlm___cls")
 
-    def get_output_embeddings(self):
-        return self.mobilebert.embeddings
-
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
-        self.mlm.predictions.resize_bias(new_num_tokens)
+        if new_num_tokens is not None:
+            num_tokens_to_copy = min(self.mlm.predictions.bias.shape[0], new_num_tokens)
+            self.mlm.predictions.vocab_size = num_tokens_to_copy
+            init_bias = self.mlm.predictions.bias.value()[:num_tokens_to_copy]
+            name = self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name + "/bias"
+            self.mlm.predictions.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=name
+            )
+            self.mlm.predictions.bias.assign(init_bias)
+
+            init_weights = self.mlm.predictions.decoder.value()[:num_tokens_to_copy]
+            name = (
+                self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name + "/decoder/weight"
+            )
+            self.mlm.predictions.decoder = self.add_weight(
+                shape=(new_num_tokens, self.mlm.predictions.config.embedding_size),
+                initializer="zeros",
+                trainable=True,
+                name=name,
+            )
+            self.mlm.predictions.decoder.assign(init_weights)
 
     @add_start_docstrings_to_model_forward(MOBILEBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -1043,7 +1043,9 @@ class TFMobileBertForPreTraining(TFMobileBertPreTrainedModel):
 
             init_weights = tf.zeros((new_num_tokens,))
             init_weights[:num_tokens_to_copy] = self.predictions.predictions.decoder.value()[:num_tokens_to_copy]
-            name = self.name + "/" + self.predictions.name + "/" + self.predictions.predictions.name + "/decoder/weight"
+            name = (
+                self.name + "/" + self.predictions.name + "/" + self.predictions.predictions.name + "/decoder/weight"
+            )
             self.predictions.predictions.decoder = self.add_weight(
                 shape=(new_num_tokens, self.predictions.predictions.config.embedding_size),
                 initializer="zeros",

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -829,7 +829,7 @@ class TFMPNetForMaskedLM(TFMPNetPreTrainedModel, TFMaskedLanguageModelingLoss):
 
     def get_output_embeddings(self):
         return self.mpnet.embeddings
-    
+
     def get_output_layer_with_bias(self):
         return self.lm_head
 

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -829,6 +829,12 @@ class TFMPNetForMaskedLM(TFMPNetPreTrainedModel, TFMaskedLanguageModelingLoss):
 
     def get_output_embeddings(self):
         return self.mpnet.embeddings
+    
+    def get_output_layer_with_bias(self):
+        return self.lm_head
+
+    def get_prefix_bias_name(self):
+        return self.name + "/" + self.lm_head.name
 
     @add_start_docstrings_to_model_forward(MPNET_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -785,15 +785,6 @@ class TFRobertaLMHead(tf.keras.layers.Layer):
 
         super().build(input_shape)
 
-    def resize_bias(self, new_num_tokens):
-        if new_num_tokens is not None:
-            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
-            init_bias = self.bias.value()[:num_tokens_to_copy]
-            self.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
-            )
-            self.bias.assign(init_bias)
-
     def call(self, hidden_states):
         hidden_states = self.dense(hidden_states)
         hidden_states = self.act(hidden_states)
@@ -816,13 +807,11 @@ class TFRobertaForMaskedLM(TFRobertaPreTrainedModel, TFMaskedLanguageModelingLos
         self.roberta = TFRobertaMainLayer(config, add_pooling_layer=False, name="roberta")
         self.lm_head = TFRobertaLMHead(config, self.roberta.embeddings, name="lm_head")
 
-    def get_output_embeddings(self):
-        return self.lm_head.decoder
+    def get_output_layer_with_bias(self):
+        return self.lm_head
 
-    def resize_token_embeddings(self, new_num_tokens):
-        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
-
-        self.lm_head.resize_bias(new_num_tokens)
+    def get_prefix_bias_name(self):
+        return self.name + "/" + self.lm_head.name
 
     @add_start_docstrings_to_model_forward(ROBERTA_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -785,6 +785,15 @@ class TFRobertaLMHead(tf.keras.layers.Layer):
 
         super().build(input_shape)
 
+    def resize_bias(self, new_num_tokens):
+        if new_num_tokens is not None:
+            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
+            init_bias = self.bias.value()[:num_tokens_to_copy]
+            self.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
+            )
+            self.bias.assign(init_bias)
+
     def call(self, hidden_states):
         hidden_states = self.dense(hidden_states)
         hidden_states = self.act(hidden_states)
@@ -813,10 +822,7 @@ class TFRobertaForMaskedLM(TFRobertaPreTrainedModel, TFMaskedLanguageModelingLos
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
-        if new_num_tokens is not None:
-            self.lm_head.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
-            )
+        self.lm_head.resize_bias(new_num_tokens)
 
     @add_start_docstrings_to_model_forward(ROBERTA_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -807,6 +807,9 @@ class TFRobertaForMaskedLM(TFRobertaPreTrainedModel, TFMaskedLanguageModelingLos
         self.roberta = TFRobertaMainLayer(config, add_pooling_layer=False, name="roberta")
         self.lm_head = TFRobertaLMHead(config, self.roberta.embeddings, name="lm_head")
 
+    def get_output_embeddings(self):
+        return self.lm_head.decoder
+
     def get_output_layer_with_bias(self):
         return self.lm_head
 

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -810,6 +810,14 @@ class TFRobertaForMaskedLM(TFRobertaPreTrainedModel, TFMaskedLanguageModelingLos
     def get_output_embeddings(self):
         return self.lm_head.decoder
 
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.lm_head.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
+
     @add_start_docstrings_to_model_forward(ROBERTA_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/src/transformers/models/xlm/modeling_tf_xlm.py
+++ b/src/transformers/models/xlm/modeling_tf_xlm.py
@@ -780,6 +780,15 @@ class TFXLMPredLayer(tf.keras.layers.Layer):
 
         super().build(input_shape)
 
+    def resize_bias(self, new_num_tokens):
+        if new_num_tokens is not None:
+            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
+            init_bias = self.bias.value()[:num_tokens_to_copy]
+            self.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
+            )
+            self.bias.assign(init_bias)
+
     def call(self, hidden_states):
         hidden_states = self.input_embeddings(hidden_states, mode="linear")
         hidden_states = hidden_states + self.bias
@@ -806,10 +815,7 @@ class TFXLMWithLMHeadModel(TFXLMPreTrainedModel):
     def resize_token_embeddings(self, new_num_tokens):
         super().resize_token_embeddings(new_num_tokens=new_num_tokens)
 
-        if new_num_tokens is not None:
-            self.pred_layer.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
-            )
+        self.pred_layer.resize_bias(new_num_tokens)
 
     def prepare_inputs_for_generation(self, inputs, **kwargs):
         mask_token_id = self.config.mask_token_id

--- a/src/transformers/models/xlm/modeling_tf_xlm.py
+++ b/src/transformers/models/xlm/modeling_tf_xlm.py
@@ -780,15 +780,6 @@ class TFXLMPredLayer(tf.keras.layers.Layer):
 
         super().build(input_shape)
 
-    def resize_bias(self, new_num_tokens):
-        if new_num_tokens is not None:
-            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
-            init_bias = self.bias.value()[:num_tokens_to_copy]
-            self.bias = self.add_weight(
-                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
-            )
-            self.bias.assign(init_bias)
-
     def call(self, hidden_states):
         hidden_states = self.input_embeddings(hidden_states, mode="linear")
         hidden_states = hidden_states + self.bias
@@ -809,13 +800,11 @@ class TFXLMWithLMHeadModel(TFXLMPreTrainedModel):
         self.transformer = TFXLMMainLayer(config, name="transformer")
         self.pred_layer = TFXLMPredLayer(config, self.transformer.embeddings, name="pred_layer_._proj")
 
-    def get_output_embeddings(self):
-        return self.pred_layer.input_embeddings
+    def get_output_layer_with_bias(self):
+        return self.pred_layer
 
-    def resize_token_embeddings(self, new_num_tokens):
-        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
-
-        self.pred_layer.resize_bias(new_num_tokens)
+    def get_prefix_bias_name(self):
+        return self.name + "/" + self.pred_layer.name
 
     def prepare_inputs_for_generation(self, inputs, **kwargs):
         mask_token_id = self.config.mask_token_id

--- a/src/transformers/models/xlm/modeling_tf_xlm.py
+++ b/src/transformers/models/xlm/modeling_tf_xlm.py
@@ -803,6 +803,14 @@ class TFXLMWithLMHeadModel(TFXLMPreTrainedModel):
     def get_output_embeddings(self):
         return self.pred_layer.input_embeddings
 
+    def resize_token_embeddings(self, new_num_tokens):
+        super().resize_token_embeddings(new_num_tokens=new_num_tokens)
+
+        if new_num_tokens is not None:
+            self.pred_layer.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name="bias"
+            )
+
     def prepare_inputs_for_generation(self, inputs, **kwargs):
         mask_token_id = self.config.mask_token_id
         lang_id = self.config.lang_id

--- a/src/transformers/models/xlm/modeling_tf_xlm.py
+++ b/src/transformers/models/xlm/modeling_tf_xlm.py
@@ -800,6 +800,9 @@ class TFXLMWithLMHeadModel(TFXLMPreTrainedModel):
         self.transformer = TFXLMMainLayer(config, name="transformer")
         self.pred_layer = TFXLMPredLayer(config, self.transformer.embeddings, name="pred_layer_._proj")
 
+    def get_output_embeddings(self):
+        return self.pred_layer.input_embeddings
+
     def get_output_layer_with_bias(self):
         return self.pred_layer
 

--- a/src/transformers/models/xlnet/modeling_tf_xlnet.py
+++ b/src/transformers/models/xlnet/modeling_tf_xlnet.py
@@ -407,6 +407,15 @@ class TFXLNetLMHead(tf.keras.layers.Layer):
         self.bias = self.add_weight(shape=(self.vocab_size,), initializer="zeros", trainable=True, name="bias")
         super().build(input_shape)
 
+    def resize_bias(self, new_num_tokens):
+        if new_num_tokens is not None:
+            num_tokens_to_copy = min(self.bias.shape[0], new_num_tokens)
+            init_bias = self.bias.value()[:num_tokens_to_copy]
+            self.bias = self.add_weight(
+                shape=(new_num_tokens,), initializer="zeros", trainable=True, name=self.bias.name.split(":")[0]
+            )
+            self.bias.assign(init_bias)
+
     def call(self, hidden_states):
         hidden_states = self.input_embeddings(hidden_states, mode="linear")
         hidden_states = hidden_states + self.bias

--- a/src/transformers/models/xlnet/modeling_tf_xlnet.py
+++ b/src/transformers/models/xlnet/modeling_tf_xlnet.py
@@ -1218,6 +1218,9 @@ class TFXLNetLMHeadModel(TFXLNetPreTrainedModel, TFCausalLanguageModelingLoss):
         self.transformer = TFXLNetMainLayer(config, name="transformer")
         self.lm_loss = TFXLNetLMHead(config, self.transformer.word_embedding, name="lm_loss")
 
+    def get_output_embeddings(self):
+        return self.lm_loss.input_embeddings
+
     def get_output_layer_with_bias(self):
         return self.lm_loss
 

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -773,8 +773,11 @@ class TF{{cookiecutter.camelcase_modelname}}ForMaskedLM(TF{{cookiecutter.camelca
         self.{{cookiecutter.lowercase_modelname}} = TF{{cookiecutter.camelcase_modelname}}MainLayer(config, name="{{cookiecutter.lowercase_modelname}}")
         self.mlm = TF{{cookiecutter.camelcase_modelname}}MLMHead(config, self.{{cookiecutter.lowercase_modelname}}.embeddings, name="mlm___cls")
 
-    def get_output_embeddings(self):
-        return self.{{cookiecutter.lowercase_modelname}}.embeddings
+    def get_output_layer_with_bias(self):
+        return self.mlm.predictions
+
+    def get_prefix_bias_name(self):
+        return self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name
 
     @add_start_docstrings_to_model_forward({{cookiecutter.uppercase_modelname}}_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -772,6 +772,9 @@ class TF{{cookiecutter.camelcase_modelname}}ForMaskedLM(TF{{cookiecutter.camelca
 
         self.{{cookiecutter.lowercase_modelname}} = TF{{cookiecutter.camelcase_modelname}}MainLayer(config, name="{{cookiecutter.lowercase_modelname}}")
         self.mlm = TF{{cookiecutter.camelcase_modelname}}MLMHead(config, self.{{cookiecutter.lowercase_modelname}}.embeddings, name="mlm___cls")
+    
+    def get_output_embeddings(self):
+        return self.{{cookiecutter.lowercase_modelname}}.embeddings
 
     def get_output_layer_with_bias(self):
         return self.mlm.predictions

--- a/tests/test_modeling_tf_albert.py
+++ b/tests/test_modeling_tf_albert.py
@@ -272,6 +272,17 @@ class TFAlbertModelTest(TFModelTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_albert_for_question_answering(*config_and_inputs)
 
+    def test_model_common_attributes(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+            x = model.get_output_layer_with_bias()
+            assert x is None
+            name = model.get_prefix_bias_name()
+            assert name is None
+
     @slow
     def test_model_from_pretrained(self):
         for model_name in TF_ALBERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:

--- a/tests/test_modeling_tf_bart.py
+++ b/tests/test_modeling_tf_bart.py
@@ -126,6 +126,17 @@ class TFBartModelTest(TFModelTesterMixin, unittest.TestCase):
         # Should be uncommented during patrick TF refactor
         pass
 
+    def test_model_common_attributes(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+            x = model.get_output_layer_with_bias()
+            assert x is None
+            name = model.get_prefix_bias_name()
+            assert name is None
+
 
 @require_tf
 class TFBartHeadTests(unittest.TestCase):

--- a/tests/test_modeling_tf_bert.py
+++ b/tests/test_modeling_tf_bert.py
@@ -331,6 +331,25 @@ class TFBertModelTest(TFModelTesterMixin, unittest.TestCase):
         model = TFBertModel.from_pretrained("jplu/tiny-tf-bert-random")
         self.assertIsNotNone(model)
 
+    def test_model_common_attributes(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        list_lm_models = [TFBertForMaskedLM, TFBertForPreTraining]
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+
+            if model_class in list_lm_models:
+                x = model.get_output_layer_with_bias()
+                assert isinstance(x, tf.keras.layers.Layer)
+                name = model.get_prefix_bias_name()
+                assert isinstance(name, str)
+            else:
+                x = model.get_output_layer_with_bias()
+                assert x is None
+                name = model.get_prefix_bias_name()
+                assert x is None
+
     def test_custom_load_tf_weights(self):
         model, output_loading_info = TFBertForTokenClassification.from_pretrained(
             "jplu/tiny-tf-bert-random", output_loading_info=True

--- a/tests/test_modeling_tf_bert.py
+++ b/tests/test_modeling_tf_bert.py
@@ -333,7 +333,7 @@ class TFBertModelTest(TFModelTesterMixin, unittest.TestCase):
 
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        list_lm_models = [TFBertForMaskedLM, TFBertForPreTraining]
+        list_lm_models = [TFBertForMaskedLM, TFBertForPreTraining, TFBertLMHeadModel]
 
         for model_class in self.all_model_classes:
             model = model_class(config)

--- a/tests/test_modeling_tf_blenderbot.py
+++ b/tests/test_modeling_tf_blenderbot.py
@@ -18,18 +18,16 @@ import unittest
 from tests.test_configuration_common import ConfigTester
 from tests.test_modeling_tf_bart import TFBartModelTester
 from tests.test_modeling_tf_common import TFModelTesterMixin
-from transformers import BlenderbotConfig, is_tf_available, BlenderbotSmallTokenizer
-
+from transformers import BlenderbotConfig, BlenderbotSmallTokenizer, is_tf_available
 from transformers.file_utils import cached_property
 from transformers.testing_utils import is_pt_tf_cross_test, require_tf, require_tokenizers, slow
+
 
 if is_tf_available():
     import tensorflow as tf
 
-    from transformers import (
-        TFAutoModelForSeq2SeqLM,
-        TFBlenderbotForConditionalGeneration,
-    )
+    from transformers import TFAutoModelForSeq2SeqLM, TFBlenderbotForConditionalGeneration
+
 
 class TFBlenderbotModelTester(TFBartModelTester):
     config_updates = dict(

--- a/tests/test_modeling_tf_blenderbot.py
+++ b/tests/test_modeling_tf_blenderbot.py
@@ -18,16 +18,18 @@ import unittest
 from tests.test_configuration_common import ConfigTester
 from tests.test_modeling_tf_bart import TFBartModelTester
 from tests.test_modeling_tf_common import TFModelTesterMixin
-from transformers import (
-    BlenderbotConfig,
-    BlenderbotSmallTokenizer,
-    TFAutoModelForSeq2SeqLM,
-    TFBlenderbotForConditionalGeneration,
-    is_tf_available,
-)
+from transformers import BlenderbotConfig, is_tf_available, BlenderbotSmallTokenizer
+
 from transformers.file_utils import cached_property
 from transformers.testing_utils import is_pt_tf_cross_test, require_tf, require_tokenizers, slow
 
+if is_tf_available():
+    import tensorflow as tf
+
+    from transformers import (
+        TFAutoModelForSeq2SeqLM,
+        TFBlenderbotForConditionalGeneration,
+    )
 
 class TFBlenderbotModelTester(TFBartModelTester):
     config_updates = dict(
@@ -64,6 +66,17 @@ class TFBlenderbotModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_saved_model_with_attentions_output(self):
         # Should be uncommented during patrick TF refactor
         pass
+
+    def test_model_common_attributes(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+            x = model.get_output_layer_with_bias()
+            assert x is None
+            name = model.get_prefix_bias_name()
+            assert name is None
 
 
 @is_pt_tf_cross_test

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -592,12 +592,26 @@ class TFModelTesterMixin:
 
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        list_lm_models = (
+            list(TF_MODEL_FOR_CAUSAL_LM_MAPPING.values())
+            + list(TF_MODEL_FOR_MASKED_LM_MAPPING.values())
+            + list(TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.values())
+        )
 
         for model_class in self.all_model_classes:
             model = model_class(config)
             assert isinstance(model.get_input_embeddings(), (tf.keras.layers.Layer, TFAdaptiveEmbedding))
-            x = model.get_bias()
-            assert x is None or isinstance(x, tf.keras.layers.Layer)
+
+            if model_class in list_lm_models:
+                x = model.get_output_layer_with_bias()
+                assert isinstance(x, tf.keras.layers.Layer)
+                name = model.get_prefix_bias_name()
+                assert isinstance(name, str)
+            else:
+                x = model.get_output_layer_with_bias()
+                assert x is None
+                name = model.get_prefix_bias_name()
+                assert x is None
 
     def test_determinism(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -596,7 +596,7 @@ class TFModelTesterMixin:
         for model_class in self.all_model_classes:
             model = model_class(config)
             assert isinstance(model.get_input_embeddings(), (tf.keras.layers.Layer, TFAdaptiveEmbedding))
-            x = model.get_output_embeddings()
+            x = model.get_bias()
             assert x is None or isinstance(x, tf.keras.layers.Layer)
 
     def test_determinism(self):

--- a/tests/test_modeling_tf_gpt2.py
+++ b/tests/test_modeling_tf_gpt2.py
@@ -352,7 +352,7 @@ class TFGPT2ModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_gpt2_double_head(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_gpt2_double_head(*config_and_inputs)
-    
+
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/test_modeling_tf_gpt2.py
+++ b/tests/test_modeling_tf_gpt2.py
@@ -352,6 +352,17 @@ class TFGPT2ModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_gpt2_double_head(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_gpt2_double_head(*config_and_inputs)
+    
+    def test_model_common_attributes(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+            x = model.get_output_layer_with_bias()
+            assert x is None
+            name = model.get_prefix_bias_name()
+            assert name is None
 
     def test_gpt2_sequence_classification_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/test_modeling_tf_lxmert.py
+++ b/tests/test_modeling_tf_lxmert.py
@@ -678,6 +678,25 @@ class TFLxmertModelTest(TFModelTesterMixin, unittest.TestCase):
             extended_model = tf.keras.Model(inputs=[input_ids, visual_feats, visual_pos], outputs=[outputs])
             extended_model.compile(optimizer=optimizer, loss=loss, metrics=[metric])
 
+    def test_model_common_attributes(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        list_lm_models = [TFLxmertForPreTraining]
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+
+            if model_class in list_lm_models:
+                x = model.get_output_layer_with_bias()
+                assert isinstance(x, tf.keras.layers.Layer)
+                name = model.get_prefix_bias_name()
+                assert isinstance(name, str)
+            else:
+                x = model.get_output_layer_with_bias()
+                assert x is None
+                name = model.get_prefix_bias_name()
+                assert x is None
+
     @slow
     def test_saved_model_with_hidden_states_output(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/test_modeling_tf_marian.py
+++ b/tests/test_modeling_tf_marian.py
@@ -93,6 +93,17 @@ class TestTFMarianCommon(TFModelTesterMixin, unittest.TestCase):
         # Compile extended model
         extended_model = tf.keras.Model(inputs=[input_ids], outputs=[outputs])
         extended_model.compile(optimizer=optimizer, loss=loss, metrics=[metric])
+    
+    def test_model_common_attributes(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+            x = model.get_output_layer_with_bias()
+            assert x is None
+            name = model.get_prefix_bias_name()
+            assert name is None
 
 
 class AbstractMarianIntegrationTest(unittest.TestCase):

--- a/tests/test_modeling_tf_marian.py
+++ b/tests/test_modeling_tf_marian.py
@@ -93,7 +93,7 @@ class TestTFMarianCommon(TFModelTesterMixin, unittest.TestCase):
         # Compile extended model
         extended_model = tf.keras.Model(inputs=[input_ids], outputs=[outputs])
         extended_model.compile(optimizer=optimizer, loss=loss, metrics=[metric])
-    
+
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/test_modeling_tf_mbart.py
+++ b/tests/test_modeling_tf_mbart.py
@@ -92,6 +92,17 @@ class TestTFMBartCommon(TFModelTesterMixin, unittest.TestCase):
         # Compile extended model
         extended_model = tf.keras.Model(inputs=[input_ids], outputs=[outputs])
         extended_model.compile(optimizer=optimizer, loss=loss, metrics=[metric])
+    
+    def test_model_common_attributes(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+            x = model.get_output_layer_with_bias()
+            assert x is None
+            name = model.get_prefix_bias_name()
+            assert name is None
 
 
 @is_pt_tf_cross_test

--- a/tests/test_modeling_tf_mbart.py
+++ b/tests/test_modeling_tf_mbart.py
@@ -92,7 +92,7 @@ class TestTFMBartCommon(TFModelTesterMixin, unittest.TestCase):
         # Compile extended model
         extended_model = tf.keras.Model(inputs=[input_ids], outputs=[outputs])
         extended_model.compile(optimizer=optimizer, loss=loss, metrics=[metric])
-    
+
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/test_modeling_tf_mobilebert.py
+++ b/tests/test_modeling_tf_mobilebert.py
@@ -285,14 +285,22 @@ class TFMobileBertModelTest(TFModelTesterMixin, unittest.TestCase):
 
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        list_lm_models = [TFMobileBertForMaskedLM, TFMobileBertForPreTraining]
 
         for model_class in self.all_model_classes:
             model = model_class(config)
             assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
-            x = model.get_output_layer_with_bias()
-            assert x is None
-            name = model.get_prefix_bias_name()
-            assert name is None
+
+            if model_class in list_lm_models:
+                x = model.get_output_layer_with_bias()
+                assert isinstance(x, tf.keras.layers.Layer)
+                name = model.get_prefix_bias_name()
+                assert isinstance(name, str)
+            else:
+                x = model.get_output_layer_with_bias()
+                assert x is None
+                name = model.get_prefix_bias_name()
+                assert x is None
 
     @slow
     def test_model_from_pretrained(self):

--- a/tests/test_modeling_tf_mobilebert.py
+++ b/tests/test_modeling_tf_mobilebert.py
@@ -283,6 +283,17 @@ class TFMobileBertModelTest(TFModelTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_mobilebert_for_token_classification(*config_and_inputs)
 
+    def test_model_common_attributes(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+            x = model.get_output_layer_with_bias()
+            assert x is None
+            name = model.get_prefix_bias_name()
+            assert name is None
+
     @slow
     def test_model_from_pretrained(self):
         # for model_name in TF_MOBILEBERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:

--- a/tests/test_modeling_tf_openai.py
+++ b/tests/test_modeling_tf_openai.py
@@ -201,6 +201,17 @@ class TFOpenAIGPTModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_openai_gpt_double_head(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_openai_gpt_double_head(*config_and_inputs)
+    
+    def test_model_common_attributes(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+            x = model.get_output_layer_with_bias()
+            assert x is None
+            name = model.get_prefix_bias_name()
+            assert name is None
 
     @slow
     def test_model_from_pretrained(self):

--- a/tests/test_modeling_tf_openai.py
+++ b/tests/test_modeling_tf_openai.py
@@ -201,7 +201,7 @@ class TFOpenAIGPTModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_openai_gpt_double_head(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_openai_gpt_double_head(*config_and_inputs)
-    
+
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/test_modeling_tf_pegasus.py
+++ b/tests/test_modeling_tf_pegasus.py
@@ -98,6 +98,17 @@ class TestTFPegasusCommon(TFModelTesterMixin, unittest.TestCase):
         # Compile extended model
         extended_model = tf.keras.Model(inputs=[input_ids], outputs=[outputs])
         extended_model.compile(optimizer=optimizer, loss=loss, metrics=[metric])
+    
+    def test_model_common_attributes(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+            x = model.get_output_layer_with_bias()
+            assert x is None
+            name = model.get_prefix_bias_name()
+            assert name is None
 
 
 @is_pt_tf_cross_test

--- a/tests/test_modeling_tf_pegasus.py
+++ b/tests/test_modeling_tf_pegasus.py
@@ -98,7 +98,7 @@ class TestTFPegasusCommon(TFModelTesterMixin, unittest.TestCase):
         # Compile extended model
         extended_model = tf.keras.Model(inputs=[input_ids], outputs=[outputs])
         extended_model.compile(optimizer=optimizer, loss=loss, metrics=[metric])
-    
+
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/test_modeling_tf_pytorch.py
+++ b/tests/test_modeling_tf_pytorch.py
@@ -223,8 +223,8 @@ class TFPTAutoModelTest(unittest.TestCase):
     def test_from_pretrained_identifier(self):
         model = TFAutoModelWithLMHead.from_pretrained(SMALL_MODEL_IDENTIFIER, from_pt=True)
         self.assertIsInstance(model, TFBertForMaskedLM)
-        self.assertEqual(model.num_parameters(), 14830)
-        self.assertEqual(model.num_parameters(only_trainable=True), 14830)
+        self.assertEqual(model.num_parameters(), 14410)
+        self.assertEqual(model.num_parameters(only_trainable=True), 14410)
 
         model = AutoModelWithLMHead.from_pretrained(SMALL_MODEL_IDENTIFIER, from_tf=True)
         self.assertIsInstance(model, BertForMaskedLM)
@@ -234,8 +234,8 @@ class TFPTAutoModelTest(unittest.TestCase):
     def test_from_identifier_from_model_type(self):
         model = TFAutoModelWithLMHead.from_pretrained(DUMMY_UNKWOWN_IDENTIFIER, from_pt=True)
         self.assertIsInstance(model, TFRobertaForMaskedLM)
-        self.assertEqual(model.num_parameters(), 14830)
-        self.assertEqual(model.num_parameters(only_trainable=True), 14830)
+        self.assertEqual(model.num_parameters(), 14410)
+        self.assertEqual(model.num_parameters(only_trainable=True), 14410)
 
         model = AutoModelWithLMHead.from_pretrained(DUMMY_UNKWOWN_IDENTIFIER, from_tf=True)
         self.assertIsInstance(model, RobertaForMaskedLM)

--- a/tests/test_modeling_tf_pytorch.py
+++ b/tests/test_modeling_tf_pytorch.py
@@ -223,8 +223,8 @@ class TFPTAutoModelTest(unittest.TestCase):
     def test_from_pretrained_identifier(self):
         model = TFAutoModelWithLMHead.from_pretrained(SMALL_MODEL_IDENTIFIER, from_pt=True)
         self.assertIsInstance(model, TFBertForMaskedLM)
-        self.assertEqual(model.num_parameters(), 14410)
-        self.assertEqual(model.num_parameters(only_trainable=True), 14410)
+        self.assertEqual(model.num_parameters(), 14830)
+        self.assertEqual(model.num_parameters(only_trainable=True), 14830)
 
         model = AutoModelWithLMHead.from_pretrained(SMALL_MODEL_IDENTIFIER, from_tf=True)
         self.assertIsInstance(model, BertForMaskedLM)
@@ -234,8 +234,8 @@ class TFPTAutoModelTest(unittest.TestCase):
     def test_from_identifier_from_model_type(self):
         model = TFAutoModelWithLMHead.from_pretrained(DUMMY_UNKWOWN_IDENTIFIER, from_pt=True)
         self.assertIsInstance(model, TFRobertaForMaskedLM)
-        self.assertEqual(model.num_parameters(), 14410)
-        self.assertEqual(model.num_parameters(only_trainable=True), 14410)
+        self.assertEqual(model.num_parameters(), 14830)
+        self.assertEqual(model.num_parameters(only_trainable=True), 14830)
 
         model = AutoModelWithLMHead.from_pretrained(DUMMY_UNKWOWN_IDENTIFIER, from_tf=True)
         self.assertIsInstance(model, RobertaForMaskedLM)

--- a/tests/test_modeling_tf_t5.py
+++ b/tests/test_modeling_tf_t5.py
@@ -281,7 +281,7 @@ class TFT5ModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_t5_decoder_model_past_large_inputs(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_t5_decoder_model_past_large_inputs(*config_and_inputs)
-    
+
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/test_modeling_tf_t5.py
+++ b/tests/test_modeling_tf_t5.py
@@ -281,6 +281,17 @@ class TFT5ModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_t5_decoder_model_past_large_inputs(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_t5_decoder_model_past_large_inputs(*config_and_inputs)
+    
+    def test_model_common_attributes(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+            x = model.get_output_layer_with_bias()
+            assert x is None
+            name = model.get_prefix_bias_name()
+            assert name is None
 
     @slow
     def test_model_from_pretrained(self):

--- a/tests/test_modeling_tf_transfo_xl.py
+++ b/tests/test_modeling_tf_transfo_xl.py
@@ -162,7 +162,7 @@ class TFTransfoXLModelTest(TFModelTesterMixin, unittest.TestCase):
         self.model_tester.set_seed()
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_transfo_xl_lm_head(*config_and_inputs)
-    
+
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/test_modeling_tf_transfo_xl.py
+++ b/tests/test_modeling_tf_transfo_xl.py
@@ -162,6 +162,17 @@ class TFTransfoXLModelTest(TFModelTesterMixin, unittest.TestCase):
         self.model_tester.set_seed()
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_transfo_xl_lm_head(*config_and_inputs)
+    
+    def test_model_common_attributes(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+            x = model.get_output_layer_with_bias()
+            assert x is None
+            name = model.get_prefix_bias_name()
+            assert name is None
 
     @slow
     def test_model_from_pretrained(self):


### PR DESCRIPTION
# What does this PR do?

Currenlty when the embeddings are resized the biases are not resized in same time. In TF there is no explicit link between the decoder weights and biases in a dense layer contrarily than in PT. This PR fixes this issue by resizing in same time the biases, even thought I don't know if this is the best solution. @LysandreJik @sgugger what do you think?