### PR TITLE
[prophetnet] wrong import

### DIFF
--- a/src/transformers/models/prophetnet/modeling_prophetnet.py
+++ b/src/transformers/models/prophetnet/modeling_prophetnet.py
@@ -513,9 +513,9 @@ class ProphetNetDecoderLMOutput(ModelOutput):
 def ProphetNetLayerNorm(normalized_shape, eps=1e-5, elementwise_affine=True):
     if torch.cuda.is_available():
         try:
-            from apex.normalization import FusedProphetNetLayerNorm
+            from apex.normalization import FusedLayerNorm
 
-            return FusedProphetNetLayerNorm(normalized_shape, eps, elementwise_affine)
+            return FusedLayerNorm(normalized_shape, eps, elementwise_affine)
         except ImportError:
             pass
     return torch.nn.LayerNorm(normalized_shape, eps, elementwise_affine)


### PR DESCRIPTION
```
python -c "from apex.normalization import FusedProphetNetLayerNorm"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name 'FusedProphetNetLayerNorm' from 'apex.normalization' (/home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/apex/normalization/__init__.py)
```
It looks like this code has never been tested, so it silently fails inside try/except.

Discovered this by accident in https://github.com/huggingface/transformers/issues/9338#issuecomment-752217708

@patrickvonplaten, @LysandreJik 

note, prophetnet is missing from .github/PULL_REQUEST_TEMPLATE.md, .github/ISSUE_TEMPLATE/bug-report.md