### PR TITLE
Fix TF Transfo XL

### DIFF
--- a/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
+++ b/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
@@ -623,9 +623,9 @@ class TFTransfoXLMainLayer(tf.keras.layers.Layer):
         core_out = tf.transpose(core_out, perm=(1, 0, 2))
 
         if inputs["output_hidden_states"]:
-            # Add last layer and transpose to library standard shape [bsz, len, hidden_dim]
-            hids.append(core_out)
+            # Transpose to library standard shape [bsz, len, hidden_dim] and add last layer
             hids = tuple(tf.transpose(t, perm=(1, 0, 2)) for t in hids)
+            hids = hids + (core_out,)
         else:
             hids = None
         if inputs["output_attentions"]:


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue in TFTransfoXL the last layer was added into the complete list of `hidden_states` while being already transposed. Then adding it at the end after all the other states have been transposed.
