### PR TITLE
Fix classification script: enable dynamic padding with truncation

### DIFF
--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -283,11 +283,9 @@ def main():
     # Padding strategy
     if data_args.pad_to_max_length:
         padding = "max_length"
-        max_length = data_args.max_seq_length
     else:
         # We will pad later, dynamically at batch creation, to the max sequence length in each batch
         padding = False
-        max_length = None
 
     # Some models have set the order of the labels to use, so let's make sure we do use it.
     label_to_id = None
@@ -314,7 +312,7 @@ def main():
         args = (
             (examples[sentence1_key],) if sentence2_key is None else (examples[sentence1_key], examples[sentence2_key])
         )
-        result = tokenizer(*args, padding=padding, max_length=max_length, truncation=True)
+        result = tokenizer(*args, padding=padding, max_length=data_args.max_seq_length, truncation=True)
 
         # Map labels to IDs (not necessary for GLUE tasks)
         if label_to_id is not None and "label" in examples:


### PR DESCRIPTION
# What does this PR do?

To fix the issue (below) in the run_glue.pl script, tokenizer's `max_length` value is now assigned directly with `max_seq_length` argument. Now it is possible to truncate the sequence and use dynamic padding. By default `max_length` is 128, which means truncation to 128 tokens. To disable truncation, set `max_length = None`.

Fixes #9551 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? https://github.com/huggingface/transformers/issues/9551#issue-784679542
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?
@sgugger 