### PR TITLE
[TF Led] Fix flaky TF Led test

### DIFF
--- a/tests/test_modeling_tf_led.py
+++ b/tests/test_modeling_tf_led.py
@@ -166,7 +166,13 @@ def prepare_led_inputs_dict(
     if attention_mask is None:
         attention_mask = tf.cast(tf.math.not_equal(input_ids, config.pad_token_id), tf.int8)
     if decoder_attention_mask is None:
-        decoder_attention_mask = tf.cast(tf.math.not_equal(decoder_input_ids, config.pad_token_id), tf.int8)
+        decoder_attention_mask = tf.concat(
+            [
+                tf.ones(decoder_input_ids[:, :1].shape, dtype=tf.int8),
+                tf.cast(tf.math.not_equal(decoder_input_ids[:, 1:], config.pad_token_id), tf.int8),
+            ],
+            axis=-1,
+        )
     return {
         "input_ids": input_ids,
         "attention_mask": attention_mask,


### PR DESCRIPTION
# What does this PR do?

The reason why the TF LED test is flaky was not fully fixed in: https://github.com/huggingface/transformers/pull/9459
and is actually the following: 

Currently the `decoder_attention_mask` can have a `0` at its first input:

```python
decoder_attention_mask[:, 0] == 0
```

Since the decoder uses a causal mask, this however leads to problems as a softmax over only very large negative numbers in computed. Now since TF and PT use slightly different large numbers, we can see significant differences between the models. The solution is to make sure that the `decoder_attention_mask` used for the `tf_pt_equivalence` test cannot be zero at the first position (I've done the same changes for all TFBart models in: https://github.com/huggingface/transformers/pull/9497 and also made sure in https://github.com/huggingface/transformers/pull/9497 that the TF templates are correctly updated )

