### PR TITLE
[trainer] parametrize default output_dir

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -228,8 +228,9 @@ class Trainer:
         optimizers: Tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR] = (None, None),
     ):
         if args is None:
-            logger.info("No `TrainingArguments` passed, using the current path as `output_dir`.")
-            args = TrainingArguments("tmp_trainer")
+            output_dir = "tmp_trainer"
+            logger.info(f"No `TrainingArguments` passed, using `output_dir={output_dir}`.")
+            args = TrainingArguments(output_dir=output_dir)
         self.args = args
         # Seed must be set before instantiating the model when using model
         set_seed(self.args.seed)


### PR DESCRIPTION
This PR:

* fixes trainer to have the logger agree with the actual default `output_dir`, by setting it in one place and passing it as an argument to both places. The current logger falsely informs the user that `output_dir` is the current path, while using `tmp_trainer` as the path.

@patrickvonplaten, @sgugger
