### PR TITLE
Fixes crash when `compute_metrics` is not passed to `Trainer` in run_mlm example

### DIFF
--- a/examples/language-modeling/run_mlm.py
+++ b/examples/language-modeling/run_mlm.py
@@ -379,14 +379,15 @@ def main():
         train_result = trainer.train(model_path=model_path)
         trainer.save_model()  # Saves the tokenizer too for easy upload
 
-        output_train_file = os.path.join(training_args.output_dir, "train_results.txt")
         if trainer.is_world_process_zero():
-            with open(output_train_file, "w") as writer:
-                logger.info("***** Train results *****")
-                for key, value in sorted(train_result.metrics.items()):
-                    logger.info(f"  {key} = {value}")
-                    writer.write(f"{key} = {value}\n")
-
+            if hasattr(train_result, "metrics"):
+                output_train_file = os.path.join(training_args.output_dir, "train_results.txt")
+                with open(output_train_file, "w") as writer:
+                    logger.info("***** Train results *****")
+                    for key, value in sorted(train_result.metrics.items()):
+                        logger.info(f"  {key} = {value}")
+                        writer.write(f"{key} = {value}\n")
+                        
             # Need to save the state, since Trainer.save_model saves only the tokenizer with the model
             trainer.state.save_to_json(os.path.join(training_args.output_dir, "trainer_state.json"))
 

--- a/examples/language-modeling/run_mlm.py
+++ b/examples/language-modeling/run_mlm.py
@@ -381,7 +381,9 @@ def main():
 
         if trainer.is_world_process_zero():
             if hasattr(train_result, "metrics"):
-                output_train_file = os.path.join(training_args.output_dir, "train_results.txt")
+                output_train_file = os.path.join(
+                    training_args.output_dir, "train_results.txt"
+                )
                 with open(output_train_file, "w") as writer:
                     logger.info("***** Train results *****")
                     for key, value in sorted(train_result.metrics.items()):

--- a/examples/language-modeling/run_mlm.py
+++ b/examples/language-modeling/run_mlm.py
@@ -388,7 +388,7 @@ def main():
                         logger.info(f"  {key} = {value}")
                         writer.write(f"{key} = {value}\n")
 
-            # Need to save the state, since Trainer.save_model saves only the tokenizer with the model
+            # Need to save the state since Trainer.save_model saves only the tokenizer with the model
             trainer.state.save_to_json(os.path.join(training_args.output_dir, "trainer_state.json"))
 
     # Evaluation

--- a/examples/language-modeling/run_mlm.py
+++ b/examples/language-modeling/run_mlm.py
@@ -381,19 +381,15 @@ def main():
 
         if trainer.is_world_process_zero():
             if hasattr(train_result, "metrics"):
-                output_train_file = os.path.join(
-                    training_args.output_dir, "train_results.txt"
-                )
+                output_train_file = os.path.join(training_args.output_dir, "train_results.txt")
                 with open(output_train_file, "w") as writer:
                     logger.info("***** Train results *****")
                     for key, value in sorted(train_result.metrics.items()):
                         logger.info(f"  {key} = {value}")
                         writer.write(f"{key} = {value}\n")
-                        
+
             # Need to save the state, since Trainer.save_model saves only the tokenizer with the model
-            trainer.state.save_to_json(
-                os.path.join(training_args.output_dir, "trainer_state.json")
-            )
+            trainer.state.save_to_json(os.path.join(training_args.output_dir, "trainer_state.json"))
 
     # Evaluation
     results = {}

--- a/examples/language-modeling/run_mlm.py
+++ b/examples/language-modeling/run_mlm.py
@@ -388,7 +388,7 @@ def main():
                         logger.info(f"  {key} = {value}")
                         writer.write(f"{key} = {value}\n")
 
-            # Need to save the state since Trainer.save_model saves only the tokenizer with the model
+            # Need to save the state, since Trainer.save_model saves only the tokenizer with the model
             trainer.state.save_to_json(os.path.join(training_args.output_dir, "trainer_state.json"))
 
     # Evaluation

--- a/examples/language-modeling/run_mlm.py
+++ b/examples/language-modeling/run_mlm.py
@@ -389,7 +389,9 @@ def main():
                         writer.write(f"{key} = {value}\n")
                         
             # Need to save the state, since Trainer.save_model saves only the tokenizer with the model
-            trainer.state.save_to_json(os.path.join(training_args.output_dir, "trainer_state.json"))
+            trainer.state.save_to_json(
+                os.path.join(training_args.output_dir, "trainer_state.json")
+            )
 
     # Evaluation
     results = {}


### PR DESCRIPTION
# What does this PR do?

If I'm understanding the example run_mlm code correctly, the `metrics` attribute will not be present on the `train_result` object if `compute_metrics` is not passed to `Trainer`. This edit prevents the script from attempting to write the metrics to file if they don't exist. 

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors which may be interested in your PR.

@sgugger 
@stas00 
 
