### PR TITLE
token-classification: use is_world_process_zero instead of  is_world_master()

### DIFF
--- a/examples/token-classification/run_ner.py
+++ b/examples/token-classification/run_ner.py
@@ -369,7 +369,7 @@ def main():
         ]
 
         output_test_results_file = os.path.join(training_args.output_dir, "test_results.txt")
-        if trainer.is_world_master():
+        if trainer.is_world_process_zero():
             with open(output_test_results_file, "w") as writer:
                 for key, value in metrics.items():
                     logger.info(f"  {key} = {value}")
@@ -377,7 +377,7 @@ def main():
 
         # Save predictions
         output_test_predictions_file = os.path.join(training_args.output_dir, "test_predictions.txt")
-        if trainer.is_world_master():
+        if trainer.is_world_process_zero():
             with open(output_test_predictions_file, "w") as writer:
                 for prediction in true_predictions:
                     writer.write(" ".join(prediction) + "\n")

--- a/examples/token-classification/run_ner_old.py
+++ b/examples/token-classification/run_ner_old.py
@@ -291,7 +291,7 @@ def main():
         preds_list, _ = align_predictions(predictions, label_ids)
 
         output_test_results_file = os.path.join(training_args.output_dir, "test_results.txt")
-        if trainer.is_world_master():
+        if trainer.is_world_process_zero():
             with open(output_test_results_file, "w") as writer:
                 for key, value in metrics.items():
                     logger.info("  %s = %s", key, value)
@@ -299,7 +299,7 @@ def main():
 
         # Save predictions
         output_test_predictions_file = os.path.join(training_args.output_dir, "test_predictions.txt")
-        if trainer.is_world_master():
+        if trainer.is_world_process_zero():
             with open(output_test_predictions_file, "w") as writer:
                 with open(os.path.join(data_args.data_dir, "test.txt"), "r") as f:
                     token_classification_task.write_predictions_to_file(writer, f, preds_list)


### PR DESCRIPTION
Hi,

I just found some leftovers of the `is_world_master()` function in the token classification example.

As this method has been removed, the following error message is thrown when using the `do_prediction` option:

```bash
Traceback (most recent call last):
  File "run_ner.py", line 394, in <module>
    main()
  File "run_ner.py", line 372, in main
    if trainer.is_world_master():
AttributeError: 'Trainer' object has no attribute 'is_world_master'
```

This PR fixes it and uses the new `is_world_process_zero()` method instead!