### PR TITLE
Allow none-tensor fields in BatchEncoding

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -626,7 +626,7 @@ class BatchEncoding(UserDict):
             :class:`~transformers.BatchEncoding`:
             The same instance of :class:`~transformers.BatchEncoding` after modification.
         """
-        self.data = {k: v.to(device) for k, v in self.data.items()}
+        self.data = {k: v.to(device) if isinstance(v, torch.Tensor) else v for k, v in self.data.items()}
         return self
 
 


### PR DESCRIPTION
# What does this PR do?

This PR allows BatchEncoding to have non-tensor fields. This is useful for example when doing multi-task learning, I can add a task name (str) in the batch, and use it to decide the computation later on. 
Without this PR, I cannot use `.to('cuda')` if there is str in the batch.

I don't know who to tag. @LysandreJik

