### PR TITLE
[training] SAVE_STATE_WARNING was removed in pytorch

### DIFF
--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -34,7 +34,8 @@ from .utils import logging
 if is_torch_tpu_available():
     import torch_xla.core.xla_model as xm
 
-if version.parse(torch.__version__) <= version.parse("1.4.1"):
+# this is used to supress an undesired warning emitted by pytorch versions 1.4.2-1.7.0
+if version.parse(torch.__version__) <= version.parse("1.4.1") or version.parse(torch.__version__) > version.parse("1.7.0"):
     SAVE_STATE_WARNING = ""
 else:
     from torch.optim.lr_scheduler import SAVE_STATE_WARNING

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -35,7 +35,9 @@ if is_torch_tpu_available():
     import torch_xla.core.xla_model as xm
 
 # this is used to supress an undesired warning emitted by pytorch versions 1.4.2-1.7.0
-if version.parse(torch.__version__) <= version.parse("1.4.1") or version.parse(torch.__version__) > version.parse("1.7.0"):
+if (version.parse(torch.__version__) <= version.parse("1.4.1")) or (
+    version.parse(torch.__version__) > version.parse("1.7.0")
+):
     SAVE_STATE_WARNING = ""
 else:
     from torch.optim.lr_scheduler import SAVE_STATE_WARNING

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -35,12 +35,10 @@ if is_torch_tpu_available():
     import torch_xla.core.xla_model as xm
 
 # this is used to supress an undesired warning emitted by pytorch versions 1.4.2-1.7.0
-if (version.parse(torch.__version__) <= version.parse("1.4.1")) or (
-    version.parse(torch.__version__) > version.parse("1.7.0")
-):
-    SAVE_STATE_WARNING = ""
-else:
+try:
     from torch.optim.lr_scheduler import SAVE_STATE_WARNING
+except ImportError:
+    SAVE_STATE_WARNING = ""
 
 logger = logging.get_logger(__name__)
 

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -23,7 +23,6 @@ from typing import List, Optional, Union
 
 import numpy as np
 import torch
-from packaging import version
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data.sampler import RandomSampler, Sampler
 


### PR DESCRIPTION
`SAVE_STATE_WARNING` has been removed from pytorch 3 days ago: pytorch/pytorch#46813

I had to add redundant ()'s to avoid a terrible auto-formatter outcome.

Fixes: #8232

@sgugger, @LysandreJik 