### PR TITLE
Fix QA pipeline on Windows

### DIFF
--- a/src/transformers/pipelines.py
+++ b/src/transformers/pipelines.py
@@ -1883,6 +1883,8 @@ class QuestionAnsweringPipeline(Pipeline):
                     with torch.no_grad():
                         # Retrieve the score for the context tokens only (removing question tokens)
                         fw_args = {k: torch.tensor(v, device=self.device) for (k, v) in fw_args.items()}
+                        # On Windows, the default int type in numpy is np.int32 so we get some non-long tensors.
+                        fw_args = {k: v.long() if v.dtype == torch.int32 else v for (k, v) in fw_args.items()}
                         start, end = self.model(**fw_args)[:2]
                         start, end = start.cpu().numpy(), end.cpu().numpy()
 


### PR DESCRIPTION
# What does this PR do?

As reported on the [forum](https://discuss.huggingface.co/t/pipeline-example-in-the-doc-throws-an-error-question-answering/2632), there is a problem in the current pipeline on Windows. The problem's root is that numpy int arrays have a different default on Linux and Windows, the current snippet:
```
import numpy as np
x = np.array([1, 2, 3])
x.dtype
```
will print `dtype('int64')` on Linux/MacOS but `dtype('int32')` on Windows. So this means that just doing `torch.tensor(some_numpy_array)` may result in a tensor of dtype `int32` which PyTorch does not like. For future reference, the error:
```
Expected tensor for argument #1 'xxx' to have scalar type Long; but got torch.IntTensor instead
```
is usually a clear indicator of this behavior happening.

The PR fixes the QA pipeline by casting the tensors to long if they have the int type.