### PR TITLE
Adapt to new name of `label_smoothing_factor` training arg

### DIFF
--- a/examples/seq2seq/test_finetune_trainer.py
+++ b/examples/seq2seq/test_finetune_trainer.py
@@ -153,7 +153,7 @@ class TestFinetuneTrainer(TestCasePlus):
             --save_steps {str(eval_steps)}
             --eval_steps {str(eval_steps)}
             --sortish_sampler
-            --label_smoothing 0.1
+            --label_smoothing_factor 0.1
             --adafactor
             --task translation
             --tgt_lang ro_RO

--- a/examples/seq2seq/train_distil_marian_enro.sh
+++ b/examples/seq2seq/train_distil_marian_enro.sh
@@ -34,5 +34,5 @@ python finetune_trainer.py \
     --do_train --do_eval --do_predict \
     --evaluation_strategy steps \
     --predict_with_generate --logging_first_step \
-    --task translation --label_smoothing 0.1 \
+    --task translation --label_smoothing_factor 0.1 \
     "$@"

--- a/examples/seq2seq/train_distil_marian_enro_tpu.sh
+++ b/examples/seq2seq/train_distil_marian_enro_tpu.sh
@@ -35,5 +35,5 @@ python xla_spawn.py --num_cores $TPU_NUM_CORES \
     --do_train --do_eval \
     --evaluation_strategy steps \
     --prediction_loss_only \
-    --task translation --label_smoothing 0.1 \
+    --task translation --label_smoothing_factor 0.1 \
     "$@"


### PR DESCRIPTION
# What does this PR do?

This PR changes `label_smoothing` to its new name `label_smoothing_factor` in the tests and scripts that use it. 

Pinging @stas00 for information but will merge when CI is passing.