### PR TITLE
Pass kwargs to Pipeline's tokenizer call

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -590,6 +590,7 @@ class Pipeline(_ScikitCompat):
             return_tensors=self.framework,
             padding=padding,
             truncation=truncation,
+            **kwargs,
         )
 
         return inputs

--- a/tests/test_pipelines_fill_mask.py
+++ b/tests/test_pipelines_fill_mask.py
@@ -77,8 +77,11 @@ class FillMaskPipelineTests(MonoInputPipelineCommonMixin, unittest.TestCase):
         self.assertIsInstance(outputs, list)
 
         # This used to fail with `cannot mix args and kwargs`
-        outputs = nlp(valid_inputs, something=False)
+        outputs = nlp(valid_inputs, verbose=False)
         self.assertIsInstance(outputs, list)
+
+        # This fails because `invalid_arg` is not an argument of the pipeline's tokenizer
+        self.assertRaises(TypeError, nlp, valid_inputs, invalid_arg=False)
 
     @require_torch
     def test_torch_fill_mask_with_targets(self):


### PR DESCRIPTION
# What does this PR do?
When calling a Pipeline, the `kwargs` argument is not passed to the tokenizer (it is actually not used at all).
I think the intended behavior is to pass it (as the base tokenizer's `__call__()` method already supports `kwargs`), and that's what this PR does.
[Related to #8180]

The call order is:

```Python3
SpecificPipeline.__call__(..., **kwargs)
# Which calls
Pipeline.__call__(..., **kwargs)
# Which calls
SpecificPipeline._parse_and_tokenize(..., **kwargs)
# Which in turn calls
self.tokenizer(...) # No kwargs in this call
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
@sgugger @LysandreJik