### PR TITLE
Fix mixed precision in TF models

### DIFF
--- a/src/transformers/activations_tf.py
+++ b/src/transformers/activations_tf.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import math
+from packaging import version
 
 import tensorflow as tf
 
 
-def gelu(x):
+def _gelu(x):
     """
     Gaussian Error Linear Unit. Original Implementation of the gelu activation function in Google Bert repo when
     initially created. For information: OpenAI GPT's gelu is slightly different (and gives slightly different results):
@@ -25,7 +26,7 @@ def gelu(x):
     https://arxiv.org/abs/1606.08415
     """
     x = tf.convert_to_tensor(x)
-    cdf = 0.5 * (1.0 + tf.math.erf(x / tf.math.sqrt(2.0)))
+    cdf = 0.5 * (1.0 + tf.math.erf(x / tf.cast(tf.sqrt(2.0), x.dtype)))
 
     return x * cdf
 
@@ -62,8 +63,14 @@ def gelu_fast(x):
     return 0.5 * x * (1.0 + tf.tanh(x * coeff2 * (1.0 + coeff1 * x * x)))
 
 
+if version.parse(tf.version.VERSION) >= version.parse("2.4"):
+    gelu = tf.keras.activations.gelu
+else:
+    gelu = tf.keras.layers.Activation(_gelu)
+
+
 ACT2FN = {
-    "gelu": tf.keras.layers.Activation(gelu),
+    "gelu": gelu,
     "relu": tf.keras.activations.relu,
     "swish": tf.keras.activations.swish,
     "silu": tf.keras.activations.swish,

--- a/src/transformers/activations_tf.py
+++ b/src/transformers/activations_tf.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import math
-from packaging import version
 
 import tensorflow as tf
+from packaging import version
 
 
 def _gelu(x):

--- a/src/transformers/activations_tf.py
+++ b/src/transformers/activations_tf.py
@@ -80,7 +80,7 @@ ACT2FN = {
     "relu": tf.keras.activations.relu,
     "swish": tf.keras.activations.swish,
     "silu": tf.keras.activations.swish,
-    "gelu_new": tf.keras.layers.Activation(gelu_new),
+    "gelu_new": gelu_new,
     "mish": tf.keras.layers.Activation(mish),
     "tanh": tf.keras.activations.tanh,
     "gelu_fast": tf.keras.layers.Activation(gelu_fast),

--- a/src/transformers/activations_tf.py
+++ b/src/transformers/activations_tf.py
@@ -64,9 +64,15 @@ def gelu_fast(x):
 
 
 if version.parse(tf.version.VERSION) >= version.parse("2.4"):
+    def approximate_gelu_wrap(x):
+        return tf.keras.activations.gelu(x, approximate=True)
+
     gelu = tf.keras.activations.gelu
+    gelu_new = approximate_gelu_wrap
+
 else:
     gelu = tf.keras.layers.Activation(_gelu)
+    gelu_new = tf.keras.layers.Activation(_gelu_new)
 
 
 ACT2FN = {

--- a/src/transformers/activations_tf.py
+++ b/src/transformers/activations_tf.py
@@ -31,7 +31,7 @@ def _gelu(x):
     return x * cdf
 
 
-def gelu_new(x):
+def _gelu_new(x):
     """
     Gaussian Error Linear Unit. This is a smoother version of the GELU. Original paper: https://arxiv.org/abs/1606.0841
 

--- a/src/transformers/activations_tf.py
+++ b/src/transformers/activations_tf.py
@@ -64,12 +64,12 @@ def gelu_fast(x):
 
 
 if version.parse(tf.version.VERSION) >= version.parse("2.4"):
+
     def approximate_gelu_wrap(x):
         return tf.keras.activations.gelu(x, approximate=True)
 
     gelu = tf.keras.activations.gelu
     gelu_new = approximate_gelu_wrap
-
 else:
     gelu = tf.keras.layers.Activation(_gelu)
     gelu_new = tf.keras.layers.Activation(_gelu_new)

--- a/src/transformers/activations_tf.py
+++ b/src/transformers/activations_tf.py
@@ -57,7 +57,7 @@ def mish(x):
 
 def gelu_fast(x):
     x = tf.convert_to_tensor(x)
-    coeff1 = tf.cast(7978845608, x.dtype)
+    coeff1 = tf.cast(0.7978845608, x.dtype)
     coeff2 = tf.cast(0.044715, x.dtype)
 
     return 0.5 * x * (1.0 + tf.tanh(x * coeff2 * (1.0 + coeff1 * x * x)))

--- a/src/transformers/activations_tf.py
+++ b/src/transformers/activations_tf.py
@@ -71,8 +71,8 @@ if version.parse(tf.version.VERSION) >= version.parse("2.4"):
     gelu = tf.keras.activations.gelu
     gelu_new = approximate_gelu_wrap
 else:
-    gelu = tf.keras.layers.Activation(_gelu)
-    gelu_new = tf.keras.layers.Activation(_gelu_new)
+    gelu = _gelu
+    gelu_new = _gelu_new
 
 
 ACT2FN = {
@@ -81,9 +81,9 @@ ACT2FN = {
     "swish": tf.keras.activations.swish,
     "silu": tf.keras.activations.swish,
     "gelu_new": gelu_new,
-    "mish": tf.keras.layers.Activation(mish),
+    "mish": mish,
     "tanh": tf.keras.activations.tanh,
-    "gelu_fast": tf.keras.layers.Activation(gelu_fast),
+    "gelu_fast": gelu_fast,
 }
 
 

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -542,7 +542,7 @@ class TFAlbertMLMHead(tf.keras.layers.Layer):
 
     def call(self, hidden_states):
         hidden_states = self.dense(inputs=hidden_states)
-        hidden_states = self.activation(inputs=hidden_states)
+        hidden_states = self.activation(hidden_states)
         hidden_states = self.LayerNorm(inputs=hidden_states)
         seq_length = shape_list(tensor=hidden_states)[1]
         hidden_states = tf.reshape(tensor=hidden_states, shape=[-1, self.embedding_size])

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -428,7 +428,7 @@ class TFBertIntermediate(tf.keras.layers.Layer):
 
     def call(self, hidden_states):
         hidden_states = self.dense(inputs=hidden_states)
-        hidden_states = self.intermediate_act_fn(inputs=hidden_states)
+        hidden_states = self.intermediate_act_fn(hidden_states)
 
         return hidden_states
 

--- a/src/transformers/models/electra/modeling_tf_electra.py
+++ b/src/transformers/models/electra/modeling_tf_electra.py
@@ -327,7 +327,7 @@ class TFElectraIntermediate(tf.keras.layers.Layer):
 
     def call(self, hidden_states):
         hidden_states = self.dense(inputs=hidden_states)
-        hidden_states = self.intermediate_act_fn(inputs=hidden_states)
+        hidden_states = self.intermediate_act_fn(hidden_states)
 
         return hidden_states
 

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -709,7 +709,7 @@ class TFLongformerIntermediate(tf.keras.layers.Layer):
 
     def call(self, hidden_states):
         hidden_states = self.dense(inputs=hidden_states)
-        hidden_states = self.intermediate_act_fn(inputs=hidden_states)
+        hidden_states = self.intermediate_act_fn(hidden_states)
 
         return hidden_states
 

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -388,7 +388,7 @@ class TFMPNetIntermediate(tf.keras.layers.Layer):
 
     def call(self, hidden_states):
         hidden_states = self.dense(inputs=hidden_states)
-        hidden_states = self.intermediate_act_fn(inputs=hidden_states)
+        hidden_states = self.intermediate_act_fn(hidden_states)
 
         return hidden_states
 

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -448,7 +448,7 @@ class TFRobertaIntermediate(tf.keras.layers.Layer):
 
     def call(self, hidden_states):
         hidden_states = self.dense(inputs=hidden_states)
-        hidden_states = self.intermediate_act_fn(inputs=hidden_states)
+        hidden_states = self.intermediate_act_fn(hidden_states)
 
         return hidden_states
 

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -382,7 +382,7 @@ class TF{{cookiecutter.camelcase_modelname}}Intermediate(tf.keras.layers.Layer):
 
     def call(self, hidden_states):
         hidden_states = self.dense(inputs=hidden_states)
-        hidden_states = self.intermediate_act_fn(inputs=hidden_states)
+        hidden_states = self.intermediate_act_fn(hidden_states)
 
         return hidden_states
 


### PR DESCRIPTION
# What does this PR do?

This PR aims to fix the mixed precision issues when `tf.keras.mixed_precision.experimental.set_policy()` is set to something else than `tf.float32`.  In the same page, this PR aims to fix some TFLite quantization issues.

Before to further continue this PR, the PR #9418 has to be merged.

Fixes # (issue)

#7052 
