### PR TITLE
Tensor arrays

### DIFF
--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -422,13 +422,13 @@ class TFAlbertTransformer(tf.keras.layers.Layer):
 
             if output_attentions:
                 all_attentions = all_attentions + layer_group_output[-1]
-                
+
             if output_hidden_states:
                 all_hidden_states = all_hidden_states + (hidden_states,)
 
         if output_attentions:
             all_attentions = tf.convert_to_tensor(all_attentions)
-        
+
         if output_hidden_states:
             all_hidden_states = tf.convert_to_tensor(all_hidden_states)
 

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -422,9 +422,15 @@ class TFAlbertTransformer(tf.keras.layers.Layer):
 
             if output_attentions:
                 all_attentions = all_attentions + layer_group_output[-1]
-
+                
             if output_hidden_states:
                 all_hidden_states = all_hidden_states + (hidden_states,)
+
+        if output_attentions:
+            all_attentions = tf.convert_to_tensor(all_attentions)
+        
+        if output_hidden_states:
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
 
         if not return_dict:
             return tuple(v for v in [hidden_states, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -632,9 +632,10 @@ class TFBartDecoder(tf.keras.layers.Layer):
             all_hidden_states += (x,)
             # T x B x C -> B x T x C
             all_hidden_states = tuple(tf.transpose(hs, perm=(1, 0, 2)) for hs in all_hidden_states)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
         else:
             all_hidden_states = None
-        all_self_attns = list(all_self_attns) if output_attentions else None
+        all_self_attns = tf.convert_to_tensor(list(all_self_attns)) if output_attentions else None
 
         x = tf.transpose(x, perm=(1, 0, 2))
         encoder_hidden_states = tf.transpose(encoder_hidden_states, perm=(1, 0, 2))  # could maybe be avoided.

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -442,7 +442,7 @@ class TFBertEncoder(tf.keras.layers.Layer):
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
             all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-        
+
         if output_attentions:
             all_attentions = tf.convert_to_tensor(all_attentions)
 

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -441,6 +441,10 @@ class TFBertEncoder(tf.keras.layers.Layer):
         # Add last layer
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
+        
+        if output_attentions:
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not return_dict:
             return tuple(v for v in [hidden_states, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/ctrl/modeling_tf_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_tf_ctrl.py
@@ -397,11 +397,13 @@ class TFCTRLMainLayer(tf.keras.layers.Layer):
         hidden_states = tf.reshape(hidden_states, output_shape)
         if inputs["output_hidden_states"]:
             all_hidden_states = all_hidden_states + (hidden_states,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
 
         if inputs["output_attentions"]:
             # let the number of heads free (-1) so we can extract attention even after head pruning
             attention_output_shape = input_shape[:-1] + [-1] + shape_list(all_attentions[0])[-2:]
             all_attentions = tuple(tf.reshape(t, attention_output_shape) for t in all_attentions)
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not inputs["return_dict"]:
             return tuple(v for v in [hidden_states, presents, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/distilbert/modeling_tf_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_tf_distilbert.py
@@ -375,7 +375,7 @@ class TFTransformer(tf.keras.layers.Layer):
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_state,)
             all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-        
+
         if output_attentions:
             all_attentions = tf.convert_to_tensor(all_attentions)
 

--- a/src/transformers/models/distilbert/modeling_tf_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_tf_distilbert.py
@@ -374,6 +374,10 @@ class TFTransformer(tf.keras.layers.Layer):
         # Add last layer
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_state,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
+        
+        if output_attentions:
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not return_dict:
             return tuple(v for v in [hidden_state, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/electra/modeling_tf_electra.py
+++ b/src/transformers/models/electra/modeling_tf_electra.py
@@ -278,7 +278,7 @@ class TFElectraEncoder(tf.keras.layers.Layer):
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
             all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-        
+
         if output_attentions:
             all_attentions = tf.convert_to_tensor(all_attentions)
 

--- a/src/transformers/models/electra/modeling_tf_electra.py
+++ b/src/transformers/models/electra/modeling_tf_electra.py
@@ -277,6 +277,10 @@ class TFElectraEncoder(tf.keras.layers.Layer):
         # Add last layer
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
+        
+        if output_attentions:
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not return_dict:
             return tuple(v for v in [hidden_states, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -678,10 +678,10 @@ class TFFunnelEncoder(tf.keras.layers.Layer):
 
         if output_hidden_states:
             all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-        
+
         if output_attentions:
             all_attentions = tf.convert_to_tensor(all_attentions)
-        
+
         if not return_dict:
             return tuple(v for v in [hidden, all_hidden_states, all_attentions] if v is not None)
         return TFBaseModelOutput(last_hidden_state=hidden, hidden_states=all_hidden_states, attentions=all_attentions)

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -676,6 +676,12 @@ class TFFunnelEncoder(tf.keras.layers.Layer):
                     if output_hidden_states:
                         all_hidden_states = all_hidden_states + (hidden,)
 
+        if output_hidden_states:
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
+        
+        if output_attentions:
+            all_attentions = tf.convert_to_tensor(all_attentions)
+        
         if not return_dict:
             return tuple(v for v in [hidden, all_hidden_states, all_attentions] if v is not None)
         return TFBaseModelOutput(last_hidden_state=hidden, hidden_states=all_hidden_states, attentions=all_attentions)

--- a/src/transformers/models/gpt2/modeling_tf_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_tf_gpt2.py
@@ -388,11 +388,13 @@ class TFGPT2MainLayer(tf.keras.layers.Layer):
         # Add last hidden state
         if inputs["output_hidden_states"]:
             all_hidden_states = all_hidden_states + (hidden_states,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
 
         if inputs["output_attentions"]:
             # let the number of heads free (-1) so we can extract attention even after head pruning
             attention_output_shape = input_shape[:-1] + [-1] + shape_list(all_attentions[0])[-2:]
             all_attentions = tuple(tf.reshape(t, attention_output_shape) for t in all_attentions)
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not inputs["return_dict"]:
             return tuple(v for v in [hidden_states, presents, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -1548,6 +1548,10 @@ class TFLongformerEncoder(tf.keras.layers.Layer):
         if output_hidden_states:
             hidden_states_to_add = hidden_states[:, :-padding_len] if padding_len > 0 else hidden_states
             all_hidden_states = all_hidden_states + (hidden_states_to_add,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
+        
+        if output_hidden_states:
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not return_dict:
             return tuple(

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -1549,7 +1549,7 @@ class TFLongformerEncoder(tf.keras.layers.Layer):
             hidden_states_to_add = hidden_states[:, :-padding_len] if padding_len > 0 else hidden_states
             all_hidden_states = all_hidden_states + (hidden_states_to_add,)
             all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-        
+
         if output_hidden_states:
             all_attentions = tf.convert_to_tensor(all_attentions)
 

--- a/src/transformers/models/lxmert/modeling_tf_lxmert.py
+++ b/src/transformers/models/lxmert/modeling_tf_lxmert.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 
 import tensorflow as tf
+from tensorflow.python.framework.ops import convert_to_tensor
 
 from ...activations_tf import get_tf_activation
 from ...file_utils import (

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -593,7 +593,7 @@ class TFMobileBertEncoder(tf.keras.layers.Layer):
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
             all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-        
+
         if output_attentions:
             all_attentions = tf.convert_to_tensor(all_attentions)
 

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -592,6 +592,10 @@ class TFMobileBertEncoder(tf.keras.layers.Layer):
         # Add last layer
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
+        
+        if output_attentions:
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not return_dict:
             return tuple(v for v in [hidden_states, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/openai/modeling_tf_openai.py
+++ b/src/transformers/models/openai/modeling_tf_openai.py
@@ -337,11 +337,13 @@ class TFOpenAIGPTMainLayer(tf.keras.layers.Layer):
         # Add last hidden state
         if inputs["output_hidden_states"]:
             all_hidden_states = all_hidden_states + (hidden_states,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
 
         if inputs["output_attentions"]:
             # let the number of heads free (-1) so we can extract attention even after head pruning
             attention_output_shape = input_shape[:-1] + [-1] + shape_list(all_attentions[0])[-2:]
             all_attentions = tuple(tf.reshape(t, attention_output_shape) for t in all_attentions)
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not inputs["return_dict"]:
             return tuple(v for v in [hidden_states, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -451,6 +451,10 @@ class TFRobertaEncoder(tf.keras.layers.Layer):
         # Add last layer
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
+        
+        if output_attentions:
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not return_dict:
             return tuple(v for v in [hidden_states, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -452,7 +452,7 @@ class TFRobertaEncoder(tf.keras.layers.Layer):
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
             all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-        
+
         if output_attentions:
             all_attentions = tf.convert_to_tensor(all_attentions)
 

--- a/src/transformers/models/xlm/modeling_tf_xlm.py
+++ b/src/transformers/models/xlm/modeling_tf_xlm.py
@@ -509,6 +509,10 @@ class TFXLMMainLayer(tf.keras.layers.Layer):
         # Add last hidden state
         if inputs["output_hidden_states"]:
             hidden_states = hidden_states + (tensor,)
+            hidden_states = tf.convert_to_tensor(hidden_states)
+        
+        if output_attentions:
+            attentions = tf.convert_to_tensor(attentions)
 
         # update cache length
         if inputs["cache"] is not None:

--- a/src/transformers/models/xlm/modeling_tf_xlm.py
+++ b/src/transformers/models/xlm/modeling_tf_xlm.py
@@ -510,7 +510,7 @@ class TFXLMMainLayer(tf.keras.layers.Layer):
         if inputs["output_hidden_states"]:
             hidden_states = hidden_states + (tensor,)
             hidden_states = tf.convert_to_tensor(hidden_states)
-        
+
         if output_attentions:
             attentions = tf.convert_to_tensor(attentions)
 

--- a/src/transformers/models/xlnet/modeling_tf_xlnet.py
+++ b/src/transformers/models/xlnet/modeling_tf_xlnet.py
@@ -790,6 +790,7 @@ class TFXLNetMainLayer(tf.keras.layers.Layer):
                 hidden_states = tuple(tf.transpose(hs, perm=(1, 0, 2)) for hs in hidden_states)
         if inputs["output_attentions"]:
             attentions = tuple(tf.transpose(t, perm=(2, 3, 0, 1)) for t in attentions)
+            attentions = tf.convert_to_tensor(attentions)
 
         if not inputs["return_dict"]:
             return tuple(v for v in [output, new_mems, hidden_states, attentions] if v is not None)

--- a/src/transformers/models/xlnet/modeling_tf_xlnet.py
+++ b/src/transformers/models/xlnet/modeling_tf_xlnet.py
@@ -788,6 +788,7 @@ class TFXLNetMainLayer(tf.keras.layers.Layer):
                 hidden_states = tuple(tf.transpose(h, perm=(1, 0, 2)) for hs in hidden_states for h in hs)
             else:
                 hidden_states = tuple(tf.transpose(hs, perm=(1, 0, 2)) for hs in hidden_states)
+            hidden_states = tf.convert_to_tensor(hidden_states)
         if inputs["output_attentions"]:
             attentions = tuple(tf.transpose(t, perm=(2, 3, 0, 1)) for t in attentions)
             attentions = tf.convert_to_tensor(attentions)

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -521,6 +521,7 @@ class TFModelTesterMixin:
             out_len = len(outputs)
             self.assertEqual(out_len % 2, 0)
             decoder_attentions = outputs.decoder_attentions
+            self.assertTrue(isinstance(decoder_attentions, tf.Tensor))
             self.assertEqual(len(decoder_attentions), self.model_tester.num_hidden_layers)
             self.assertListEqual(
                 list(decoder_attentions[0].shape[-3:]),
@@ -528,9 +529,8 @@ class TFModelTesterMixin:
             )
 
         def check_encoder_attentions_output(outputs):
-            attentions = [
-                t.numpy() for t in (outputs.encoder_attentions if config.is_encoder_decoder else outputs.attentions)
-            ]
+            attentions = outputs.encoder_attentions if config.is_encoder_decoder else outputs.attentions
+            self.assertTrue(isinstance(attentions, tf.Tensor))
             self.assertEqual(len(attentions), self.model_tester.num_hidden_layers)
             self.assertListEqual(
                 list(attentions[0].shape[-3:]),
@@ -583,6 +583,7 @@ class TFModelTesterMixin:
 
             hidden_states = outputs[-1]
             self.assertEqual(config.output_attentions, False)
+            self.assertTrue(isinstance(hidden_states, tf.Tensor))
             self.assertEqual(len(hidden_states), expected_num_layers)
             self.assertListEqual(
                 list(hidden_states[0].shape[-2:]),


### PR DESCRIPTION
# What does this PR do?

This PR turns the `all_attentions` and `all_hidden_states` values into tensors instead of a tuple. This update is to properly allow the dict outputs in TF serving, because the value of each key cannot be something else than a TF tensor.