### PR TITLE
Prophetnet optimization

### DIFF
--- a/src/transformers/models/prophetnet/modeling_prophetnet.py
+++ b/src/transformers/models/prophetnet/modeling_prophetnet.py
@@ -172,11 +172,11 @@ def ngram_attention_bias(sequence_length, ngram, device, dtype):
     This function computes the bias for the predict stream
     """
     left_block = torch.ones((ngram, sequence_length, sequence_length), device=device, dtype=dtype) * float("-inf")
-    right_block = torch.ones((ngram, sequence_length, sequence_length), device=device, dtype=dtype) * float("-inf")
+    right_block = left_block.detach().clone()
     # create bias
     for stream_idx in range(ngram):
         right_block[stream_idx].fill_diagonal_(0, wrap=False)
-        left_block[stream_idx] = torch.triu(left_block[stream_idx], -stream_idx + 1)
+        left_block[stream_idx].triu_(-stream_idx + 1)
         for i in range(stream_idx):
             left_block[stream_idx][i][0] = 0
 

--- a/src/transformers/models/prophetnet/modeling_prophetnet.py
+++ b/src/transformers/models/prophetnet/modeling_prophetnet.py
@@ -176,7 +176,7 @@ def ngram_attention_bias(sequence_length, ngram, device, dtype):
     # create bias
     for stream_idx in range(ngram):
         right_block[stream_idx].fill_diagonal_(0, wrap=False)
-        left_block[stream_idx] = torch.triu(left_block[stream_idx], -stream_idx+1)
+        left_block[stream_idx] = torch.triu(left_block[stream_idx], -stream_idx + 1)
         for i in range(stream_idx):
             left_block[stream_idx][i][0] = 0
 

--- a/src/transformers/models/prophetnet/modeling_prophetnet.py
+++ b/src/transformers/models/prophetnet/modeling_prophetnet.py
@@ -171,13 +171,16 @@ def ngram_attention_bias(sequence_length, ngram, device, dtype):
     """
     This function computes the bias for the predict stream
     """
-    bias = torch.ones((ngram, sequence_length, 2 * sequence_length), device=device, dtype=dtype) * float("-inf")
+    left_block = torch.ones((ngram, sequence_length, sequence_length), device=device, dtype=dtype) * float("-inf")
+    right_block = torch.ones((ngram, sequence_length, sequence_length), device=device, dtype=dtype) * float("-inf")
     # create bias
     for stream_idx in range(ngram):
-        for i in range(sequence_length):
-            bias[stream_idx, i, sequence_length + i] = 0
-            bias[stream_idx, i, : max(i - stream_idx, 0) + 1] = 0
-    return bias
+        right_block[stream_idx].fill_diagonal_(0, wrap=False)
+        left_block[stream_idx] = torch.triu(left_block[stream_idx], -stream_idx+1)
+        for i in range(stream_idx):
+            left_block[stream_idx][i][0] = 0
+
+    return torch.cat([left_block, right_block], dim=2)
 
 
 def compute_relative_buckets(num_buckets, max_distance, relative_positions, is_bidirectional=False):

--- a/src/transformers/models/prophetnet/modeling_prophetnet.py
+++ b/src/transformers/models/prophetnet/modeling_prophetnet.py
@@ -177,9 +177,8 @@ def ngram_attention_bias(sequence_length, ngram, device, dtype):
     for stream_idx in range(ngram):
         right_block[stream_idx].fill_diagonal_(0, wrap=False)
         left_block[stream_idx].triu_(-stream_idx + 1)
-        for i in range(stream_idx):
-            left_block[stream_idx][i][0] = 0
 
+    left_block[:, :, 0] = 0
     return torch.cat([left_block, right_block], dim=2)
 
 


### PR DESCRIPTION
# What does this PR do?

This PR proposes an optimization for the ProphetNet model. The current implementation calculates an attention bias mask by looping through the position to unmask. It performs a high number of assignments (`ngram` * `sequence_length`) which can be in the order of ~1000. Single tensor assignments, especially on accelerators, are inefficient.

This PR proposes a vectorized implementation which performs at most `ngram` assignments, which should be significantly lower than `ngram * sequence_length`.

A quick experiment shown at https://gist.github.com/guillaume-be/e6b862c701fac1b54765e7af7e71c641 shows that:
1. this `ngram_attention_bias` calculation is very expensive, taking close to 230ms (!) on a GPU
2. the vectorized implementation is several orders of magnitude faster (the same calculation takes less than 1ms on the same example)

## Who can review?

@patrickvonplaten maybe you would be a good candidate? I could not find anyone assigned for ProphetNet

edit: pushed some further optimization, further accelerating by ~40%