### PR TITLE
[seq2seq] document the caveat of leaky native amp

### DIFF
--- a/examples/seq2seq/README.md
+++ b/examples/seq2seq/README.md
@@ -81,7 +81,7 @@ The `.source` files are the input, the `.target` files are the desired output.
 
 ### Potential issues
 
-- native AMP (`--fp16` and no apex) may lead to a huge memory leak and require 10x gpu memory. This has been fixed in pytorch-nightly and the minimal official version to have this fix will be pytorch-1.8. Until then if you have to use amp please use NVIDIA's apex. Reference: https://github.com/huggingface/transformers/issues/8403
+- native AMP (`--fp16` and no apex) may lead to a huge memory leak and require 10x gpu memory. This has been fixed in pytorch-nightly and the minimal official version to have this fix will be pytorch-1.8. Until then if you have to use mixed precision please use AMP only with pytorch-nightly or NVIDIA's apex. Reference: https://github.com/huggingface/transformers/issues/8403
 
 
 ### Tips and Tricks
@@ -596,5 +596,4 @@ uses 12,723 batches of length 48 and takes slightly more time 9.5 minutes.
 The feature is still experimental, because:
 + we can make it much more robust if we have memory mapped/preprocessed datasets.
 + The speedup over sortish sampler is not that large at the moment.
-
 

--- a/examples/seq2seq/README.md
+++ b/examples/seq2seq/README.md
@@ -79,6 +79,11 @@ test.target
 ```
 The `.source` files are the input, the `.target` files are the desired output.
 
+### Potential issues
+
+- native AMP (`--fp16` and no apex) may lead to a huge memory leak and require 10x gpu memory. This has been fixed in pytorch-nightly and the minimal official version to have this fix will be pytorch-1.8. Until then if you have to use amp please use NVIDIA's apex. Reference: https://github.com/huggingface/transformers/issues/8403
+
+
 ### Tips and Tricks
 
 General Tips:


### PR DESCRIPTION
the native amp leak will be fixed in pt18 (already available in pt-nightly) - this PR documents this caveat and proposes to use apex for pt < 1.8.

@sgugger 