### PR TITLE
[trainer] remove `--model_parallel`

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -53,6 +53,8 @@ class HfArgumentParser(ArgumentParser):
 
     def _add_dataclass_arguments(self, dtype: DataClassType):
         for field in dataclasses.fields(dtype):
+            if not field.init:
+                continue
             field_name = f"--{field.name}"
             kwargs = field.metadata.copy()
             # field.metadata is not used at all by Data Classes,
@@ -142,7 +144,7 @@ class HfArgumentParser(ArgumentParser):
         namespace, remaining_args = self.parse_known_args(args=args)
         outputs = []
         for dtype in self.dataclass_types:
-            keys = {f.name for f in dataclasses.fields(dtype)}
+            keys = {f.name for f in dataclasses.fields(dtype) if f.init}
             inputs = {k: v for k, v in vars(namespace).items() if k in keys}
             for k in keys:
                 delattr(namespace, k)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -276,6 +276,9 @@ class Trainer:
         # Model parallel
         if not (model.is_parallelizable and model.parallel):
             model = model.to(args.device)
+        else:
+            # Force n_gpu to 1 to avoid DataParallel.
+            self.args._force_n_gpu = 1
 
         # later use `self.model is self.model_wrapped` to check if it's wrapped or not
         self.model_wrapped = model
@@ -719,7 +722,7 @@ class Trainer:
             model, self.optimizer = amp.initialize(model, self.optimizer, opt_level=self.args.fp16_opt_level)
 
         # Multi-gpu training (should be after apex fp16 initialization)
-        if self.args.n_gpu > 1 and not (model.is_parallelizable and model.parallel):
+        if self.args.n_gpu > 1:
             model = torch.nn.DataParallel(model)
 
         # Distributed training (should be after apex fp16 initialization)
@@ -1481,7 +1484,7 @@ class Trainer:
 
         model = self.model
         # multi-gpu eval
-        if self.args.n_gpu > 1 and not (model.is_parallelizable and model.parallel):
+        if self.args.n_gpu > 1:
             model = torch.nn.DataParallel(model)
         # Note: in torch.distributed mode, there's no point in wrapping the model
         # inside a DistributedDataParallel as we'll be under `no_grad` anyways.

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -221,16 +221,14 @@ class Trainer:
 
     Important attributes:
 
-        ``self.model`` - always points to the core model. If using a transformers model, it will be a
-        :class:`PreTrainedModel` subclass.
-
-        ``self.model_wrapped`` - always points to the most external model in case one or more other modules wrap the
-        original model. This is the model that should be used for the forward pass. For example, under ``DeepSpeed``,
-        the inner model is wrapped in ``DeepSpeed`` and then again in ``DistributedDataParallel``. If the inner model
-        hasn't been wrapped, then ``self.model_wrapped`` is the same as ``self.model``.
-
-       ``self.is_model_parallel`` - is True if a model has been switched to a model parallel mode.
-
+        - **model** -- Always points to the core model. If using a transformers model, it will be a
+          :class:`~transformers.PreTrainedModel` subclass.
+        - **model_wrapped** -- Always points to the most external model in case one or more other modules wrap the
+          original model. This is the model that should be used for the forward pass. For example, under ``DeepSpeed``,
+          the inner model is wrapped in ``DeepSpeed`` and then again in ``torch.nn.DistributedDataParallel``. If the
+          inner model hasn't been wrapped, then ``self.model_wrapped`` is the same as ``self.model``.
+        - **is_model_parallel** -- Whether or not a model has been switched to a model parallel mode (different from
+          data parallelism, this means some of the model layers are split on different GPUs).
     """
 
     def __init__(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -278,7 +278,7 @@ class Trainer:
             model = model.to(args.device)
         else:
             # Force n_gpu to 1 to avoid DataParallel.
-            self.args._force_n_gpu = 1
+            self.args._n_gpu = 1
 
         # later use `self.model is self.model_wrapped` to check if it's wrapped or not
         self.model_wrapped = model

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -169,7 +169,8 @@ def _model_unwrap(model: nn.Module) -> nn.Module:
 
 
 class Trainer:
-    """Trainer is a simple but feature-complete training and eval loop for PyTorch, optimized for 🤗 Transformers.
+    """
+    Trainer is a simple but feature-complete training and eval loop for PyTorch, optimized for 🤗 Transformers.
 
     Args:
         model (:class:`~transformers.PreTrainedModel` or :obj:`torch.nn.Module`, `optional`):
@@ -218,17 +219,17 @@ class Trainer:
             :class:`~transformers.AdamW` on your model and a scheduler given by
             :func:`~transformers.get_linear_schedule_with_warmup` controlled by :obj:`args`.
 
-    Important accessors:
+    Important attributes:
 
         ``self.model`` - always points to the core model. If using a transformers model, it will be a
-          :class:`PreTrainedModel` subclass.
+        :class:`PreTrainedModel` subclass.
 
         ``self.model_wrapped`` - always points to the most external model in case one or more other modules wrap the
         original model. This is the model that should be used for the forward pass. For example, under ``DeepSpeed``,
         the inner model is wrapped in ``DeepSpeed`` and then again in ``DistributedDataParallel``. If the inner model
         hasn't been wrapped, then ``self.model_wrapped`` is the same as ``self.model``.
 
-       ``self.is_model_parallel`` - is true if a model has been switched to a model parallel mode.
+       ``self.is_model_parallel`` - is True if a model has been switched to a model parallel mode.
 
     """
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -169,8 +169,7 @@ def _model_unwrap(model: nn.Module) -> nn.Module:
 
 
 class Trainer:
-    """
-    Trainer is a simple but feature-complete training and eval loop for PyTorch, optimized for 🤗 Transformers.
+    """Trainer is a simple but feature-complete training and eval loop for PyTorch, optimized for 🤗 Transformers.
 
     Args:
         model (:class:`~transformers.PreTrainedModel` or :obj:`torch.nn.Module`, `optional`):
@@ -221,15 +220,16 @@ class Trainer:
 
     Important accessors:
 
-        * ``self.model`` - always points to the core model. If using a transformers model, it will be a
+        ``self.model`` - always points to the core model. If using a transformers model, it will be a
           :class:`PreTrainedModel` subclass.
 
-        * ``self.model_wrapped`` - always points to the most external model in case one or more other modules wrap the
+        ``self.model_wrapped`` - always points to the most external model in case one or more other modules wrap the
         original model. This is the model that should be used for the forward pass. For example, under ``DeepSpeed``,
         the inner model is wrapped in ``DeepSpeed`` and then again in ``DistributedDataParallel``. If the inner model
         hasn't been wrapped, then ``self.model_wrapped`` is the same as ``self.model``.
 
-        * ``self.is_model_parallel`` - is true if a model has been switched to a model parallel mode.
+       ``self.is_model_parallel`` - is true if a model has been switched to a model parallel mode.
+
     """
 
     def __init__(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -267,6 +267,11 @@ class Trainer:
                 )
             self.model_init = model_init
 
+        if self.args.model_parallel and not model.is_parallelizable:
+            raise ValueError(
+                f"{model.__class__.__name__} implementation currently doesn't support model parallelism, therefore --model_parallel cl arg cannot be used"
+            )
+
         default_collator = default_data_collator if tokenizer is None else DataCollatorWithPadding(tokenizer)
         self.data_collator = data_collator if data_collator is not None else default_collator
         self.train_dataset = train_dataset

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -161,7 +161,7 @@ logger = logging.get_logger(__name__)
 
 
 def is_parallel(model):
-    return hasattr(model, "is_parallelizable") and model.is_parallelizable and model.parallel
+    return hasattr(model, "is_parallelizable") and model.is_parallelizable and model.model_parallel
 
 
 def _model_unwrap(model: nn.Module) -> nn.Module:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -398,7 +398,7 @@ class TrainingArguments:
         default=0.0, metadata={"help": "The label smoothing epsilon to apply (zero means no label smoothing)."}
     )
     adafactor: bool = field(default=False, metadata={"help": "Whether or not to replace Adam by Adafactor."})
-    _n_gpu: int = field(default=0, repr=False)
+    _n_gpu: int = field(init=False, repr=False, default=0)
 
     def __post_init__(self):
         if self.disable_tqdm is None:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -418,6 +418,7 @@ class TrainingArguments:
 
         if is_torch_available() and self.device.type != "cuda" and self.fp16:
             raise ValueError("Mixed precision training with AMP or APEX (`--fp16`) can only be used on CUDA devices.")
+        self._force_n_gpu = None
 
     def __repr__(self):
         # We override the default repr to remove deprecated arguments from the repr. This method should be removed once
@@ -480,7 +481,7 @@ class TrainingArguments:
             # GPUs available in the environment, so `CUDA_VISIBLE_DEVICES=1,2` with `cuda:0`
             # will use the first GPU in that env, i.e. GPU#1
             device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-            n_gpu = torch.cuda.device_count()
+            n_gpu = torch.cuda.device_count() if self._force_n_gpu is None else self._force_n_gpu
         else:
             # Here, we'll use torch.distributed.
             # Initializes the distributed backend which will take care of synchronizing nodes/GPUs

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -210,9 +210,6 @@ class TrainingArguments:
             - :obj:`True` if :obj:`metric_for_best_model` is set to a value that isn't :obj:`"loss"` or
               :obj:`"eval_loss"`.
             - :obj:`False` if :obj:`metric_for_best_model` is not set, or set to :obj:`"loss"` or :obj:`"eval_loss"`.
-        model_parallel (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            If the model supports model parallelism and there is more than one device, whether to use model parallelism
-            to distribute the model's modules across devices or not.
         ignore_skip_data (:obj:`bool`, `optional`, defaults to :obj:`False`):
             When resuming training, whether or not to skip the epochs and batches to get the data loading at the same
             stage as in the previous training. If set to :obj:`True`, the training will begin faster (as that skipping
@@ -245,15 +242,6 @@ class TrainingArguments:
     do_train: bool = field(default=False, metadata={"help": "Whether to run training."})
     do_eval: bool = field(default=None, metadata={"help": "Whether to run eval on the dev set."})
     do_predict: bool = field(default=False, metadata={"help": "Whether to run predictions on the test set."})
-    model_parallel: bool = field(
-        default=False,
-        metadata={
-            "help": (
-                "If there are more than one devices, whether to use model parallelism to distribute the "
-                "model's modules across devices."
-            )
-        },
-    )
     evaluation_strategy: EvaluationStrategy = field(
         default="no",
         metadata={"help": "The evaluation strategy to use."},

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -398,7 +398,7 @@ class TrainingArguments:
         default=0.0, metadata={"help": "The label smoothing epsilon to apply (zero means no label smoothing)."}
     )
     adafactor: bool = field(default=False, metadata={"help": "Whether or not to replace Adam by Adafactor."})
-    _n_gpu: int = field(init=False, repr=False, default=0)
+    _n_gpu: int = field(default=0, repr=False)
 
     def __post_init__(self):
         if self.disable_tqdm is None:


### PR DESCRIPTION
Per @sgugger's request removing `--model_parallel` in trainer, as it was never tested or made to work with the trainer.

We will get back to it in the future.

This PR doesn't introduce breaking changes, since  `--model_parallel` never worked (well other than in my MP PRs that have been parked for now, since they are very inefficient and we are looking for a better approach, rather than waste time on sorting those out).

@LysandreJik, @sgugger 