### PR TITLE
Full rework of the TF input/output embeddings and bias resizing

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -17,10 +17,10 @@
 
 import functools
 import inspect
-from operator import ne
 import os
 import re
 import warnings
+from operator import ne
 from typing import Dict, List, Optional, Union
 
 import h5py

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -17,6 +17,7 @@
 
 import functools
 import inspect
+from operator import ne
 import os
 import re
 import warnings
@@ -921,7 +922,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
             :obj:`tf.Variable`: Pointer to the resized decoder or None if the output embeddings are differents of the
             input ones.
         """
-        new_lm_head_decoder = None
+        new_lm_head_decoder = old_lm_head_decoder
         is_input_output_equals = tf.reduce_any(self._find_weights(self.get_input_embeddings()) == old_lm_head_decoder)
 
         if old_lm_head_decoder is not None and not is_input_output_equals:

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -20,7 +20,7 @@ import inspect
 import os
 import re
 import warnings
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Union
 
 import h5py
 import numpy as np

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -652,7 +652,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
             else:
                 raise NotImplementedError
 
-    def get_output_embeddings(self) -> tf.keras.layers.Layer:
+    def get_output_embeddings(self) -> tf.Variable:
         """
         Returns the model's output embeddings
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -20,7 +20,6 @@ import inspect
 import os
 import re
 import warnings
-from operator import ne
 from typing import Dict, List, Optional, Union
 
 import h5py

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -689,8 +689,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
         Returns:
             :obj:`tf.Variable`: The new weights mapping vocabulary to hidden states.
         """
-
-        if hasattr(self, "get_lm_head"):
+        if self.get_lm_head() is not None:
             lm_head = self.get_lm_head()
             try:
                 return lm_head.get_output_embeddings()
@@ -709,14 +708,13 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
             value (:obj:`tf.Variable`):
                 The new weights mapping hidden states to vocabulary.
         """
-        if value is not None:
-            if hasattr(self, "get_lm_head"):
-                lm_head = self.get_lm_head()
-                try:
-                    lm_head.set_output_embeddings(value)
-                except AttributeError:
-                    self(self.dummy_inputs)
-                    lm_head.set_output_embeddings(value)
+        if value is not None and self.get_lm_head() is not None:
+            lm_head = self.get_lm_head()
+            try:
+                lm_head.set_output_embeddings(value)
+            except AttributeError:
+                self(self.dummy_inputs)
+                lm_head.set_output_embeddings(value)
 
     def get_bias(self) -> Union[None, Dict[str, tf.Variable]]:
         """
@@ -725,7 +723,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
         Return:
             :obj:`tf.Variable`: The weights representing the bias, None if not an LM model.
         """
-        if hasattr(self, "get_lm_head"):
+        if self.get_lm_head() is not None:
             lm_head = self.get_lm_head()
             try:
                 return lm_head.get_bias()
@@ -743,14 +741,13 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
             value (:obj:`Dict[tf.Variable]`):
                 All the new bias attached to an LM head.
         """
-        if value is not None:
-            if hasattr(self, "get_lm_head"):
-                lm_head = self.get_lm_head()
-                try:
-                    lm_head.set_bias(value)
-                except AttributeError:
-                    self(self.dummy_inputs)
-                    lm_head.set_bias(value)
+        if value is not None and self.get_lm_head() is not None:
+            lm_head = self.get_lm_head()
+            try:
+                lm_head.set_bias(value)
+            except AttributeError:
+                self(self.dummy_inputs)
+                lm_head.set_bias(value)
     
     def get_lm_head(self) -> tf.keras.layers.Layer:
         """

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -752,7 +752,13 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
                     self(self.dummy_inputs)
                     lm_head.set_bias(value)
     
-    def get_lm_head(self):
+    def get_lm_head(self) -> tf.keras.layers.Layer:
+        """
+        The LM Head layer.
+
+        Return:
+            :obj:`tf.keras.layers.Layer`: The LM head layer if the model has one, None if not.
+        """
         return None
 
     def resize_token_embeddings(self, new_num_tokens=None) -> tf.Variable:

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -545,9 +545,7 @@ def init_copy_embeddings(old_embeddings, new_num_tokens):
         )
         num_tokens_to_copy = min(old_num_tokens, new_num_tokens)
         mask = tf.fill(tf.convert_to_tensor([num_tokens_to_copy, 1]), True)
-        mask = tf.pad(
-            mask, tf.convert_to_tensor([[0, size_diff], [0, 0]]), constant_values=False
-        )
+        mask = tf.pad(mask, tf.convert_to_tensor([[0, size_diff], [0, 0]]), constant_values=False)
     else:
         # if the new size if lower than the old one, we take the current embeddings until the new size
         current_weights = tf.slice(
@@ -748,7 +746,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
             except AttributeError:
                 self(self.dummy_inputs)
                 lm_head.set_bias(value)
-    
+
     def get_lm_head(self) -> tf.keras.layers.Layer:
         """
         The LM Head layer.
@@ -892,7 +890,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
             init_decoder = tf.where(decoder_mask, current_decoder, new_lm_head_decoder.value())
 
             new_lm_head_decoder.assign(init_decoder)
-        
+
         return new_lm_head_decoder
 
     def _get_resized_embeddings(self, old_embeddings, new_num_tokens=None) -> tf.Variable:

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -632,6 +632,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
         else:
             raise NotImplementedError
     
+    def get_full_word_embeddings_name(self):
+        return None
+    
     def set_input_embeddings(self, value):
         """
         Set model's input embeddings.

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -471,7 +471,7 @@ class TFAlbertMLMHead(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def get_output_embeddings(self):
-        return self.decoder.word_embeddings
+        return self.decoder
 
     def set_output_embeddings(self, value):
         self.decoder.word_embeddings = value
@@ -516,7 +516,7 @@ class TFAlbertMainLayer(tf.keras.layers.Layer):
         )
 
     def get_input_embeddings(self):
-        return self.embeddings.word_embeddings
+        return self.embeddings
 
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -481,9 +481,9 @@ class TFAlbertMLMHead(tf.keras.layers.Layer):
         return {"bias": self.bias, "decoder_bias": self.decoder_bias}
 
     def set_bias(self, value):
-        for attr, weight in value.items():
-            setattr(self, attr, weight)
-            self.vocab_size = shape_list(weight)[0]
+        self.bias = value["bias"]
+        self.decoder_bias = value["decoder_bias"]
+        self.vocab_size = shape_list(value["bias"])[0]
 
     def call(self, hidden_states):
         hidden_states = self.dense(hidden_states)

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -19,6 +19,7 @@
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
+import numpy as np
 import tensorflow as tf
 
 from ...activations_tf import get_tf_activation
@@ -854,7 +855,7 @@ class TFAlbertForPreTraining(TFAlbertPreTrainedModel):
             )
             self.predictions.bias.assign(init_bias)
 
