### PR TITLE
Put Transformers on Conda

### DIFF
--- a/.github/conda/build.sh
+++ b/.github/conda/build.sh
@@ -1,0 +1,1 @@
+$PYTHON setup.py install     # Python command to install the script.

--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "transformers" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ TRANSFORMERS_VERSION }}"
+
+source:
+  path: ../../
+
+build:
+  noarch: python
+
+requirements:
+  host:
+    - python
+    - pip
+    - numpy
+    - dataclasses
+    - packaging
+    - filelock
+    - requests
+    - tqdm >=4.27
+    - sacremoses
+    - regex !=2019.12.17
+    - protobuf
+    - tokenizers ==0.9.4
+  run:
+    - python
+    - numpy
+    - dataclasses
+    - packaging
+    - filelock
+    - requests
+    - tqdm >=4.27
+    - sacremoses
+    - regex !=2019.12.17
+    - protobuf
+    - tokenizers ==0.9.4
+
+test:
+  imports:
+    - transformers
+
+about:
+  home: https://huggingface.co
+  license: Apache License 2.0
+  license_file: LICENSE
+  summary: "🤗Transformers: State-of-the-art Natural Language Processing for Pytorch and TensorFlow 2.0."

--- a/.github/workflows/release-conda.yml
+++ b/.github/workflows/release-conda.yml
@@ -1,0 +1,43 @@
+name: Release - Conda
+
+on:
+  push:
+    tags:
+      - python-v*
+
+env:
+  ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+
+jobs:
+  build_and_package:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+
+      - name: Install miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          auto-activate-base: false
+          activate-environment: "build-transformers"
+          channels: huggingface
+
+      - name: Setup conda env
+        run: |
+          conda install -c defaults anaconda-client conda-build
+
+      - name: Extract version
+        run: echo "TRANSFORMERS_VERSION=`python setup.py --version`" >> $GITHUB_ENV
+
+      - name: Build conda packages
+        run: |
+          conda info
+          conda build .github/conda
+
+      - name: Upload to Anaconda
+        run: anaconda upload `conda build .github/conda --output` --force

--- a/.github/workflows/release-conda.yml
+++ b/.github/workflows/release-conda.yml
@@ -3,7 +3,7 @@ name: Release - Conda
 on:
   push:
     tags:
-      - python-v*
+      - v*
 
 env:
   ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You should install 🤗 Transformers in a [virtual environment](https://docs.pyt
 First, create a virtual environment with the version of Python you're going to use and activate it.
 
 Then, you will need to install at least one of TensorFlow 2.0, PyTorch or Flax.
-Please refer to [TensorFlow installation page](https://www.tensorflow.org/install/pip#tensorflow-2.0-rc-is-available) and/or [PyTorch installation page](https://pytorch.org/get-started/locally/#start-locally) regarding the specific install command for your platform.
+Please refer to [TensorFlow installation page](https://www.tensorflow.org/install/pip#tensorflow-2.0-rc-is-available), [PyTorch installation page](https://pytorch.org/get-started/locally/#start-locally) regarding the specific install command for your platform and/or [Flax installation page](https://github.com/google/flax#quick-install).
 
 When TensorFlow 2.0 and/or PyTorch has been installed, 🤗 Transformers can be installed using pip as follows:
 

--- a/README.md
+++ b/README.md
@@ -137,13 +137,15 @@ The model itself is a regular [Pytorch `nn.Module`](https://pytorch.org/docs/sta
 
 ## Installation
 
+### With pip
+
 This repository is tested on Python 3.6+, PyTorch 1.0.0+ (PyTorch 1.3.1+ for [examples](https://github.com/huggingface/transformers/tree/master/examples)) and TensorFlow 2.0.
 
 You should install 🤗 Transformers in a [virtual environment](https://docs.python.org/3/library/venv.html). If you're unfamiliar with Python virtual environments, check out the [user guide](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/).
 
 First, create a virtual environment with the version of Python you're going to use and activate it.
 
-Then, you will need to install one of, or both, TensorFlow 2.0 and PyTorch.
+Then, you will need to install at least one of TensorFlow 2.0, PyTorch or Flax.
 Please refer to [TensorFlow installation page](https://www.tensorflow.org/install/pip#tensorflow-2.0-rc-is-available) and/or [PyTorch installation page](https://pytorch.org/get-started/locally/#start-locally) regarding the specific install command for your platform.
 
 When TensorFlow 2.0 and/or PyTorch has been installed, 🤗 Transformers can be installed using pip as follows:
@@ -153,6 +155,18 @@ pip install transformers
 ```
 
 If you'd like to play with the examples, you must [install the library from source](https://huggingface.co/transformers/installation.html#installing-from-source).
+
+### With conda
+
+Since Transformers version v4.0.0, we now have a conda channel: `huggingface`.
+
+🤗 Transformers can be installed using conda as follows:
+
+```shell script
+conda install -c huggingface transformers
+```
+
+TensorFlow, PyTorch or Flax should be installed from their respective conda channels. 
 
 ## Models architectures
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Since Transformers version v4.0.0, we now have a conda channel: `huggingface`.
 conda install -c huggingface transformers
 ```
 
-TensorFlow, PyTorch or Flax should be installed from their respective conda channels. 
+Follow the installation pages of TensorFlow, PyTorch or Flax to see how to install them with conda. 
 
 ## Models architectures
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -77,7 +77,7 @@ Since Transformers version v4.0.0, we now have a conda channel: `huggingface`.
 conda install -c huggingface transformers
 ```
 
-TensorFlow, PyTorch or Flax should be installed from their respective conda channels. 
+Follow the installation pages of TensorFlow, PyTorch or Flax to see how to install them with conda. 
 
 ## Caching models
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -66,6 +66,19 @@ python -c "from transformers import pipeline; print(pipeline('sentiment-analysis
 
 to check 🤗 Transformers is properly installed.
 
+
+## With conda
+
+Since Transformers version v4.0.0, we now have a conda channel: `huggingface`.
+
+🤗 Transformers can be installed using conda as follows:
+
+```shell script
+conda install -c huggingface transformers
+```
+
+TensorFlow, PyTorch or Flax should be installed from their respective conda channels. 
+
 ## Caching models
 
 This library provides pretrained models that will be downloaded and cached locally. Unless you specify a location with

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -12,9 +12,10 @@ must install it from source.
 ## Installation with pip
 
 First you need to install one of, or both, TensorFlow 2.0 and PyTorch.
-Please refer to [TensorFlow installation page](https://www.tensorflow.org/install/pip#tensorflow-2.0-rc-is-available) 
-and/or [PyTorch installation page](https://pytorch.org/get-started/locally/#start-locally) regarding the specific 
-install command for your platform.
+Please refer to [TensorFlow installation page](https://www.tensorflow.org/install/pip#tensorflow-2.0-rc-is-available), 
+[PyTorch installation page](https://pytorch.org/get-started/locally/#start-locally) and/or 
+[Flax installation page](https://github.com/google/flax#quick-install)
+regarding the specific install command for your platform.
 
 When TensorFlow 2.0 and/or PyTorch has been installed, 🤗 Transformers can be installed using pip as follows:
 
@@ -32,6 +33,12 @@ or 🤗 Transformers and TensorFlow 2.0 in one line with:
 
 ```bash
 pip install transformers[tf-cpu]
+```
+
+or 🤗 Transformers and Flax in one line with:
+
+```bash
+pip install transformers[flax]
 ```
 
 To check 🤗 Transformers is properly installed, run the following command:
@@ -73,7 +80,7 @@ Since Transformers version v4.0.0, we now have a conda channel: `huggingface`.
 
 🤗 Transformers can be installed using conda as follows:
 
-```shell script
+```
 conda install -c huggingface transformers
 ```
 


### PR DESCRIPTION
Puts transformers on conda, on the `huggingface` channel. Installation can be done as:

```
conda install -c huggingface transformers
```
Will push a build on the channel on every new tag.