### PR TITLE
Fix barthez tokenizer

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -199,7 +199,6 @@ TOKENIZER_MAPPING = OrderedDict(
         (AlbertConfig, (AlbertTokenizer, AlbertTokenizerFast)),
         (CamembertConfig, (CamembertTokenizer, CamembertTokenizerFast)),
         (PegasusConfig, (PegasusTokenizer, PegasusTokenizerFast)),
-        (MBartConfig, (BarthezTokenizer, BarthezTokenizerFast)),
         (MBartConfig, (MBartTokenizer, MBartTokenizerFast)),
         (XLMRobertaConfig, (XLMRobertaTokenizer, XLMRobertaTokenizerFast)),
         (MarianConfig, (MarianTokenizer, None)),
@@ -243,6 +242,7 @@ NO_CONFIG_TOKENIZER = [
     HerbertTokenizer,
     HerbertTokenizerFast,
     PhobertTokenizer,
+    BarthezTokenizer,
 ]
 
 


### PR DESCRIPTION
The barthez tokenizer should be put in the "no config tokenizer", as two tokenizers with the same configs can't be put together.

Running the [following code](https://github.com/huggingface/transformers/issues/9422#issuecomment-759327863) works now:

```py
from transformers import AutoTokenizer

barthez_tokenizer = AutoTokenizer.from_pretrained("moussaKam/barthez")
```