### PR TITLE
LayoutLM Config

### DIFF
--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -460,6 +460,7 @@ MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING = OrderedDict(
         (LongformerConfig, LongformerForSequenceClassification),
         (RobertaConfig, RobertaForSequenceClassification),
         (SqueezeBertConfig, SqueezeBertForSequenceClassification),
+        (LayoutLMConfig, LayoutLMForSequenceClassification),
         (BertConfig, BertForSequenceClassification),
         (XLNetConfig, XLNetForSequenceClassification),
         (MobileBertConfig, MobileBertForSequenceClassification),
@@ -475,7 +476,6 @@ MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING = OrderedDict(
         (TransfoXLConfig, TransfoXLForSequenceClassification),
         (MPNetConfig, MPNetForSequenceClassification),
         (TapasConfig, TapasForSequenceClassification),
-        (LayoutLMConfig, LayoutLMForSequenceClassification),
     ]
 )
 

--- a/tests/test_modeling_auto.py
+++ b/tests/test_modeling_auto.py
@@ -241,7 +241,7 @@ class AutoModelTest(unittest.TestCase):
                 for parent_config, parent_model in mapping[: index + 1]:
                     assert not issubclass(
                         child_config, parent_config
-                    ), "{child_config.__name__} is child of {parent_config.__name__}"
+                    ), f"{child_config.__name__} is child of {parent_config.__name__}"
                     assert not issubclass(
                         child_model, parent_model
-                    ), "{child_config.__name__} is child of {parent_config.__name__}"
+                    ), f"{child_config.__name__} is child of {parent_config.__name__}"


### PR DESCRIPTION
The `LayoutLM` configuration inherits from `BertConfig`, which should be fixed.

This was failing the `test_parents_and_children_in_mappings` test as it was placed after the `BertConfig` in the `AutoModelForSequenceClassification` test.