### PR TITLE
Fast imports part 3

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -51,7 +51,7 @@ from .utils import logging
 
 
 # The package importlib_metadata is in a different place, depending on the python version.
-if version.parse(sys.version) < version.parse("3.8"):
+if sys.version_info < (3, 8):
     import importlib_metadata
 else:
     import importlib.metadata as importlib_metadata

--- a/src/transformers/models/albert/__init__.py
+++ b/src/transformers/models/albert/__init__.py
@@ -16,40 +16,107 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_sentencepiece_available, is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_albert import ALBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, AlbertConfig
+from typing import TYPE_CHECKING
 
+from ...file_utils import (
+    _BaseLazyModule,
+    is_sentencepiece_available,
+    is_tf_available,
+    is_tokenizers_available,
+    is_torch_available,
+)
+
+
+_import_structure = {
+    "configuration_albert": ["ALBERT_PRETRAINED_CONFIG_ARCHIVE_MAP", "AlbertConfig"],
+}
 
 if is_sentencepiece_available():
-    from .tokenization_albert import AlbertTokenizer
+    _import_structure["tokenization_albert"] = ["AlbertTokenizer"]
 
 if is_tokenizers_available():
-    from .tokenization_albert_fast import AlbertTokenizerFast
+    _import_structure["tokenization_albert_fast"] = ["AlbertTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_albert import (
-        ALBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        AlbertForMaskedLM,
-        AlbertForMultipleChoice,
-        AlbertForPreTraining,
-        AlbertForQuestionAnswering,
-        AlbertForSequenceClassification,
-        AlbertForTokenClassification,
-        AlbertModel,
-        AlbertPreTrainedModel,
-        load_tf_weights_in_albert,
-    )
+    _import_structure["modeling_albert"] = [
+        "ALBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "AlbertForMaskedLM",
+        "AlbertForMultipleChoice",
+        "AlbertForPreTraining",
+        "AlbertForQuestionAnswering",
+        "AlbertForSequenceClassification",
+        "AlbertForTokenClassification",
+        "AlbertModel",
+        "AlbertPreTrainedModel",
+        "load_tf_weights_in_albert",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_albert import (
-        TF_ALBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFAlbertForMaskedLM,
-        TFAlbertForMultipleChoice,
-        TFAlbertForPreTraining,
-        TFAlbertForQuestionAnswering,
-        TFAlbertForSequenceClassification,
-        TFAlbertForTokenClassification,
-        TFAlbertMainLayer,
-        TFAlbertModel,
-        TFAlbertPreTrainedModel,
-    )
+    _import_structure["modeling_tf_albert"] = [
+        "TF_ALBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFAlbertForMaskedLM",
+        "TFAlbertForMultipleChoice",
+        "TFAlbertForPreTraining",
+        "TFAlbertForQuestionAnswering",
+        "TFAlbertForSequenceClassification",
+        "TFAlbertForTokenClassification",
+        "TFAlbertMainLayer",
+        "TFAlbertModel",
+        "TFAlbertPreTrainedModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_albert import ALBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, AlbertConfig
+
+    if is_sentencepiece_available():
+        from .tokenization_albert import AlbertTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_albert_fast import AlbertTokenizerFast
+
+    if is_torch_available():
+        from .modeling_albert import (
+            ALBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            AlbertForMaskedLM,
+            AlbertForMultipleChoice,
+            AlbertForPreTraining,
+            AlbertForQuestionAnswering,
+            AlbertForSequenceClassification,
+            AlbertForTokenClassification,
+            AlbertModel,
+            AlbertPreTrainedModel,
+            load_tf_weights_in_albert,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_albert import (
+            TF_ALBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFAlbertForMaskedLM,
+            TFAlbertForMultipleChoice,
+            TFAlbertForPreTraining,
+            TFAlbertForQuestionAnswering,
+            TFAlbertForSequenceClassification,
+            TFAlbertForTokenClassification,
+            TFAlbertMainLayer,
+            TFAlbertModel,
+            TFAlbertPreTrainedModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/auto/__init__.py
+++ b/src/transformers/models/auto/__init__.py
@@ -16,63 +16,147 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_flax_available, is_tf_available, is_torch_available
-from .configuration_auto import ALL_PRETRAINED_CONFIG_ARCHIVE_MAP, CONFIG_MAPPING, MODEL_NAMES_MAPPING, AutoConfig
-from .tokenization_auto import TOKENIZER_MAPPING, AutoTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_flax_available, is_tf_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_auto": ["ALL_PRETRAINED_CONFIG_ARCHIVE_MAP", "CONFIG_MAPPING", "MODEL_NAMES_MAPPING", "AutoConfig"],
+    "tokenization_auto": ["TOKENIZER_MAPPING", "AutoTokenizer"],
+}
 
 if is_torch_available():
-    from .modeling_auto import (
-        MODEL_FOR_CAUSAL_LM_MAPPING,
-        MODEL_FOR_MASKED_LM_MAPPING,
-        MODEL_FOR_MULTIPLE_CHOICE_MAPPING,
-        MODEL_FOR_NEXT_SENTENCE_PREDICTION_MAPPING,
-        MODEL_FOR_PRETRAINING_MAPPING,
-        MODEL_FOR_QUESTION_ANSWERING_MAPPING,
-        MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
-        MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING,
-        MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING,
-        MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING,
-        MODEL_MAPPING,
-        MODEL_WITH_LM_HEAD_MAPPING,
-        AutoModel,
-        AutoModelForCausalLM,
-        AutoModelForMaskedLM,
-        AutoModelForMultipleChoice,
-        AutoModelForNextSentencePrediction,
-        AutoModelForPreTraining,
-        AutoModelForQuestionAnswering,
-        AutoModelForSeq2SeqLM,
-        AutoModelForSequenceClassification,
-        AutoModelForTableQuestionAnswering,
-        AutoModelForTokenClassification,
-        AutoModelWithLMHead,
-    )
+    _import_structure["modeling_auto"] = [
+        "MODEL_FOR_CAUSAL_LM_MAPPING",
+        "MODEL_FOR_MASKED_LM_MAPPING",
+        "MODEL_FOR_MULTIPLE_CHOICE_MAPPING",
+        "MODEL_FOR_NEXT_SENTENCE_PREDICTION_MAPPING",
+        "MODEL_FOR_PRETRAINING_MAPPING",
+        "MODEL_FOR_QUESTION_ANSWERING_MAPPING",
+        "MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING",
+        "MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING",
+        "MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING",
+        "MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING",
+        "MODEL_MAPPING",
+        "MODEL_WITH_LM_HEAD_MAPPING",
+        "AutoModel",
+        "AutoModelForCausalLM",
+        "AutoModelForMaskedLM",
+        "AutoModelForMultipleChoice",
+        "AutoModelForNextSentencePrediction",
+        "AutoModelForPreTraining",
+        "AutoModelForQuestionAnswering",
+        "AutoModelForSeq2SeqLM",
+        "AutoModelForSequenceClassification",
+        "AutoModelForTableQuestionAnswering",
+        "AutoModelForTokenClassification",
+        "AutoModelWithLMHead",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_auto import (
-        TF_MODEL_FOR_CAUSAL_LM_MAPPING,
-        TF_MODEL_FOR_MASKED_LM_MAPPING,
-        TF_MODEL_FOR_MULTIPLE_CHOICE_MAPPING,
-        TF_MODEL_FOR_NEXT_SENTENCE_PREDICTION_MAPPING,
-        TF_MODEL_FOR_PRETRAINING_MAPPING,
-        TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING,
-        TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
-        TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING,
-        TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING,
-        TF_MODEL_MAPPING,
-        TF_MODEL_WITH_LM_HEAD_MAPPING,
-        TFAutoModel,
-        TFAutoModelForCausalLM,
-        TFAutoModelForMaskedLM,
-        TFAutoModelForMultipleChoice,
-        TFAutoModelForPreTraining,
-        TFAutoModelForQuestionAnswering,
-        TFAutoModelForSeq2SeqLM,
-        TFAutoModelForSequenceClassification,
-        TFAutoModelForTokenClassification,
-        TFAutoModelWithLMHead,
-    )
+    _import_structure["modeling_tf_auto"] = [
+        "TF_MODEL_FOR_CAUSAL_LM_MAPPING",
+        "TF_MODEL_FOR_MASKED_LM_MAPPING",
+        "TF_MODEL_FOR_MULTIPLE_CHOICE_MAPPING",
+        "TF_MODEL_FOR_NEXT_SENTENCE_PREDICTION_MAPPING",
+        "TF_MODEL_FOR_PRETRAINING_MAPPING",
+        "TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING",
+        "TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING",
+        "TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING",
+        "TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING",
+        "TF_MODEL_MAPPING",
+        "TF_MODEL_WITH_LM_HEAD_MAPPING",
+        "TFAutoModel",
+        "TFAutoModelForCausalLM",
+        "TFAutoModelForMaskedLM",
+        "TFAutoModelForMultipleChoice",
+        "TFAutoModelForPreTraining",
+        "TFAutoModelForQuestionAnswering",
+        "TFAutoModelForSeq2SeqLM",
+        "TFAutoModelForSequenceClassification",
+        "TFAutoModelForTokenClassification",
+        "TFAutoModelWithLMHead",
+    ]
 
 if is_flax_available():
-    from .modeling_flax_auto import FLAX_MODEL_MAPPING, FlaxAutoModel
+    _import_structure["modeling_flax_auto"] = ["FLAX_MODEL_MAPPING", "FlaxAutoModel"]
+
+
+if TYPE_CHECKING:
+    from .configuration_auto import ALL_PRETRAINED_CONFIG_ARCHIVE_MAP, CONFIG_MAPPING, MODEL_NAMES_MAPPING, AutoConfig
+    from .tokenization_auto import TOKENIZER_MAPPING, AutoTokenizer
+
+    if is_torch_available():
+        from .modeling_auto import (
+            MODEL_FOR_CAUSAL_LM_MAPPING,
+            MODEL_FOR_MASKED_LM_MAPPING,
+            MODEL_FOR_MULTIPLE_CHOICE_MAPPING,
+            MODEL_FOR_NEXT_SENTENCE_PREDICTION_MAPPING,
+            MODEL_FOR_PRETRAINING_MAPPING,
+            MODEL_FOR_QUESTION_ANSWERING_MAPPING,
+            MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
+            MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING,
+            MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING,
+            MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING,
+            MODEL_MAPPING,
+            MODEL_WITH_LM_HEAD_MAPPING,
+            AutoModel,
+            AutoModelForCausalLM,
+            AutoModelForMaskedLM,
+            AutoModelForMultipleChoice,
+            AutoModelForNextSentencePrediction,
+            AutoModelForPreTraining,
+            AutoModelForQuestionAnswering,
+            AutoModelForSeq2SeqLM,
+            AutoModelForSequenceClassification,
+            AutoModelForTableQuestionAnswering,
+            AutoModelForTokenClassification,
+            AutoModelWithLMHead,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_auto import (
+            TF_MODEL_FOR_CAUSAL_LM_MAPPING,
+            TF_MODEL_FOR_MASKED_LM_MAPPING,
+            TF_MODEL_FOR_MULTIPLE_CHOICE_MAPPING,
+            TF_MODEL_FOR_NEXT_SENTENCE_PREDICTION_MAPPING,
+            TF_MODEL_FOR_PRETRAINING_MAPPING,
+            TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING,
+            TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
+            TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING,
+            TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING,
+            TF_MODEL_MAPPING,
+            TF_MODEL_WITH_LM_HEAD_MAPPING,
+            TFAutoModel,
+            TFAutoModelForCausalLM,
+            TFAutoModelForMaskedLM,
+            TFAutoModelForMultipleChoice,
+            TFAutoModelForPreTraining,
+            TFAutoModelForQuestionAnswering,
+            TFAutoModelForSeq2SeqLM,
+            TFAutoModelForSequenceClassification,
+            TFAutoModelForTokenClassification,
+            TFAutoModelWithLMHead,
+        )
+
+    if is_flax_available():
+        from .modeling_flax_auto import FLAX_MODEL_MAPPING, FlaxAutoModel
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/bart/__init__.py
+++ b/src/transformers/models/bart/__init__.py
@@ -15,24 +15,69 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from ...file_utils import is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_bart import BART_PRETRAINED_CONFIG_ARCHIVE_MAP, BartConfig
-from .tokenization_bart import BartTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tf_available, is_tokenizers_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_bart": ["BART_PRETRAINED_CONFIG_ARCHIVE_MAP", "BartConfig"],
+    "tokenization_bart": ["BartTokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_bart_fast import BartTokenizerFast
+    _import_structure["tokenization_bart_fast"] = ["BartTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_bart import (
-        BART_PRETRAINED_MODEL_ARCHIVE_LIST,
-        BartForConditionalGeneration,
-        BartForQuestionAnswering,
-        BartForSequenceClassification,
-        BartModel,
-        BartPretrainedModel,
-        PretrainedBartModel,
-    )
+    _import_structure["modeling_bart"] = [
+        "BART_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "BartForConditionalGeneration",
+        "BartForQuestionAnswering",
+        "BartForSequenceClassification",
+        "BartModel",
+        "BartPretrainedModel",
+        "PretrainedBartModel",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_bart import TFBartForConditionalGeneration, TFBartModel, TFBartPretrainedModel
+    _import_structure["modeling_tf_bart"] = ["TFBartForConditionalGeneration", "TFBartModel", "TFBartPretrainedModel"]
+
+
+if TYPE_CHECKING:
+    from .configuration_bart import BART_PRETRAINED_CONFIG_ARCHIVE_MAP, BartConfig
+    from .tokenization_bart import BartTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_bart_fast import BartTokenizerFast
+
+    if is_torch_available():
+        from .modeling_bart import (
+            BART_PRETRAINED_MODEL_ARCHIVE_LIST,
+            BartForConditionalGeneration,
+            BartForQuestionAnswering,
+            BartForSequenceClassification,
+            BartModel,
+            BartPretrainedModel,
+            PretrainedBartModel,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_bart import TFBartForConditionalGeneration, TFBartModel, TFBartPretrainedModel
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/barthez/__init__.py
+++ b/src/transformers/models/barthez/__init__.py
@@ -16,11 +16,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_sentencepiece_available, is_tokenizers_available
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_sentencepiece_available, is_tokenizers_available
+
+
+_import_structure = {}
 
 if is_sentencepiece_available():
-    from .tokenization_barthez import BarthezTokenizer
+    _import_structure["tokenization_barthez"] = ["BarthezTokenizer"]
 
 if is_tokenizers_available():
-    from .tokenization_barthez_fast import BarthezTokenizerFast
+    _import_structure["tokenization_barthez_fast"] = ["BarthezTokenizerFast"]
+
+
+if TYPE_CHECKING:
+
+    if is_sentencepiece_available():
+        from .tokenization_barthez import BarthezTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_barthez_fast import BarthezTokenizerFast
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/bert/__init__.py
+++ b/src/transformers/models/bert/__init__.py
@@ -16,47 +16,121 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_flax_available, is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_bert import BERT_PRETRAINED_CONFIG_ARCHIVE_MAP, BertConfig
-from .tokenization_bert import BasicTokenizer, BertTokenizer, WordpieceTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import (
+    _BaseLazyModule,
+    is_flax_available,
+    is_tf_available,
+    is_tokenizers_available,
+    is_torch_available,
+)
+
+
+_import_structure = {
+    "configuration_bert": ["BERT_PRETRAINED_CONFIG_ARCHIVE_MAP", "BertConfig"],
+    "tokenization_bert": ["BasicTokenizer", "BertTokenizer", "WordpieceTokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_bert_fast import BertTokenizerFast
+    _import_structure["tokenization_bert_fast"] = ["BertTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_bert import (
-        BERT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        BertForMaskedLM,
-        BertForMultipleChoice,
-        BertForNextSentencePrediction,
-        BertForPreTraining,
-        BertForQuestionAnswering,
-        BertForSequenceClassification,
-        BertForTokenClassification,
-        BertLayer,
-        BertLMHeadModel,
-        BertModel,
-        BertPreTrainedModel,
-        load_tf_weights_in_bert,
-    )
+    _import_structure["modeling_bert"] = [
+        "BERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "BertForMaskedLM",
+        "BertForMultipleChoice",
+        "BertForNextSentencePrediction",
+        "BertForPreTraining",
+        "BertForQuestionAnswering",
+        "BertForSequenceClassification",
+        "BertForTokenClassification",
+        "BertLayer",
+        "BertLMHeadModel",
+        "BertModel",
+        "BertPreTrainedModel",
+        "load_tf_weights_in_bert",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_bert import (
-        TF_BERT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFBertEmbeddings,
-        TFBertForMaskedLM,
-        TFBertForMultipleChoice,
-        TFBertForNextSentencePrediction,
-        TFBertForPreTraining,
-        TFBertForQuestionAnswering,
-        TFBertForSequenceClassification,
-        TFBertForTokenClassification,
-        TFBertLMHeadModel,
-        TFBertMainLayer,
-        TFBertModel,
-        TFBertPreTrainedModel,
-    )
+    _import_structure["modeling_tf_bert"] = [
+        "TF_BERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFBertEmbeddings",
+        "TFBertForMaskedLM",
+        "TFBertForMultipleChoice",
+        "TFBertForNextSentencePrediction",
+        "TFBertForPreTraining",
+        "TFBertForQuestionAnswering",
+        "TFBertForSequenceClassification",
+        "TFBertForTokenClassification",
+        "TFBertLMHeadModel",
+        "TFBertMainLayer",
+        "TFBertModel",
+        "TFBertPreTrainedModel",
+    ]
 
 if is_flax_available():
-    from .modeling_flax_bert import FlaxBertForMaskedLM, FlaxBertModel
+    _import_structure["modeling_flax_bert"] = ["FlaxBertForMaskedLM", "FlaxBertModel"]
+
+
+if TYPE_CHECKING:
+    from .configuration_bert import BERT_PRETRAINED_CONFIG_ARCHIVE_MAP, BertConfig
+    from .tokenization_bert import BasicTokenizer, BertTokenizer, WordpieceTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_bert_fast import BertTokenizerFast
+
+    if is_torch_available():
+        from .modeling_bert import (
+            BERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            BertForMaskedLM,
+            BertForMultipleChoice,
+            BertForNextSentencePrediction,
+            BertForPreTraining,
+            BertForQuestionAnswering,
+            BertForSequenceClassification,
+            BertForTokenClassification,
+            BertLayer,
+            BertLMHeadModel,
+            BertModel,
+            BertPreTrainedModel,
+            load_tf_weights_in_bert,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_bert import (
+            TF_BERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFBertEmbeddings,
+            TFBertForMaskedLM,
+            TFBertForMultipleChoice,
+            TFBertForNextSentencePrediction,
+            TFBertForPreTraining,
+            TFBertForQuestionAnswering,
+            TFBertForSequenceClassification,
+            TFBertForTokenClassification,
+            TFBertLMHeadModel,
+            TFBertMainLayer,
+            TFBertModel,
+            TFBertPreTrainedModel,
+        )
+
+    if is_flax_available():
+        from .modeling_flax_bert import FlaxBertForMaskedLM, FlaxBertModel
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/bert_generation/__init__.py
+++ b/src/transformers/models/bert_generation/__init__.py
@@ -16,16 +16,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_sentencepiece_available, is_torch_available
-from .configuration_bert_generation import BertGenerationConfig
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_sentencepiece_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_bert_generation": ["BertGenerationConfig"],
+}
 
 if is_sentencepiece_available():
-    from .tokenization_bert_generation import BertGenerationTokenizer
+    _import_structure["tokenization_bert_generation"] = ["BertGenerationTokenizer"]
 
 if is_torch_available():
-    from .modeling_bert_generation import (
-        BertGenerationDecoder,
-        BertGenerationEncoder,
-        load_tf_weights_in_bert_generation,
-    )
+    _import_structure["modeling_bert_generation"] = [
+        "BertGenerationDecoder",
+        "BertGenerationEncoder",
+        "load_tf_weights_in_bert_generation",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_bert_generation import BertGenerationConfig
+
+    if is_sentencepiece_available():
+        from .tokenization_bert_generation import BertGenerationTokenizer
+
+    if is_torch_available():
+        from .modeling_bert_generation import (
+            BertGenerationDecoder,
+            BertGenerationEncoder,
+            load_tf_weights_in_bert_generation,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/bert_japanese/__init__.py
+++ b/src/transformers/models/bert_japanese/__init__.py
@@ -16,4 +16,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .tokenization_bert_japanese import BertJapaneseTokenizer, CharacterTokenizer, MecabTokenizer
+from typing import TYPE_CHECKING
+
+from ...file_utils import _BaseLazyModule
+
+
+_import_structure = {
+    "tokenization_bert_japanese": ["BertJapaneseTokenizer", "CharacterTokenizer", "MecabTokenizer"],
+}
+
+
+if TYPE_CHECKING:
+    from .tokenization_bert_japanese import BertJapaneseTokenizer, CharacterTokenizer, MecabTokenizer
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/bertweet/__init__.py
+++ b/src/transformers/models/bertweet/__init__.py
@@ -16,4 +16,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .tokenization_bertweet import BertweetTokenizer
+from typing import TYPE_CHECKING
+
+from ...file_utils import _BaseLazyModule
+
+
+_import_structure = {
+    "tokenization_bertweet": ["BertweetTokenizer"],
+}
+
+
+if TYPE_CHECKING:
+    from .tokenization_bertweet import BertweetTokenizer
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/blenderbot/__init__.py
+++ b/src/transformers/models/blenderbot/__init__.py
@@ -16,19 +16,58 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tf_available, is_torch_available
-from .configuration_blenderbot import BLENDERBOT_PRETRAINED_CONFIG_ARCHIVE_MAP, BlenderbotConfig
-from .tokenization_blenderbot import BlenderbotTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tf_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_blenderbot": ["BLENDERBOT_PRETRAINED_CONFIG_ARCHIVE_MAP", "BlenderbotConfig"],
+    "tokenization_blenderbot": ["BlenderbotTokenizer"],
+}
 
 if is_torch_available():
-    from .modeling_blenderbot import (
-        BLENDERBOT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        BlenderbotForConditionalGeneration,
-        BlenderbotModel,
-        BlenderbotPreTrainedModel,
-    )
+    _import_structure["modeling_blenderbot"] = [
+        "BLENDERBOT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "BlenderbotForConditionalGeneration",
+        "BlenderbotModel",
+        "BlenderbotPreTrainedModel",
+    ]
 
 
 if is_tf_available():
-    from .modeling_tf_blenderbot import TFBlenderbotForConditionalGeneration
+    _import_structure["modeling_tf_blenderbot"] = ["TFBlenderbotForConditionalGeneration"]
+
+
+if TYPE_CHECKING:
+    from .configuration_blenderbot import BLENDERBOT_PRETRAINED_CONFIG_ARCHIVE_MAP, BlenderbotConfig
+    from .tokenization_blenderbot import BlenderbotTokenizer
+
+    if is_torch_available():
+        from .modeling_blenderbot import (
+            BLENDERBOT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            BlenderbotForConditionalGeneration,
+            BlenderbotModel,
+            BlenderbotPreTrainedModel,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_blenderbot import TFBlenderbotForConditionalGeneration
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/blenderbot_small/__init__.py
+++ b/src/transformers/models/blenderbot_small/__init__.py
@@ -15,15 +15,51 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from ...file_utils import is_torch_available
-from .configuration_blenderbot_small import BLENDERBOT_SMALL_PRETRAINED_CONFIG_ARCHIVE_MAP, BlenderbotSmallConfig
-from .tokenization_blenderbot_small import BlenderbotSmallTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_torch_available
+
+
+_import_structure = {
+    "configuration_blenderbot_small": ["BLENDERBOT_SMALL_PRETRAINED_CONFIG_ARCHIVE_MAP", "BlenderbotSmallConfig"],
+    "tokenization_blenderbot_small": ["BlenderbotSmallTokenizer"],
+}
 
 if is_torch_available():
-    from .modeling_blenderbot_small import (
-        BLENDERBOT_SMALL_PRETRAINED_MODEL_ARCHIVE_LIST,
-        BlenderbotSmallForConditionalGeneration,
-        BlenderbotSmallModel,
-        BlenderbotSmallPreTrainedModel,
-    )
+    _import_structure["modeling_blenderbot_small"] = [
+        "BLENDERBOT_SMALL_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "BlenderbotSmallForConditionalGeneration",
+        "BlenderbotSmallModel",
+        "BlenderbotSmallPreTrainedModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_blenderbot_small import BLENDERBOT_SMALL_PRETRAINED_CONFIG_ARCHIVE_MAP, BlenderbotSmallConfig
+    from .tokenization_blenderbot_small import BlenderbotSmallTokenizer
+
+    if is_torch_available():
+        from .modeling_blenderbot_small import (
+            BLENDERBOT_SMALL_PRETRAINED_MODEL_ARCHIVE_LIST,
+            BlenderbotSmallForConditionalGeneration,
+            BlenderbotSmallModel,
+            BlenderbotSmallPreTrainedModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/camembert/__init__.py
+++ b/src/transformers/models/camembert/__init__.py
@@ -16,35 +16,97 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_sentencepiece_available, is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_camembert import CAMEMBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, CamembertConfig
+from typing import TYPE_CHECKING
 
+from ...file_utils import (
+    _BaseLazyModule,
+    is_sentencepiece_available,
+    is_tf_available,
+    is_tokenizers_available,
+    is_torch_available,
+)
+
+
+_import_structure = {
+    "configuration_camembert": ["CAMEMBERT_PRETRAINED_CONFIG_ARCHIVE_MAP", "CamembertConfig"],
+}
 
 if is_sentencepiece_available():
-    from .tokenization_camembert import CamembertTokenizer
+    _import_structure["tokenization_camembert"] = ["CamembertTokenizer"]
 
 if is_tokenizers_available():
-    from .tokenization_camembert_fast import CamembertTokenizerFast
+    _import_structure["tokenization_camembert_fast"] = ["CamembertTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_camembert import (
-        CAMEMBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        CamembertForCausalLM,
-        CamembertForMaskedLM,
-        CamembertForMultipleChoice,
-        CamembertForQuestionAnswering,
-        CamembertForSequenceClassification,
-        CamembertForTokenClassification,
-        CamembertModel,
-    )
+    _import_structure["modeling_camembert"] = [
+        "CAMEMBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "CamembertForCausalLM",
+        "CamembertForMaskedLM",
+        "CamembertForMultipleChoice",
+        "CamembertForQuestionAnswering",
+        "CamembertForSequenceClassification",
+        "CamembertForTokenClassification",
+        "CamembertModel",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_camembert import (
-        TF_CAMEMBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFCamembertForMaskedLM,
-        TFCamembertForMultipleChoice,
-        TFCamembertForQuestionAnswering,
-        TFCamembertForSequenceClassification,
-        TFCamembertForTokenClassification,
-        TFCamembertModel,
-    )
+    _import_structure["modeling_tf_camembert"] = [
+        "TF_CAMEMBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFCamembertForMaskedLM",
+        "TFCamembertForMultipleChoice",
+        "TFCamembertForQuestionAnswering",
+        "TFCamembertForSequenceClassification",
+        "TFCamembertForTokenClassification",
+        "TFCamembertModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_camembert import CAMEMBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, CamembertConfig
+
+    if is_sentencepiece_available():
+        from .tokenization_camembert import CamembertTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_camembert_fast import CamembertTokenizerFast
+
+    if is_torch_available():
+        from .modeling_camembert import (
+            CAMEMBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            CamembertForCausalLM,
+            CamembertForMaskedLM,
+            CamembertForMultipleChoice,
+            CamembertForQuestionAnswering,
+            CamembertForSequenceClassification,
+            CamembertForTokenClassification,
+            CamembertModel,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_camembert import (
+            TF_CAMEMBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFCamembertForMaskedLM,
+            TFCamembertForMultipleChoice,
+            TFCamembertForQuestionAnswering,
+            TFCamembertForSequenceClassification,
+            TFCamembertForTokenClassification,
+            TFCamembertModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/ctrl/__init__.py
+++ b/src/transformers/models/ctrl/__init__.py
@@ -16,25 +16,71 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tf_available, is_torch_available
-from .configuration_ctrl import CTRL_PRETRAINED_CONFIG_ARCHIVE_MAP, CTRLConfig
-from .tokenization_ctrl import CTRLTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tf_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_ctrl": ["CTRL_PRETRAINED_CONFIG_ARCHIVE_MAP", "CTRLConfig"],
+    "tokenization_ctrl": ["CTRLTokenizer"],
+}
 
 if is_torch_available():
-    from .modeling_ctrl import (
-        CTRL_PRETRAINED_MODEL_ARCHIVE_LIST,
-        CTRLForSequenceClassification,
-        CTRLLMHeadModel,
-        CTRLModel,
-        CTRLPreTrainedModel,
-    )
+    _import_structure["modeling_ctrl"] = [
+        "CTRL_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "CTRLForSequenceClassification",
+        "CTRLLMHeadModel",
+        "CTRLModel",
+        "CTRLPreTrainedModel",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_ctrl import (
-        TF_CTRL_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFCTRLForSequenceClassification,
-        TFCTRLLMHeadModel,
-        TFCTRLModel,
-        TFCTRLPreTrainedModel,
-    )
+    _import_structure["modeling_tf_ctrl"] = [
+        "TF_CTRL_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFCTRLForSequenceClassification",
+        "TFCTRLLMHeadModel",
+        "TFCTRLModel",
+        "TFCTRLPreTrainedModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_ctrl import CTRL_PRETRAINED_CONFIG_ARCHIVE_MAP, CTRLConfig
+    from .tokenization_ctrl import CTRLTokenizer
+
+    if is_torch_available():
+        from .modeling_ctrl import (
+            CTRL_PRETRAINED_MODEL_ARCHIVE_LIST,
+            CTRLForSequenceClassification,
+            CTRLLMHeadModel,
+            CTRLModel,
+            CTRLPreTrainedModel,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_ctrl import (
+            TF_CTRL_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFCTRLForSequenceClassification,
+            TFCTRLLMHeadModel,
+            TFCTRLModel,
+            TFCTRLPreTrainedModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/deberta/__init__.py
+++ b/src/transformers/models/deberta/__init__.py
@@ -16,15 +16,51 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_torch_available
-from .configuration_deberta import DEBERTA_PRETRAINED_CONFIG_ARCHIVE_MAP, DebertaConfig
-from .tokenization_deberta import DebertaTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_torch_available
+
+
+_import_structure = {
+    "configuration_deberta": ["DEBERTA_PRETRAINED_CONFIG_ARCHIVE_MAP", "DebertaConfig"],
+    "tokenization_deberta": ["DebertaTokenizer"],
+}
 
 if is_torch_available():
-    from .modeling_deberta import (
-        DEBERTA_PRETRAINED_MODEL_ARCHIVE_LIST,
-        DebertaForSequenceClassification,
-        DebertaModel,
-        DebertaPreTrainedModel,
-    )
+    _import_structure["modeling_deberta"] = [
+        "DEBERTA_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "DebertaForSequenceClassification",
+        "DebertaModel",
+        "DebertaPreTrainedModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_deberta import DEBERTA_PRETRAINED_CONFIG_ARCHIVE_MAP, DebertaConfig
+    from .tokenization_deberta import DebertaTokenizer
+
+    if is_torch_available():
+        from .modeling_deberta import (
+            DEBERTA_PRETRAINED_MODEL_ARCHIVE_LIST,
+            DebertaForSequenceClassification,
+            DebertaModel,
+            DebertaPreTrainedModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/distilbert/__init__.py
+++ b/src/transformers/models/distilbert/__init__.py
@@ -16,35 +16,91 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_distilbert import DISTILBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, DistilBertConfig
-from .tokenization_distilbert import DistilBertTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tf_available, is_tokenizers_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_distilbert": ["DISTILBERT_PRETRAINED_CONFIG_ARCHIVE_MAP", "DistilBertConfig"],
+    "tokenization_distilbert": ["DistilBertTokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_distilbert_fast import DistilBertTokenizerFast
+    _import_structure["tokenization_distilbert_fast"] = ["DistilBertTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_distilbert import (
-        DISTILBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        DistilBertForMaskedLM,
-        DistilBertForMultipleChoice,
-        DistilBertForQuestionAnswering,
-        DistilBertForSequenceClassification,
-        DistilBertForTokenClassification,
-        DistilBertModel,
-        DistilBertPreTrainedModel,
-    )
+    _import_structure["modeling_distilbert"] = [
+        "DISTILBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "DistilBertForMaskedLM",
+        "DistilBertForMultipleChoice",
+        "DistilBertForQuestionAnswering",
+        "DistilBertForSequenceClassification",
+        "DistilBertForTokenClassification",
+        "DistilBertModel",
+        "DistilBertPreTrainedModel",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_distilbert import (
-        TF_DISTILBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFDistilBertForMaskedLM,
-        TFDistilBertForMultipleChoice,
-        TFDistilBertForQuestionAnswering,
-        TFDistilBertForSequenceClassification,
-        TFDistilBertForTokenClassification,
-        TFDistilBertMainLayer,
-        TFDistilBertModel,
-        TFDistilBertPreTrainedModel,
-    )
+    _import_structure["modeling_tf_distilbert"] = [
+        "TF_DISTILBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFDistilBertForMaskedLM",
+        "TFDistilBertForMultipleChoice",
+        "TFDistilBertForQuestionAnswering",
+        "TFDistilBertForSequenceClassification",
+        "TFDistilBertForTokenClassification",
+        "TFDistilBertMainLayer",
+        "TFDistilBertModel",
+        "TFDistilBertPreTrainedModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_distilbert import DISTILBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, DistilBertConfig
+    from .tokenization_distilbert import DistilBertTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_distilbert_fast import DistilBertTokenizerFast
+
+    if is_torch_available():
+        from .modeling_distilbert import (
+            DISTILBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            DistilBertForMaskedLM,
+            DistilBertForMultipleChoice,
+            DistilBertForQuestionAnswering,
+            DistilBertForSequenceClassification,
+            DistilBertForTokenClassification,
+            DistilBertModel,
+            DistilBertPreTrainedModel,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_distilbert import (
+            TF_DISTILBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFDistilBertForMaskedLM,
+            TFDistilBertForMultipleChoice,
+            TFDistilBertForQuestionAnswering,
+            TFDistilBertForSequenceClassification,
+            TFDistilBertForTokenClassification,
+            TFDistilBertMainLayer,
+            TFDistilBertModel,
+            TFDistilBertPreTrainedModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/dpr/__init__.py
+++ b/src/transformers/models/dpr/__init__.py
@@ -16,45 +16,112 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_dpr import DPR_PRETRAINED_CONFIG_ARCHIVE_MAP, DPRConfig
-from .tokenization_dpr import (
-    DPRContextEncoderTokenizer,
-    DPRQuestionEncoderTokenizer,
-    DPRReaderOutput,
-    DPRReaderTokenizer,
-)
+from typing import TYPE_CHECKING
+
+from ...file_utils import _BaseLazyModule, is_tf_available, is_tokenizers_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_dpr": ["DPR_PRETRAINED_CONFIG_ARCHIVE_MAP", "DPRConfig"],
+    "tokenization_dpr": [
+        "DPRContextEncoderTokenizer",
+        "DPRQuestionEncoderTokenizer",
+        "DPRReaderOutput",
+        "DPRReaderTokenizer",
+    ],
+}
 
 
 if is_tokenizers_available():
-    from .tokenization_dpr_fast import (
-        DPRContextEncoderTokenizerFast,
-        DPRQuestionEncoderTokenizerFast,
-        DPRReaderTokenizerFast,
-    )
+    _import_structure["tokenization_dpr_fast"] = [
+        "DPRContextEncoderTokenizerFast",
+        "DPRQuestionEncoderTokenizerFast",
+        "DPRReaderTokenizerFast",
+    ]
 
 if is_torch_available():
-    from .modeling_dpr import (
-        DPR_CONTEXT_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST,
-        DPR_QUESTION_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST,
-        DPR_READER_PRETRAINED_MODEL_ARCHIVE_LIST,
-        DPRContextEncoder,
-        DPRPretrainedContextEncoder,
-        DPRPretrainedQuestionEncoder,
-        DPRPretrainedReader,
-        DPRQuestionEncoder,
-        DPRReader,
-    )
+    _import_structure["modeling_dpr"] = [
+        "DPR_CONTEXT_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "DPR_QUESTION_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "DPR_READER_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "DPRContextEncoder",
+        "DPRPretrainedContextEncoder",
+        "DPRPretrainedQuestionEncoder",
+        "DPRPretrainedReader",
+        "DPRQuestionEncoder",
+        "DPRReader",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_dpr import (
-        TF_DPR_CONTEXT_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TF_DPR_QUESTION_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TF_DPR_READER_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFDPRContextEncoder,
-        TFDPRPretrainedContextEncoder,
-        TFDPRPretrainedQuestionEncoder,
-        TFDPRPretrainedReader,
-        TFDPRQuestionEncoder,
-        TFDPRReader,
+    _import_structure["modeling_tf_dpr"] = [
+        "TF_DPR_CONTEXT_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TF_DPR_QUESTION_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TF_DPR_READER_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFDPRContextEncoder",
+        "TFDPRPretrainedContextEncoder",
+        "TFDPRPretrainedQuestionEncoder",
+        "TFDPRPretrainedReader",
+        "TFDPRQuestionEncoder",
+        "TFDPRReader",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_dpr import DPR_PRETRAINED_CONFIG_ARCHIVE_MAP, DPRConfig
+    from .tokenization_dpr import (
+        DPRContextEncoderTokenizer,
+        DPRQuestionEncoderTokenizer,
+        DPRReaderOutput,
+        DPRReaderTokenizer,
     )
+
+    if is_tokenizers_available():
+        from .tokenization_dpr_fast import (
+            DPRContextEncoderTokenizerFast,
+            DPRQuestionEncoderTokenizerFast,
+            DPRReaderTokenizerFast,
+        )
+
+    if is_torch_available():
+        from .modeling_dpr import (
+            DPR_CONTEXT_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST,
+            DPR_QUESTION_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST,
+            DPR_READER_PRETRAINED_MODEL_ARCHIVE_LIST,
+            DPRContextEncoder,
+            DPRPretrainedContextEncoder,
+            DPRPretrainedQuestionEncoder,
+            DPRPretrainedReader,
+            DPRQuestionEncoder,
+            DPRReader,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_dpr import (
+            TF_DPR_CONTEXT_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TF_DPR_QUESTION_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TF_DPR_READER_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFDPRContextEncoder,
+            TFDPRPretrainedContextEncoder,
+            TFDPRPretrainedQuestionEncoder,
+            TFDPRPretrainedReader,
+            TFDPRQuestionEncoder,
+            TFDPRReader,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/electra/__init__.py
+++ b/src/transformers/models/electra/__init__.py
@@ -16,37 +16,95 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_electra import ELECTRA_PRETRAINED_CONFIG_ARCHIVE_MAP, ElectraConfig
-from .tokenization_electra import ElectraTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tf_available, is_tokenizers_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_electra": ["ELECTRA_PRETRAINED_CONFIG_ARCHIVE_MAP", "ElectraConfig"],
+    "tokenization_electra": ["ElectraTokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_electra_fast import ElectraTokenizerFast
+    _import_structure["tokenization_electra_fast"] = ["ElectraTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_electra import (
-        ELECTRA_PRETRAINED_MODEL_ARCHIVE_LIST,
-        ElectraForMaskedLM,
-        ElectraForMultipleChoice,
-        ElectraForPreTraining,
-        ElectraForQuestionAnswering,
-        ElectraForSequenceClassification,
-        ElectraForTokenClassification,
-        ElectraModel,
-        ElectraPreTrainedModel,
-        load_tf_weights_in_electra,
-    )
+    _import_structure["modeling_electra"] = [
+        "ELECTRA_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "ElectraForMaskedLM",
+        "ElectraForMultipleChoice",
+        "ElectraForPreTraining",
+        "ElectraForQuestionAnswering",
+        "ElectraForSequenceClassification",
+        "ElectraForTokenClassification",
+        "ElectraModel",
+        "ElectraPreTrainedModel",
+        "load_tf_weights_in_electra",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_electra import (
-        TF_ELECTRA_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFElectraForMaskedLM,
-        TFElectraForMultipleChoice,
-        TFElectraForPreTraining,
-        TFElectraForQuestionAnswering,
-        TFElectraForSequenceClassification,
-        TFElectraForTokenClassification,
-        TFElectraModel,
-        TFElectraPreTrainedModel,
-    )
+    _import_structure["modeling_tf_electra"] = [
+        "TF_ELECTRA_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFElectraForMaskedLM",
+        "TFElectraForMultipleChoice",
+        "TFElectraForPreTraining",
+        "TFElectraForQuestionAnswering",
+        "TFElectraForSequenceClassification",
+        "TFElectraForTokenClassification",
+        "TFElectraModel",
+        "TFElectraPreTrainedModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_electra import ELECTRA_PRETRAINED_CONFIG_ARCHIVE_MAP, ElectraConfig
+    from .tokenization_electra import ElectraTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_electra_fast import ElectraTokenizerFast
+
+    if is_torch_available():
+        from .modeling_electra import (
+            ELECTRA_PRETRAINED_MODEL_ARCHIVE_LIST,
+            ElectraForMaskedLM,
+            ElectraForMultipleChoice,
+            ElectraForPreTraining,
+            ElectraForQuestionAnswering,
+            ElectraForSequenceClassification,
+            ElectraForTokenClassification,
+            ElectraModel,
+            ElectraPreTrainedModel,
+            load_tf_weights_in_electra,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_electra import (
+            TF_ELECTRA_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFElectraForMaskedLM,
+            TFElectraForMultipleChoice,
+            TFElectraForPreTraining,
+            TFElectraForQuestionAnswering,
+            TFElectraForSequenceClassification,
+            TFElectraForTokenClassification,
+            TFElectraModel,
+            TFElectraPreTrainedModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/encoder_decoder/__init__.py
+++ b/src/transformers/models/encoder_decoder/__init__.py
@@ -16,9 +16,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_torch_available
-from .configuration_encoder_decoder import EncoderDecoderConfig
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_torch_available
+
+
+_import_structure = {
+    "configuration_encoder_decoder": ["EncoderDecoderConfig"],
+}
 
 if is_torch_available():
-    from .modeling_encoder_decoder import EncoderDecoderModel
+    _import_structure["modeling_encoder_decoder"] = ["EncoderDecoderModel"]
+
+
+if TYPE_CHECKING:
+    from .configuration_encoder_decoder import EncoderDecoderConfig
+
+    if is_torch_available():
+        from .modeling_encoder_decoder import EncoderDecoderModel
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/flaubert/__init__.py
+++ b/src/transformers/models/flaubert/__init__.py
@@ -16,30 +16,81 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tf_available, is_torch_available
-from .configuration_flaubert import FLAUBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, FlaubertConfig
-from .tokenization_flaubert import FlaubertTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tf_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_flaubert": ["FLAUBERT_PRETRAINED_CONFIG_ARCHIVE_MAP", "FlaubertConfig"],
+    "tokenization_flaubert": ["FlaubertTokenizer"],
+}
 
 if is_torch_available():
-    from .modeling_flaubert import (
-        FLAUBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        FlaubertForMultipleChoice,
-        FlaubertForQuestionAnswering,
-        FlaubertForQuestionAnsweringSimple,
-        FlaubertForSequenceClassification,
-        FlaubertForTokenClassification,
-        FlaubertModel,
-        FlaubertWithLMHeadModel,
-    )
+    _import_structure["modeling_flaubert"] = [
+        "FLAUBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "FlaubertForMultipleChoice",
+        "FlaubertForQuestionAnswering",
+        "FlaubertForQuestionAnsweringSimple",
+        "FlaubertForSequenceClassification",
+        "FlaubertForTokenClassification",
+        "FlaubertModel",
+        "FlaubertWithLMHeadModel",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_flaubert import (
-        TF_FLAUBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFFlaubertForMultipleChoice,
-        TFFlaubertForQuestionAnsweringSimple,
-        TFFlaubertForSequenceClassification,
-        TFFlaubertForTokenClassification,
-        TFFlaubertModel,
-        TFFlaubertWithLMHeadModel,
-    )
+    _import_structure["modeling_tf_flaubert"] = [
+        "TF_FLAUBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFFlaubertForMultipleChoice",
+        "TFFlaubertForQuestionAnsweringSimple",
+        "TFFlaubertForSequenceClassification",
+        "TFFlaubertForTokenClassification",
+        "TFFlaubertModel",
+        "TFFlaubertWithLMHeadModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_flaubert import FLAUBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, FlaubertConfig
+    from .tokenization_flaubert import FlaubertTokenizer
+
+    if is_torch_available():
+        from .modeling_flaubert import (
+            FLAUBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            FlaubertForMultipleChoice,
+            FlaubertForQuestionAnswering,
+            FlaubertForQuestionAnsweringSimple,
+            FlaubertForSequenceClassification,
+            FlaubertForTokenClassification,
+            FlaubertModel,
+            FlaubertWithLMHeadModel,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_flaubert import (
+            TF_FLAUBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFFlaubertForMultipleChoice,
+            TFFlaubertForQuestionAnsweringSimple,
+            TFFlaubertForSequenceClassification,
+            TFFlaubertForTokenClassification,
+            TFFlaubertModel,
+            TFFlaubertWithLMHeadModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/fsmt/__init__.py
+++ b/src/transformers/models/fsmt/__init__.py
@@ -16,10 +16,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_torch_available
-from .configuration_fsmt import FSMT_PRETRAINED_CONFIG_ARCHIVE_MAP, FSMTConfig
-from .tokenization_fsmt import FSMTTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_torch_available
+
+
+_import_structure = {
+    "configuration_fsmt": ["FSMT_PRETRAINED_CONFIG_ARCHIVE_MAP", "FSMTConfig"],
+    "tokenization_fsmt": ["FSMTTokenizer"],
+}
 
 if is_torch_available():
-    from .modeling_fsmt import FSMTForConditionalGeneration, FSMTModel, PretrainedFSMTModel
+    _import_structure["modeling_fsmt"] = ["FSMTForConditionalGeneration", "FSMTModel", "PretrainedFSMTModel"]
+
+
+if TYPE_CHECKING:
+    from .configuration_fsmt import FSMT_PRETRAINED_CONFIG_ARCHIVE_MAP, FSMTConfig
+    from .tokenization_fsmt import FSMTTokenizer
+
+    if is_torch_available():
+        from .modeling_fsmt import FSMTForConditionalGeneration, FSMTModel, PretrainedFSMTModel
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/funnel/__init__.py
+++ b/src/transformers/models/funnel/__init__.py
@@ -16,37 +16,95 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_funnel import FUNNEL_PRETRAINED_CONFIG_ARCHIVE_MAP, FunnelConfig
-from .tokenization_funnel import FunnelTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tf_available, is_tokenizers_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_funnel": ["FUNNEL_PRETRAINED_CONFIG_ARCHIVE_MAP", "FunnelConfig"],
+    "tokenization_funnel": ["FunnelTokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_funnel_fast import FunnelTokenizerFast
+    _import_structure["tokenization_funnel_fast"] = ["FunnelTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_funnel import (
-        FUNNEL_PRETRAINED_MODEL_ARCHIVE_LIST,
-        FunnelBaseModel,
-        FunnelForMaskedLM,
-        FunnelForMultipleChoice,
-        FunnelForPreTraining,
-        FunnelForQuestionAnswering,
-        FunnelForSequenceClassification,
-        FunnelForTokenClassification,
-        FunnelModel,
-        load_tf_weights_in_funnel,
-    )
+    _import_structure["modeling_funnel"] = [
+        "FUNNEL_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "FunnelBaseModel",
+        "FunnelForMaskedLM",
+        "FunnelForMultipleChoice",
+        "FunnelForPreTraining",
+        "FunnelForQuestionAnswering",
+        "FunnelForSequenceClassification",
+        "FunnelForTokenClassification",
+        "FunnelModel",
+        "load_tf_weights_in_funnel",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_funnel import (
-        TF_FUNNEL_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFFunnelBaseModel,
-        TFFunnelForMaskedLM,
-        TFFunnelForMultipleChoice,
-        TFFunnelForPreTraining,
-        TFFunnelForQuestionAnswering,
-        TFFunnelForSequenceClassification,
-        TFFunnelForTokenClassification,
-        TFFunnelModel,
-    )
+    _import_structure["modeling_tf_funnel"] = [
+        "TF_FUNNEL_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFFunnelBaseModel",
+        "TFFunnelForMaskedLM",
+        "TFFunnelForMultipleChoice",
+        "TFFunnelForPreTraining",
+        "TFFunnelForQuestionAnswering",
+        "TFFunnelForSequenceClassification",
+        "TFFunnelForTokenClassification",
+        "TFFunnelModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_funnel import FUNNEL_PRETRAINED_CONFIG_ARCHIVE_MAP, FunnelConfig
+    from .tokenization_funnel import FunnelTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_funnel_fast import FunnelTokenizerFast
+
+    if is_torch_available():
+        from .modeling_funnel import (
+            FUNNEL_PRETRAINED_MODEL_ARCHIVE_LIST,
+            FunnelBaseModel,
+            FunnelForMaskedLM,
+            FunnelForMultipleChoice,
+            FunnelForPreTraining,
+            FunnelForQuestionAnswering,
+            FunnelForSequenceClassification,
+            FunnelForTokenClassification,
+            FunnelModel,
+            load_tf_weights_in_funnel,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_funnel import (
+            TF_FUNNEL_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFFunnelBaseModel,
+            TFFunnelForMaskedLM,
+            TFFunnelForMultipleChoice,
+            TFFunnelForPreTraining,
+            TFFunnelForQuestionAnswering,
+            TFFunnelForSequenceClassification,
+            TFFunnelForTokenClassification,
+            TFFunnelModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/gpt2/__init__.py
+++ b/src/transformers/models/gpt2/__init__.py
@@ -16,32 +16,85 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_gpt2 import GPT2_PRETRAINED_CONFIG_ARCHIVE_MAP, GPT2Config
-from .tokenization_gpt2 import GPT2Tokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tf_available, is_tokenizers_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_gpt2": ["GPT2_PRETRAINED_CONFIG_ARCHIVE_MAP", "GPT2Config"],
+    "tokenization_gpt2": ["GPT2Tokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_gpt2_fast import GPT2TokenizerFast
+    _import_structure["tokenization_gpt2_fast"] = ["GPT2TokenizerFast"]
 
 if is_torch_available():
-    from .modeling_gpt2 import (
-        GPT2_PRETRAINED_MODEL_ARCHIVE_LIST,
-        GPT2DoubleHeadsModel,
-        GPT2ForSequenceClassification,
-        GPT2LMHeadModel,
-        GPT2Model,
-        GPT2PreTrainedModel,
-        load_tf_weights_in_gpt2,
-    )
+    _import_structure["modeling_gpt2"] = [
+        "GPT2_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "GPT2DoubleHeadsModel",
+        "GPT2ForSequenceClassification",
+        "GPT2LMHeadModel",
+        "GPT2Model",
+        "GPT2PreTrainedModel",
+        "load_tf_weights_in_gpt2",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_gpt2 import (
-        TF_GPT2_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFGPT2DoubleHeadsModel,
-        TFGPT2ForSequenceClassification,
-        TFGPT2LMHeadModel,
-        TFGPT2MainLayer,
-        TFGPT2Model,
-        TFGPT2PreTrainedModel,
-    )
+    _import_structure["modeling_tf_gpt2"] = [
+        "TF_GPT2_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFGPT2DoubleHeadsModel",
+        "TFGPT2ForSequenceClassification",
+        "TFGPT2LMHeadModel",
+        "TFGPT2MainLayer",
+        "TFGPT2Model",
+        "TFGPT2PreTrainedModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_gpt2 import GPT2_PRETRAINED_CONFIG_ARCHIVE_MAP, GPT2Config
+    from .tokenization_gpt2 import GPT2Tokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_gpt2_fast import GPT2TokenizerFast
+
+    if is_torch_available():
+        from .modeling_gpt2 import (
+            GPT2_PRETRAINED_MODEL_ARCHIVE_LIST,
+            GPT2DoubleHeadsModel,
+            GPT2ForSequenceClassification,
+            GPT2LMHeadModel,
+            GPT2Model,
+            GPT2PreTrainedModel,
+            load_tf_weights_in_gpt2,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_gpt2 import (
+            TF_GPT2_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFGPT2DoubleHeadsModel,
+            TFGPT2ForSequenceClassification,
+            TFGPT2LMHeadModel,
+            TFGPT2MainLayer,
+            TFGPT2Model,
+            TFGPT2PreTrainedModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/herbert/__init__.py
+++ b/src/transformers/models/herbert/__init__.py
@@ -16,9 +16,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tokenizers_available
-from .tokenization_herbert import HerbertTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tokenizers_available
+
+
+_import_structure = {
+    "tokenization_herbert": ["HerbertTokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_herbert_fast import HerbertTokenizerFast
+    _import_structure["tokenization_herbert_fast"] = ["HerbertTokenizerFast"]
+
+
+if TYPE_CHECKING:
+    from .tokenization_herbert import HerbertTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_herbert_fast import HerbertTokenizerFast
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/layoutlm/__init__.py
+++ b/src/transformers/models/layoutlm/__init__.py
@@ -16,18 +16,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tokenizers_available, is_torch_available
-from .configuration_layoutlm import LAYOUTLM_PRETRAINED_CONFIG_ARCHIVE_MAP, LayoutLMConfig
-from .tokenization_layoutlm import LayoutLMTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tokenizers_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_layoutlm": ["LAYOUTLM_PRETRAINED_CONFIG_ARCHIVE_MAP", "LayoutLMConfig"],
+    "tokenization_layoutlm": ["LayoutLMTokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_layoutlm_fast import LayoutLMTokenizerFast
+    _import_structure["tokenization_layoutlm_fast"] = ["LayoutLMTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_layoutlm import (
-        LAYOUTLM_PRETRAINED_MODEL_ARCHIVE_LIST,
-        LayoutLMForMaskedLM,
-        LayoutLMForTokenClassification,
-        LayoutLMModel,
-    )
+    _import_structure["modeling_layoutlm"] = [
+        "LAYOUTLM_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "LayoutLMForMaskedLM",
+        "LayoutLMForTokenClassification",
+        "LayoutLMModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_layoutlm import LAYOUTLM_PRETRAINED_CONFIG_ARCHIVE_MAP, LayoutLMConfig
+    from .tokenization_layoutlm import LayoutLMTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_layoutlm_fast import LayoutLMTokenizerFast
+
+    if is_torch_available():
+        from .modeling_layoutlm import (
+            LAYOUTLM_PRETRAINED_MODEL_ARCHIVE_LIST,
+            LayoutLMForMaskedLM,
+            LayoutLMForTokenClassification,
+            LayoutLMModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/led/__init__.py
+++ b/src/transformers/models/led/__init__.py
@@ -15,24 +15,68 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from ...file_utils import is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_led import LED_PRETRAINED_CONFIG_ARCHIVE_MAP, LEDConfig
-from .tokenization_led import LEDTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tf_available, is_tokenizers_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_led": ["LED_PRETRAINED_CONFIG_ARCHIVE_MAP", "LEDConfig"],
+    "tokenization_led": ["LEDTokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_led_fast import LEDTokenizerFast
+    _import_structure["tokenization_led_fast"] = ["LEDTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_led import (
-        LED_PRETRAINED_MODEL_ARCHIVE_LIST,
-        LEDForConditionalGeneration,
-        LEDForQuestionAnswering,
-        LEDForSequenceClassification,
-        LEDModel,
-        LEDPreTrainedModel,
-    )
+    _import_structure["modeling_led"] = [
+        "LED_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "LEDForConditionalGeneration",
+        "LEDForQuestionAnswering",
+        "LEDForSequenceClassification",
+        "LEDModel",
+        "LEDPreTrainedModel",
+    ]
 
 
 if is_tf_available():
-    from .modeling_tf_led import TFLEDForConditionalGeneration, TFLEDModel, TFLEDPreTrainedModel
+    _import_structure["modeling_tf_led"] = ["TFLEDForConditionalGeneration", "TFLEDModel", "TFLEDPreTrainedModel"]
+
+
+if TYPE_CHECKING:
+    from .configuration_led import LED_PRETRAINED_CONFIG_ARCHIVE_MAP, LEDConfig
+    from .tokenization_led import LEDTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_led_fast import LEDTokenizerFast
+
+    if is_torch_available():
+        from .modeling_led import (
+            LED_PRETRAINED_MODEL_ARCHIVE_LIST,
+            LEDForConditionalGeneration,
+            LEDForQuestionAnswering,
+            LEDForSequenceClassification,
+            LEDModel,
+            LEDPreTrainedModel,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_led import TFLEDForConditionalGeneration, TFLEDModel, TFLEDPreTrainedModel
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/longformer/__init__.py
+++ b/src/transformers/models/longformer/__init__.py
@@ -16,34 +16,89 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_longformer import LONGFORMER_PRETRAINED_CONFIG_ARCHIVE_MAP, LongformerConfig
-from .tokenization_longformer import LongformerTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tf_available, is_tokenizers_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_longformer": ["LONGFORMER_PRETRAINED_CONFIG_ARCHIVE_MAP", "LongformerConfig"],
+    "tokenization_longformer": ["LongformerTokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_longformer_fast import LongformerTokenizerFast
+    _import_structure["tokenization_longformer_fast"] = ["LongformerTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_longformer import (
-        LONGFORMER_PRETRAINED_MODEL_ARCHIVE_LIST,
-        LongformerForMaskedLM,
-        LongformerForMultipleChoice,
-        LongformerForQuestionAnswering,
-        LongformerForSequenceClassification,
-        LongformerForTokenClassification,
-        LongformerModel,
-        LongformerSelfAttention,
-    )
+    _import_structure["modeling_longformer"] = [
+        "LONGFORMER_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "LongformerForMaskedLM",
+        "LongformerForMultipleChoice",
+        "LongformerForQuestionAnswering",
+        "LongformerForSequenceClassification",
+        "LongformerForTokenClassification",
+        "LongformerModel",
+        "LongformerSelfAttention",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_longformer import (
-        TF_LONGFORMER_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFLongformerForMaskedLM,
-        TFLongformerForMultipleChoice,
-        TFLongformerForQuestionAnswering,
-        TFLongformerForSequenceClassification,
-        TFLongformerForTokenClassification,
-        TFLongformerModel,
-        TFLongformerSelfAttention,
-    )
+    _import_structure["modeling_tf_longformer"] = [
+        "TF_LONGFORMER_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFLongformerForMaskedLM",
+        "TFLongformerForMultipleChoice",
+        "TFLongformerForQuestionAnswering",
+        "TFLongformerForSequenceClassification",
+        "TFLongformerForTokenClassification",
+        "TFLongformerModel",
+        "TFLongformerSelfAttention",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_longformer import LONGFORMER_PRETRAINED_CONFIG_ARCHIVE_MAP, LongformerConfig
+    from .tokenization_longformer import LongformerTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_longformer_fast import LongformerTokenizerFast
+
+    if is_torch_available():
+        from .modeling_longformer import (
+            LONGFORMER_PRETRAINED_MODEL_ARCHIVE_LIST,
+            LongformerForMaskedLM,
+            LongformerForMultipleChoice,
+            LongformerForQuestionAnswering,
+            LongformerForSequenceClassification,
+            LongformerForTokenClassification,
+            LongformerModel,
+            LongformerSelfAttention,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_longformer import (
+            TF_LONGFORMER_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFLongformerForMaskedLM,
+            TFLongformerForMultipleChoice,
+            TFLongformerForQuestionAnswering,
+            TFLongformerForSequenceClassification,
+            TFLongformerForTokenClassification,
+            TFLongformerModel,
+            TFLongformerSelfAttention,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/lxmert/__init__.py
+++ b/src/transformers/models/lxmert/__init__.py
@@ -16,31 +16,83 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_lxmert import LXMERT_PRETRAINED_CONFIG_ARCHIVE_MAP, LxmertConfig
-from .tokenization_lxmert import LxmertTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tf_available, is_tokenizers_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_lxmert": ["LXMERT_PRETRAINED_CONFIG_ARCHIVE_MAP", "LxmertConfig"],
+    "tokenization_lxmert": ["LxmertTokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_lxmert_fast import LxmertTokenizerFast
+    _import_structure["tokenization_lxmert_fast"] = ["LxmertTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_lxmert import (
-        LxmertEncoder,
-        LxmertForPreTraining,
-        LxmertForQuestionAnswering,
-        LxmertModel,
-        LxmertPreTrainedModel,
-        LxmertVisualFeatureEncoder,
-        LxmertXLayer,
-    )
+    _import_structure["modeling_lxmert"] = [
+        "LxmertEncoder",
+        "LxmertForPreTraining",
+        "LxmertForQuestionAnswering",
+        "LxmertModel",
+        "LxmertPreTrainedModel",
+        "LxmertVisualFeatureEncoder",
+        "LxmertXLayer",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_lxmert import (
-        TF_LXMERT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFLxmertForPreTraining,
-        TFLxmertMainLayer,
-        TFLxmertModel,
-        TFLxmertPreTrainedModel,
-        TFLxmertVisualFeatureEncoder,
-    )
+    _import_structure["modeling_tf_lxmert"] = [
+        "TF_LXMERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFLxmertForPreTraining",
+        "TFLxmertMainLayer",
+        "TFLxmertModel",
+        "TFLxmertPreTrainedModel",
+        "TFLxmertVisualFeatureEncoder",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_lxmert import LXMERT_PRETRAINED_CONFIG_ARCHIVE_MAP, LxmertConfig
+    from .tokenization_lxmert import LxmertTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_lxmert_fast import LxmertTokenizerFast
+
+    if is_torch_available():
+        from .modeling_lxmert import (
+            LxmertEncoder,
+            LxmertForPreTraining,
+            LxmertForQuestionAnswering,
+            LxmertModel,
+            LxmertPreTrainedModel,
+            LxmertVisualFeatureEncoder,
+            LxmertXLayer,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_lxmert import (
+            TF_LXMERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFLxmertForPreTraining,
+            TFLxmertMainLayer,
+            TFLxmertModel,
+            TFLxmertPreTrainedModel,
+            TFLxmertVisualFeatureEncoder,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/marian/__init__.py
+++ b/src/transformers/models/marian/__init__.py
@@ -15,20 +15,67 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from ...file_utils import is_sentencepiece_available, is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_marian import MARIAN_PRETRAINED_CONFIG_ARCHIVE_MAP, MarianConfig
+from typing import TYPE_CHECKING
 
+from ...file_utils import (
+    _BaseLazyModule,
+    is_sentencepiece_available,
+    is_tf_available,
+    is_tokenizers_available,
+    is_torch_available,
+)
+
+
+_import_structure = {
+    "configuration_marian": ["MARIAN_PRETRAINED_CONFIG_ARCHIVE_MAP", "MarianConfig"],
+}
 
 if is_sentencepiece_available():
-    from .tokenization_marian import MarianTokenizer
+    _import_structure["tokenization_marian"] = ["MarianTokenizer"]
 
 if is_torch_available():
-    from .modeling_marian import (
-        MARIAN_PRETRAINED_MODEL_ARCHIVE_LIST,
-        MarianModel,
-        MarianMTModel,
-        MarianPreTrainedModel,
-    )
+    _import_structure["modeling_marian"] = [
+        "MARIAN_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "MarianModel",
+        "MarianMTModel",
+        "MarianPreTrainedModel",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_marian import TFMarianMTModel
+    _import_structure["modeling_tf_marian"] = ["TFMarianMTModel"]
+
+
+if TYPE_CHECKING:
+    from .configuration_marian import MARIAN_PRETRAINED_CONFIG_ARCHIVE_MAP, MarianConfig
+
+    if is_sentencepiece_available():
+        from .tokenization_marian import MarianTokenizer
+
+    if is_torch_available():
+        from .modeling_marian import (
+            MARIAN_PRETRAINED_MODEL_ARCHIVE_LIST,
+            MarianModel,
+            MarianMTModel,
+            MarianPreTrainedModel,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_marian import TFMarianMTModel
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/mbart/__init__.py
+++ b/src/transformers/models/mbart/__init__.py
@@ -15,25 +15,77 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from ...file_utils import is_sentencepiece_available, is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_mbart import MBART_PRETRAINED_CONFIG_ARCHIVE_MAP, MBartConfig
+from typing import TYPE_CHECKING
 
+from ...file_utils import (
+    _BaseLazyModule,
+    is_sentencepiece_available,
+    is_tf_available,
+    is_tokenizers_available,
+    is_torch_available,
+)
+
+
+_import_structure = {
+    "configuration_mbart": ["MBART_PRETRAINED_CONFIG_ARCHIVE_MAP", "MBartConfig"],
+}
 
 if is_sentencepiece_available():
-    from .tokenization_mbart import MBartTokenizer
+    _import_structure["tokenization_mbart"] = ["MBartTokenizer"]
 
 if is_tokenizers_available():
-    from .tokenization_mbart_fast import MBartTokenizerFast
+    _import_structure["tokenization_mbart_fast"] = ["MBartTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_mbart import (
-        MBART_PRETRAINED_MODEL_ARCHIVE_LIST,
-        MBartForConditionalGeneration,
-        MBartForQuestionAnswering,
-        MBartForSequenceClassification,
-        MBartModel,
-        MBartPreTrainedModel,
-    )
+    _import_structure["modeling_mbart"] = [
+        "MBART_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "MBartForConditionalGeneration",
+        "MBartForQuestionAnswering",
+        "MBartForSequenceClassification",
+        "MBartModel",
+        "MBartPreTrainedModel",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_mbart import TFMBartForConditionalGeneration
+    _import_structure["modeling_tf_mbart"] = ["TFMBartForConditionalGeneration"]
+
+
+if TYPE_CHECKING:
+    from .configuration_mbart import MBART_PRETRAINED_CONFIG_ARCHIVE_MAP, MBartConfig
+
+    if is_sentencepiece_available():
+        from .tokenization_mbart import MBartTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_mbart_fast import MBartTokenizerFast
+
+    if is_torch_available():
+        from .modeling_mbart import (
+            MBART_PRETRAINED_MODEL_ARCHIVE_LIST,
+            MBartForConditionalGeneration,
+            MBartForQuestionAnswering,
+            MBartForSequenceClassification,
+            MBartModel,
+            MBartPreTrainedModel,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_mbart import TFMBartForConditionalGeneration
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/mmbt/__init__.py
+++ b/src/transformers/models/mmbt/__init__.py
@@ -16,9 +16,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_torch_available
-from .configuration_mmbt import MMBTConfig
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_torch_available
+
+
+_import_structure = {
+    "configuration_mmbt": ["MMBTConfig"],
+}
 
 if is_torch_available():
-    from .modeling_mmbt import MMBTForClassification, MMBTModel, ModalEmbeddings
+    _import_structure["modeling_mmbt"] = ["MMBTForClassification", "MMBTModel", "ModalEmbeddings"]
+
+
+if TYPE_CHECKING:
+    from .configuration_mmbt import MMBTConfig
+
+    if is_torch_available():
+        from .modeling_mmbt import MMBTForClassification, MMBTModel, ModalEmbeddings
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/mobilebert/__init__.py
+++ b/src/transformers/models/mobilebert/__init__.py
@@ -16,41 +16,103 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_mobilebert import MOBILEBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, MobileBertConfig
-from .tokenization_mobilebert import MobileBertTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tf_available, is_tokenizers_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_mobilebert": ["MOBILEBERT_PRETRAINED_CONFIG_ARCHIVE_MAP", "MobileBertConfig"],
+    "tokenization_mobilebert": ["MobileBertTokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_mobilebert_fast import MobileBertTokenizerFast
+    _import_structure["tokenization_mobilebert_fast"] = ["MobileBertTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_mobilebert import (
-        MOBILEBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        MobileBertForMaskedLM,
-        MobileBertForMultipleChoice,
-        MobileBertForNextSentencePrediction,
-        MobileBertForPreTraining,
-        MobileBertForQuestionAnswering,
-        MobileBertForSequenceClassification,
-        MobileBertForTokenClassification,
-        MobileBertLayer,
-        MobileBertModel,
-        MobileBertPreTrainedModel,
-        load_tf_weights_in_mobilebert,
-    )
+    _import_structure["modeling_mobilebert"] = [
+        "MOBILEBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "MobileBertForMaskedLM",
+        "MobileBertForMultipleChoice",
+        "MobileBertForNextSentencePrediction",
+        "MobileBertForPreTraining",
+        "MobileBertForQuestionAnswering",
+        "MobileBertForSequenceClassification",
+        "MobileBertForTokenClassification",
+        "MobileBertLayer",
+        "MobileBertModel",
+        "MobileBertPreTrainedModel",
+        "load_tf_weights_in_mobilebert",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_mobilebert import (
-        TF_MOBILEBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFMobileBertForMaskedLM,
-        TFMobileBertForMultipleChoice,
-        TFMobileBertForNextSentencePrediction,
-        TFMobileBertForPreTraining,
-        TFMobileBertForQuestionAnswering,
-        TFMobileBertForSequenceClassification,
-        TFMobileBertForTokenClassification,
-        TFMobileBertMainLayer,
-        TFMobileBertModel,
-        TFMobileBertPreTrainedModel,
-    )
+    _import_structure["modeling_tf_mobilebert"] = [
+        "TF_MOBILEBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFMobileBertForMaskedLM",
+        "TFMobileBertForMultipleChoice",
+        "TFMobileBertForNextSentencePrediction",
+        "TFMobileBertForPreTraining",
+        "TFMobileBertForQuestionAnswering",
+        "TFMobileBertForSequenceClassification",
+        "TFMobileBertForTokenClassification",
+        "TFMobileBertMainLayer",
+        "TFMobileBertModel",
+        "TFMobileBertPreTrainedModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_mobilebert import MOBILEBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, MobileBertConfig
+    from .tokenization_mobilebert import MobileBertTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_mobilebert_fast import MobileBertTokenizerFast
+
+    if is_torch_available():
+        from .modeling_mobilebert import (
+            MOBILEBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            MobileBertForMaskedLM,
+            MobileBertForMultipleChoice,
+            MobileBertForNextSentencePrediction,
+            MobileBertForPreTraining,
+            MobileBertForQuestionAnswering,
+            MobileBertForSequenceClassification,
+            MobileBertForTokenClassification,
+            MobileBertLayer,
+            MobileBertModel,
+            MobileBertPreTrainedModel,
+            load_tf_weights_in_mobilebert,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_mobilebert import (
+            TF_MOBILEBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFMobileBertForMaskedLM,
+            TFMobileBertForMultipleChoice,
+            TFMobileBertForNextSentencePrediction,
+            TFMobileBertForPreTraining,
+            TFMobileBertForQuestionAnswering,
+            TFMobileBertForSequenceClassification,
+            TFMobileBertForTokenClassification,
+            TFMobileBertMainLayer,
+            TFMobileBertModel,
+            TFMobileBertPreTrainedModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/mpnet/__init__.py
+++ b/src/transformers/models/mpnet/__init__.py
@@ -16,37 +16,101 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_flax_available, is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_mpnet import MPNET_PRETRAINED_CONFIG_ARCHIVE_MAP, MPNetConfig
-from .tokenization_mpnet import MPNetTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import (
+    _BaseLazyModule,
+    is_flax_available,
+    is_tf_available,
+    is_tokenizers_available,
+    is_torch_available,
+)
+
+
+_import_structure = {
+    "configuration_mpnet": ["MPNET_PRETRAINED_CONFIG_ARCHIVE_MAP", "MPNetConfig"],
+    "tokenization_mpnet": ["MPNetTokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_mpnet_fast import MPNetTokenizerFast
+    _import_structure["tokenization_mpnet_fast"] = ["MPNetTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_mpnet import (
-        MPNET_PRETRAINED_MODEL_ARCHIVE_LIST,
-        MPNetForMaskedLM,
-        MPNetForMultipleChoice,
-        MPNetForQuestionAnswering,
-        MPNetForSequenceClassification,
-        MPNetForTokenClassification,
-        MPNetLayer,
-        MPNetModel,
-        MPNetPreTrainedModel,
-    )
+    _import_structure["modeling_mpnet"] = [
+        "MPNET_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "MPNetForMaskedLM",
+        "MPNetForMultipleChoice",
+        "MPNetForQuestionAnswering",
+        "MPNetForSequenceClassification",
+        "MPNetForTokenClassification",
+        "MPNetLayer",
+        "MPNetModel",
+        "MPNetPreTrainedModel",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_mpnet import (
-        TF_MPNET_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFMPNetEmbeddings,
-        TFMPNetForMaskedLM,
-        TFMPNetForMultipleChoice,
-        TFMPNetForQuestionAnswering,
-        TFMPNetForSequenceClassification,
-        TFMPNetForTokenClassification,
-        TFMPNetMainLayer,
-        TFMPNetModel,
-        TFMPNetPreTrainedModel,
-    )
+    _import_structure["modeling_tf_mpnet"] = [
+        "TF_MPNET_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFMPNetEmbeddings",
+        "TFMPNetForMaskedLM",
+        "TFMPNetForMultipleChoice",
+        "TFMPNetForQuestionAnswering",
+        "TFMPNetForSequenceClassification",
+        "TFMPNetForTokenClassification",
+        "TFMPNetMainLayer",
+        "TFMPNetModel",
+        "TFMPNetPreTrainedModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_mpnet import MPNET_PRETRAINED_CONFIG_ARCHIVE_MAP, MPNetConfig
+    from .tokenization_mpnet import MPNetTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_mpnet_fast import MPNetTokenizerFast
+
+    if is_torch_available():
+        from .modeling_mpnet import (
+            MPNET_PRETRAINED_MODEL_ARCHIVE_LIST,
+            MPNetForMaskedLM,
+            MPNetForMultipleChoice,
+            MPNetForQuestionAnswering,
+            MPNetForSequenceClassification,
+            MPNetForTokenClassification,
+            MPNetLayer,
+            MPNetModel,
+            MPNetPreTrainedModel,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_mpnet import (
+            TF_MPNET_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFMPNetEmbeddings,
+            TFMPNetForMaskedLM,
+            TFMPNetForMultipleChoice,
+            TFMPNetForQuestionAnswering,
+            TFMPNetForSequenceClassification,
+            TFMPNetForTokenClassification,
+            TFMPNetMainLayer,
+            TFMPNetModel,
+            TFMPNetPreTrainedModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/mt5/__init__.py
+++ b/src/transformers/models/mt5/__init__.py
@@ -16,8 +16,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_sentencepiece_available, is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_mt5 import MT5Config
+from typing import TYPE_CHECKING
+
+from ...file_utils import (
+    _BaseLazyModule,
+    is_sentencepiece_available,
+    is_tf_available,
+    is_tokenizers_available,
+    is_torch_available,
+)
 
 
 if is_sentencepiece_available():
@@ -30,8 +37,58 @@ if is_tokenizers_available():
 
     MT5TokenizerFast = T5TokenizerFast
 
+_import_structure = {
+    "configuration_mt5": ["MT5Config"],
+}
+
 if is_torch_available():
-    from .modeling_mt5 import MT5EncoderModel, MT5ForConditionalGeneration, MT5Model
+    _import_structure["modeling_mt5"] = ["MT5EncoderModel", "MT5ForConditionalGeneration", "MT5Model"]
 
 if is_tf_available():
-    from .modeling_tf_mt5 import TFMT5EncoderModel, TFMT5ForConditionalGeneration, TFMT5Model
+    _import_structure["modeling_tf_mt5"] = ["TFMT5EncoderModel", "TFMT5ForConditionalGeneration", "TFMT5Model"]
+
+
+if TYPE_CHECKING:
+    from .configuration_mt5 import MT5Config
+
+    if is_sentencepiece_available():
+        from ..t5.tokenization_t5 import T5Tokenizer
+
+        MT5Tokenizer = T5Tokenizer
+
+    if is_tokenizers_available():
+        from ..t5.tokenization_t5_fast import T5TokenizerFast
+
+        MT5TokenizerFast = T5TokenizerFast
+
+    if is_torch_available():
+        from .modeling_mt5 import MT5EncoderModel, MT5ForConditionalGeneration, MT5Model
+
+    if is_tf_available():
+        from .modeling_tf_mt5 import TFMT5EncoderModel, TFMT5ForConditionalGeneration, TFMT5Model
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+        def __getattr__(self, name):
+            if name == "MT5Tokenizer":
+                return MT5Tokenizer
+            elif name == name == "MT5TokenizerFast":
+                return MT5TokenizerFast
+            else:
+                return super().__getattr__(name)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/openai/__init__.py
+++ b/src/transformers/models/openai/__init__.py
@@ -16,32 +16,85 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_openai import OPENAI_GPT_PRETRAINED_CONFIG_ARCHIVE_MAP, OpenAIGPTConfig
-from .tokenization_openai import OpenAIGPTTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tf_available, is_tokenizers_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_openai": ["OPENAI_GPT_PRETRAINED_CONFIG_ARCHIVE_MAP", "OpenAIGPTConfig"],
+    "tokenization_openai": ["OpenAIGPTTokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_openai_fast import OpenAIGPTTokenizerFast
+    _import_structure["tokenization_openai_fast"] = ["OpenAIGPTTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_openai import (
-        OPENAI_GPT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        OpenAIGPTDoubleHeadsModel,
-        OpenAIGPTForSequenceClassification,
-        OpenAIGPTLMHeadModel,
-        OpenAIGPTModel,
-        OpenAIGPTPreTrainedModel,
-        load_tf_weights_in_openai_gpt,
-    )
+    _import_structure["modeling_openai"] = [
+        "OPENAI_GPT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "OpenAIGPTDoubleHeadsModel",
+        "OpenAIGPTForSequenceClassification",
+        "OpenAIGPTLMHeadModel",
+        "OpenAIGPTModel",
+        "OpenAIGPTPreTrainedModel",
+        "load_tf_weights_in_openai_gpt",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_openai import (
-        TF_OPENAI_GPT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFOpenAIGPTDoubleHeadsModel,
-        TFOpenAIGPTForSequenceClassification,
-        TFOpenAIGPTLMHeadModel,
-        TFOpenAIGPTMainLayer,
-        TFOpenAIGPTModel,
-        TFOpenAIGPTPreTrainedModel,
-    )
+    _import_structure["modeling_tf_openai"] = [
+        "TF_OPENAI_GPT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFOpenAIGPTDoubleHeadsModel",
+        "TFOpenAIGPTForSequenceClassification",
+        "TFOpenAIGPTLMHeadModel",
+        "TFOpenAIGPTMainLayer",
+        "TFOpenAIGPTModel",
+        "TFOpenAIGPTPreTrainedModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_openai import OPENAI_GPT_PRETRAINED_CONFIG_ARCHIVE_MAP, OpenAIGPTConfig
+    from .tokenization_openai import OpenAIGPTTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_openai_fast import OpenAIGPTTokenizerFast
+
+    if is_torch_available():
+        from .modeling_openai import (
+            OPENAI_GPT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            OpenAIGPTDoubleHeadsModel,
+            OpenAIGPTForSequenceClassification,
+            OpenAIGPTLMHeadModel,
+            OpenAIGPTModel,
+            OpenAIGPTPreTrainedModel,
+            load_tf_weights_in_openai_gpt,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_openai import (
+            TF_OPENAI_GPT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFOpenAIGPTDoubleHeadsModel,
+            TFOpenAIGPTForSequenceClassification,
+            TFOpenAIGPTLMHeadModel,
+            TFOpenAIGPTMainLayer,
+            TFOpenAIGPTModel,
+            TFOpenAIGPTPreTrainedModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/pegasus/__init__.py
+++ b/src/transformers/models/pegasus/__init__.py
@@ -15,23 +15,73 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from ...file_utils import is_sentencepiece_available, is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_pegasus import PEGASUS_PRETRAINED_CONFIG_ARCHIVE_MAP, PegasusConfig
+from typing import TYPE_CHECKING
 
+from ...file_utils import (
+    _BaseLazyModule,
+    is_sentencepiece_available,
+    is_tf_available,
+    is_tokenizers_available,
+    is_torch_available,
+)
+
+
+_import_structure = {
+    "configuration_pegasus": ["PEGASUS_PRETRAINED_CONFIG_ARCHIVE_MAP", "PegasusConfig"],
+}
 
 if is_sentencepiece_available():
-    from .tokenization_pegasus import PegasusTokenizer
+    _import_structure["tokenization_pegasus"] = ["PegasusTokenizer"]
 
 if is_tokenizers_available():
-    from .tokenization_pegasus_fast import PegasusTokenizerFast
+    _import_structure["tokenization_pegasus_fast"] = ["PegasusTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_pegasus import (
-        PEGASUS_PRETRAINED_MODEL_ARCHIVE_LIST,
-        PegasusForConditionalGeneration,
-        PegasusModel,
-        PegasusPreTrainedModel,
-    )
+    _import_structure["modeling_pegasus"] = [
+        "PEGASUS_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "PegasusForConditionalGeneration",
+        "PegasusModel",
+        "PegasusPreTrainedModel",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_pegasus import TFPegasusForConditionalGeneration
+    _import_structure["modeling_tf_pegasus"] = ["TFPegasusForConditionalGeneration"]
+
+
+if TYPE_CHECKING:
+    from .configuration_pegasus import PEGASUS_PRETRAINED_CONFIG_ARCHIVE_MAP, PegasusConfig
+
+    if is_sentencepiece_available():
+        from .tokenization_pegasus import PegasusTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_pegasus_fast import PegasusTokenizerFast
+
+    if is_torch_available():
+        from .modeling_pegasus import (
+            PEGASUS_PRETRAINED_MODEL_ARCHIVE_LIST,
+            PegasusForConditionalGeneration,
+            PegasusModel,
+            PegasusPreTrainedModel,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_pegasus import TFPegasusForConditionalGeneration
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/phobert/__init__.py
+++ b/src/transformers/models/phobert/__init__.py
@@ -16,4 +16,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .tokenization_phobert import PhobertTokenizer
+from typing import TYPE_CHECKING
+
+from ...file_utils import _BaseLazyModule
+
+
+_import_structure = {
+    "tokenization_phobert": ["PhobertTokenizer"],
+}
+
+
+if TYPE_CHECKING:
+    from .tokenization_phobert import PhobertTokenizer
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/prophetnet/__init__.py
+++ b/src/transformers/models/prophetnet/__init__.py
@@ -16,18 +16,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_torch_available
-from .configuration_prophetnet import PROPHETNET_PRETRAINED_CONFIG_ARCHIVE_MAP, ProphetNetConfig
-from .tokenization_prophetnet import ProphetNetTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_torch_available
+
+
+_import_structure = {
+    "configuration_prophetnet": ["PROPHETNET_PRETRAINED_CONFIG_ARCHIVE_MAP", "ProphetNetConfig"],
+    "tokenization_prophetnet": ["ProphetNetTokenizer"],
+}
 
 if is_torch_available():
-    from .modeling_prophetnet import (
-        PROPHETNET_PRETRAINED_MODEL_ARCHIVE_LIST,
-        ProphetNetDecoder,
-        ProphetNetEncoder,
-        ProphetNetForCausalLM,
-        ProphetNetForConditionalGeneration,
-        ProphetNetModel,
-        ProphetNetPreTrainedModel,
-    )
+    _import_structure["modeling_prophetnet"] = [
+        "PROPHETNET_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "ProphetNetDecoder",
+        "ProphetNetEncoder",
+        "ProphetNetForCausalLM",
+        "ProphetNetForConditionalGeneration",
+        "ProphetNetModel",
+        "ProphetNetPreTrainedModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_prophetnet import PROPHETNET_PRETRAINED_CONFIG_ARCHIVE_MAP, ProphetNetConfig
+    from .tokenization_prophetnet import ProphetNetTokenizer
+
+    if is_torch_available():
+        from .modeling_prophetnet import (
+            PROPHETNET_PRETRAINED_MODEL_ARCHIVE_LIST,
+            ProphetNetDecoder,
+            ProphetNetEncoder,
+            ProphetNetForCausalLM,
+            ProphetNetForConditionalGeneration,
+            ProphetNetModel,
+            ProphetNetPreTrainedModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/rag/__init__.py
+++ b/src/transformers/models/rag/__init__.py
@@ -16,11 +16,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_torch_available
-from .configuration_rag import RagConfig
-from .retrieval_rag import RagRetriever
-from .tokenization_rag import RagTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_torch_available
+
+
+_import_structure = {
+    "configuration_rag": ["RagConfig"],
+    "retrieval_rag": ["RagRetriever"],
+    "tokenization_rag": ["RagTokenizer"],
+}
 
 if is_torch_available():
-    from .modeling_rag import RagModel, RagSequenceForGeneration, RagTokenForGeneration
+    _import_structure["modeling_rag"] = ["RagModel", "RagSequenceForGeneration", "RagTokenForGeneration"]
+
+
+if TYPE_CHECKING:
+    from .configuration_rag import RagConfig
+    from .retrieval_rag import RagRetriever
+    from .tokenization_rag import RagTokenizer
+
+    if is_torch_available():
+        from .modeling_rag import RagModel, RagSequenceForGeneration, RagTokenForGeneration
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/reformer/__init__.py
+++ b/src/transformers/models/reformer/__init__.py
@@ -16,24 +16,69 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_sentencepiece_available, is_tokenizers_available, is_torch_available
-from .configuration_reformer import REFORMER_PRETRAINED_CONFIG_ARCHIVE_MAP, ReformerConfig
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_sentencepiece_available, is_tokenizers_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_reformer": ["REFORMER_PRETRAINED_CONFIG_ARCHIVE_MAP", "ReformerConfig"],
+}
 
 if is_sentencepiece_available():
-    from .tokenization_reformer import ReformerTokenizer
+    _import_structure["tokenization_reformer"] = ["ReformerTokenizer"]
 
 if is_tokenizers_available():
-    from .tokenization_reformer_fast import ReformerTokenizerFast
+    _import_structure["tokenization_reformer_fast"] = ["ReformerTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_reformer import (
-        REFORMER_PRETRAINED_MODEL_ARCHIVE_LIST,
-        ReformerAttention,
-        ReformerForMaskedLM,
-        ReformerForQuestionAnswering,
-        ReformerForSequenceClassification,
-        ReformerLayer,
-        ReformerModel,
-        ReformerModelWithLMHead,
-    )
+    _import_structure["modeling_reformer"] = [
+        "REFORMER_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "ReformerAttention",
+        "ReformerForMaskedLM",
+        "ReformerForQuestionAnswering",
+        "ReformerForSequenceClassification",
+        "ReformerLayer",
+        "ReformerModel",
+        "ReformerModelWithLMHead",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_reformer import REFORMER_PRETRAINED_CONFIG_ARCHIVE_MAP, ReformerConfig
+
+    if is_sentencepiece_available():
+        from .tokenization_reformer import ReformerTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_reformer_fast import ReformerTokenizerFast
+
+    if is_torch_available():
+        from .modeling_reformer import (
+            REFORMER_PRETRAINED_MODEL_ARCHIVE_LIST,
+            ReformerAttention,
+            ReformerForMaskedLM,
+            ReformerForQuestionAnswering,
+            ReformerForSequenceClassification,
+            ReformerLayer,
+            ReformerModel,
+            ReformerModelWithLMHead,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/retribert/__init__.py
+++ b/src/transformers/models/retribert/__init__.py
@@ -16,13 +16,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tokenizers_available, is_torch_available
-from .configuration_retribert import RETRIBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, RetriBertConfig
-from .tokenization_retribert import RetriBertTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tokenizers_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_retribert": ["RETRIBERT_PRETRAINED_CONFIG_ARCHIVE_MAP", "RetriBertConfig"],
+    "tokenization_retribert": ["RetriBertTokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_retribert_fast import RetriBertTokenizerFast
+    _import_structure["tokenization_retribert_fast"] = ["RetriBertTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_retribert import RETRIBERT_PRETRAINED_MODEL_ARCHIVE_LIST, RetriBertModel, RetriBertPreTrainedModel
+    _import_structure["modeling_retribert"] = [
+        "RETRIBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "RetriBertModel",
+        "RetriBertPreTrainedModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_retribert import RETRIBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, RetriBertConfig
+    from .tokenization_retribert import RetriBertTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_retribert_fast import RetriBertTokenizerFast
+
+    if is_torch_available():
+        from .modeling_retribert import (
+            RETRIBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            RetriBertModel,
+            RetriBertPreTrainedModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/roberta/__init__.py
+++ b/src/transformers/models/roberta/__init__.py
@@ -16,38 +16,103 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_flax_available, is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_roberta import ROBERTA_PRETRAINED_CONFIG_ARCHIVE_MAP, RobertaConfig
-from .tokenization_roberta import RobertaTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import (
+    _BaseLazyModule,
+    is_flax_available,
+    is_tf_available,
+    is_tokenizers_available,
+    is_torch_available,
+)
+
+
+_import_structure = {
+    "configuration_roberta": ["ROBERTA_PRETRAINED_CONFIG_ARCHIVE_MAP", "RobertaConfig"],
+    "tokenization_roberta": ["RobertaTokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_roberta_fast import RobertaTokenizerFast
+    _import_structure["tokenization_roberta_fast"] = ["RobertaTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_roberta import (
-        ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST,
-        RobertaForCausalLM,
-        RobertaForMaskedLM,
-        RobertaForMultipleChoice,
-        RobertaForQuestionAnswering,
-        RobertaForSequenceClassification,
-        RobertaForTokenClassification,
-        RobertaModel,
-    )
+    _import_structure["modeling_roberta"] = [
+        "ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "RobertaForCausalLM",
+        "RobertaForMaskedLM",
+        "RobertaForMultipleChoice",
+        "RobertaForQuestionAnswering",
+        "RobertaForSequenceClassification",
+        "RobertaForTokenClassification",
+        "RobertaModel",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_roberta import (
-        TF_ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFRobertaForMaskedLM,
-        TFRobertaForMultipleChoice,
-        TFRobertaForQuestionAnswering,
-        TFRobertaForSequenceClassification,
-        TFRobertaForTokenClassification,
-        TFRobertaMainLayer,
-        TFRobertaModel,
-        TFRobertaPreTrainedModel,
-    )
+    _import_structure["modeling_tf_roberta"] = [
+        "TF_ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFRobertaForMaskedLM",
+        "TFRobertaForMultipleChoice",
+        "TFRobertaForQuestionAnswering",
+        "TFRobertaForSequenceClassification",
+        "TFRobertaForTokenClassification",
+        "TFRobertaMainLayer",
+        "TFRobertaModel",
+        "TFRobertaPreTrainedModel",
+    ]
 
 if is_flax_available():
-    from .modeling_flax_roberta import FlaxRobertaModel
+    _import_structure["modeling_flax_roberta"] = ["FlaxRobertaModel"]
+
+
+if TYPE_CHECKING:
+    from .configuration_roberta import ROBERTA_PRETRAINED_CONFIG_ARCHIVE_MAP, RobertaConfig
+    from .tokenization_roberta import RobertaTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_roberta_fast import RobertaTokenizerFast
+
+    if is_torch_available():
+        from .modeling_roberta import (
+            ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST,
+            RobertaForCausalLM,
+            RobertaForMaskedLM,
+            RobertaForMultipleChoice,
+            RobertaForQuestionAnswering,
+            RobertaForSequenceClassification,
+            RobertaForTokenClassification,
+            RobertaModel,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_roberta import (
+            TF_ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFRobertaForMaskedLM,
+            TFRobertaForMultipleChoice,
+            TFRobertaForQuestionAnswering,
+            TFRobertaForSequenceClassification,
+            TFRobertaForTokenClassification,
+            TFRobertaMainLayer,
+            TFRobertaModel,
+            TFRobertaPreTrainedModel,
+        )
+
+    if is_flax_available():
+        from .modeling_flax_roberta import FlaxRobertaModel
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/squeezebert/__init__.py
+++ b/src/transformers/models/squeezebert/__init__.py
@@ -16,23 +16,67 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tokenizers_available, is_torch_available
-from .configuration_squeezebert import SQUEEZEBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, SqueezeBertConfig
-from .tokenization_squeezebert import SqueezeBertTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tokenizers_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_squeezebert": ["SQUEEZEBERT_PRETRAINED_CONFIG_ARCHIVE_MAP", "SqueezeBertConfig"],
+    "tokenization_squeezebert": ["SqueezeBertTokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_squeezebert_fast import SqueezeBertTokenizerFast
+    _import_structure["tokenization_squeezebert_fast"] = ["SqueezeBertTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_squeezebert import (
-        SQUEEZEBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
-        SqueezeBertForMaskedLM,
-        SqueezeBertForMultipleChoice,
-        SqueezeBertForQuestionAnswering,
-        SqueezeBertForSequenceClassification,
-        SqueezeBertForTokenClassification,
-        SqueezeBertModel,
-        SqueezeBertModule,
-        SqueezeBertPreTrainedModel,
-    )
+    _import_structure["modeling_squeezebert"] = [
+        "SQUEEZEBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "SqueezeBertForMaskedLM",
+        "SqueezeBertForMultipleChoice",
+        "SqueezeBertForQuestionAnswering",
+        "SqueezeBertForSequenceClassification",
+        "SqueezeBertForTokenClassification",
+        "SqueezeBertModel",
+        "SqueezeBertModule",
+        "SqueezeBertPreTrainedModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_squeezebert import SQUEEZEBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, SqueezeBertConfig
+    from .tokenization_squeezebert import SqueezeBertTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_squeezebert_fast import SqueezeBertTokenizerFast
+
+    if is_torch_available():
+        from .modeling_squeezebert import (
+            SQUEEZEBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            SqueezeBertForMaskedLM,
+            SqueezeBertForMultipleChoice,
+            SqueezeBertForQuestionAnswering,
+            SqueezeBertForSequenceClassification,
+            SqueezeBertForTokenClassification,
+            SqueezeBertModel,
+            SqueezeBertModule,
+            SqueezeBertPreTrainedModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/t5/__init__.py
+++ b/src/transformers/models/t5/__init__.py
@@ -16,31 +16,89 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_sentencepiece_available, is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_t5 import T5_PRETRAINED_CONFIG_ARCHIVE_MAP, T5Config
+from typing import TYPE_CHECKING
 
+from ...file_utils import (
+    _BaseLazyModule,
+    is_sentencepiece_available,
+    is_tf_available,
+    is_tokenizers_available,
+    is_torch_available,
+)
+
+
+_import_structure = {
+    "configuration_t5": ["T5_PRETRAINED_CONFIG_ARCHIVE_MAP", "T5Config"],
+}
 
 if is_sentencepiece_available():
-    from .tokenization_t5 import T5Tokenizer
+    _import_structure["tokenization_t5"] = ["T5Tokenizer"]
 
 if is_tokenizers_available():
-    from .tokenization_t5_fast import T5TokenizerFast
+    _import_structure["tokenization_t5_fast"] = ["T5TokenizerFast"]
 
 if is_torch_available():
-    from .modeling_t5 import (
-        T5_PRETRAINED_MODEL_ARCHIVE_LIST,
-        T5EncoderModel,
-        T5ForConditionalGeneration,
-        T5Model,
-        T5PreTrainedModel,
-        load_tf_weights_in_t5,
-    )
+    _import_structure["modeling_t5"] = [
+        "T5_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "T5EncoderModel",
+        "T5ForConditionalGeneration",
+        "T5Model",
+        "T5PreTrainedModel",
+        "load_tf_weights_in_t5",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_t5 import (
-        TF_T5_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFT5EncoderModel,
-        TFT5ForConditionalGeneration,
-        TFT5Model,
-        TFT5PreTrainedModel,
-    )
+    _import_structure["modeling_tf_t5"] = [
+        "TF_T5_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFT5EncoderModel",
+        "TFT5ForConditionalGeneration",
+        "TFT5Model",
+        "TFT5PreTrainedModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_t5 import T5_PRETRAINED_CONFIG_ARCHIVE_MAP, T5Config
+
+    if is_sentencepiece_available():
+        from .tokenization_t5 import T5Tokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_t5_fast import T5TokenizerFast
+
+    if is_torch_available():
+        from .modeling_t5 import (
+            T5_PRETRAINED_MODEL_ARCHIVE_LIST,
+            T5EncoderModel,
+            T5ForConditionalGeneration,
+            T5Model,
+            T5PreTrainedModel,
+            load_tf_weights_in_t5,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_t5 import (
+            TF_T5_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFT5EncoderModel,
+            TFT5ForConditionalGeneration,
+            TFT5Model,
+            TFT5PreTrainedModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/tapas/__init__.py
+++ b/src/transformers/models/tapas/__init__.py
@@ -16,16 +16,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_torch_available
-from .configuration_tapas import TAPAS_PRETRAINED_CONFIG_ARCHIVE_MAP, TapasConfig
-from .tokenization_tapas import TapasTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_torch_available
+
+
+_import_structure = {
+    "configuration_tapas": ["TAPAS_PRETRAINED_CONFIG_ARCHIVE_MAP", "TapasConfig"],
+    "tokenization_tapas": ["TapasTokenizer"],
+}
 
 if is_torch_available():
-    from .modeling_tapas import (
-        TAPAS_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TapasForMaskedLM,
-        TapasForQuestionAnswering,
-        TapasForSequenceClassification,
-        TapasModel,
-    )
+    _import_structure["modeling_tapas"] = [
+        "TAPAS_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TapasForMaskedLM",
+        "TapasForQuestionAnswering",
+        "TapasForSequenceClassification",
+        "TapasModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_tapas import TAPAS_PRETRAINED_CONFIG_ARCHIVE_MAP, TapasConfig
+    from .tokenization_tapas import TapasTokenizer
+
+    if is_torch_available():
+        from .modeling_tapas import (
+            TAPAS_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TapasForMaskedLM,
+            TapasForQuestionAnswering,
+            TapasForSequenceClassification,
+            TapasModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/transfo_xl/__init__.py
+++ b/src/transformers/models/transfo_xl/__init__.py
@@ -16,29 +16,79 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tf_available, is_torch_available
-from .configuration_transfo_xl import TRANSFO_XL_PRETRAINED_CONFIG_ARCHIVE_MAP, TransfoXLConfig
-from .tokenization_transfo_xl import TransfoXLCorpus, TransfoXLTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tf_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_transfo_xl": ["TRANSFO_XL_PRETRAINED_CONFIG_ARCHIVE_MAP", "TransfoXLConfig"],
+    "tokenization_transfo_xl": ["TransfoXLCorpus", "TransfoXLTokenizer"],
+}
 
 if is_torch_available():
-    from .modeling_transfo_xl import (
-        TRANSFO_XL_PRETRAINED_MODEL_ARCHIVE_LIST,
-        AdaptiveEmbedding,
-        TransfoXLForSequenceClassification,
-        TransfoXLLMHeadModel,
-        TransfoXLModel,
-        TransfoXLPreTrainedModel,
-        load_tf_weights_in_transfo_xl,
-    )
+    _import_structure["modeling_transfo_xl"] = [
+        "TRANSFO_XL_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "AdaptiveEmbedding",
+        "TransfoXLForSequenceClassification",
+        "TransfoXLLMHeadModel",
+        "TransfoXLModel",
+        "TransfoXLPreTrainedModel",
+        "load_tf_weights_in_transfo_xl",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_transfo_xl import (
-        TF_TRANSFO_XL_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFAdaptiveEmbedding,
-        TFTransfoXLForSequenceClassification,
-        TFTransfoXLLMHeadModel,
-        TFTransfoXLMainLayer,
-        TFTransfoXLModel,
-        TFTransfoXLPreTrainedModel,
-    )
+    _import_structure["modeling_tf_transfo_xl"] = [
+        "TF_TRANSFO_XL_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFAdaptiveEmbedding",
+        "TFTransfoXLForSequenceClassification",
+        "TFTransfoXLLMHeadModel",
+        "TFTransfoXLMainLayer",
+        "TFTransfoXLModel",
+        "TFTransfoXLPreTrainedModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_transfo_xl import TRANSFO_XL_PRETRAINED_CONFIG_ARCHIVE_MAP, TransfoXLConfig
+    from .tokenization_transfo_xl import TransfoXLCorpus, TransfoXLTokenizer
+
+    if is_torch_available():
+        from .modeling_transfo_xl import (
+            TRANSFO_XL_PRETRAINED_MODEL_ARCHIVE_LIST,
+            AdaptiveEmbedding,
+            TransfoXLForSequenceClassification,
+            TransfoXLLMHeadModel,
+            TransfoXLModel,
+            TransfoXLPreTrainedModel,
+            load_tf_weights_in_transfo_xl,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_transfo_xl import (
+            TF_TRANSFO_XL_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFAdaptiveEmbedding,
+            TFTransfoXLForSequenceClassification,
+            TFTransfoXLLMHeadModel,
+            TFTransfoXLMainLayer,
+            TFTransfoXLModel,
+            TFTransfoXLPreTrainedModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/xlm/__init__.py
+++ b/src/transformers/models/xlm/__init__.py
@@ -16,33 +16,87 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_tf_available, is_torch_available
-from .configuration_xlm import XLM_PRETRAINED_CONFIG_ARCHIVE_MAP, XLMConfig
-from .tokenization_xlm import XLMTokenizer
+from typing import TYPE_CHECKING
 
+from ...file_utils import _BaseLazyModule, is_tf_available, is_torch_available
+
+
+_import_structure = {
+    "configuration_xlm": ["XLM_PRETRAINED_CONFIG_ARCHIVE_MAP", "XLMConfig"],
+    "tokenization_xlm": ["XLMTokenizer"],
+}
 
 if is_torch_available():
-    from .modeling_xlm import (
-        XLM_PRETRAINED_MODEL_ARCHIVE_LIST,
-        XLMForMultipleChoice,
-        XLMForQuestionAnswering,
-        XLMForQuestionAnsweringSimple,
-        XLMForSequenceClassification,
-        XLMForTokenClassification,
-        XLMModel,
-        XLMPreTrainedModel,
-        XLMWithLMHeadModel,
-    )
+    _import_structure["modeling_xlm"] = [
+        "XLM_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "XLMForMultipleChoice",
+        "XLMForQuestionAnswering",
+        "XLMForQuestionAnsweringSimple",
+        "XLMForSequenceClassification",
+        "XLMForTokenClassification",
+        "XLMModel",
+        "XLMPreTrainedModel",
+        "XLMWithLMHeadModel",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_xlm import (
-        TF_XLM_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFXLMForMultipleChoice,
-        TFXLMForQuestionAnsweringSimple,
-        TFXLMForSequenceClassification,
-        TFXLMForTokenClassification,
-        TFXLMMainLayer,
-        TFXLMModel,
-        TFXLMPreTrainedModel,
-        TFXLMWithLMHeadModel,
-    )
+    _import_structure["modeling_tf_xlm"] = [
+        "TF_XLM_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFXLMForMultipleChoice",
+        "TFXLMForQuestionAnsweringSimple",
+        "TFXLMForSequenceClassification",
+        "TFXLMForTokenClassification",
+        "TFXLMMainLayer",
+        "TFXLMModel",
+        "TFXLMPreTrainedModel",
+        "TFXLMWithLMHeadModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_xlm import XLM_PRETRAINED_CONFIG_ARCHIVE_MAP, XLMConfig
+    from .tokenization_xlm import XLMTokenizer
+
+    if is_torch_available():
+        from .modeling_xlm import (
+            XLM_PRETRAINED_MODEL_ARCHIVE_LIST,
+            XLMForMultipleChoice,
+            XLMForQuestionAnswering,
+            XLMForQuestionAnsweringSimple,
+            XLMForSequenceClassification,
+            XLMForTokenClassification,
+            XLMModel,
+            XLMPreTrainedModel,
+            XLMWithLMHeadModel,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_xlm import (
+            TF_XLM_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFXLMForMultipleChoice,
+            TFXLMForQuestionAnsweringSimple,
+            TFXLMForSequenceClassification,
+            TFXLMForTokenClassification,
+            TFXLMMainLayer,
+            TFXLMModel,
+            TFXLMPreTrainedModel,
+            TFXLMWithLMHeadModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/xlm_roberta/__init__.py
+++ b/src/transformers/models/xlm_roberta/__init__.py
@@ -16,35 +16,97 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_sentencepiece_available, is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_xlm_roberta import XLM_ROBERTA_PRETRAINED_CONFIG_ARCHIVE_MAP, XLMRobertaConfig
+from typing import TYPE_CHECKING
 
+from ...file_utils import (
+    _BaseLazyModule,
+    is_sentencepiece_available,
+    is_tf_available,
+    is_tokenizers_available,
+    is_torch_available,
+)
+
+
+_import_structure = {
+    "configuration_xlm_roberta": ["XLM_ROBERTA_PRETRAINED_CONFIG_ARCHIVE_MAP", "XLMRobertaConfig"],
+}
 
 if is_sentencepiece_available():
-    from .tokenization_xlm_roberta import XLMRobertaTokenizer
+    _import_structure["tokenization_xlm_roberta"] = ["XLMRobertaTokenizer"]
 
 if is_tokenizers_available():
-    from .tokenization_xlm_roberta_fast import XLMRobertaTokenizerFast
+    _import_structure["tokenization_xlm_roberta_fast"] = ["XLMRobertaTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_xlm_roberta import (
-        XLM_ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST,
-        XLMRobertaForCausalLM,
-        XLMRobertaForMaskedLM,
-        XLMRobertaForMultipleChoice,
-        XLMRobertaForQuestionAnswering,
-        XLMRobertaForSequenceClassification,
-        XLMRobertaForTokenClassification,
-        XLMRobertaModel,
-    )
+    _import_structure["modeling_xlm_roberta"] = [
+        "XLM_ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "XLMRobertaForCausalLM",
+        "XLMRobertaForMaskedLM",
+        "XLMRobertaForMultipleChoice",
+        "XLMRobertaForQuestionAnswering",
+        "XLMRobertaForSequenceClassification",
+        "XLMRobertaForTokenClassification",
+        "XLMRobertaModel",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_xlm_roberta import (
-        TF_XLM_ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFXLMRobertaForMaskedLM,
-        TFXLMRobertaForMultipleChoice,
-        TFXLMRobertaForQuestionAnswering,
-        TFXLMRobertaForSequenceClassification,
-        TFXLMRobertaForTokenClassification,
-        TFXLMRobertaModel,
-    )
+    _import_structure["modeling_tf_xlm_roberta"] = [
+        "TF_XLM_ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFXLMRobertaForMaskedLM",
+        "TFXLMRobertaForMultipleChoice",
+        "TFXLMRobertaForQuestionAnswering",
+        "TFXLMRobertaForSequenceClassification",
+        "TFXLMRobertaForTokenClassification",
+        "TFXLMRobertaModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_xlm_roberta import XLM_ROBERTA_PRETRAINED_CONFIG_ARCHIVE_MAP, XLMRobertaConfig
+
+    if is_sentencepiece_available():
+        from .tokenization_xlm_roberta import XLMRobertaTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_xlm_roberta_fast import XLMRobertaTokenizerFast
+
+    if is_torch_available():
+        from .modeling_xlm_roberta import (
+            XLM_ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST,
+            XLMRobertaForCausalLM,
+            XLMRobertaForMaskedLM,
+            XLMRobertaForMultipleChoice,
+            XLMRobertaForQuestionAnswering,
+            XLMRobertaForSequenceClassification,
+            XLMRobertaForTokenClassification,
+            XLMRobertaModel,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_xlm_roberta import (
+            TF_XLM_ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFXLMRobertaForMaskedLM,
+            TFXLMRobertaForMultipleChoice,
+            TFXLMRobertaForQuestionAnswering,
+            TFXLMRobertaForSequenceClassification,
+            TFXLMRobertaForTokenClassification,
+            TFXLMRobertaModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/models/xlnet/__init__.py
+++ b/src/transformers/models/xlnet/__init__.py
@@ -16,39 +16,105 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...file_utils import is_sentencepiece_available, is_tf_available, is_tokenizers_available, is_torch_available
-from .configuration_xlnet import XLNET_PRETRAINED_CONFIG_ARCHIVE_MAP, XLNetConfig
+from typing import TYPE_CHECKING
 
+from ...file_utils import (
+    _BaseLazyModule,
+    is_sentencepiece_available,
+    is_tf_available,
+    is_tokenizers_available,
+    is_torch_available,
+)
+
+
+_import_structure = {
+    "configuration_xlnet": ["XLNET_PRETRAINED_CONFIG_ARCHIVE_MAP", "XLNetConfig"],
+}
 
 if is_sentencepiece_available():
-    from .tokenization_xlnet import XLNetTokenizer
+    _import_structure["tokenization_xlnet"] = ["XLNetTokenizer"]
 
 if is_tokenizers_available():
-    from .tokenization_xlnet_fast import XLNetTokenizerFast
+    _import_structure["tokenization_xlnet_fast"] = ["XLNetTokenizerFast"]
 
 if is_torch_available():
-    from .modeling_xlnet import (
-        XLNET_PRETRAINED_MODEL_ARCHIVE_LIST,
-        XLNetForMultipleChoice,
-        XLNetForQuestionAnswering,
-        XLNetForQuestionAnsweringSimple,
-        XLNetForSequenceClassification,
-        XLNetForTokenClassification,
-        XLNetLMHeadModel,
-        XLNetModel,
-        XLNetPreTrainedModel,
-        load_tf_weights_in_xlnet,
-    )
+    _import_structure["modeling_xlnet"] = [
+        "XLNET_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "XLNetForMultipleChoice",
+        "XLNetForQuestionAnswering",
+        "XLNetForQuestionAnsweringSimple",
+        "XLNetForSequenceClassification",
+        "XLNetForTokenClassification",
+        "XLNetLMHeadModel",
+        "XLNetModel",
+        "XLNetPreTrainedModel",
+        "load_tf_weights_in_xlnet",
+    ]
 
 if is_tf_available():
-    from .modeling_tf_xlnet import (
-        TF_XLNET_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TFXLNetForMultipleChoice,
-        TFXLNetForQuestionAnsweringSimple,
-        TFXLNetForSequenceClassification,
-        TFXLNetForTokenClassification,
-        TFXLNetLMHeadModel,
-        TFXLNetMainLayer,
-        TFXLNetModel,
-        TFXLNetPreTrainedModel,
-    )
+    _import_structure["modeling_tf_xlnet"] = [
+        "TF_XLNET_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFXLNetForMultipleChoice",
+        "TFXLNetForQuestionAnsweringSimple",
+        "TFXLNetForSequenceClassification",
+        "TFXLNetForTokenClassification",
+        "TFXLNetLMHeadModel",
+        "TFXLNetMainLayer",
+        "TFXLNetModel",
+        "TFXLNetPreTrainedModel",
+    ]
+
+
+if TYPE_CHECKING:
+    from .configuration_xlnet import XLNET_PRETRAINED_CONFIG_ARCHIVE_MAP, XLNetConfig
+
+    if is_sentencepiece_available():
+        from .tokenization_xlnet import XLNetTokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_xlnet_fast import XLNetTokenizerFast
+
+    if is_torch_available():
+        from .modeling_xlnet import (
+            XLNET_PRETRAINED_MODEL_ARCHIVE_LIST,
+            XLNetForMultipleChoice,
+            XLNetForQuestionAnswering,
+            XLNetForQuestionAnsweringSimple,
+            XLNetForSequenceClassification,
+            XLNetForTokenClassification,
+            XLNetLMHeadModel,
+            XLNetModel,
+            XLNetPreTrainedModel,
+            load_tf_weights_in_xlnet,
+        )
+
+    if is_tf_available():
+        from .modeling_tf_xlnet import (
+            TF_XLNET_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFXLNetForMultipleChoice,
+            TFXLNetForQuestionAnsweringSimple,
+            TFXLNetForSequenceClassification,
+            TFXLNetForTokenClassification,
+            TFXLNetLMHeadModel,
+            TFXLNetMainLayer,
+            TFXLNetModel,
+            TFXLNetPreTrainedModel,
+        )
+
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -25,7 +25,7 @@ import warnings
 from collections import OrderedDict, UserDict
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -44,22 +44,33 @@ from .file_utils import (
 )
 from .utils import logging
 
-
-if is_tf_available():
-    import tensorflow as tf
-
-if is_torch_available():
-    import torch
-
-if is_flax_available():
-    import jax.numpy as jnp
-
+if TYPE_CHECKING:
+    if is_torch_available():
+        import torch
+    if is_tf_available():
+        import tensorflow as tf
+    if is_flax_available():
+        import jax.numpy as jnp
 
 def _is_numpy(x):
     return isinstance(x, np.ndarray)
 
 
+def _is_torch(x):
+    import torch
+
+    return isinstance(x, torch.Tensor)
+
+
+def _is_tensorflow(x):
+    import tensorflow as tf
+
+    return isinstance(x, tf.Tensor)
+
+
 def _is_jax(x):
+    import jax.numpy as jnp
+
     return isinstance(x, jnp.ndarray)
 
 
@@ -196,9 +207,9 @@ def to_py_obj(obj):
         return {k: to_py_obj(v) for k, v in obj.items()}
     elif isinstance(obj, (list, tuple)):
         return [to_py_obj(o) for o in obj]
-    elif is_tf_available() and isinstance(obj, tf.Tensor):
+    elif is_tf_available() and _is_tensorflow(obj):
         return obj.numpy().tolist()
-    elif is_torch_available() and isinstance(obj, torch.Tensor):
+    elif is_torch_available() and _is_torch(obj):
         return obj.detach().cpu().tolist()
     elif isinstance(obj, np.ndarray):
         return obj.tolist()
@@ -714,16 +725,22 @@ class BatchEncoding(UserDict):
                 raise ImportError(
                     "Unable to convert output to TensorFlow tensors format, TensorFlow is not installed."
                 )
+            import tensorflow as tf
+
             as_tensor = tf.constant
             is_tensor = tf.is_tensor
         elif tensor_type == TensorType.PYTORCH:
             if not is_torch_available():
                 raise ImportError("Unable to convert output to PyTorch tensors format, PyTorch is not installed.")
+            import torch
+
             as_tensor = torch.tensor
             is_tensor = torch.is_tensor
         elif tensor_type == TensorType.JAX:
             if not is_flax_available():
                 raise ImportError("Unable to convert output to JAX tensors format, JAX is not installed.")
+            import jax.numpy as jnp
+
             as_tensor = jnp.array
             is_tensor = _is_jax
         else:
@@ -2684,9 +2701,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
                 first_element = encoded_inputs["input_ids"][index][0]
         # At this state, if `first_element` is still a list/tuple, it's an empty one so there is nothing to do.
         if not isinstance(first_element, (int, list, tuple)):
-            if is_tf_available() and isinstance(first_element, tf.Tensor):
+            if is_tf_available() and _is_tensorflow(first_element):
                 return_tensors = "tf" if return_tensors is None else return_tensors
-            elif is_torch_available() and isinstance(first_element, torch.Tensor):
+            elif is_torch_available() and _is_torch(first_element):
                 return_tensors = "pt" if return_tensors is None else return_tensors
             elif isinstance(first_element, np.ndarray):
                 return_tensors = "np" if return_tensors is None else return_tensors

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -44,6 +44,7 @@ from .file_utils import (
 )
 from .utils import logging
 
+
 if TYPE_CHECKING:
     if is_torch_available():
         import torch
@@ -51,6 +52,7 @@ if TYPE_CHECKING:
         import tensorflow as tf
     if is_flax_available():
         import jax.numpy as jnp
+
 
 def _is_numpy(x):
     return isinstance(x, np.ndarray)

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     if is_tf_available():
         import tensorflow as tf
     if is_flax_available():
-        import jax.numpy as jnp
+        import jax.numpy as jnp  # noqa: F401
 
 
 def _is_numpy(x):
@@ -71,7 +71,7 @@ def _is_tensorflow(x):
 
 
 def _is_jax(x):
-    import jax.numpy as jnp
+    import jax.numpy as jnp  # noqa: F811
 
     return isinstance(x, jnp.ndarray)
 
@@ -741,7 +741,7 @@ class BatchEncoding(UserDict):
         elif tensor_type == TensorType.JAX:
             if not is_flax_available():
                 raise ImportError("Unable to convert output to JAX tensors format, JAX is not installed.")
-            import jax.numpy as jnp
+            import jax.numpy as jnp  # noqa: F811
 
             as_tensor = jnp.array
             is_tensor = _is_jax

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/__init__.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/__init__.py
@@ -15,69 +15,150 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import TYPE_CHECKING
 
 {%- if cookiecutter.generate_tensorflow_and_pytorch == "PyTorch & TensorFlow" %}
-from ...file_utils import is_tf_available, is_torch_available, is_tokenizers_available
+from ...file_utils import _BaseLazyModule, is_tf_available, is_torch_available, is_tokenizers_available
 {%- elif cookiecutter.generate_tensorflow_and_pytorch == "PyTorch" %}
-from ...file_utils import is_torch_available, is_tokenizers_available
+from ...file_utils import _BaseLazyModule, is_torch_available, is_tokenizers_available
 {%- elif cookiecutter.generate_tensorflow_and_pytorch == "TensorFlow" %}
-from ...file_utils import is_tf_available, is_tokenizers_available
+from ...file_utils import _BaseLazyModule, is_tf_available, is_tokenizers_available
 {% endif %}
-from .configuration_{{cookiecutter.lowercase_modelname}} import {{cookiecutter.uppercase_modelname}}_PRETRAINED_CONFIG_ARCHIVE_MAP, {{cookiecutter.camelcase_modelname}}Config
-from .tokenization_{{cookiecutter.lowercase_modelname}} import {{cookiecutter.camelcase_modelname}}Tokenizer
+_import_structure = {
+    "configuration_{{cookiecutter.lowercase_modelname}}": ["{{cookiecutter.uppercase_modelname}}_PRETRAINED_CONFIG_ARCHIVE_MAP", "{{cookiecutter.camelcase_modelname}}Config"],
+    "tokenization_{{cookiecutter.lowercase_modelname}}": ["{{cookiecutter.camelcase_modelname}}Tokenizer"],
+}
 
 if is_tokenizers_available():
-    from .tokenization_{{cookiecutter.lowercase_modelname}}_fast import {{cookiecutter.camelcase_modelname}}TokenizerFast
+    _import_structure["tokenization_{{cookiecutter.lowercase_modelname}}_fast"] = ["{{cookiecutter.camelcase_modelname}}TokenizerFast"]
 
 {%- if (cookiecutter.generate_tensorflow_and_pytorch == "PyTorch & TensorFlow" or cookiecutter.generate_tensorflow_and_pytorch == "PyTorch") %}
 {% if cookiecutter.is_encoder_decoder_model == "False" %}
 if is_torch_available():
-    from .modeling_{{cookiecutter.lowercase_modelname}} import (
-        {{cookiecutter.uppercase_modelname}}_PRETRAINED_MODEL_ARCHIVE_LIST,
-        {{cookiecutter.camelcase_modelname}}ForMaskedLM,
-        {{cookiecutter.camelcase_modelname}}ForCausalLM,
-        {{cookiecutter.camelcase_modelname}}ForMultipleChoice,
-        {{cookiecutter.camelcase_modelname}}ForQuestionAnswering,
-        {{cookiecutter.camelcase_modelname}}ForSequenceClassification,
-        {{cookiecutter.camelcase_modelname}}ForTokenClassification,
-        {{cookiecutter.camelcase_modelname}}Layer,
-        {{cookiecutter.camelcase_modelname}}Model,
-        {{cookiecutter.camelcase_modelname}}PreTrainedModel,
-        load_tf_weights_in_{{cookiecutter.lowercase_modelname}},
-    )
+    _import_structure["modeling_{{cookiecutter.lowercase_modelname}}"] = [
+        "{{cookiecutter.uppercase_modelname}}_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "{{cookiecutter.camelcase_modelname}}ForMaskedLM",
+        "{{cookiecutter.camelcase_modelname}}ForCausalLM",
+        "{{cookiecutter.camelcase_modelname}}ForMultipleChoice",
+        "{{cookiecutter.camelcase_modelname}}ForQuestionAnswering",
+        "{{cookiecutter.camelcase_modelname}}ForSequenceClassification",
+        "{{cookiecutter.camelcase_modelname}}ForTokenClassification",
+        "{{cookiecutter.camelcase_modelname}}Layer",
+        "{{cookiecutter.camelcase_modelname}}Model",
+        "{{cookiecutter.camelcase_modelname}}PreTrainedModel",
+        "load_tf_weights_in_{{cookiecutter.lowercase_modelname}}",
+    ]
 {% else %}
 if is_torch_available():
-    from .modeling_{{cookiecutter.lowercase_modelname}} import (
-        {{cookiecutter.uppercase_modelname}}_PRETRAINED_MODEL_ARCHIVE_LIST,
-        {{cookiecutter.camelcase_modelname}}ForConditionalGeneration,
-        {{cookiecutter.camelcase_modelname}}ForQuestionAnswering,
-        {{cookiecutter.camelcase_modelname}}ForSequenceClassification,
-        {{cookiecutter.camelcase_modelname}}Model,
-        {{cookiecutter.camelcase_modelname}}PreTrainedModel,
-    )
+    _import_structure["modeling_{{cookiecutter.lowercase_modelname}}"] = [
+        "{{cookiecutter.uppercase_modelname}}_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "{{cookiecutter.camelcase_modelname}}ForConditionalGeneration",
+        "{{cookiecutter.camelcase_modelname}}ForQuestionAnswering",
+        "{{cookiecutter.camelcase_modelname}}ForSequenceClassification",
+        "{{cookiecutter.camelcase_modelname}}Model",
+        "{{cookiecutter.camelcase_modelname}}PreTrainedModel",
+    ]
 {% endif %}
 {% endif %}
 {%- if (cookiecutter.generate_tensorflow_and_pytorch == "PyTorch & TensorFlow" or cookiecutter.generate_tensorflow_and_pytorch == "TensorFlow") %}
 {% if cookiecutter.is_encoder_decoder_model == "False" %}
 if is_tf_available():
-    from .modeling_tf_{{cookiecutter.lowercase_modelname}} import (
-        TF_{{cookiecutter.uppercase_modelname}}_PRETRAINED_MODEL_ARCHIVE_LIST,
-        TF{{cookiecutter.camelcase_modelname}}ForMaskedLM,
-        TF{{cookiecutter.camelcase_modelname}}ForCausalLM,
-        TF{{cookiecutter.camelcase_modelname}}ForMultipleChoice,
-        TF{{cookiecutter.camelcase_modelname}}ForQuestionAnswering,
-        TF{{cookiecutter.camelcase_modelname}}ForSequenceClassification,
-        TF{{cookiecutter.camelcase_modelname}}ForTokenClassification,
-        TF{{cookiecutter.camelcase_modelname}}Layer,
-        TF{{cookiecutter.camelcase_modelname}}Model,
-        TF{{cookiecutter.camelcase_modelname}}PreTrainedModel,
-    )
+    _import_structure["modeling_tf_{{cookiecutter.lowercase_modelname}}"] = [
+        "TF_{{cookiecutter.uppercase_modelname}}_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TF{{cookiecutter.camelcase_modelname}}ForMaskedLM",
+        "TF{{cookiecutter.camelcase_modelname}}ForCausalLM",
+        "TF{{cookiecutter.camelcase_modelname}}ForMultipleChoice",
+        "TF{{cookiecutter.camelcase_modelname}}ForQuestionAnswering",
+        "TF{{cookiecutter.camelcase_modelname}}ForSequenceClassification",
+        "TF{{cookiecutter.camelcase_modelname}}ForTokenClassification",
+        "TF{{cookiecutter.camelcase_modelname}}Layer",
+        "TF{{cookiecutter.camelcase_modelname}}Model",
+        "TF{{cookiecutter.camelcase_modelname}}PreTrainedModel",
+    ]
 {% else %}
 if is_tf_available():
-    from .modeling_tf_{{cookiecutter.lowercase_modelname}} import (
-        TF{{cookiecutter.camelcase_modelname}}ForConditionalGeneration,
-        TF{{cookiecutter.camelcase_modelname}}Model,
-        TF{{cookiecutter.camelcase_modelname}}PreTrainedModel,
-    )
+    _import_structure["modeling_tf_{{cookiecutter.lowercase_modelname}}"] = [
+        "TF{{cookiecutter.camelcase_modelname}}ForConditionalGeneration",
+        "TF{{cookiecutter.camelcase_modelname}}Model",
+        "TF{{cookiecutter.camelcase_modelname}}PreTrainedModel",
+    ]
 {% endif %}
 {% endif %}
+
+
+if TYPE_CHECKING:
+    from .configuration_{{cookiecutter.lowercase_modelname}} import {{cookiecutter.uppercase_modelname}}_PRETRAINED_CONFIG_ARCHIVE_MAP, {{cookiecutter.camelcase_modelname}}Config
+    from .tokenization_{{cookiecutter.lowercase_modelname}} import {{cookiecutter.camelcase_modelname}}Tokenizer
+
+    if is_tokenizers_available():
+        from .tokenization_{{cookiecutter.lowercase_modelname}}_fast import {{cookiecutter.camelcase_modelname}}TokenizerFast
+
+{%- if (cookiecutter.generate_tensorflow_and_pytorch == "PyTorch & TensorFlow" or cookiecutter.generate_tensorflow_and_pytorch == "PyTorch") %}
+{% if cookiecutter.is_encoder_decoder_model == "False" %}
+    if is_torch_available():
+        from .modeling_{{cookiecutter.lowercase_modelname}} import (
+            {{cookiecutter.uppercase_modelname}}_PRETRAINED_MODEL_ARCHIVE_LIST,
+            {{cookiecutter.camelcase_modelname}}ForMaskedLM,
+            {{cookiecutter.camelcase_modelname}}ForCausalLM,
+            {{cookiecutter.camelcase_modelname}}ForMultipleChoice,
+            {{cookiecutter.camelcase_modelname}}ForQuestionAnswering,
+            {{cookiecutter.camelcase_modelname}}ForSequenceClassification,
+            {{cookiecutter.camelcase_modelname}}ForTokenClassification,
+            {{cookiecutter.camelcase_modelname}}Layer,
+            {{cookiecutter.camelcase_modelname}}Model,
+            {{cookiecutter.camelcase_modelname}}PreTrainedModel,
+            load_tf_weights_in_{{cookiecutter.lowercase_modelname}},
+        )
+{% else %}
+    if is_torch_available():
+        from .modeling_{{cookiecutter.lowercase_modelname}} import (
+            {{cookiecutter.uppercase_modelname}}_PRETRAINED_MODEL_ARCHIVE_LIST,
+            {{cookiecutter.camelcase_modelname}}ForConditionalGeneration,
+            {{cookiecutter.camelcase_modelname}}ForQuestionAnswering,
+            {{cookiecutter.camelcase_modelname}}ForSequenceClassification,
+            {{cookiecutter.camelcase_modelname}}Model,
+            {{cookiecutter.camelcase_modelname}}PreTrainedModel,
+        )
+{% endif %}
+{% endif %}
+{%- if (cookiecutter.generate_tensorflow_and_pytorch == "PyTorch & TensorFlow" or cookiecutter.generate_tensorflow_and_pytorch == "TensorFlow") %}
+{% if cookiecutter.is_encoder_decoder_model == "False" %}
+    if is_tf_available():
+        from .modeling_tf_{{cookiecutter.lowercase_modelname}} import (
+            TF_{{cookiecutter.uppercase_modelname}}_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TF{{cookiecutter.camelcase_modelname}}ForMaskedLM,
+            TF{{cookiecutter.camelcase_modelname}}ForCausalLM,
+            TF{{cookiecutter.camelcase_modelname}}ForMultipleChoice,
+            TF{{cookiecutter.camelcase_modelname}}ForQuestionAnswering,
+            TF{{cookiecutter.camelcase_modelname}}ForSequenceClassification,
+            TF{{cookiecutter.camelcase_modelname}}ForTokenClassification,
+            TF{{cookiecutter.camelcase_modelname}}Layer,
+            TF{{cookiecutter.camelcase_modelname}}Model,
+            TF{{cookiecutter.camelcase_modelname}}PreTrainedModel,
+        )
+{% else %}
+    if is_tf_available():
+        from .modeling_tf_{{cookiecutter.lowercase_modelname}} import (
+            TF{{cookiecutter.camelcase_modelname}}ForConditionalGeneration,
+            TF{{cookiecutter.camelcase_modelname}}Model,
+            TF{{cookiecutter.camelcase_modelname}}PreTrainedModel,
+        )
+{% endif %}
+{% endif %}
+else:
+    import importlib
+    import os
+    import sys
+
+    class _LazyModule(_BaseLazyModule):
+        """
+        Module class that surfaces all objects but only performs associated imports when the objects are requested.
+        """
+
+        __file__ = globals()["__file__"]
+        __path__ = [os.path.dirname(__file__)]
+
+        def _get_module(self, module_name: str):
+            return importlib.import_module("." + module_name, self.__name__)
+
+    sys.modules[__name__] = _LazyModule(__name__, _import_structure)


### PR DESCRIPTION
# What does this PR do?

This is the last PR to make the import of transformers and defer the imports of torch/tensorflow to when is necessary. It does the same work as #9446 but in each itnermediate init, so that
```
from transformers import BertModel
```
only imports torch and not TensorFlow (ans is thus very fast).

The templates are adapted to the new init format, so users adding models don't have to worry about this.
In passing, I noticed that the `tokenization_utils_base` was importing everything at init, so I deferred imports there to only do them when necessary. There might be a few places like this left, but we can address those later on.

Fixes #8733