### PR TITLE
transformers-cli: LFS multipart uploads (> 5GB)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,7 @@ jobs:
                   keys:
                       - v0.4-torch-{{ checksum "setup.py" }}
                       - v0.4-{{ checksum "setup.py" }}
+            - run: sudo apt-get install git-lfs
             - run: pip install --upgrade pip
             - run: pip install .[sklearn,torch,testing]
             - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
                       - v0.4-torch-{{ checksum "setup.py" }}
                       - v0.4-{{ checksum "setup.py" }}
             - run: pip install --upgrade pip
-            - run: pip install .[sklearn,torch,testing,sentencepiece]
+            - run: pip install .[sklearn,torch,testing]
             - save_cache:
                   key: v0.4-torch-{{ checksum "setup.py" }}
                   paths:
@@ -113,6 +113,7 @@ jobs:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
                   path: ~/transformers/reports
+
     run_tests_tf:
         working_directory: ~/transformers
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,15 +98,21 @@ jobs:
         parallelism: 1
         steps:
             - checkout
-            - run: sudo apt-get install git-lfs
-            - run: |
-                git config --global user.email "ci@dummy.com"
-                git config --global user.name "ci"
+            - restore_cache:
+                  keys:
+                      - v0.4-torch-{{ checksum "setup.py" }}
+                      - v0.4-{{ checksum "setup.py" }}
             - run: pip install --upgrade pip
-            - run: pip install .[testing]
-            # - run: python -m pytest -n 8 --dist=loadfile -s --make-reports=tests_torch ./tests/ | tee tests_output.txt
-            - run: python -m pytest -sv ./tests/test_hf_api.py -k "HfLargefilesTest"
-
+            - run: pip install .[sklearn,torch,testing,sentencepiece]
+            - save_cache:
+                  key: v0.4-torch-{{ checksum "setup.py" }}
+                  paths:
+                      - '~/.cache/pip'
+            - run: python -m pytest -n 8 --dist=loadfile -s --make-reports=tests_torch ./tests/ | tee tests_output.txt
+            - store_artifacts:
+                  path: ~/transformers/tests_output.txt
+            - store_artifacts:
+                  path: ~/transformers/reports
     run_tests_tf:
         working_directory: ~/transformers
         docker:
@@ -263,6 +269,22 @@ jobs:
             - store_artifacts:
                   path: ~/transformers/reports
 
+    run_tests_git_lfs:
+        working_directory: ~/transformers
+        docker:
+            - image: circleci/python:3.7
+        resource_class: xlarge
+        parallelism: 1
+        steps:
+            - checkout
+            - run: sudo apt-get install git-lfs
+            - run: |
+                git config --global user.email "ci@dummy.com"
+                git config --global user.name "ci"
+            - run: pip install --upgrade pip
+            - run: pip install .[testing]
+            - run: RUN_GIT_LFS_TESTS=1 python -m pytest -sv ./tests/test_hf_api.py -k "HfLargefilesTest"
+
     build_doc:
         working_directory: ~/transformers
         docker:
@@ -385,11 +407,12 @@ workflows:
             # - run_examples_torch
             # - run_tests_custom_tokenizers
             # - run_tests_torch_and_tf
-            - run_tests_torch
+            # - run_tests_torch
             # - run_tests_tf
             # - run_tests_flax
             # - run_tests_pipelines_torch
             # - run_tests_pipelines_tf
+            - run_tests_git_lfs
             # - build_doc
             # - deploy_doc: *workflow_filters
     tpu_testing_jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,7 +403,7 @@ workflows:
     version: 2
     build_and_test:
         jobs:
-            # - check_code_quality
+            - check_code_quality
             # - check_repository_consistency
             # - run_examples_torch
             # - run_tests_custom_tokenizers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,11 +108,8 @@ jobs:
                   key: v0.4-torch-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: python -m pytest -n 8 --dist=loadfile -s --make-reports=tests_torch ./tests/ | tee tests_output.txt
-            - store_artifacts:
-                  path: ~/transformers/tests_output.txt
-            - store_artifacts:
-                  path: ~/transformers/reports
+            # - run: python -m pytest -n 8 --dist=loadfile -s --make-reports=tests_torch ./tests/ | tee tests_output.txt
+            - run: python -m pytest -sv ./tests/test_hf_api.py
 
     run_tests_tf:
         working_directory: ~/transformers
@@ -387,18 +384,18 @@ workflows:
     version: 2
     build_and_test:
         jobs:
-            - check_code_quality
-            - check_repository_consistency
-            - run_examples_torch
-            - run_tests_custom_tokenizers
-            - run_tests_torch_and_tf
+            # - check_code_quality
+            # - check_repository_consistency
+            # - run_examples_torch
+            # - run_tests_custom_tokenizers
+            # - run_tests_torch_and_tf
             - run_tests_torch
-            - run_tests_tf
-            - run_tests_flax
-            - run_tests_pipelines_torch
-            - run_tests_pipelines_tf
-            - build_doc
-            - deploy_doc: *workflow_filters
+            # - run_tests_tf
+            # - run_tests_flax
+            # - run_tests_pipelines_torch
+            # - run_tests_pipelines_tf
+            # - build_doc
+            # - deploy_doc: *workflow_filters
     tpu_testing_jobs:
         triggers:
             - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
                   paths:
                       - '~/.cache/pip'
             # - run: python -m pytest -n 8 --dist=loadfile -s --make-reports=tests_torch ./tests/ | tee tests_output.txt
