### PR TITLE
Revert renaming in finetune_trainer

### DIFF
--- a/examples/seq2seq/test_finetune_trainer.py
+++ b/examples/seq2seq/test_finetune_trainer.py
@@ -137,8 +137,8 @@ class TestFinetuneTrainer(TestCasePlus):
             --n_train 8
             --n_val 8
             --max_source_length {max_len}
-            --max_length {max_len}
-            --eval_max_length {max_len}
+            --max_target_length {max_len}
+            --val_max_target_length {max_len}
             --do_train
             --do_eval
             --do_predict

--- a/examples/seq2seq/train_distil_marian_enro.sh
+++ b/examples/seq2seq/train_distil_marian_enro.sh
@@ -29,7 +29,8 @@ python finetune_trainer.py \
     --freeze_encoder --freeze_embeds \
     --num_train_epochs=6 \
     --save_steps 3000 --eval_steps 3000 \
-    --max_source_length $MAX_LEN --max_length $MAX_LEN --eval_max_length $MAX_LEN \
+    --max_source_length $MAX_LEN --max_target_length $MAX_LEN \
+    --val_max_target_length $MAX_TGT_LEN --test_max_target_length $MAX_TGT_LEN \
     --do_train --do_eval --do_predict \
     --evaluation_strategy steps \
     --predict_with_generate --logging_first_step \

--- a/examples/seq2seq/train_distil_marian_enro_tpu.sh
+++ b/examples/seq2seq/train_distil_marian_enro_tpu.sh
@@ -30,7 +30,8 @@ python xla_spawn.py --num_cores $TPU_NUM_CORES \
     --num_train_epochs=6 \
     --save_steps 500 --eval_steps 500 \
     --logging_first_step --logging_steps 200 \
-    --max_source_length $MAX_LEN --max_length $MAX_LEN --eval_max_length $MAX_LEN \
+    --max_source_length $MAX_LEN --max_target_length $MAX_LEN \
+    --val_max_target_length $MAX_TGT_LEN --test_max_target_length $MAX_TGT_LEN \
     --do_train --do_eval \
     --evaluation_strategy steps \
     --prediction_loss_only \

--- a/examples/seq2seq/train_distilbart_cnn.sh
+++ b/examples/seq2seq/train_distilbart_cnn.sh
@@ -32,7 +32,7 @@ python finetune_trainer.py \
     --num_train_epochs=2 \
     --save_steps 3000 --eval_steps 3000 \
     --logging_first_step \
-    --max_length 56 --eval_max_length $MAX_TGT_LEN \
+    --max_target_length 56 --val_max_target_length $MAX_TGT_LEN --test_max_target_length $MAX_TGT_LEN\
     --do_train --do_eval --do_predict \
     --evaluation_strategy steps \
     --predict_with_generate --sortish_sampler \

--- a/examples/seq2seq/train_mbart_cc25_enro.sh
+++ b/examples/seq2seq/train_mbart_cc25_enro.sh
@@ -24,7 +24,7 @@ python finetune_trainer.py \
     --src_lang en_XX --tgt_lang ro_RO \
     --freeze_embeds \
     --per_device_train_batch_size=4 --per_device_eval_batch_size=4 \
-    --max_source_length 128 --max_length 128 --eval_max_length 128 \
+    --max_source_length 128 --max_target_length 128 --val_max_target_length 128 --test_max_target_length 128\
     --sortish_sampler \
     --num_train_epochs 6 \
     --save_steps 25000 --eval_steps 25000 --logging_steps 1000 \

--- a/examples/seq2seq/utils.py
+++ b/examples/seq2seq/utils.py
@@ -330,7 +330,7 @@ class Seq2SeqDataCollator:
             [x["src_texts"] for x in batch],
             tgt_texts=[x["tgt_texts"] for x in batch],
             max_length=self.data_args.max_source_length,
-            max_target_length=self.data_args.max_length,
+            max_target_length=self.data_args.max_target_length,
             padding="max_length" if self.tpu_num_cores is not None else "longest",  # TPU hack
             return_tensors="pt",
             **self.dataset_kwargs,


### PR DESCRIPTION
# What does this PR do?

As per the discussion in #9241, reverting all renaming in the `finetune_trainer.py` script for now.