-            init_decoder_bias = tf.zeros((new_num_tokens,))
+            init_decoder_bias = np.zeros((new_num_tokens,))
             init_decoder_bias[:num_tokens_to_copy] = self.predictions.decoder_bias.value()[:num_tokens_to_copy]
             name = self.name + "/" + self.predictions.name + "/decoder_bias"
             self.predictions.decoder_bias = self.add_weight(
@@ -991,7 +992,7 @@ class TFAlbertForMaskedLM(TFAlbertPreTrainedModel, TFMaskedLanguageModelingLoss)
         if new_num_tokens is not None:
             num_tokens_to_copy = min(self.predictions.bias.shape[0], new_num_tokens)
             self.predictions.vocab_size = num_tokens_to_copy
-            init_bias = tf.zeros((new_num_tokens,))
+            init_bias = np.zeros((new_num_tokens,))
             init_bias[:num_tokens_to_copy] = self.predictions.bias.value()[:num_tokens_to_copy]
             name = self.name + "/" + self.predictions.name + "/bias"
             self.predictions.bias = self.add_weight(
@@ -999,7 +1000,7 @@ class TFAlbertForMaskedLM(TFAlbertPreTrainedModel, TFMaskedLanguageModelingLoss)
             )
             self.predictions.bias.assign(init_bias)
 
-            init_decoder_bias = tf.zeros((new_num_tokens,))
+            init_decoder_bias = np.zeros((new_num_tokens,))
             init_decoder_bias[:num_tokens_to_copy] = self.predictions.decoder_bias.value()[:num_tokens_to_copy]
             name = self.name + "/" + self.predictions.name + "/decoder_bias"
             self.predictions.decoder_bias = self.add_weight(

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -1198,18 +1198,41 @@ class TFBartForConditionalGeneration(TFBartPretrainedModel):
             return self.model.shared.weight
 
     def set_input_embeddings(self, value):
+        if value is not None:
+            try:
+                self.model.shared.weight = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.model.shared.weight = value
+
+            self.model.shared.vocab_size = shape_list(self.model.shared.weight)[0]
+            with tf.compat.v1.variable_scope("model.shared") as shared_abs_scope_name:
+                pass
+            embed_tokens = TFWrappedEmbeddings(self.model.shared, abs_scope_name=shared_abs_scope_name)
+            self.model.encoder.set_embed_tokens(embed_tokens)
+            self.model.decoder.set_embed_tokens(embed_tokens)
+
+    def get_output_embeddings(self):
         try:
-            self.model.shared.weight = value
+            return self.model.shared.weight
         except AttributeError:
             self(self.dummy_inputs)
-            self.model.shared.weight = value
+            return self.model.shared.weight
 
-        self.model.shared.vocab_size = shape_list(self.model.shared.weight)[0]
-        with tf.compat.v1.variable_scope("model.shared") as shared_abs_scope_name:
-            pass
-        embed_tokens = TFWrappedEmbeddings(self.model.shared, abs_scope_name=shared_abs_scope_name)
-        self.model.encoder.set_embed_tokens(embed_tokens)
-        self.model.decoder.set_embed_tokens(embed_tokens)
+    def set_output_embeddings(self, value):
+        if value is not None:
+            try:
+                self.model.shared.weight = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.model.shared.weight = value
+
+            self.model.shared.vocab_size = shape_list(self.model.shared.weight)[0]
+            with tf.compat.v1.variable_scope("model.shared") as shared_abs_scope_name:
+                pass
+            embed_tokens = TFWrappedEmbeddings(self.model.shared, abs_scope_name=shared_abs_scope_name)
+            self.model.encoder.set_embed_tokens(embed_tokens)
+            self.model.decoder.set_embed_tokens(embed_tokens)
 
     def get_final_logits_bias(self):
         return self.final_logits_bias

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -484,12 +484,7 @@ class TFBartPretrainedModel(TFPreTrainedModel):
     def get_input_embeddings(self):
         base_model = getattr(self, self.base_model_prefix, self)
 
-        try:
-            return base_model.shared.weight
-        except AttributeError:
-            self(self.dummy_inputs)
-
-        return base_model.shared.weight
+        return base_model.shared
 
     def set_input_embeddings(self, value):
         if value is not None:

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -504,18 +504,6 @@ class TFBartPretrainedModel(TFPreTrainedModel):
         base_model.encoder.set_embed_tokens(embed_tokens)
         base_model.decoder.set_embed_tokens(embed_tokens)
 
-    def get_output_embeddings(self):
-        return self.get_input_embeddings()
-
-    def set_output_embeddings(self, value):
-        self.set_input_embeddings(value)
-
-    def get_output_embeddings(self):
-        return self.get_input_embeddings()
-
-    def set_output_embeddings(self, value):
-        self.set_input_embeddings(value)
-
     @tf.function(
         input_signature=[
             {

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -1204,6 +1204,12 @@ class TFBartForConditionalGeneration(TFBartPretrainedModel):
     def get_encoder(self):
         return self.model.encoder
 
+    def get_output_embeddings(self):
+        return self.get_input_embeddings()
+
+    def set_output_embeddings(self, value):
+        self.set_input_embeddings(value)
+
     def get_bias(self):
         return {"final_logits_bias": self.final_logits_bias}
 

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -1011,6 +1011,15 @@ class TFBartModel(TFBartPretrainedModel):
 
     def get_decoder(self):
         return self.decoder
+    
+    def get_input_embeddings(self):
+        return self.shared
+
+    def set_input_embeddings(self, value):
+        self.shared = value
+
+    def get_output_embeddings(self):
+        return self.shared
 
     @add_start_docstrings_to_model_forward(BART_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
@@ -1133,15 +1142,6 @@ class TFBartModel(TFBartPretrainedModel):
             encoder_hidden_states=enc_hs,
             encoder_attentions=enc_attns,
         )
-
-    def get_input_embeddings(self):
-        return self.shared
-
-    def set_input_embeddings(self, value):
-        self.shared = value
-
-    def get_output_embeddings(self):
-        return self.shared
 
 
 @add_start_docstrings(

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -487,23 +487,28 @@ class TFBartPretrainedModel(TFPreTrainedModel):
         return base_model.shared
 
     def set_input_embeddings(self, value):
-        if value is not None:
-            base_model = getattr(self, self.base_model_prefix, self)
+        base_model = getattr(self, self.base_model_prefix, self)
 
-            try:
-                base_model.shared.weight = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                base_model.shared.weight = value
+        try:
+            base_model.shared.weight = value
+        except AttributeError:
+            self(self.dummy_inputs)
+            base_model.shared.weight = value
 
-            base_model.shared.vocab_size = shape_list(base_model.shared.weight)[0]
+        base_model.shared.vocab_size = shape_list(base_model.shared.weight)[0]
 
-            with tf.compat.v1.variable_scope("model.shared") as shared_abs_scope_name:
-                pass
+        with tf.compat.v1.variable_scope("model.shared") as shared_abs_scope_name:
+            pass
 
-            embed_tokens = TFWrappedEmbeddings(base_model.shared, abs_scope_name=shared_abs_scope_name)
-            base_model.encoder.set_embed_tokens(embed_tokens)
-            base_model.decoder.set_embed_tokens(embed_tokens)
+        embed_tokens = TFWrappedEmbeddings(base_model.shared, abs_scope_name=shared_abs_scope_name)
+        base_model.encoder.set_embed_tokens(embed_tokens)
+        base_model.decoder.set_embed_tokens(embed_tokens)
+
+    def get_output_embeddings(self):
+        return self.get_input_embeddings()
+
+    def set_output_embeddings(self, value):
+        self.set_input_embeddings(value)
 
     def get_output_embeddings(self):
         return self.get_input_embeddings()
@@ -1198,12 +1203,6 @@ class TFBartForConditionalGeneration(TFBartPretrainedModel):
 
     def get_encoder(self):
         return self.model.encoder
-
-    def get_output_embeddings(self):
-        return self.get_input_embeddings()
-
-    def set_output_embeddings(self, value):
-        self.set_input_embeddings(value)
 
     def get_bias(self):
         return {"final_logits_bias": self.final_logits_bias}

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -578,11 +578,11 @@ class TFBertMainLayer(tf.keras.layers.Layer):
         self.pooler = TFBertPooler(config, name="pooler") if add_pooling_layer else None
 
     def get_input_embeddings(self):
-        return self.embeddings
+        return self.embeddings.word_embeddings
 
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
-        self.embeddings.vocab_size = value.shape[0]
+        self.embeddings.vocab_size = shape_list(value)[0]
 
     def _prune_heads(self, heads_to_prune):
         """
@@ -919,13 +919,10 @@ class TFBertForPreTraining(TFBertPreTrainedModel, TFBertPreTrainingLoss):
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
     def get_output_embeddings(self):
-        return self.bert.embeddings
+        return self.get_input_embeddings()
 
-    def get_output_layer_with_bias(self):
+    def get_lm_head(self):
         return self.mlm.predictions
-
-    def get_prefix_bias_name(self):
-        return self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name
 
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFBertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
@@ -1045,13 +1042,10 @@ class TFBertForMaskedLM(TFBertPreTrainedModel, TFMaskedLanguageModelingLoss):
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
     def get_output_embeddings(self):
-        return self.bert.embeddings
+        return self.get_input_embeddings()
 
-    def get_output_layer_with_bias(self):
+    def get_lm_head(self):
         return self.mlm.predictions
-
-    def get_prefix_bias_name(self):
-        return self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name
 
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
@@ -1156,11 +1150,8 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
     def get_output_embeddings(self):
         return self.bert.embeddings
 
-    def get_output_layer_with_bias(self):
+    def get_lm_head(self):
         return self.mlm.predictions
-
-    def get_prefix_bias_name(self):
-        return self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name
 
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -526,6 +526,20 @@ class TFBertLMPredictionHead(tf.keras.layers.Layer):
 
         super().build(input_shape)
 
+    def get_output_embeddings(self):
+        return self.input_embeddings.word_embeddings
+
+    def set_output_embeddings(self, value):
+        self.input_embeddings.word_embeddings = value
+        self.input_embeddings.vocab_size = shape_list(value)[0]
+
+    def get_bias(self):
+        return {"bias": self.bias}
+
+    def set_bias(self, value):
+        self.bias = value["bias"]
+        self.vocab_size = shape_list(value["bias"])[0]
+
     def call(self, hidden_states):
         hidden_states = self.transform(hidden_states)
         hidden_states = self.input_embeddings(hidden_states, mode="linear")
@@ -918,37 +932,8 @@ class TFBertForPreTraining(TFBertPreTrainedModel, TFBertPreTrainingLoss):
         self.nsp = TFBertNSPHead(config, name="nsp___cls")
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
-    def get_output_embeddings(self):
-        try:
-            return self.mlm.predictions.input_embeddings.word_embeddings
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.mlm.predictions.input_embeddings.word_embeddings
-
-    def set_output_embeddings(self, value):
-        if value is not None:
-            try:
-                self.mlm.predictions.input_embeddings.word_embeddings = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.mlm.predictions.input_embeddings.word_embeddings = value
-            self.mlm.predictions.input_embeddings.vocab_size = shape_list(value)[0]
-
-    def get_bias(self):
-        try:
-            return self.mlm.predictions.bias
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.mlm.predictions.bias
-
-    def set_bias(self, value):
-        if value is not None:
-            try:
-                self.mlm.predictions.bias = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.mlm.predictions.bias = value
-            self.mlm.predictions.vocab_size = shape_list(value)[0]
+    def get_lm_head(self):
+        return self.mlm.predictions
 
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFBertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
@@ -1067,37 +1052,8 @@ class TFBertForMaskedLM(TFBertPreTrainedModel, TFMaskedLanguageModelingLoss):
         self.bert = TFBertMainLayer(config, add_pooling_layer=False, name="bert")
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
-    def get_output_embeddings(self):
-        try:
-            return self.mlm.predictions.input_embeddings.word_embeddings
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.mlm.predictions.input_embeddings.word_embeddings
-
-    def set_output_embeddings(self, value):
-        if value is not None:
-            try:
-                self.mlm.predictions.input_embeddings.word_embeddings = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.mlm.predictions.input_embeddings.word_embeddings = value
-            self.mlm.predictions.input_embeddings.vocab_size = shape_list(value)[0]
-
-    def get_bias(self):
-        try:
-            return self.mlm.predictions.bias
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.mlm.predictions.bias
-
-    def set_bias(self, value):
-        if value is not None:
-            try:
-                self.mlm.predictions.bias = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.mlm.predictions.bias = value
-            self.mlm.predictions.vocab_size = shape_list(value)[0]
+    def get_lm_head(self):
+        return self.mlm.predictions
 
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
@@ -1199,37 +1155,8 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
         self.bert = TFBertMainLayer(config, add_pooling_layer=False, name="bert")
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
-    def get_output_embeddings(self):
-        try:
-            return self.mlm.predictions.input_embeddings.word_embeddings
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.mlm.predictions.input_embeddings.word_embeddings
-
-    def set_output_embeddings(self, value):
-        if value is not None:
-            try:
-                self.mlm.predictions.input_embeddings.word_embeddings = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.mlm.predictions.input_embeddings.word_embeddings = value
-            self.mlm.predictions.input_embeddings.vocab_size = shape_list(value)[0]
-
-    def get_bias(self):
-        try:
-            return self.mlm.predictions.bias
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.mlm.predictions.bias
-
-    def set_bias(self, value):
-        if value is not None:
-            try:
-                self.mlm.predictions.bias = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.mlm.predictions.bias = value
-            self.mlm.predictions.vocab_size = shape_list(value)[0]
+    def get_lm_head(self):
+        return self.mlm.predictions
 
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """ TF 2.0 BERT model. """
 
+import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -527,7 +528,7 @@ class TFBertLMPredictionHead(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def get_output_embeddings(self):
-        return self.input_embeddings.word_embeddings
+        return self.input_embeddings
 
     def set_output_embeddings(self, value):
         self.input_embeddings.word_embeddings = value
@@ -592,7 +593,7 @@ class TFBertMainLayer(tf.keras.layers.Layer):
         self.pooler = TFBertPooler(config, name="pooler") if add_pooling_layer else None
 
     def get_input_embeddings(self):
-        return self.embeddings.word_embeddings
+        return self.embeddings
 
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
@@ -935,6 +936,16 @@ class TFBertForPreTraining(TFBertPreTrainedModel, TFBertPreTrainingLoss):
     def get_lm_head(self):
         return self.mlm.predictions
 
+    def get_output_layer_with_bias(self):
+        warnings.warn(
+            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
+        )
+        return self.mlm.predictions
+
+    def get_prefix_bias_name(self):
+        warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
+        return self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name
+
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFBertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
     def call(
@@ -1055,6 +1066,16 @@ class TFBertForMaskedLM(TFBertPreTrainedModel, TFMaskedLanguageModelingLoss):
     def get_lm_head(self):
         return self.mlm.predictions
 
+    def get_output_layer_with_bias(self):
+        warnings.warn(
+            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
+        )
+        return self.mlm.predictions
+
+    def get_prefix_bias_name(self):
+        warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
+        return self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name
+
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,
@@ -1157,6 +1178,16 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
 
     def get_lm_head(self):
         return self.mlm.predictions
+
+    def get_output_layer_with_bias(self):
+        warnings.warn(
+            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
+        )
+        return self.mlm.predictions
+
+    def get_prefix_bias_name(self):
+        warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
+        return self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name
 
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -919,10 +919,20 @@ class TFBertForPreTraining(TFBertPreTrainedModel, TFBertPreTrainingLoss):
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
     def get_output_embeddings(self):
-        return self.get_input_embeddings()
-    
+        try:
+            return self.mlm.predictions.input_embeddings.word_embeddings
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.mlm.predictions.input_embeddings.word_embeddings
+
     def set_output_embeddings(self, value):
-        self.set_input_embeddings(value)
+        if value is not None:
+            try:
+                self.mlm.predictions.input_embeddings.word_embeddings = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.mlm.predictions.input_embeddings.word_embeddings = value
+            self.mlm.predictions.input_embeddings.vocab_size = shape_list(value)[0]
 
     def get_bias(self):
         try:
@@ -930,12 +940,15 @@ class TFBertForPreTraining(TFBertPreTrainedModel, TFBertPreTrainingLoss):
         except AttributeError:
             self(self.dummy_inputs)
             return self.mlm.predictions.bias
-    
-    def set_bias(self, value):
-        super().set_bias(value)
 
-        self.mlm.predictions.bias = value
-        self.mlm.predictions.vocab_size = shape_list(value)[0]
+    def set_bias(self, value):
+        if value is not None:
+            try:
+                self.mlm.predictions.bias = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.mlm.predictions.bias = value
+            self.mlm.predictions.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFBertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
@@ -1055,10 +1068,20 @@ class TFBertForMaskedLM(TFBertPreTrainedModel, TFMaskedLanguageModelingLoss):
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
     def get_output_embeddings(self):
-        return self.get_input_embeddings()
-    
+        try:
+            return self.mlm.predictions.input_embeddings.word_embeddings
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.mlm.predictions.input_embeddings.word_embeddings
+
     def set_output_embeddings(self, value):
-        self.set_input_embeddings(value)
+        if value is not None:
+            try:
+                self.mlm.predictions.input_embeddings.word_embeddings = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.mlm.predictions.input_embeddings.word_embeddings = value
+            self.mlm.predictions.input_embeddings.vocab_size = shape_list(value)[0]
 
     def get_bias(self):
         try:
@@ -1066,12 +1089,15 @@ class TFBertForMaskedLM(TFBertPreTrainedModel, TFMaskedLanguageModelingLoss):
         except AttributeError:
             self(self.dummy_inputs)
             return self.mlm.predictions.bias
-    
-    def set_bias(self, value):
-        super().set_bias(value)
 
-        self.mlm.predictions.bias = value
-        self.mlm.predictions.vocab_size = shape_list(value)[0]
+    def set_bias(self, value):
+        if value is not None:
+            try:
+                self.mlm.predictions.bias = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.mlm.predictions.bias = value
+            self.mlm.predictions.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
@@ -1174,10 +1200,20 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
     def get_output_embeddings(self):
-        return self.get_input_embeddings()
-    
+        try:
+            return self.mlm.predictions.input_embeddings.word_embeddings
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.mlm.predictions.input_embeddings.word_embeddings
+
     def set_output_embeddings(self, value):
-        self.set_input_embeddings(value)
+        if value is not None:
+            try:
+                self.mlm.predictions.input_embeddings.word_embeddings = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.mlm.predictions.input_embeddings.word_embeddings = value
+            self.mlm.predictions.input_embeddings.vocab_size = shape_list(value)[0]
 
     def get_bias(self):
         try:
@@ -1185,12 +1221,15 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
         except AttributeError:
             self(self.dummy_inputs)
             return self.mlm.predictions.bias
-    
-    def set_bias(self, value):
-        super().set_bias(value)
 
-        self.mlm.predictions.bias = value
-        self.mlm.predictions.vocab_size = shape_list(value)[0]
+    def set_bias(self, value):
+        if value is not None:
+            try:
+                self.mlm.predictions.bias = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.mlm.predictions.bias = value
+            self.mlm.predictions.vocab_size = shape_list(value)[0]
 
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -920,9 +920,22 @@ class TFBertForPreTraining(TFBertPreTrainedModel, TFBertPreTrainingLoss):
 
     def get_output_embeddings(self):
         return self.get_input_embeddings()
+    
+    def set_output_embeddings(self, value):
+        self.set_input_embeddings(value)
 
-    def get_lm_head(self):
-        return self.mlm.predictions
+    def get_bias(self):
+        try:
+            return self.mlm.predictions.bias
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.mlm.predictions.bias
+    
+    def set_bias(self, value):
+        super().set_bias(value)
+
+        self.mlm.predictions.bias = value
+        self.mlm.predictions.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFBertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
@@ -1043,9 +1056,22 @@ class TFBertForMaskedLM(TFBertPreTrainedModel, TFMaskedLanguageModelingLoss):
 
     def get_output_embeddings(self):
         return self.get_input_embeddings()
+    
+    def set_output_embeddings(self, value):
+        self.set_input_embeddings(value)
 
-    def get_lm_head(self):
-        return self.mlm.predictions
+    def get_bias(self):
+        try:
+            return self.mlm.predictions.bias
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.mlm.predictions.bias
+    
+    def set_bias(self, value):
+        super().set_bias(value)
+
+        self.mlm.predictions.bias = value
+        self.mlm.predictions.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
@@ -1148,10 +1174,23 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
     def get_output_embeddings(self):
-        return self.bert.embeddings
+        return self.get_input_embeddings()
+    
+    def set_output_embeddings(self, value):
+        self.set_input_embeddings(value)
 
-    def get_lm_head(self):
-        return self.mlm.predictions
+    def get_bias(self):
+        try:
+            return self.mlm.predictions.bias
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.mlm.predictions.bias
+    
+    def set_bias(self, value):
+        super().set_bias(value)
+
+        self.mlm.predictions.bias = value
+        self.mlm.predictions.vocab_size = shape_list(value)[0]
 
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -936,12 +936,6 @@ class TFBertForPreTraining(TFBertPreTrainedModel, TFBertPreTrainingLoss):
     def get_lm_head(self):
         return self.mlm.predictions
 
-    def get_output_layer_with_bias(self):
-        warnings.warn(
-            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
-        )
-        return self.mlm.predictions
-
     def get_prefix_bias_name(self):
         warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
         return self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name
@@ -1066,12 +1060,6 @@ class TFBertForMaskedLM(TFBertPreTrainedModel, TFMaskedLanguageModelingLoss):
     def get_lm_head(self):
         return self.mlm.predictions
 
-    def get_output_layer_with_bias(self):
-        warnings.warn(
-            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
-        )
-        return self.mlm.predictions
-
     def get_prefix_bias_name(self):
         warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
         return self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name
@@ -1177,12 +1165,6 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
         self.mlm = TFBertMLMHead(config, self.bert.embeddings, name="mlm___cls")
 
     def get_lm_head(self):
-        return self.mlm.predictions
-
-    def get_output_layer_with_bias(self):
-        warnings.warn(
-            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
-        )
         return self.mlm.predictions
 
     def get_prefix_bias_name(self):

--- a/src/transformers/models/ctrl/modeling_tf_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_tf_ctrl.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 """ TF 2.0 CTRL model."""
 
+import warnings
+
 import numpy as np
 import tensorflow as tf
 
@@ -238,11 +240,11 @@ class TFCTRLMainLayer(tf.keras.layers.Layer):
         self.layernorm = tf.keras.layers.LayerNormalization(epsilon=config.layer_norm_epsilon, name="layernorm")
 
     def get_input_embeddings(self):
-        return self.w.weight
+        return self.w
 
     def set_input_embeddings(self, value):
         self.w.weight = value
-        self.w.vocab_size = value.shape[0]
+        self.w.vocab_size = shape_list(value)[0]
 
     def _prune_heads(self, heads_to_prune):
         """
@@ -618,7 +620,7 @@ class TFCTRLLMHead(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def get_output_embeddings(self):
-        return self.input_embeddings.weight
+        return self.input_embeddings
 
     def set_output_embeddings(self, value):
         self.input_embeddings.weight = value
@@ -653,6 +655,16 @@ class TFCTRLLMHeadModel(TFCTRLPreTrainedModel, TFCausalLanguageModelingLoss):
 
     def get_lm_head(self):
         return self.lm_head
+
+    def get_output_layer_with_bias(self):
+        warnings.warn(
+            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
+        )
+        return self.lm_head
+
+    def get_prefix_bias_name(self):
+        warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
+        return self.name + "/" + self.lm_head.name
 
     def prepare_inputs_for_generation(self, inputs, past, **kwargs):
         # only last token for inputs_ids if past is defined in kwargs

--- a/src/transformers/models/ctrl/modeling_tf_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_tf_ctrl.py
@@ -656,12 +656,6 @@ class TFCTRLLMHeadModel(TFCTRLPreTrainedModel, TFCausalLanguageModelingLoss):
     def get_lm_head(self):
         return self.lm_head
 
-    def get_output_layer_with_bias(self):
-        warnings.warn(
-            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
-        )
-        return self.lm_head
-
     def get_prefix_bias_name(self):
         warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
         return self.name + "/" + self.lm_head.name

--- a/src/transformers/models/distilbert/modeling_tf_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_tf_distilbert.py
@@ -16,6 +16,8 @@
  TF 2.0 DistilBERT model
 """
 
+import warnings
+
 import tensorflow as tf
 
 from ...activations_tf import get_tf_activation
@@ -395,7 +397,7 @@ class TFDistilBertMainLayer(tf.keras.layers.Layer):
         self.transformer = TFTransformer(config, name="transformer")  # Encoder
 
     def get_input_embeddings(self):
-        return self.embeddings.word_embeddings
+        return self.embeddings
 
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
@@ -649,7 +651,7 @@ class TFDistilBertLMHead(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def get_output_embeddings(self):
-        return self.input_embeddings.word_embeddings
+        return self.input_embeddings
 
     def set_output_embeddings(self, value):
         self.input_embeddings.word_embeddings = value
@@ -687,6 +689,16 @@ class TFDistilBertForMaskedLM(TFDistilBertPreTrainedModel, TFMaskedLanguageModel
 
     def get_lm_head(self):
         return self.vocab_projector
+
+    def get_output_layer_with_bias(self):
+        warnings.warn(
+            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
+        )
+        return self.vocab_projector
+
+    def get_prefix_bias_name(self):
+        warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
+        return self.name + "/" + self.vocab_projector.name
 
     @add_start_docstrings_to_model_forward(DISTILBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/distilbert/modeling_tf_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_tf_distilbert.py
@@ -690,12 +690,6 @@ class TFDistilBertForMaskedLM(TFDistilBertPreTrainedModel, TFMaskedLanguageModel
     def get_lm_head(self):
         return self.vocab_projector
 
-    def get_output_layer_with_bias(self):
-        warnings.warn(
-            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
-        )
-        return self.vocab_projector
-
     def get_prefix_bias_name(self):
         warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
         return self.name + "/" + self.vocab_projector.name

--- a/src/transformers/models/dpr/modeling_tf_dpr.py
+++ b/src/transformers/models/dpr/modeling_tf_dpr.py
@@ -576,6 +576,13 @@ class TFDPRContextEncoder(TFDPRPretrainedContextEncoder):
         super().__init__(config, *args, **kwargs)
         self.ctx_encoder = TFDPREncoderLayer(config, name="ctx_encoder")
 
+    def get_input_embeddings(self):
+        try:
+            return self.ctx_encoder.bert_model.get_input_embeddings()
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.ctx_encoder.bert_model.get_input_embeddings()
+
     @add_start_docstrings_to_model_forward(TF_DPR_ENCODERS_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFDPRContextEncoderOutput, config_class=_CONFIG_FOR_DOC)
     def call(
@@ -671,6 +678,13 @@ class TFDPRQuestionEncoder(TFDPRPretrainedQuestionEncoder):
         super().__init__(config, *args, **kwargs)
         self.question_encoder = TFDPREncoderLayer(config, name="question_encoder")
 
+    def get_input_embeddings(self):
+        try:
+            return self.question_encoder.bert_model.get_input_embeddings()
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.question_encoder.bert_model.get_input_embeddings()
+
     @add_start_docstrings_to_model_forward(TF_DPR_ENCODERS_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFDPRQuestionEncoderOutput, config_class=_CONFIG_FOR_DOC)
     def call(
@@ -764,6 +778,13 @@ class TFDPRReader(TFDPRPretrainedReader):
     def __init__(self, config: DPRConfig, *args, **kwargs):
         super().__init__(config, *args, **kwargs)
         self.span_predictor = TFDPRSpanPredictorLayer(config, name="span_predictor")
+
+    def get_input_embeddings(self):
+        try:
+            return self.span_predictor.encoder.bert_model.get_input_embeddings()
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.span_predictor.encoder.bert_model.get_input_embeddings()
 
     @add_start_docstrings_to_model_forward(TF_DPR_READER_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFDPRReaderOutput, config_class=_CONFIG_FOR_DOC)

--- a/src/transformers/models/dpr/modeling_tf_dpr.py
+++ b/src/transformers/models/dpr/modeling_tf_dpr.py
@@ -578,6 +578,9 @@ class TFDPRContextEncoder(TFDPRPretrainedContextEncoder):
 
     def get_input_embeddings(self):
         return self.ctx_encoder.bert_model.get_input_embeddings()
+    
+    def set_input_embeddings(self, value):
+        self.ctx_encoder.bert_model.set_input_embeddings(value)
 
     @add_start_docstrings_to_model_forward(TF_DPR_ENCODERS_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFDPRContextEncoderOutput, config_class=_CONFIG_FOR_DOC)
@@ -676,6 +679,9 @@ class TFDPRQuestionEncoder(TFDPRPretrainedQuestionEncoder):
 
     def get_input_embeddings(self):
         return self.question_encoder.bert_model.get_input_embeddings()
+    
+    def set_input_embeddings(self, value):
+        self.question_encoder.bert_model.set_input_embeddings(value)
 
     @add_start_docstrings_to_model_forward(TF_DPR_ENCODERS_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFDPRQuestionEncoderOutput, config_class=_CONFIG_FOR_DOC)
@@ -773,6 +779,9 @@ class TFDPRReader(TFDPRPretrainedReader):
 
     def get_input_embeddings(self):
         return self.span_predictor.encoder.bert_model.get_input_embeddings()
+    
+    def set_input_embeddings(self, value):
+        self.span_predictor.encoder.bert_model.set_input_embeddings(value)
 
     @add_start_docstrings_to_model_forward(TF_DPR_READER_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFDPRReaderOutput, config_class=_CONFIG_FOR_DOC)

--- a/src/transformers/models/dpr/modeling_tf_dpr.py
+++ b/src/transformers/models/dpr/modeling_tf_dpr.py
@@ -577,10 +577,20 @@ class TFDPRContextEncoder(TFDPRPretrainedContextEncoder):
         self.ctx_encoder = TFDPREncoderLayer(config, name="ctx_encoder")
 
     def get_input_embeddings(self):
-        return self.ctx_encoder.bert_model.get_input_embeddings()
-    
+        try:
+            return self.ctx_encoder.bert_model.embeddings.word_embeddings
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.ctx_encoder.bert_model.embeddings.word_embeddings
+
     def set_input_embeddings(self, value):
-        self.ctx_encoder.bert_model.set_input_embeddings(value)
+        if value is not None:
+            try:
+                self.ctx_encoder.bert_model.embeddings.word_embeddings = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.ctx_encoder.bert_model.embeddings.word_embeddings = value
+            self.ctx_encoder.bert_model.embeddings.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(TF_DPR_ENCODERS_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFDPRContextEncoderOutput, config_class=_CONFIG_FOR_DOC)
@@ -678,10 +688,20 @@ class TFDPRQuestionEncoder(TFDPRPretrainedQuestionEncoder):
         self.question_encoder = TFDPREncoderLayer(config, name="question_encoder")
 
     def get_input_embeddings(self):
-        return self.question_encoder.bert_model.get_input_embeddings()
-    
+        try:
+            return self.question_encoder.bert_model.embeddings.word_embeddings
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.question_encoder.bert_model.embeddings.word_embeddings
+
     def set_input_embeddings(self, value):
-        self.question_encoder.bert_model.set_input_embeddings(value)
+        if value is not None:
+            try:
+                self.question_encoder.bert_model.embeddings.word_embeddings = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.question_encoder.bert_model.embeddings.word_embeddings = value
+            self.question_encoder.bert_model.embeddings.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(TF_DPR_ENCODERS_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFDPRQuestionEncoderOutput, config_class=_CONFIG_FOR_DOC)
@@ -778,10 +798,20 @@ class TFDPRReader(TFDPRPretrainedReader):
         self.span_predictor = TFDPRSpanPredictorLayer(config, name="span_predictor")
 
     def get_input_embeddings(self):
-        return self.span_predictor.encoder.bert_model.get_input_embeddings()
-    
+        try:
+            return self.span_predictor.encoder.bert_model.embeddings.word_embeddings
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.span_predictor.encoder.bert_model.embeddings.word_embeddings
+
     def set_input_embeddings(self, value):
-        self.span_predictor.encoder.bert_model.set_input_embeddings(value)
+        if value is not None:
+            try:
+                self.span_predictor.encoder.bert_model.embeddings.word_embeddings = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.span_predictor.encoder.bert_model.embeddings.word_embeddings = value
+            self.span_predictor.encoder.bert_model.embeddings.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(TF_DPR_READER_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFDPRReaderOutput, config_class=_CONFIG_FOR_DOC)

--- a/src/transformers/models/dpr/modeling_tf_dpr.py
+++ b/src/transformers/models/dpr/modeling_tf_dpr.py
@@ -576,22 +576,6 @@ class TFDPRContextEncoder(TFDPRPretrainedContextEncoder):
         super().__init__(config, *args, **kwargs)
         self.ctx_encoder = TFDPREncoderLayer(config, name="ctx_encoder")
 
-    def get_input_embeddings(self):
-        try:
-            return self.ctx_encoder.bert_model.embeddings.word_embeddings
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.ctx_encoder.bert_model.embeddings.word_embeddings
-
-    def set_input_embeddings(self, value):
-        if value is not None:
-            try:
-                self.ctx_encoder.bert_model.embeddings.word_embeddings = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.ctx_encoder.bert_model.embeddings.word_embeddings = value
-            self.ctx_encoder.bert_model.embeddings.vocab_size = shape_list(value)[0]
-
     @add_start_docstrings_to_model_forward(TF_DPR_ENCODERS_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFDPRContextEncoderOutput, config_class=_CONFIG_FOR_DOC)
     def call(
@@ -687,22 +671,6 @@ class TFDPRQuestionEncoder(TFDPRPretrainedQuestionEncoder):
         super().__init__(config, *args, **kwargs)
         self.question_encoder = TFDPREncoderLayer(config, name="question_encoder")
 
-    def get_input_embeddings(self):
-        try:
-            return self.question_encoder.bert_model.embeddings.word_embeddings
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.question_encoder.bert_model.embeddings.word_embeddings
-
-    def set_input_embeddings(self, value):
-        if value is not None:
-            try:
-                self.question_encoder.bert_model.embeddings.word_embeddings = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.question_encoder.bert_model.embeddings.word_embeddings = value
-            self.question_encoder.bert_model.embeddings.vocab_size = shape_list(value)[0]
-
     @add_start_docstrings_to_model_forward(TF_DPR_ENCODERS_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFDPRQuestionEncoderOutput, config_class=_CONFIG_FOR_DOC)
     def call(
@@ -796,22 +764,6 @@ class TFDPRReader(TFDPRPretrainedReader):
     def __init__(self, config: DPRConfig, *args, **kwargs):
         super().__init__(config, *args, **kwargs)
         self.span_predictor = TFDPRSpanPredictorLayer(config, name="span_predictor")
-
-    def get_input_embeddings(self):
-        try:
-            return self.span_predictor.encoder.bert_model.embeddings.word_embeddings
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.span_predictor.encoder.bert_model.embeddings.word_embeddings
-
-    def set_input_embeddings(self, value):
-        if value is not None:
-            try:
-                self.span_predictor.encoder.bert_model.embeddings.word_embeddings = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.span_predictor.encoder.bert_model.embeddings.word_embeddings = value
-            self.span_predictor.encoder.bert_model.embeddings.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(TF_DPR_READER_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFDPRReaderOutput, config_class=_CONFIG_FOR_DOC)

--- a/src/transformers/models/electra/modeling_tf_electra.py
+++ b/src/transformers/models/electra/modeling_tf_electra.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """ TF Electra model. """
 
+import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -507,7 +508,7 @@ class TFElectraMainLayer(tf.keras.layers.Layer):
         self.config = config
 
     def get_input_embeddings(self):
-        return self.embeddings.word_embeddings
+        return self.embeddings
 
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
@@ -917,7 +918,7 @@ class TFElectraMaskedLMHead(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def get_output_embeddings(self):
-        return self.input_embeddings.word_embeddings
+        return self.input_embeddings
 
     def set_output_embeddings(self, value):
         self.input_embeddings.word_embeddings = value
@@ -963,6 +964,16 @@ class TFElectraForMaskedLM(TFElectraPreTrainedModel, TFMaskedLanguageModelingLos
 
     def get_lm_head(self):
         return self.generator_lm_head
+
+    def get_output_layer_with_bias(self):
+        warnings.warn(
+            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
+        )
+        return self.generator_lm_head
+
+    def get_prefix_bias_name(self):
+        warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
+        return self.name + "/" + self.generator_lm_head.name
 
     @add_start_docstrings_to_model_forward(ELECTRA_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/electra/modeling_tf_electra.py
+++ b/src/transformers/models/electra/modeling_tf_electra.py
@@ -965,12 +965,6 @@ class TFElectraForMaskedLM(TFElectraPreTrainedModel, TFMaskedLanguageModelingLos
     def get_lm_head(self):
         return self.generator_lm_head
 
-    def get_output_layer_with_bias(self):
-        warnings.warn(
-            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
-        )
-        return self.generator_lm_head
-
     def get_prefix_bias_name(self):
         warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
         return self.name + "/" + self.generator_lm_head.name

--- a/src/transformers/models/flaubert/modeling_tf_flaubert.py
+++ b/src/transformers/models/flaubert/modeling_tf_flaubert.py
@@ -775,10 +775,20 @@ class TFFlaubertWithLMHeadModel(TFFlaubertPreTrainedModel):
         self.pred_layer = TFFlaubertPredLayer(config, self.transformer.embeddings, name="pred_layer_._proj")
 
     def get_output_embeddings(self):
-        return self.get_input_embeddings()
-    
+        try:
+            return self.pred_layer.input_embeddings.weight
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.pred_layer.input_embeddings.weight
+
     def set_output_embeddings(self, value):
-        self.set_input_embeddings(value)
+        if value is not None:
+            try:
+                self.pred_layer.input_embeddings.weight = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.pred_layer.input_embeddings.weight = value
+            self.pred_layer.input_embeddings.vocab_size = shape_list(value)[0]
 
     def get_bias(self):
         try:
@@ -786,12 +796,15 @@ class TFFlaubertWithLMHeadModel(TFFlaubertPreTrainedModel):
         except AttributeError:
             self(self.dummy_inputs)
             return self.pred_layer.bias
-    
-    def set_bias(self, value):
-        super().set_bias(value)
 
-        self.pred_layer.bias = value
-        self.pred_layer.n_words = shape_list(value)[0]
+    def set_bias(self, value):
+        if value is not None:
+            try:
+                self.pred_layer.bias = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.pred_layer.bias = value
+            self.pred_layer.n_words = shape_list(value)[0]
 
     def prepare_inputs_for_generation(self, inputs, **kwargs):
         mask_token_id = self.config.mask_token_id

--- a/src/transformers/models/flaubert/modeling_tf_flaubert.py
+++ b/src/transformers/models/flaubert/modeling_tf_flaubert.py
@@ -18,6 +18,7 @@
 
 import itertools
 import random
+import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -479,7 +480,7 @@ class TFFlaubertMainLayer(tf.keras.layers.Layer):
             )
 
     def get_input_embeddings(self):
-        return self.embeddings.weight
+        return self.embeddings
 
     def set_input_embeddings(self, value):
         self.embeddings.weight = value
@@ -729,7 +730,7 @@ class TFFlaubertPredLayer(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def get_output_embeddings(self):
-        return self.input_embeddings.weight
+        return self.input_embeddings
 
     def set_output_embeddings(self, value):
         self.input_embeddings.weight = value
@@ -790,6 +791,16 @@ class TFFlaubertWithLMHeadModel(TFFlaubertPreTrainedModel):
 
     def get_lm_head(self):
         return self.pred_layer
+
+    def get_output_layer_with_bias(self):
+        warnings.warn(
+            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
+        )
+        return self.pred_layer
+
+    def get_prefix_bias_name(self):
+        warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
+        return self.name + "/" + self.pred_layer.name
 
     def prepare_inputs_for_generation(self, inputs, **kwargs):
         mask_token_id = self.config.mask_token_id

--- a/src/transformers/models/flaubert/modeling_tf_flaubert.py
+++ b/src/transformers/models/flaubert/modeling_tf_flaubert.py
@@ -728,6 +728,20 @@ class TFFlaubertPredLayer(tf.keras.layers.Layer):
 
         super().build(input_shape)
 
+    def get_output_embeddings(self):
+        return self.input_embeddings.weight
+
+    def set_output_embeddings(self, value):
+        self.input_embeddings.weight = value
+        self.input_embeddings.vocab_size = shape_list(value)[0]
+
+    def get_bias(self):
+        return {"bias": self.bias}
+
+    def set_bias(self, value):
+        self.bias = value["bias"]
+        self.vocab_size = shape_list(value["bias"])[0]
+
     def call(self, hidden_states):
         hidden_states = self.input_embeddings(hidden_states, mode="linear")
         hidden_states = hidden_states + self.bias
@@ -774,37 +788,8 @@ class TFFlaubertWithLMHeadModel(TFFlaubertPreTrainedModel):
         self.transformer = TFFlaubertMainLayer(config, name="transformer")
         self.pred_layer = TFFlaubertPredLayer(config, self.transformer.embeddings, name="pred_layer_._proj")
 
-    def get_output_embeddings(self):
-        try:
-            return self.pred_layer.input_embeddings.weight
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.pred_layer.input_embeddings.weight
-
-    def set_output_embeddings(self, value):
-        if value is not None:
-            try:
-                self.pred_layer.input_embeddings.weight = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.pred_layer.input_embeddings.weight = value
-            self.pred_layer.input_embeddings.vocab_size = shape_list(value)[0]
-
-    def get_bias(self):
-        try:
-            return self.pred_layer.bias
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.pred_layer.bias
-
-    def set_bias(self, value):
-        if value is not None:
-            try:
-                self.pred_layer.bias = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.pred_layer.bias = value
-            self.pred_layer.n_words = shape_list(value)[0]
+    def get_lm_head(self):
+        return self.pred_layer
 
     def prepare_inputs_for_generation(self, inputs, **kwargs):
         mask_token_id = self.config.mask_token_id

--- a/src/transformers/models/flaubert/modeling_tf_flaubert.py
+++ b/src/transformers/models/flaubert/modeling_tf_flaubert.py
@@ -792,12 +792,6 @@ class TFFlaubertWithLMHeadModel(TFFlaubertPreTrainedModel):
     def get_lm_head(self):
         return self.pred_layer
 
-    def get_output_layer_with_bias(self):
-        warnings.warn(
-            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
-        )
-        return self.pred_layer
-
     def get_prefix_bias_name(self):
         warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
         return self.name + "/" + self.pred_layer.name

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -784,7 +784,7 @@ class TFFunnelBaseLayer(tf.keras.layers.Layer):
         self.encoder = TFFunnelEncoder(config, name="encoder")
 
     def get_input_embeddings(self):
-        return self.embeddings.word_embeddings
+        return self.embeddings
 
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -992,6 +992,20 @@ class TFFunnelMaskedLMHead(tf.keras.layers.Layer):
         self.bias = self.add_weight(shape=(self.vocab_size,), initializer="zeros", trainable=True, name="bias")
         super().build(input_shape)
 
+    def get_output_embeddings(self):
+        return self.input_embeddings.word_embeddings
+
+    def set_output_embeddings(self, value):
+        self.input_embeddings.word_embeddings = value
+        self.input_embeddings.vocab_size = shape_list(value)[0]
+
+    def get_bias(self):
+        return {"bias": self.bias}
+
+    def set_bias(self, value):
+        self.bias = value["bias"]
+        self.vocab_size = shape_list(value["bias"])[0]
+
     def call(self, hidden_states, training=False):
         hidden_states = self.input_embeddings(hidden_states, mode="linear")
         hidden_states = hidden_states + self.bias
@@ -1359,37 +1373,8 @@ class TFFunnelForMaskedLM(TFFunnelPreTrainedModel, TFMaskedLanguageModelingLoss)
         self.funnel = TFFunnelMainLayer(config, name="funnel")
         self.lm_head = TFFunnelMaskedLMHead(config, self.funnel.embeddings, name="lm_head")
 
-    def get_output_embeddings(self):
-        try:
-            return self.lm_head.input_embeddings.word_embeddings
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.lm_head.input_embeddings.word_embeddings
-
-    def set_output_embeddings(self, value):
-        if value is not None:
-            try:
-                self.lm_head.input_embeddings.word_embeddings = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.lm_head.input_embeddings.word_embeddings = value
-            self.lm_head.input_embeddings.vocab_size = shape_list(value)[0]
-
-    def get_bias(self):
-        try:
-            return self.lm_head.bias
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.lm_head.bias
-
-    def set_bias(self, value):
-        if value is not None:
-            try:
-                self.lm_head.bias = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.lm_head.bias = value
-            self.lm_head.vocab_size = shape_list(value)[0]
+    def get_lm_head(self):
+        return self.lm_head
 
     @add_start_docstrings_to_model_forward(FUNNEL_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -1377,12 +1377,6 @@ class TFFunnelForMaskedLM(TFFunnelPreTrainedModel, TFMaskedLanguageModelingLoss)
     def get_lm_head(self):
         return self.lm_head
 
-    def get_output_layer_with_bias(self):
-        warnings.warn(
-            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
-        )
-        return self.lm_head
-
     def get_prefix_bias_name(self):
         warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
         return self.name + "/" + self.lm_head.name

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """ TF 2.0 Funnel model. """
 
+import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -869,7 +870,7 @@ class TFFunnelMainLayer(tf.keras.layers.Layer):
         self.decoder = TFFunnelDecoder(config, name="decoder")
 
     def get_input_embeddings(self):
-        return self.embeddings.word_embeddings
+        return self.embeddings
 
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
@@ -993,7 +994,7 @@ class TFFunnelMaskedLMHead(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def get_output_embeddings(self):
-        return self.input_embeddings.word_embeddings
+        return self.input_embeddings
 
     def set_output_embeddings(self, value):
         self.input_embeddings.word_embeddings = value
@@ -1375,6 +1376,16 @@ class TFFunnelForMaskedLM(TFFunnelPreTrainedModel, TFMaskedLanguageModelingLoss)
 
     def get_lm_head(self):
         return self.lm_head
+
+    def get_output_layer_with_bias(self):
+        warnings.warn(
+            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
+        )
+        return self.lm_head
+
+    def get_prefix_bias_name(self):
+        warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
+        return self.name + "/" + self.lm_head.name
 
     @add_start_docstrings_to_model_forward(FUNNEL_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -1360,10 +1360,20 @@ class TFFunnelForMaskedLM(TFFunnelPreTrainedModel, TFMaskedLanguageModelingLoss)
         self.lm_head = TFFunnelMaskedLMHead(config, self.funnel.embeddings, name="lm_head")
 
     def get_output_embeddings(self):
-        return self.get_input_embeddings()
-    
+        try:
+            return self.lm_head.input_embeddings.word_embeddings
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.lm_head.input_embeddings.word_embeddings
+
     def set_output_embeddings(self, value):
-        self.set_input_embeddings(value)
+        if value is not None:
+            try:
+                self.lm_head.input_embeddings.word_embeddings = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.lm_head.input_embeddings.word_embeddings = value
+            self.lm_head.input_embeddings.vocab_size = shape_list(value)[0]
 
     def get_bias(self):
         try:
@@ -1371,12 +1381,15 @@ class TFFunnelForMaskedLM(TFFunnelPreTrainedModel, TFMaskedLanguageModelingLoss)
         except AttributeError:
             self(self.dummy_inputs)
             return self.lm_head.bias
-    
-    def set_bias(self, value):
-        super().set_bias(value)
 
-        self.lm_head.bias = value
-        self.lm_head.vocab_size = shape_list(value)[0]
+    def set_bias(self, value):
+        if value is not None:
+            try:
+                self.lm_head.bias = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.lm_head.bias = value
+            self.lm_head.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(FUNNEL_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -783,11 +783,11 @@ class TFFunnelBaseLayer(tf.keras.layers.Layer):
         self.encoder = TFFunnelEncoder(config, name="encoder")
 
     def get_input_embeddings(self):
-        return self.embeddings
+        return self.embeddings.word_embeddings
 
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
-        self.embeddings.vocab_size = value.shape[0]
+        self.embeddings.vocab_size = shape_list(value)[0]
 
     def _prune_heads(self, heads_to_prune):
         raise NotImplementedError  # Not implemented yet in the library fr TF 2.0 models
@@ -869,11 +869,11 @@ class TFFunnelMainLayer(tf.keras.layers.Layer):
         self.decoder = TFFunnelDecoder(config, name="decoder")
 
     def get_input_embeddings(self):
-        return self.embeddings
+        return self.embeddings.word_embeddings
 
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
-        self.embeddings.vocab_size = value.shape[0]
+        self.embeddings.vocab_size = shape_list(value)[0]
 
     def _prune_heads(self, heads_to_prune):
         raise NotImplementedError  # Not implemented yet in the library fr TF 2.0 models
@@ -1360,13 +1360,23 @@ class TFFunnelForMaskedLM(TFFunnelPreTrainedModel, TFMaskedLanguageModelingLoss)
         self.lm_head = TFFunnelMaskedLMHead(config, self.funnel.embeddings, name="lm_head")
 
     def get_output_embeddings(self):
-        return self.funnel.embeddings
+        return self.get_input_embeddings()
+    
+    def set_output_embeddings(self, value):
+        self.set_input_embeddings(value)
 
-    def get_output_layer_with_bias(self):
-        return self.lm_head
+    def get_bias(self):
+        try:
+            return self.lm_head.bias
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.lm_head.bias
+    
+    def set_bias(self, value):
+        super().set_bias(value)
 
-    def get_prefix_bias_name(self):
-        return self.name + "/" + self.lm_head.name
+        self.lm_head.bias = value
+        self.lm_head.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(FUNNEL_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/gpt2/modeling_tf_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_tf_gpt2.py
@@ -656,20 +656,10 @@ class TFGPT2LMHeadModel(TFGPT2PreTrainedModel, TFCausalLanguageModelingLoss):
         self.transformer = TFGPT2MainLayer(config, name="transformer")
 
     def get_output_embeddings(self):
-        try:
-            return self.transformer.wte.weight
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.transformer.wte.weight
+        return self.get_input_embeddings()
 
     def set_output_embeddings(self, value):
-        if value is not None:
-            try:
-                self.transformer.wte.weight = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.transformer.wte.weight = value
-            self.transformer.wte.vocab_size = shape_list(value)[0]
+        self.set_input_embeddings(value)
 
     def prepare_inputs_for_generation(self, inputs, past, **kwargs):
         # only last token for inputs_ids if past is defined in kwargs
@@ -791,22 +781,6 @@ class TFGPT2DoubleHeadsModel(TFGPT2PreTrainedModel):
         self.multiple_choice_head = TFSequenceSummary(
             config, initializer_range=config.initializer_range, name="multiple_choice_head"
         )
-
-    def get_output_embeddings(self):
-        try:
-            return self.transformer.wte.weight
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.transformer.wte.weight
-
-    def set_output_embeddings(self, value):
-        if value is not None:
-            try:
-                self.transformer.wte.weight = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.transformer.wte.weight = value
-            self.transformer.wte.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(GPT2_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFGPT2DoubleHeadsModelOutput, config_class=_CONFIG_FOR_DOC)

--- a/src/transformers/models/gpt2/modeling_tf_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_tf_gpt2.py
@@ -239,7 +239,7 @@ class TFGPT2MainLayer(tf.keras.layers.Layer):
         self.ln_f = tf.keras.layers.LayerNormalization(epsilon=config.layer_norm_epsilon, name="ln_f")
 
     def get_input_embeddings(self):
-        return self.wte.weight
+        return self.wte
 
     def set_input_embeddings(self, value):
         self.wte.weight = value

--- a/src/transformers/models/gpt2/modeling_tf_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_tf_gpt2.py
@@ -656,10 +656,20 @@ class TFGPT2LMHeadModel(TFGPT2PreTrainedModel, TFCausalLanguageModelingLoss):
         self.transformer = TFGPT2MainLayer(config, name="transformer")
 
     def get_output_embeddings(self):
-        return self.get_input_embeddings()
-    
+        try:
+            return self.transformer.wte.weight
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.transformer.wte.weight
+
     def set_output_embeddings(self, value):
-        self.set_input_embeddings(value)
+        if value is not None:
+            try:
+                self.transformer.wte.weight = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.transformer.wte.weight = value
+            self.transformer.wte.vocab_size = shape_list(value)[0]
 
     def prepare_inputs_for_generation(self, inputs, past, **kwargs):
         # only last token for inputs_ids if past is defined in kwargs
@@ -783,10 +793,20 @@ class TFGPT2DoubleHeadsModel(TFGPT2PreTrainedModel):
         )
 
     def get_output_embeddings(self):
-        return self.get_input_embeddings()
-    
+        try:
+            return self.transformer.wte.weight
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.transformer.wte.weight
+
     def set_output_embeddings(self, value):
-        self.set_input_embeddings(value)
+        if value is not None:
+            try:
+                self.transformer.wte.weight = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.transformer.wte.weight = value
+            self.transformer.wte.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(GPT2_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFGPT2DoubleHeadsModelOutput, config_class=_CONFIG_FOR_DOC)

--- a/src/transformers/models/led/modeling_tf_led.py
+++ b/src/transformers/models/led/modeling_tf_led.py
@@ -1956,9 +1956,6 @@ class TFLEDModel(TFLEDPreTrainedModel):
     def get_decoder(self):
         return self.decoder
 
-    def get_output_embeddings(self):
-        return self.shared
-
     @add_start_docstrings_to_model_forward(LED_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/src/transformers/models/led/modeling_tf_led.py
+++ b/src/transformers/models/led/modeling_tf_led.py
@@ -1205,12 +1205,6 @@ class TFLEDPreTrainedModel(TFPreTrainedModel):
         base_model.encoder.set_embed_tokens(embed_tokens)
         base_model.decoder.set_embed_tokens(embed_tokens)
 
-    def get_output_embeddings(self):
-        return self.get_input_embeddings()
-
-    def set_output_embeddings(self, value):
-        self.set_input_embeddings(value)
-
 
 @dataclass
 # Copied from transformers.models.longformer.modeling_tf_longformer.TFLongformerBaseModelOutput with TFLongformer->TFLEDEncoder
@@ -1512,6 +1506,9 @@ class TFLEDEncoder(tf.keras.layers.Layer):
         self.layers = [TFLEDEncoderLayer(config, i, name=f"layers.{i}") for i in range(config.encoder_layers)]
         self.layernorm_embedding = tf.keras.layers.LayerNormalization(epsilon=1e-5, name="layernorm_embedding")
 
+    def set_embed_tokens(self, embed_tokens):
+        self.embed_tokens = embed_tokens
+
     def call(
         self,
         input_ids=None,
@@ -1742,6 +1739,9 @@ class TFLEDDecoder(tf.keras.layers.Layer):
         self.layernorm_embedding = tf.keras.layers.LayerNormalization(epsilon=1e-5, name="layernorm_embedding")
 
         self.dropout = tf.keras.layers.Dropout(config.dropout)
+
+    def set_embed_tokens(self, embed_tokens):
+        self.embed_tokens = embed_tokens
 
     def call(
         self,
@@ -2109,16 +2109,22 @@ class TFLEDForConditionalGeneration(TFLEDPreTrainedModel):
         )
 
     def get_decoder(self):
-        return self.model.decoder
+        return self.led.decoder
 
     def get_encoder(self):
-        return self.model.encoder
+        return self.led.encoder
 
     def get_bias(self):
         return {"final_logits_bias": self.final_logits_bias}
 
     def set_bias(self, value):
         self.final_logits_bias = value["final_logits_bias"]
+
+    def get_output_embeddings(self):
+        return self.get_input_embeddings()
+
+    def set_output_embeddings(self, value):
+        self.set_input_embeddings(value)
 
     @add_start_docstrings_to_model_forward(LED_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFLEDSeq2SeqLMOutput, config_class=_CONFIG_FOR_DOC)

--- a/src/transformers/models/led/modeling_tf_led.py
+++ b/src/transformers/models/led/modeling_tf_led.py
@@ -1205,6 +1205,21 @@ class TFLEDPreTrainedModel(TFPreTrainedModel):
         base_model.encoder.set_embed_tokens(embed_tokens)
         base_model.decoder.set_embed_tokens(embed_tokens)
 
+    @tf.function(
+        input_signature=[
+            {
+                "input_ids": tf.TensorSpec((None, None), tf.int32, name="input_ids"),
+                "attention_mask": tf.TensorSpec((None, None), tf.int32, name="attention_mask"),
+                "decoder_input_ids": tf.TensorSpec((None, None), tf.int32, name="decoder_input_ids"),
+                "decoder_attention_mask": tf.TensorSpec((None, None), tf.int32, name="decoder_attention_mask"),
+            }
+        ]
+    )
+    def serving(self, inputs):
+        output = self.call(inputs)
+
+        return self.serving_output(output)
+
 
 @dataclass
 # Copied from transformers.models.longformer.modeling_tf_longformer.TFLongformerBaseModelOutput with TFLongformer->TFLEDEncoder
@@ -2078,15 +2093,6 @@ class TFLEDModel(TFLEDPreTrainedModel):
             encoder_attentions=enc_attns,
             encoder_global_attentions=enc_g_attns,
         )
-
-    def get_input_embeddings(self):
-        return self.shared
-
-    def set_input_embeddings(self, value):
-        self.shared = value
-
-    def get_output_embeddings(self):
-        return self.shared
 
 
 @add_start_docstrings(

--- a/src/transformers/models/led/modeling_tf_led.py
+++ b/src/transformers/models/led/modeling_tf_led.py
@@ -1956,6 +1956,9 @@ class TFLEDModel(TFLEDPreTrainedModel):
     def get_decoder(self):
         return self.decoder
 
+    def get_output_embeddings(self):
+        return self.shared
+
     @add_start_docstrings_to_model_forward(LED_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -2041,10 +2041,20 @@ class TFLongformerForMaskedLM(TFLongformerPreTrainedModel, TFMaskedLanguageModel
         self.lm_head = TFLongformerLMHead(config, self.longformer.embeddings, name="lm_head")
 
     def get_output_embeddings(self):
-        return self.get_input_embeddings()
-    
+        try:
+            return self.lm_head.decoder.word_embeddings
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.lm_head.decoder.word_embeddings
+
     def set_output_embeddings(self, value):
-        self.set_input_embeddings(value)
+        if value is not None:
+            try:
+                self.lm_head.decoder.word_embeddings = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.lm_head.decoder.word_embeddings = value
+            self.lm_head.decoder.vocab_size = shape_list(value)[0]
 
     def get_bias(self):
         try:
@@ -2052,12 +2062,15 @@ class TFLongformerForMaskedLM(TFLongformerPreTrainedModel, TFMaskedLanguageModel
         except AttributeError:
             self(self.dummy_inputs)
             return self.lm_head.bias
-    
-    def set_bias(self, value):
-        super().set_bias(value)
 
-        self.lm_head.bias = value
-        self.lm_head.vocab_size = shape_list(value)[0]
+    def set_bias(self, value):
+        if value is not None:
+            try:
+                self.lm_head.bias = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.lm_head.bias = value
+            self.lm_head.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(LONGFORMER_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -2058,12 +2058,6 @@ class TFLongformerForMaskedLM(TFLongformerPreTrainedModel, TFMaskedLanguageModel
     def get_lm_head(self):
         return self.lm_head
 
-    def get_output_layer_with_bias(self):
-        warnings.warn(
-            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
-        )
-        return self.lm_head
-
     def get_prefix_bias_name(self):
         warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
         return self.name + "/" + self.lm_head.name

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -437,6 +437,20 @@ class TFLongformerLMHead(tf.keras.layers.Layer):
 
         super().build(input_shape)
 
+    def get_output_embeddings(self):
+        return self.decoder.word_embeddings
+
+    def set_output_embeddings(self, value):
+        self.decoder.word_embeddings = value
+        self.decoder.vocab_size = shape_list(value)[0]
+
+    def get_bias(self):
+        return {"bias": self.bias}
+
+    def set_bias(self, value):
+        self.bias = value["bias"]
+        self.vocab_size = shape_list(value["bias"])[0]
+
     def call(self, hidden_states):
         hidden_states = self.dense(hidden_states)
         hidden_states = self.act(hidden_states)
@@ -2040,37 +2054,8 @@ class TFLongformerForMaskedLM(TFLongformerPreTrainedModel, TFMaskedLanguageModel
         self.longformer = TFLongformerMainLayer(config, add_pooling_layer=False, name="longformer")
         self.lm_head = TFLongformerLMHead(config, self.longformer.embeddings, name="lm_head")
 
-    def get_output_embeddings(self):
-        try:
-            return self.lm_head.decoder.word_embeddings
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.lm_head.decoder.word_embeddings
-
-    def set_output_embeddings(self, value):
-        if value is not None:
-            try:
-                self.lm_head.decoder.word_embeddings = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.lm_head.decoder.word_embeddings = value
-            self.lm_head.decoder.vocab_size = shape_list(value)[0]
-
-    def get_bias(self):
-        try:
-            return self.lm_head.bias
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.lm_head.bias
-
-    def set_bias(self, value):
-        if value is not None:
-            try:
-                self.lm_head.bias = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.lm_head.bias = value
-            self.lm_head.vocab_size = shape_list(value)[0]
+    def get_lm_head(self):
+        return self.lm_head
 
     @add_start_docstrings_to_model_forward(LONGFORMER_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -1598,11 +1598,11 @@ class TFLongformerMainLayer(tf.keras.layers.Layer):
         self.pooler = TFLongformerPooler(config, name="pooler") if add_pooling_layer else None
 
     def get_input_embeddings(self):
-        return self.embeddings
+        return self.embeddings.word_embeddings
 
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
-        self.embeddings.vocab_size = value.shape[0]
+        self.embeddings.vocab_size = shape_list(value)[0]
 
     def _prune_heads(self, heads_to_prune):
         """
@@ -2041,13 +2041,23 @@ class TFLongformerForMaskedLM(TFLongformerPreTrainedModel, TFMaskedLanguageModel
         self.lm_head = TFLongformerLMHead(config, self.longformer.embeddings, name="lm_head")
 
     def get_output_embeddings(self):
-        return self.lm_head.decoder
+        return self.get_input_embeddings()
+    
+    def set_output_embeddings(self, value):
+        self.set_input_embeddings(value)
 
-    def get_output_layer_with_bias(self):
-        return self.lm_head
+    def get_bias(self):
+        try:
+            return self.lm_head.bias
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.lm_head.bias
+    
+    def set_bias(self, value):
+        super().set_bias(value)
 
-    def get_prefix_bias_name(self):
-        return self.name + "/" + self.lm_head.name
+        self.lm_head.bias = value
+        self.lm_head.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(LONGFORMER_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Tensorflow Longformer model. """
 
+import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -438,7 +439,7 @@ class TFLongformerLMHead(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def get_output_embeddings(self):
-        return self.decoder.word_embeddings
+        return self.decoder
 
     def set_output_embeddings(self, value):
         self.decoder.word_embeddings = value
@@ -1612,7 +1613,7 @@ class TFLongformerMainLayer(tf.keras.layers.Layer):
         self.pooler = TFLongformerPooler(config, name="pooler") if add_pooling_layer else None
 
     def get_input_embeddings(self):
-        return self.embeddings.word_embeddings
+        return self.embeddings
 
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
@@ -2056,6 +2057,16 @@ class TFLongformerForMaskedLM(TFLongformerPreTrainedModel, TFMaskedLanguageModel
 
     def get_lm_head(self):
         return self.lm_head
+
+    def get_output_layer_with_bias(self):
+        warnings.warn(
+            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
+        )
+        return self.lm_head
+
+    def get_prefix_bias_name(self):
+        warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
+        return self.name + "/" + self.lm_head.name
 
     @add_start_docstrings_to_model_forward(LONGFORMER_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/lxmert/modeling_tf_lxmert.py
+++ b/src/transformers/models/lxmert/modeling_tf_lxmert.py
@@ -1307,12 +1307,6 @@ class TFLxmertForPreTraining(TFLxmertPreTrainedModel):
     def get_lm_head(self):
         return self.cls.predictions
 
-    def get_output_layer_with_bias(self):
-        warnings.warn(
-            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
-        )
-        return self.cls.predictions
-
     def get_prefix_bias_name(self):
         warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
         return self.name + "/" + self.cls.name + "/" + self.cls.predictions.name

--- a/src/transformers/models/lxmert/modeling_tf_lxmert.py
+++ b/src/transformers/models/lxmert/modeling_tf_lxmert.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 """ TF 2.0 LXMERT model. """
 
+import warnings
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 
@@ -702,7 +703,7 @@ class TFLxmertMainLayer(tf.keras.layers.Layer):
         self.config = config
 
     def get_input_embeddings(self):
-        return self.embeddings.word_embeddings
+        return self.embeddings
 
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
@@ -1101,7 +1102,7 @@ class TFLxmertLMPredictionHead(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def get_output_embeddings(self):
-        return self.input_embeddings.word_embeddings
+        return self.input_embeddings
 
     def set_output_embeddings(self, value):
         self.input_embeddings.word_embeddings = value
@@ -1305,6 +1306,16 @@ class TFLxmertForPreTraining(TFLxmertPreTrainedModel):
 
     def get_lm_head(self):
         return self.cls.predictions
+
+    def get_output_layer_with_bias(self):
+        warnings.warn(
+            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
+        )
+        return self.cls.predictions
+
+    def get_prefix_bias_name(self):
+        warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
+        return self.name + "/" + self.cls.name + "/" + self.cls.predictions.name
 
     @add_start_docstrings_to_model_forward(LXMERT_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFLxmertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -704,7 +704,7 @@ class TFMobileBertMainLayer(tf.keras.layers.Layer):
 
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
-        self.embeddings.vocab_size = shape_list(value.shape[0])
+        self.embeddings.vocab_size = shape_list(value)[0]
 
     def _prune_heads(self, heads_to_prune):
         """
@@ -1036,20 +1036,30 @@ class TFMobileBertForPreTraining(TFMobileBertPreTrainedModel):
         self.seq_relationship = TFMobileBertOnlyNSPHead(2, name="seq_relationship___cls")
 
     def get_output_embeddings(self):
-        return self.predictions.predictions.decoder
+        try:
+            return self.predictions.predictions.decoder
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.predictions.predictions.decoder
     
     def set_output_embeddings(self, value):
-        if value is not None:
-            try:
-                self.predictions.predictions.decoder = value
-                self.predictions.predictions.vocab_size = shape_list(value)[0]
-            except AttributeError:
-                self.predictions.predictions.build([])
-                self.predictions.predictions.decoder = value
-                self.predictions.predictions.vocab_size = shape_list(value)[0]
+        super().set_output_embeddings(value)
 
-    def get_lm_head(self):
-        return self.predictions.predictions
+        self.predictions.predictions.decoder = value
+        self.predictions.predictions.vocab_size = shape_list(value)[0]
+
+    def get_bias(self):
+        try:
+            return self.predictions.predictions.bias
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.predictions.predictions.bias
+    
+    def set_bias(self, value):
+        super().set_bias(value)
+        
+        self.predictions.predictions.bias = value
+        self.predictions.predictions.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(MOBILEBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFMobileBertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
@@ -1153,14 +1163,30 @@ class TFMobileBertForMaskedLM(TFMobileBertPreTrainedModel, TFMaskedLanguageModel
         self.mlm = TFMobileBertMLMHead(config, name="mlm___cls")
 
     def get_output_embeddings(self):
-        return self.mlm.predictions.decoder
+        try:
+            return self.mlm.predictions.decoder
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.mlm.predictions.decoder
     
     def set_output_embeddings(self, value):
+        super().set_output_embeddings(value)
+
         self.mlm.predictions.decoder = value
         self.mlm.predictions.vocab_size = shape_list(value)[0]
 
-    def get_lm_head(self):
-        return self.mlm.predictions
+    def get_bias(self):
+        try:
+            return self.mlm.predictions.bias
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.mlm.predictions.bias
+    
+    def set_bias(self, value):
+        super().set_bias(value)
+
+        self.mlm.predictions.bias = value
+        self.mlm.predictions.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(MOBILEBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -1041,12 +1041,15 @@ class TFMobileBertForPreTraining(TFMobileBertPreTrainedModel):
         except AttributeError:
             self(self.dummy_inputs)
             return self.predictions.predictions.decoder
-    
-    def set_output_embeddings(self, value):
-        super().set_output_embeddings(value)
 
-        self.predictions.predictions.decoder = value
-        self.predictions.predictions.vocab_size = shape_list(value)[0]
+    def set_output_embeddings(self, value):
+        if value is not None:
+            try:
+                self.predictions.predictions.decoder = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.predictions.predictions.decoder = value
+            self.predictions.predictions.vocab_size = shape_list(value)[0]
 
     def get_bias(self):
         try:
@@ -1054,12 +1057,15 @@ class TFMobileBertForPreTraining(TFMobileBertPreTrainedModel):
         except AttributeError:
             self(self.dummy_inputs)
             return self.predictions.predictions.bias
-    
+
     def set_bias(self, value):
-        super().set_bias(value)
-        
-        self.predictions.predictions.bias = value
-        self.predictions.predictions.vocab_size = shape_list(value)[0]
+        if value is not None:
+            try:
+                self.predictions.predictions.bias = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.predictions.predictions.bias = value
+            self.predictions.predictions.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(MOBILEBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFMobileBertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
@@ -1168,12 +1174,15 @@ class TFMobileBertForMaskedLM(TFMobileBertPreTrainedModel, TFMaskedLanguageModel
         except AttributeError:
             self(self.dummy_inputs)
             return self.mlm.predictions.decoder
-    
-    def set_output_embeddings(self, value):
-        super().set_output_embeddings(value)
 
-        self.mlm.predictions.decoder = value
-        self.mlm.predictions.vocab_size = shape_list(value)[0]
+    def set_output_embeddings(self, value):
+        if value is not None:
+            try:
+                self.mlm.predictions.decoder = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.mlm.predictions.decoder = value
+            self.mlm.predictions.vocab_size = shape_list(value)[0]
 
     def get_bias(self):
         try:
@@ -1181,12 +1190,15 @@ class TFMobileBertForMaskedLM(TFMobileBertPreTrainedModel, TFMaskedLanguageModel
         except AttributeError:
             self(self.dummy_inputs)
             return self.mlm.predictions.bias
-    
-    def set_bias(self, value):
-        super().set_bias(value)
 
-        self.mlm.predictions.bias = value
-        self.mlm.predictions.vocab_size = shape_list(value)[0]
+    def set_bias(self, value):
+        if value is not None:
+            try:
+                self.mlm.predictions.bias = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.mlm.predictions.bias = value
+            self.mlm.predictions.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(MOBILEBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """ TF 2.0 MobileBERT model. """
 
+import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -666,7 +667,7 @@ class TFMobileBertLMPredictionHead(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def get_output_embeddings(self):
-        return self.decoder
+        return self
 
     def set_output_embeddings(self, value):
         self.decoder = value
@@ -714,7 +715,7 @@ class TFMobileBertMainLayer(tf.keras.layers.Layer):
         self.pooler = TFMobileBertPooler(config, name="pooler") if add_pooling_layer else None
 
     def get_input_embeddings(self):
-        return self.embeddings.word_embeddings
+        return self.embeddings
 
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
@@ -1052,6 +1053,16 @@ class TFMobileBertForPreTraining(TFMobileBertPreTrainedModel):
     def get_lm_head(self):
         return self.predictions.predictions
 
+    def get_output_layer_with_bias(self):
+        warnings.warn(
+            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
+        )
+        return self.predictions.predictions
+
+    def get_prefix_bias_name(self):
+        warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
+        return self.name + "/" + self.predictions.name + "/" + self.predictions.predictions.name
+
     @add_start_docstrings_to_model_forward(MOBILEBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @replace_return_docstrings(output_type=TFMobileBertForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
     def call(
@@ -1155,6 +1166,16 @@ class TFMobileBertForMaskedLM(TFMobileBertPreTrainedModel, TFMaskedLanguageModel
 
     def get_lm_head(self):
         return self.mlm.predictions
+
+    def get_output_layer_with_bias(self):
+        warnings.warn(
+            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
+        )
+        return self.mlm.predictions
+
+    def get_prefix_bias_name(self):
+        warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
+        return self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name
 
     @add_start_docstrings_to_model_forward(MOBILEBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -704,10 +704,7 @@ class TFMobileBertMainLayer(tf.keras.layers.Layer):
 
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
-        self.embeddings.vocab_size = value.shape[0]
-
-    def _resize_token_embeddings(self, new_num_tokens):
-        raise NotImplementedError
+        self.embeddings.vocab_size = shape_list(value.shape[0])
 
     def _prune_heads(self, heads_to_prune):
         """

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -1053,12 +1053,6 @@ class TFMobileBertForPreTraining(TFMobileBertPreTrainedModel):
     def get_lm_head(self):
         return self.predictions.predictions
 
-    def get_output_layer_with_bias(self):
-        warnings.warn(
-            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
-        )
-        return self.predictions.predictions
-
     def get_prefix_bias_name(self):
         warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
         return self.name + "/" + self.predictions.name + "/" + self.predictions.predictions.name
@@ -1165,12 +1159,6 @@ class TFMobileBertForMaskedLM(TFMobileBertPreTrainedModel, TFMaskedLanguageModel
         self.mlm = TFMobileBertMLMHead(config, name="mlm___cls")
 
     def get_lm_head(self):
-        return self.mlm.predictions
-
-    def get_output_layer_with_bias(self):
-        warnings.warn(
-            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
-        )
         return self.mlm.predictions
 
     def get_prefix_bias_name(self):

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -879,12 +879,6 @@ class TFMPNetForMaskedLM(TFMPNetPreTrainedModel, TFMaskedLanguageModelingLoss):
     def get_lm_head(self):
         return self.lm_head
 
-    def get_output_layer_with_bias(self):
-        warnings.warn(
-            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
-        )
-        return self.lm_head
-
     def get_prefix_bias_name(self):
         warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
         return self.name + "/" + self.lm_head.name

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -17,6 +17,7 @@
 
 
 import math
+import warnings
 
 import tensorflow as tf
 
@@ -536,7 +537,7 @@ class TFMPNetMainLayer(tf.keras.layers.Layer):
 
     # Copied from transformers.models.bert.modeling_tf_bert.TFBertMainLayer.get_input_embeddings
     def get_input_embeddings(self):
-        return self.embeddings.word_embeddings
+        return self.embeddings
 
     # Copied from transformers.models.bert.modeling_tf_bert.TFBertMainLayer.set_input_embeddings
     def set_input_embeddings(self, value):
@@ -840,7 +841,7 @@ class TFMPNetLMHead(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def get_output_embeddings(self):
-        return self.decoder.word_embeddings
+        return self.decoder
 
     def set_output_embeddings(self, value):
         self.decoder.word_embeddings = value
@@ -877,6 +878,16 @@ class TFMPNetForMaskedLM(TFMPNetPreTrainedModel, TFMaskedLanguageModelingLoss):
 
     def get_lm_head(self):
         return self.lm_head
+
+    def get_output_layer_with_bias(self):
+        warnings.warn(
+            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
+        )
+        return self.lm_head
+
+    def get_prefix_bias_name(self):
+        warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
+        return self.name + "/" + self.lm_head.name
 
     @add_start_docstrings_to_model_forward(MPNET_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -839,6 +839,20 @@ class TFMPNetLMHead(tf.keras.layers.Layer):
 
         super().build(input_shape)
 
+    def get_output_embeddings(self):
+        return self.decoder.word_embeddings
+
+    def set_output_embeddings(self, value):
+        self.decoder.word_embeddings = value
+        self.decoder.vocab_size = shape_list(value)[0]
+
+    def get_bias(self):
+        return {"bias": self.bias}
+
+    def set_bias(self, value):
+        self.bias = value["bias"]
+        self.vocab_size = shape_list(value["bias"])[0]
+
     def call(self, features):
         x = self.dense(features)
         x = self.act(x)
@@ -861,37 +875,8 @@ class TFMPNetForMaskedLM(TFMPNetPreTrainedModel, TFMaskedLanguageModelingLoss):
         self.mpnet = TFMPNetMainLayer(config, name="mpnet")
         self.lm_head = TFMPNetLMHead(config, self.mpnet.embeddings, name="lm_head")
 
-    def get_output_embeddings(self):
-        try:
-            return self.lm_head.decoder.word_embeddings
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.lm_head.decoder.word_embeddings
-
-    def set_output_embeddings(self, value):
-        if value is not None:
-            try:
-                self.lm_head.decoder.word_embeddings = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.lm_head.decoder.word_embeddings = value
-            self.lm_head.decoder.vocab_size = shape_list(value)[0]
-
-    def get_bias(self):
-        try:
-            return self.lm_head.bias
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.lm_head.bias
-
-    def set_bias(self, value):
-        if value is not None:
-            try:
-                self.lm_head.bias = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.lm_head.bias = value
-            self.lm_head.vocab_size = shape_list(value)[0]
+    def get_lm_head(self):
+        return self.lm_head
 
     @add_start_docstrings_to_model_forward(MPNET_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -536,12 +536,12 @@ class TFMPNetMainLayer(tf.keras.layers.Layer):
 
     # Copied from transformers.models.bert.modeling_tf_bert.TFBertMainLayer.get_input_embeddings
     def get_input_embeddings(self):
-        return self.embeddings
+        return self.embeddings.word_embeddings
 
     # Copied from transformers.models.bert.modeling_tf_bert.TFBertMainLayer.set_input_embeddings
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
-        self.embeddings.vocab_size = value.shape[0]
+        self.embeddings.vocab_size = shape_list(value)[0]
 
     # Copied from transformers.models.bert.modeling_tf_bert.TFBertMainLayer._prune_heads
     def _prune_heads(self, heads_to_prune):
@@ -862,13 +862,23 @@ class TFMPNetForMaskedLM(TFMPNetPreTrainedModel, TFMaskedLanguageModelingLoss):
         self.lm_head = TFMPNetLMHead(config, self.mpnet.embeddings, name="lm_head")
 
     def get_output_embeddings(self):
-        return self.mpnet.embeddings
+        return self.get_input_embeddings()
+    
+    def set_output_embeddings(self, value):
+        self.set_input_embeddings(value)
 
-    def get_output_layer_with_bias(self):
-        return self.lm_head
+    def get_bias(self):
+        try:
+            return self.lm_head.bias
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.lm_head.bias
+    
+    def set_bias(self, value):
+        super().set_bias(value)
 
-    def get_prefix_bias_name(self):
-        return self.name + "/" + self.lm_head.name
+        self.lm_head.bias = value
+        self.lm_head.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(MPNET_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/openai/modeling_tf_openai.py
+++ b/src/transformers/models/openai/modeling_tf_openai.py
@@ -215,7 +215,7 @@ class TFOpenAIGPTMainLayer(tf.keras.layers.Layer):
         self.h = [TFBlock(config.n_ctx, config, scale=True, name="h_._{}".format(i)) for i in range(config.n_layer)]
 
     def get_input_embeddings(self):
-        return self.tokens_embed.weight
+        return self.tokens_embed
 
     def set_input_embeddings(self, value):
         self.tokens_embed.weight = value

--- a/src/transformers/models/openai/modeling_tf_openai.py
+++ b/src/transformers/models/openai/modeling_tf_openai.py
@@ -580,20 +580,10 @@ class TFOpenAIGPTLMHeadModel(TFOpenAIGPTPreTrainedModel, TFCausalLanguageModelin
         self.transformer = TFOpenAIGPTMainLayer(config, name="transformer")
 
     def get_output_embeddings(self):
-        try:
-            return self.transformer.tokens_embed.weight
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.transformer.tokens_embed.weight
+        return self.get_input_embeddings()
 
     def set_output_embeddings(self, value):
-        if value is not None:
-            try:
-                self.transformer.tokens_embed.weight = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.transformer.tokens_embed.weight = value
-            self.transformer.tokens_embed.vocab_size = shape_list(value)[0]
+        self.set_input_embeddings(value)
 
     @add_start_docstrings_to_model_forward(OPENAI_GPT_INPUTS_DOCSTRING)
     @add_code_sample_docstrings(
@@ -700,22 +690,6 @@ class TFOpenAIGPTDoubleHeadsModel(TFOpenAIGPTPreTrainedModel):
         self.multiple_choice_head = TFSequenceSummary(
             config, initializer_range=config.initializer_range, name="multiple_choice_head"
         )
-
-    def get_output_embeddings(self):
-        try:
-            return self.transformer.tokens_embed.weight
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.transformer.tokens_embed.weight
-
-    def set_output_embeddings(self, value):
-        if value is not None:
-            try:
-                self.transformer.tokens_embed.weight = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.transformer.tokens_embed.weight = value
-            self.transformer.tokens_embed.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(OPENAI_GPT_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFOpenAIGPTDoubleHeadsModelOutput, config_class=_CONFIG_FOR_DOC)

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 """ TF 2.0 RoBERTa model. """
 
+import warnings
+
 import tensorflow as tf
 
 from ...activations_tf import get_tf_activation
@@ -497,7 +499,7 @@ class TFRobertaMainLayer(tf.keras.layers.Layer):
 
     # Copied from transformers.models.bert.modeling_tf_bert.TFBertMainLayer.get_input_embeddings
     def get_input_embeddings(self):
-        return self.embeddings.word_embeddings
+        return self.embeddings
 
     # Copied from transformers.models.bert.modeling_tf_bert.TFBertMainLayer.set_input_embeddings
     def set_input_embeddings(self, value):
@@ -827,7 +829,7 @@ class TFRobertaLMHead(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def get_output_embeddings(self):
-        return self.decoder.word_embeddings
+        return self.decoder
 
     def set_output_embeddings(self, value):
         self.decoder.word_embeddings = value
@@ -864,6 +866,16 @@ class TFRobertaForMaskedLM(TFRobertaPreTrainedModel, TFMaskedLanguageModelingLos
 
     def get_lm_head(self):
         return self.lm_head
+
+    def get_output_layer_with_bias(self):
+        warnings.warn(
+            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
+        )
+        return self.lm_head
+
+    def get_prefix_bias_name(self):
+        warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
+        return self.name + "/" + self.lm_head.name
 
     @add_start_docstrings_to_model_forward(ROBERTA_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -849,10 +849,20 @@ class TFRobertaForMaskedLM(TFRobertaPreTrainedModel, TFMaskedLanguageModelingLos
         self.lm_head = TFRobertaLMHead(config, self.roberta.embeddings, name="lm_head")
 
     def get_output_embeddings(self):
-        return self.get_input_embeddings()
-    
+        try:
+            return self.roberta.embeddings.word_embeddings
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.roberta.embeddings.word_embeddings
+
     def set_output_embeddings(self, value):
-        self.set_input_embeddings(value)
+        if value is not None:
+            try:
+                self.roberta.embeddings.word_embeddings = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.roberta.embeddings.word_embeddings = value
+            self.roberta.embeddings.vocab_size = shape_list(value)[0]
 
     def get_bias(self):
         try:
@@ -860,12 +870,15 @@ class TFRobertaForMaskedLM(TFRobertaPreTrainedModel, TFMaskedLanguageModelingLos
         except AttributeError:
             self(self.dummy_inputs)
             return self.lm_head.bias
-    
-    def set_bias(self, value):
-        super().set_bias(value)
 
-        self.lm_head.bias = value
-        self.lm_head.vocab_size = shape_list(value)[0]
+    def set_bias(self, value):
+        if value is not None:
+            try:
+                self.lm_head.bias = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.lm_head.bias = value
+            self.lm_head.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward(ROBERTA_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -867,12 +867,6 @@ class TFRobertaForMaskedLM(TFRobertaPreTrainedModel, TFMaskedLanguageModelingLos
     def get_lm_head(self):
         return self.lm_head
 
-    def get_output_layer_with_bias(self):
-        warnings.warn(
-            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
-        )
-        return self.lm_head
-
     def get_prefix_bias_name(self):
         warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
         return self.name + "/" + self.lm_head.name

--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -853,7 +853,8 @@ class TFT5PreTrainedModel(TFPreTrainedModel):
             # Wraps layer to avoid problems with weight restoring and ensuring we're in the correct TF scope.
             embed_tokens = TFWrappedEmbeddings(self.shared, abs_scope_name=shared_abs_scope_name)
             self.encoder.embed_tokens = embed_tokens
-            self.decoder.embed_tokens = embed_tokens
+            if hasattr(self, "decoder"):
+                self.decoder.embed_tokens = embed_tokens
 
     def _shift_right(self, input_ids):
         decoder_start_token_id = self.config.decoder_start_token_id

--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -832,11 +832,7 @@ class TFT5PreTrainedModel(TFPreTrainedModel):
         return self.serving_output(output)
 
     def get_input_embeddings(self):
-        try:
-            return self.shared.weight
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.shared.weight
+        return self.shared
 
     def set_input_embeddings(self, value):
         if value is not None:

--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -831,6 +831,30 @@ class TFT5PreTrainedModel(TFPreTrainedModel):
 
         return self.serving_output(output)
 
+    def get_input_embeddings(self):
+        try:
+            return self.shared.weight
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.shared.weight
+
+    def set_input_embeddings(self, value):
+        if value is not None:
+            try:
+                self.shared.weight = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.shared.weight = value
+
+            self.shared.vocab_size = shape_list(value)[0]
+            # retrieve correct absolute scope for embed token wrapper
+            with tf.compat.v1.variable_scope("shared") as shared_abs_scope_name:
+                pass
+            # Wraps layer to avoid problems with weight restoring and ensuring we're in the correct TF scope.
+            embed_tokens = TFWrappedEmbeddings(self.shared, abs_scope_name=shared_abs_scope_name)
+            self.encoder.embed_tokens = embed_tokens
+            self.decoder.embed_tokens = embed_tokens
+
     def _shift_right(self, input_ids):
         decoder_start_token_id = self.config.decoder_start_token_id
         pad_token_id = self.config.pad_token_id
@@ -1042,30 +1066,6 @@ class TFT5Model(TFT5PreTrainedModel):
         decoder_config.is_decoder = True
         self.decoder = TFT5MainLayer(decoder_config, embed_tokens, name="decoder")
 
-    def get_input_embeddings(self):
-        try:
-            return self.shared.weight
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.shared.weight
-
-    def set_input_embeddings(self, value):
-        if value is not None:
-            try:
-                self.shared.weight = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.shared.weight = value
-
-            self.shared.vocab_size = shape_list(value)[0]
-            # retrieve correct absolute scope for embed token wrapper
-            with tf.compat.v1.variable_scope("shared") as shared_abs_scope_name:
-                pass
-            # Wraps layer to avoid problems with weight restoring and ensuring we're in the correct TF scope.
-            embed_tokens = TFWrappedEmbeddings(self.shared, abs_scope_name=shared_abs_scope_name)
-            self.encoder.embed_tokens = embed_tokens
-            self.decoder.embed_tokens = embed_tokens
-
     def get_encoder(self):
         return self.encoder
 
@@ -1223,30 +1223,6 @@ class TFT5ForConditionalGeneration(TFT5PreTrainedModel, TFCausalLanguageModeling
 
         if not config.tie_word_embeddings:
             self.lm_head = tf.keras.layers.Dense(config.vocab_size, use_bias=False, name="lm_head")
-
-    def get_input_embeddings(self):
-        try:
-            return self.shared.weight
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.shared.weight
-
-    def set_input_embeddings(self, value):
-        if value is not None:
-            try:
-                self.shared.weight = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.shared.weight = value
-
-            self.shared.vocab_size = shape_list(value)[0]
-            # retrieve correct absolute scope for embed token wrapper
-            with tf.compat.v1.variable_scope("shared") as shared_abs_scope_name:
-                pass
-            # Wraps layer to avoid problems with weight restoring and ensuring we're in the correct TF scope.
-            embed_tokens = TFWrappedEmbeddings(self.shared, abs_scope_name=shared_abs_scope_name)
-            self.encoder.embed_tokens = embed_tokens
-            self.decoder.embed_tokens = embed_tokens
 
     def get_output_embeddings(self):
         if self.config.tie_word_embeddings:
@@ -1513,29 +1489,6 @@ class TFT5EncoderModel(TFT5PreTrainedModel):
         encoder_config = copy.deepcopy(config)
         encoder_config.use_cache = False
         self.encoder = TFT5MainLayer(encoder_config, embed_tokens, name="encoder")
-
-    def get_input_embeddings(self):
-        try:
-            return self.shared.weight
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.shared.weight
-
-    def set_input_embeddings(self, value):
-        if value is not None:
-            try:
-                self.shared.weight = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.shared.weight = value
-
-            self.shared.vocab_size = shape_list(value)[0]
-            # retrieve correct absolute scope for embed token wrapper
-            with tf.compat.v1.variable_scope("shared") as shared_abs_scope_name:
-                pass
-            # Wraps layer to avoid problems with weight restoring and ensuring we're in the correct TF scope.
-            embed_tokens = TFWrappedEmbeddings(self.shared, abs_scope_name=shared_abs_scope_name)
-            self.encoder.embed_tokens = embed_tokens
 
     def get_encoder(self):
         return self.encoder

--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -1043,18 +1043,28 @@ class TFT5Model(TFT5PreTrainedModel):
         self.decoder = TFT5MainLayer(decoder_config, embed_tokens, name="decoder")
 
     def get_input_embeddings(self):
-        return self.shared.weight
+        try:
+            return self.shared.weight
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.shared.weight
 
-    def set_input_embeddings(self, new_embeddings):
-        self.shared.weight = new_embeddings
-        self.shared.vocab_size = shape_list(new_embeddings)[0]
-        # retrieve correct absolute scope for embed token wrapper
-        with tf.compat.v1.variable_scope("shared") as shared_abs_scope_name:
-            pass
-        # Wraps layer to avoid problems with weight restoring and ensuring we're in the correct TF scope.
-        embed_tokens = TFWrappedEmbeddings(self.shared, abs_scope_name=shared_abs_scope_name)
-        self.encoder.set_embed_tokens(embed_tokens)
-        self.decoder.set_embed_tokens(embed_tokens)
+    def set_input_embeddings(self, value):
+        if value is not None:
+            try:
+                self.shared.weight = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.shared.weight = value
+
+            self.shared.vocab_size = shape_list(value)[0]
+            # retrieve correct absolute scope for embed token wrapper
+            with tf.compat.v1.variable_scope("shared") as shared_abs_scope_name:
+                pass
+            # Wraps layer to avoid problems with weight restoring and ensuring we're in the correct TF scope.
+            embed_tokens = TFWrappedEmbeddings(self.shared, abs_scope_name=shared_abs_scope_name)
+            self.encoder.embed_tokens = embed_tokens
+            self.decoder.embed_tokens = embed_tokens
 
     def get_encoder(self):
         return self.encoder
@@ -1215,18 +1225,28 @@ class TFT5ForConditionalGeneration(TFT5PreTrainedModel, TFCausalLanguageModeling
             self.lm_head = tf.keras.layers.Dense(config.vocab_size, use_bias=False, name="lm_head")
 
     def get_input_embeddings(self):
-        return self.shared.weight
-    
-    def set_input_embeddings(self, new_embeddings):
-        self.shared.weight = new_embeddings
-        self.shared.vocab_size = shape_list(new_embeddings)[0]
-        # retrieve correct absolute scope for embed token wrapper
-        with tf.compat.v1.variable_scope("shared") as shared_abs_scope_name:
-            pass
-        # Wraps layer to avoid problems with weight restoring and ensuring we're in the correct TF scope.
-        embed_tokens = TFWrappedEmbeddings(self.shared, abs_scope_name=shared_abs_scope_name)
-        self.encoder.set_embed_tokens(embed_tokens)
-        self.decoder.set_embed_tokens(embed_tokens)
+        try:
+            return self.shared.weight
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.shared.weight
+
+    def set_input_embeddings(self, value):
+        if value is not None:
+            try:
+                self.shared.weight = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.shared.weight = value
+
+            self.shared.vocab_size = shape_list(value)[0]
+            # retrieve correct absolute scope for embed token wrapper
+            with tf.compat.v1.variable_scope("shared") as shared_abs_scope_name:
+                pass
+            # Wraps layer to avoid problems with weight restoring and ensuring we're in the correct TF scope.
+            embed_tokens = TFWrappedEmbeddings(self.shared, abs_scope_name=shared_abs_scope_name)
+            self.encoder.embed_tokens = embed_tokens
+            self.decoder.embed_tokens = embed_tokens
 
     def get_output_embeddings(self):
         if self.config.tie_word_embeddings:
@@ -1235,16 +1255,17 @@ class TFT5ForConditionalGeneration(TFT5PreTrainedModel, TFCausalLanguageModeling
             # in a dense layer the kernel has a shape (last_dim, units), for us (dim, num_tokens)
             # value has a shape (num_tokens, dim) then needs to be transposed
             return tf.transpose(self.lm_head.kernel)
-        
+
     def set_output_embeddings(self, value):
-        if self.config.tie_word_embeddings:
-            self.set_input_embeddings(value)
-        else:
-            self.lm_head = tf.keras.layers.Dense(shape_list(value)[0], use_bias=False, name="lm_head")
-            # in a dense layer the kernel has a shape (last_dim, units), for us (dim, num_tokens)
-            # value has a shape (num_tokens, dim) then needs to be transposed
-            transposed_value = tf.transpose(value)  
-            self.lm_head.kernel = transposed_value
+        if value is not None:
+            if self.config.tie_word_embeddings:
+                self.set_input_embeddings(value)
+            else:
+                self.lm_head = tf.keras.layers.Dense(shape_list(value)[0], use_bias=False, name="lm_head")
+                # in a dense layer the kernel has a shape (last_dim, units), for us (dim, num_tokens)
+                # value has a shape (num_tokens, dim) then needs to be transposed
+                transposed_value = tf.transpose(value)
+                self.lm_head.kernel = transposed_value
 
     def get_encoder(self):
         return self.encoder
@@ -1363,9 +1384,9 @@ class TFT5ForConditionalGeneration(TFT5PreTrainedModel, TFCausalLanguageModeling
         # T5v1.1 does not tie output word embeddings and thus does not require downscaling
         if self.config.tie_word_embeddings:
             sequence_output = sequence_output * (self.model_dim ** -0.5)
-            logits = self.get_output_embeddings()(sequence_output, mode="linear")
+            logits = self.shared(sequence_output, mode="linear")
         else:
-            logits = self.get_output_embeddings()(sequence_output)
+            logits = self.lm_head(sequence_output)
 
         loss = None if inputs["labels"] is None else self.compute_loss(inputs["labels"], logits)
 
@@ -1494,18 +1515,27 @@ class TFT5EncoderModel(TFT5PreTrainedModel):
         self.encoder = TFT5MainLayer(encoder_config, embed_tokens, name="encoder")
 
     def get_input_embeddings(self):
-        return self.shared.weight
-    
-    def set_input_embeddings(self, new_embeddings):
-        self.shared.weight = new_embeddings
-        self.shared.vocab_size = shape_list(new_embeddings)[0]
-        # retrieve correct absolute scope for embed token wrapper
-        with tf.compat.v1.variable_scope("shared") as shared_abs_scope_name:
-            pass
-        # Wraps layer to avoid problems with weight restoring and ensuring we're in the correct TF scope.
-        embed_tokens = TFWrappedEmbeddings(self.shared, abs_scope_name=shared_abs_scope_name)
-        self.encoder.set_embed_tokens(embed_tokens)
-        self.decoder.set_embed_tokens(embed_tokens)
+        try:
+            return self.shared.weight
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.shared.weight
+
+    def set_input_embeddings(self, value):
+        if value is not None:
+            try:
+                self.shared.weight = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.shared.weight = value
+
+            self.shared.vocab_size = shape_list(value)[0]
+            # retrieve correct absolute scope for embed token wrapper
+            with tf.compat.v1.variable_scope("shared") as shared_abs_scope_name:
+                pass
+            # Wraps layer to avoid problems with weight restoring and ensuring we're in the correct TF scope.
+            embed_tokens = TFWrappedEmbeddings(self.shared, abs_scope_name=shared_abs_scope_name)
+            self.encoder.embed_tokens = embed_tokens
 
     def get_encoder(self):
         return self.encoder

--- a/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
+++ b/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
@@ -468,9 +468,6 @@ class TFTransfoXLMainLayer(tf.keras.layers.Layer):
     def set_input_embeddings(self, value):
         raise NotImplementedError
 
-    def _resize_token_embeddings(self, new_num_tokens):
-        return self.word_emb
-
     def backward_compatible(self):
         self.sample_softmax = -1
 
@@ -909,25 +906,6 @@ class TFTransfoXLModel(TFTransfoXLPreTrainedModel):
         )
 
 
-class TFTransfoXLMHead(tf.keras.layers.Layer):
-    def __init__(self, config, input_embeddings, **kwargs):
-        super().__init__(**kwargs)
-        self.vocab_size = config.vocab_size
-
-        # The output weights are the same as the input embeddings, but there is
-        # an output-only bias for each token.
-        self.input_embeddings = input_embeddings
-
-    def build(self, input_shape):
-        self.bias = self.add_weight(shape=(self.vocab_size,), initializer="zeros", trainable=True, name="bias")
-        super().build(input_shape)
-
-    def call(self, hidden_states):
-        hidden_states = self.input_embeddings(hidden_states, mode="linear")
-        hidden_states = hidden_states + self.bias
-        return hidden_states
-
-
 @add_start_docstrings(
     """
     The Transformer-XL Model with a language modeling head on top (adaptive softmax with weights tied to the adaptive
@@ -947,6 +925,9 @@ class TFTransfoXLLMHeadModel(TFTransfoXLPreTrainedModel):
         self.crit = TFAdaptiveSoftmaxMask(
             config.vocab_size, config.d_embed, config.d_model, config.cutoffs, div_val=config.div_val, name="crit"
         )
+    
+    def _resize_token_embeddings(self, new_num_tokens):
+        return None
 
     def get_output_embeddings(self):
         """Double-check if you are using adaptive softmax."""

--- a/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
+++ b/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
@@ -927,7 +927,7 @@ class TFTransfoXLLMHeadModel(TFTransfoXLPreTrainedModel):
         )
 
     def _resize_token_embeddings(self, new_num_tokens):
-        return None
+        raise NotImplementedError()
 
     def get_output_embeddings(self):
         """Double-check if you are using adaptive softmax."""

--- a/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
+++ b/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
@@ -925,7 +925,7 @@ class TFTransfoXLLMHeadModel(TFTransfoXLPreTrainedModel):
         self.crit = TFAdaptiveSoftmaxMask(
             config.vocab_size, config.d_embed, config.d_model, config.cutoffs, div_val=config.div_val, name="crit"
         )
-    
+
     def _resize_token_embeddings(self, new_num_tokens):
         return None
 

--- a/src/transformers/models/xlm/modeling_tf_xlm.py
+++ b/src/transformers/models/xlm/modeling_tf_xlm.py
@@ -825,12 +825,6 @@ class TFXLMWithLMHeadModel(TFXLMPreTrainedModel):
     def get_lm_head(self):
         return self.pred_layer
 
-    def get_output_layer_with_bias(self):
-        warnings.warn(
-            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
-        )
-        return self.pred_layer
-
     def get_prefix_bias_name(self):
         warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
         return self.name + "/" + self.pred_layer.name

--- a/src/transformers/models/xlm/modeling_tf_xlm.py
+++ b/src/transformers/models/xlm/modeling_tf_xlm.py
@@ -17,6 +17,7 @@
 """
 
 import itertools
+import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -326,7 +327,7 @@ class TFXLMMainLayer(tf.keras.layers.Layer):
                     self.prune_heads({int(layer): list(map(int, heads))})
 
     def get_input_embeddings(self):
-        return self.embeddings.weight
+        return self.embeddings
 
     def set_input_embeddings(self, value):
         self.embeddings.weight = value
@@ -788,7 +789,7 @@ class TFXLMPredLayer(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def get_output_embeddings(self):
-        return self.input_embeddings.weight
+        return self.input_embeddings
 
     def set_output_embeddings(self, value):
         self.input_embeddings.weight = value
@@ -823,6 +824,16 @@ class TFXLMWithLMHeadModel(TFXLMPreTrainedModel):
 
     def get_lm_head(self):
         return self.pred_layer
+
+    def get_output_layer_with_bias(self):
+        warnings.warn(
+            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
+        )
+        return self.pred_layer
+
+    def get_prefix_bias_name(self):
+        warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
+        return self.name + "/" + self.pred_layer.name
 
     def prepare_inputs_for_generation(self, inputs, **kwargs):
         mask_token_id = self.config.mask_token_id

--- a/src/transformers/models/xlnet/modeling_tf_xlnet.py
+++ b/src/transformers/models/xlnet/modeling_tf_xlnet.py
@@ -17,6 +17,7 @@
  TF 2.0 XLNet model.
 """
 
+import warnings
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
@@ -408,7 +409,7 @@ class TFXLNetLMHead(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def get_output_embeddings(self):
-        return self.input_embeddings.weight
+        return self.input_embeddings
 
     def set_output_embeddings(self, value):
         self.input_embeddings.weight = value
@@ -460,7 +461,7 @@ class TFXLNetMainLayer(tf.keras.layers.Layer):
         self.use_mems_train = config.use_mems_train
 
     def get_input_embeddings(self):
-        return self.word_embedding.weight
+        return self.word_embedding
 
     def set_input_embeddings(self, value):
         self.word_embedding.weight = value
@@ -1243,6 +1244,16 @@ class TFXLNetLMHeadModel(TFXLNetPreTrainedModel, TFCausalLanguageModelingLoss):
 
     def get_lm_head(self):
         return self.lm_loss
+
+    def get_output_layer_with_bias(self):
+        warnings.warn(
+            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
+        )
+        return self.lm_loss
+
+    def get_prefix_bias_name(self):
+        warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
+        return self.name + "/" + self.lm_loss.name
 
     def prepare_inputs_for_generation(self, inputs, past, use_mems=None, **kwargs):
         # Add dummy token at the end (no attention on this one)

--- a/src/transformers/models/xlnet/modeling_tf_xlnet.py
+++ b/src/transformers/models/xlnet/modeling_tf_xlnet.py
@@ -1245,12 +1245,6 @@ class TFXLNetLMHeadModel(TFXLNetPreTrainedModel, TFCausalLanguageModelingLoss):
     def get_lm_head(self):
         return self.lm_loss
 
-    def get_output_layer_with_bias(self):
-        warnings.warn(
-            "The method get_output_layer_with_bias is deprecated. Please use `get_lm_head` instead.", FutureWarning
-        )
-        return self.lm_loss
-
     def get_prefix_bias_name(self):
         warnings.warn("The method get_prefix_bias_name is deprecated. Please use `get_bias` instead.", FutureWarning)
         return self.name + "/" + self.lm_loss.name

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -1877,20 +1877,6 @@ class TF{{cookiecutter.camelcase_modelname}}PreTrainedModel(TFPreTrainedModel):
         }
         return dummy_inputs
     
-    @tf.function(
-        input_signature=[
-            {
-                "input_ids": tf.TensorSpec((None, None), tf.int32, name="input_ids"),
-                "attention_mask": tf.TensorSpec((None, None), tf.int32, name="attention_mask"),
-                "decoder_input_ids": tf.TensorSpec((None, None), tf.int32, name="decoder_input_ids"),
-                "decoder_attention_mask": tf.TensorSpec((None, None), tf.int32, name="decoder_attention_mask"),
-            }
-        ]
-    )
-    def serving(self, inputs):
-        output = self.call(inputs)
-
-        return self.serving_output(output)
     def get_input_embeddings(self):
         base_model = getattr(self, self.base_model_prefix, self)
 
@@ -1913,6 +1899,21 @@ class TF{{cookiecutter.camelcase_modelname}}PreTrainedModel(TFPreTrainedModel):
         embed_tokens = TFWrappedEmbeddings(base_model.shared, abs_scope_name=shared_abs_scope_name)
         base_model.encoder.set_embed_tokens(embed_tokens)
         base_model.decoder.set_embed_tokens(embed_tokens)
+    
+    @tf.function(
+        input_signature=[
+            {
+                "input_ids": tf.TensorSpec((None, None), tf.int32, name="input_ids"),
+                "attention_mask": tf.TensorSpec((None, None), tf.int32, name="attention_mask"),
+                "decoder_input_ids": tf.TensorSpec((None, None), tf.int32, name="decoder_input_ids"),
+                "decoder_attention_mask": tf.TensorSpec((None, None), tf.int32, name="decoder_attention_mask"),
+            }
+        ]
+    )
+    def serving(self, inputs):
+        output = self.call(inputs)
+
+        return self.serving_output(output)
 
 
 {{cookiecutter.uppercase_modelname}}_START_DOCSTRING = r"""

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -2386,9 +2386,6 @@ class TF{{cookiecutter.camelcase_modelname}}Model(TF{{cookiecutter.camelcase_mod
 
     def get_decoder(self):
         return self.decoder
-    
-    def get_output_embeddings(self):
-        return self.shared
 
     @add_start_docstrings_to_model_forward({{cookiecutter.uppercase_modelname}}_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -804,13 +804,36 @@ class TF{{cookiecutter.camelcase_modelname}}ForMaskedLM(TF{{cookiecutter.camelca
         self.mlm = TF{{cookiecutter.camelcase_modelname}}MLMHead(config, self.{{cookiecutter.lowercase_modelname}}.embeddings, name="mlm___cls")
     
     def get_output_embeddings(self):
-        return self.{{cookiecutter.lowercase_modelname}}.embeddings
+        try:
+            return self.mlm.predictions.input_embeddings.word_embeddings
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.mlm.predictions.input_embeddings.word_embeddings
 
-    def get_output_layer_with_bias(self):
-        return self.mlm.predictions
+    def set_output_embeddings(self, value):
+        if value is not None:
+            try:
+                self.mlm.predictions.input_embeddings.word_embeddings = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.mlm.predictions.input_embeddings.word_embeddings = value
+            self.mlm.predictions.input_embeddings.vocab_size = shape_list(value)[0]
 
-    def get_prefix_bias_name(self):
-        return self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name
+    def get_bias(self):
+        try:
+            return self.mlm.predictions.bias
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.mlm.predictions.bias
+
+    def set_bias(self, value):
+        if value is not None:
+            try:
+                self.mlm.predictions.bias = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.mlm.predictions.bias = value
+            self.mlm.predictions.vocab_size = shape_list(value)[0]
 
     @add_start_docstrings_to_model_forward({{cookiecutter.uppercase_modelname}}_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
@@ -910,13 +933,36 @@ class TF{{cookiecutter.camelcase_modelname}}ForCausalLM(TF{{cookiecutter.camelca
         self.mlm = TF{{cookiecutter.camelcase_modelname}}MLMHead(config, self.{{cookiecutter.lowercase_modelname}}.embeddings, name="mlm___cls")
 
     def get_output_embeddings(self):
-        return self.{{cookiecutter.lowercase_modelname}}.embeddings
+        try:
+            return self.mlm.predictions.input_embeddings.word_embeddings
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.mlm.predictions.input_embeddings.word_embeddings
 
-    def get_output_layer_with_bias(self):
-        return self.mlm.predictions
+    def set_output_embeddings(self, value):
+        if value is not None:
+            try:
+                self.mlm.predictions.input_embeddings.word_embeddings = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.mlm.predictions.input_embeddings.word_embeddings = value
+            self.mlm.predictions.input_embeddings.vocab_size = shape_list(value)[0]
 
-    def get_prefix_bias_name(self):
-        return self.name + "/" + self.mlm.name + "/" + self.mlm.predictions.name
+    def get_bias(self):
+        try:
+            return self.mlm.predictions.bias
+        except AttributeError:
+            self(self.dummy_inputs)
+            return self.mlm.predictions.bias
+
+    def set_bias(self, value):
+        if value is not None:
+            try:
+                self.mlm.predictions.bias = value
+            except AttributeError:
+                self(self.dummy_inputs)
+                self.mlm.predictions.bias = value
+            self.mlm.predictions.vocab_size = shape_list(value)[0]
 
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -2386,6 +2386,9 @@ class TF{{cookiecutter.camelcase_modelname}}Model(TF{{cookiecutter.camelcase_mod
 
     def get_decoder(self):
         return self.decoder
+    
+    def get_output_embeddings(self):
+        return self.shared
 
     @add_start_docstrings_to_model_forward({{cookiecutter.uppercase_modelname}}_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -460,6 +460,20 @@ class TF{{cookiecutter.camelcase_modelname}}LMPredictionHead(tf.keras.layers.Lay
         self.bias = self.add_weight(shape=(self.vocab_size,), initializer="zeros", trainable=True, name="bias")
 
         super().build(input_shape)
+    
+    def get_output_embeddings(self):
+        return self.input_embeddings.word_embeddings
+
+    def set_output_embeddings(self, value):
+        self.input_embeddings.word_embeddings = value
+        self.input_embeddings.vocab_size = shape_list(value)[0]
+
+    def get_bias(self):
+        return {"bias": self.bias}
+
+    def set_bias(self, value):
+        self.bias = value["bias"]
+        self.vocab_size = shape_list(value["bias"])[0]
 
     def call(self, hidden_states):
         hidden_states = self.transform(hidden_states)
@@ -803,37 +817,8 @@ class TF{{cookiecutter.camelcase_modelname}}ForMaskedLM(TF{{cookiecutter.camelca
         self.{{cookiecutter.lowercase_modelname}} = TF{{cookiecutter.camelcase_modelname}}MainLayer(config, name="{{cookiecutter.lowercase_modelname}}")
         self.mlm = TF{{cookiecutter.camelcase_modelname}}MLMHead(config, self.{{cookiecutter.lowercase_modelname}}.embeddings, name="mlm___cls")
     
-    def get_output_embeddings(self):
-        try:
-            return self.mlm.predictions.input_embeddings.word_embeddings
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.mlm.predictions.input_embeddings.word_embeddings
-
-    def set_output_embeddings(self, value):
-        if value is not None:
-            try:
-                self.mlm.predictions.input_embeddings.word_embeddings = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.mlm.predictions.input_embeddings.word_embeddings = value
-            self.mlm.predictions.input_embeddings.vocab_size = shape_list(value)[0]
-
-    def get_bias(self):
-        try:
-            return self.mlm.predictions.bias
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.mlm.predictions.bias
-
-    def set_bias(self, value):
-        if value is not None:
-            try:
-                self.mlm.predictions.bias = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.mlm.predictions.bias = value
-            self.mlm.predictions.vocab_size = shape_list(value)[0]
+    def get_lm_head(self):
+        return self.mlm.predictions
 
     @add_start_docstrings_to_model_forward({{cookiecutter.uppercase_modelname}}_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
@@ -932,37 +917,8 @@ class TF{{cookiecutter.camelcase_modelname}}ForCausalLM(TF{{cookiecutter.camelca
         self.{{cookiecutter.lowercase_modelname}} = TF{{cookiecutter.camelcase_modelname}}MainLayer(config, name="{{cookiecutter.lowercase_modelname}}")
         self.mlm = TF{{cookiecutter.camelcase_modelname}}MLMHead(config, self.{{cookiecutter.lowercase_modelname}}.embeddings, name="mlm___cls")
 
-    def get_output_embeddings(self):
-        try:
-            return self.mlm.predictions.input_embeddings.word_embeddings
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.mlm.predictions.input_embeddings.word_embeddings
-
-    def set_output_embeddings(self, value):
-        if value is not None:
-            try:
-                self.mlm.predictions.input_embeddings.word_embeddings = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.mlm.predictions.input_embeddings.word_embeddings = value
-            self.mlm.predictions.input_embeddings.vocab_size = shape_list(value)[0]
-
-    def get_bias(self):
-        try:
-            return self.mlm.predictions.bias
-        except AttributeError:
-            self(self.dummy_inputs)
-            return self.mlm.predictions.bias
-
-    def set_bias(self, value):
-        if value is not None:
-            try:
-                self.mlm.predictions.bias = value
-            except AttributeError:
-                self(self.dummy_inputs)
-                self.mlm.predictions.bias = value
-            self.mlm.predictions.vocab_size = shape_list(value)[0]
+    def get_lm_head(self):
+        return self.mlm.predictions
 
     @add_code_sample_docstrings(
         tokenizer_class=_TOKENIZER_FOR_DOC,

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -1913,12 +1913,6 @@ class TF{{cookiecutter.camelcase_modelname}}PreTrainedModel(TFPreTrainedModel):
         embed_tokens = TFWrappedEmbeddings(base_model.shared, abs_scope_name=shared_abs_scope_name)
         base_model.encoder.set_embed_tokens(embed_tokens)
         base_model.decoder.set_embed_tokens(embed_tokens)
-    
-    def get_output_embeddings(self):
-        return self.get_input_embeddings()
-
-    def set_output_embeddings(self, value):
-        self.set_input_embeddings(value)
 
 
 {{cookiecutter.uppercase_modelname}}_START_DOCSTRING = r"""
@@ -2034,6 +2028,9 @@ class TF{{cookiecutter.camelcase_modelname}}Encoder(tf.keras.layers.Layer):
         self.layers = [TF{{cookiecutter.camelcase_modelname}}EncoderLayer(config, name=f"layers.{i}") for i in range(config.encoder_layers)]
         self.layernorm_embedding = tf.keras.layers.LayerNormalization(epsilon=1e-5, name="layernorm_embedding")
 
+    def set_embed_tokens(self, embed_tokens):
+        self.embed_tokens = embed_tokens
+    
     def call(
         self,
         input_ids=None,
@@ -2174,6 +2171,9 @@ class TF{{cookiecutter.camelcase_modelname}}Decoder(tf.keras.layers.Layer):
 
         self.dropout = tf.keras.layers.Dropout(config.dropout)
 
+    def set_embed_tokens(self, embed_tokens):
+        self.embed_tokens = embed_tokens
+    
     def call(
         self,
         input_ids=None,
@@ -2535,6 +2535,12 @@ class TF{{cookiecutter.camelcase_modelname}}ForConditionalGeneration(TF{{cookiec
 
     def set_bias(self, value):
         self.final_logits_bias = value["final_logits_bias"]
+    
+    def get_output_embeddings(self):
+        return self.get_input_embeddings()
+
+    def set_output_embeddings(self, value):
+        self.set_input_embeddings(value)
 
     @add_start_docstrings_to_model_forward({{cookiecutter.uppercase_modelname}}_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=TFSeq2SeqLMOutput, config_class=_CONFIG_FOR_DOC)

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/test_modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/test_modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -486,10 +486,82 @@ class TF{{cookiecutter.camelcase_modelname}}ModelTest(TFModelTesterMixin, unitte
         for model_class in self.all_model_classes:
             model = model_class(config)
             assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
-            x = model.get_output_layer_with_bias()
-            assert x is None
-            name = model.get_prefix_bias_name()
-            assert name is None
+
+            if model_class in self.all_generative_model_classes:
+                x = model.get_output_embeddings()
+                assert isinstance(x, tf.keras.layers.Layer)
+                name = model.get_bias()
+                assert isinstance(name, dict)
+                for k, v in name.items():
+                    assert isinstance(v, tf.Variable)
+            else:
+                x = model.get_output_embeddings()
+                assert x is None
+                name = model.get_bias()
+                assert name is None
+
+    def test_resize_token_embeddings(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        def _find_weights(model, embedding_layer):
+            if hasattr(embedding_layer, "weight"):
+                return embedding_layer.weight
+            else:
+                # Here we build the word embeddings weights if not exists.
+                # And then we retry to get the attribute once built.
+                model(model.dummy_inputs)
+                if hasattr(embedding_layer, "weight"):
+                    return embedding_layer.weight
+                else:
+                    return None
+
+        for model_class in self.all_model_classes:
+            for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
+                # build the embeddings
+                model = model_class(config=config)
+                old_input_embeddings = _find_weights(model, model.get_input_embeddings())
+                old_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                old_final_logits_bias = model.get_bias()
+
+                # reshape the embeddings
+                model.resize_token_embeddings(size)
+                new_input_embeddings = _find_weights(model, model.get_input_embeddings())
+                new_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                new_final_logits_bias = model.get_bias()
+
+                # check that the resized embeddings size matches the desired size.
+                assert_size = size if size is not None else config.vocab_size
+
+                self.assertEqual(new_input_embeddings.shape[0], assert_size)
+
+                # check that weights remain the same after resizing
+                models_equal = True
+                for p1, p2 in zip(old_input_embeddings.value(), new_input_embeddings.value()):
+                    if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                        models_equal = False
+                self.assertTrue(models_equal)
+
+                if old_output_embeddings is not None and new_output_embeddings is not None:
+                    self.assertEqual(new_output_embeddings.shape[0], assert_size)
+
+                    models_equal = True
+                    for p1, p2 in zip(old_output_embeddings.value(), new_output_embeddings.value()):
+                        if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                            models_equal = False
+                    self.assertTrue(models_equal)
+
+                if old_final_logits_bias is not None and new_final_logits_bias is not None:
+                    old_final_logits_bias = old_final_logits_bias["final_logits_bias"]
+                    new_final_logits_bias = new_final_logits_bias["final_logits_bias"]
+                    self.assertEqual(new_final_logits_bias.shape[0], 1)
+                    self.assertEqual(new_final_logits_bias.shape[1], assert_size)
+
+                    models_equal = True
+                    for old, new in zip(old_final_logits_bias.value(), new_final_logits_bias.value()):
+                        for p1, p2 in zip(old, new):
+                            if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                                models_equal = False
+                    self.assertTrue(models_equal)
 
 
 def _assert_tensors_equal(a, b, atol=1e-12, prefix=""):

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/test_modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/test_modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -503,7 +503,7 @@ class TF{{cookiecutter.camelcase_modelname}}ModelTest(TFModelTesterMixin, unitte
     def test_resize_token_embeddings(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
-        def _find_weights(model, embedding_layer):
+        def _get_word_embedding_weight(model, embedding_layer):
             if hasattr(embedding_layer, "weight"):
                 return embedding_layer.weight
             else:
@@ -519,14 +519,14 @@ class TF{{cookiecutter.camelcase_modelname}}ModelTest(TFModelTesterMixin, unitte
             for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
                 # build the embeddings
                 model = model_class(config=config)
-                old_input_embeddings = _find_weights(model, model.get_input_embeddings())
-                old_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                old_input_embeddings = _get_word_embedding_weight(model, model.get_input_embeddings())
+                old_output_embeddings = _get_word_embedding_weight(model, model.get_output_embeddings())
                 old_final_logits_bias = model.get_bias()
 
                 # reshape the embeddings
                 model.resize_token_embeddings(size)
-                new_input_embeddings = _find_weights(model, model.get_input_embeddings())
-                new_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                new_input_embeddings = _get_word_embedding_weight(model, model.get_input_embeddings())
+                new_output_embeddings = _get_word_embedding_weight(model, model.get_output_embeddings())
                 new_final_logits_bias = model.get_bias()
 
                 # check that the resized embeddings size matches the desired size.

--- a/tests/test_modeling_tf_albert.py
+++ b/tests/test_modeling_tf_albert.py
@@ -291,6 +291,7 @@ class TFAlbertModelTest(TFModelTesterMixin, unittest.TestCase):
                 name = model.get_bias()
                 assert name is None
 
+    """
     def test_resize_token_embeddings(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
@@ -353,6 +354,7 @@ class TFAlbertModelTest(TFModelTesterMixin, unittest.TestCase):
                         if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
                             models_equal = False
                     self.assertTrue(models_equal)
+    """
 
     @slow
     def test_model_from_pretrained(self):

--- a/tests/test_modeling_tf_albert.py
+++ b/tests/test_modeling_tf_albert.py
@@ -278,11 +278,11 @@ class TFAlbertModelTest(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.Variable)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
 
             if model_class in list_lm_models:
                 x = model.get_output_embeddings()
-                assert isinstance(x, tf.Variable)
+                assert isinstance(x, tf.keras.layers.Layer)
                 name = model.get_bias()
                 assert isinstance(name, dict)
                 for k, v in name.items():

--- a/tests/test_modeling_tf_albert.py
+++ b/tests/test_modeling_tf_albert.py
@@ -284,77 +284,14 @@ class TFAlbertModelTest(TFModelTesterMixin, unittest.TestCase):
                 x = model.get_output_embeddings()
                 assert isinstance(x, tf.Variable)
                 name = model.get_bias()
-                assert isinstance(name, tf.Variable)
+                assert isinstance(name, dict)
+                for k, v in name.items():
+                    assert isinstance(v, tf.Variable)
             else:
                 x = model.get_output_embeddings()
                 assert x is None
                 name = model.get_bias()
                 assert name is None
-
-    """
-    def test_resize_token_embeddings(self):
-        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
-                # build the embeddings
-                model = model_class(config=config)
-                old_input_embeddings = model.get_input_embeddings()
-                old_bias = model.get_bias()
-                old_decoder_bias = None
-
-                if old_bias is not None:
-                    old_decoder_bias = model.get_decoder_bias()
-
-                old_output_embeddings = model.get_output_embeddings()
-                # reshape the embeddings
-                model.resize_token_embeddings(size)
-                new_input_embeddings = model.get_input_embeddings()
-                new_bias = model.get_bias()
-                new_decoder_bias = None
-
-                if new_bias is not None:
-                    new_decoder_bias = model.get_decoder_bias()
-
-                new_output_embeddings = model.get_output_embeddings()
-
-                # check that the resized embeddings size matches the desired size.
-                assert_size = size if size is not None else config.vocab_size
-                self.assertEqual(new_input_embeddings.shape[0], assert_size)
-
-                # check that weights remain the same after resizing
-                models_equal = True
-                for p1, p2 in zip(old_input_embeddings.value(), new_input_embeddings.value()):
-                    if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
-                        models_equal = False
-                self.assertTrue(models_equal)
-
-                if old_bias is not None and new_bias is not None:
-                    self.assertEqual(new_bias.shape[0], assert_size)
-                    self.assertEqual(new_decoder_bias.shape[0], assert_size)
-
-                    models_equal = True
-                    for p1, p2 in zip(old_bias.value(), new_bias.value()):
-                        if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
-                            models_equal = False
-                    self.assertTrue(models_equal)
-
-                    models_equal = True
-                    for p1, p2 in zip(old_decoder_bias.value(), new_decoder_bias.value()):
-                        if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
-                            models_equal = False
-                    self.assertTrue(models_equal)
-
-                if old_output_embeddings is not None and new_output_embeddings is not None:
-                    self.assertEqual(new_output_embeddings.shape[0], assert_size)
-                    self.assertEqual(new_output_embeddings.shape[1], old_output_embeddings.shape[1])
-
-                    models_equal = True
-                    for p1, p2 in zip(old_output_embeddings.value(), new_output_embeddings.value()):
-                        if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
-                            models_equal = False
-                    self.assertTrue(models_equal)
-    """
 
     @slow
     def test_model_from_pretrained(self):

--- a/tests/test_modeling_tf_albert.py
+++ b/tests/test_modeling_tf_albert.py
@@ -274,14 +274,85 @@ class TFAlbertModelTest(TFModelTesterMixin, unittest.TestCase):
 
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        list_lm_models = [TFAlbertForPreTraining, TFAlbertForMaskedLM]
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
-            x = model.get_output_layer_with_bias()
-            assert x is None
-            name = model.get_prefix_bias_name()
-            assert name is None
+            assert isinstance(model.get_input_embeddings(), tf.Variable)
+
+            if model_class in list_lm_models:
+                x = model.get_output_embeddings()
+                assert isinstance(x, tf.Variable)
+                name = model.get_bias()
+                assert isinstance(name, tf.Variable)
+            else:
+                x = model.get_output_embeddings()
+                assert x is None
+                name = model.get_bias()
+                assert name is None
+
+    def test_resize_token_embeddings(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
+                # build the embeddings
+                model = model_class(config=config)
+                old_input_embeddings = model.get_input_embeddings()
+                old_bias = model.get_bias()
+                old_decoder_bias = None
+
+                if old_bias is not None:
+                    old_decoder_bias = model.get_decoder_bias()
+
+                old_output_embeddings = model.get_output_embeddings()
+                # reshape the embeddings
+                model.resize_token_embeddings(size)
+                new_input_embeddings = model.get_input_embeddings()
+                new_bias = model.get_bias()
+                new_decoder_bias = None
+
+                if new_bias is not None:
+                    new_decoder_bias = model.get_decoder_bias()
+
+                new_output_embeddings = model.get_output_embeddings()
+
+                # check that the resized embeddings size matches the desired size.
+                assert_size = size if size is not None else config.vocab_size
+                self.assertEqual(new_input_embeddings.shape[0], assert_size)
+
+                # check that weights remain the same after resizing
+                models_equal = True
+                for p1, p2 in zip(old_input_embeddings.value(), new_input_embeddings.value()):
+                    if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                        models_equal = False
+                self.assertTrue(models_equal)
+
+                if old_bias is not None and new_bias is not None:
+                    self.assertEqual(new_bias.shape[0], assert_size)
+                    self.assertEqual(new_decoder_bias.shape[0], assert_size)
+
+                    models_equal = True
+                    for p1, p2 in zip(old_bias.value(), new_bias.value()):
+                        if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                            models_equal = False
+                    self.assertTrue(models_equal)
+
+                    models_equal = True
+                    for p1, p2 in zip(old_decoder_bias.value(), new_decoder_bias.value()):
+                        if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                            models_equal = False
+                    self.assertTrue(models_equal)
+
+                if old_output_embeddings is not None and new_output_embeddings is not None:
+                    self.assertEqual(new_output_embeddings.shape[0], assert_size)
+                    self.assertEqual(new_output_embeddings.shape[1], old_output_embeddings.shape[1])
+
+                    models_equal = True
+                    for p1, p2 in zip(old_output_embeddings.value(), new_output_embeddings.value()):
+                        if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                            models_equal = False
+                    self.assertTrue(models_equal)
 
     @slow
     def test_model_from_pretrained(self):

--- a/tests/test_modeling_tf_bart.py
+++ b/tests/test_modeling_tf_bart.py
@@ -176,7 +176,7 @@ class TFBartModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_resize_token_embeddings(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
-        def _find_weights(model, embedding_layer):
+        def _get_word_embedding_weight(model, embedding_layer):
             if hasattr(embedding_layer, "weight"):
                 return embedding_layer.weight
             else:
@@ -192,14 +192,14 @@ class TFBartModelTest(TFModelTesterMixin, unittest.TestCase):
             for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
                 # build the embeddings
                 model = model_class(config=config)
-                old_input_embeddings = _find_weights(model, model.get_input_embeddings())
-                old_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                old_input_embeddings = _get_word_embedding_weight(model, model.get_input_embeddings())
+                old_output_embeddings = _get_word_embedding_weight(model, model.get_output_embeddings())
                 old_final_logits_bias = model.get_bias()
 
                 # reshape the embeddings
                 model.resize_token_embeddings(size)
-                new_input_embeddings = _find_weights(model, model.get_input_embeddings())
-                new_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                new_input_embeddings = _get_word_embedding_weight(model, model.get_input_embeddings())
+                new_output_embeddings = _get_word_embedding_weight(model, model.get_output_embeddings())
                 new_final_logits_bias = model.get_bias()
 
                 # check that the resized embeddings size matches the desired size.

--- a/tests/test_modeling_tf_bart.py
+++ b/tests/test_modeling_tf_bart.py
@@ -155,13 +155,12 @@ class TFBartModelTest(TFModelTesterMixin, unittest.TestCase):
 
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        list_lm_models = [TFBartForConditionalGeneration]
 
         for model_class in self.all_model_classes:
             model = model_class(config)
             assert isinstance(model.get_input_embeddings(), tf.Variable)
 
-            if model_class in list_lm_models:
+            if model_class in self.all_generative_model_classes:
                 x = model.get_output_embeddings()
                 assert isinstance(x, tf.Variable)
                 name = model.get_bias()

--- a/tests/test_modeling_tf_bart.py
+++ b/tests/test_modeling_tf_bart.py
@@ -158,11 +158,11 @@ class TFBartModelTest(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.Variable)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
 
             if model_class in self.all_generative_model_classes:
                 x = model.get_output_embeddings()
-                assert isinstance(x, tf.Variable)
+                assert isinstance(x, tf.keras.layers.Layer)
                 name = model.get_bias()
                 assert isinstance(name, dict)
                 for k, v in name.items():
@@ -176,18 +176,30 @@ class TFBartModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_resize_token_embeddings(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
+        def _find_weights(model, embedding_layer):
+            if hasattr(embedding_layer, "weight"):
+                return embedding_layer.weight
+            else:
+                # Here we build the word embeddings weights if not exists.
+                # And then we retry to get the attribute once built.
+                model(model.dummy_inputs)
+                if hasattr(embedding_layer, "weight"):
+                    return embedding_layer.weight
+                else:
+                    return None
+
         for model_class in self.all_model_classes:
             for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
                 # build the embeddings
                 model = model_class(config=config)
-                old_input_embeddings = model.get_input_embeddings()
-                old_output_embeddings = model.get_output_embeddings()
+                old_input_embeddings = _find_weights(model, model.get_input_embeddings())
+                old_output_embeddings = _find_weights(model, model.get_output_embeddings())
                 old_final_logits_bias = model.get_bias()
 
                 # reshape the embeddings
                 model.resize_token_embeddings(size)
-                new_input_embeddings = model.get_input_embeddings()
-                new_output_embeddings = model.get_output_embeddings()
+                new_input_embeddings = _find_weights(model, model.get_input_embeddings())
+                new_output_embeddings = _find_weights(model, model.get_output_embeddings())
                 new_final_logits_bias = model.get_bias()
 
                 # check that the resized embeddings size matches the desired size.

--- a/tests/test_modeling_tf_bart.py
+++ b/tests/test_modeling_tf_bart.py
@@ -173,7 +173,6 @@ class TFBartModelTest(TFModelTesterMixin, unittest.TestCase):
                 name = model.get_bias()
                 assert name is None
 
-    """
     def test_resize_token_embeddings(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
@@ -183,22 +182,17 @@ class TFBartModelTest(TFModelTesterMixin, unittest.TestCase):
                 model = model_class(config=config)
                 old_input_embeddings = model.get_input_embeddings()
                 old_output_embeddings = model.get_output_embeddings()
-                old_final_logits_bias = None
-
-                if hasattr(model, "get_final_logits_bias"):
-                    old_final_logits_bias = model.get_final_logits_bias()
+                old_final_logits_bias = model.get_bias()
 
                 # reshape the embeddings
                 model.resize_token_embeddings(size)
                 new_input_embeddings = model.get_input_embeddings()
                 new_output_embeddings = model.get_output_embeddings()
-                new_final_logits_bias = None
-
-                if hasattr(model, "get_final_logits_bias"):
-                    new_final_logits_bias = model.get_final_logits_bias()
+                new_final_logits_bias = model.get_bias()
 
                 # check that the resized embeddings size matches the desired size.
                 assert_size = size if size is not None else config.vocab_size
+
                 self.assertEqual(new_input_embeddings.shape[0], assert_size)
 
                 # check that weights remain the same after resizing
@@ -218,6 +212,8 @@ class TFBartModelTest(TFModelTesterMixin, unittest.TestCase):
                     self.assertTrue(models_equal)
 
                 if old_final_logits_bias is not None and new_final_logits_bias is not None:
+                    old_final_logits_bias = old_final_logits_bias["final_logits_bias"]
+                    new_final_logits_bias = new_final_logits_bias["final_logits_bias"]
                     self.assertEqual(new_final_logits_bias.shape[0], 1)
                     self.assertEqual(new_final_logits_bias.shape[1], assert_size)
 
@@ -227,7 +223,6 @@ class TFBartModelTest(TFModelTesterMixin, unittest.TestCase):
                             if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
                                 models_equal = False
                     self.assertTrue(models_equal)
-    """
 
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI

--- a/tests/test_modeling_tf_bart.py
+++ b/tests/test_modeling_tf_bart.py
@@ -164,9 +164,9 @@ class TFBartModelTest(TFModelTesterMixin, unittest.TestCase):
                 x = model.get_output_embeddings()
                 assert isinstance(x, tf.Variable)
                 name = model.get_bias()
-                assert name is None
-                name = model.get_final_logits_bias()
-                assert isinstance(name, tf.Variable)
+                assert isinstance(name, dict)
+                for k, v in name.items():
+                    assert isinstance(v, tf.Variable)
             else:
                 x = model.get_output_embeddings()
                 assert x is None

--- a/tests/test_modeling_tf_bart.py
+++ b/tests/test_modeling_tf_bart.py
@@ -173,6 +173,7 @@ class TFBartModelTest(TFModelTesterMixin, unittest.TestCase):
                 name = model.get_bias()
                 assert name is None
 
+    """
     def test_resize_token_embeddings(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
@@ -226,6 +227,7 @@ class TFBartModelTest(TFModelTesterMixin, unittest.TestCase):
                             if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
                                 models_equal = False
                     self.assertTrue(models_equal)
+    """
 
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI

--- a/tests/test_modeling_tf_bert.py
+++ b/tests/test_modeling_tf_bert.py
@@ -337,11 +337,11 @@ class TFBertModelTest(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.Variable)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
 
             if model_class in list_lm_models:
                 x = model.get_output_embeddings()
-                assert isinstance(x, tf.Variable)
+                assert isinstance(x, tf.keras.layers.Layer)
                 name = model.get_bias()
                 assert isinstance(name, dict)
                 for k, v in name.items():

--- a/tests/test_modeling_tf_bert.py
+++ b/tests/test_modeling_tf_bert.py
@@ -337,17 +337,17 @@ class TFBertModelTest(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+            assert isinstance(model.get_input_embeddings(), tf.Variable)
 
             if model_class in list_lm_models:
-                x = model.get_output_layer_with_bias()
-                assert isinstance(x, tf.keras.layers.Layer)
-                name = model.get_prefix_bias_name()
-                assert isinstance(name, str)
+                x = model.get_output_embeddings()
+                assert isinstance(x, tf.Variable)
+                name = model.get_bias()
+                assert isinstance(name, tf.Variable)
             else:
-                x = model.get_output_layer_with_bias()
+                x = model.get_output_embeddings()
                 assert x is None
-                name = model.get_prefix_bias_name()
+                name = model.get_bias()
                 assert x is None
 
     def test_custom_load_tf_weights(self):

--- a/tests/test_modeling_tf_bert.py
+++ b/tests/test_modeling_tf_bert.py
@@ -343,7 +343,9 @@ class TFBertModelTest(TFModelTesterMixin, unittest.TestCase):
                 x = model.get_output_embeddings()
                 assert isinstance(x, tf.Variable)
                 name = model.get_bias()
-                assert isinstance(name, tf.Variable)
+                assert isinstance(name, dict)
+                for k, v in name.items():
+                    assert isinstance(v, tf.Variable)
             else:
                 x = model.get_output_embeddings()
                 assert x is None

--- a/tests/test_modeling_tf_bert.py
+++ b/tests/test_modeling_tf_bert.py
@@ -350,7 +350,7 @@ class TFBertModelTest(TFModelTesterMixin, unittest.TestCase):
                 x = model.get_output_embeddings()
                 assert x is None
                 name = model.get_bias()
-                assert x is None
+                assert name is None
 
     def test_custom_load_tf_weights(self):
         model, output_loading_info = TFBertForTokenClassification.from_pretrained(

--- a/tests/test_modeling_tf_blenderbot.py
+++ b/tests/test_modeling_tf_blenderbot.py
@@ -68,18 +68,71 @@ class TFBlenderbotModelTest(TFModelTesterMixin, unittest.TestCase):
                 x = model.get_output_embeddings()
                 assert isinstance(x, tf.Variable)
                 name = model.get_bias()
-                assert name is None
-                name = model.get_final_logits_bias()
-                assert isinstance(name, tf.Variable)
+                assert isinstance(name, dict)
+                for k, v in name.items():
+                    assert isinstance(v, tf.Variable)
             else:
                 x = model.get_output_embeddings()
                 assert x is None
                 name = model.get_bias()
                 assert name is None
 
+<<<<<<< HEAD
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI
         pass
+=======
+    def test_resize_token_embeddings(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
+                # build the embeddings
+                model = model_class(config=config)
+                old_input_embeddings = model.get_input_embeddings()
+                old_output_embeddings = model.get_output_embeddings()
+                old_final_logits_bias = model.get_bias()
+
+                # reshape the embeddings
+                model.resize_token_embeddings(size)
+                new_input_embeddings = model.get_input_embeddings()
+                new_output_embeddings = model.get_output_embeddings()
+                new_final_logits_bias = model.get_bias()
+
+                # check that the resized embeddings size matches the desired size.
+                assert_size = size if size is not None else config.vocab_size
+
+                self.assertEqual(new_input_embeddings.shape[0], assert_size)
+
+                # check that weights remain the same after resizing
+                models_equal = True
+                for p1, p2 in zip(old_input_embeddings.value(), new_input_embeddings.value()):
+                    if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                        models_equal = False
+                self.assertTrue(models_equal)
+
+                if old_output_embeddings is not None and new_output_embeddings is not None:
+                    self.assertEqual(new_output_embeddings.shape[0], assert_size)
+
+                    models_equal = True
+                    for p1, p2 in zip(old_output_embeddings.value(), new_output_embeddings.value()):
+                        if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                            models_equal = False
+                    self.assertTrue(models_equal)
+
+                if old_final_logits_bias is not None and new_final_logits_bias is not None:
+                    old_final_logits_bias = old_final_logits_bias["final_logits_bias"]
+                    new_final_logits_bias = new_final_logits_bias["final_logits_bias"]
+                    self.assertEqual(new_final_logits_bias.shape[0], 1)
+                    self.assertEqual(new_final_logits_bias.shape[1], assert_size)
+
+                    models_equal = True
+                    for old, new in zip(old_final_logits_bias.value(), new_final_logits_bias.value()):
+                        for p1, p2 in zip(old, new):
+                            if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                                models_equal = False
+                    self.assertTrue(models_equal)
+>>>>>>> 328b8edbf... Rework bert+blenderbot
 
 
 @is_pt_tf_cross_test

--- a/tests/test_modeling_tf_blenderbot.py
+++ b/tests/test_modeling_tf_blenderbot.py
@@ -57,24 +57,19 @@ class TFBlenderbotModelTest(TFModelTesterMixin, unittest.TestCase):
         # inputs_embeds not supported
         pass
 
-    def test_saved_model_with_hidden_states_output(self):
-        # Should be uncommented during patrick TF refactor
-        pass
-
-    def test_saved_model_with_attentions_output(self):
-        # Should be uncommented during patrick TF refactor
-        pass
-
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
-            x = model.get_output_layer_with_bias()
+            assert isinstance(model.get_input_embeddings(), tf.Variable)
+
+            x = model.get_output_embeddings()
             assert x is None
-            name = model.get_prefix_bias_name()
+            name = model.get_bias()
             assert name is None
+            name = model.get_final_logits_bias()
+            assert isinstance(name, tf.Variable)
 
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI

--- a/tests/test_modeling_tf_blenderbot.py
+++ b/tests/test_modeling_tf_blenderbot.py
@@ -64,12 +64,18 @@ class TFBlenderbotModelTest(TFModelTesterMixin, unittest.TestCase):
             model = model_class(config)
             assert isinstance(model.get_input_embeddings(), tf.Variable)
 
-            x = model.get_output_embeddings()
-            assert x is None
-            name = model.get_bias()
-            assert name is None
-            name = model.get_final_logits_bias()
-            assert isinstance(name, tf.Variable)
+            if model_class in self.all_generative_model_classes:
+                x = model.get_output_embeddings()
+                assert isinstance(x, tf.Variable)
+                name = model.get_bias()
+                assert name is None
+                name = model.get_final_logits_bias()
+                assert isinstance(name, tf.Variable)
+            else:
+                x = model.get_output_embeddings()
+                assert x is None
+                name = model.get_bias()
+                assert name is None
 
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI

--- a/tests/test_modeling_tf_blenderbot.py
+++ b/tests/test_modeling_tf_blenderbot.py
@@ -85,7 +85,7 @@ class TFBlenderbotModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_resize_token_embeddings(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
-        def _find_weights(model, embedding_layer):
+        def _get_word_embedding_weight(model, embedding_layer):
             if hasattr(embedding_layer, "weight"):
                 return embedding_layer.weight
             else:
@@ -101,14 +101,14 @@ class TFBlenderbotModelTest(TFModelTesterMixin, unittest.TestCase):
             for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
                 # build the embeddings
                 model = model_class(config=config)
-                old_input_embeddings = _find_weights(model, model.get_input_embeddings())
-                old_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                old_input_embeddings = _get_word_embedding_weight(model, model.get_input_embeddings())
+                old_output_embeddings = _get_word_embedding_weight(model, model.get_output_embeddings())
                 old_final_logits_bias = model.get_bias()
 
                 # reshape the embeddings
                 model.resize_token_embeddings(size)
-                new_input_embeddings = _find_weights(model, model.get_input_embeddings())
-                new_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                new_input_embeddings = _get_word_embedding_weight(model, model.get_input_embeddings())
+                new_output_embeddings = _get_word_embedding_weight(model, model.get_output_embeddings())
                 new_final_logits_bias = model.get_bias()
 
                 # check that the resized embeddings size matches the desired size.

--- a/tests/test_modeling_tf_blenderbot.py
+++ b/tests/test_modeling_tf_blenderbot.py
@@ -62,11 +62,11 @@ class TFBlenderbotModelTest(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.Variable)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
 
             if model_class in self.all_generative_model_classes:
                 x = model.get_output_embeddings()
-                assert isinstance(x, tf.Variable)
+                assert isinstance(x, tf.keras.layers.Layer)
                 name = model.get_bias()
                 assert isinstance(name, dict)
                 for k, v in name.items():
@@ -85,18 +85,30 @@ class TFBlenderbotModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_resize_token_embeddings(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
+        def _find_weights(model, embedding_layer):
+            if hasattr(embedding_layer, "weight"):
+                return embedding_layer.weight
+            else:
+                # Here we build the word embeddings weights if not exists.
+                # And then we retry to get the attribute once built.
+                model(model.dummy_inputs)
+                if hasattr(embedding_layer, "weight"):
+                    return embedding_layer.weight
+                else:
+                    return None
+
         for model_class in self.all_model_classes:
             for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
                 # build the embeddings
                 model = model_class(config=config)
-                old_input_embeddings = model.get_input_embeddings()
-                old_output_embeddings = model.get_output_embeddings()
+                old_input_embeddings = _find_weights(model, model.get_input_embeddings())
+                old_output_embeddings = _find_weights(model, model.get_output_embeddings())
                 old_final_logits_bias = model.get_bias()
 
                 # reshape the embeddings
                 model.resize_token_embeddings(size)
-                new_input_embeddings = model.get_input_embeddings()
-                new_output_embeddings = model.get_output_embeddings()
+                new_input_embeddings = _find_weights(model, model.get_input_embeddings())
+                new_output_embeddings = _find_weights(model, model.get_output_embeddings())
                 new_final_logits_bias = model.get_bias()
 
                 # check that the resized embeddings size matches the desired size.

--- a/tests/test_modeling_tf_blenderbot.py
+++ b/tests/test_modeling_tf_blenderbot.py
@@ -77,11 +77,10 @@ class TFBlenderbotModelTest(TFModelTesterMixin, unittest.TestCase):
                 name = model.get_bias()
                 assert name is None
 
-<<<<<<< HEAD
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI
         pass
-=======
+
     def test_resize_token_embeddings(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
@@ -144,7 +143,6 @@ class TFBlenderbotModelTest(TFModelTesterMixin, unittest.TestCase):
                             if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
                                 models_equal = False
                     self.assertTrue(models_equal)
->>>>>>> 328b8edbf... Rework bert+blenderbot
 
 
 @is_pt_tf_cross_test

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -676,7 +676,9 @@ class TFModelTesterMixin:
                 x = model.get_output_embeddings()
                 assert isinstance(x, tf.Variable)
                 name = model.get_bias()
-                assert isinstance(name, tf.Variable)
+                assert isinstance(name, dict)
+                for k, v in name.items():
+                    assert isinstance(v, tf.Variable)
             else:
                 x = model.get_output_embeddings()
                 assert x is None

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -818,6 +818,8 @@ class TFModelTesterMixin:
                 old_input_embeddings = model.get_input_embeddings()
                 old_bias = model.get_bias()
                 old_output_embeddings = model.get_output_embeddings()
+                print(model_class)
+                print(old_output_embeddings)
                 # reshape the embeddings
                 model.resize_token_embeddings(size)
                 new_input_embeddings = model.get_input_embeddings()

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -834,13 +834,14 @@ class TFModelTesterMixin:
                 self.assertTrue(models_equal)
 
                 if old_bias is not None and new_bias is not None:
-                    self.assertEqual(new_bias.shape[0], assert_size)
+                    for old_weight, new_weight in zip(old_bias.values(), new_bias.values()):
+                        self.assertEqual(new_weight.shape[0], assert_size)
 
-                    models_equal = True
-                    for p1, p2 in zip(old_bias.value(), new_bias.value()):
-                        if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
-                            models_equal = False
-                    self.assertTrue(models_equal)
+                        models_equal = True
+                        for p1, p2 in zip(old_weight.value(), new_weight.value()):
+                            if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                                models_equal = False
+                        self.assertTrue(models_equal)
 
                 if old_output_embeddings is not None and new_output_embeddings is not None:
                     self.assertEqual(new_output_embeddings.shape[0], assert_size)

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -683,7 +683,7 @@ class TFModelTesterMixin:
                 x = model.get_output_embeddings()
                 assert x is None
                 name = model.get_bias()
-                assert x is None
+                assert name is None
 
     def test_determinism(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -811,7 +811,7 @@ class TFModelTesterMixin:
             return
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
-        def _find_weights(model, embedding_layer):
+        def _get_word_embedding_weight(model, embedding_layer):
             if hasattr(embedding_layer, "word_embeddings"):
                 return embedding_layer.word_embeddings
             elif hasattr(embedding_layer, "weight"):
@@ -835,14 +835,14 @@ class TFModelTesterMixin:
             for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
                 # build the embeddings
                 model = model_class(config=config)
-                old_input_embeddings = _find_weights(model, model.get_input_embeddings())
+                old_input_embeddings = _get_word_embedding_weight(model, model.get_input_embeddings())
                 old_bias = model.get_bias()
-                old_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                old_output_embeddings = _get_word_embedding_weight(model, model.get_output_embeddings())
                 # reshape the embeddings
                 model.resize_token_embeddings(size)
-                new_input_embeddings = _find_weights(model, model.get_input_embeddings())
+                new_input_embeddings = _get_word_embedding_weight(model, model.get_input_embeddings())
                 new_bias = model.get_bias()
-                new_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                new_output_embeddings = _get_word_embedding_weight(model, model.get_output_embeddings())
 
                 # check that the resized embeddings size matches the desired size.
                 assert_size = size if size is not None else config.vocab_size

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -818,8 +818,6 @@ class TFModelTesterMixin:
                 old_input_embeddings = model.get_input_embeddings()
                 old_bias = model.get_bias()
                 old_output_embeddings = model.get_output_embeddings()
-                print(model_class)
-                print(old_output_embeddings)
                 # reshape the embeddings
                 model.resize_token_embeddings(size)
                 new_input_embeddings = model.get_input_embeddings()

--- a/tests/test_modeling_tf_ctrl.py
+++ b/tests/test_modeling_tf_ctrl.py
@@ -192,7 +192,7 @@ class TFCTRLModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_ctrl_sequence_classification_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_ctrl_for_sequence_classification(*config_and_inputs)
-    
+
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         list_lm_models = [TFCTRLLMHeadModel]

--- a/tests/test_modeling_tf_ctrl.py
+++ b/tests/test_modeling_tf_ctrl.py
@@ -192,6 +192,33 @@ class TFCTRLModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_ctrl_sequence_classification_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_ctrl_for_sequence_classification(*config_and_inputs)
+    
+    def test_model_common_attributes(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        list_lm_models = [TFCTRLLMHeadModel]
+        list_other_models_with_output_ebd = [TFCTRLForSequenceClassification]
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+
+            if model_class in list_lm_models:
+                x = model.get_output_embeddings()
+                assert isinstance(x, tf.keras.layers.Layer)
+                name = model.get_bias()
+                assert isinstance(name, dict)
+                for k, v in name.items():
+                    assert isinstance(v, tf.Variable)
+            elif model_class in list_other_models_with_output_ebd:
+                x = model.get_output_embeddings()
+                assert isinstance(x, tf.keras.layers.Layer)
+                name = model.get_bias()
+                assert name is None
+            else:
+                x = model.get_output_embeddings()
+                assert x is None
+                name = model.get_bias()
+                assert name is None
 
     @slow
     def test_model_from_pretrained(self):

--- a/tests/test_modeling_tf_dpr.py
+++ b/tests/test_modeling_tf_dpr.py
@@ -208,6 +208,9 @@ class TFDPRModelTest(TFModelTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_dpr_reader(*config_and_inputs)
 
+    def test_model_common_attributes(self):
+        pass
+
     @slow
     def test_model_from_pretrained(self):
         for model_name in TF_DPR_CONTEXT_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:

--- a/tests/test_modeling_tf_dpr.py
+++ b/tests/test_modeling_tf_dpr.py
@@ -208,9 +208,6 @@ class TFDPRModelTest(TFModelTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_dpr_reader(*config_and_inputs)
 
-    def test_model_common_attributes(self):
-        pass
-
     @slow
     def test_model_from_pretrained(self):
         for model_name in TF_DPR_CONTEXT_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:

--- a/tests/test_modeling_tf_gpt2.py
+++ b/tests/test_modeling_tf_gpt2.py
@@ -361,13 +361,12 @@ class TFGPT2ModelTest(TFModelTesterMixin, unittest.TestCase):
 
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        list_lm_models = [TFGPT2LMHeadModel, TFGPT2DoubleHeadsModel]
 
         for model_class in self.all_model_classes:
             model = model_class(config)
             assert isinstance(model.get_input_embeddings(), tf.Variable)
 
-            if model_class in list_lm_models:
+            if model_class in self.all_generative_model_classes:
                 x = model.get_output_embeddings()
                 assert isinstance(x, tf.Variable)
                 name = model.get_bias()

--- a/tests/test_modeling_tf_gpt2.py
+++ b/tests/test_modeling_tf_gpt2.py
@@ -361,14 +361,22 @@ class TFGPT2ModelTest(TFModelTesterMixin, unittest.TestCase):
 
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        list_lm_models = [TFGPT2LMHeadModel, TFGPT2DoubleHeadsModel]
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
-            x = model.get_output_layer_with_bias()
-            assert x is None
-            name = model.get_prefix_bias_name()
-            assert name is None
+            assert isinstance(model.get_input_embeddings(), tf.Variable)
+
+            if model_class in list_lm_models:
+                x = model.get_output_embeddings()
+                assert isinstance(x, tf.Variable)
+                name = model.get_bias()
+                assert name is None
+            else:
+                x = model.get_output_embeddings()
+                assert x is None
+                name = model.get_bias()
+                assert name is None
 
     def test_gpt2_sequence_classification_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/test_modeling_tf_gpt2.py
+++ b/tests/test_modeling_tf_gpt2.py
@@ -364,11 +364,11 @@ class TFGPT2ModelTest(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.Variable)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
 
             if model_class in self.all_generative_model_classes:
                 x = model.get_output_embeddings()
-                assert isinstance(x, tf.Variable)
+                assert isinstance(x, tf.keras.layers.Layer)
                 name = model.get_bias()
                 assert name is None
             else:

--- a/tests/test_modeling_tf_led.py
+++ b/tests/test_modeling_tf_led.py
@@ -216,7 +216,7 @@ class TFLEDModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_resize_token_embeddings(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
-        def _find_weights(model, embedding_layer):
+        def _get_word_embedding_weight(model, embedding_layer):
             if hasattr(embedding_layer, "weight"):
                 return embedding_layer.weight
             else:
@@ -232,14 +232,14 @@ class TFLEDModelTest(TFModelTesterMixin, unittest.TestCase):
             for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
                 # build the embeddings
                 model = model_class(config=config)
-                old_input_embeddings = _find_weights(model, model.get_input_embeddings())
-                old_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                old_input_embeddings = _get_word_embedding_weight(model, model.get_input_embeddings())
+                old_output_embeddings = _get_word_embedding_weight(model, model.get_output_embeddings())
                 old_final_logits_bias = model.get_bias()
 
                 # reshape the embeddings
                 model.resize_token_embeddings(size)
-                new_input_embeddings = _find_weights(model, model.get_input_embeddings())
-                new_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                new_input_embeddings = _get_word_embedding_weight(model, model.get_input_embeddings())
+                new_output_embeddings = _get_word_embedding_weight(model, model.get_output_embeddings())
                 new_final_logits_bias = model.get_bias()
 
                 # check that the resized embeddings size matches the desired size.

--- a/tests/test_modeling_tf_led.py
+++ b/tests/test_modeling_tf_led.py
@@ -199,10 +199,82 @@ class TFLEDModelTest(TFModelTesterMixin, unittest.TestCase):
         for model_class in self.all_model_classes:
             model = model_class(config)
             assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
-            x = model.get_output_layer_with_bias()
-            assert x is None
-            name = model.get_prefix_bias_name()
-            assert name is None
+
+            if model_class in self.all_generative_model_classes:
+                x = model.get_output_embeddings()
+                assert isinstance(x, tf.keras.layers.Layer)
+                name = model.get_bias()
+                assert isinstance(name, dict)
+                for k, v in name.items():
+                    assert isinstance(v, tf.Variable)
+            else:
+                x = model.get_output_embeddings()
+                assert x is None
+                name = model.get_bias()
+                assert name is None
+
+    def test_resize_token_embeddings(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        def _find_weights(model, embedding_layer):
+            if hasattr(embedding_layer, "weight"):
+                return embedding_layer.weight
+            else:
+                # Here we build the word embeddings weights if not exists.
+                # And then we retry to get the attribute once built.
+                model(model.dummy_inputs)
+                if hasattr(embedding_layer, "weight"):
+                    return embedding_layer.weight
+                else:
+                    return None
+
+        for model_class in self.all_model_classes:
+            for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
+                # build the embeddings
+                model = model_class(config=config)
+                old_input_embeddings = _find_weights(model, model.get_input_embeddings())
+                old_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                old_final_logits_bias = model.get_bias()
+
+                # reshape the embeddings
+                model.resize_token_embeddings(size)
+                new_input_embeddings = _find_weights(model, model.get_input_embeddings())
+                new_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                new_final_logits_bias = model.get_bias()
+
+                # check that the resized embeddings size matches the desired size.
+                assert_size = size if size is not None else config.vocab_size
+
+                self.assertEqual(new_input_embeddings.shape[0], assert_size)
+
+                # check that weights remain the same after resizing
+                models_equal = True
+                for p1, p2 in zip(old_input_embeddings.value(), new_input_embeddings.value()):
+                    if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                        models_equal = False
+                self.assertTrue(models_equal)
+
+                if old_output_embeddings is not None and new_output_embeddings is not None:
+                    self.assertEqual(new_output_embeddings.shape[0], assert_size)
+
+                    models_equal = True
+                    for p1, p2 in zip(old_output_embeddings.value(), new_output_embeddings.value()):
+                        if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                            models_equal = False
+                    self.assertTrue(models_equal)
+
+                if old_final_logits_bias is not None and new_final_logits_bias is not None:
+                    old_final_logits_bias = old_final_logits_bias["final_logits_bias"]
+                    new_final_logits_bias = new_final_logits_bias["final_logits_bias"]
+                    self.assertEqual(new_final_logits_bias.shape[0], 1)
+                    self.assertEqual(new_final_logits_bias.shape[1], assert_size)
+
+                    models_equal = True
+                    for old, new in zip(old_final_logits_bias.value(), new_final_logits_bias.value()):
+                        for p1, p2 in zip(old, new):
+                            if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                                models_equal = False
+                    self.assertTrue(models_equal)
 
     def test_attention_outputs(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/test_modeling_tf_lxmert.py
+++ b/tests/test_modeling_tf_lxmert.py
@@ -690,7 +690,9 @@ class TFLxmertModelTest(TFModelTesterMixin, unittest.TestCase):
                 x = model.get_output_embeddings()
                 assert isinstance(x, tf.Variable)
                 name = model.get_bias()
-                assert isinstance(name, tf.Variable)
+                assert isinstance(name, dict)
+                for k, v in name.items():
+                    assert isinstance(v, tf.Variable)
             else:
                 x = model.get_output_embeddings()
                 assert x is None

--- a/tests/test_modeling_tf_lxmert.py
+++ b/tests/test_modeling_tf_lxmert.py
@@ -684,17 +684,17 @@ class TFLxmertModelTest(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+            assert isinstance(model.get_input_embeddings(), tf.Variable)
 
             if model_class in list_lm_models:
-                x = model.get_output_layer_with_bias()
-                assert isinstance(x, tf.keras.layers.Layer)
-                name = model.get_prefix_bias_name()
-                assert isinstance(name, str)
+                x = model.get_output_embeddings()
+                assert isinstance(x, tf.Variable)
+                name = model.get_bias()
+                assert isinstance(name, tf.Variable)
             else:
-                x = model.get_output_layer_with_bias()
+                x = model.get_output_embeddings()
                 assert x is None
-                name = model.get_prefix_bias_name()
+                name = model.get_bias()
                 assert x is None
 
     def test_saved_model_creation(self):

--- a/tests/test_modeling_tf_lxmert.py
+++ b/tests/test_modeling_tf_lxmert.py
@@ -697,7 +697,7 @@ class TFLxmertModelTest(TFModelTesterMixin, unittest.TestCase):
                 x = model.get_output_embeddings()
                 assert x is None
                 name = model.get_bias()
-                assert x is None
+                assert name is None
 
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI

--- a/tests/test_modeling_tf_lxmert.py
+++ b/tests/test_modeling_tf_lxmert.py
@@ -684,11 +684,11 @@ class TFLxmertModelTest(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.Variable)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
 
             if model_class in list_lm_models:
                 x = model.get_output_embeddings()
-                assert isinstance(x, tf.Variable)
+                assert isinstance(x, tf.keras.layers.Layer)
                 name = model.get_bias()
                 assert isinstance(name, dict)
                 for k, v in name.items():

--- a/tests/test_modeling_tf_marian.py
+++ b/tests/test_modeling_tf_marian.py
@@ -98,9 +98,9 @@ class TFMarianMTModelTest(TFModelTesterMixin, unittest.TestCase):
                 x = model.get_output_embeddings()
                 assert isinstance(x, tf.Variable)
                 name = model.get_bias()
-                assert name is None
-                name = model.get_final_logits_bias()
-                assert isinstance(name, tf.Variable)
+                assert isinstance(name, dict)
+                for k, v in name.items():
+                    assert isinstance(v, tf.Variable)
             else:
                 x = model.get_output_embeddings()
                 assert x is None
@@ -110,6 +110,57 @@ class TFMarianMTModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI
         pass
+
+    def test_resize_token_embeddings(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
+                # build the embeddings
+                model = model_class(config=config)
+                old_input_embeddings = model.get_input_embeddings()
+                old_output_embeddings = model.get_output_embeddings()
+                old_final_logits_bias = model.get_bias()
+
+                # reshape the embeddings
+                model.resize_token_embeddings(size)
+                new_input_embeddings = model.get_input_embeddings()
+                new_output_embeddings = model.get_output_embeddings()
+                new_final_logits_bias = model.get_bias()
+
+                # check that the resized embeddings size matches the desired size.
+                assert_size = size if size is not None else config.vocab_size
+
+                self.assertEqual(new_input_embeddings.shape[0], assert_size)
+
+                # check that weights remain the same after resizing
+                models_equal = True
+                for p1, p2 in zip(old_input_embeddings.value(), new_input_embeddings.value()):
+                    if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                        models_equal = False
+                self.assertTrue(models_equal)
+
+                if old_output_embeddings is not None and new_output_embeddings is not None:
+                    self.assertEqual(new_output_embeddings.shape[0], assert_size)
+
+                    models_equal = True
+                    for p1, p2 in zip(old_output_embeddings.value(), new_output_embeddings.value()):
+                        if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                            models_equal = False
+                    self.assertTrue(models_equal)
+
+                if old_final_logits_bias is not None and new_final_logits_bias is not None:
+                    old_final_logits_bias = old_final_logits_bias["final_logits_bias"]
+                    new_final_logits_bias = new_final_logits_bias["final_logits_bias"]
+                    self.assertEqual(new_final_logits_bias.shape[0], 1)
+                    self.assertEqual(new_final_logits_bias.shape[1], assert_size)
+
+                    models_equal = True
+                    for old, new in zip(old_final_logits_bias.value(), new_final_logits_bias.value()):
+                        for p1, p2 in zip(old, new):
+                            if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                                models_equal = False
+                    self.assertTrue(models_equal)
 
 
 class AbstractMarianIntegrationTest(unittest.TestCase):

--- a/tests/test_modeling_tf_marian.py
+++ b/tests/test_modeling_tf_marian.py
@@ -38,7 +38,7 @@ class ModelTester(TFBartModelTester):
 
 
 @require_tf
-class TestTFMarianCommon(TFModelTesterMixin, unittest.TestCase):
+class TFMarianMTModelTest(TFModelTesterMixin, unittest.TestCase):
     all_model_classes = (TFMarianMTModel,) if is_tf_available() else ()
     all_generative_model_classes = (TFMarianMTModel,) if is_tf_available() else ()
     model_tester_cls = ModelTester
@@ -54,13 +54,6 @@ class TestTFMarianCommon(TFModelTesterMixin, unittest.TestCase):
 
     def test_inputs_embeds(self):
         # inputs_embeds not supported
-        pass
-
-    def test_saved_model_with_hidden_states_output(self):
-        # Should be uncommented during patrick TF refactor
-        pass
-
-    def test_saved_model_with_attentions_output(self):
         pass
 
     def test_compile_tf_model(self):
@@ -99,11 +92,14 @@ class TestTFMarianCommon(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
-            x = model.get_output_layer_with_bias()
+            assert isinstance(model.get_input_embeddings(), tf.Variable)
+
+            x = model.get_output_embeddings()
             assert x is None
-            name = model.get_prefix_bias_name()
+            name = model.get_bias()
             assert name is None
+            name = model.get_final_logits_bias()
+            assert isinstance(name, tf.Variable)
 
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI

--- a/tests/test_modeling_tf_marian.py
+++ b/tests/test_modeling_tf_marian.py
@@ -94,12 +94,18 @@ class TFMarianMTModelTest(TFModelTesterMixin, unittest.TestCase):
             model = model_class(config)
             assert isinstance(model.get_input_embeddings(), tf.Variable)
 
-            x = model.get_output_embeddings()
-            assert x is None
-            name = model.get_bias()
-            assert name is None
-            name = model.get_final_logits_bias()
-            assert isinstance(name, tf.Variable)
+            if model_class in self.all_generative_model_classes:
+                x = model.get_output_embeddings()
+                assert isinstance(x, tf.Variable)
+                name = model.get_bias()
+                assert name is None
+                name = model.get_final_logits_bias()
+                assert isinstance(name, tf.Variable)
+            else:
+                x = model.get_output_embeddings()
+                assert x is None
+                name = model.get_bias()
+                assert name is None
 
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI

--- a/tests/test_modeling_tf_marian.py
+++ b/tests/test_modeling_tf_marian.py
@@ -114,7 +114,7 @@ class TFMarianMTModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_resize_token_embeddings(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
-        def _find_weights(model, embedding_layer):
+        def _get_word_embedding_weight(model, embedding_layer):
             if hasattr(embedding_layer, "weight"):
                 return embedding_layer.weight
             else:
@@ -130,14 +130,14 @@ class TFMarianMTModelTest(TFModelTesterMixin, unittest.TestCase):
             for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
                 # build the embeddings
                 model = model_class(config=config)
-                old_input_embeddings = _find_weights(model, model.get_input_embeddings())
-                old_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                old_input_embeddings = _get_word_embedding_weight(model, model.get_input_embeddings())
+                old_output_embeddings = _get_word_embedding_weight(model, model.get_output_embeddings())
                 old_final_logits_bias = model.get_bias()
 
                 # reshape the embeddings
                 model.resize_token_embeddings(size)
-                new_input_embeddings = _find_weights(model, model.get_input_embeddings())
-                new_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                new_input_embeddings = _get_word_embedding_weight(model, model.get_input_embeddings())
+                new_output_embeddings = _get_word_embedding_weight(model, model.get_output_embeddings())
                 new_final_logits_bias = model.get_bias()
 
                 # check that the resized embeddings size matches the desired size.

--- a/tests/test_modeling_tf_mbart.py
+++ b/tests/test_modeling_tf_mbart.py
@@ -36,7 +36,7 @@ class ModelTester(TFBartModelTester):
 
 
 @require_tf
-class TestTFMBartCommon(TFModelTesterMixin, unittest.TestCase):
+class TFMBartModelTest(TFModelTesterMixin, unittest.TestCase):
     all_model_classes = (TFMBartForConditionalGeneration,) if is_tf_available() else ()
     all_generative_model_classes = (TFMBartForConditionalGeneration,) if is_tf_available() else ()
     model_tester_cls = ModelTester
@@ -52,14 +52,6 @@ class TestTFMBartCommon(TFModelTesterMixin, unittest.TestCase):
 
     def test_inputs_embeds(self):
         # inputs_embeds not supported
-        pass
-
-    def test_saved_model_with_hidden_states_output(self):
-        # Should be uncommented during patrick TF refactor
-        pass
-
-    def test_saved_model_with_attentions_output(self):
-        # Should be uncommented during patrick TF refactor
         pass
 
     def test_compile_tf_model(self):
@@ -98,11 +90,14 @@ class TestTFMBartCommon(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
-            x = model.get_output_layer_with_bias()
+            assert isinstance(model.get_input_embeddings(), tf.Variable)
+
+            x = model.get_output_embeddings()
             assert x is None
-            name = model.get_prefix_bias_name()
+            name = model.get_bias()
             assert name is None
+            name = model.get_final_logits_bias()
+            assert isinstance(name, tf.Variable)
 
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI

--- a/tests/test_modeling_tf_mbart.py
+++ b/tests/test_modeling_tf_mbart.py
@@ -92,12 +92,18 @@ class TFMBartModelTest(TFModelTesterMixin, unittest.TestCase):
             model = model_class(config)
             assert isinstance(model.get_input_embeddings(), tf.Variable)
 
-            x = model.get_output_embeddings()
-            assert x is None
-            name = model.get_bias()
-            assert name is None
-            name = model.get_final_logits_bias()
-            assert isinstance(name, tf.Variable)
+            if model_class in self.all_generative_model_classes:
+                x = model.get_output_embeddings()
+                assert isinstance(x, tf.Variable)
+                name = model.get_bias()
+                assert name is None
+                name = model.get_final_logits_bias()
+                assert isinstance(name, tf.Variable)
+            else:
+                x = model.get_output_embeddings()
+                assert x is None
+                name = model.get_bias()
+                assert name is None
 
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI

--- a/tests/test_modeling_tf_mbart.py
+++ b/tests/test_modeling_tf_mbart.py
@@ -90,11 +90,11 @@ class TFMBartModelTest(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.Variable)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
 
             if model_class in self.all_generative_model_classes:
                 x = model.get_output_embeddings()
-                assert isinstance(x, tf.Variable)
+                assert isinstance(x, tf.keras.layers.Layer)
                 name = model.get_bias()
                 assert isinstance(name, dict)
                 for k, v in name.items():
@@ -112,18 +112,30 @@ class TFMBartModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_resize_token_embeddings(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
+        def _find_weights(model, embedding_layer):
+            if hasattr(embedding_layer, "weight"):
+                return embedding_layer.weight
+            else:
+                # Here we build the word embeddings weights if not exists.
+                # And then we retry to get the attribute once built.
+                model(model.dummy_inputs)
+                if hasattr(embedding_layer, "weight"):
+                    return embedding_layer.weight
+                else:
+                    return None
+
         for model_class in self.all_model_classes:
             for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
                 # build the embeddings
                 model = model_class(config=config)
-                old_input_embeddings = model.get_input_embeddings()
-                old_output_embeddings = model.get_output_embeddings()
+                old_input_embeddings = _find_weights(model, model.get_input_embeddings())
+                old_output_embeddings = _find_weights(model, model.get_output_embeddings())
                 old_final_logits_bias = model.get_bias()
 
                 # reshape the embeddings
                 model.resize_token_embeddings(size)
-                new_input_embeddings = model.get_input_embeddings()
-                new_output_embeddings = model.get_output_embeddings()
+                new_input_embeddings = _find_weights(model, model.get_input_embeddings())
+                new_output_embeddings = _find_weights(model, model.get_output_embeddings())
                 new_final_logits_bias = model.get_bias()
 
                 # check that the resized embeddings size matches the desired size.

--- a/tests/test_modeling_tf_mbart.py
+++ b/tests/test_modeling_tf_mbart.py
@@ -112,7 +112,7 @@ class TFMBartModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_resize_token_embeddings(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
-        def _find_weights(model, embedding_layer):
+        def _get_word_embedding_weight(model, embedding_layer):
             if hasattr(embedding_layer, "weight"):
                 return embedding_layer.weight
             else:
@@ -128,14 +128,14 @@ class TFMBartModelTest(TFModelTesterMixin, unittest.TestCase):
             for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
                 # build the embeddings
                 model = model_class(config=config)
-                old_input_embeddings = _find_weights(model, model.get_input_embeddings())
-                old_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                old_input_embeddings = _get_word_embedding_weight(model, model.get_input_embeddings())
+                old_output_embeddings = _get_word_embedding_weight(model, model.get_output_embeddings())
                 old_final_logits_bias = model.get_bias()
 
                 # reshape the embeddings
                 model.resize_token_embeddings(size)
-                new_input_embeddings = _find_weights(model, model.get_input_embeddings())
-                new_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                new_input_embeddings = _get_word_embedding_weight(model, model.get_input_embeddings())
+                new_output_embeddings = _get_word_embedding_weight(model, model.get_output_embeddings())
                 new_final_logits_bias = model.get_bias()
 
                 # check that the resized embeddings size matches the desired size.

--- a/tests/test_modeling_tf_mbart.py
+++ b/tests/test_modeling_tf_mbart.py
@@ -96,9 +96,9 @@ class TFMBartModelTest(TFModelTesterMixin, unittest.TestCase):
                 x = model.get_output_embeddings()
                 assert isinstance(x, tf.Variable)
                 name = model.get_bias()
-                assert name is None
-                name = model.get_final_logits_bias()
-                assert isinstance(name, tf.Variable)
+                assert isinstance(name, dict)
+                for k, v in name.items():
+                    assert isinstance(v, tf.Variable)
             else:
                 x = model.get_output_embeddings()
                 assert x is None
@@ -108,6 +108,57 @@ class TFMBartModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI
         pass
+
+    def test_resize_token_embeddings(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
+                # build the embeddings
+                model = model_class(config=config)
+                old_input_embeddings = model.get_input_embeddings()
+                old_output_embeddings = model.get_output_embeddings()
+                old_final_logits_bias = model.get_bias()
+
+                # reshape the embeddings
+                model.resize_token_embeddings(size)
+                new_input_embeddings = model.get_input_embeddings()
+                new_output_embeddings = model.get_output_embeddings()
+                new_final_logits_bias = model.get_bias()
+
+                # check that the resized embeddings size matches the desired size.
+                assert_size = size if size is not None else config.vocab_size
+
+                self.assertEqual(new_input_embeddings.shape[0], assert_size)
+
+                # check that weights remain the same after resizing
+                models_equal = True
+                for p1, p2 in zip(old_input_embeddings.value(), new_input_embeddings.value()):
+                    if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                        models_equal = False
+                self.assertTrue(models_equal)
+
+                if old_output_embeddings is not None and new_output_embeddings is not None:
+                    self.assertEqual(new_output_embeddings.shape[0], assert_size)
+
+                    models_equal = True
+                    for p1, p2 in zip(old_output_embeddings.value(), new_output_embeddings.value()):
+                        if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                            models_equal = False
+                    self.assertTrue(models_equal)
+
+                if old_final_logits_bias is not None and new_final_logits_bias is not None:
+                    old_final_logits_bias = old_final_logits_bias["final_logits_bias"]
+                    new_final_logits_bias = new_final_logits_bias["final_logits_bias"]
+                    self.assertEqual(new_final_logits_bias.shape[0], 1)
+                    self.assertEqual(new_final_logits_bias.shape[1], assert_size)
+
+                    models_equal = True
+                    for old, new in zip(old_final_logits_bias.value(), new_final_logits_bias.value()):
+                        for p1, p2 in zip(old, new):
+                            if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                                models_equal = False
+                    self.assertTrue(models_equal)
 
 
 @is_pt_tf_cross_test

--- a/tests/test_modeling_tf_mobilebert.py
+++ b/tests/test_modeling_tf_mobilebert.py
@@ -289,17 +289,17 @@ class TFMobileBertModelTest(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
+            assert isinstance(model.get_input_embeddings(), tf.Variable)
 
             if model_class in list_lm_models:
-                x = model.get_output_layer_with_bias()
-                assert isinstance(x, tf.keras.layers.Layer)
-                name = model.get_prefix_bias_name()
-                assert isinstance(name, str)
+                x = model.get_output_embeddings()
+                assert isinstance(x, tf.Variable)
+                name = model.get_bias()
+                assert isinstance(name, tf.Variable)
             else:
-                x = model.get_output_layer_with_bias()
+                x = model.get_output_embeddings()
                 assert x is None
-                name = model.get_prefix_bias_name()
+                name = model.get_bias()
                 assert x is None
 
     def test_saved_model_creation(self):

--- a/tests/test_modeling_tf_mobilebert.py
+++ b/tests/test_modeling_tf_mobilebert.py
@@ -289,11 +289,11 @@ class TFMobileBertModelTest(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.Variable)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
 
             if model_class in list_lm_models:
                 x = model.get_output_embeddings()
-                assert isinstance(x, tf.Variable)
+                assert isinstance(x, tf.keras.layers.Layer)
                 name = model.get_bias()
                 assert isinstance(name, dict)
                 for k, v in name.items():

--- a/tests/test_modeling_tf_mobilebert.py
+++ b/tests/test_modeling_tf_mobilebert.py
@@ -302,7 +302,7 @@ class TFMobileBertModelTest(TFModelTesterMixin, unittest.TestCase):
                 x = model.get_output_embeddings()
                 assert x is None
                 name = model.get_bias()
-                assert x is None
+                assert name is None
 
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI

--- a/tests/test_modeling_tf_mobilebert.py
+++ b/tests/test_modeling_tf_mobilebert.py
@@ -295,7 +295,9 @@ class TFMobileBertModelTest(TFModelTesterMixin, unittest.TestCase):
                 x = model.get_output_embeddings()
                 assert isinstance(x, tf.Variable)
                 name = model.get_bias()
-                assert isinstance(name, tf.Variable)
+                assert isinstance(name, dict)
+                for k, v in name.items():
+                    assert isinstance(v, tf.Variable)
             else:
                 x = model.get_output_embeddings()
                 assert x is None

--- a/tests/test_modeling_tf_openai.py
+++ b/tests/test_modeling_tf_openai.py
@@ -224,13 +224,12 @@ class TFOpenAIGPTModelTest(TFModelTesterMixin, unittest.TestCase):
 
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        list_lm_models = [TFOpenAIGPTLMHeadModel, TFOpenAIGPTDoubleHeadsModel]
 
         for model_class in self.all_model_classes:
             model = model_class(config)
             assert isinstance(model.get_input_embeddings(), tf.Variable)
 
-            if model_class in list_lm_models:
+            if model_class in self.all_generative_model_classes:
                 x = model.get_output_embeddings()
                 assert isinstance(x, tf.Variable)
                 name = model.get_bias()

--- a/tests/test_modeling_tf_openai.py
+++ b/tests/test_modeling_tf_openai.py
@@ -227,11 +227,11 @@ class TFOpenAIGPTModelTest(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.Variable)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
 
             if model_class in self.all_generative_model_classes:
                 x = model.get_output_embeddings()
-                assert isinstance(x, tf.Variable)
+                assert isinstance(x, tf.keras.layers.Layer)
                 name = model.get_bias()
                 assert name is None
             else:

--- a/tests/test_modeling_tf_openai.py
+++ b/tests/test_modeling_tf_openai.py
@@ -224,14 +224,22 @@ class TFOpenAIGPTModelTest(TFModelTesterMixin, unittest.TestCase):
 
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        list_lm_models = [TFOpenAIGPTLMHeadModel, TFOpenAIGPTDoubleHeadsModel]
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
-            x = model.get_output_layer_with_bias()
-            assert x is None
-            name = model.get_prefix_bias_name()
-            assert name is None
+            assert isinstance(model.get_input_embeddings(), tf.Variable)
+
+            if model_class in list_lm_models:
+                x = model.get_output_embeddings()
+                assert isinstance(x, tf.Variable)
+                name = model.get_bias()
+                assert name is None
+            else:
+                x = model.get_output_embeddings()
+                assert x is None
+                name = model.get_bias()
+                assert name is None
 
     def test_openai_gpt_sequence_classification_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/test_modeling_tf_pegasus.py
+++ b/tests/test_modeling_tf_pegasus.py
@@ -41,7 +41,7 @@ class ModelTester(TFBartModelTester):
 
 
 @require_tf
-class TestTFPegasusCommon(TFModelTesterMixin, unittest.TestCase):
+class TFPegasusModelTest(TFModelTesterMixin, unittest.TestCase):
     all_model_classes = (TFPegasusForConditionalGeneration,) if is_tf_available() else ()
     all_generative_model_classes = (TFPegasusForConditionalGeneration,) if is_tf_available() else ()
     model_tester_cls = ModelTester
@@ -57,14 +57,6 @@ class TestTFPegasusCommon(TFModelTesterMixin, unittest.TestCase):
 
     def test_inputs_embeds(self):
         # inputs_embeds not supported
-        pass
-
-    def test_saved_model_with_hidden_states_output(self):
-        # Should be uncommented during patrick TF refactor
-        pass
-
-    def test_saved_model_with_attentions_output(self):
-        # Should be uncommented during patrick TF refactor
         pass
 
     def test_compile_tf_model(self):
@@ -103,11 +95,14 @@ class TestTFPegasusCommon(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
-            x = model.get_output_layer_with_bias()
+            assert isinstance(model.get_input_embeddings(), tf.Variable)
+
+            x = model.get_output_embeddings()
             assert x is None
-            name = model.get_prefix_bias_name()
+            name = model.get_bias()
             assert name is None
+            name = model.get_final_logits_bias()
+            assert isinstance(name, tf.Variable)
 
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI

--- a/tests/test_modeling_tf_pegasus.py
+++ b/tests/test_modeling_tf_pegasus.py
@@ -101,9 +101,9 @@ class TFPegasusModelTest(TFModelTesterMixin, unittest.TestCase):
                 x = model.get_output_embeddings()
                 assert isinstance(x, tf.Variable)
                 name = model.get_bias()
-                assert name is None
-                name = model.get_final_logits_bias()
-                assert isinstance(name, tf.Variable)
+                assert isinstance(name, dict)
+                for k, v in name.items():
+                    assert isinstance(v, tf.Variable)
             else:
                 x = model.get_output_embeddings()
                 assert x is None
@@ -113,6 +113,57 @@ class TFPegasusModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI
         pass
+
+    def test_resize_token_embeddings(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
+                # build the embeddings
+                model = model_class(config=config)
+                old_input_embeddings = model.get_input_embeddings()
+                old_output_embeddings = model.get_output_embeddings()
+                old_final_logits_bias = model.get_bias()
+
+                # reshape the embeddings
+                model.resize_token_embeddings(size)
+                new_input_embeddings = model.get_input_embeddings()
+                new_output_embeddings = model.get_output_embeddings()
+                new_final_logits_bias = model.get_bias()
+
+                # check that the resized embeddings size matches the desired size.
+                assert_size = size if size is not None else config.vocab_size
+
+                self.assertEqual(new_input_embeddings.shape[0], assert_size)
+
+                # check that weights remain the same after resizing
+                models_equal = True
+                for p1, p2 in zip(old_input_embeddings.value(), new_input_embeddings.value()):
+                    if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                        models_equal = False
+                self.assertTrue(models_equal)
+
+                if old_output_embeddings is not None and new_output_embeddings is not None:
+                    self.assertEqual(new_output_embeddings.shape[0], assert_size)
+
+                    models_equal = True
+                    for p1, p2 in zip(old_output_embeddings.value(), new_output_embeddings.value()):
+                        if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                            models_equal = False
+                    self.assertTrue(models_equal)
+
+                if old_final_logits_bias is not None and new_final_logits_bias is not None:
+                    old_final_logits_bias = old_final_logits_bias["final_logits_bias"]
+                    new_final_logits_bias = new_final_logits_bias["final_logits_bias"]
+                    self.assertEqual(new_final_logits_bias.shape[0], 1)
+                    self.assertEqual(new_final_logits_bias.shape[1], assert_size)
+
+                    models_equal = True
+                    for old, new in zip(old_final_logits_bias.value(), new_final_logits_bias.value()):
+                        for p1, p2 in zip(old, new):
+                            if tf.math.reduce_sum(tf.math.abs(p1 - p2)) > 0:
+                                models_equal = False
+                    self.assertTrue(models_equal)
 
 
 @is_pt_tf_cross_test

--- a/tests/test_modeling_tf_pegasus.py
+++ b/tests/test_modeling_tf_pegasus.py
@@ -97,12 +97,18 @@ class TFPegasusModelTest(TFModelTesterMixin, unittest.TestCase):
             model = model_class(config)
             assert isinstance(model.get_input_embeddings(), tf.Variable)
 
-            x = model.get_output_embeddings()
-            assert x is None
-            name = model.get_bias()
-            assert name is None
-            name = model.get_final_logits_bias()
-            assert isinstance(name, tf.Variable)
+            if model_class in self.all_generative_model_classes:
+                x = model.get_output_embeddings()
+                assert isinstance(x, tf.Variable)
+                name = model.get_bias()
+                assert name is None
+                name = model.get_final_logits_bias()
+                assert isinstance(name, tf.Variable)
+            else:
+                x = model.get_output_embeddings()
+                assert x is None
+                name = model.get_bias()
+                assert name is None
 
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI

--- a/tests/test_modeling_tf_pegasus.py
+++ b/tests/test_modeling_tf_pegasus.py
@@ -117,7 +117,7 @@ class TFPegasusModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_resize_token_embeddings(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
-        def _find_weights(model, embedding_layer):
+        def _get_word_embedding_weight(model, embedding_layer):
             if hasattr(embedding_layer, "weight"):
                 return embedding_layer.weight
             else:
@@ -133,14 +133,14 @@ class TFPegasusModelTest(TFModelTesterMixin, unittest.TestCase):
             for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
                 # build the embeddings
                 model = model_class(config=config)
-                old_input_embeddings = _find_weights(model, model.get_input_embeddings())
-                old_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                old_input_embeddings = _get_word_embedding_weight(model, model.get_input_embeddings())
+                old_output_embeddings = _get_word_embedding_weight(model, model.get_output_embeddings())
                 old_final_logits_bias = model.get_bias()
 
                 # reshape the embeddings
                 model.resize_token_embeddings(size)
-                new_input_embeddings = _find_weights(model, model.get_input_embeddings())
-                new_output_embeddings = _find_weights(model, model.get_output_embeddings())
+                new_input_embeddings = _get_word_embedding_weight(model, model.get_input_embeddings())
+                new_output_embeddings = _get_word_embedding_weight(model, model.get_output_embeddings())
                 new_final_logits_bias = model.get_bias()
 
                 # check that the resized embeddings size matches the desired size.

--- a/tests/test_modeling_tf_pegasus.py
+++ b/tests/test_modeling_tf_pegasus.py
@@ -95,11 +95,11 @@ class TFPegasusModelTest(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.Variable)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
 
             if model_class in self.all_generative_model_classes:
                 x = model.get_output_embeddings()
-                assert isinstance(x, tf.Variable)
+                assert isinstance(x, tf.keras.layers.Layer)
                 name = model.get_bias()
                 assert isinstance(name, dict)
                 for k, v in name.items():
@@ -117,18 +117,30 @@ class TFPegasusModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_resize_token_embeddings(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
+        def _find_weights(model, embedding_layer):
+            if hasattr(embedding_layer, "weight"):
+                return embedding_layer.weight
+            else:
+                # Here we build the word embeddings weights if not exists.
+                # And then we retry to get the attribute once built.
+                model(model.dummy_inputs)
+                if hasattr(embedding_layer, "weight"):
+                    return embedding_layer.weight
+                else:
+                    return None
+
         for model_class in self.all_model_classes:
             for size in [config.vocab_size - 10, config.vocab_size + 10, None]:
                 # build the embeddings
                 model = model_class(config=config)
-                old_input_embeddings = model.get_input_embeddings()
-                old_output_embeddings = model.get_output_embeddings()
+                old_input_embeddings = _find_weights(model, model.get_input_embeddings())
+                old_output_embeddings = _find_weights(model, model.get_output_embeddings())
                 old_final_logits_bias = model.get_bias()
 
                 # reshape the embeddings
                 model.resize_token_embeddings(size)
-                new_input_embeddings = model.get_input_embeddings()
-                new_output_embeddings = model.get_output_embeddings()
+                new_input_embeddings = _find_weights(model, model.get_input_embeddings())
+                new_output_embeddings = _find_weights(model, model.get_output_embeddings())
                 new_final_logits_bias = model.get_bias()
 
                 # check that the resized embeddings size matches the desired size.

--- a/tests/test_modeling_tf_t5.py
+++ b/tests/test_modeling_tf_t5.py
@@ -288,11 +288,11 @@ class TFT5ModelTest(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.Variable)
+            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
 
             if model_class in self.all_generative_model_classes:
                 x = model.get_output_embeddings()
-                assert isinstance(x, tf.Variable)
+                assert isinstance(x, tf.keras.layers.Layer)
                 name = model.get_bias()
                 assert name is None
             else:

--- a/tests/test_modeling_tf_t5.py
+++ b/tests/test_modeling_tf_t5.py
@@ -288,11 +288,18 @@ class TFT5ModelTest(TFModelTesterMixin, unittest.TestCase):
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
-            x = model.get_output_layer_with_bias()
-            assert x is None
-            name = model.get_prefix_bias_name()
-            assert name is None
+            assert isinstance(model.get_input_embeddings(), tf.Variable)
+
+            if model_class in self.all_generative_model_classes:
+                x = model.get_output_embeddings()
+                assert isinstance(x, tf.Variable)
+                name = model.get_bias()
+                assert name is None
+            else:
+                x = model.get_output_embeddings()
+                assert x is None
+                name = model.get_bias()
+                assert name is None
 
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI

--- a/tests/test_modeling_tf_transfo_xl.py
+++ b/tests/test_modeling_tf_transfo_xl.py
@@ -187,14 +187,21 @@ class TFTransfoXLModelTest(TFModelTesterMixin, unittest.TestCase):
 
     def test_model_common_attributes(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        list_other_models_with_output_ebd = [TFTransfoXLForSequenceClassification]
 
         for model_class in self.all_model_classes:
             model = model_class(config)
             assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
-            x = model.get_output_embeddings()
-            assert x is None
-            name = model.get_bias()
-            assert name is None
+            if model_class in list_other_models_with_output_ebd:
+                x = model.get_output_embeddings()
+                assert isinstance(x, tf.keras.layers.Layer)
+                name = model.get_bias()
+                assert name is None
+            else:
+                x = model.get_output_embeddings()
+                assert x is None
+                name = model.get_bias()
+                assert name is None
 
     @slow
     def test_model_from_pretrained(self):

--- a/tests/test_modeling_tf_transfo_xl.py
+++ b/tests/test_modeling_tf_transfo_xl.py
@@ -191,9 +191,9 @@ class TFTransfoXLModelTest(TFModelTesterMixin, unittest.TestCase):
         for model_class in self.all_model_classes:
             model = model_class(config)
             assert isinstance(model.get_input_embeddings(), tf.keras.layers.Layer)
-            x = model.get_output_layer_with_bias()
+            x = model.get_output_embeddings()
             assert x is None
-            name = model.get_prefix_bias_name()
+            name = model.get_bias()
             assert name is None
 
     @slow


### PR DESCRIPTION
# What does this PR do?

This PR 100% reworks the entire process of input/output and bias resizing. Now the exceptions are better handled including the names that now are always similar. The corresponding tests have also been entirely reworked and now have a better coverage of this feature.

This PR adds a small breaking change. Now the `get_input_embeddings` methods returns the weights and not anymore the embedding layer.