### PR TITLE
Use return_dict in RagModel forward pass

### DIFF
--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -556,7 +556,9 @@ class RagModel(RagPreTrainedModel):
         if encoder_outputs is None:
 
             if has_to_retrieve:
-                question_enc_outputs = self.question_encoder(input_ids, attention_mask=attention_mask)
+                question_enc_outputs = self.question_encoder(
+                    input_ids, attention_mask=attention_mask, return_dict=True
+                )
                 question_encoder_last_hidden_state = question_enc_outputs[0]  # hidden states of question encoder
 
                 retriever_outputs = self.retriever(
@@ -616,6 +618,7 @@ class RagModel(RagPreTrainedModel):
             decoder_attention_mask=decoder_attention_mask,
             past_key_values=past_key_values,
             use_cache=use_cache,
+            return_dict=True,
         )
 
         if not has_to_retrieve:


### PR DESCRIPTION
There were changes in the output format of models bu it looks like the RagModel forward pass was not updated to use `return_dict` as noticed in #8653 

I'm running the slow tests right now. If they pass I will update from draft pull request to open request