### PR TITLE
Fix T5 and BART for TF

### DIFF
--- a/docs/source/internal/modeling_utils.rst
+++ b/docs/source/internal/modeling_utils.rst
@@ -91,8 +91,6 @@ TensorFlow loss functions
 TensorFlow Helper Functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autofunction:: transformers.modeling_tf_utils.cast_bool_to_primitive
-
 .. autofunction:: transformers.modeling_tf_utils.get_initializer
 
 .. autofunction:: transformers.modeling_tf_utils.keras_serializable

--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -52,7 +52,7 @@ def convert_tf_weight_name_to_pt_weight_name(tf_name, start_prefix_to_remove="")
     tf_name = re.sub(r"//+", "/", tf_name)  # Remove empty levels at the end
     tf_name = tf_name.split("/")  # Convert from TF2.0 '/' separators to PyTorch '.' separators
     # Some weights have a single name withtout "/" such as final_logits_bias in BART
-    if len(tf_name) > 0:
+    if len(tf_name) > 1:
         tf_name = tf_name[1:]  # Remove level zero
 
     # When should we transpose the weights

--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -51,7 +51,9 @@ def convert_tf_weight_name_to_pt_weight_name(tf_name, start_prefix_to_remove="")
     )  # '_._' is replaced by a level separation (can be used to convert TF2.0 lists in PyTorch nn.ModulesList)
     tf_name = re.sub(r"//+", "/", tf_name)  # Remove empty levels at the end
     tf_name = tf_name.split("/")  # Convert from TF2.0 '/' separators to PyTorch '.' separators
-    tf_name = tf_name[1:]  # Remove level zero
+    # Some weights have a single name withtout "/" such as final_logits_bias in BART
+    if len(tf_name) > 0:
+        tf_name = tf_name[1:]  # Remove level zero
 
     # When should we transpose the weights
     transpose = bool(tf_name[-1] == "kernel" or "emb_projs" in tf_name or "out_projs" in tf_name)

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -354,7 +354,6 @@ def input_processing(func, config, input_ids, **kwargs):
         if isinstance(v, allowed_types) or v is None:
             output[k] = v
         else:
-            print(k, v)
             raise ValueError(f"Data of type {type(v)} is not allowed only {allowed_types} is accepted for {k}.")
 
     if isinstance(input_ids, (tuple, list)):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -354,7 +354,8 @@ def input_processing(func, config, input_ids, **kwargs):
         if isinstance(v, allowed_types) or v is None:
             output[k] = v
         else:
-            raise ValueError(f"Data of type {type(v)} is not allowed only tf.Tensor is accepted for {k}.")
+            print(k, v)
+            raise ValueError(f"Data of type {type(v)} is not allowed only {allowed_types} is accepted for {k}.")
 
     if isinstance(input_ids, (tuple, list)):
         for i, input in enumerate(input_ids):
@@ -372,7 +373,7 @@ def input_processing(func, config, input_ids, **kwargs):
                 output[parameter_names[i]] = input
             else:
                 raise ValueError(
-                    f"Data of type {type(input)} is not allowed only tf.Tensor is accepted for {parameter_names[i]}."
+                    f"Data of type {type(input)} is not allowed only {allowed_types} is accepted for {parameter_names[i]}."
                 )
     elif isinstance(input_ids, (dict, BatchEncoding)):
         if "inputs" in input_ids:
@@ -399,13 +400,13 @@ def input_processing(func, config, input_ids, **kwargs):
                 )
                 continue
             else:
-                raise ValueError(f"Data of type {type(v)} is not allowed only tf.Tensor is accepted for {k}.")
+                raise ValueError(f"Data of type {type(v)} is not allowed only {allowed_types} is accepted for {k}.")
     else:
         if isinstance(input_ids, tf.Tensor) or input_ids is None:
             output[parameter_names[0]] = input_ids
         else:
             raise ValueError(
-                f"Data of type {type(input_ids)} is not allowed only tf.Tensor is accepted for {parameter_names[0]}."
+                f"Data of type {type(input_ids)} is not allowed only {allowed_types} is accepted for {parameter_names[0]}."
             )
 
     for name in parameter_names:

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -20,7 +20,7 @@ import inspect
 import os
 import re
 import warnings
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import h5py
 import numpy as np

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -20,7 +20,7 @@ import inspect
 import os
 import re
 import warnings
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 import h5py
 import numpy as np
