### PR TITLE
Fix typo in docstring in src/transformers/models/bert_japanese/tokenization_bert_japanese.py

### DIFF
--- a/src/transformers/models/bert_japanese/tokenization_bert_japanese.py
+++ b/src/transformers/models/bert_japanese/tokenization_bert_japanese.py
@@ -218,7 +218,7 @@ class MecabTokenizer:
                 Whether to apply unicode normalization to text before tokenization.
             **mecab_dic**: (`optional`) string (default "ipadic")
                 Name of dictionary to be used for MeCab initialization. If you are using a system-installed dictionary,
-                set thi option to `None` and modify `mecab_option`.
+                set this option to `None` and modify `mecab_option`.
             **mecab_option**: (`optional`) string
                 String passed to MeCab constructor.
         """


### PR DESCRIPTION
# What does this PR do?
Only fix typo (thi -> this).

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?



@sgugger, @LysandreJik