### PR TITLE
[wip] [ci] doc-job-skip take #4 dry-run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,20 +11,30 @@ commands:
       - run:
           name: docs-only changes skip check
           command: |
-            # pipeline.git.base_revision is not always defined, so only proceed if all external vars are defined
-            if test -n "<< pipeline.git.base_revision >>" && test -n "<< pipeline.git.revision >>" && test -n "$(git diff --name-only << pipeline.git.base_revision >>...<< pipeline.git.revision >>)"
+            if test -n "$CIRCLE_PR_NUMBER"
             then
-                if git diff --name-only << pipeline.git.base_revision >>...<< pipeline.git.revision >> | egrep -qv '\.(md|rst)$'
+                resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
+                base_ref=$(jq -r .base.ref <<< $resp)
+                head_ref=$(jq -r .head.ref <<< $resp)
+                echo "$(base_ref}..${head_ref}"
+            fi
+
+            if test -n "${base_ref}" && test -n "${head_ref}" && test -n "$(git diff --name-only ${base_ref}..${head_ref})"
+            then
+                # XXX: remove the next debug line when ready
+                git diff --name-only ${base_ref}..${head_ref}
+                if git diff --name-only ${base_ref}..${head_ref} | egrep -qv '\.(md|rst)$'
                 then
                     echo "Non-docs were modified in this PR, proceeding normally"
                 else
                     echo "Only docs were modified in this PR, quitting this job"
-                    # disable skipping for now, as circleCI's base_revision is inconsistent leading to invalid ranges
+                    # enable skipping once we get this sorted out
                     # circleci step halt
                 fi
             else
-                echo "Can't perform skipping check w/o base_revision defined, continuing the job"
+                echo "Not enough data to perform a skipping check - continuing the job"
             fi
+
 
 # TPU REFERENCES
 references:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,56 +15,22 @@ commands:
             then
                 echo $CIRCLE_PR_NUMBER
                 resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
-                base_sha=$(jq -r .base.sha \<<< $resp)
-                head_sha=$(jq -r .head.sha \<<< $resp)
-                base_ref=$(jq -r .base.ref \<<< $resp)
                 head_ref=$(jq -r .head.ref \<<< $resp)
-                commits=$(jq -r .commits \<<< $resp)
                 user=$(jq -r .user.login \<<< $resp)
                 
-                echo base_ref=$base_ref, head_ref=$head_ref, commits=$commits
-                echo base_sha=$base_sha, head_sha=$head_sha, commits=$commits
+                echo head_ref=$head_ref, user=$user
 
-                # CIRCLE_PR_USERNAME (forked PRs)
+                # CIRCLE_PR_USERNAME (only forked PRs)
                 echo CIRCLE_PR_USERNAME=$CIRCLE_PR_USERNAME, user=$user
-                mkdir user-clone
+                git clone https://github.com/$user/transformers user-clone
                 cd user-clone
-                pwd
-                git clone https://github.com/$user/transformers
-                cd transformers
                 git checkout $head_ref
-                git merge-base --fork-point master
-                echo done
+                fork_point_sha=$(git merge-base --fork-point master)
+                cd -
 
-                echo log
-                git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -$(($commits+1)) || if [[ $? -eq 141 ]]; then true; else exit $?; fi
-
-                echo current branch
-                git rev-parse --abbrev-ref HEAD
-
-                circle_head_sha=$(git rev-parse $CIRCLE_BRANCH)
-                base_ref=$(jq -r .base.ref \<<< $resp)
-                echo CIRCLE_BRANCH=$CIRCLE_BRANCH circle_head_sha=$circle_head_sha head_ref=$head_ref
-                if test -n "$circle_head_sha" && test -n "$head_sha"
-                then
-                    echo base_ref CIRCLE_BRANCH
-                    git --no-pager diff --name-only $base_ref $CIRCLE_BRANCH
-                    echo base_sha circle_head_sha
-                    git --no-pager diff --name-only $base_sha $circle_head_sha
-                fi
-
-            fi
-
-            if test -n "$base_sha" && test -n "$head_sha" && test -n "$(git diff --name-only $base_sha $head_sha)"
+            if test -n "$fork_point_sha" && test -n "$(git diff --name-only $fork_point_sha)"
             then
