### PR TITLE
Update quicktour docs to showcase the use of truncation

### DIFF
--- a/docs/source/quicktour.rst
+++ b/docs/source/quicktour.rst
@@ -182,6 +182,7 @@ and get tensors back. You can specify all of that to the tokenizer:
     ...     ["We are very happy to show you the 🤗 Transformers library.", "We hope you don't hate it."],
     ...     padding=True,
     ...     truncation=True,
+    ...     max_length=512,
     ...     return_tensors="pt"
     ... )
     >>> ## TENSORFLOW CODE
@@ -189,6 +190,7 @@ and get tensors back. You can specify all of that to the tokenizer:
     ...     ["We are very happy to show you the 🤗 Transformers library.", "We hope you don't hate it."],
     ...     padding=True,
     ...     truncation=True,
+    ...     max_length=512,
     ...     return_tensors="tf"
     ... )
 


### PR DESCRIPTION
# What does this PR do?
Currently, running the tokenizer batch example on https://huggingface.co/transformers/quicktour.html gives an error 

```
Asking to truncate to max_length but no maximum length is provided and the model has no predefined maximum length. Default to no truncation.
```

This PR fixes the above by passing the `max_length` param explicitly (instead of depending on it having a default, which might not be the case for all models).

The fix also adds clarity to the statement in the docs above this example
> If your goal is to send them through your model as a batch, you probably want to pad them all to the same length, truncate them to the maximum length the model can accept and get tensors back

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?
@sgugger 
