### PR TITLE
Correct docstring.

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2604,7 +2604,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
 
                 Instead of :obj:`List[int]` you can have tensors (numpy arrays, PyTorch tensors or TensorFlow tensors),
                 see the note above for the return type.
-            padding (:obj:`bool`, :obj:`str` or :class:`~transformers.tokenization_utils_base.PaddingStrategy`, `optional`, defaults to :obj:`False`):
+            padding (:obj:`bool`, :obj:`str` or :class:`~transformers.tokenization_utils_base.PaddingStrategy`, `optional`, defaults to :obj:`True`):
                  Select a strategy to pad the returned sequences (according to the model's padding side and padding
                  index) among:
 


### PR DESCRIPTION
Related issue: https://github.com/huggingface/transformers/issues/8837

# What does this PR do?

Updating the PreTrainedTokenizerBase.pad argument default value docstring to show the correct default value.

**Current**
docstring: 
https://github.com/huggingface/transformers/blob/d5b3e56de5376aa85ef46e7f0325139d9e299a41/src/transformers/tokenization_utils_base.py#L2469-L2470
arg:
https://github.com/huggingface/transformers/blob/d5b3e56de5376aa85ef46e7f0325139d9e299a41/src/transformers/tokenization_utils_base.py#L2431-L2472

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

Fixes #8837 (issue)

I'm also curious why this method has default `padding=True`? Other methods (prepare_for_model, encode, __call__, encode_plus, batch_encode_plus) have `padding=False`.

Its default means the DataCollatorForLanguageModeling pads input examples which means it can't be simply switched with the default collator in the [example script](https://github.com/huggingface/transformers/blob/master/templates/adding_a_new_example_script/%7B%7Bcookiecutter.directory_name%7D%7D/run_%7B%7Bcookiecutter.example_shortcut%7D%7D.py#L287-L306) without breaking the attention mask.
https://github.com/huggingface/transformers/blob/610cb106a216cfb99d840648b576f9502189e4d1/src/transformers/data/data_collator.py#L253

@mfuntowicz
@LysandreJik 
@sgugger
