### PR TITLE
[CI] use correct deps for torchhub

### DIFF
--- a/.github/workflows/github-torch-hub.yml
+++ b/.github/workflows/github-torch-hub.yml
@@ -1,6 +1,6 @@
 name: Torch hub integration
 
-on: 
+on:
   push:
     branches:
       - "*"
@@ -32,8 +32,10 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
-        pip install torch
-        pip install numpy filelock protobuf requests tqdm regex sentencepiece sacremoses tokenizers==0.9.4 packaging importlib_metadata
+        # install torch-hub specific dependencies
+        pip install -e git+https://github.com/huggingface/transformers.git#egg=transformers[torchhub]
+        # no longer needed
+        pip uninstall -y transformers
 
     - name: Torch hub list
       run: |

--- a/setup.py
+++ b/setup.py
@@ -229,6 +229,8 @@ extras["dev"] = (
     + extras["modelcreation"]
 )
 
+extras["torchhub"] = deps_list("filelock", "importlib_metadata", "numpy", "packaging", "protobuf", "regex",
+                               "requests", "sacremoses", "sentencepiece", "torch", "tokenizers", "tqdm")
 
 # when modifying the following list, make sure to update src/transformers/dependency_versions_check.py
 install_requires = [


### PR DESCRIPTION
As a follow up to https://github.com/huggingface/transformers/pull/9550, here is a clean solution that requires only one source  (`setup.py`) to edit for dependencies and groups of thereof.

The PR 
1. defines a new dependency group for `torchhub` in `setup.py`
2. installs the exact dependencies of that group inside .github workflow
3. uninstalls  `transformers` since Sylvain said it shouldn't be there, but it had to be installed to get the deps easily.

Of course, it'll need to be merged first for:
```
pip install -e git+https://github.com/huggingface/transformers.git#egg=transformers[torchhub]
```
to work, since it's not there now... meanwhile you can test it from this branch:
```
pip install -e git+https://github.com/stas00/transformers.git@torchhub-deps#egg=transformers[torchhub]
```

-------------

Alternatively to:
```
pip install -e git+https://github.com/huggingface/transformers.git#egg=transformers[torchhub]
pip uninstall -y transformers
```
we can do:
```
git clone https://github.com/huggingface/transformers
cd transformers
pip install -e .[torchhub]
pip uninstall -y transformers
```
for a few fractions of seconds faster.

----------------

Yet, another approach it to extend `setup.py` with what I created here a few year back:

https://github.com/fastai/fastai1/blob/a8327427ad5137c4899a1b4f74745193c9ea5be3/setup.py#L11-L22

This then:
```
python setup.py -q deps --dep-groups=torchhub
```
would dump the dependencies just for the specified extra groups, which can then be fed to `pip install`, so there will be no need to install the main package. Literally, the above command would just dump `extras["torchhub"]` in this case.

--------------

Finally, we could make `src/transformers/dependency_versions_table.py` contain the full dependency groups as well, and again then it'll just be needed to get one's hands on that file to extract groups of dependencies, e.g.:

```
wget https://raw.githubusercontent.com/huggingface/transformers/master/src/transformers/dependency_versions_table.py
python -c 'import sys; from dependency_versions_table import dep_group; print(dep_group[sys.argv[1]])' torchhub
```
this is hypothetical since we don't currently have `dep_group` dict in `dependency_versions_table.py`.

@sgugger, @LysandreJik  