### PR TITLE
Attempt to fix Flax CI error(s)

### DIFF
--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -48,7 +48,6 @@ class FlaxBertModelTest(unittest.TestCase):
 
 
 @require_flax
-@require_torch
 @pytest.mark.parametrize("jit", ["disable_jit", "enable_jit"])
 def test_multiple_sentences(jit):
     tokenizer = BertTokenizerFast.from_pretrained("bert-base-cased")

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -48,6 +48,7 @@ class FlaxBertModelTest(unittest.TestCase):
 
 
 @require_flax
+@require_torch
 @pytest.mark.parametrize("jit", [False, True])
 def test_multiple_sentences(jit):
     tokenizer = BertTokenizerFast.from_pretrained("bert-base-cased")

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -45,12 +45,12 @@ class FlaxBertModelTest(unittest.TestCase):
                 for fx_output, pt_output in zip(fx_outputs, pt_outputs):
                     self.assert_almost_equals(fx_output, pt_output.numpy(), 5e-3)
 
-    def test_multiple_sentences(self):
+    def test_multiple_sequences(self):
         tokenizer = BertTokenizerFast.from_pretrained("bert-base-cased")
         model = FlaxBertModel.from_pretrained("bert-base-cased")
 
-        sentences = ["this is an example sentence", "this is another", "and a third one"]
-        encodings = tokenizer(sentences, return_tensors=TensorType.JAX, padding=True, truncation=True)
+        sequences = ["this is an example sentence", "this is another", "and a third one"]
+        encodings = tokenizer(sequences, return_tensors=TensorType.JAX, padding=True, truncation=True)
 
         @jax.jit
         def model_jitted(input_ids, attention_mask=None, token_type_ids=None):

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -48,7 +48,7 @@ class FlaxBertModelTest(unittest.TestCase):
 
 
 @require_flax
-@pytest.mark.parametrize("jit", ["disable_jit", "enable_jit"])
+@pytest.mark.parametrize("jit", [False, True])
 def test_multiple_sentences(jit):
     tokenizer = BertTokenizerFast.from_pretrained("bert-base-cased")
     model = FlaxBertModel.from_pretrained("bert-base-cased")
@@ -60,11 +60,11 @@ def test_multiple_sentences(jit):
     def model_jitted(input_ids, attention_mask, token_type_ids):
         return model(input_ids, attention_mask, token_type_ids)
 
-    if jit == "disable_jit":
+    if jit:
+        tokens, pooled = model_jitted(**encodings)
+    else:
         with jax.disable_jit():
             tokens, pooled = model_jitted(**encodings)
-    else:
-        tokens, pooled = model_jitted(**encodings)
 
     assert tokens.shape == (3, 7, 768)
     assert pooled.shape == (3, 768)

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -67,4 +67,3 @@ class FlaxBertModelTest(unittest.TestCase):
 
             self.assertEqual(jitted_tokens.shape, (3, 7, 768))
             self.assertEqual(jitted_pooled.shape, (3, 768))
-

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -25,7 +25,7 @@ if is_torch_available():
 class FlaxBertModelTest(unittest.TestCase):
     def assert_almost_equals(self, a: ndarray, b: ndarray, tol: float):
         diff = (a - b).sum()
-        self.assertLessEqual(diff, tol, "Difference between torch and flax is {} (>= {})".format(diff, tol))
+        self.assertLessEqual(diff, tol, f"Difference between torch and flax is {diff} (>= {tol})")
 
     def test_from_pytorch(self):
         with torch.no_grad():

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -53,7 +53,7 @@ class FlaxBertModelTest(unittest.TestCase):
         encodings = tokenizer(sentences, return_tensors=TensorType.JAX, padding=True, truncation=True)
 
         @jax.jit
-        def model_jitted(input_ids, attention_mask, token_type_ids):
+        def model_jitted(input_ids, attention_mask=None, token_type_ids=None):
             return model(input_ids, attention_mask, token_type_ids)
 
         with self.subTest("JIT Disabled"):

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -49,8 +49,8 @@ class FlaxBertModelTest(unittest.TestCase):
 
 @require_flax
 @require_torch
-@pytest.mark.parametrize("jit", [False, True])
-def test_multiple_sentences(jit):
+@pytest.mark.parametrize("use_jit", [False, True])
+def test_multiple_sentences(use_jit):
     tokenizer = BertTokenizerFast.from_pretrained("bert-base-cased")
     model = FlaxBertModel.from_pretrained("bert-base-cased")
 
@@ -61,7 +61,7 @@ def test_multiple_sentences(jit):
     def model_jitted(input_ids, attention_mask, token_type_ids):
         return model(input_ids, attention_mask, token_type_ids)
 
-    if jit:
+    if use_jit:
         tokens, pooled = model_jitted(**encodings)
     else:
         with jax.disable_jit():

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -24,6 +24,10 @@ if is_torch_available():
 @require_flax
 @require_torch
 class FlaxBertModelTest(unittest.TestCase):
