### PR TITLE
[setup.py] note on how to get to transformers exact dependencies from shell

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ deps = {b: a for a, b in (re.findall(r"^(([^!=<>]+)(?:[!=<>].*)?$)", x)[0] for x
 #
 # Just pass the desired package names to that script as it's shown with 2 packages above.
 #
-# If transformers is not yet installed remember and the work is done from the cloned repo add `PYTHONPATH=src to the script above`
+# If transformers is not yet installed and the work is done from the cloned repo remember to add `PYTHONPATH=src` to the script above
 #
 # You can then feed this for example to `pip`:
 #

--- a/setup.py
+++ b/setup.py
@@ -140,9 +140,29 @@ _deps = [
 ]
 
 
-# tokenizers: "tokenizers==0.9.4" lookup table
-# support non-versions file too so that they can be checked at run time
+# this is a lookup table with items like:
+#
+# tokenizers: "tokenizers==0.9.4"
+# packaging: "packaging"
+#
+# some of the values are versioned whereas others aren't.
 deps = {b: a for a, b in (re.findall(r"^(([^!=<>]+)(?:[!=<>].*)?$)", x)[0] for x in _deps)}
+
+# since we save this data in src/transformers/dependency_versions_table.py it can be easily accessed from
+# anywhere. If you need to quickly access the data from this table in a shell, you can do so easily with:
+#
+# python -c 'import sys; from transformers.dependency_versions_table import deps; \
+# print(" ".join([ deps[x] for x in sys.argv[1:]]))' tokenizers datasets
+#
+# just pass the desired package names to that script as it's shown with 2 packages above
+#
+# If transformers is not yet installed remember and the work is done from the cloned repo add `PYTHONPATH=src to the script above`
+#
+# you can then feed this for example to `pip`
+#
+# pip install -U $(python -c 'import sys; from transformers.dependency_versions_table import deps; \
+# print(" ".join([ deps[x] for x in sys.argv[1:]]))' tokenizers datasets)
+#
 
 
 def deps_list(*pkgs):

--- a/setup.py
+++ b/setup.py
@@ -154,11 +154,11 @@ deps = {b: a for a, b in (re.findall(r"^(([^!=<>]+)(?:[!=<>].*)?$)", x)[0] for x
 # python -c 'import sys; from transformers.dependency_versions_table import deps; \
 # print(" ".join([ deps[x] for x in sys.argv[1:]]))' tokenizers datasets
 #
-# just pass the desired package names to that script as it's shown with 2 packages above
+# Just pass the desired package names to that script as it's shown with 2 packages above.
 #
 # If transformers is not yet installed remember and the work is done from the cloned repo add `PYTHONPATH=src to the script above`
 #
-# you can then feed this for example to `pip`
+# You can then feed this for example to `pip`:
 #
 # pip install -U $(python -c 'import sys; from transformers.dependency_versions_table import deps; \
 # print(" ".join([ deps[x] for x in sys.argv[1:]]))' tokenizers datasets)


### PR DESCRIPTION
As a follow up to #9550, this PR adds a few handy one liners to quickly access the correct dependency versions from shell.

e.g if you want to install deps for a group of packages we control and with their correct versions, you just need to run:

```
pip install -U $(python -c 'import sys; from transformers.dependency_versions_table import deps; \
print(" ".join([deps[x] for x in sys.argv[1:]]))' numpy filelock protobuf requests tqdm regex \
sentencepiece sacremoses tokenizers packaging importlib_metadata)
```

that was one option for torchhub, but since it didn't have `transformers` installed it didn't work and a different solution was provided https://github.com/huggingface/transformers/pull/9552

@sgugger, @LysandreJik 