### PR TITLE
[make fixup] a more reliable version of branching point discovery

### DIFF
--- a/utils/get_modified_files.py
+++ b/utils/get_modified_files.py
@@ -24,7 +24,7 @@ import subprocess
 import sys
 
 
-fork_point_sha = subprocess.check_output("git merge-base --fork-point master".split()).decode("utf-8")
+fork_point_sha = subprocess.check_output("git merge-base master HEAD".split()).decode("utf-8")
 modified_files = subprocess.check_output(f"git diff --name-only {fork_point_sha}".split()).decode("utf-8").split()
 
 joined_dirs = "|".join(sys.argv[1:])


### PR DESCRIPTION
This PR replaces:
```
git merge-base --fork-point master
```
with:
```
git merge-base master HEAD
```
in `utils/get_modified_files.py` (which is used by `make fixup`)

As I reported in https://github.com/huggingface/transformers/issues/9425 the former method sometimes doesn't work when used with `gh pr checkout` or `git-pr`, rendering the relatively recently added git ` --fork-point` feature unreliable.

I have re-tested and the new way works for any of:
1. `gh pr checkout`
2. `git-pr`
3. `git pr`
4. normal local git branch

So this is what we are doing now to get only the modified files of the current branch:
```
git diff --name-only $(git merge-base master HEAD)
```

If we get complex branches that have various re-merges we will want to find not the most recent ancestor which the above gives, but the oldest ancestor - after some research found this: https://stackoverflow.com/a/4991675/9201239, which suggests:
```
diff --changed-group-format='' <(git rev-list --first-parent "${1:-master}") <(git rev-list --first-parent "${2:-HEAD}") | head -1
```
and in the simple case where there is just one common ancestor it will find it too. So let's keep this as an option if you find the current solution isn't satisfactory.

Fixes: #9425 

@LysandreJik 