+    def assert_almost_equals(self, a: ndarray, b: ndarray, tol: float):
+        diff = (a - b).sum()
+        self.assertLessEqual(diff, tol, "Difference between torch and flax is {} (>= {})".format(diff, tol))
+
     def test_from_pytorch(self):
         with torch.no_grad():
             with self.subTest("bert-base-cased"):
@@ -40,32 +44,28 @@ class FlaxBertModelTest(unittest.TestCase):
                 self.assertEqual(len(fx_outputs), len(pt_outputs), "Output lengths differ between Flax and PyTorch")
 
                 for fx_output, pt_output in zip(fx_outputs, pt_outputs):
-                    self.assert_almost_equals(fx_output, pt_output.numpy(), 6e-4)
+                    self.assert_almost_equals(fx_output, pt_output.numpy(), 5e-3)
 
-    def assert_almost_equals(self, a: ndarray, b: ndarray, tol: float):
-        diff = (a - b).sum()
-        self.assertLessEqual(diff, tol, "Difference between torch and flax is {} (>= {})".format(diff, tol))
+    def test_multiple_sentences(self):
+        tokenizer = BertTokenizerFast.from_pretrained("bert-base-cased")
+        model = FlaxBertModel.from_pretrained("bert-base-cased")
 
+        sentences = ["this is an example sentence", "this is another", "and a third one"]
+        encodings = tokenizer(sentences, return_tensors=TensorType.JAX, padding=True, truncation=True)
 
-@require_flax
-@require_torch
-@pytest.mark.parametrize("use_jit", [False, True])
-def test_multiple_sentences(use_jit):
-    tokenizer = BertTokenizerFast.from_pretrained("bert-base-cased")
-    model = FlaxBertModel.from_pretrained("bert-base-cased")
+        @jax.jit
+        def model_jitted(input_ids, attention_mask, token_type_ids):
+            return model(input_ids, attention_mask, token_type_ids)
 
-    sentences = ["this is an example sentence", "this is another", "and a third one"]
-    encodings = tokenizer(sentences, return_tensors=TensorType.JAX, padding=True, truncation=True)
+        with self.subTest("JIT Disabled"):
+            with jax.disable_jit():
+                tokens, pooled = model_jitted(**encodings)
+                self.assertEqual(tokens.shape, (3, 7, 768))
+                self.assertEqual(pooled.shape, (3, 768))
 
-    @jax.jit
-    def model_jitted(input_ids, attention_mask, token_type_ids):
-        return model(input_ids, attention_mask, token_type_ids)
+        with self.subTest("JIT Enabled"):
+            jitted_tokens, jitted_pooled = model_jitted(**encodings)
 
-    if use_jit:
-        tokens, pooled = model_jitted(**encodings)
-    else:
-        with jax.disable_jit():
-            tokens, pooled = model_jitted(**encodings)
+            self.assertEqual(jitted_tokens.shape, (3, 7, 768))
+            self.assertEqual(jitted_pooled.shape, (3, 768))
 
-    assert tokens.shape == (3, 7, 768)
-    assert pooled.shape == (3, 768)

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -40,7 +40,7 @@ class FlaxBertModelTest(unittest.TestCase):
                 self.assertEqual(len(fx_outputs), len(pt_outputs), "Output lengths differ between Flax and PyTorch")
 
                 for fx_output, pt_output in zip(fx_outputs, pt_outputs):
-                    self.assert_almost_equals(fx_output, pt_output.numpy(), 5e-4)
+                    self.assert_almost_equals(fx_output, pt_output.numpy(), 6e-4)
 
     def assert_almost_equals(self, a: ndarray, b: ndarray, tol: float):
         diff = (a - b).sum()

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -1,6 +1,5 @@
 import unittest
 
-import pytest
 from numpy import ndarray
 
 from transformers import BertTokenizerFast, TensorType, is_flax_available, is_torch_available

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -48,7 +48,7 @@ class FlaxRobertaModelTest(unittest.TestCase):
 
 
 @require_flax
-@pytest.mark.parametrize("jit", ["disable_jit", "enable_jit"])
+@pytest.mark.parametrize("jit", [False, True])
 def test_multiple_sentences(jit):
     tokenizer = RobertaTokenizerFast.from_pretrained("roberta-base")
     model = FlaxRobertaModel.from_pretrained("roberta-base")
@@ -60,11 +60,11 @@ def test_multiple_sentences(jit):
     def model_jitted(input_ids, attention_mask):
         return model(input_ids, attention_mask)
 
-    if jit == "disable_jit":
+    if jit:
+        tokens, pooled = model_jitted(**encodings)
+    else:
         with jax.disable_jit():
             tokens, pooled = model_jitted(**encodings)
-    else:
-        tokens, pooled = model_jitted(**encodings)
 
     assert tokens.shape == (3, 7, 768)
     assert pooled.shape == (3, 768)

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -49,8 +49,8 @@ class FlaxRobertaModelTest(unittest.TestCase):
 
 @require_flax
 @require_torch
