### PR TITLE
Alternative to globals()

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -237,7 +237,6 @@ def tokenizer_class_from_name(class_name: str):
     for c in all_tokenizer_classes:
         if c.__name__ == class_name:
             return c
-    raise ValueError(f"There is no tokenizer class named {class_name}.")
 
 
 class AutoTokenizer:

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -230,7 +230,7 @@ SLOW_TOKENIZER_MAPPING[HerbertTokenizer] = HerbertTokenizerFast
 
 def tokenizer_class_from_name(class_name: str):
     all_tokenizer_classes = (
-        [v[0] for v in TOKENIZER_MAPPING.values()]
+        [v[0] for v in TOKENIZER_MAPPING.values() if v[0] is not None]
         + [v[1] for v in TOKENIZER_MAPPING.values() if v[1] is not None]
         + NO_CONFIG_TOKENIZER
     )

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -225,7 +225,6 @@ SLOW_TOKENIZER_MAPPING = {
     for k, v in TOKENIZER_MAPPING.items()
     if (v[0] is not None or v[1] is not None)
 }
-SLOW_TOKENIZER_MAPPING[HerbertTokenizer] = HerbertTokenizerFast
 
 
 def tokenizer_class_from_name(class_name: str):


### PR DESCRIPTION
# What does this PR do?

This PR does two things:
- remove some tokenizer classes that were used in a dictionary before being erased which was super weird
- add a function that goes from tokenizer class name to tokenizer class to avoid using `globals`