### PR TITLE
Make the big table creation/check platform independent

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -214,6 +214,7 @@ if is_sentencepiece_available():
     from .models.camembert import CamembertTokenizer
     from .models.marian import MarianTokenizer
     from .models.mbart import MBartTokenizer
+    from .models.mt5 import MT5Tokenizer
     from .models.pegasus import PegasusTokenizer
     from .models.reformer import ReformerTokenizer
     from .models.t5 import T5Tokenizer
@@ -240,6 +241,7 @@ if is_tokenizers_available():
     from .models.lxmert import LxmertTokenizerFast
     from .models.mbart import MBartTokenizerFast
     from .models.mobilebert import MobileBertTokenizerFast
+    from .models.mt5 import MT5TokenizerFast
     from .models.openai import OpenAIGPTTokenizerFast
     from .models.pegasus import PegasusTokenizerFast
     from .models.reformer import ReformerTokenizerFast

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -98,6 +98,7 @@ if is_sentencepiece_available():
     from ..camembert.tokenization_camembert import CamembertTokenizer
     from ..marian.tokenization_marian import MarianTokenizer
     from ..mbart.tokenization_mbart import MBartTokenizer
+    from ..mt5 import MT5Tokenizer
     from ..pegasus.tokenization_pegasus import PegasusTokenizer
     from ..reformer.tokenization_reformer import ReformerTokenizer
     from ..t5.tokenization_t5 import T5Tokenizer
@@ -111,6 +112,7 @@ else:
     CamembertTokenizer = None
     MarianTokenizer = None
     MBartTokenizer = None
+    MT5Tokenizer = None
     PegasusTokenizer = None
     ReformerTokenizer = None
     T5Tokenizer = None
@@ -135,6 +137,7 @@ if is_tokenizers_available():
     from ..lxmert.tokenization_lxmert_fast import LxmertTokenizerFast
     from ..mbart.tokenization_mbart_fast import MBartTokenizerFast
     from ..mobilebert.tokenization_mobilebert_fast import MobileBertTokenizerFast
+    from ..mt5 import MT5TokenizerFast
     from ..openai.tokenization_openai_fast import OpenAIGPTTokenizerFast
     from ..pegasus.tokenization_pegasus_fast import PegasusTokenizerFast
     from ..reformer.tokenization_reformer_fast import ReformerTokenizerFast
@@ -161,6 +164,7 @@ else:
     LxmertTokenizerFast = None
     MBartTokenizerFast = None
     MobileBertTokenizerFast = None
+    MT5TokenizerFast = None
     OpenAIGPTTokenizerFast = None
     PegasusTokenizerFast = None
     ReformerTokenizerFast = None
@@ -178,7 +182,7 @@ TOKENIZER_MAPPING = OrderedDict(
     [
         (RetriBertConfig, (RetriBertTokenizer, RetriBertTokenizerFast)),
         (T5Config, (T5Tokenizer, T5TokenizerFast)),
-        (MT5Config, (T5Tokenizer, T5TokenizerFast)),
+        (MT5Config, (MT5Tokenizer, MT5TokenizerFast)),
         (MobileBertConfig, (MobileBertTokenizer, MobileBertTokenizerFast)),
         (DistilBertConfig, (DistilBertTokenizer, DistilBertTokenizerFast)),
         (AlbertConfig, (AlbertTokenizer, AlbertTokenizerFast)),

--- a/src/transformers/models/mt5/__init__.py
+++ b/src/transformers/models/mt5/__init__.py
@@ -2,9 +2,19 @@
 # There's no way to ignore "F401 '...' imported but unused" warnings in this
 # module, but to preserve other warnings. So, don't check this module at all.
 
-from ...file_utils import is_tf_available, is_torch_available
+from ...file_utils import is_sentencepiece_available, is_tf_available, is_tokenizers_available, is_torch_available
 from .configuration_mt5 import MT5Config
 
+
+if is_sentencepiece_available():
+    from ..t5.tokenization_t5 import T5Tokenizer
+
+    MT5Tokenizer = T5Tokenizer
+
+if is_tokenizers_available():
+    from ..t5.tokenization_t5_fast import T5TokenizerFast
+
+    MT5TokenizerFast = T5TokenizerFast
 
 if is_torch_available():
     from .modeling_mt5 import MT5EncoderModel, MT5ForConditionalGeneration, MT5Model

--- a/src/transformers/utils/dummy_sentencepiece_objects.py
+++ b/src/transformers/utils/dummy_sentencepiece_objects.py
@@ -56,6 +56,15 @@ class MBartTokenizer:
         requires_sentencepiece(self)
 
 
+class MT5Tokenizer:
+    def __init__(self, *args, **kwargs):
+        requires_sentencepiece(self)
+
+    @classmethod
+    def from_pretrained(self, *args, **kwargs):
+        requires_sentencepiece(self)
+
+
 class PegasusTokenizer:
     def __init__(self, *args, **kwargs):
         requires_sentencepiece(self)

--- a/src/transformers/utils/dummy_tokenizers_objects.py
+++ b/src/transformers/utils/dummy_tokenizers_objects.py
@@ -164,6 +164,15 @@ class MobileBertTokenizerFast:
         requires_tokenizers(self)
 
 
+class MT5TokenizerFast:
+    def __init__(self, *args, **kwargs):
+        requires_tokenizers(self)
+
+    @classmethod
+    def from_pretrained(self, *args, **kwargs):
+        requires_tokenizers(self)
+
+
 class OpenAIGPTTokenizerFast:
     def __init__(self, *args, **kwargs):
         requires_tokenizers(self)


### PR DESCRIPTION
# What does this PR do?

As @jplu mentioned in #8813, the check that the big table of models/tokenziers is up-to-date (done in `make quality`) requires all three backends installed (plus tokenizers and sentencepiece). This PR amends the script to use the objects in the init (that are always there, thanks to the dummies) instead of the dicts in the auto modules (which are set to None if a specific backend is not installed).

In passing, it adds aliases `MT5Tokenizer` and `MT5TokenizerFast` (to `T5Tokenizer` and `T5TokenizerFast` respectively) because otherwise the script does not detect the tokenizers associated to this model, cc @patrickvonplaten 