### PR TITLE
Add a `parallel_mode` property to TrainingArguments

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -455,6 +455,18 @@ class TrainingArguments:
         """
         return self._setup_devices[1]
 
+    @property
+    @torch_required
+    def distributed_env(self):
+        if is_torch_tpu_available():
+            return DistributedEnvironment.TPU
+        elif self.local_rank != -1:
+            return DistributedEnvironment.DISTRIBUTED_PARALLEL
+        elif self.n_gpu > 1:
+            return DistributedEnvironment.PARALLEL
+        else:
+            return DistributedEnvironment.SINGLE
+
     def to_dict(self):
         """
         Serializes this instance while replace `Enum` by their values (for JSON serialization support).
@@ -483,3 +495,10 @@ class TrainingArguments:
             valid_types.append(torch.Tensor)
 
         return {k: v if type(v) in valid_types else str(v) for k, v in d.items()}
+
+
+class DistributedEnvironment(Enum):
+    SINGLE = "single"
+    PARALLEL = "parallel"
+    DISTRIBUTED_PARALLEL = "distributed_parallel"
+    TPU = "tpu"

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -461,7 +461,7 @@ class TrainingArguments:
         """
         The current mode used for parallelism if multiple GPUs/TPU cores are available. One of:
 
-        - :obj:`ParallelMode.NO`: no parallelism (CPU or one GPU).
+        - :obj:`ParallelMode.NOT_PARALLEL`: no parallelism (CPU or one GPU).
         - :obj:`ParallelMode.NOT_DISTRIBUTED`: several GPUs in one single process (uses :obj:`torch.nn.DataParallel`).
         - :obj:`ParallelMode.DISTRIBUTED`: several GPUs, each ahving its own process (uses
           :obj:`torch.nn.DistributedDataParallel`).
@@ -474,7 +474,7 @@ class TrainingArguments:
         elif self.n_gpu > 1:
             return ParallelMode.NOT_DISTRIBUTED
         else:
-            return ParallelMode.NO
+            return ParallelMode.NOT_PARALLEL
 
     def to_dict(self):
         """
@@ -507,7 +507,7 @@ class TrainingArguments:
 
 
 class ParallelMode(Enum):
-    NO = "no"
+    NOT_PARALLEL = "not_parallel"
     NOT_DISTRIBUTED = "not_distributed"
     DISTRIBUTED = "distributed"
     TPU = "tpu"


### PR DESCRIPTION
# What does this PR do?

This PR adds a `distributed_env` property to the `TrainingArugments` making it clear if we are in:
- a single process (CPU or one GPU)
- a parallel setting (one process but several GPUs)
- a distributed parallel setting (several processes, one per GPU)
- a TPU setting

Fixes #8858