-
-                echo count backward $commits commits
-                git --no-pager diff --name-only HEAD~$commits
-                
-                echo github api note: base.sha could be outdated
-                git --no-pager diff --name-only $base_sha $head_sha
-
-                if git diff --name-only $base_sha $head_sha | egrep -qv '\.(md|rst)$'
+                if git diff --name-only $fork_point_sha | egrep -qv '\.(md|rst)$'
                 then
                     echo "Non-docs were modified in this PR, proceeding normally"
                 else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,16 +20,17 @@ commands:
 
                 echo log
                 git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -15
-            fi
-
-            if test -n "$base_sha" && test -n "$head_sha" && test -n "$(git diff --name-only $base_sha $head_sha)"
-            then
-
+                
                 echo github api (base.sha could be outdated)
                 git --no-pager diff --name-only $base_sha $head_sha
 
                 echo count backward $commits commits
                 git --no-pager diff --name-only HEAD~$commits
+
+            fi
+
+            if test -n "$base_sha" && test -n "$head_sha" && test -n "$(git diff --name-only $base_sha $head_sha)"
+            then
 
                 if git diff --name-only $base_sha $head_sha | egrep -qv '\.(yml|md|rst)$'
                 then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,24 +14,24 @@ commands:
             if test -n "$CIRCLE_PR_NUMBER"
             then
                 # resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
-                # base_ref=$(jq -r .base.ref \<<< $resp)
-                # head_ref=$(jq -r .head.ref \<<< $resp)
-                git merge-base --fork-point master
-                echo $base_ref $head_ref $CIRCLE_SHA1
-                git diff --name-only master $CIRCLE_SHA1
-                head=$(git rev-parse HEAD)
-                base=$(git rev-parse --verify refs/heads/master)
-                echo base: $base head: $head 
-                git diff --name-only $base $head
-                git log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -15
+                base_sha=$(jq -r .base.sha \<<< $resp)
+                head_sha=$(jq -r .head.sha \<<< $resp)
+                commits=$(jq -r .commits \<<< $resp)
+
+                echo log
+                git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -15
             fi
 
-            #if test -n "$base_ref" && test -n "$head_ref" && test -n "$(git diff --name-only $base_ref $head_ref)"
-            if test -n "$base_ref" && test -n "$head_ref" && test -n "$(git diff --name-only master $CIRCLE_SHA1)"
+            if test -n "$base_sha" && test -n "$head_sha" && test -n "$(git diff --name-only $base_sha $head_sha)"
             then
-                # XXX: remove the next debug line when ready
-                git diff --name-only master $CIRCLE_SHA1
-                if git diff --name-only $base_ref $head_ref | egrep -qv '\.(yml|md|rst)$'
+
+                echo github api (base.sha could be outdated)
+                git --no-pager diff --name-only $base_sha $head_sha
+
+                echo count backward $commits commits
+                git --no-pager diff --name-only HEAD~$commits
+
+                if git diff --name-only $base_sha $head_sha | egrep -qv '\.(yml|md|rst)$'
                 then
                     echo "Non-docs were modified in this PR, proceeding normally"
                 else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ commands:
                 git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -$(($commits+1)) || if [[ $? -eq 141 ]]; then true; else exit $?; fi
 
                 echo current branch
-                git branch --show-current
+                git rev-parse --abbrev-ref HEAD
 
                 circle_base_sha=$(git rev-parse $CIRCLE_BRANCH)
                 head_ref=$(jq -r .head.ref \<<< $resp)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,12 @@ commands:
                 resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
                 base_sha=$(jq -r .base.sha \<<< $resp)
                 head_sha=$(jq -r .head.sha \<<< $resp)
+                base_ref=$(jq -r .base.ref \<<< $resp)
+                head_ref=$(jq -r .head.ref \<<< $resp)
                 commits=$(jq -r .commits \<<< $resp)
+
+                git fetch upstream pull/$CIRCLE_PR_NUMBER/head && git checkout FETCH_HEAD
+                git merge-base --fork-point master
 
                 echo base_sha=$base_sha, head_sha=$head_sha, commits=$commits
                 
@@ -33,9 +38,9 @@ commands:
                 if test -n "$circle_head_sha" && test -n "$head_sha"
                 then
                     echo base_ref CIRCLE_BRANCH
