### PR TITLE
fix rag index names in eval_rag.py example

### DIFF
--- a/examples/rag/eval_rag.py
+++ b/examples/rag/eval_rag.py
@@ -153,7 +153,7 @@ def get_args():
     parser.add_argument(
         "--index_name",
         default=None,
-        choices=["hf", "legacy"],
+        choices=["exact", "compressed", "legacy"],
         type=str,
         help="RAG model retriever type",
     )


### PR DESCRIPTION
There was a mistake in the eval_rag.py parameters choices.

As specified in the rag configuration (see [documentation](https://huggingface.co/transformers/model_doc/rag.html?highlight=rag#transformers.RagConfig)), one can choose between 'legacy', 'exact' and 'compressed'. The legacy index is the original index used for RAG/DPR while the other two use the `datasets` library indexing implementation.

This issue was reported on the forum https://discuss.huggingface.co/t/rag-retriever-hf-vs-legacy-vs-exact-vs-compressed/2135/5