### PR TITLE
[setup] correct transformers version format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -244,7 +244,7 @@ install_requires = [
 
 setup(
     name="transformers",
-    version="4.2.0dev0",
+    version="4.2.0.dev0", # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
     author="Thomas Wolf, Lysandre Debut, Victor Sanh, Julien Chaumond, Sam Shleifer, Patrick von Platen, Sylvain Gugger, Google AI Language Team Authors, Open AI team Authors, Facebook AI Authors, Carnegie Mellon University Authors",
     author_email="thomas@huggingface.co",
     description="State-of-the-art Natural Language Processing for TensorFlow 2.0 and PyTorch",


### PR DESCRIPTION
setuptools has a pretty fixed expectation of version numbers.

```
x.y.z
x.y.z.dev0
x.y.z.rc1
```

This PR fixes the dev version number and adds a comment with correct formats for the future editors

This fix removes this warning on `make fixup|style|etc` or any other time `setup.py` is being run.
```
setuptools/dist.py:452: UserWarning: Normalizing '4.2.0dev0' to '4.2.0.dev0'
  warnings.warn(tmpl.format(**locals()))
```
and the alternative:
```
/setuptools/dist.py:452: UserWarning: Normalizing '4.0.0-rc-1' to '4.0.0rc1'
```

Fixes: #8749

@LysandreJik, @sgugger
