### PR TITLE
Document adam betas TrainingArguments

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -89,6 +89,10 @@ class TrainingArguments:
             The initial learning rate for Adam.
         weight_decay (:obj:`float`, `optional`, defaults to 0):
             The weight decay to apply (if not zero).
+        adam_beta1 (:obj:`float`, `optional`, defaults to 0.9):
+            The beta1 for the Adam optimizer.
+        adam_beta2 (:obj:`float`, `optional`, defaults to 0.999):
+            The beta2 for the Adam optimizer.
         adam_epsilon (:obj:`float`, `optional`, defaults to 1e-8):
             Epsilon for the Adam optimizer.
         max_grad_norm (:obj:`float`, `optional`, defaults to 1.0):


### PR DESCRIPTION
# What does this PR do?

#5592 introduced two new fields in `TrainingArguments` (`adam_beta1` and `adam_beta2`) without documenting them in the docstring. This PR fixes that.