### PR TITLE
[run_glue] add speed metrics

### DIFF
--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -354,7 +354,6 @@ def main():
             model_path=model_args.model_name_or_path if os.path.isdir(model_args.model_name_or_path) else None
         )
         metrics = train_result.metrics
-        metrics["train_n_objs"] = len(train_dataset)
 
         trainer.save_model()  # Saves the tokenizer too for easy upload
 
@@ -368,10 +367,6 @@ def main():
 
             # Need to save the state, since Trainer.save_model saves only the tokenizer with the model
             trainer.state.save_to_json(os.path.join(training_args.output_dir, "trainer_state.json"))
-
-            # For convenience, we also re-save the tokenizer to the same directory,
-            # so that you can share your model easily on huggingface.co/models =)
-            tokenizer.save_pretrained(training_args.output_dir)
 
     # Evaluation
     eval_results = {}
@@ -387,7 +382,6 @@ def main():
 
         for eval_dataset, task in zip(eval_datasets, tasks):
             eval_result = trainer.evaluate(eval_dataset=eval_dataset)
-            eval_result["eval_n_objs"] = len(eval_dataset)
 
             output_eval_file = os.path.join(training_args.output_dir, f"eval_results_{task}.txt")
             if trainer.is_world_process_zero():

--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -350,10 +350,28 @@ def main():
 
     # Training
     if training_args.do_train:
-        trainer.train(
+        train_result = trainer.train(
             model_path=model_args.model_name_or_path if os.path.isdir(model_args.model_name_or_path) else None
         )
+        metrics = train_result.metrics
+        metrics["train_n_objs"] = len(train_dataset)
+
         trainer.save_model()  # Saves the tokenizer too for easy upload
+
+        output_train_file = os.path.join(training_args.output_dir, "train_results.txt")
+        if trainer.is_world_process_zero():
+            with open(output_train_file, "w") as writer:
+                logger.info("***** Train results *****")
+                for key, value in sorted(metrics.items()):
+                    logger.info(f"  {key} = {value}")
+                    writer.write(f"{key} = {value}\n")
+
+            # Need to save the state, since Trainer.save_model saves only the tokenizer with the model
+            trainer.state.save_to_json(os.path.join(training_args.output_dir, "trainer_state.json"))
+
+            # For convenience, we also re-save the tokenizer to the same directory,
+            # so that you can share your model easily on huggingface.co/models =)
+            tokenizer.save_pretrained(training_args.output_dir)
 
     # Evaluation
     eval_results = {}
@@ -369,12 +387,13 @@ def main():
 
         for eval_dataset, task in zip(eval_datasets, tasks):
             eval_result = trainer.evaluate(eval_dataset=eval_dataset)
+            eval_result["eval_n_objs"] = len(eval_dataset)
 
             output_eval_file = os.path.join(training_args.output_dir, f"eval_results_{task}.txt")
             if trainer.is_world_process_zero():
                 with open(output_eval_file, "w") as writer:
                     logger.info(f"***** Eval results {task} *****")
-                    for key, value in eval_result.items():
+                    for key, value in sorted(eval_result.items()):
                         logger.info(f"  {key} = {value}")
                         writer.write(f"{key} = {value}\n")
 


### PR DESCRIPTION
This PR starts to sync with recent changes in trainer+finetune_trainer.py

* train: (sync with finetune_trainer):
   - prints and saves train speed metrics - needed for benchmarking
   - saves the state,
* eval: sorts metrics logging info

@sgugger 