### PR TITLE
Fixed typo in README.md of bert-base-greek-uncased-v1

### DIFF
--- a/model_cards/nlpaueb/bert-base-greek-uncased-v1/README.md
+++ b/model_cards/nlpaueb/bert-base-greek-uncased-v1/README.md
@@ -91,7 +91,7 @@ print(tokenizer_greek.convert_ids_to_tokens(outputs[0, 5].max(0)[1].item()))
 # ================ EXAMPLE 2 ================
 text_2 = 'Είναι ένας [MASK] άνθρωπος.'
 # EN: 'He is a [MASK] person.'
-input_ids = tokenizer_greek.encode(text_1)
+input_ids = tokenizer_greek.encode(text_2)
 print(tokenizer_greek.convert_ids_to_tokens(input_ids))
 # ['[CLS]', 'ειναι', 'ενας', '[MASK]', 'ανθρωπος', '.', '[SEP]']
 outputs = lm_model_greek(torch.tensor([input_ids]))[0]


### PR DESCRIPTION
# What does this PR do?

The tokenizer called at the input_ids var of Example 2 is currently encoding text_1. This PR is changing the input to text_2.

Motivation and context for this change: I am considering using this model for a uni assignment and it took me a while to understand why the example code was yielding the wrong results. Hopefully, the next person who is eager to try these examples will not get confused by that typo.

- [x] This PR fixes a typo or improves the docs.

 documentation: @sgugger
