### PR TITLE
[docs] Fix TF base model examples: outputs.last_hidden_states -> state

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -851,7 +851,7 @@ TF_BASE_MODEL_SAMPLE = r"""
         >>> inputs = tokenizer("Hello, my dog is cute", return_tensors="tf")
         >>> outputs = model(inputs)
 
-        >>> last_hidden_states = outputs.last_hidden_states
+        >>> last_hidden_states = outputs.last_hidden_state
 """
 
 TF_MULTIPLE_CHOICE_SAMPLE = r"""


### PR DESCRIPTION
# What does this PR do?

Fixes a typo in the examples of Tensorflow-based base models, in which the returned last_hidden_state attribute of model output is incorrectly listed as "last_hidden_states".

Fixes #9376 

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?

@julien-c @patrickvonplaten