-                    git diff --name-only $base_ref $CIRCLE_BRANCH
+                    git --no-pager diff --name-only $base_ref $CIRCLE_BRANCH
                     echo base_sha circle_head_sha
-                    git diff --name-only $base_sha $circle_head_sha
+                    git --no-pager diff --name-only $base_sha $circle_head_sha
                 fi
 
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,13 @@ commands:
                 echo log
                 git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -$(($commits+1)) || if [[ $? -eq 141 ]]; then true; else exit $?; fi
 
+                head_ref=$(jq -r .head.ref \<<< $resp)
+                echo CIRCLE_BRANCH=$CIRCLE_BRANCH head_ref=$head_ref
+                if test -n "$head_ref" && test -n "$CIRCLE_BRANCH" && test -n "$(git diff --name-only ${CIRCLE_BRANCH}..${head_ref})"
+                then
+                    git diff --name-only ${CIRCLE_BRANCH}..${head_ref}
+                fi
+
             fi
 
             if test -n "$base_sha" && test -n "$head_sha" && test -n "$(git diff --name-only $base_sha $head_sha)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,14 +18,17 @@ commands:
                 head_sha=$(jq -r .head.sha \<<< $resp)
                 commits=$(jq -r .commits \<<< $resp)
 
+                echo base_sha=$base_sha, head_sha=$head_sha, commits=$commits
+
                 echo log
                 git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -15
+                
+                echo count backward $commits commits
+                git --no-pager diff --name-only HEAD~$commits
                 
                 echo github api base.sha could be outdated
                 git --no-pager diff --name-only $base_sha $head_sha
 
-                echo count backward $commits commits
-                git --no-pager diff --name-only HEAD~$commits
 
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
                 resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
                 base_ref=$(jq -r .base.ref \<<< $resp)
                 head_ref=$(jq -r .head.ref \<<< $resp)
-                echo "$(base_ref}..${head_ref}"
+                echo {base_ref}..${head_ref}
             fi
 
             if test -n "${base_ref}" && test -n "${head_ref}" && test -n "$(git diff --name-only ${base_ref}..${head_ref})"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
           command: |
             if test -n "$CIRCLE_PR_NUMBER"
             then
-                # resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
+                resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
                 base_sha=$(jq -r .base.sha \<<< $resp)
                 head_sha=$(jq -r .head.sha \<<< $resp)
                 commits=$(jq -r .commits \<<< $resp)
@@ -21,7 +21,7 @@ commands:
                 echo base_sha=$base_sha, head_sha=$head_sha, commits=$commits
 
                 echo log
-                git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -15
+                git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -20
                 
                 echo count backward $commits commits
                 git --no-pager diff --name-only HEAD~$commits

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
                 resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
                 base_ref=$(jq -r .base.ref \<<< $resp)
                 head_ref=$(jq -r .head.ref \<<< $resp)
-                echo {base_ref} ${head_ref}
+                echo ${base_ref} ${head_ref}
             fi
 
             if test -n "${base_ref}" && test -n "${head_ref}" && test -n "$(git diff --name-only ${base_ref} ${head_ref})"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
 
                 head_ref=$(jq -r .head.ref \<<< $resp)
                 echo CIRCLE_BRANCH=$CIRCLE_BRANCH head_ref=$head_ref
-                if test -n "$head_ref" && test -n "$CIRCLE_BRANCH" && test -n "$(git diff --name-only ${CIRCLE_BRANCH}..${head_sha})"
+                if test -n "$head_ref" && test -n "$CIRCLE_BRANCH"
                 then
                     echo with head_sha
                     git diff --name-only ${CIRCLE_BRANCH}..${head_sha}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,21 +17,21 @@ commands:
                 resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
                 head_ref=$(jq -r .head.ref \<<< $resp)
                 user=$(jq -r .user.login \<<< $resp)
-                
                 echo head_ref=$head_ref, user=$user