-@pytest.mark.parametrize("jit", [False, True])
-def test_multiple_sentences(jit):
+@pytest.mark.parametrize("use_jit", [False, True])
+def test_multiple_sentences(use_jit):
     tokenizer = RobertaTokenizerFast.from_pretrained("roberta-base")
     model = FlaxRobertaModel.from_pretrained("roberta-base")
 
@@ -61,7 +61,7 @@ def test_multiple_sentences(jit):
     def model_jitted(input_ids, attention_mask):
         return model(input_ids, attention_mask)
 
-    if jit:
+    if use_jit:
         tokens, pooled = model_jitted(**encodings)
     else:
         with jax.disable_jit():

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -25,7 +25,7 @@ if is_torch_available():
 class FlaxRobertaModelTest(unittest.TestCase):
     def assert_almost_equals(self, a: ndarray, b: ndarray, tol: float):
         diff = (a - b).sum()
-        self.assertLessEqual(diff, tol, "Difference between torch and flax is {} (>= {})".format(diff, tol))
+        self.assertLessEqual(diff, tol, f"Difference between torch and flax is {diff} (>= {tol})")
 
     def test_from_pytorch(self):
         with torch.no_grad():

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -23,7 +23,6 @@ if is_torch_available():
 @require_flax
 @require_torch
 class FlaxRobertaModelTest(unittest.TestCase):
-
     def assert_almost_equals(self, a: ndarray, b: ndarray, tol: float):
         diff = (a - b).sum()
         self.assertLessEqual(diff, tol, "Difference between torch and flax is {} (>= {})".format(diff, tol))
@@ -68,4 +67,3 @@ class FlaxRobertaModelTest(unittest.TestCase):
 
             self.assertEqual(jitted_tokens.shape, (3, 7, 768))
             self.assertEqual(jitted_pooled.shape, (3, 768))
-

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -53,7 +53,7 @@ class FlaxRobertaModelTest(unittest.TestCase):
         encodings = tokenizer(sentences, return_tensors=TensorType.JAX, padding=True, truncation=True)
 
         @jax.jit
-        def model_jitted(input_ids, attention_mask, token_type_ids):
+        def model_jitted(input_ids, attention_mask=None, token_type_ids=None):
             return model(input_ids, attention_mask, token_type_ids)
 
         with self.subTest("JIT Disabled"):

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -1,6 +1,5 @@
 import unittest
 
-import pytest
 from numpy import ndarray
 
 from transformers import RobertaTokenizerFast, TensorType, is_flax_available, is_torch_available

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -45,12 +45,12 @@ class FlaxRobertaModelTest(unittest.TestCase):
                 for fx_output, pt_output in zip(fx_outputs, pt_outputs.to_tuple()):
                     self.assert_almost_equals(fx_output, pt_output.numpy(), 6e-4)
 
-    def test_multiple_sentences(self):
+    def test_multiple_sequences(self):
         tokenizer = RobertaTokenizerFast.from_pretrained("roberta-base")
         model = FlaxRobertaModel.from_pretrained("roberta-base")
 
-        sentences = ["this is an example sentence", "this is another", "and a third one"]
-        encodings = tokenizer(sentences, return_tensors=TensorType.JAX, padding=True, truncation=True)
+        sequences = ["this is an example sentence", "this is another", "and a third one"]
+        encodings = tokenizer(sequences, return_tensors=TensorType.JAX, padding=True, truncation=True)
 
         @jax.jit
         def model_jitted(input_ids, attention_mask=None, token_type_ids=None):

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -48,7 +48,6 @@ class FlaxRobertaModelTest(unittest.TestCase):
 
 
 @require_flax
-@require_torch
 @pytest.mark.parametrize("jit", ["disable_jit", "enable_jit"])
 def test_multiple_sentences(jit):
     tokenizer = RobertaTokenizerFast.from_pretrained("roberta-base")

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -40,7 +40,7 @@ class FlaxRobertaModelTest(unittest.TestCase):
                 self.assertEqual(len(fx_outputs), len(pt_outputs), "Output lengths differ between Flax and PyTorch")
 
                 for fx_output, pt_output in zip(fx_outputs, pt_outputs.to_tuple()):
-                    self.assert_almost_equals(fx_output, pt_output.numpy(), 5e-4)
+                    self.assert_almost_equals(fx_output, pt_output.numpy(), 6e-4)
 
     def assert_almost_equals(self, a: ndarray, b: ndarray, tol: float):
         diff = (a - b).sum()

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -48,6 +48,7 @@ class FlaxRobertaModelTest(unittest.TestCase):
 
 
 @require_flax
+@require_torch
 @pytest.mark.parametrize("jit", [False, True])
 def test_multiple_sentences(jit):
     tokenizer = RobertaTokenizerFast.from_pretrained("roberta-base")


### PR DESCRIPTION
- Increased the tolerance when comparing Flax et PyTorch output (_~0.00058 on my dev box_)
- Removed the `jit` parametrization when running `test_multiple_sentences` because it leads to instabilities
- Introduced subtests expliciting what we're doing by enabling / disabling JIT. 