### PR TITLE
Turn attentions and hidden-states into a tensor

### DIFF
--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -422,13 +422,13 @@ class TFAlbertTransformer(tf.keras.layers.Layer):
 
             if output_attentions:
                 all_attentions = all_attentions + layer_group_output[-1]
-                
+
             if output_hidden_states:
                 all_hidden_states = all_hidden_states + (hidden_states,)
 
         if output_attentions:
             all_attentions = tf.convert_to_tensor(all_attentions)
-        
+
         if output_hidden_states:
             all_hidden_states = tf.convert_to_tensor(all_hidden_states)
 

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -422,9 +422,15 @@ class TFAlbertTransformer(tf.keras.layers.Layer):
 
             if output_attentions:
                 all_attentions = all_attentions + layer_group_output[-1]
-
+                
             if output_hidden_states:
                 all_hidden_states = all_hidden_states + (hidden_states,)
+
+        if output_attentions:
+            all_attentions = tf.convert_to_tensor(all_attentions)
+        
+        if output_hidden_states:
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
 
         if not return_dict:
             return tuple(v for v in [hidden_states, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -624,9 +624,7 @@ class TFAlbertMainLayer(tf.keras.layers.Layer):
             hidden_states=tf.convert_to_tensor(encoder_outputs.hidden_states)
             if inputs["output_hidden_states"]
             else None,
-            attentions=tf.convert_to_tensor(encoder_outputs.attentions)
-            if inputs["output_attentions"]
-            else None,
+            attentions=tf.convert_to_tensor(encoder_outputs.attentions) if inputs["output_attentions"] else None,
         )
 
 

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -632,9 +632,10 @@ class TFBartDecoder(tf.keras.layers.Layer):
             all_hidden_states += (x,)
             # T x B x C -> B x T x C
             all_hidden_states = tuple(tf.transpose(hs, perm=(1, 0, 2)) for hs in all_hidden_states)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
         else:
             all_hidden_states = None
-        all_self_attns = list(all_self_attns) if output_attentions else None
+        all_self_attns = tf.convert_to_tensor(list(all_self_attns)) if output_attentions else None
 
         x = tf.transpose(x, perm=(1, 0, 2))
         encoder_hidden_states = tf.transpose(encoder_hidden_states, perm=(1, 0, 2))  # could maybe be avoided.

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -397,6 +397,9 @@ class TFBartEncoder(tf.keras.layers.Layer):
         if output_hidden_states:
             encoder_states.append(x)
             encoder_states = [tf.transpose(hidden_state, perm=(1, 0, 2)) for hidden_state in encoder_states]
+            encoder_states = tf.convert_to_tensor(encoder_states)
+        if output_attentions:
+            all_attentions = tf.convert_to_tensor(all_attentions)
         x = tf.transpose(x, perm=(1, 0, 2))
         if not return_dict:
             return tuple(v for v in [x, encoder_states, all_attentions] if v is not None)

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -442,7 +442,7 @@ class TFBertEncoder(tf.keras.layers.Layer):
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
             all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-        
+
         if output_attentions:
             all_attentions = tf.convert_to_tensor(all_attentions)
 

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -441,10 +441,6 @@ class TFBertEncoder(tf.keras.layers.Layer):
         # Add last layer
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
-            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-
-        if output_attentions:
-            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not return_dict:
             return tuple(v for v in [hidden_states, all_hidden_states, all_attentions] if v is not None)
@@ -670,16 +666,23 @@ class TFBertMainLayer(tf.keras.layers.Layer):
         pooled_output = self.pooler(sequence_output) if self.pooler is not None else None
 
         if not inputs["return_dict"]:
-            return (
-                sequence_output,
-                pooled_output,
-            ) + encoder_outputs[1:]
+            idx = 0
+            outputs = (sequence_output, pooled_output)
+            if inputs["output_hidden_states"]:
+                idx += 1
+                outputs = outputs + (tf.convert_to_tensor(encoder_outputs[idx]),)
+            if inputs["output_attentions"]:
+                idx += 1
+                outputs = outputs + (tf.convert_to_tensor(encoder_outputs[idx]),)
+            return outputs
 
         return TFBaseModelOutputWithPooling(
             last_hidden_state=sequence_output,
             pooler_output=pooled_output,
-            hidden_states=encoder_outputs.hidden_states,
-            attentions=encoder_outputs.attentions,
+            hidden_states=tf.convert_to_tensor(encoder_outputs.hidden_states)
+            if inputs["output_hidden_states"]
+            else None,
+            attentions=tf.convert_to_tensor(encoder_outputs.attentions) if inputs["output_attentions"] else None,
         )
 
 

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -441,6 +441,10 @@ class TFBertEncoder(tf.keras.layers.Layer):
         # Add last layer
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
+        
+        if output_attentions:
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not return_dict:
             return tuple(v for v in [hidden_states, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/ctrl/modeling_tf_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_tf_ctrl.py
@@ -397,11 +397,13 @@ class TFCTRLMainLayer(tf.keras.layers.Layer):
         hidden_states = tf.reshape(hidden_states, output_shape)
         if inputs["output_hidden_states"]:
             all_hidden_states = all_hidden_states + (hidden_states,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
 
         if inputs["output_attentions"]:
             # let the number of heads free (-1) so we can extract attention even after head pruning
             attention_output_shape = input_shape[:-1] + [-1] + shape_list(all_attentions[0])[-2:]
             all_attentions = tuple(tf.reshape(t, attention_output_shape) for t in all_attentions)
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not inputs["return_dict"]:
             return tuple(v for v in [hidden_states, presents, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/distilbert/modeling_tf_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_tf_distilbert.py
@@ -375,7 +375,7 @@ class TFTransformer(tf.keras.layers.Layer):
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_state,)
             all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-        
+
         if output_attentions:
             all_attentions = tf.convert_to_tensor(all_attentions)
 

--- a/src/transformers/models/distilbert/modeling_tf_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_tf_distilbert.py
@@ -374,6 +374,10 @@ class TFTransformer(tf.keras.layers.Layer):
         # Add last layer
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_state,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
+        
+        if output_attentions:
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not return_dict:
             return tuple(v for v in [hidden_state, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/electra/modeling_tf_electra.py
+++ b/src/transformers/models/electra/modeling_tf_electra.py
@@ -278,7 +278,7 @@ class TFElectraEncoder(tf.keras.layers.Layer):
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
             all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-        
+
         if output_attentions:
             all_attentions = tf.convert_to_tensor(all_attentions)
 

--- a/src/transformers/models/electra/modeling_tf_electra.py
+++ b/src/transformers/models/electra/modeling_tf_electra.py
@@ -277,6 +277,10 @@ class TFElectraEncoder(tf.keras.layers.Layer):
         # Add last layer
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
+        
+        if output_attentions:
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not return_dict:
             return tuple(v for v in [hidden_states, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/flaubert/modeling_tf_flaubert.py
+++ b/src/transformers/models/flaubert/modeling_tf_flaubert.py
@@ -677,8 +677,8 @@ class TFFlaubertMainLayer(tf.keras.layers.Layer):
         # tensor = tensor.transpose(0, 1)
 
         # Set to None here if the output booleans are at False
-        hidden_states = hidden_states if inputs["output_hidden_states"] else None
-        attentions = attentions if inputs["output_attentions"] else None
+        hidden_states = tf.convert_to_tensor(hidden_states) if inputs["output_hidden_states"] else None
+        attentions = tf.convert_to_tensor(attentions) if inputs["output_attentions"] else None
 
         if not inputs["return_dict"]:
             return tuple(v for v in [tensor, hidden_states, attentions] if v is not None)

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -80,16 +80,16 @@ def tuples_to_ragged_tensors(encoder_output, decoder_output=None):
     for i, v in enumerate(output):
         current_shape = shape_list(output[i])
         padding_shape = []
-    
+
         for ref, current in zip(ref_shape, current_shape):
             padding_shape.append([0, ref - current])
 
         output[i] = tf.pad(output[i], tf.convert_to_tensor(padding_shape), constant_values=-1)
-    
+
     if decoder_output is not None:
         output.extend(decoder_output)
 
-    return tf.RaggedTensor.from_tensor(output, padding=tf.fill(ref_shape[1:], -1.))
+    return tf.RaggedTensor.from_tensor(output, padding=tf.fill(ref_shape[1:], -1.0))
 
 
 class TFFunnelEmbeddings(tf.keras.layers.Layer):
@@ -872,9 +872,7 @@ class TFFunnelBaseLayer(tf.keras.layers.Layer):
             hidden_states=tuples_to_ragged_tensors(encoder_outputs.hidden_states)
             if inputs["output_hidden_states"]
             else None,
-            attentions=tuples_to_ragged_tensors(encoder_outputs.attentions)
-            if inputs["output_attentions"]
-            else None,
+            attentions=tuples_to_ragged_tensors(encoder_outputs.attentions) if inputs["output_attentions"] else None,
         )
 
 

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -678,10 +678,10 @@ class TFFunnelEncoder(tf.keras.layers.Layer):
 
         if output_hidden_states:
             all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-        
+
         if output_attentions:
             all_attentions = tf.convert_to_tensor(all_attentions)
-        
+
         if not return_dict:
             return tuple(v for v in [hidden, all_hidden_states, all_attentions] if v is not None)
         return TFBaseModelOutput(last_hidden_state=hidden, hidden_states=all_hidden_states, attentions=all_attentions)

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -676,6 +676,12 @@ class TFFunnelEncoder(tf.keras.layers.Layer):
                     if output_hidden_states:
                         all_hidden_states = all_hidden_states + (hidden,)
 
+        if output_hidden_states:
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
+        
+        if output_attentions:
+            all_attentions = tf.convert_to_tensor(all_attentions)
+        
         if not return_dict:
             return tuple(v for v in [hidden, all_hidden_states, all_attentions] if v is not None)
         return TFBaseModelOutput(last_hidden_state=hidden, hidden_states=all_hidden_states, attentions=all_attentions)

--- a/src/transformers/models/gpt2/modeling_tf_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_tf_gpt2.py
@@ -388,11 +388,13 @@ class TFGPT2MainLayer(tf.keras.layers.Layer):
         # Add last hidden state
         if inputs["output_hidden_states"]:
             all_hidden_states = all_hidden_states + (hidden_states,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
 
         if inputs["output_attentions"]:
             # let the number of heads free (-1) so we can extract attention even after head pruning
             attention_output_shape = input_shape[:-1] + [-1] + shape_list(all_attentions[0])[-2:]
             all_attentions = tuple(tf.reshape(t, attention_output_shape) for t in all_attentions)
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not inputs["return_dict"]:
             return tuple(v for v in [hidden_states, presents, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -1716,7 +1716,7 @@ class TFLongformerMainLayer(tf.keras.layers.Layer):
         if padding_len > 0:
             # unpad `sequence_output` because the calling function is expecting a length == input_ids.size(1)
             sequence_output = sequence_output[:, :-padding_len]
-        
+
         if not inputs["return_dict"]:
             idx = 0
             outputs = (sequence_output, pooled_output)
@@ -1726,26 +1726,24 @@ class TFLongformerMainLayer(tf.keras.layers.Layer):
             if inputs["output_attentions"]:
                 idx += 1
                 outputs = outputs + (tf.convert_to_tensor(encoder_outputs[idx]),)
-            
+
             idx += 1
             gl_attn = encoder_outputs[idx:]
-            
+
             if len(gl_attn) > 0:
                 outputs = outputs + (tf.convert_to_tensor(encoder_outputs[idx]),)
             return outputs
-        
+
         return TFLongformerBaseModelOutputWithPooling(
             last_hidden_state=sequence_output,
             pooler_output=pooled_output,
             hidden_states=tf.convert_to_tensor(encoder_outputs.hidden_states)
             if inputs["output_hidden_states"]
             else None,
-            attentions=tf.convert_to_tensor(encoder_outputs.attentions)
-            if inputs["output_attentions"]
-            else None,
+            attentions=tf.convert_to_tensor(encoder_outputs.attentions) if inputs["output_attentions"] else None,
             global_attentions=tf.convert_to_tensor(encoder_outputs.global_attentions)
             if encoder_outputs.global_attentions is not None
-            else None
+            else None,
         )
 
     def _pad_to_window_size(

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -1548,6 +1548,10 @@ class TFLongformerEncoder(tf.keras.layers.Layer):
         if output_hidden_states:
             hidden_states_to_add = hidden_states[:, :-padding_len] if padding_len > 0 else hidden_states
             all_hidden_states = all_hidden_states + (hidden_states_to_add,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
+        
+        if output_hidden_states:
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not return_dict:
             return tuple(

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -1549,7 +1549,7 @@ class TFLongformerEncoder(tf.keras.layers.Layer):
             hidden_states_to_add = hidden_states[:, :-padding_len] if padding_len > 0 else hidden_states
             all_hidden_states = all_hidden_states + (hidden_states_to_add,)
             all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-        
+
         if output_hidden_states:
             all_attentions = tf.convert_to_tensor(all_attentions)
 

--- a/src/transformers/models/lxmert/modeling_tf_lxmert.py
+++ b/src/transformers/models/lxmert/modeling_tf_lxmert.py
@@ -20,7 +20,6 @@ from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 
 import tensorflow as tf
-from tensorflow.python.framework.ops import convert_to_tensor
 
 from ...activations_tf import get_tf_activation
 from ...file_utils import (

--- a/src/transformers/models/lxmert/modeling_tf_lxmert.py
+++ b/src/transformers/models/lxmert/modeling_tf_lxmert.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 
 import tensorflow as tf
+from tensorflow.python.framework.ops import convert_to_tensor
 
 from ...activations_tf import get_tf_activation
 from ...file_utils import (

--- a/src/transformers/models/lxmert/modeling_tf_lxmert.py
+++ b/src/transformers/models/lxmert/modeling_tf_lxmert.py
@@ -813,29 +813,44 @@ class TFLxmertMainLayer(tf.keras.layers.Layer):
             vision_attentions = visual_encoder_outputs[1]
             cross_encoder_attentions = encoder_outputs[2]
             all_attentions = (
-                language_attentions,
-                vision_attentions,
-                cross_encoder_attentions,
+                tf.convert_to_tensor(language_attentions),
+                tf.convert_to_tensor(vision_attentions),
+                tf.convert_to_tensor(cross_encoder_attentions),
             )
 
-        hidden_states = (language_hidden_states, vision_hidden_states) if inputs["output_hidden_states"] else ()
+        hidden_states = (
+            (tf.convert_to_tensor(language_hidden_states), tf.convert_to_tensor(vision_hidden_states))
+            if inputs["output_hidden_states"]
+            else ()
+        )
 
         visual_output = vision_hidden_states[-1]
         lang_output = language_hidden_states[-1]
         pooled_output = self.pooler(lang_output)
 
         if not inputs["return_dict"]:
-            return (lang_output, visual_output, pooled_output) + hidden_states + all_attentions
+            outputs = (lang_output, visual_output, pooled_output)
+            if inputs["output_hidden_states"]:
+                outputs = outputs + hidden_states
+            if inputs["output_attentions"]:
+                outputs = outputs + all_attentions
+            return outputs
 
         return TFLxmertModelOutput(
             pooled_output=pooled_output,
             language_output=lang_output,
             vision_output=visual_output,
-            language_hidden_states=language_hidden_states if inputs["output_hidden_states"] else None,
-            vision_hidden_states=vision_hidden_states if inputs["output_hidden_states"] else None,
-            language_attentions=language_attentions if inputs["output_attentions"] else None,
-            vision_attentions=vision_attentions if inputs["output_attentions"] else None,
-            cross_encoder_attentions=cross_encoder_attentions if inputs["output_attentions"] else None,
+            language_hidden_states=tf.convert_to_tensor(language_hidden_states)
+            if inputs["output_hidden_states"]
+            else None,
+            vision_hidden_states=tf.convert_to_tensor(vision_hidden_states)
+            if inputs["output_hidden_states"]
+            else None,
+            language_attentions=tf.convert_to_tensor(language_attentions) if inputs["output_attentions"] else None,
+            vision_attentions=tf.convert_to_tensor(vision_attentions) if inputs["output_attentions"] else None,
+            cross_encoder_attentions=tf.convert_to_tensor(cross_encoder_attentions)
+            if inputs["output_attentions"]
+            else None,
         )
 
 

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -592,10 +592,6 @@ class TFMobileBertEncoder(tf.keras.layers.Layer):
         # Add last layer
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
-            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-
-        if output_attentions:
-            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not return_dict:
             return tuple(v for v in [hidden_states, all_hidden_states, all_attentions] if v is not None)
@@ -808,16 +804,23 @@ class TFMobileBertMainLayer(tf.keras.layers.Layer):
         pooled_output = self.pooler(sequence_output) if self.pooler is not None else None
 
         if not inputs["return_dict"]:
-            return (
-                sequence_output,
-                pooled_output,
-            ) + encoder_outputs[1:]
+            idx = 0
+            outputs = (sequence_output, pooled_output)
+            if inputs["output_hidden_states"]:
+                idx += 1
+                outputs = outputs + (tf.convert_to_tensor(encoder_outputs[idx]),)
+            if inputs["output_attentions"]:
+                idx += 1
+                outputs = outputs + (tf.convert_to_tensor(encoder_outputs[idx]),)
+            return outputs
 
         return TFBaseModelOutputWithPooling(
             last_hidden_state=sequence_output,
             pooler_output=pooled_output,
-            hidden_states=encoder_outputs.hidden_states,
-            attentions=encoder_outputs.attentions,
+            hidden_states=tf.convert_to_tensor(encoder_outputs.hidden_states)
+            if inputs["output_hidden_states"]
+            else None,
+            attentions=tf.convert_to_tensor(encoder_outputs.attentions) if inputs["output_attentions"] else None,
         )
 
 

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -593,7 +593,7 @@ class TFMobileBertEncoder(tf.keras.layers.Layer):
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
             all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-        
+
         if output_attentions:
             all_attentions = tf.convert_to_tensor(all_attentions)
 

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -592,6 +592,10 @@ class TFMobileBertEncoder(tf.keras.layers.Layer):
         # Add last layer
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
+        
+        if output_attentions:
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not return_dict:
             return tuple(v for v in [hidden_states, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -620,16 +620,23 @@ class TFMPNetMainLayer(tf.keras.layers.Layer):
         pooled_output = self.pooler(sequence_output)
 
         if not inputs["return_dict"]:
-            return (
-                sequence_output,
-                pooled_output,
-            ) + encoder_outputs[1:]
+            idx = 0
+            outputs = (sequence_output, pooled_output)
+            if inputs["output_hidden_states"]:
+                idx += 1
+                outputs = outputs + (tf.convert_to_tensor(encoder_outputs[idx]),)
+            if inputs["output_attentions"]:
+                idx += 1
+                outputs = outputs + (tf.convert_to_tensor(encoder_outputs[idx]),)
+            return outputs
 
         return TFBaseModelOutputWithPooling(
             last_hidden_state=sequence_output,
             pooler_output=pooled_output,
-            hidden_states=encoder_outputs.hidden_states,
-            attentions=encoder_outputs.attentions,
+            hidden_states=tf.convert_to_tensor(encoder_outputs.hidden_states)
+            if inputs["output_hidden_states"]
+            else None,
+            attentions=tf.convert_to_tensor(encoder_outputs.attentions) if inputs["output_attentions"] else None,
         )
 
 

--- a/src/transformers/models/openai/modeling_tf_openai.py
+++ b/src/transformers/models/openai/modeling_tf_openai.py
@@ -337,11 +337,13 @@ class TFOpenAIGPTMainLayer(tf.keras.layers.Layer):
         # Add last hidden state
         if inputs["output_hidden_states"]:
             all_hidden_states = all_hidden_states + (hidden_states,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
 
         if inputs["output_attentions"]:
             # let the number of heads free (-1) so we can extract attention even after head pruning
             attention_output_shape = input_shape[:-1] + [-1] + shape_list(all_attentions[0])[-2:]
             all_attentions = tuple(tf.reshape(t, attention_output_shape) for t in all_attentions)
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not inputs["return_dict"]:
             return tuple(v for v in [hidden_states, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -451,10 +451,6 @@ class TFRobertaEncoder(tf.keras.layers.Layer):
         # Add last layer
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
-            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-
-        if output_attentions:
-            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not return_dict:
             return tuple(v for v in [hidden_states, all_hidden_states, all_attentions] if v is not None)
@@ -593,16 +589,23 @@ class TFRobertaMainLayer(tf.keras.layers.Layer):
         pooled_output = self.pooler(sequence_output) if self.pooler is not None else None
 
         if not inputs["return_dict"]:
-            return (
-                sequence_output,
-                pooled_output,
-            ) + encoder_outputs[1:]
+            idx = 0
+            outputs = (sequence_output, pooled_output)
+            if inputs["output_hidden_states"]:
+                idx += 1
+                outputs = outputs + (tf.convert_to_tensor(encoder_outputs[idx]),)
+            if inputs["output_attentions"]:
+                idx += 1
+                outputs = outputs + (tf.convert_to_tensor(encoder_outputs[idx]),)
+            return outputs
 
         return TFBaseModelOutputWithPooling(
             last_hidden_state=sequence_output,
             pooler_output=pooled_output,
-            hidden_states=encoder_outputs.hidden_states,
-            attentions=encoder_outputs.attentions,
+            hidden_states=tf.convert_to_tensor(encoder_outputs.hidden_states)
+            if inputs["output_hidden_states"]
+            else None,
+            attentions=tf.convert_to_tensor(encoder_outputs.attentions) if inputs["output_attentions"] else None,
         )
 
 

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -451,6 +451,10 @@ class TFRobertaEncoder(tf.keras.layers.Layer):
         # Add last layer
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
+        
+        if output_attentions:
+            all_attentions = tf.convert_to_tensor(all_attentions)
 
         if not return_dict:
             return tuple(v for v in [hidden_states, all_hidden_states, all_attentions] if v is not None)

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -452,7 +452,7 @@ class TFRobertaEncoder(tf.keras.layers.Layer):
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
             all_hidden_states = tf.convert_to_tensor(all_hidden_states)
-        
+
         if output_attentions:
             all_attentions = tf.convert_to_tensor(all_attentions)
 

--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -761,6 +761,7 @@ class TFT5MainLayer(tf.keras.layers.Layer):
         # Add last layer
         if inputs["output_hidden_states"]:
             all_hidden_states = all_hidden_states + (hidden_states,)
+            all_hidden_states = tf.convert_to_tensor(all_hidden_states)
 
         outputs = (hidden_states,)
         # need to check if is decoder here as well for special cases when using keras compile
@@ -769,6 +770,7 @@ class TFT5MainLayer(tf.keras.layers.Layer):
         if inputs["output_hidden_states"]:
             outputs = outputs + (all_hidden_states,)
         if inputs["output_attentions"]:
+            all_attentions = tf.convert_to_tensor(all_attentions)
             outputs = outputs + (all_attentions,)
         return outputs  # last-layer hidden state, (all hidden states), (all attentions)
 

--- a/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
+++ b/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
@@ -624,13 +624,15 @@ class TFTransfoXLMainLayer(tf.keras.layers.Layer):
 
         if inputs["output_hidden_states"]:
             # Add last layer and transpose to library standard shape [bsz, len, hidden_dim]
-            hids.append(core_out)
             hids = tuple(tf.transpose(t, perm=(1, 0, 2)) for t in hids)
+            hids = hids + (core_out,)
+            hids = tf.convert_to_tensor(hids)
         else:
             hids = None
         if inputs["output_attentions"]:
             # Transpose to library standard shape [bsz, n_heads, query_seq_len, key_seq_len]
             attentions = tuple(tf.transpose(t, perm=(2, 3, 0, 1)) for t in attentions)
+            attentions = tf.convert_to_tensor(attentions)
 
         if not inputs["return_dict"]:
             return tuple(v for v in [core_out, new_mems, hids, attentions] if v is not None)

--- a/src/transformers/models/xlm/modeling_tf_xlm.py
+++ b/src/transformers/models/xlm/modeling_tf_xlm.py
@@ -509,6 +509,10 @@ class TFXLMMainLayer(tf.keras.layers.Layer):
         # Add last hidden state
         if inputs["output_hidden_states"]:
             hidden_states = hidden_states + (tensor,)
+            hidden_states = tf.convert_to_tensor(hidden_states)
+        
+        if output_attentions:
+            attentions = tf.convert_to_tensor(attentions)
 
         # update cache length
         if inputs["cache"] is not None:

--- a/src/transformers/models/xlm/modeling_tf_xlm.py
+++ b/src/transformers/models/xlm/modeling_tf_xlm.py
@@ -510,7 +510,7 @@ class TFXLMMainLayer(tf.keras.layers.Layer):
         if inputs["output_hidden_states"]:
             hidden_states = hidden_states + (tensor,)
             hidden_states = tf.convert_to_tensor(hidden_states)
-        
+
         if output_attentions:
             attentions = tf.convert_to_tensor(attentions)
 

--- a/src/transformers/models/xlnet/modeling_tf_xlnet.py
+++ b/src/transformers/models/xlnet/modeling_tf_xlnet.py
@@ -790,6 +790,7 @@ class TFXLNetMainLayer(tf.keras.layers.Layer):
                 hidden_states = tuple(tf.transpose(hs, perm=(1, 0, 2)) for hs in hidden_states)
         if inputs["output_attentions"]:
             attentions = tuple(tf.transpose(t, perm=(2, 3, 0, 1)) for t in attentions)
+            attentions = tf.convert_to_tensor(attentions)
 
         if not inputs["return_dict"]:
             return tuple(v for v in [output, new_mems, hidden_states, attentions] if v is not None)

--- a/src/transformers/models/xlnet/modeling_tf_xlnet.py
+++ b/src/transformers/models/xlnet/modeling_tf_xlnet.py
@@ -788,6 +788,7 @@ class TFXLNetMainLayer(tf.keras.layers.Layer):
                 hidden_states = tuple(tf.transpose(h, perm=(1, 0, 2)) for hs in hidden_states for h in hs)
             else:
                 hidden_states = tuple(tf.transpose(hs, perm=(1, 0, 2)) for hs in hidden_states)
+            hidden_states = tf.convert_to_tensor(hidden_states)
         if inputs["output_attentions"]:
             attentions = tuple(tf.transpose(t, perm=(2, 3, 0, 1)) for t in attentions)
             attentions = tf.convert_to_tensor(attentions)

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -583,16 +583,26 @@ class TF{{cookiecutter.camelcase_modelname}}MainLayer(tf.keras.layers.Layer):
 
         sequence_output = encoder_outputs[0]
 
-        if not return_dict:
-            return (
-                sequence_output,
-            ) + encoder_outputs[1:]
+        if not inputs["return_dict"]:
+            idx = 0
+            outputs = (sequence_output,)
+            if inputs["output_hidden_states"]:
+                idx += 1
+                outputs = outputs + (tf.convert_to_tensor(encoder_outputs[idx]),)
+            if inputs["output_attentions"]:
+                idx += 1
+                outputs = outputs + (tf.convert_to_tensor(encoder_outputs[idx]),)
+            return outputs
 
-        return TFBaseModelOutput(
+        return TFBaseModelOutputWithPooling(
             last_hidden_state=sequence_output,
-            hidden_states=encoder_outputs.hidden_states,
-            attentions=encoder_outputs.attentions,
+            hidden_states=tf.convert_to_tensor(encoder_outputs.hidden_states)
+            if inputs["output_hidden_states"]
+            else None,
+            attentions=tf.convert_to_tensor(encoder_outputs.attentions) if inputs["output_attentions"] else None,
         )
+
+
 
 
 class TF{{cookiecutter.camelcase_modelname}}PreTrainedModel(TFPreTrainedModel):

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -523,7 +523,7 @@ class TFModelTesterMixin:
 
         def check_encoder_attentions_output(outputs):
             attentions = outputs.encoder_attentions if config.is_encoder_decoder else outputs.attentions
-            
+
             self.assertTrue(isinstance(attentions, (tf.Tensor, tf.RaggedTensor)))
             self.assertEqual(attentions.shape[0], self.model_tester.num_hidden_layers)
             self.assertListEqual(
@@ -577,7 +577,7 @@ class TFModelTesterMixin:
             )
 
             hidden_states = outputs[-1]
-            
+
             self.assertEqual(config.output_attentions, False)
             self.assertTrue(isinstance(hidden_states, (tf.Tensor, tf.RaggedTensor)))
             self.assertEqual(hidden_states.shape[0], expected_num_layers)

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -514,6 +514,7 @@ class TFModelTesterMixin:
             out_len = len(outputs)
             self.assertEqual(out_len % 2, 0)
             decoder_attentions = outputs.decoder_attentions
+            self.assertTrue(isinstance(decoder_attentions, tf.Tensor))
             self.assertEqual(len(decoder_attentions), self.model_tester.num_hidden_layers)
             self.assertListEqual(
                 list(decoder_attentions[0].shape[-3:]),
@@ -521,9 +522,8 @@ class TFModelTesterMixin:
             )
 
         def check_encoder_attentions_output(outputs):
-            attentions = [
-                t.numpy() for t in (outputs.encoder_attentions if config.is_encoder_decoder else outputs.attentions)
-            ]
+            attentions = outputs.encoder_attentions if config.is_encoder_decoder else outputs.attentions
+            self.assertTrue(isinstance(attentions, tf.Tensor))
             self.assertEqual(len(attentions), self.model_tester.num_hidden_layers)
             self.assertListEqual(
                 list(attentions[0].shape[-3:]),
@@ -576,6 +576,7 @@ class TFModelTesterMixin:
 
             hidden_states = outputs[-1]
             self.assertEqual(config.output_attentions, False)
+            self.assertTrue(isinstance(hidden_states, tf.Tensor))
             self.assertEqual(len(hidden_states), expected_num_layers)
             self.assertListEqual(
                 list(hidden_states[0].shape[-2:]),

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -514,8 +514,8 @@ class TFModelTesterMixin:
             out_len = len(outputs)
             self.assertEqual(out_len % 2, 0)
             decoder_attentions = outputs.decoder_attentions
-            self.assertTrue(isinstance(decoder_attentions, tf.Tensor))
-            self.assertEqual(len(decoder_attentions), self.model_tester.num_hidden_layers)
+            self.assertTrue(isinstance(decoder_attentions, (tf.Tensor, tf.RaggedTensor)))
+            self.assertEqual(decoder_attentions.shape[0], self.model_tester.num_hidden_layers)
             self.assertListEqual(
                 list(decoder_attentions[0].shape[-3:]),
                 [self.model_tester.num_attention_heads, decoder_seq_length, decoder_key_length],
@@ -523,8 +523,9 @@ class TFModelTesterMixin:
 
         def check_encoder_attentions_output(outputs):
             attentions = outputs.encoder_attentions if config.is_encoder_decoder else outputs.attentions
-            self.assertTrue(isinstance(attentions, tf.Tensor))
-            self.assertEqual(len(attentions), self.model_tester.num_hidden_layers)
+            
+            self.assertTrue(isinstance(attentions, (tf.Tensor, tf.RaggedTensor)))
+            self.assertEqual(attentions.shape[0], self.model_tester.num_hidden_layers)
             self.assertListEqual(
                 list(attentions[0].shape[-3:]),
                 [self.model_tester.num_attention_heads, encoder_seq_length, encoder_key_length],
@@ -551,6 +552,7 @@ class TFModelTesterMixin:
             config.output_attentions = True
             model = model_class(config)
             outputs = model(self._prepare_for_class(inputs_dict, model_class))
+
             self.assertEqual(config.output_hidden_states, False)
             check_encoder_attentions_output(outputs)
 
@@ -575,9 +577,10 @@ class TFModelTesterMixin:
             )
 
             hidden_states = outputs[-1]
+            
             self.assertEqual(config.output_attentions, False)
-            self.assertTrue(isinstance(hidden_states, tf.Tensor))
-            self.assertEqual(len(hidden_states), expected_num_layers)
+            self.assertTrue(isinstance(hidden_states, (tf.Tensor, tf.RaggedTensor)))
+            self.assertEqual(hidden_states.shape[0], expected_num_layers)
             self.assertListEqual(
                 list(hidden_states[0].shape[-2:]),
                 [self.model_tester.seq_length, self.model_tester.hidden_size],


### PR DESCRIPTION
# What does this PR do?

This PR turns the `all_attentions` and `all_hidden_states` values into tensors instead of a tuple. This update is to properly allow the dict outputs in TF serving, because the value of each key cannot be something else than a TF tensor.

Here a simple piece of code to produce the issue:
```
from transformers import TFBertModel, BertConfig
import tensorflow as tf
config = BertConfig.from_pretrained("bert-base-cased", output_attentions=True)
model = TFBertModel.from_pretrained("bert-base-cased", config=config)
tf.saved_model.save(model, "my_model")
```

Gets the error:
```
ValueError: Got a dictionary containing non-Tensor value (<tf.Tensor 'StatefulPartitionedCall:0' shape=(None, 12, None, None) dtype=float32>, <tf.Tensor 'StatefulPartitionedCall:1' shape=(None, 12, None, None) dtype=float32>, <tf.Tensor 'StatefulPartitionedCall:2' shape=(None, 12, None, None) dtype=float32>, <tf.Tensor 'StatefulPartitionedCall:3' shape=(None, 12, None, None) dtype=float32>, <tf.Tensor 'StatefulPartitionedCall:4' shape=(None, 12, None, None) dtype=float32>, <tf.Tensor 'StatefulPartitionedCall:5' shape=(None, 12, None, None) dtype=float32>, <tf.Tensor 'StatefulPartitionedCall:6' shape=(None, 12, None, None) dtype=float32>, <tf.Tensor 'StatefulPartitionedCall:7' shape=(None, 12, None, None) dtype=float32>, <tf.Tensor 'StatefulPartitionedCall:8' shape=(None, 12, None, None) dtype=float32>, <tf.Tensor 'StatefulPartitionedCall:9' shape=(None, 12, None, None) dtype=float32>, <tf.Tensor 'StatefulPartitionedCall:10' shape=(None, 12, None, None) dtype=float32>, <tf.Tensor 'StatefulPartitionedCall:11' shape=(None, 12, None, None) dtype=float32>) for key attentions in the output of the function __inference_serving_15889 used to generate a SavedModel signature. Dictionaries outputs for functions used as signatures should have one Tensor output per string key.
```