-
-                # CIRCLE_PR_USERNAME (only forked PRs)
-                echo CIRCLE_PR_USERNAME=$CIRCLE_PR_USERNAME, user=$user
-                git clone https://github.com/$user/transformers user-clone
-                cd user-clone
-                git checkout $head_ref
-                fork_point_sha=$(git merge-base --fork-point master)
-                cd -
+            fi
+            
+            if test -n "$user" and test -n "$head_ref"
+            then
+                git clone https://github.com/$user/transformers user-clone &&
+                cd user-clone &&
+                git checkout $head_ref &&
+                fork_point_sha=$(git merge-base --fork-point master) &&
+                cd - || true
             fi
 
             if test -n "$fork_point_sha" && test -n "$(git diff --name-only $fork_point_sha)"
             then
-                git diff --name-only $fork_point_sha
+                git --no-pager diff --name-only $fork_point_sha
                 if git diff --name-only $fork_point_sha | egrep -qv '\.(md|rst)$'
                 then
                     echo "Non-docs were modified in this PR, proceeding normally"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,15 +27,15 @@ commands:
                 echo current branch
                 git rev-parse --abbrev-ref HEAD
 
-                circle_base_sha=$(git rev-parse $CIRCLE_BRANCH)
-                head_ref=$(jq -r .head.ref \<<< $resp)
-                echo CIRCLE_BRANCH=$CIRCLE_BRANCH circle_base_sha=$circle_base_sha head_ref=$head_ref
-                if test -n "$circle_base_sha" && test -n "$head_sha"
+                circle_head_sha=$(git rev-parse $CIRCLE_BRANCH)
+                base_ref=$(jq -r .base.ref \<<< $resp)
+                echo CIRCLE_BRANCH=$CIRCLE_BRANCH circle_head_sha=$circle_head_sha head_ref=$head_ref
+                if test -n "$circle_head_sha" && test -n "$head_sha"
                 then
-                    echo with head_sha
-                    git diff --name-only $CIRCLE_BRANCH $head_sha
-                    echo with HEAD
-                    git diff --name-only $CIRCLE_BRANCH HEAD
+                    echo base_ref CIRCLE_BRANCH
+                    git diff --name-only $base_ref $CIRCLE_BRANCH
+                    echo base_sha circle_head_sha
+                    git diff --name-only $base_sha $circle_head_sha
                 fi
 
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
                 echo log
                 git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -15
                 
-                echo github api (base.sha could be outdated)
+                echo github api base.sha could be outdated
                 git --no-pager diff --name-only $base_sha $head_sha
 
                 echo count backward $commits commits

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
 
                 head_ref=$(jq -r .head.ref \<<< $resp)
                 echo CIRCLE_BRANCH=$CIRCLE_BRANCH head_ref=$head_ref
-                if test -n "$head_ref" && test -n "$CIRCLE_BRANCH" && test -n "$(git diff --name-only ${CIRCLE_BRANCH}..${head_ref})"
+                if test -n "$head_ref" && test -n "$CIRCLE_BRANCH" && test -n "$(git diff --name-only ${CIRCLE_BRANCH}..${head_sha})"
                 then
                     echo with head_sha
                     git diff --name-only ${CIRCLE_BRANCH}..${head_sha}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,14 +16,14 @@ commands:
                 resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
                 base_ref=$(jq -r .base.ref \<<< $resp)
                 head_ref=$(jq -r .head.ref \<<< $resp)
-                echo {base_ref}..${head_ref}
+                echo {base_ref} ${head_ref}
             fi
 
-            if test -n "${base_ref}" && test -n "${head_ref}" && test -n "$(git diff --name-only ${base_ref}..${head_ref})"
+            if test -n "${base_ref}" && test -n "${head_ref}" && test -n "$(git diff --name-only ${base_ref} ${head_ref})"
             then
                 # XXX: remove the next debug line when ready
-                git diff --name-only ${base_ref}..${head_ref}
-                if git diff --name-only ${base_ref}..${head_ref} | egrep -qv '\.(md|rst)$'
+                git diff --name-only ${base_ref} ${head_ref}
+                if git diff --name-only ${base_ref} ${head_ref} | egrep -qv '\.(md|rst)$'
                 then
                     echo "Non-docs were modified in this PR, proceeding normally"
                 else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ commands:
             if test -n "$CIRCLE_PR_NUMBER"
             then
                 resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