-            - run: python -m pytest -sv ./tests/test_hf_api.py
+            - run: python -m pytest -sv ./tests/test_hf_api.py -k "HfLargefilesTest"
 
     run_tests_tf:
         working_directory: ~/transformers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,18 +404,18 @@ workflows:
     build_and_test:
         jobs:
             - check_code_quality
-            # - check_repository_consistency
-            # - run_examples_torch
-            # - run_tests_custom_tokenizers
-            # - run_tests_torch_and_tf
-            # - run_tests_torch
-            # - run_tests_tf
-            # - run_tests_flax
-            # - run_tests_pipelines_torch
-            # - run_tests_pipelines_tf
+            - check_repository_consistency
+            - run_examples_torch
+            - run_tests_custom_tokenizers
+            - run_tests_torch_and_tf
+            - run_tests_torch
+            - run_tests_tf
+            - run_tests_flax
+            - run_tests_pipelines_torch
+            - run_tests_pipelines_tf
             - run_tests_git_lfs
-            # - build_doc
-            # - deploy_doc: *workflow_filters
+            - build_doc
+            - deploy_doc: *workflow_filters
     tpu_testing_jobs:
         triggers:
             - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,17 +98,12 @@ jobs:
         parallelism: 1
         steps:
             - checkout
-            - restore_cache:
-                  keys:
-                      - v0.4-torch-{{ checksum "setup.py" }}
-                      - v0.4-{{ checksum "setup.py" }}
             - run: sudo apt-get install git-lfs
+            - run: |
+                git config --global user.email "ci@dummy.com"
+                git config --global user.name "ci"
             - run: pip install --upgrade pip
-            - run: pip install .[sklearn,torch,testing]
-            - save_cache:
-                  key: v0.4-torch-{{ checksum "setup.py" }}
-                  paths:
-                      - '~/.cache/pip'
+            - run: pip install .[testing]
             # - run: python -m pytest -n 8 --dist=loadfile -s --make-reports=tests_torch ./tests/ | tee tests_output.txt
             - run: python -m pytest -sv ./tests/test_hf_api.py -k "HfLargefilesTest"
 

--- a/.github/workflows/github-torch-hub.yml
+++ b/.github/workflows/github-torch-hub.yml
@@ -1,9 +1,9 @@
 name: Torch hub integration
 
-# on: 
-#   push:
-#     branches:
-#       - "*"
+on: 
+  push:
+    branches:
+      - "*"
 
 jobs:
   torch_hub_integration:

--- a/.github/workflows/github-torch-hub.yml
+++ b/.github/workflows/github-torch-hub.yml
@@ -1,9 +1,9 @@
 name: Torch hub integration
 
-on: 
-  push:
-    branches:
-      - "*"
+# on: 
+#   push:
+#     branches:
+#       - "*"
 
 jobs:
   torch_hub_integration:

--- a/src/transformers/commands/lfs.py
+++ b/src/transformers/commands/lfs.py
@@ -37,22 +37,22 @@ LFS_MULTIPART_UPLOAD_COMMAND = "lfs-multipart-upload"
 
 
 class LfsCommands(BaseTransformersCLICommand):
-    # Implementation of a custom transfer agent for the transfer type "multipart" for git-lfs.
-    # This lets users upload large files >5GB 🔥.
-    # Spec for LFS custom transfer agent is: https://github.com/git-lfs/git-lfs/blob/master/docs/custom-transfers.md
-    #
-    # This introduces two commands to the CLI:
-    #
-    #    1. $ transformers-cli lfs-enable-largefiles
-    #
-    This should be executed once for each model repo that contains a model file >5GB.
-    # It's documented in the error message you get if you just try to git push a 5GB file
-    # without having enabled it before.
-    #
-    #  2. $ transformers-cli lfs-multipart-upload
-    #
-    # This command is called by lfs directly and is not meant to be called by the user.
-    # called by the user, but by lfs directly.
+    """
+    Implementation of a custom transfer agent for the transfer type "multipart" for git-lfs. This lets users upload
+    large files >5GB 🔥. Spec for LFS custom transfer agent is:
+    https://github.com/git-lfs/git-lfs/blob/master/docs/custom-transfers.md
+
+    This introduces two commands to the CLI:
+
+    1. $ transformers-cli lfs-enable-largefiles
+
+    This should be executed once for each model repo that contains a model file >5GB. It's documented in the error
+    message you get if you just try to git push a 5GB file without having enabled it before.
+
+    2. $ transformers-cli lfs-multipart-upload
+
+    This command is called by lfs directly and is not meant to be called by the user.
+    """
 
     @staticmethod
     def register_subcommand(parser: ArgumentParser):

--- a/src/transformers/commands/lfs.py
+++ b/src/transformers/commands/lfs.py
@@ -166,11 +166,9 @@ class LfsUploadCommand:
 
             parts = []
             for i, presigned_url in enumerate(presigned_urls):
-                # with FileSlice(filepath, seek_from=i * chunk_size, read_limit=chunk_size) as data:
-                with open(filepath, "rb") as data:
+                with FileSlice(filepath, seek_from=i * chunk_size, read_limit=chunk_size) as data:
                     r = requests.put(presigned_url, data=data)
                     r.raise_for_status()
