### PR TITLE
Update run_glue for do_predict with local test data (#9442)

### DIFF
--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -421,10 +421,10 @@ def main():
             extension = data_args.test_file.split(".")[-1]
             assert extension in ["csv", "json"], "`test_file` should be a csv or a json file."
             if data_args.test_file.endswith(".csv"):
-                # Loading a dataset from local csv files
+                # Loading a dataset from a local csv file
                 test_dataset = load_dataset("csv", data_files={"test": data_args.test_file})
             else:
-                # Loading a dataset from local json files
+                # Loading a dataset from a local json file
                 test_dataset = load_dataset("json", data_files={"test": data_args.test_file})
             test_dataset = test_dataset.map(
                 preprocess_function, batched=True, load_from_cache_file=not data_args.overwrite_cache

--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -226,14 +226,10 @@ def main():
 
         if data_args.train_file.endswith(".csv"):
             # Loading a dataset from local csv files
-            datasets = load_dataset(
-                "csv", data_files=data_files
-            )
+            datasets = load_dataset("csv", data_files=data_files)
         else:
             # Loading a dataset from local json files
-            datasets = load_dataset(
-                "json", data_files=data_files
-            )
+            datasets = load_dataset("json", data_files=data_files)
     # See more about loading any type of standard or custom dataset at
     # https://huggingface.co/docs/datasets/loading_datasets.html.
 

--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -103,10 +103,12 @@ class DataTrainingArguments:
         elif self.train_file is None or self.validation_file is None:
             raise ValueError("Need either a GLUE task or a training/validation file.")
         else:
-            extension = self.train_file.split(".")[-1]
-            assert extension in ["csv", "json"], "`train_file` should be a csv or a json file."
-            extension = self.validation_file.split(".")[-1]
-            assert extension in ["csv", "json"], "`validation_file` should be a csv or a json file."
+            train_extension = self.train_file.split(".")[-1]
+            assert train_extension in ["csv", "json"], "`train_file` should be a csv or a json file."
+            validation_extension = self.validation_file.split(".")[-1]
+            assert (
+                validation_extension == train_extension
+            ), "`validation_file` should have the same extension (csv or json) as `train_file`."
 
 
 @dataclass
@@ -215,8 +217,11 @@ def main():
         # when you use `do_predict` without specifying a GLUE benchmark task.
         if training_args.do_predict:
             if data_args.test_file is not None:
-                extension = data_args.test_file.split(".")[-1]
-                assert extension in ["csv", "json"], "`test_file` should be a csv or a json file."
+                train_extension = data_args.train_file.split(".")[-1]
+                test_extension = data_args.test_file.split(".")[-1]
+                assert (
+                    test_extension == train_extension
+                ), "`test_file` should have the same extension (csv or json) as `train_file`."
                 data_files["test"] = data_args.test_file
             else:
                 raise ValueError("Need either a GLUE task or a test file for `do_predict`.")

--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -206,16 +206,34 @@ def main():
     if data_args.task_name is not None:
         # Downloading and loading a dataset from the hub.
         datasets = load_dataset("glue", data_args.task_name)
-    elif data_args.train_file.endswith(".csv"):
-        # Loading a dataset from local csv files
-        datasets = load_dataset(
-            "csv", data_files={"train": data_args.train_file, "validation": data_args.validation_file}
-        )
     else:
-        # Loading a dataset from local json files
-        datasets = load_dataset(
-            "json", data_files={"train": data_args.train_file, "validation": data_args.validation_file}
-        )
+        # Loading a dataset from your local files.
+        # CSV/JSON training and evaluation files are needed.
+        data_files = {"train": data_args.train_file, "validation": data_args.validation_file}
+
+        # Get the test dataset: you can provide your own CSV/JSON test file (see below)
+        # when you use `do_predict` without specifying a GLUE benchmark task.
+        if training_args.do_predict:
+            if data_args.test_file is not None:
+                extension = data_args.test_file.split(".")[-1]
+                assert extension in ["csv", "json"], "`test_file` should be a csv or a json file."
+                data_files["test"] = data_args.test_file
+            else:
+                raise ValueError("Need either a GLUE task or a test file for `do_predict`.")
+
+        for key in data_files.keys():
+            logger.info(f"load a local file for {key}: {data_files[key]}")
+
+        if data_args.train_file.endswith(".csv"):
+            # Loading a dataset from local csv files
+            datasets = load_dataset(
+                "csv", data_files=data_files
+            )
+        else:
+            # Loading a dataset from local json files
+            datasets = load_dataset(
+                "json", data_files=data_files
+            )
     # See more about loading any type of standard or custom dataset at
     # https://huggingface.co/docs/datasets/loading_datasets.html.
 
@@ -326,7 +344,7 @@ def main():
 
     train_dataset = datasets["train"]
     eval_dataset = datasets["validation_matched" if data_args.task_name == "mnli" else "validation"]
-    if data_args.task_name is not None:
+    if data_args.task_name is not None or data_args.test_file is not None:
         test_dataset = datasets["test_matched" if data_args.task_name == "mnli" else "test"]
 
     # Log a few random samples from the training set:
@@ -413,25 +431,6 @@ def main():
 
     if training_args.do_predict:
         logger.info("*** Test ***")
-
-        # Get the datasets: you can provide your own CSV/JSON test file (see below)
-        # when you use `do_predict` without specifying a GLUE benchmark task.
-
-        if data_args.task_name is None and data_args.test_file is not None:
-            extension = data_args.test_file.split(".")[-1]
-            assert extension in ["csv", "json"], "`test_file` should be a csv or a json file."
-            if data_args.test_file.endswith(".csv"):
-                # Loading a dataset from a local csv file
-                test_dataset = load_dataset("csv", data_files={"test": data_args.test_file})
-            else:
-                # Loading a dataset from a local json file
-                test_dataset = load_dataset("json", data_files={"test": data_args.test_file})
-            test_dataset = test_dataset.map(
-                preprocess_function, batched=True, load_from_cache_file=not data_args.overwrite_cache
-            )
-            test_dataset = test_dataset["test"]
-        else:
-            raise ValueError("Need either a GLUE task or a test file for `do_predict`.")
 
         # Loop to handle MNLI double evaluation (matched, mis-matched)
         tasks = [data_args.task_name]


### PR DESCRIPTION
# What does this PR do?

Currently, run_glue.py cannot use the test set (`do_predict`) unless we give it a GLUE task name.
This PR will allow us to use the local test dataset.

As commented in #9442, I tried to achieve the functionality with only simple changes.

- It still works with only the local train and valid files (in other words, this PR does not break the current operation.).
- If we add `--do_predict` with out adding specific params, we will get an error statement saying that we need either the GLUE task name or the path of the local test file.

Fixes #9442 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sgugger

Thank you for your kind comments on the issue. 
I have tried to keep it simple and hope there is no problem as an example script.