-                base_ref=$(jq -r .base.ref \\<<< $resp)
-                head_ref=$(jq -r .head.ref \\<<< $resp)
+                base_ref=$(jq -r .base.ref \<<< $resp)
+                head_ref=$(jq -r .head.ref \<<< $resp)
                 echo "$(base_ref}..${head_ref}"
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ commands:
 
                 echo base_sha=$base_sha, head_sha=$head_sha, commits=$commits
 
-                echo log
-                git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -20
+                #echo log
+                #git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -20
                 
                 echo count backward $commits commits
                 git --no-pager diff --name-only HEAD~$commits

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ commands:
             if test -n "$CIRCLE_PR_NUMBER"
             then
                 resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
-                base_ref=$(jq -r .base.ref <<< $resp)
-                head_ref=$(jq -r .head.ref <<< $resp)
+                base_ref=$(jq -r .base.ref \\<<< $resp)
+                head_ref=$(jq -r .head.ref \\<<< $resp)
                 echo "$(base_ref}..${head_ref}"
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ commands:
           command: |
             if test -n "$CIRCLE_PR_NUMBER"
             then
+                echo $CIRCLE_PR_NUMBER
                 resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
                 base_sha=$(jq -r .base.sha \<<< $resp)
                 head_sha=$(jq -r .head.sha \<<< $resp)
@@ -32,9 +33,9 @@ commands:
                 if test -n "$circle_base_sha" && test -n "$head_sha"
                 then
                     echo with head_sha
-                    git diff --name-only $circle_base_sha $head_sha
+                    git diff --name-only $CIRCLE_BRANCH $head_sha
                     echo with HEAD
-                    git diff --name-only $circle_base_sha HEAD
+                    git diff --name-only $CIRCLE_BRANCH HEAD
                 fi
 
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,13 @@ commands:
                 echo CIRCLE_BRANCH=$CIRCLE_BRANCH head_ref=$head_ref
                 if test -n "$head_ref" && test -n "$CIRCLE_BRANCH" && test -n "$(git diff --name-only ${CIRCLE_BRANCH}..${head_ref})"
                 then
-                    git diff --name-only ${CIRCLE_BRANCH}..${head_ref}
+                    #echo with head_ref
+                    #git diff --name-only ${CIRCLE_BRANCH}..${head_ref}
+                    echo with HEAD
+                    git diff --name-only ${CIRCLE_BRANCH}..HEAD
                 fi
+
+              
 
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ commands:
                 echo log
                 git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -$(($commits+1)) || if [[ $? -eq 141 ]]; then true; else exit $?; fi
 
+                echo current branch
+                git branch --show-current
+
                 circle_base_sha=$(git rev-parse $CIRCLE_BRANCH)
                 head_ref=$(jq -r .head.ref \<<< $resp)
                 echo CIRCLE_BRANCH=$CIRCLE_BRANCH circle_base_sha=$circle_base_sha head_ref=$head_ref

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,8 @@ commands:
 
                 # CIRCLE_PR_USERNAME (forked PRs)
                 echo CIRCLE_PR_USERNAME=$CIRCLE_PR_USERNAME, user=$user
+                mkdir user-clone
+                cd user-clone
                 git clone --branch $head_ref https://github.com/$user/transformers
                 cd transformers
                 git merge-base --fork-point master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
             then
                 # XXX: remove the next debug line when ready
                 git diff --name-only ${base_ref} ${head_ref}
-                if git diff --name-only ${base_ref} ${head_ref} | egrep -qv '\.(md|rst)$'
+                if git diff --name-only ${base_ref} ${head_ref} | egrep -qv '\.(yml|md|rst)$'
                 then
                     echo "Non-docs were modified in this PR, proceeding normally"
                 else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,21 +19,20 @@ commands:
                 commits=$(jq -r .commits \<<< $resp)
 
                 echo base_sha=$base_sha, head_sha=$head_sha, commits=$commits
-
-                #echo log
-                #git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -20
                 
-                echo count backward $commits commits
-                git --no-pager diff --name-only HEAD~$commits
-                
-                echo github api base.sha could be outdated
-                git --no-pager diff --name-only $base_sha $head_sha
-
+                echo log
+                git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -$(($commits+1)) || if [[ $? -eq 141 ]]; then true; else exit $?; fi
 
             fi
 
             if test -n "$base_sha" && test -n "$head_sha" && test -n "$(git diff --name-only $base_sha $head_sha)"
             then
