### PR TITLE
Use the right version of tokenizers

### DIFF
--- a/.github/workflows/github-torch-hub.yml
+++ b/.github/workflows/github-torch-hub.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install torch
-        pip install numpy filelock protobuf requests tqdm regex sentencepiece sacremoses tokenizers packaging importlib_metadata
+        pip install numpy filelock protobuf requests tqdm regex sentencepiece sacremoses tokenizers==0.9.4 packaging importlib_metadata
 
     - name: Torch hub list
       run: |

--- a/.github/workflows/github-torch-hub.yml
+++ b/.github/workflows/github-torch-hub.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install torch
-        pip install numpy filelock protobuf requests tqdm regex sentencepiece sacremoses tokenizers==0.9.4 packaging importlib_metadata
+        pip install -U $(PYTHONPATH="src" python -c 'import sys; from transformers.dependency_versions_table import deps; print(" ".join([ deps[x] for x in sys.argv[1:]]))' numpy filelock protobuf requests tqdm regex sentencepiece sacremoses tokenizers packaging importlib_metadata)
 
     - name: Torch hub list
       run: |

--- a/.github/workflows/github-torch-hub.yml
+++ b/.github/workflows/github-torch-hub.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install torch
-        pip install -U $(PYTHONPATH="src" python -c 'import sys; from transformers.dependency_versions_table import deps; print(" ".join([ deps[x] for x in sys.argv[1:]]))' numpy filelock protobuf requests tqdm regex sentencepiece sacremoses tokenizers packaging importlib_metadata)
+        pip install numpy filelock protobuf requests tqdm regex sentencepiece sacremoses tokenizers==0.9.4 packaging importlib_metadata
 
     - name: Torch hub list
       run: |

--- a/hubconf.py
+++ b/hubconf.py
@@ -30,7 +30,7 @@ from transformers import (
 )
 # from transformers.dependency_versions_table import deps
 
-dependencies = ["torch", "numpy", "tokenizers==0.9.4", "filelock", "requests", "tqdm", "regex", "sentencepiece", "sacremoses", "importlib_metadata"]
+dependencies = ["torch", "numpy", "tokenizers", "filelock", "requests", "tqdm", "regex", "sentencepiece", "sacremoses", "importlib_metadata"]
 
 
 @add_start_docstrings(AutoConfig.__doc__)

--- a/hubconf.py
+++ b/hubconf.py
@@ -28,10 +28,10 @@ from transformers import (
     AutoTokenizer,
     add_start_docstrings,
 )
-from transformers.dependency_versions_table import deps
+# from transformers.dependency_versions_table import deps
 
 dependencies = ["torch", "numpy", "filelock", "requests", "tqdm", "regex", "sentencepiece", "sacremoses", "importlib_metadata"]
-dependencies += deps["tokenizers"]
+dependencies += ["tokenizers==0.9.4"]
 
 
 @add_start_docstrings(AutoConfig.__doc__)

--- a/hubconf.py
+++ b/hubconf.py
@@ -30,8 +30,7 @@ from transformers import (
 )
 # from transformers.dependency_versions_table import deps
 
-dependencies = ["torch", "numpy", "filelock", "requests", "tqdm", "regex", "sentencepiece", "sacremoses", "importlib_metadata"]
-dependencies += ["tokenizers==0.9.4"]
+dependencies = ["torch", "numpy", "tokenizers==0.9.4", "filelock", "requests", "tqdm", "regex", "sentencepiece", "sacremoses", "importlib_metadata"]
 
 
 @add_start_docstrings(AutoConfig.__doc__)

--- a/hubconf.py
+++ b/hubconf.py
@@ -28,9 +28,10 @@ from transformers import (
     AutoTokenizer,
     add_start_docstrings,
 )
+from transformers.dependency_versions_table import deps
 
-
-dependencies = ["torch", "numpy", "tokenizers", "filelock", "requests", "tqdm", "regex", "sentencepiece", "sacremoses", "importlib_metadata"]
+dependencies = ["torch", "numpy", "filelock", "requests", "tqdm", "regex", "sentencepiece", "sacremoses", "importlib_metadata"]
+dependencies += deps["tokenizers"]
 
 
 @add_start_docstrings(AutoConfig.__doc__)

--- a/hubconf.py
+++ b/hubconf.py
@@ -28,7 +28,7 @@ from transformers import (
     AutoTokenizer,
     add_start_docstrings,
 )
-# from transformers.dependency_versions_table import deps
+
 
 dependencies = ["torch", "numpy", "tokenizers", "filelock", "requests", "tqdm", "regex", "sentencepiece", "sacremoses", "importlib_metadata"]
 


### PR DESCRIPTION
# What does this PR do?

Pulls the version of tokenziers from our deps in the `hubconf.py` otherwise it might install a version of tokenizers that is more recent (if available on pypi). When that is the case, the check of our packages fails at import.