### PR TITLE
Fix PreTrainedTokenizer.pad when first inputs are empty

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2672,7 +2672,8 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
                 index += 1
             if index < len(encoded_inputs["input_ids"]):
                 first_element = encoded_inputs["input_ids"][index][0]
-        if not isinstance(first_element, int):
+        # At this state, if `first_element` is still a list/tuple, it's an empty one so there is nothing to do.
+        if not isinstance(first_element, (int, list, tuple)):
             if is_tf_available() and isinstance(first_element, tf.Tensor):
                 return_tensors = "tf" if return_tensors is None else return_tensors
             elif is_torch_available() and isinstance(first_element, torch.Tensor):

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2663,9 +2663,15 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
         # If we have PyTorch/TF/NumPy tensors/arrays as inputs, we cast them as python objects
         # and rebuild them afterwards if no return_tensors is specified
         # Note that we lose the specific device the tensor may be on for PyTorch
+
         first_element = encoded_inputs["input_ids"][0]
-        if isinstance(first_element, (list, tuple)) and first_element:
-            first_element = first_element[0]
+        if isinstance(first_element, (list, tuple)):
+            # first_element might be an empty list/tuple in some edge cases so we grab the first non empty element.
+            index = 0
+            while len(encoded_inputs["input_ids"][index]) == 0:
+                index += 1
+            if index < len(encoded_inputs["input_ids"]):
+                first_element = encoded_inputs["input_ids"][index][0]
         if not isinstance(first_element, int):
             if is_tf_available() and isinstance(first_element, tf.Tensor):
                 return_tensors = "tf" if return_tensors is None else return_tensors


### PR DESCRIPTION
# What does this PR do?

Currently, `PreTrainedTokenizer.pad` errors when the first `input_ids` are empty (because it tries to guess the type of the tokens by looking at the first element). This PR slightly changes the behavior to loop until we find a non empty list.

Fixes #8674 (not the initial issue but the one mentioned at the end)