+
+                echo count backward $commits commits
+                git --no-pager diff --name-only HEAD~$commits
+                
+                echo github api base.sha could be outdated
+                git --no-pager diff --name-only $base_sha $head_sha
 
                 if git diff --name-only $base_sha $head_sha | egrep -qv '\.(yml|md|rst)$'
                 then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,11 @@ commands:
                 git merge-base --fork-point master
                 echo $base_ref $head_ref $CIRCLE_SHA1
                 git diff --name-only master $CIRCLE_SHA1
+                head=$(git rev-parse HEAD)
+                base=$(git rev-parse --verify refs/heads/master)
+                echo base: $base head: $head 
+                git diff --name-only $base $head
+                git log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -15
             fi
 
             #if test -n "$base_ref" && test -n "$head_ref" && test -n "$(git diff --name-only $base_ref $head_ref)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,10 @@ commands:
                 echo count backward $commits commits
                 git --no-pager diff --name-only HEAD~$commits
                 
-                echo github api base.sha could be outdated
+                echo github api note: base.sha could be outdated
                 git --no-pager diff --name-only $base_sha $head_sha
 
-                if git diff --name-only $base_sha $head_sha | egrep -qv '\.(yml|md|rst)$'
+                if git diff --name-only $base_sha $head_sha | egrep -qv '\.(md|rst)$'
                 then
                     echo "Non-docs were modified in this PR, proceeding normally"
                 else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,8 @@ commands:
                 echo CIRCLE_BRANCH=$CIRCLE_BRANCH head_ref=$head_ref
                 if test -n "$head_ref" && test -n "$CIRCLE_BRANCH" && test -n "$(git diff --name-only ${CIRCLE_BRANCH}..${head_ref})"
                 then
-                    #echo with head_ref
-                    #git diff --name-only ${CIRCLE_BRANCH}..${head_ref}
+                    echo with head_sha
+                    git diff --name-only ${CIRCLE_BRANCH}..${head_sha}
                     echo with HEAD
                     git diff --name-only ${CIRCLE_BRANCH}..HEAD
                 fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,12 @@ commands:
                 echo CIRCLE_PR_USERNAME=$CIRCLE_PR_USERNAME, user=$user
                 mkdir user-clone
                 cd user-clone
-                git clone --branch $head_ref https://github.com/$user/transformers
+                pwd
+                git clone https://github.com/$user/transformers
                 cd transformers
+                git checkout $head_ref
                 git merge-base --fork-point master
+                echo done
 
                 echo log
                 git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -$(($commits+1)) || if [[ $? -eq 141 ]]; then true; else exit $?; fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ commands:
                 # resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
                 # base_ref=$(jq -r .base.ref \<<< $resp)
                 # head_ref=$(jq -r .head.ref \<<< $resp)
+                git merge-base --fork-point master
                 echo $base_ref $head_ref $CIRCLE_SHA1
                 git diff --name-only master $CIRCLE_SHA1
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,18 +23,6 @@ commands:
                 echo log
                 git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -$(($commits+1)) || if [[ $? -eq 141 ]]; then true; else exit $?; fi
 
-                head_ref=$(jq -r .head.ref \<<< $resp)
-                echo CIRCLE_BRANCH=$CIRCLE_BRANCH head_ref=$head_ref
-                if test -n "$head_ref" && test -n "$CIRCLE_BRANCH"
-                then
-                    echo with head_sha
-                    git diff --name-only ${CIRCLE_BRANCH}..${head_sha}
-                    echo with HEAD
-                    git diff --name-only ${CIRCLE_BRANCH}..HEAD
-                fi
-
-              
-
             fi
 
             if test -n "$base_sha" && test -n "$head_sha" && test -n "$(git diff --name-only $base_sha $head_sha)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,17 @@ commands:
                 echo log
                 git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -$(($commits+1)) || if [[ $? -eq 141 ]]; then true; else exit $?; fi
 
