### PR TITLE
Make sure to use return dict for the encoder call inside RagTokenForGeneration

### DIFF
--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1437,7 +1437,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
         batch_size = context_input_ids.shape[0] // n_docs
 
         encoder = self.rag.generator.get_encoder()
-        encoder_outputs = encoder(input_ids=context_input_ids, attention_mask=context_attention_mask)
+        encoder_outputs = encoder(input_ids=context_input_ids, attention_mask=context_attention_mask, return_dict=True)
 
         input_ids = torch.full(
             (batch_size * num_beams, 1),


### PR DESCRIPTION
## What does this PR do?

At some point, `return_dict` was set to be `False` by default inside BART. However, this created a type error inside `RagTokenForGeneration`, which was still written with the expectation that `return_dict=True` by default. This PR simply adds `return_dict=True` to the call to the BART encoder inside the `RagTokenForGeneration` code.

## Tests
I did not create new tests because this change is very minor. I did run all the existing tests and they pass.

## Who can review?

Anyone can review, but I tagged these two because this involves RAG and BART:

@patrickvonplaten @lhoestq
