### PR TITLE
Fix link to stable version in the doc navbar

### DIFF
--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -1,10 +1,10 @@
 // These two things need to be updated at each release for the version selector.
 // Last stable version
 const stableVersion = "v4.0.0"
-// Dictionary doc folder to label
+// Dictionary doc folder to label. The last stable version should have an empty key.
 const versionMapping = {
     "master": "master",
-    "v4.0.0": "v4.0.0",
+    "": "v4.0.0 (stable)",
     "v3.5.1": "v3.5.0/v3.5.1",
     "v3.4.0": "v3.4.0",
     "v3.3.1": "v3.3.0/v3.3.1",


### PR DESCRIPTION
# What does this PR do?

Currently the link to the stable version in the navigation bar of the docs does not work properly, this PR fixes that.