### PR TITLE
fix BlenderbotSmallTokenizer

### DIFF
--- a/src/transformers/models/blenderbot_small/tokenization_blenderbot_small.py
+++ b/src/transformers/models/blenderbot_small/tokenization_blenderbot_small.py
@@ -92,6 +92,7 @@ class BlenderbotSmallTokenizer(PreTrainedTokenizer):
         },
     }
     max_model_input_sizes = {"facebook/blenderbot_small-90M": 512}
+    model_input_names = ["attention_mask"]
 
     def __init__(
         self,

--- a/tests/test_modeling_blenderbot_small.py
+++ b/tests/test_modeling_blenderbot_small.py
@@ -302,8 +302,6 @@ class Blenderbot90MIntegrationTests(unittest.TestCase):
     def test_90_generation_from_short_input(self):
         model_inputs = self.tokenizer(["sam"], return_tensors="pt").to(torch_device)
 
-        # model does not have "token_type_ids"
-        model_inputs.pop("token_type_ids")
         generated_utterances = self.model.generate(**model_inputs)
 
         clean_txt = self.tokenizer.decode(

--- a/tests/test_modeling_blenderbot_small.py
+++ b/tests/test_modeling_blenderbot_small.py
@@ -288,8 +288,6 @@ class Blenderbot90MIntegrationTests(unittest.TestCase):
 
         model_inputs = self.tokenizer(src_text, return_tensors="pt").to(torch_device)
 
-        # model does not have "token_type_ids"
-        model_inputs.pop("token_type_ids")
         assert isinstance(self.tokenizer, BlenderbotSmallTokenizer)
         generated_ids = self.model.generate(**model_inputs)[0]
         reply = self.tokenizer.decode(generated_ids, skip_special_tokens=True, clean_up_tokenization_spaces=True)


### PR DESCRIPTION
# What does this PR do?
`BlenderbotSmallTokenizer` returns `token_type_ids` but those are not needed by the model. This PR fixes the tokniezer to not return `token_type_ids`