+                circle_base_sha=$(git rev-parse $CIRCLE_BRANCH)
+                head_ref=$(jq -r .head.ref \<<< $resp)
+                echo CIRCLE_BRANCH=$CIRCLE_BRANCH circle_base_sha=$circle_base_sha head_ref=$head_ref
+                if test -n "$circle_base_sha" && test -n "$head_sha"
+                then
+                    echo with head_sha
+                    git diff --name-only $circle_base_sha $head_sha
+                    echo with HEAD
+                    git diff --name-only $circle_base_sha HEAD
+                fi
+
             fi
 
             if test -n "$base_sha" && test -n "$head_sha" && test -n "$(git diff --name-only $base_sha $head_sha)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,18 +15,18 @@ commands:
             then
                 echo $CIRCLE_PR_NUMBER
                 resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
-                head_ref=$(jq -r .head.ref \<<< $resp)
-                user=$(jq -r .user.login \<<< $resp)
+                user=$(jq -r .user.login \<<< $resp)   # PR creator username
+                head_ref=$(jq -r .head.ref \<<< $resp) # PR user's branch name
                 echo head_ref=$head_ref, user=$user
             fi
             
-            if test -n "$user" and test -n "$head_ref"
+            if test -n "$user" && test -n "$head_ref"
             then
-                git clone https://github.com/$user/transformers user-clone &&
-                cd user-clone &&
-                git checkout $head_ref &&
-                fork_point_sha=$(git merge-base --fork-point master) &&
-                cd - || true
+                git clone https://github.com/$user/transformers user-clone
+                cd user-clone
+                git checkout $head_ref
+                fork_point_sha=$(git merge-base --fork-point master)
+                cd -
             fi
 
             if test -n "$fork_point_sha" && test -n "$(git diff --name-only $fork_point_sha)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,14 +16,15 @@ commands:
                 resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
                 base_ref=$(jq -r .base.ref \<<< $resp)
                 head_ref=$(jq -r .head.ref \<<< $resp)
-                echo ${base_ref} ${head_ref}
+                echo $base_ref $head_ref $CIRCLE_SHA1
+                git diff --name-only $base_ref $CIRCLE_SHA1
             fi
 
-            if test -n "${base_ref}" && test -n "${head_ref}" && test -n "$(git diff --name-only ${base_ref} ${head_ref})"
+            if test -n "$base_ref" && test -n "$head_ref" && test -n "$(git diff --name-only $base_ref $head_ref)"
             then
                 # XXX: remove the next debug line when ready
-                git diff --name-only ${base_ref} ${head_ref}
-                if git diff --name-only ${base_ref} ${head_ref} | egrep -qv '\.(yml|md|rst)$'
+                git diff --name-only $base_ref $head_ref
+                if git diff --name-only $base_ref $head_ref | egrep -qv '\.(yml|md|rst)$'
                 then
                     echo "Non-docs were modified in this PR, proceeding normally"
                 else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ commands:
                 git checkout $head_ref
                 fork_point_sha=$(git merge-base --fork-point master)
                 cd -
+            fi
 
             if test -n "$fork_point_sha" && test -n "$(git diff --name-only $fork_point_sha)"
             then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ commands:
 
             if test -n "$fork_point_sha" && test -n "$(git diff --name-only $fork_point_sha)"
             then
+                git diff --name-only $fork_point_sha
                 if git diff --name-only $fork_point_sha | egrep -qv '\.(md|rst)$'
                 then
                     echo "Non-docs were modified in this PR, proceeding normally"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,15 @@ commands:
                 base_ref=$(jq -r .base.ref \<<< $resp)
                 head_ref=$(jq -r .head.ref \<<< $resp)
                 commits=$(jq -r .commits \<<< $resp)
-
+                user=$(jq -r .user.login \<<< $resp)
+                
                 echo base_ref=$base_ref, head_ref=$head_ref, commits=$commits
                 echo base_sha=$base_sha, head_sha=$head_sha, commits=$commits
-                
-                git fetch origin pull/$CIRCLE_PR_NUMBER/head
-                git checkout $head_ref
+
+                # CIRCLE_PR_USERNAME (forked PRs)
+                echo CIRCLE_PR_USERNAME=$CIRCLE_PR_USERNAME, user=$user
+                git clone --branch $head_ref https://github.com/$user/transformers
+                cd transformers
                 git merge-base --fork-point master
 
                 echo log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
                 head_ref=$(jq -r .head.ref \<<< $resp)
                 commits=$(jq -r .commits \<<< $resp)
 
