### PR TITLE
Make doc styler detect lists on rst and better support for Windows

### DIFF
--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -99,6 +99,7 @@ An instantiated benchmark object can then simply be run by calling ``benchmark.r
     --------------------------------------------------------------------------------
 
     ====================        ENVIRONMENT INFORMATION         ====================
+
     - transformers_version: 2.11.0
     - framework: PyTorch
     - use_torchscript: False
@@ -145,6 +146,7 @@ An instantiated benchmark object can then simply be run by calling ``benchmark.r
     --------------------------------------------------------------------------------
 
     ====================        ENVIRONMENT INFORMATION         ====================
+
     - transformers_version: 2.11.0
     - framework: Tensorflow
     - use_xla: False
@@ -228,6 +230,7 @@ configurations must be inserted with the benchmark args as follows.
     --------------------------------------------------------------------------------
 
     ====================        ENVIRONMENT INFORMATION         ====================
+
     - transformers_version: 2.11.0
     - framework: PyTorch
     - use_torchscript: False
@@ -297,6 +300,7 @@ configurations must be inserted with the benchmark args as follows.
     --------------------------------------------------------------------------------
 
     ====================        ENVIRONMENT INFORMATION         ====================
+
     - transformers_version: 2.11.0
     - framework: Tensorflow
     - use_xla: False

--- a/utils/style_doc.py
+++ b/utils/style_doc.py
@@ -381,9 +381,9 @@ def style_rst_file(doc_file, max_len=119, check_only=False):
         doc = f.read()
 
     # Add missing new lines before lists
-    doc = _add_new_lines_before_list(doc)
+    clean_doc = _add_new_lines_before_list(doc)
     # Style
-    clean_doc = rst_styler.style(doc, max_len=max_len)
+    clean_doc = rst_styler.style(clean_doc, max_len=max_len)
 
     diff = clean_doc != doc
     if not check_only and diff:


### PR DESCRIPTION
# What does this PR do?

The new lines for the lists in rst files were not actually added because I made a mistake, this PR fixes that. @patrickvonplaten it adds some new lines in the benchmarking files which I think are okay, but let me know if I should write some special code to get the scripts to ignore them.

Also, changed the line that added the new lines before doc special words since it seems to be not working properly on Windows. Let's see if this version is better!

(Failures are because master is red at the time of this PR.)

Fixes #9438