### PR TITLE
Fix gradient clipping for Sharded DDP

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -811,10 +811,10 @@ class Trainer:
                             self.scaler.unscale_(self.optimizer)
 
                         if hasattr(self.optimizer, "clip_grad_norm"):
-                            # Some optimizer (like the sharded optimizer) have a specific gradient clipping
+                            # Some optimizers (like the sharded optimizer) have a specific way to do gradient clipping
                             self.optimizer.clip_grad_norm(self.args.max_grad_norm)
                         else:
-                            # Revert to normal cliiping otherwise, handling Apex or full precision
+                            # Revert to normal clipping otherwise, handling Apex or full precision
                             torch.nn.utils.clip_grad_norm_(
                                 amp.master_params(self.optimizer) if self.use_apex else model.parameters(),
                                 self.args.max_grad_norm,

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -804,14 +804,23 @@ class Trainer:
                     steps_in_epoch <= self.args.gradient_accumulation_steps
                     and (step + 1) == steps_in_epoch
                 ):
-                    if self.use_amp:
-                        self.scaler.unscale_(self.optimizer)
-                        torch.nn.utils.clip_grad_norm_(model.parameters(), self.args.max_grad_norm)
-                    elif self.use_apex:
-                        torch.nn.utils.clip_grad_norm_(amp.master_params(self.optimizer), self.args.max_grad_norm)
-                    else:
-                        torch.nn.utils.clip_grad_norm_(model.parameters(), self.args.max_grad_norm)
+                    # Gradient clipping
+                    if self.args.max_grad_norm is not None and self.args.max_grad_norm > 0:
+                        if self.use_amp:
+                            # AMP: gradients need unscaling
+                            self.scaler.unscale_(self.optimizer)
 
+                        if hasattr(self.optimizer, "clip_grad_norm"):
+                            # Some optimizer (like the sharded optimizer) have a specific gradient clipping
+                            self.optimizer.clip_grad_norm(self.args.max_grad_norm)
+                        else:
+                            # Revert to normal cliiping otherwise, handling Apex or full precision
+                            torch.nn.utils.clip_grad_norm_(
+                                amp.master_params(self.optimizer) if self.use_apex else model.parameters(),
+                                self.args.max_grad_norm,
+                            )
+
+                    # Optimizer step
                     if is_torch_tpu_available():
                         xm.optimizer_step(self.optimizer)
                     elif self.use_amp:


### PR DESCRIPTION
# What does this PR do?

As mentioned in the discussion of #9156, `Trainer` does not do gradient clipping correctly when using a sharded optimizer. This PR fixes that, and also allows `Trainer` to not perform any gradient clipping (by passing `None` or `0` to the corresponding argument).