### PR TITLE
Fix a broken link in documentation

### DIFF
--- a/docs/source/bertology.rst
+++ b/docs/source/bertology.rst
@@ -34,5 +34,5 @@ help people access the inner representations, mainly adapted from the great work
   in https://arxiv.org/abs/1905.10650.
 
 To help you understand and use these features, we have added a specific example script: `bertology.py
-<https://github.com/huggingface/transformers/blob/master/examples/bertology/run_bertology.py>`_ while extract
-information and prune a model pre-trained on GLUE.
+<https://github.com/huggingface/transformers/blob/master/examples/research_projects/bertology/run_bertology.py>`_ while
+extract information and prune a model pre-trained on GLUE.


### PR DESCRIPTION
# What does this PR do?

Fixes a broken link to the BERTology example in documentation

Fixes #9100 

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?

 documentation: @sgugger 