-                    logger.warning(f"kiki {i}")
                     parts.append(
                         {
                             "etag": r.headers.get("etag"),

--- a/src/transformers/commands/lfs.py
+++ b/src/transformers/commands/lfs.py
@@ -37,6 +37,23 @@ LFS_MULTIPART_UPLOAD_COMMAND = "lfs-multipart-upload"
 
 
 class LfsCommands(BaseTransformersCLICommand):
+    # Implementation of a custom transfer agent for the transfer type "multipart" for git-lfs.
+    # This lets users upload large files >5GB 🔥.
+    # Spec for LFS custom transfer agent is: https://github.com/git-lfs/git-lfs/blob/master/docs/custom-transfers.md
+    #
+    # This introduces two commands to the CLI:
+    #
+    #     transformers-cli lfs-enable-largefiles
+    #
+    # Do this once per model repo where you want to push >5GB files.
+    # It's documented in the error message you get if you just try to git push a 5GB file
+    # without having enabled it before.
+    #
+    #     transformers-cli lfs-multipart-upload
+    #
+    # is the custom transfer agent itself. This is not meant to be
+    # called by the user, but by lfs directly.
+
     @staticmethod
     def register_subcommand(parser: ArgumentParser):
         enable_parser = parser.add_parser(

--- a/src/transformers/commands/lfs.py
+++ b/src/transformers/commands/lfs.py
@@ -16,16 +16,16 @@ args = -m debugpy --listen 5678 --wait-for-client /path/to/transformers/src/tran
 lfs-multipart-upload ```
 """
 
-import io
 import json
 import os
 import subprocess
 import sys
 from argparse import ArgumentParser
 from contextlib import AbstractContextManager
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 import requests
+
 from transformers.commands import BaseTransformersCLICommand
 
 from ..utils import logging

--- a/src/transformers/commands/lfs.py
+++ b/src/transformers/commands/lfs.py
@@ -116,9 +116,9 @@ class FileSlice(AbstractContextManager):
         if self.n_seen >= self.read_limit:
             return b""
         remaining_amount = self.read_limit - self.n_seen
-        data = self.f.read(remaining_amount if n < 0 else min(n, remaining_amount))
-        self.n_seen += len(data)
-        return data
+        n_to_read = remaining_amount if n < 0 else min(n, remaining_amount)
+        self.n_seen += n_to_read
+        return self.f.read(n_to_read)
 
     def __iter__(self):
         yield self.read(n=io.DEFAULT_BUFFER_SIZE)

--- a/src/transformers/commands/lfs.py
+++ b/src/transformers/commands/lfs.py
@@ -61,11 +61,11 @@ class LfsEnableCommand:
         if not os.path.isdir(local_path):
             print("This does not look like a valid git repo")
             exit(1)
-        print(local_path)
-        subprocess.run("git config lfs.customtransfer.multipart.path transformers-cli".split(), cwd=local_path)
+        subprocess.run("git config lfs.customtransfer.multipart.path transformers-cli".split(), check=True, cwd=local_path)
         subprocess.run(
-            f"git config lfs.customtransfer.multipart.args {LFS_MULTIPART_UPLOAD_COMMAND}".split(), cwd=local_path
+            f"git config lfs.customtransfer.multipart.args {LFS_MULTIPART_UPLOAD_COMMAND}".split(), check=True, cwd=local_path
         )
+        print("Done")
 
 
 def write_msg(msg: Dict):

--- a/src/transformers/commands/lfs.py
+++ b/src/transformers/commands/lfs.py
@@ -25,7 +25,6 @@ from contextlib import AbstractContextManager
 from typing import Dict, List, Optional
 
 import requests
-
 from transformers.commands import BaseTransformersCLICommand
 
 from ..utils import logging

--- a/src/transformers/commands/lfs.py
+++ b/src/transformers/commands/lfs.py
@@ -43,27 +43,27 @@ class LfsCommands(BaseTransformersCLICommand):
     #
     # This introduces two commands to the CLI:
     #
-    #     transformers-cli lfs-enable-largefiles
+    #    1. $ transformers-cli lfs-enable-largefiles
     #
-    # Do this once per model repo where you want to push >5GB files.
+    This should be executed once for each model repo that contains a model file >5GB.
     # It's documented in the error message you get if you just try to git push a 5GB file
     # without having enabled it before.
     #
-    #     transformers-cli lfs-multipart-upload
+    #  2. $ transformers-cli lfs-multipart-upload
     #
-    # is the custom transfer agent itself. This is not meant to be
+    # This command is called by lfs directly and is not meant to be called by the user.
     # called by the user, but by lfs directly.
 
     @staticmethod
     def register_subcommand(parser: ArgumentParser):
         enable_parser = parser.add_parser(
-            "lfs-enable-largefiles", help="Configure your repository to enable upload of files > 5GB"
+            "lfs-enable-largefiles", help="Configure your repository to enable upload of files > 5GB."
         )
         enable_parser.add_argument("path", type=str, help="Local path to repository you want to configure.")
         enable_parser.set_defaults(func=lambda args: LfsEnableCommand(args))
 
         upload_parser = parser.add_parser(
-            LFS_MULTIPART_UPLOAD_COMMAND, help="This will get called by git-lfs, do not call it directly."
+            LFS_MULTIPART_UPLOAD_COMMAND, help="Command will get called by git-lfs, do not call it directly."
         )
         upload_parser.set_defaults(func=lambda args: LfsUploadCommand(args))
 
@@ -75,7 +75,7 @@ class LfsEnableCommand:
     def run(self):
         local_path = os.path.abspath(self.args.path)
         if not os.path.isdir(local_path):
-            print("This does not look like a valid git repo")
+            print("This does not look like a valid git repo.")
             exit(1)
         subprocess.run(
             "git config lfs.customtransfer.multipart.path transformers-cli".split(), check=True, cwd=local_path
@@ -201,7 +201,7 @@ class LfsUploadCommand:
                         {
                             "event": "progress",
                             "oid": oid,
-                            "bytesSoFar": i * chunk_size,
+                            "bytesSoFar": (i + 1) * chunk_size,
                             "bytesSinceLast": chunk_size,
                         }
                     )

--- a/src/transformers/commands/lfs.py
+++ b/src/transformers/commands/lfs.py
@@ -116,9 +116,9 @@ class FileSlice(AbstractContextManager):
         if self.n_seen >= self.read_limit:
             return b""
         remaining_amount = self.read_limit - self.n_seen
-        n_to_read = remaining_amount if n < 0 else min(n, remaining_amount)
-        self.n_seen += n_to_read
-        return self.f.read(n_to_read)
+        data = self.f.read(remaining_amount if n < 0 else min(n, remaining_amount))
+        self.n_seen += len(data)
+        return data
 
     def __iter__(self):
         yield self.read(n=4*1024*1024)

--- a/src/transformers/commands/lfs.py
+++ b/src/transformers/commands/lfs.py
@@ -61,9 +61,13 @@ class LfsEnableCommand:
         if not os.path.isdir(local_path):
             print("This does not look like a valid git repo")
             exit(1)
-        subprocess.run("git config lfs.customtransfer.multipart.path transformers-cli".split(), check=True, cwd=local_path)
         subprocess.run(
-            f"git config lfs.customtransfer.multipart.args {LFS_MULTIPART_UPLOAD_COMMAND}".split(), check=True, cwd=local_path
+            "git config lfs.customtransfer.multipart.path transformers-cli".split(), check=True, cwd=local_path
+        )
+        subprocess.run(
+            f"git config lfs.customtransfer.multipart.args {LFS_MULTIPART_UPLOAD_COMMAND}".split(),
+            check=True,
+            cwd=local_path,
         )
         print("Local repo set up for largefiles")
 
@@ -121,7 +125,7 @@ class FileSlice(AbstractContextManager):
         return data
 
     def __iter__(self):
-        yield self.read(n=4*1024*1024)
+        yield self.read(n=4 * 1024 * 1024)
 
     def __exit__(self, *args):
         self.f.close()

--- a/src/transformers/commands/lfs.py
+++ b/src/transformers/commands/lfs.py
@@ -1,0 +1,174 @@
+"""
+Implementation of a custom transfer agent for the transfer type "multipart" for git-lfs.
+
+Inspired by: github.com/cbartz/git-lfs-swift-transfer-agent/blob/master/git_lfs_swift_transfer.py
+
+Spec is: github.com/git-lfs/git-lfs/blob/master/docs/custom-transfers.md
+
+
+To launch debugger while developing:
+
+```
+[lfs "customtransfer.multipart"]
+
+path = /path/to/transformers/.env/bin/python
+
+args = -m debugpy --listen 5678 --wait-for-client /path/to/transformers/src/transformers/commands/transformers_cli.py lfs-multipart-upload
+```
+"""
+
+import json
+import os
+import subprocess
+import sys
+from argparse import ArgumentParser
+from contextlib import AbstractContextManager
+from typing import Dict, Optional
+
+import requests
+
+from transformers.commands import BaseTransformersCLICommand
+
+from ..utils import logging
+
+
+logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
+
+
+LFS_MULTIPART_UPLOAD_COMMAND = "lfs-multipart-upload"
+
+
+class LfsCommands(BaseTransformersCLICommand):
+    @staticmethod
+    def register_subcommand(parser: ArgumentParser):
+        enable_parser = parser.add_parser("lfs-enable-largefiles", help="Configure your repository to enable upload of files > 5GB")
+        enable_parser.add_argument("path", type=str, help="Local path to repository you want to configure.")
+        enable_parser.set_defaults(func=lambda args: LfsEnableCommand(args))
+
+        upload_parser = parser.add_parser(LFS_MULTIPART_UPLOAD_COMMAND, help="This will get called by git-lfs, do not call it directly.")
+        upload_parser.set_defaults(func=lambda args: LfsUploadCommand(args))
+
+
+class LfsEnableCommand:
+    def __init__(self, args):
+        self.args = args
+
+    def run(self):
+        local_path = os.path.abspath(self.args.path)
+        if not os.path.isdir(local_path):
+            print("This does not look like a valid git repo")
+            exit(1)
+        print(local_path)
+        subprocess.run("git config lfs.customtransfer.multipart.path transformers-cli".split(), cwd=local_path)
+        subprocess.run(f"git config lfs.customtransfer.multipart.args {LFS_MULTIPART_UPLOAD_COMMAND}".split(), cwd=local_path)
+
+
+def write_msg(msg: Dict):
+    """Write out the message in Line delimited JSON."""
+    msg = json.dumps(msg) + "\n"
+    sys.stdout.write(msg)
+    sys.stdout.flush()
+
+
+def read_msg() -> Optional[Dict]:
+    """Read Line delimited JSON from stdin. """
+    msg = json.loads(sys.stdin.readline().strip())
+
+    if "terminate" in (msg.get("type"), msg.get("event")):
+        # terminate message received
+        return None
+
+    if msg.get("event") not in ("download", "upload"):
+        logger.critical("Received unexpected message")
+        sys.exit(1)
+
+    return msg
+
+
+class FileSlice(AbstractContextManager):
+    def __init__(self, filepath: str, seek_from: int, max_size: int):
+        self.filepath = filepath
+        self.seek_from = seek_from
+        self.max_size = max_size
+
+    def __enter__(self):
+        self.f = open(self.filepath, "rb")
+        self.f.seek(self.seek_from)
+
+    def read(self, n=-1):
+        return self.f.read(n)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.f.close()
+
+
+class LfsUploadCommand:
+    def __init__(self, args):
+        self.args = args
+
+    def run(self):
+        # Immediately after invoking a custom transfer process, git-lfs
+        # sends initiation data to the process over stdin.
+        # This tells the process useful information about the configuration.
+        init_msg = json.loads(sys.stdin.readline().strip())
+        if not (init_msg.get("event") == "init" and init_msg.get("operation") == "upload"):
+            write_msg({"error": {"code": 32, "message": "Wrong lfs init operation"}})
+            sys.exit(1)
+
+        # The transfer process should use the information it needs from the
+        # initiation structure, and also perform any one-off setup tasks it
+        # needs to do. It should then respond on stdout with a simple empty
+        # confirmation structure, as follows:
+        write_msg({})
+
+        # After the initiation exchange, git-lfs will send any number of
+        # transfer requests to the stdin of the transfer process, in a serial sequence.
+        while True:
+            msg = read_msg()
+            if msg is None:
+                # When all transfers have been processed, git-lfs will send
+                # a terminate event to the stdin of the transfer process.
+                # On receiving this message the transfer process should
+                # clean up and terminate. No response is expected.
+                sys.exit(0)
+
+            oid = msg["oid"]
+            filepath = msg["path"]
+            completion_url = msg["action"]["href"]
+            header = msg["action"]["header"]
+            chunk_size = int(header.pop("chunk_size"))
+            presigned_urls: List[str] = list(header.values())
+
+            parts = []
+            for i, presigned_url in enumerate(presigned_urls):
+                with FileSlice(filepath, seek_from=i * chunk_size, max_size=chunk_size) as data:
+                    r = requests.put(presigned_url, data=data)
+                    r.raise_for_status()
+                    parts.append(
+                        {
+                            "etag": r.headers.get("etag"),
+                            "partNumber": i + 1,
+                        }
+                    )
+                    # In order to support progress reporting while data is uploading / downloading,
+                    # the transfer process should post messages to stdout
+                    write_msg(
+                        {
+                            "event": "progress",
+                            "oid": oid,
+                            "bytesSoFar": i * chunk_size,
+                            "bytesSinceLast": chunk_size,
+                        }
+                    )
+                    # Not precise but that's ok.
+
+            r = requests.post(
+                completion_url,
+                json={
+                    "oid": oid,
+                    "parts": parts,
+                },
+            )
+            r.raise_for_status()
+
+            write_msg({"event": "complete", "oid": oid})

--- a/src/transformers/commands/transformers_cli.py
+++ b/src/transformers/commands/transformers_cli.py
@@ -5,6 +5,7 @@ from transformers.commands.add_new_model import AddNewModelCommand
 from transformers.commands.convert import ConvertCommand
 from transformers.commands.download import DownloadCommand
 from transformers.commands.env import EnvironmentCommand
+from transformers.commands.lfs import LfsCommands
 from transformers.commands.run import RunCommand
 from transformers.commands.serving import ServeCommand
 from transformers.commands.user import UserCommands
@@ -22,6 +23,7 @@ def main():
     ServeCommand.register_subcommand(commands_parser)
     UserCommands.register_subcommand(commands_parser)
     AddNewModelCommand.register_subcommand(commands_parser)
+    LfsCommands.register_subcommand(commands_parser)
 
     # Let's go
     args = parser.parse_args()

--- a/src/transformers/hf_api.py
+++ b/src/transformers/hf_api.py
@@ -138,10 +138,8 @@ class HfApi:
 
         Call HF API to get a presigned url to upload `filename` to S3.
         """
-        assert filetype in self.ALLOWED_S3_FILE_TYPES, "Please specify filetype from {}".format(
-            self.ALLOWED_S3_FILE_TYPES
-        )
-        path = "{}/api/{}/presign".format(self.endpoint, filetype)
+        assert filetype in self.ALLOWED_S3_FILE_TYPES, f"Please specify filetype from {self.ALLOWED_S3_FILE_TYPES}"
+        path = f"{self.endpoint}/api/{filetype}/presign"
         r = requests.post(
             path,
             headers={"authorization": "Bearer {}".format(token)},

--- a/src/transformers/hf_api.py
+++ b/src/transformers/hf_api.py
@@ -151,7 +151,9 @@ class HfApi:
         d = r.json()
         return PresignedUrl(**d)
 
-    def presign_and_upload(self, token: str, filetype: str, filename: str, filepath: str, organization: Optional[str] = None) -> str:
+    def presign_and_upload(
+        self, token: str, filetype: str, filename: str, filepath: str, organization: Optional[str] = None
+    ) -> str:
         """
         HuggingFace S3-based system, used for datasets and metrics.
 
@@ -233,7 +235,9 @@ class HfApi:
         d = r.json()
         return [RepoObj(**x) for x in d]
 
-    def create_repo(self, token: str, name: str, organization: Optional[str] = None, lfsmultipartthresh: Optional[int] = None) -> str:
+    def create_repo(
+        self, token: str, name: str, organization: Optional[str] = None, lfsmultipartthresh: Optional[int] = None
+    ) -> str:
         """
         HuggingFace git-based system, used for models.
 

--- a/src/transformers/hf_api.py
+++ b/src/transformers/hf_api.py
@@ -95,6 +95,8 @@ class ModelInfo:
 
 
 class HfApi:
+    ALLOWED_S3_FILE_TYPES = ["datasets", "metrics"]
+
     def __init__(self, endpoint=None):
         self.endpoint = endpoint if endpoint is not None else ENDPOINT
 
@@ -130,13 +132,16 @@ class HfApi:
         r = requests.post(path, headers={"authorization": "Bearer {}".format(token)})
         r.raise_for_status()
 
-    def presign(self, token: str, filename: str, organization: Optional[str] = None) -> PresignedUrl:
+    def presign(self, token: str, filetype: str, filename: str, organization: Optional[str] = None) -> PresignedUrl:
         """
         HuggingFace S3-based system, used for datasets and metrics.
 
         Call HF API to get a presigned url to upload `filename` to S3.
         """
-        path = "{}/api/datasets/presign".format(self.endpoint)
+        assert filetype in self.ALLOWED_S3_FILE_TYPES, "Please specify filetype from {}".format(
+            self.ALLOWED_S3_FILE_TYPES
+        )
+        path = "{}/api/{}/presign".format(self.endpoint, filetype)
         r = requests.post(
             path,
             headers={"authorization": "Bearer {}".format(token)},
@@ -146,7 +151,7 @@ class HfApi:
         d = r.json()
         return PresignedUrl(**d)
 
-    def presign_and_upload(self, token: str, filename: str, filepath: str, organization: Optional[str] = None) -> str:
+    def presign_and_upload(self, token: str, filetype: str, filename: str, filepath: str, organization: Optional[str] = None) -> str:
         """
         HuggingFace S3-based system, used for datasets and metrics.
 
@@ -154,7 +159,10 @@ class HfApi:
 
         Outputs: url: Read-only url for the stored file on S3.
         """
-        urls = self.presign(token, filename=filename, organization=organization)
+        assert filetype in self.ALLOWED_S3_FILE_TYPES, "Please specify filetype from {}".format(
+            self.ALLOWED_S3_FILE_TYPES
+        )
+        urls = self.presign(token, filetype=filetype, filename=filename, organization=organization)
         # streaming upload:
         # https://2.python-requests.org/en/master/user/advanced/#streaming-uploads
         #
@@ -169,26 +177,32 @@ class HfApi:
             pf.close()
         return urls.access
 
-    def list_objs(self, token: str, organization: Optional[str] = None) -> List[S3Obj]:
+    def list_objs(self, token: str, filetype: str, organization: Optional[str] = None) -> List[S3Obj]:
         """
         HuggingFace S3-based system, used for datasets and metrics.
 
         Call HF API to list all stored files for user (or one of their organizations).
         """
-        path = "{}/api/datasets/listObjs".format(self.endpoint)
+        assert filetype in self.ALLOWED_S3_FILE_TYPES, "Please specify filetype from {}".format(
+            self.ALLOWED_S3_FILE_TYPES
+        )
+        path = "{}/api/{}/listObjs".format(self.endpoint, filetype)
         params = {"organization": organization} if organization is not None else None
         r = requests.get(path, params=params, headers={"authorization": "Bearer {}".format(token)})
         r.raise_for_status()
         d = r.json()
         return [S3Obj(**x) for x in d]
 
-    def delete_obj(self, token: str, filename: str, organization: Optional[str] = None):
+    def delete_obj(self, token: str, filetype: str, filename: str, organization: Optional[str] = None):
         """
         HuggingFace S3-based system, used for datasets and metrics.
 
         Call HF API to delete a file stored by user
         """
-        path = "{}/api/datasets/deleteObj".format(self.endpoint)
+        assert filetype in self.ALLOWED_S3_FILE_TYPES, "Please specify filetype from {}".format(
+            self.ALLOWED_S3_FILE_TYPES
+        )
+        path = "{}/api/{}/deleteObj".format(self.endpoint, filetype)
         r = requests.delete(
             path,
             headers={"authorization": "Bearer {}".format(token)},

--- a/src/transformers/hf_api.py
+++ b/src/transformers/hf_api.py
@@ -159,9 +159,7 @@ class HfApi:
 
         Outputs: url: Read-only url for the stored file on S3.
         """
-        assert filetype in self.ALLOWED_S3_FILE_TYPES, "Please specify filetype from {}".format(
-            self.ALLOWED_S3_FILE_TYPES
-        )
+        assert filetype in self.ALLOWED_S3_FILE_TYPES, f"Please specify filetype from {self.ALLOWED_S3_FILE_TYPES}"
         urls = self.presign(token, filetype=filetype, filename=filename, organization=organization)
         # streaming upload:
         # https://2.python-requests.org/en/master/user/advanced/#streaming-uploads
@@ -183,9 +181,7 @@ class HfApi:
 
         Call HF API to list all stored files for user (or one of their organizations).
         """
-        assert filetype in self.ALLOWED_S3_FILE_TYPES, "Please specify filetype from {}".format(
-            self.ALLOWED_S3_FILE_TYPES
-        )
+        assert filetype in self.ALLOWED_S3_FILE_TYPES, f"Please specify filetype from {self.ALLOWED_S3_FILE_TYPES}"
         path = "{}/api/{}/listObjs".format(self.endpoint, filetype)
         params = {"organization": organization} if organization is not None else None
         r = requests.get(path, params=params, headers={"authorization": "Bearer {}".format(token)})
@@ -199,9 +195,7 @@ class HfApi:
 
         Call HF API to delete a file stored by user
         """
-        assert filetype in self.ALLOWED_S3_FILE_TYPES, "Please specify filetype from {}".format(
-            self.ALLOWED_S3_FILE_TYPES
-        )
+        assert filetype in self.ALLOWED_S3_FILE_TYPES, f"Please specify filetype from {self.ALLOWED_S3_FILE_TYPES}"
         path = "{}/api/{}/deleteObj".format(self.endpoint, filetype)
         r = requests.delete(
             path,

--- a/src/transformers/hf_api.py
+++ b/src/transformers/hf_api.py
@@ -233,17 +233,23 @@ class HfApi:
         d = r.json()
         return [RepoObj(**x) for x in d]
 
-    def create_repo(self, token: str, name: str, organization: Optional[str] = None) -> str:
+    def create_repo(self, token: str, name: str, organization: Optional[str] = None, lfsmultipartthresh: Optional[int] = None) -> str:
         """
         HuggingFace git-based system, used for models.
 
         Call HF API to create a whole repo.
+
+        Params:
+            lfsmultipartthresh: Optional: internal param for testing purposes.
         """
         path = "{}/api/repos/create".format(self.endpoint)
+        json = {"name": name, "organization": organization}
+        if lfsmultipartthresh is not None:
+            json["lfsmultipartthresh"] = lfsmultipartthresh
         r = requests.post(
             path,
             headers={"authorization": "Bearer {}".format(token)},
-            json={"name": name, "organization": organization},
+            json=json,
         )
         r.raise_for_status()
         d = r.json()

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -62,6 +62,7 @@ _run_slow_tests = parse_flag_from_env("RUN_SLOW", default=False)
 _run_pt_tf_cross_tests = parse_flag_from_env("RUN_PT_TF_CROSS_TESTS", default=False)
 _run_custom_tokenizers = parse_flag_from_env("RUN_CUSTOM_TOKENIZERS", default=False)
 _run_pipeline_tests = parse_flag_from_env("RUN_PIPELINE_TESTS", default=False)
+_run_git_lfs_tests = parse_flag_from_env("RUN_GIT_LFS_TESTS", default=False)
 _tf_gpu_memory_limit = parse_int_from_env("TF_GPU_MEMORY_LIMIT", default=None)
 
 
@@ -125,6 +126,19 @@ def custom_tokenizers(test_case):
     """
     if not _run_custom_tokenizers:
         return unittest.skip("test of custom tokenizers")(test_case)
+    else:
+        return test_case
+
+
+def require_git_lfs(test_case):
+    """
+    Decorator marking a test that requires git-lfs.
+
+    git-lfs requires additional dependencies, and tests are skipped by default. Set the RUN_GIT_LFS_TESTS
+    environment variable to a truthy value to run them.
+    """
+    if not _run_git_lfs_tests:
+        return unittest.skip("test of git lfs workflow")(test_case)
     else:
         return test_case
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -134,8 +134,8 @@ def require_git_lfs(test_case):
     """
     Decorator marking a test that requires git-lfs.
 
-    git-lfs requires additional dependencies, and tests are skipped by default. Set the RUN_GIT_LFS_TESTS
-    environment variable to a truthy value to run them.
+    git-lfs requires additional dependencies, and tests are skipped by default. Set the RUN_GIT_LFS_TESTS environment
+    variable to a truthy value to run them.
     """
     if not _run_git_lfs_tests:
         return unittest.skip("test of git lfs workflow")(test_case)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -172,6 +172,9 @@ class HfLargefilesTest(HfApiCommonTest):
         except FileNotFoundError:
             pass
 
+    def tearDown(self):
+        self._api.delete_repo(token=self._token, name=REPO_NAME_LARGE_FILE)
+
     def setup_local_clone(self, REMOTE_URL):
         REMOTE_URL_AUTH = REMOTE_URL.replace(ENDPOINT_STAGING, ENDPOINT_STAGING_BASIC_AUTH)
         subprocess.run(["git", "clone", REMOTE_URL_AUTH, WORKING_REPO_DIR], check=True, capture_output=True)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -172,8 +172,8 @@ class HfLargefilesTest(HfApiCommonTest):
         subprocess.run(["git", "lfs", "track", "*.pdf"], cwd=WORKING_REPO_DIR)
         subprocess.run(["git", "lfs", "track", "*.epub"], cwd=WORKING_REPO_DIR)
         subprocess.run(["wget", LARGE_FILE_18MB], check=True, capture_output=True, cwd=WORKING_REPO_DIR)
-        subprocess.run(["git", "add", "*"], cwd=WORKING_REPO_DIR)
-        subprocess.run(["git", "commit", "-m", "commit message"], cwd=WORKING_REPO_DIR)
+        subprocess.run(["git", "add", "*"], check=True, cwd=WORKING_REPO_DIR)
+        subprocess.run(["git", "commit", "-m", "commit message"], check=True, cwd=WORKING_REPO_DIR)
 
         # This will fail as we haven't set up our custom transfer agent yet.
         with self.assertRaises(subprocess.CalledProcessError) as context:

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -196,7 +196,7 @@ class HfLargefilesTest(HfApiCommonTest):
         pdf_url = f"{REMOTE_URL}/resolve/main/progit.pdf"
         DEST_FILENAME = "uploaded.pdf"
         subprocess.run(["wget", pdf_url, "-O", DEST_FILENAME], check=True, capture_output=True, cwd=WORKING_REPO_DIR)
-        dest_filesize = os.fstat(os.path.join(WORKING_REPO_DIR, DEST_FILENAME)).st_size
+        dest_filesize = os.stat(os.path.join(WORKING_REPO_DIR, DEST_FILENAME)).st_size
         self.assertEquals(dest_filesize, 18685041)
 
         

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -38,9 +38,8 @@ FILES = [
         os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures/empty.txt"),
     ),
 ]
-# ENDPOINT_STAGING = "https://moon-staging.huggingface.co"
-ENDPOINT_STAGING = "https://moon-gibbon.ngrok.io"
-ENDPOINT_STAGING_BASIC_AUTH = f"https://{USER}:{PASS}@moon-gibbon.ngrok.io"
+ENDPOINT_STAGING = "https://moon-staging.huggingface.co"
+ENDPOINT_STAGING_BASIC_AUTH = f"https://{USER}:{PASS}@moon-staging.huggingface.co"
 
 REPO_NAME = "my-model-{}".format(int(time.time()))
 REPO_NAME_LARGE_FILE = "my-model-largefiles-{}".format(int(time.time()))

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -164,8 +164,8 @@ class HfLargefilesTest(HfApiCommonTest):
         except FileNotFoundError:
             pass
 
-    def test_end_to_end_thresh_5M(self):
-        REMOTE_URL = self._api.create_repo(token=self._token, name=REPO_NAME_LARGE_FILE, lfsmultipartthresh=5 * 10**6)
+    def test_end_to_end_thresh_6M(self):
+        REMOTE_URL = self._api.create_repo(token=self._token, name=REPO_NAME_LARGE_FILE, lfsmultipartthresh=6 * 10**6)
         REMOTE_URL_AUTH = REMOTE_URL.replace(ENDPOINT_STAGING, ENDPOINT_STAGING_BASIC_AUTH)
         subprocess.run(["git", "clone", REMOTE_URL_AUTH, WORKING_REPO_DIR], check=True, capture_output=True)
         subprocess.run(["git", "lfs", "track", "*.pdf"], check=True, cwd=WORKING_REPO_DIR)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -22,8 +22,8 @@ import unittest
 
 import requests
 from requests.exceptions import HTTPError
-from testing_utils import require_git_lfs
 from transformers.hf_api import HfApi, HfFolder, ModelInfo, PresignedUrl, RepoObj, S3Obj
+from transformers.testing_utils import require_git_lfs
 
 
 USER = "__DUMMY_TRANSFORMERS_USER__"

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -150,6 +150,7 @@ class HfFolderTest(unittest.TestCase):
         self.assertEqual(HfFolder.get_token(), None)
 
 
+@require_git_lfs
 class HfLargefilesTest(HfApiCommonTest):
     @classmethod
     def setUpClass(cls):
@@ -179,9 +180,9 @@ class HfLargefilesTest(HfApiCommonTest):
         subprocess.run(["git", "commit", "-m", "commit message"], check=True, cwd=WORKING_REPO_DIR)
 
         # This will fail as we haven't set up our custom transfer agent yet.
-        # failed_process = subprocess.run(["git", "push"], capture_output=True, cwd=WORKING_REPO_DIR)
-        # self.assertEquals(failed_process.returncode, 1)
-        # self.assertIn("transformers-cli lfs-enable-largefiles", failed_process.stderr.decode())
+        failed_process = subprocess.run(["git", "push"], capture_output=True, cwd=WORKING_REPO_DIR)
+        self.assertEqual(failed_process.returncode, 1)
+        self.assertIn("transformers-cli lfs-enable-largefiles", failed_process.stderr.decode())
         # ^ Instructions on how to fix this are included in the error message.
 
 
@@ -197,6 +198,5 @@ class HfLargefilesTest(HfApiCommonTest):
         DEST_FILENAME = "uploaded.pdf"
         subprocess.run(["wget", pdf_url, "-O", DEST_FILENAME], check=True, capture_output=True, cwd=WORKING_REPO_DIR)
         dest_filesize = os.stat(os.path.join(WORKING_REPO_DIR, DEST_FILENAME)).st_size
-        self.assertEquals(dest_filesize, 18685041)
+        self.assertEqual(dest_filesize, 18685041)
 
-        


### PR DESCRIPTION
### Implementation of a custom transfer agent for the transfer type "multipart" for git-lfs. This lets users upload large files >5GB 🔥.

Spec for LFS custom transfer agent is: https://github.com/git-lfs/git-lfs/blob/master/docs/custom-transfers.md

The PR introduces two commands to the CLI:
```
transformers-cli lfs-enable-largefiles ./path/to/repo
```
^ Do this once per model repo where you want to push >5GB files. It's documented in the error message you get if you just try to `git push` a 5GB file without having enabled it before.

```
transformers-cli lfs-multipart-upload
```

^ is the custom transfer agent itself. This is not meant to be called by the user, but by lfs directly.

### Things to experiment with:
- [ ] upload speed. Is it sufficient? Please comment with your upload speeds e.g. for https://huggingface.co/t5-3b

Experiment:
```bash
time git clone https://huggingface.co/t5-3b
cd t5-3b
git remote set-url origin https://huggingface.co/$USER/t5-3b-clone
# ^ After having created this model repo in your account
transformers-cli lfs-enable-largefiles .

git reset 5e0a32db352b33091ea9fb2f8d8782d47a505986 # go back to initial commit for lfs to reupload files
git add pytorch_model.bin
git commit -m "ok"
time git push
```