@@ -1365,31 +1365,6 @@ def get_initializer(initializer_range: float = 0.02) -> tf.initializers.Truncate
         :obj:`tf.initializers.TruncatedNormal`: The truncated normal initializer.
     """
     return tf.keras.initializers.TruncatedNormal(stddev=initializer_range)
-
-
-def cast_bool_to_primitive(bool_variable: Union[tf.Tensor, bool], default_tensor_to_true=False) -> bool:
-    """
-    Function arguments can be inserted as boolean tensor and bool variables to cope with Keras serialization we need to
-    cast the bool arguments (like :obj:`output_attentions` for instance) to correct boolean if it is a tensor.
-
-    Args:
-        bool_variable (:obj:`Union[tf.Tensor, bool]`):
-            The variable to convert to a boolean.
-        default_tensor_to_true (:obj:`bool`, `optional`, defaults to `False`):
-            The default value to use in case the tensor has no numpy attribute.
-
-    Returns:
-        :obj:`bool`: The converted value.
-    """
-    # if bool variable is tensor and has numpy value
-    if tf.is_tensor(bool_variable):
-        if hasattr(bool_variable, "numpy"):
-            return bool(bool_variable.numpy())
-        elif default_tensor_to_true:
-            return True
-
-    # else variable is bool
-    return bool_variable
 
 
 class TFWrappedEmbeddings:

--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -27,12 +27,12 @@ from transformers.modeling_tf_utils import TFWrappedEmbeddings
 from ...activations_tf import get_tf_activation
 from ...file_utils import (
     DUMMY_INPUTS,
-    DUMMY_MASK,
+    DUMMY_MASK, ModelOutput,
     add_start_docstrings,
     add_start_docstrings_to_model_forward,
     replace_return_docstrings,
 )
-from ...modeling_tf_outputs import TFBaseModelOutput, TFSeq2SeqLMOutput, TFSeq2SeqModelOutput
+from ...modeling_tf_outputs import TFBaseModelOutput, TFBaseModelOutputWithPast, TFSeq2SeqLMOutput, TFSeq2SeqModelOutput
 from ...modeling_tf_utils import (
     TFCausalLanguageModelingLoss,
     TFPreTrainedModel,
@@ -594,6 +594,7 @@ class TFT5MainLayer(tf.keras.layers.Layer):
         use_cache=None,
         output_attentions=None,
         output_hidden_states=None,
+        return_dict=None,
         training=False,
         **kwargs,
     ) -> Tuple:
@@ -610,6 +611,7 @@ class TFT5MainLayer(tf.keras.layers.Layer):
             use_cache=use_cache,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
             training=training,
             kwargs_call=kwargs,
         )
@@ -713,10 +715,9 @@ class TFT5MainLayer(tf.keras.layers.Layer):
 
         assert inputs["head_mask"] is None, "Head mask not supported"
         inputs["head_mask"] = [None] * self.num_hidden_layers
-
-        present_key_value_states = ()
-        all_hidden_states = ()
-        all_attentions = ()
+        present_key_value_states = () if inputs["use_cache"] and self.is_decoder else None
+        all_hidden_states = () if inputs["output_hidden_states"] else None
+        all_attentions = () if inputs["output_attentions"] else None
         position_bias = None
         encoder_decoder_position_bias = None
 
@@ -725,7 +726,6 @@ class TFT5MainLayer(tf.keras.layers.Layer):
         for i, (layer_module, past_key_value) in enumerate(zip(self.block, inputs["past_key_values"])):
             if inputs["output_hidden_states"]:
                 all_hidden_states = all_hidden_states + (hidden_states,)
-
             layer_outputs = layer_module(
                 hidden_states,
                 attention_mask=extended_attention_mask,
@@ -739,6 +739,7 @@ class TFT5MainLayer(tf.keras.layers.Layer):
                 output_attentions=inputs["output_attentions"],
                 training=inputs["training"],
             )
+
             # layer_outputs is a tuple with:
             # hidden-states, key-value-states, (self-attention weights), (self-attention position bias), (cross-attention weights), (cross-attention position bias)
             hidden_states, present_key_value_state = layer_outputs[:2]
@@ -747,10 +748,13 @@ class TFT5MainLayer(tf.keras.layers.Layer):
             # layer_outputs = hidden-states, past_key_values, (self-attention weights),
             # (self-attention position bias), (cross-attention position bias), (cross-attention weights),
             position_bias = layer_outputs[2]
+
             if self.is_decoder and inputs["encoder_hidden_states"] is not None:
-                encoder_decoder_position_bias = layer_outputs[4 if output_attentions else 3]
+                encoder_decoder_position_bias = layer_outputs[4 if inputs["output_attentions"] else 3]
+
             # append next layer key value states
-            present_key_value_states = present_key_value_states + (present_key_value_state,)
+            if present_key_value_state is not None and inputs["use_cache"] and self.is_decoder:
+                present_key_value_states = present_key_value_states + (present_key_value_state,)
 
             if inputs["output_attentions"]:
                 all_attentions = all_attentions + (layer_outputs[3],)
@@ -762,15 +766,30 @@ class TFT5MainLayer(tf.keras.layers.Layer):
         if inputs["output_hidden_states"]:
             all_hidden_states = all_hidden_states + (hidden_states,)
 
-        outputs = (hidden_states,)
-        # need to check if is decoder here as well for special cases when using keras compile
-        if cast_bool_to_primitive(inputs["use_cache"], self.use_cache) is True and self.is_decoder:
-            outputs = outputs + (present_key_value_states,)
-        if inputs["output_hidden_states"]:
-            outputs = outputs + (all_hidden_states,)
-        if inputs["output_attentions"]:
-            outputs = outputs + (all_attentions,)
-        return outputs  # last-layer hidden state, (all hidden states), (all attentions)
+        if not inputs["return_dict"]:
+            outputs = (hidden_states,)
+            # need to check if is decoder here as well for special cases when using keras compile
+            if inputs["use_cache"] and self.is_decoder:
+                outputs = outputs + (present_key_value_states,)
+            if inputs["output_hidden_states"]:
+                outputs = outputs + (all_hidden_states,)
+            if inputs["output_attentions"]:
+                outputs = outputs + (all_attentions,)
+            return outputs  # last-layer hidden state, (all hidden states), (all attentions)
+
+        if self.is_decoder:
+            return TFBaseModelOutputWithPast(
+                last_hidden_state=hidden_states,
+                past_key_values=present_key_value_states,
+                hidden_states=all_hidden_states,
+                attentions=all_attentions,
+            )
+        else:
+            return TFBaseModelOutput(
+                last_hidden_state=hidden_states,
+                hidden_states=all_hidden_states,
+                attentions=all_attentions,
+            )
 
 
 ####################################################
@@ -1102,6 +1121,7 @@ class TFT5Model(TFT5PreTrainedModel):
                 use_cache=False,
                 output_attentions=inputs["output_attentions"],
                 output_hidden_states=inputs["output_hidden_states"],
+                return_dict=inputs["return_dict"],
                 training=inputs["training"],
             )
 
@@ -1119,38 +1139,29 @@ class TFT5Model(TFT5PreTrainedModel):
             use_cache=inputs["use_cache"],
             output_attentions=inputs["output_attentions"],
             output_hidden_states=inputs["output_hidden_states"],
+            return_dict=inputs["return_dict"],
             training=inputs["training"],
         )
 
         past = (
             (inputs["encoder_outputs"], decoder_outputs[1])
-            if cast_bool_to_primitive(inputs["use_cache"], self.config.use_cache)
+            if inputs["use_cache"]
             else None
         )
+
         if not inputs["return_dict"]:
             if past is not None:
                 decoder_outputs = decoder_outputs[:1] + (past,) + decoder_outputs[2:]
             return decoder_outputs + inputs["encoder_outputs"]
 
-        # This is long and annoying but if we introduce return_dict at the TFT5MainLayer level (like in PyTorch)
-        # TF refuses to compile anymore.
-        if not cast_bool_to_primitive(inputs["use_cache"], self.config.use_cache):
-            decoder_outputs = decoder_outputs[:1] + (None,) + decoder_outputs[1:]
-        if not cast_bool_to_primitive(inputs["output_hidden_states"], self.config.output_hidden_states):
-            inputs["encoder_outputs"] = inputs["encoder_outputs"][:1] + (None,) + inputs["encoder_outputs"][1:]
-            decoder_outputs = decoder_outputs[:2] + (None,) + decoder_outputs[2:]
-        if not cast_bool_to_primitive(inputs["output_attentions"], self.config.output_attentions):
-            inputs["encoder_outputs"] = inputs["encoder_outputs"] + (None,)
-            decoder_outputs = decoder_outputs + (None,)
-
         return TFSeq2SeqModelOutput(
-            last_hidden_state=decoder_outputs[0],
+            last_hidden_state=decoder_outputs.last_hidden_state,
             past_key_values=past,
-            decoder_hidden_states=decoder_outputs[2],
-            decoder_attentions=decoder_outputs[3],
-            encoder_last_hidden_state=inputs["encoder_outputs"][0],
-            encoder_hidden_states=inputs["encoder_outputs"][1],
-            encoder_attentions=inputs["encoder_outputs"][2],
+            decoder_hidden_states=decoder_outputs.hidden_states,
+            decoder_attentions=decoder_outputs.attentions,
+            encoder_last_hidden_state=inputs["encoder_outputs"].last_hidden_state,
+            encoder_hidden_states=inputs["encoder_outputs"].hidden_states,
+            encoder_attentions=inputs["encoder_outputs"].attentions,
         )
 
 
@@ -1280,6 +1291,7 @@ class TFT5ForConditionalGeneration(TFT5PreTrainedModel, TFCausalLanguageModeling
                 head_mask=inputs["head_mask"],
                 output_attentions=inputs["output_attentions"],
                 output_hidden_states=inputs["output_hidden_states"],
+                return_dict=inputs["return_dict"],
                 training=inputs["training"],
             )
 
@@ -1313,6 +1325,7 @@ class TFT5ForConditionalGeneration(TFT5PreTrainedModel, TFCausalLanguageModeling
             use_cache=inputs["use_cache"],
             output_attentions=inputs["output_attentions"],
             output_hidden_states=inputs["output_hidden_states"],
+            return_dict=inputs["return_dict"],
             training=inputs["training"],
         )
 
@@ -1329,7 +1342,7 @@ class TFT5ForConditionalGeneration(TFT5PreTrainedModel, TFCausalLanguageModeling
 
         past = (
             (inputs["encoder_outputs"], decoder_outputs[1])
-            if cast_bool_to_primitive(inputs["use_cache"], self.config.use_cache)
+            if inputs["use_cache"]
             else None
         )
         if not inputs["return_dict"]:
@@ -1338,26 +1351,34 @@ class TFT5ForConditionalGeneration(TFT5PreTrainedModel, TFCausalLanguageModeling
             output = (logits,) + decoder_outputs[1:] + inputs["encoder_outputs"]
             return ((loss,) + output) if loss is not None else output
 
-        # This is long and annoying but if we introduce return_dict at the TFT5MainLayer level (like in PyTorch)
-        # TF refuses to compile anymore.
-        if not cast_bool_to_primitive(inputs["use_cache"], self.config.use_cache):
-            decoder_outputs = decoder_outputs[:1] + (None,) + decoder_outputs[1:]
-        if not cast_bool_to_primitive(inputs["output_hidden_states"], self.config.output_hidden_states):
-            inputs["encoder_outputs"] = inputs["encoder_outputs"][:1] + (None,) + inputs["encoder_outputs"][1:]
-            decoder_outputs = decoder_outputs[:2] + (None,) + decoder_outputs[2:]
-        if not cast_bool_to_primitive(inputs["output_attentions"], self.config.output_attentions):
-            inputs["encoder_outputs"] = inputs["encoder_outputs"] + (None,)
-            decoder_outputs = decoder_outputs + (None,)
+        # If the user passed a tuple for encoder_outputs, we wrap it in a TFBaseModelOutput when return_dict=True
+        elif isinstance(inputs["encoder_outputs"], tuple):
+            last_hidden_state = inputs["encoder_outputs"][0]
+            hidden_states = None
+            attentions = None
+            idx = 0
+            if inputs["output_hidden_states"]:
+                idx += 1
+                hidden_states = inputs["encoder_outputs"][idx]
+            if inputs["output_attentions"]:
+                idx += 1
+                attentions = inputs["encoder_outputs"][idx]
+
+            inputs["encoder_outputs"] = TFBaseModelOutput(
+                last_hidden_state=last_hidden_state,
+                hidden_states=hidden_states,
+                attentions=attentions,
+            )
 
         return TFSeq2SeqLMOutput(
             loss=loss,
             logits=logits,
             past_key_values=past,
-            decoder_hidden_states=decoder_outputs[2],
-            decoder_attentions=decoder_outputs[3],
-            encoder_last_hidden_state=inputs["encoder_outputs"][0],
-            encoder_hidden_states=inputs["encoder_outputs"][1],
-            encoder_attentions=inputs["encoder_outputs"][2],
+            decoder_hidden_states=decoder_outputs.hidden_states,
+            decoder_attentions=decoder_outputs.attentions,
+            encoder_last_hidden_state=inputs["encoder_outputs"].last_hidden_state,
+            encoder_hidden_states=inputs["encoder_outputs"].hidden_states,
+            encoder_attentions=inputs["encoder_outputs"].attentions,
         )
 
     def prepare_inputs_for_generation(self, inputs, past, attention_mask, use_cache, **kwargs):
@@ -1498,19 +1519,15 @@ class TFT5EncoderModel(TFT5PreTrainedModel):
             use_cache=False,
             output_attentions=inputs["output_attentions"],
             output_hidden_states=inputs["output_hidden_states"],
+            return_dict=inputs["return_dict"],
             training=inputs["training"],
         )
 
         if not inputs["return_dict"]:
             return encoder_outputs
 
-        if not cast_bool_to_primitive(inputs["output_hidden_states"], self.config.output_hidden_states):
-            encoder_outputs = encoder_outputs[:1] + (None,) + encoder_outputs[1:]
-        if not cast_bool_to_primitive(inputs["output_attentions"], self.config.output_attentions):
-            encoder_outputs = encoder_outputs + (None,)
-
         return TFBaseModelOutput(
-            last_hidden_state=encoder_outputs[0],
-            hidden_states=encoder_outputs[1],
-            attentions=encoder_outputs[2],
+            last_hidden_state=encoder_outputs.last_hidden_state,
+            hidden_states=encoder_outputs.hidden_states,
+            attentions=encoder_outputs.attentions,
         )

--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -27,17 +27,21 @@ from transformers.modeling_tf_utils import TFWrappedEmbeddings
 from ...activations_tf import get_tf_activation
 from ...file_utils import (
     DUMMY_INPUTS,
-    DUMMY_MASK, ModelOutput,
+    DUMMY_MASK,
     add_start_docstrings,
     add_start_docstrings_to_model_forward,
     replace_return_docstrings,
 )
-from ...modeling_tf_outputs import TFBaseModelOutput, TFBaseModelOutputWithPast, TFSeq2SeqLMOutput, TFSeq2SeqModelOutput
+from ...modeling_tf_outputs import (
+    TFBaseModelOutput,
+    TFBaseModelOutputWithPast,
+    TFSeq2SeqLMOutput,
+    TFSeq2SeqModelOutput,
+)
 from ...modeling_tf_utils import (
     TFCausalLanguageModelingLoss,
     TFPreTrainedModel,
     TFSharedEmbeddings,
-    cast_bool_to_primitive,
     input_processing,
     keras_serializable,
     shape_list,
@@ -311,7 +315,7 @@ class TFT5Attention(tf.keras.layers.Layer):
         )
 
         # to cope with keras serialization
-        if self.is_decoder and cast_bool_to_primitive(use_cache, self.use_cache) is True:
+        if self.is_decoder and use_cache:
             present_key_value_state = (key_states, value_states)
         else:
             present_key_value_state = None
@@ -1143,11 +1147,7 @@ class TFT5Model(TFT5PreTrainedModel):
             training=inputs["training"],
         )
 
-        past = (
-            (inputs["encoder_outputs"], decoder_outputs[1])
-            if inputs["use_cache"]
-            else None
-        )
+        past = (inputs["encoder_outputs"], decoder_outputs[1]) if inputs["use_cache"] else None
 
         if not inputs["return_dict"]:
             if past is not None:
@@ -1340,11 +1340,7 @@ class TFT5ForConditionalGeneration(TFT5PreTrainedModel, TFCausalLanguageModeling
 
         loss = None if inputs["labels"] is None else self.compute_loss(inputs["labels"], logits)
 
-        past = (
-            (inputs["encoder_outputs"], decoder_outputs[1])
-            if inputs["use_cache"]
-            else None
-        )
+        past = (inputs["encoder_outputs"], decoder_outputs[1]) if inputs["use_cache"] else None
         if not inputs["return_dict"]:
             if past is not None:
                 decoder_outputs = decoder_outputs[:1] + (past,) + decoder_outputs[2:]

--- a/tests/test_modeling_tf_bart.py
+++ b/tests/test_modeling_tf_bart.py
@@ -118,14 +118,6 @@ class TFBartModelTest(TFModelTesterMixin, unittest.TestCase):
         # inputs_embeds not supported
         pass
 
-    def test_saved_model_with_hidden_states_output(self):
-        # Should be uncommented during patrick TF refactor
-        pass
-
-    def test_saved_model_with_attentions_output(self):
-        # Should be uncommented during patrick TF refactor
-        pass
-
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -305,7 +305,7 @@ class TFModelTesterMixin:
         max_diff = np.amax(np.abs(out_1 - out_2))
         self.assertLessEqual(max_diff, 1e-5)
 
-    # @is_pt_tf_cross_test
+    @is_pt_tf_cross_test
     def test_pt_tf_model_equivalence(self):
 
         import torch

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -595,7 +595,7 @@ class TFModelTesterMixin:
                 hidden_states = outputs.decoder_hidden_states
             else:
                 hidden_states = outputs.hidden_states
-                
+
             self.assertEqual(config.output_attentions, False)
             self.assertEqual(len(hidden_states), expected_num_layers)
             self.assertListEqual(

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -591,17 +591,29 @@ class TFModelTesterMixin:
                 self.model_tester, "expected_num_hidden_layers", self.model_tester.num_hidden_layers + 1
             )
 
-            if self.is_encoder_decoder:
-                hidden_states = outputs.decoder_hidden_states
+            if model.config.is_encoder_decoder:
+                encoder_hidden_states = outputs.encoder_hidden_states
+                decoder_hidden_states = outputs.decoder_hidden_states
+
+                self.assertEqual(config.output_attentions, False)
+                self.assertEqual(len(encoder_hidden_states), expected_num_layers)
+                self.assertListEqual(
+                    list(encoder_hidden_states[0].shape[-2:]),
+                    [self.model_tester.seq_length, self.model_tester.hidden_size],
+                )
+                self.assertEqual(len(decoder_hidden_states), expected_num_layers)
+                self.assertListEqual(
+                    list(decoder_hidden_states[0].shape[-2:]),
+                    [self.model_tester.seq_length, self.model_tester.hidden_size],
+                )
             else:
                 hidden_states = outputs.hidden_states
-
-            self.assertEqual(config.output_attentions, False)
-            self.assertEqual(len(hidden_states), expected_num_layers)
-            self.assertListEqual(
-                list(hidden_states[0].shape[-2:]),
-                [self.model_tester.seq_length, self.model_tester.hidden_size],
-            )
+                self.assertEqual(config.output_attentions, False)
+                self.assertEqual(len(hidden_states), expected_num_layers)
+                self.assertListEqual(
+                    list(hidden_states[0].shape[-2:]),
+                    [self.model_tester.seq_length, self.model_tester.hidden_size],
+                )
 
         for model_class in self.all_model_classes:
             inputs_dict["output_hidden_states"] = True

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -165,7 +165,7 @@ class TFModelTesterMixin:
                 expected_arg_names = ["input_ids"]
                 self.assertListEqual(arg_names[:1], expected_arg_names)
 
-    # @slow
+    @slow
     def test_saved_model_with_hidden_states_output(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.output_hidden_states = True
@@ -262,8 +262,11 @@ class TFModelTesterMixin:
                 shared = TFSharedEmbeddings(99, 32, name="shared")
                 config.use_cache = False
                 main_layer = main_layer_class(config, embed_tokens=shared)
+                # We already set use_cache in the config above
+                inputs_dict.pop("use_cache")
             else:
                 main_layer = main_layer_class(config)
+
             symbolic_inputs = {
                 name: tf.keras.Input(tensor.shape[1:], dtype=tensor.dtype) for name, tensor in inputs_dict.items()
             }
@@ -570,7 +573,7 @@ class TFModelTesterMixin:
             config.output_hidden_states = True
             model = model_class(config)
             outputs = model(self._prepare_for_class(inputs_dict, model_class))
-            
+
             self.assertEqual(out_len + (2 if self.is_encoder_decoder else 1), len(outputs))
             self.assertEqual(model.config.output_hidden_states, True)
             check_encoder_attentions_output(outputs)

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -335,8 +335,7 @@ class TFModelTesterMixin:
             pt_inputs_dict = {}
             for name, key in self._prepare_for_class(inputs_dict, model_class).items():
                 if type(key) == bool:
-                    key = np.array(key, dtype=bool)
-                    pt_inputs_dict[name] = torch.from_numpy(key).to(torch.long)
+                    pt_inputs_dict[name] = key
                 else:
                     pt_inputs_dict[name] = torch.from_numpy(key.numpy()).to(torch.long)
 

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -338,7 +338,7 @@ class TFModelTesterMixin:
             for name, key in self._prepare_for_class(inputs_dict, model_class).items():
                 if not type(key) == bool:
                     key = key.numpy()
-                pt_inputs_dict = dict((name, torch.from_numpy(key.numpy()).to(torch.long)))
+                pt_inputs_dict = dict((name, torch.from_numpy(key).to(torch.long)))
 
             # need to rename encoder-decoder "inputs" for PyTorch
             if "inputs" in pt_inputs_dict and self.is_encoder_decoder:

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -591,10 +591,11 @@ class TFModelTesterMixin:
                 self.model_tester, "expected_num_hidden_layers", self.model_tester.num_hidden_layers + 1
             )
 
-            if hasattr(outputs, "hidden_states"):
-                hidden_states = outputs.hidden_states
-            else:
+            if self.is_encoder_decoder:
                 hidden_states = outputs.decoder_hidden_states
+            else:
+                hidden_states = outputs.hidden_states
+                
             self.assertEqual(config.output_attentions, False)
             self.assertEqual(len(hidden_states), expected_num_layers)
             self.assertListEqual(

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -45,7 +45,6 @@ if is_tf_available():
         TFSharedEmbeddings,
         tf_top_k_top_p_filtering,
     )
-    from transformers.modeling_tf_outputs import TFBaseModelOutput, TFBaseModelOutputWithPooling
 
     if _tf_gpu_memory_limit is not None:
         gpus = tf.config.list_physical_devices("GPU")

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -24,7 +24,6 @@ from importlib import import_module
 from typing import List, Tuple
 
 from transformers import is_tf_available
-from transformers.modeling_tf_outputs import TFBaseModelOutput
 from transformers.testing_utils import _tf_gpu_memory_limit, is_pt_tf_cross_test, require_tf, slow
 
 
@@ -46,6 +45,7 @@ if is_tf_available():
         TFSharedEmbeddings,
         tf_top_k_top_p_filtering,
     )
+    from transformers.modeling_tf_outputs import TFBaseModelOutput
 
     if _tf_gpu_memory_limit is not None:
         gpus = tf.config.list_physical_devices("GPU")

--- a/tests/test_modeling_tf_t5.py
+++ b/tests/test_modeling_tf_t5.py
@@ -399,6 +399,7 @@ class TFT5EncoderOnlyModelTester:
 
 
 class TFT5EncoderOnlyModelTest(TFModelTesterMixin, unittest.TestCase):
+    is_encoder_decoder = False
     all_model_classes = (TFT5EncoderModel,) if is_tf_available() else ()
 
     def setUp(self):

--- a/tests/test_modeling_tf_t5.py
+++ b/tests/test_modeling_tf_t5.py
@@ -133,8 +133,6 @@ class TFT5ModelTester:
         self.parent.assertTrue(len(outputs) == len(outputs_use_cache_conf))
         self.parent.assertTrue(len(outputs) == len(outputs_no_past) + 1)
 
-        output, past_key_values = outputs
-
         # create hypothetical next token and extent to next_input_ids
         next_tokens = ids_tensor((self.batch_size, 1), config.vocab_size)
 
@@ -142,7 +140,7 @@ class TFT5ModelTester:
         next_input_ids = tf.concat([input_ids, next_tokens], axis=-1)
 
         output_from_no_past = model(next_input_ids)[0]
-        output_from_past = model(next_tokens, past_key_values=past_key_values)[0]
+        output_from_past = model(next_tokens, past_key_values=outputs.past_key_values)[0]
 
         # select random slice
         random_slice_idx = int(ids_tensor((1,), output_from_past.shape[-1]))
@@ -164,7 +162,7 @@ class TFT5ModelTester:
         attn_mask = tf.concat([attn_mask_begin, attn_mask_end], axis=1)
 
         # first forward pass
-        _, past_key_values = model(input_ids, attention_mask=attn_mask, use_cache=True)
+        outputs = model(input_ids, attention_mask=attn_mask, use_cache=True)
 
         # create hypothetical next token and extent to next_input_ids
         next_tokens = ids_tensor((self.batch_size, 1), config.vocab_size)
@@ -187,7 +185,7 @@ class TFT5ModelTester:
 
         # get two different outputs
         output_from_no_past = model(next_input_ids, attention_mask=attn_mask)[0]
-        output_from_past = model(next_tokens, past_key_values=past_key_values, attention_mask=attn_mask)[0]
+        output_from_past = model(next_tokens, past_key_values=outputs.past_key_values, attention_mask=attn_mask)[0]
 
         # select random slice
         random_slice_idx = ids_tensor((1,), output_from_past.shape[-1]).numpy().item()
@@ -208,8 +206,6 @@ class TFT5ModelTester:
         # first forward pass
         outputs = model(input_ids, use_cache=True)
 
-        output, past_key_values = outputs
-
         # create hypothetical next token and extent to next_input_ids
         next_tokens = ids_tensor((self.batch_size, 3), config.vocab_size)
 
@@ -217,7 +213,7 @@ class TFT5ModelTester:
         next_input_ids = tf.concat([input_ids, next_tokens], axis=-1)
 
         output_from_no_past = model(next_input_ids)[0]
-        output_from_past = model(next_tokens, past_key_values=past_key_values)[0]
+        output_from_past = model(next_tokens, past_key_values=outputs.past_key_values)[0]
 
         self.parent.assertEqual(next_tokens.shape[1], output_from_past.shape[1])
 
@@ -236,7 +232,7 @@ class TFT5ModelTester:
             "input_ids": input_ids,
             "decoder_input_ids": input_ids,
             "decoder_attention_mask": input_mask,
-            "use_cache": tf.convert_to_tensor([False]),
+            "use_cache": False,
         }
         return config, inputs_dict
 
@@ -297,14 +293,6 @@ class TFT5ModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_model_from_pretrained(self):
         model = TFT5Model.from_pretrained("t5-small")
         self.assertIsNotNone(model)
-
-    @slow
-    def test_saved_model_with_attentions_output(self):
-        pass
-
-    @slow
-    def test_saved_model_with_hidden_states_output(self):
-        pass
 
 
 class TFT5EncoderOnlyModelTester:


### PR DESCRIPTION
# What does this PR do?

This PR fix the TensorFlow implementation of T5 and BART to make them graph compilation+execution compliant and then be able to create a savedmodel for each them.

The slow tests `test_saved_model_with_hidden_states_output` and `test_saved_model_with_attentions_output` are now passing for both models.
