### PR TITLE
[docs] outline sharded ddp doc

### DIFF
--- a/docs/source/training.rst
+++ b/docs/source/training.rst
@@ -286,7 +286,7 @@ fit bigger models.
 
 The main part that is being integrated at the moment is based on the paper `ZeRO: Memory Optimizations Toward Training
 Trillion Parameter Models, by Samyam Rajbhandari, Jeff Rasley, Olatunji Ruwase, Yuxiong He
-<https://arxiv.org/abs/1910.02054>`_.
+<https://arxiv.org/abs/1910.02054>`__.
 
 You can already deploy the following features from this paper:
 
@@ -294,9 +294,9 @@ You can already deploy the following features from this paper:
 * Gradient Sharding
 
 using the `--sharded_ddp` trainer argument. This is implemented via `fairscale
-<https://github.com/facebookresearch/fairscale/>`_. You will have to install `fairscale`.
+<https://github.com/facebookresearch/fairscale/>`__, so you will have to install this library.
 
-This feature requires distributed training.
+This feature requires distributed training (so multiple GPUs) and is not implemented for TPUs.
 
 For example here is how you could use it for `finetune_trainer.py`:
 
@@ -307,10 +307,10 @@ For example here is how you could use it for `finetune_trainer.py`:
 
 Note that it works with `--fp16` too, to make things even faster.
 
-One of the main benefits of enabling `--sharded_ddp` is that you should be able to use significantly larger batch sizes
-using the same hardware (e.g. 3x or bigger).
+One of the main benefits of enabling `--sharded_ddp` is that it uses a lot less GPU memory, so you should be able to
+use significantly larger batch sizes using the same hardware (e.g. 3x or bigger).
 
-Eventually more parts will be supported via integrating `DeepSpeed <https://github.com/microsoft/DeepSpeed>`_.
+Eventually more parts will be supported via integrating `DeepSpeed <https://github.com/microsoft/DeepSpeed>`__.
 
 
 .. _additional-resources:

--- a/docs/source/training.rst
+++ b/docs/source/training.rst
@@ -278,6 +278,31 @@ pass it to the trainer.
 Finally, you can view the results, including any calculated metrics, by launching tensorboard in your specified
 ``logging_dir`` directory.
 
+Trainer Integrations
+-----------------------------------------------------------------------------------------------------------------------
+
+The trainer is being extended to support experimental libraries that may dramatically improve your training time and
+fit bigger models.
+
+The main part that is being integrated at the moment is based on the paper `ZeRO: Memory Optimizations Toward Training
+Trillion Parameter Models, by Samyam Rajbhandari, Jeff Rasley, Olatunji Ruwase, Yuxiong He
+<https://arxiv.org/abs/1910.02054>`_.
+
+You can already deploy the following features from this paper:
+
+* Optimizer State Sharding
+* Gradient Sharding
+
+using the `--sharded_ddp` trainer argument. This is implemented via `fairscale
+<https://github.com/facebookresearch/fairscale/>`_. You will have to install `fairscale`.
+
+Note that it works with `--fp16` too, to make things even faster.
+
+One of the main benefits of enabling `--sharded_ddp` is that you should be able to use significantly larger batch sizes
+using the same hardware (e.g. 3x or bigger).
+
+Eventually more parts will be supported via integrating `DeepSpeed <https://github.com/microsoft/DeepSpeed>`.
+
 
 .. _additional-resources:
 

--- a/docs/source/training.rst
+++ b/docs/source/training.rst
@@ -303,7 +303,13 @@ For example here is how you could use it for `finetune_trainer.py`:
 .. code-block:: bash
 
     cd examples/seq2seq
-    python -m torch.distributed.launch --nproc_per_node=2 ./finetune_trainer.py --model_name_or_path sshleifer/distill-mbart-en-ro-12-4 --output_dir output_dir --adam_eps 1e-06 --data_dir wmt_en_ro --do_train --freeze_embeds --label_smoothing 0.1 --learning_rate 3e-5 --logging_first_step --logging_steps 1000 --max_source_length 128 --max_target_length 128 --num_train_epochs 1 --overwrite_output_dir --per_device_train_batch_size 4 --sortish_sampler --src_lang en_XX --task translation --tgt_lang ro_RO  --warmup_steps 500 --n_train 500 --fp16 --sharded_ddp
+    python -m torch.distributed.launch --nproc_per_node=2 ./finetune_trainer.py \
+    --model_name_or_path sshleifer/distill-mbart-en-ro-12-4 --data_dir wmt_en_ro \
+    --output_dir output_dir --overwrite_output_dir \
+    --do_train --n_train 500 --num_train_epochs 1 \
+    --per_device_train_batch_size 1  --freeze_embeds \
+    --src_lang en_XX --tgt_lang ro_RO --task translation \
+    --fp16 --sharded_ddp
 
 Note that it works with `--fp16` too, to make things even faster.
 

--- a/docs/source/training.rst
+++ b/docs/source/training.rst
@@ -296,6 +296,15 @@ You can already deploy the following features from this paper:
 using the `--sharded_ddp` trainer argument. This is implemented via `fairscale
 <https://github.com/facebookresearch/fairscale/>`_. You will have to install `fairscale`.
 
+This feature requires distributed training.
+
+For example here is how you could use it for `finetune_trainer.py`:
+
+.. code-block:: bash
+
+    cd examples/seq2seq
+    python -m torch.distributed.launch --nproc_per_node=2 ./finetune_trainer.py --model_name_or_path sshleifer/distill-mbart-en-ro-12-4 --output_dir output_dir --adam_eps 1e-06 --data_dir wmt_en_ro --do_train --freeze_embeds --label_smoothing 0.1 --learning_rate 3e-5 --logging_first_step --logging_steps 1000 --max_source_length 128 --max_target_length 128 --num_train_epochs 1 --overwrite_output_dir --per_device_train_batch_size 4 --sortish_sampler --src_lang en_XX --task translation --tgt_lang ro_RO  --warmup_steps 500 --n_train 500 --fp16 --sharded_ddp
+
 Note that it works with `--fp16` too, to make things even faster.
 
 One of the main benefits of enabling `--sharded_ddp` is that you should be able to use significantly larger batch sizes

--- a/docs/source/training.rst
+++ b/docs/source/training.rst
@@ -301,7 +301,7 @@ Note that it works with `--fp16` too, to make things even faster.
 One of the main benefits of enabling `--sharded_ddp` is that you should be able to use significantly larger batch sizes
 using the same hardware (e.g. 3x or bigger).
 
-Eventually more parts will be supported via integrating `DeepSpeed <https://github.com/microsoft/DeepSpeed>`.
+Eventually more parts will be supported via integrating `DeepSpeed <https://github.com/microsoft/DeepSpeed>`_.
 
 
 .. _additional-resources:


### PR DESCRIPTION
This PR provides an initial outline of HF Trainer integration starting with ZeRO. We have fairscale's Sharded optimizer/gradients supported already and deepspeed is coming 

We won't merge this until fairscale merged all the required fixes and released a new version, but I thought it'd be good to start the doc going so it's ready when fairscale is ready.

I hope to submit a deepspeed integration shortly as well, so we will extend it then with deepspeed info. edit (https://github.com/huggingface/transformers/pull/9211)

@sgugger 