### PR TITLE
[make docs] parallel build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,4 +67,4 @@ test-examples:
 # Check that docs can build
 
 docs:
-	cd docs && make html SPHINXOPTS="-W"
+	cd docs && make html SPHINXOPTS="-W -j 4"


### PR DESCRIPTION
This PR enables multi-worker doc building.

After experimenting with different number of workers https://github.com/huggingface/transformers/issues/9496#issuecomment-758145868 4-5 workers seems to be the most optimal - let's go with 4 as surely we wouldn't find a cpu with less cores these days.

Fixes part of https://github.com/huggingface/transformers/issues/9496

@sgugger
