### PR TITLE
Remove use of deprecated method in Trainer HP search

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -543,7 +543,7 @@ class Trainer:
             self.args.output_dir = checkpoint_dir
             output_dir = os.path.join(self.args.output_dir, f"{PREFIX_CHECKPOINT_DIR}-{self.state.global_step}")
             self.save_model(output_dir)
-            if self.is_world_master():
+            if self.is_world_process_zero():
                 self.state.save_to_json(os.path.join(output_dir, "trainer_state.json"))
                 torch.save(self.optimizer.state_dict(), os.path.join(output_dir, "optimizer.pt"))
                 torch.save(self.lr_scheduler.state_dict(), os.path.join(output_dir, "scheduler.pt"))


### PR DESCRIPTION
# What does this PR do?

Somehow this one slip in the cracks and was forgotten when we removed old deprecated method. This might warrant a release patch if we don't do a new release soon.

Fixes #8995