-                git fetch upstream pull/$CIRCLE_PR_NUMBER/head && git checkout FETCH_HEAD
+                git fetch origin pull/$CIRCLE_PR_NUMBER/head && git checkout FETCH_HEAD
                 git merge-base --fork-point master
 
                 echo base_sha=$base_sha, head_sha=$head_sha, commits=$commits

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,17 +13,18 @@ commands:
           command: |
             if test -n "$CIRCLE_PR_NUMBER"
             then
-                resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
-                base_ref=$(jq -r .base.ref \<<< $resp)
-                head_ref=$(jq -r .head.ref \<<< $resp)
+                # resp=$(curl -Ls https://api.github.com/repos/huggingface/transformers/pulls/${CIRCLE_PR_NUMBER})
+                # base_ref=$(jq -r .base.ref \<<< $resp)
+                # head_ref=$(jq -r .head.ref \<<< $resp)
                 echo $base_ref $head_ref $CIRCLE_SHA1
-                git diff --name-only $base_ref $CIRCLE_SHA1
+                git diff --name-only master $CIRCLE_SHA1
             fi
 
-            if test -n "$base_ref" && test -n "$head_ref" && test -n "$(git diff --name-only $base_ref $head_ref)"
+            #if test -n "$base_ref" && test -n "$head_ref" && test -n "$(git diff --name-only $base_ref $head_ref)"
+            if test -n "$base_ref" && test -n "$head_ref" && test -n "$(git diff --name-only master $CIRCLE_SHA1)"
             then
                 # XXX: remove the next debug line when ready
-                git diff --name-only $base_ref $head_ref
+                git diff --name-only master $CIRCLE_SHA1
                 if git diff --name-only $base_ref $head_ref | egrep -qv '\.(yml|md|rst)$'
                 then
                     echo "Non-docs were modified in this PR, proceeding normally"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,13 @@ commands:
                 head_ref=$(jq -r .head.ref \<<< $resp)
                 commits=$(jq -r .commits \<<< $resp)
 
-                git fetch origin pull/$CIRCLE_PR_NUMBER/head && git checkout FETCH_HEAD
-                git merge-base --fork-point master
-
+                echo base_ref=$base_ref, head_ref=$head_ref, commits=$commits
                 echo base_sha=$base_sha, head_sha=$head_sha, commits=$commits
                 
+                git fetch origin pull/$CIRCLE_PR_NUMBER/head
+                git checkout $head_ref
+                git merge-base --fork-point master
+
                 echo log
                 git --no-pager log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit | head -$(($commits+1)) || if [[ $? -eq 141 ]]; then true; else exit $?; fi
 


### PR DESCRIPTION
This is take 4 on attempting to find a reliable way to get a list of modified files of this PR.

Spent the whole day trying many different ideas, none worked. github API for 
`https://api.github.com/repos/${CIRCLE_USERNAME}/${CIRCLE_REPO_NAME}/pulls/${CIRCLE_PR_NUMER}"`
is broken. It gives a bogus `base.sha` at times, e.g. when someone force-pushes into master and then you end up with a base.sha which has nothing to do with the fork. on github website everything is valid, but github API gives bogus info.

So after many attempts I give up on trying to get a reliable way via the SHA information provided via github or circleCI.

The only solution that seems to work is to replicate user's original branch on their fork. Cost is about 3secs.

To do that one has to clone user's repo, switch to their branch and find the branching point identical to what `make fixup` does. This is what the latest incarnation of this PR does.

This PR doesn't enable the skipping yet, just reporting what it would have done and dumps the list of modified files so that we could check if we get some edge cases again which this incarnation doesn't cover. 

Please have a look and see if it looks safe to merge and then monitor for a while and if all seems in order then we can enable skipping.

This PR will not be able to handle PRs originating from github direct file edit as it can be seen from https://github.com/huggingface/transformers/pull/8997 as CircleCI fails to pass PR number to the job in this situation :( The whole skip check is skipped in that case the job continues normally - we just don't get the saving on direct doc PRs. I'm still trying to see if CircleCI should be providing this data, since according to https://developer.github.com/webhooks/event-payloads/#pull_request this hook should be sending PR number to circleCI.

When I had the idea first little did I know that this trivial one-liner on user-side (we use it in `make fixup`) will turn out to be such a complicated and unreliable thing on CI.

@LysandreJik 