### PR TITLE
Fix TF input for np.ndarray

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -328,7 +328,7 @@ def input_processing(func, config, input_ids, **kwargs):
     signature.pop("kwargs", None)
     parameter_names = list(signature.keys())
     output = {}
-    allowed_types = (tf.Tensor, bool, int, ModelOutput, tuple, list, dict)
+    allowed_types = (tf.Tensor, bool, int, ModelOutput, tuple, list, dict, np.ndarray)
 
     if "inputs" in kwargs["kwargs_call"]:
         warnings.warn(

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -766,6 +766,20 @@ class TFModelTesterMixin:
                 inputs["decoder_inputs_embeds"] = self._get_embeds(wte, decoder_input_ids)
 
             model(inputs)
+    
+    def test_models_with_numpy_arrays(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        def prepare_numpy_arrays(inputs_dict):
+            inputs_np_dict = {}
+            for k, v in inputs_dict.items():
+                inputs_np_dict[k] = v.numpy()
+        
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+
+            inputs = self._prepare_for_class(inputs_dict, model_class)
+            inputs_np = prepare_numpy_arrays(inputs)
 
     def test_resize_token_embeddings(self):
         if not self.test_resize_embeddings:

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -781,6 +781,8 @@ class TFModelTesterMixin:
             inputs = self._prepare_for_class(inputs_dict, model_class)
             inputs_np = prepare_numpy_arrays(inputs)
 
+            
+
     def test_resize_token_embeddings(self):
         if not self.test_resize_embeddings:
             return

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -767,13 +767,15 @@ class TFModelTesterMixin:
 
             model(inputs)
     
-    def test_models_with_numpy_arrays(self):
+    def test_numpy_arrays_inputs(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         def prepare_numpy_arrays(inputs_dict):
             inputs_np_dict = {}
             for k, v in inputs_dict.items():
                 inputs_np_dict[k] = v.numpy()
+            
+            return inputs_np_dict
         
         for model_class in self.all_model_classes:
             model = model_class(config)
@@ -781,7 +783,7 @@ class TFModelTesterMixin:
             inputs = self._prepare_for_class(inputs_dict, model_class)
             inputs_np = prepare_numpy_arrays(inputs)
 
-            
+            model(inputs_np)
 
     def test_resize_token_embeddings(self):
         if not self.test_resize_embeddings:

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -773,7 +773,10 @@ class TFModelTesterMixin:
         def prepare_numpy_arrays(inputs_dict):
             inputs_np_dict = {}
             for k, v in inputs_dict.items():
-                inputs_np_dict[k] = v.numpy()
+                if tf.is_tensor(v):
+                    inputs_np_dict[k] = v.numpy()
+                else:
+                    inputs_np_dict[k] = np.array(k)
 
             return inputs_np_dict
 

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -766,7 +766,7 @@ class TFModelTesterMixin:
                 inputs["decoder_inputs_embeds"] = self._get_embeds(wte, decoder_input_ids)
 
             model(inputs)
-    
+
     def test_numpy_arrays_inputs(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
@@ -774,9 +774,9 @@ class TFModelTesterMixin:
             inputs_np_dict = {}
             for k, v in inputs_dict.items():
                 inputs_np_dict[k] = v.numpy()
-            
+
             return inputs_np_dict
-        
+
         for model_class in self.all_model_classes:
             model = model_class(config)
 


### PR DESCRIPTION
# What does this PR do?

This PR allows `np.ndarray` datatype as input of the models.

# Fixes
#9248 
