### PR TITLE
Fix setup.py on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,7 @@ class DepsTableUpdateCommand(Command):
         ]
         target = "src/transformers/dependency_versions_table.py"
         print(f"updating {target}")
-        with open(target, "w") as f:
+        with open(target, "w", encoding="utf-8", newline="\n") as f:
             f.write("\n".join(content))
 
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes the target `deps_table_update` on Windows by forcing the newline to be LF.