### PR TITLE
Removing duplicated code for Translation,Summarization and Text2TextGeneration pipelines

### DIFF
--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -44,8 +44,7 @@ class Text2TextGenerationPipeline(Pipeline):
 
     def check_inputs(self, input_length: int, min_length: int, max_length: int):
         """
-        Checks wether there might be something wrong with given input with
-        regard to the model.
+        Checks wether there might be something wrong with given input with regard to the model.
         """
         return True
 
@@ -185,8 +184,7 @@ class SummarizationPipeline(Text2TextGenerationPipeline):
 
     def check_inputs(self, input_length: int, min_length: int, max_length: int) -> bool:
         """
-        Checks wether there might be something wrong with given input with
-        regard to the model.
+        Checks wether there might be something wrong with given input with regard to the model.
         """
         if input_length < min_length // 2:
             logger.warning(

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -31,6 +31,7 @@ class Text2TextGenerationPipeline(Pipeline):
         text2text_generator("question: What is 42 ? context: 42 is the answer to life, the universe and everything")
     """
 
+    # Used in the return key of the pipeline.
     return_name = "generated"
 
     def __init__(self, *args, **kwargs):
@@ -153,6 +154,7 @@ class SummarizationPipeline(Text2TextGenerationPipeline):
         summarizer("An apple a day, keeps the doctor away", min_length=5, max_length=20)
     """
 
+    # Used in the return key of the pipeline.
     return_name = "summary"
 
     def __call__(self, *args, **kwargs):
@@ -218,6 +220,7 @@ class TranslationPipeline(Text2TextGenerationPipeline):
         en_fr_translator("How old are you?")
     """
 
+    # Used in the return key of the pipeline.
     return_name = "translation"
 
     def check_inputs(self, input_length: int, min_length: int, max_length: int):

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -6,248 +6,12 @@ from .base import PIPELINE_INIT_ARGS, Pipeline
 if is_tf_available():
     import tensorflow as tf
 
-    from ..models.auto.modeling_tf_auto import TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING, TF_MODEL_WITH_LM_HEAD_MAPPING
+    from ..models.auto.modeling_tf_auto import TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING
 
 if is_torch_available():
     from ..models.auto.modeling_auto import MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING
 
 logger = logging.get_logger(__name__)
-
-
-@add_end_docstrings(PIPELINE_INIT_ARGS)
-class SummarizationPipeline(Pipeline):
-    """
-    Summarize news articles and other documents.
-
-    This summarizing pipeline can currently be loaded from :func:`~transformers.pipeline` using the following task
-    identifier: :obj:`"summarization"`.
-
-    The models that this pipeline can use are models that have been fine-tuned on a summarization task, which is
-    currently, '`bart-large-cnn`', '`t5-small`', '`t5-base`', '`t5-large`', '`t5-3b`', '`t5-11b`'. See the up-to-date
-    list of available models on `huggingface.co/models <https://huggingface.co/models?filter=summarization>`__.
-
-    Usage::
-
-        # use bart in pytorch
-        summarizer = pipeline("summarization")
-        summarizer("Sam Shleifer writes the best docstring examples in the whole world.", min_length=5, max_length=20)
-
-        # use t5 in tf
-        summarizer = pipeline("summarization", model="t5-base", tokenizer="t5-base", framework="tf")
-        summarizer("Sam Shleifer writes the best docstring examples in the whole world.", min_length=5, max_length=20)
-    """
-
-    def __init__(self, *args, **kwargs):
-        kwargs.update(task="summarization")
-        super().__init__(*args, **kwargs)
-
-        self.check_model_type(
-            TF_MODEL_WITH_LM_HEAD_MAPPING if self.framework == "tf" else MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING
-        )
-
-    def __call__(
-        self, *documents, return_tensors=False, return_text=True, clean_up_tokenization_spaces=False, **generate_kwargs
-    ):
-        r"""
-        Summarize the text(s) given as inputs.
-
-        Args:
-            documents (`str` or :obj:`List[str]`):
-                One or several articles (or one list of articles) to summarize.
-            return_text (:obj:`bool`, `optional`, defaults to :obj:`True`):
-                Whether or not to include the decoded texts in the outputs
-            return_tensors (:obj:`bool`, `optional`, defaults to :obj:`False`):
-                Whether or not to include the tensors of predictions (as token indices) in the outputs.
-            clean_up_tokenization_spaces (:obj:`bool`, `optional`, defaults to :obj:`False`):
-                Whether or not to clean up the potential extra spaces in the text output.
-            generate_kwargs:
-                Additional keyword arguments to pass along to the generate method of the model (see the generate method
-                corresponding to your framework `here <./model.html#generative-models>`__).
-
-        Return:
-            A list or a list of list of :obj:`dict`: Each result comes as a dictionary with the following keys:
-
-            - **summary_text** (:obj:`str`, present when ``return_text=True``) -- The summary of the corresponding
-              input.
-            - **summary_token_ids** (:obj:`torch.Tensor` or :obj:`tf.Tensor`, present when ``return_tensors=True``) --
-              The token ids of the summary.
-        """
-        assert return_tensors or return_text, "You must specify return_tensors=True or return_text=True"
-        assert len(documents) > 0, "Please provide a document to summarize"
-
-        prefix = self.model.config.prefix if self.model.config.prefix is not None else ""
-
-        if isinstance(documents[0], list):
-            assert (
-                self.tokenizer.pad_token_id is not None
-            ), "Please make sure that the tokenizer has a pad_token_id when using a batch input"
-
-            documents = ([prefix + document for document in documents[0]],)
-            padding = True
-
-        elif isinstance(documents[0], str):
-            documents = (prefix + documents[0],)
-            padding = False
-        else:
-            raise ValueError(
-                " `documents[0]`: {} have the wrong format. The should be either of type `str` or type `list`".format(
-                    documents[0]
-                )
-            )
-
-        with self.device_placement():
-            inputs = self._parse_and_tokenize(*documents, padding=padding)
-
-            if self.framework == "pt":
-                inputs = self.ensure_tensor_on_device(**inputs)
-                input_length = inputs["input_ids"].shape[-1]
-            elif self.framework == "tf":
-                input_length = tf.shape(inputs["input_ids"])[-1].numpy()
-
-            min_length = generate_kwargs.get("min_length", self.model.config.min_length)
-            if input_length < min_length // 2:
-                logger.warning(
-                    "Your min_length is set to {}, but you input_length is only {}. You might consider decreasing min_length manually, e.g. summarizer('...', min_length=10)".format(
-                        min_length, input_length
-                    )
-                )
-
-            max_length = generate_kwargs.get("max_length", self.model.config.max_length)
-            if input_length < max_length:
-                logger.warning(
-                    "Your max_length is set to {}, but you input_length is only {}. You might consider decreasing max_length manually, e.g. summarizer('...', max_length=50)".format(
-                        max_length, input_length
-                    )
-                )
-
-            summaries = self.model.generate(
-                inputs["input_ids"],
-                attention_mask=inputs["attention_mask"],
-                **generate_kwargs,
-            )
-
-            results = []
-            for summary in summaries:
-                record = {}
-                if return_tensors:
-                    record["summary_token_ids"] = summary
-                if return_text:
-                    record["summary_text"] = self.tokenizer.decode(
-                        summary,
-                        skip_special_tokens=True,
-                        clean_up_tokenization_spaces=clean_up_tokenization_spaces,
-                    )
-                results.append(record)
-            return results
-
-
-@add_end_docstrings(PIPELINE_INIT_ARGS)
-class TranslationPipeline(Pipeline):
-    """
-    Translates from one language to another.
-
-    This translation pipeline can currently be loaded from :func:`~transformers.pipeline` using the following task
-    identifier: :obj:`"translation_xx_to_yy"`.
-
-    The models that this pipeline can use are models that have been fine-tuned on a translation task. See the
-    up-to-date list of available models on `huggingface.co/models
-    <https://huggingface.co/models?filter=translation>`__.
-
-    Usage::
-        en_fr_translator = pipeline("translation_en_to_fr")
-        en_fr_translator("How old are you?")
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.check_model_type(
-            TF_MODEL_WITH_LM_HEAD_MAPPING if self.framework == "tf" else MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING
-        )
-
-    def __call__(
-        self, *args, return_tensors=False, return_text=True, clean_up_tokenization_spaces=False, **generate_kwargs
-    ):
-        r"""
-        Translate the text(s) given as inputs.
-
-        Args:
-            args (:obj:`str` or :obj:`List[str]`):
-                Texts to be translated.
-            return_tensors (:obj:`bool`, `optional`, defaults to :obj:`False`):
-                Whether or not to include the tensors of predictions (as token indices) in the outputs.
-            return_text (:obj:`bool`, `optional`, defaults to :obj:`True`):
-                Whether or not to include the decoded texts in the outputs.
-            clean_up_tokenization_spaces (:obj:`bool`, `optional`, defaults to :obj:`False`):
-                Whether or not to clean up the potential extra spaces in the text output.
-            generate_kwargs:
-                Additional keyword arguments to pass along to the generate method of the model (see the generate method
-                corresponding to your framework `here <./model.html#generative-models>`__).
-
-        Return:
-            A list or a list of list of :obj:`dict`: Each result comes as a dictionary with the following keys:
-
-            - **translation_text** (:obj:`str`, present when ``return_text=True``) -- The translation.
-            - **translation_token_ids** (:obj:`torch.Tensor` or :obj:`tf.Tensor`, present when ``return_tensors=True``)
-              -- The token ids of the translation.
-        """
-        assert return_tensors or return_text, "You must specify return_tensors=True or return_text=True"
-
-        prefix = self.model.config.prefix if self.model.config.prefix is not None else ""
-
-        if isinstance(args[0], list):
-            assert (
-                self.tokenizer.pad_token_id is not None
-            ), "Please make sure that the tokenizer has a pad_token_id when using a batch input"
-            args = ([prefix + text for text in args[0]],)
-            padding = True
-
-        elif isinstance(args[0], str):
-            args = (prefix + args[0],)
-            padding = False
-        else:
-            raise ValueError(
-                " `documents[0]`: {} have the wrong format. The should be either of type `str` or type `list`".format(
-                    args[0]
-                )
-            )
-
-        with self.device_placement():
-            inputs = self._parse_and_tokenize(*args, padding=padding)
-
-            if self.framework == "pt":
-                inputs = self.ensure_tensor_on_device(**inputs)
-                input_length = inputs["input_ids"].shape[-1]
-
-            elif self.framework == "tf":
-                input_length = tf.shape(inputs["input_ids"])[-1].numpy()
-
-            max_length = generate_kwargs.get("max_length", self.model.config.max_length)
-            if input_length > 0.9 * max_length:
-                logger.warning(
-                    "Your input_length: {} is bigger than 0.9 * max_length: {}. You might consider increasing your max_length manually, e.g. translator('...', max_length=400)".format(
-                        input_length, max_length
-                    )
-                )
-
-            translations = self.model.generate(
-                inputs["input_ids"],
-                attention_mask=inputs["attention_mask"],
-                **generate_kwargs,
-            )
-            results = []
-            for translation in translations:
-                record = {}
-                if return_tensors:
-                    record["translation_token_ids"] = translation
-                if return_text:
-                    record["translation_text"] = self.tokenizer.decode(
-                        translation,
-                        skip_special_tokens=True,
-                        clean_up_tokenization_spaces=clean_up_tokenization_spaces,
-                    )
-                results.append(record)
-            return results
 
 
 @add_end_docstrings(PIPELINE_INIT_ARGS)
@@ -267,6 +31,8 @@ class Text2TextGenerationPipeline(Pipeline):
         text2text_generator("question: What is 42 ? context: 42 is the answer to life, the universe and everything")
     """
 
+    return_name = "generated"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -275,6 +41,13 @@ class Text2TextGenerationPipeline(Pipeline):
             if self.framework == "tf"
             else MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING
         )
+
+    def check_inputs(self, input_length: int, min_length: int, max_length: int):
+        """
+        Checks wether there might be something wrong with given input with
+        regard to the model.
+        """
+        return True
 
     def __call__(
         self, *args, return_tensors=False, return_text=True, clean_up_tokenization_spaces=False, **generate_kwargs
@@ -304,26 +77,39 @@ class Text2TextGenerationPipeline(Pipeline):
         """
         assert return_tensors or return_text, "You must specify return_tensors=True or return_text=True"
 
+        prefix = self.model.config.prefix if self.model.config.prefix is not None else ""
         if isinstance(args[0], list):
             assert (
                 self.tokenizer.pad_token_id is not None
             ), "Please make sure that the tokenizer has a pad_token_id when using a batch input"
+            args = ([prefix + arg for arg in args[0]],)
             padding = True
 
         elif isinstance(args[0], str):
+            args = (prefix + args[0],)
             padding = False
         else:
             raise ValueError(
-                " `documents[0]`: {} have the wrong format. The should be either of type `str` or type `list`".format(
+                " `args[0]`: {} have the wrong format. The should be either of type `str` or type `list`".format(
                     args[0]
                 )
             )
 
         with self.device_placement():
-            inputs = self._parse_and_tokenize(*args, padding=padding)
+            inputs = self._parse_and_tokenize(*args, padding=padding, **generate_kwargs)
 
             if self.framework == "pt":
                 inputs = self.ensure_tensor_on_device(**inputs)
+                input_length = inputs["input_ids"].shape[-1]
+            elif self.framework == "tf":
+                input_length = tf.shape(inputs["input_ids"])[-1].numpy()
+
+            min_length = generate_kwargs.get("min_length", self.model.config.min_length)
+            max_length = generate_kwargs.get("max_length", self.model.config.max_length)
+            self.check_inputs(input_length, min_length, max_length)
+
+            # truncation should be used by _parse_and_tokenize
+            generate_kwargs.pop("truncation", None)
 
             generations = self.model.generate(
                 inputs["input_ids"],
@@ -334,12 +120,138 @@ class Text2TextGenerationPipeline(Pipeline):
             for generation in generations:
                 record = {}
                 if return_tensors:
-                    record["generated_token_ids"] = generation
+                    record[f"{self.return_name}_token_ids"] = generation
                 if return_text:
-                    record["generated_text"] = self.tokenizer.decode(
+                    record[f"{self.return_name}_text"] = self.tokenizer.decode(
                         generation,
                         skip_special_tokens=True,
                         clean_up_tokenization_spaces=clean_up_tokenization_spaces,
                     )
                 results.append(record)
             return results
+
+
+@add_end_docstrings(PIPELINE_INIT_ARGS)
+class SummarizationPipeline(Text2TextGenerationPipeline):
+    """
+    Summarize news articles and other documents.
+
+    This summarizing pipeline can currently be loaded from :func:`~transformers.pipeline` using the following task
+    identifier: :obj:`"summarization"`.
+
+    The models that this pipeline can use are models that have been fine-tuned on a summarization task, which is
+    currently, '`bart-large-cnn`', '`t5-small`', '`t5-base`', '`t5-large`', '`t5-3b`', '`t5-11b`'. See the up-to-date
+    list of available models on `huggingface.co/models <https://huggingface.co/models?filter=summarization>`__.
+
+    Usage::
+
+        # use bart in pytorch
+        summarizer = pipeline("summarization")
+        summarizer("Sam Shleifer writes the best docstring examples in the whole world.", min_length=5, max_length=20)
+
+        # use t5 in tf
+        summarizer = pipeline("summarization", model="t5-base", tokenizer="t5-base", framework="tf")
+        summarizer("Sam Shleifer writes the best docstring examples in the whole world.", min_length=5, max_length=20)
+    """
+
+    return_name = "summary"
+
+    def __call__(self, *args, **kwargs):
+        r"""
+        Summarize the text(s) given as inputs.
+
+        Args:
+            documents (`str` or :obj:`List[str]`):
+                One or several articles (or one list of articles) to summarize.
+            return_text (:obj:`bool`, `optional`, defaults to :obj:`True`):
+                Whether or not to include the decoded texts in the outputs
+            return_tensors (:obj:`bool`, `optional`, defaults to :obj:`False`):
+                Whether or not to include the tensors of predictions (as token indices) in the outputs.
+            clean_up_tokenization_spaces (:obj:`bool`, `optional`, defaults to :obj:`False`):
+                Whether or not to clean up the potential extra spaces in the text output.
+            generate_kwargs:
+                Additional keyword arguments to pass along to the generate method of the model (see the generate method
+                corresponding to your framework `here <./model.html#generative-models>`__).
+
+        Return:
+            A list or a list of list of :obj:`dict`: Each result comes as a dictionary with the following keys:
+
+            - **summary_text** (:obj:`str`, present when ``return_text=True``) -- The summary of the corresponding
+              input.
+            - **summary_token_ids** (:obj:`torch.Tensor` or :obj:`tf.Tensor`, present when ``return_tensors=True``) --
+              The token ids of the summary.
+        """
+        return super().__call__(*args, **kwargs)
+
+    def check_inputs(self, input_length: int, min_length: int, max_length: int) -> bool:
+        """
+        Checks wether there might be something wrong with given input with
+        regard to the model.
+        """
+        if input_length < min_length // 2:
+            logger.warning(
+                "Your min_length is set to {}, but you input_length is only {}. You might consider decreasing min_length manually, e.g. summarizer('...', min_length=10)".format(
+                    min_length, input_length
+                )
+            )
+
+        if input_length < max_length:
+            logger.warning(
+                "Your max_length is set to {}, but you input_length is only {}. You might consider decreasing max_length manually, e.g. summarizer('...', max_length=50)".format(
+                    max_length, input_length
+                )
+            )
+
+
+@add_end_docstrings(PIPELINE_INIT_ARGS)
+class TranslationPipeline(Pipeline):
+    """
+    Translates from one language to another.
+
+    This translation pipeline can currently be loaded from :func:`~transformers.pipeline` using the following task
+    identifier: :obj:`"translation_xx_to_yy"`.
+
+    The models that this pipeline can use are models that have been fine-tuned on a translation task. See the
+    up-to-date list of available models on `huggingface.co/models
+    <https://huggingface.co/models?filter=translation>`__.
+
+    Usage::
+        en_fr_translator = pipeline("translation_en_to_fr")
+        en_fr_translator("How old are you?")
+    """
+
+    return_name = "translated"
+
+    def check_inputs(self, input_length: int, min_length: int, max_length: int):
+        if input_length > 0.9 * max_length:
+            logger.warning(
+                "Your input_length: {} is bigger than 0.9 * max_length: {}. You might consider increasing your max_length manually, e.g. translator('...', max_length=400)".format(
+                    input_length, max_length
+                )
+            )
+
+    def __call__(self, *args, **kwargs):
+        r"""
+        Translate the text(s) given as inputs.
+
+        Args:
+            args (:obj:`str` or :obj:`List[str]`):
+                Texts to be translated.
+            return_tensors (:obj:`bool`, `optional`, defaults to :obj:`False`):
+                Whether or not to include the tensors of predictions (as token indices) in the outputs.
+            return_text (:obj:`bool`, `optional`, defaults to :obj:`True`):
+                Whether or not to include the decoded texts in the outputs.
+            clean_up_tokenization_spaces (:obj:`bool`, `optional`, defaults to :obj:`False`):
+                Whether or not to clean up the potential extra spaces in the text output.
+            generate_kwargs:
+                Additional keyword arguments to pass along to the generate method of the model (see the generate method
+                corresponding to your framework `here <./model.html#generative-models>`__).
+
+        Return:
+            A list or a list of list of :obj:`dict`: Each result comes as a dictionary with the following keys:
+
+            - **translation_text** (:obj:`str`, present when ``return_text=True``) -- The translation.
+            - **translation_token_ids** (:obj:`torch.Tensor` or :obj:`tf.Tensor`, present when ``return_tensors=True``)
+              -- The token ids of the translation.
+        """
+        return super().__call__(*args, **kwargs)

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -146,11 +146,11 @@ class SummarizationPipeline(Text2TextGenerationPipeline):
 
         # use bart in pytorch
         summarizer = pipeline("summarization")
-        summarizer("Sam Shleifer writes the best docstring examples in the whole world.", min_length=5, max_length=20)
+        summarizer("An apple a day, keeps the doctor away", min_length=5, max_length=20)
 
         # use t5 in tf
         summarizer = pipeline("summarization", model="t5-base", tokenizer="t5-base", framework="tf")
-        summarizer("Sam Shleifer writes the best docstring examples in the whole world.", min_length=5, max_length=20)
+        summarizer("An apple a day, keeps the doctor away", min_length=5, max_length=20)
     """
 
     return_name = "summary"

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -204,7 +204,7 @@ class SummarizationPipeline(Text2TextGenerationPipeline):
 
 
 @add_end_docstrings(PIPELINE_INIT_ARGS)
-class TranslationPipeline(Pipeline):
+class TranslationPipeline(Text2TextGenerationPipeline):
     """
     Translates from one language to another.
 
@@ -220,7 +220,7 @@ class TranslationPipeline(Pipeline):
         en_fr_translator("How old are you?")
     """
 
-    return_name = "translated"
+    return_name = "translation"
 
     def check_inputs(self, input_length: int, min_length: int, max_length: int):
         if input_length > 0.9 * max_length:

--- a/tests/test_pipelines_summarization.py
+++ b/tests/test_pipelines_summarization.py
@@ -14,13 +14,75 @@
 
 import unittest
 
-from transformers import pipeline
+from transformers import is_torch_available, pipeline
+from transformers.models.bart import BartConfig, BartForConditionalGeneration
 from transformers.testing_utils import require_torch, slow, torch_device
+from transformers.tokenization_utils import TruncationStrategy
 
 from .test_pipelines_common import MonoInputPipelineCommonMixin
 
 
 DEFAULT_DEVICE_NUM = -1 if torch_device == "cpu" else 0
+
+if is_torch_available():
+    import torch
+
+
+class DummyTok:
+    pad_token_id = 0
+
+    def __init__(self, **kwargs):
+        for name, v in kwargs.items():
+            setattr(self, name, v)
+
+    def __call__(self, inputs, **kwargs):
+        if isinstance(inputs, str):
+            input_ids = self.encode(inputs).unsqueeze(0)
+        else:
+            input_ids = torch.nn.utils.rnn.pad_sequence(
+                [self.encode(input_) for input_ in inputs],
+                padding_value=self.pad_token_id,
+            )
+
+        if kwargs.get("truncation", TruncationStrategy.DO_NOT_TRUNCATE) == TruncationStrategy.ONLY_FIRST:
+            input_ids = input_ids[:, : self.model_max_length]
+        attention_mask = torch.zeros_like(input_ids).long() + 1
+        return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+    def encode(self, input_):
+        return torch.LongTensor(list(input_.encode("utf-8")))
+
+    def decode(self, sequence, **kwargs):
+        return "D" * len(sequence)
+
+
+class SimpleSummarizationPipelineTests(unittest.TestCase):
+    @require_torch
+    def test_input_too_long(self):
+        config = BartConfig(
+            vocab_size=257,
+            d_model=32,
+            encoder_layers=1,
+            decoder_layers=1,
+            encoder_ffn_dim=32,
+            decoder_ffn_dim=32,
+            # So any text > 4 should raise an exception
+            max_position_embeddings=4,
+            encoder_attention_heads=1,
+            decoder_attention_heads=1,
+            max_length=4,
+            min_length=1,
+        )
+        model = BartForConditionalGeneration(config)
+        tokenizer = DummyTok(model_max_length=4)
+        nlp = pipeline(task="summarization", model=model, tokenizer=tokenizer)
+
+        with self.assertRaises(IndexError):
+            _ = nlp("This is a test")
+
+        output = nlp("This is a test", truncation=TruncationStrategy.ONLY_FIRST)
+
+        self.assertEqual(output, [{"summary_text": "DDDD"}])
 
 
 class SummarizationPipelineTests(MonoInputPipelineCommonMixin, unittest.TestCase):

--- a/tests/test_pipelines_summarization.py
+++ b/tests/test_pipelines_summarization.py
@@ -15,17 +15,18 @@
 import unittest
 
 from transformers import is_torch_available, pipeline
-from transformers.models.bart import BartConfig, BartForConditionalGeneration
 from transformers.testing_utils import require_torch, slow, torch_device
 from transformers.tokenization_utils import TruncationStrategy
 
 from .test_pipelines_common import MonoInputPipelineCommonMixin
 
 
-DEFAULT_DEVICE_NUM = -1 if torch_device == "cpu" else 0
-
 if is_torch_available():
     import torch
+
+    from transformers.models.bart import BartConfig, BartForConditionalGeneration
+
+DEFAULT_DEVICE_NUM = -1 if torch_device == "cpu" else 0
 
 
 class DummyTok:

--- a/tests/test_pipelines_summarization.py
+++ b/tests/test_pipelines_summarization.py
@@ -14,76 +14,13 @@
 
 import unittest
 
-from transformers import is_torch_available, pipeline
+from transformers import pipeline
 from transformers.testing_utils import require_torch, slow, torch_device
-from transformers.tokenization_utils import TruncationStrategy
 
 from .test_pipelines_common import MonoInputPipelineCommonMixin
 
 
-if is_torch_available():
-    import torch
-
-    from transformers.models.bart import BartConfig, BartForConditionalGeneration
-
 DEFAULT_DEVICE_NUM = -1 if torch_device == "cpu" else 0
-
-
-class DummyTok:
-    pad_token_id = 0
-
-    def __init__(self, **kwargs):
-        for name, v in kwargs.items():
-            setattr(self, name, v)
-
-    def __call__(self, inputs, **kwargs):
-        if isinstance(inputs, str):
-            input_ids = self.encode(inputs).unsqueeze(0)
-        else:
-            input_ids = torch.nn.utils.rnn.pad_sequence(
-                [self.encode(input_) for input_ in inputs],
-                padding_value=self.pad_token_id,
-            )
-
-        if kwargs.get("truncation", TruncationStrategy.DO_NOT_TRUNCATE) == TruncationStrategy.ONLY_FIRST:
-            input_ids = input_ids[:, : self.model_max_length]
-        attention_mask = torch.zeros_like(input_ids).long() + 1
-        return {"input_ids": input_ids, "attention_mask": attention_mask}
-
-    def encode(self, input_):
-        return torch.LongTensor(list(input_.encode("utf-8")))
-
-    def decode(self, sequence, **kwargs):
-        return "D" * len(sequence)
-
-
-class SimpleSummarizationPipelineTests(unittest.TestCase):
-    @require_torch
-    def test_input_too_long(self):
-        config = BartConfig(
-            vocab_size=257,
-            d_model=32,
-            encoder_layers=1,
-            decoder_layers=1,
-            encoder_ffn_dim=32,
-            decoder_ffn_dim=32,
-            # So any text > 4 should raise an exception
-            max_position_embeddings=4,
-            encoder_attention_heads=1,
-            decoder_attention_heads=1,
-            max_length=4,
-            min_length=1,
-        )
-        model = BartForConditionalGeneration(config)
-        tokenizer = DummyTok(model_max_length=4)
-        nlp = pipeline(task="summarization", model=model, tokenizer=tokenizer)
-
-        with self.assertRaises(IndexError):
-            _ = nlp("This is a test")
-
-        output = nlp("This is a test", truncation=TruncationStrategy.ONLY_FIRST)
-
-        self.assertEqual(output, [{"summary_text": "DDDD"}])
 
 
 class SummarizationPipelineTests(MonoInputPipelineCommonMixin, unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

`TranslationPipeline`, `SummarizationPipeline` and `Text2TextGenerationPipeline` share quite a bit of code for the generation
part. This PR aims to remove that code duplication to prevent future errors in argument handling while preserving, documentation
for all methods and functions and the full behavior.

Translation and Summarization now inherit from Text2TextGenerationPipeline. They retain their own docstrings to be more readable in the docs.

New function `check_inputs` has appeared which does all the current variation between the 3 classes, basically by raising different warnings
based on inputs and underlying model config.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@LysandreJik
@sgugger

Edit: Sorry about the diff, just gave a look, it's totally unreadable mostly because I reordered the classes so that the Base classe (Text2TextGenerationPipeline) is before the subclasses.
I'll happily switch that back to make review on the actual code easier (and maybe change back later the order for cleaner code in the end)

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors which may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

 albert, bert, XLM: @LysandreJik
 GPT2: @LysandreJik, @patrickvonplaten
 tokenizers: @mfuntowicz
 Trainer: @sgugger
 Benchmarks: @patrickvonplaten
 Model Cards: @julien-c
 examples/distillation: @VictorSanh
 nlp datasets: [different repo](https://github.com/huggingface/nlp)
 rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
 Text Generation: @patrickvonplaten, @TevenLeScao
 Blenderbot, Bart, Marian, Pegasus: @patrickvonplaten
 T5: @patrickvonplaten
 Rag: @patrickvonplaten, @lhoestq
 EncoderDecoder: @patrickvonplaten
 Longformer, Reformer: @patrickvonplaten
 TransfoXL, XLNet: @TevenLeScao, @patrickvonplaten
 examples/seq2seq: @patil-suraj
 examples/bert-loses-patience: @JetRunner
 tensorflow: @jplu
 examples/token-classification: @stefan-it
 documentation: @sgugger
 FSMT: @stas00
 -->