### PR TITLE
Remove unused token_type_ids in MPNet

### DIFF
--- a/src/transformers/models/mpnet/modeling_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_mpnet.py
@@ -17,7 +17,6 @@
 
 
 import math
-import warnings
 
 import torch
 from torch import nn

--- a/src/transformers/models/mpnet/modeling_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_mpnet.py
@@ -796,7 +796,7 @@ class MPNetForMultipleChoice(MPNetPreTrainedModel):
             num_choices-1]`` where :obj:`num_choices` is the size of the second dimension of the input tensors. (See
             :obj:`input_ids` above)
         """
-        
+
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         num_choices = input_ids.shape[1] if input_ids is not None else inputs_embeds.shape[1]
 
@@ -887,7 +887,7 @@ class MPNetForTokenClassification(MPNetPreTrainedModel):
             Labels for computing the token classification loss. Indices should be in ``[0, ..., config.num_labels -
             1]``.
         """
-        
+
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         outputs = self.mpnet(

--- a/src/transformers/models/mpnet/modeling_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_mpnet.py
@@ -524,11 +524,6 @@ class MPNetModel(MPNetPreTrainedModel):
         return_dict=None,
         **kwargs,
     ):
-        if "token_type_ids" in kwargs:
-            warnings.warn(
-                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
-            )
-
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -603,7 +598,6 @@ class MPNetForMaskedLM(MPNetPreTrainedModel):
         self,
         input_ids=None,
         attention_mask=None,
-        token_type_ids=None,
         position_ids=None,
         head_mask=None,
         inputs_embeds=None,
@@ -618,11 +612,6 @@ class MPNetForMaskedLM(MPNetPreTrainedModel):
             config.vocab_size]`` (see ``input_ids`` docstring) Tokens with indices set to ``-100`` are ignored
             (masked), the loss is only computed for the tokens with labels in ``[0, ..., config.vocab_size]``
         """
-        if token_type_ids is not None:
-            warnings.warn(
-                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
-            )
-
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         outputs = self.mpnet(
@@ -711,7 +700,6 @@ class MPNetForSequenceClassification(MPNetPreTrainedModel):
         self,
         input_ids=None,
         attention_mask=None,
-        token_type_ids=None,
         position_ids=None,
         head_mask=None,
         inputs_embeds=None,
@@ -726,10 +714,6 @@ class MPNetForSequenceClassification(MPNetPreTrainedModel):
             config.num_labels - 1]`. If :obj:`config.num_labels == 1` a regression loss is computed (Mean-Square loss),
             If :obj:`config.num_labels > 1` a classification loss is computed (Cross-Entropy).
         """
-        if token_type_ids is not None:
-            warnings.warn(
-                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
-            )
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
@@ -797,7 +781,6 @@ class MPNetForMultipleChoice(MPNetPreTrainedModel):
     def forward(
         self,
         input_ids=None,
-        token_type_ids=None,
         attention_mask=None,
         position_ids=None,
         head_mask=None,
@@ -813,11 +796,7 @@ class MPNetForMultipleChoice(MPNetPreTrainedModel):
             num_choices-1]`` where :obj:`num_choices` is the size of the second dimension of the input tensors. (See
             :obj:`input_ids` above)
         """
-        if token_type_ids is not None:
-            warnings.warn(
-                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
-            )
-
+        
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         num_choices = input_ids.shape[1] if input_ids is not None else inputs_embeds.shape[1]
 
@@ -895,7 +874,6 @@ class MPNetForTokenClassification(MPNetPreTrainedModel):
         self,
         input_ids=None,
         attention_mask=None,
-        token_type_ids=None,
         position_ids=None,
         head_mask=None,
         inputs_embeds=None,
@@ -909,11 +887,7 @@ class MPNetForTokenClassification(MPNetPreTrainedModel):
             Labels for computing the token classification loss. Indices should be in ``[0, ..., config.num_labels -
             1]``.
         """
-        if token_type_ids is not None:
-            warnings.warn(
-                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
-            )
-
+        
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         outputs = self.mpnet(
@@ -1008,7 +982,6 @@ class MPNetForQuestionAnswering(MPNetPreTrainedModel):
         self,
         input_ids=None,
         attention_mask=None,
-        token_type_ids=None,
         position_ids=None,
         head_mask=None,
         inputs_embeds=None,
@@ -1028,11 +1001,6 @@ class MPNetForQuestionAnswering(MPNetPreTrainedModel):
             Positions are clamped to the length of the sequence (:obj:`sequence_length`). Position outside of the
             sequence are not taken into account for computing the loss.
         """
-
-        if token_type_ids is not None:
-            warnings.warn(
-                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
-            )
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 

--- a/src/transformers/models/mpnet/modeling_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_mpnet.py
@@ -18,7 +18,6 @@
 
 import math
 import warnings
-from logging import warning
 
 import torch
 from torch import nn

--- a/src/transformers/models/mpnet/modeling_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_mpnet.py
@@ -526,7 +526,7 @@ class MPNetModel(MPNetPreTrainedModel):
     ):
         if "token_type_ids" in kwargs:
             warnings.warn(
-                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
             )
 
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
@@ -620,7 +620,7 @@ class MPNetForMaskedLM(MPNetPreTrainedModel):
         """
         if token_type_ids is not None:
             warnings.warn(
-                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
             )
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -728,7 +728,7 @@ class MPNetForSequenceClassification(MPNetPreTrainedModel):
         """
         if token_type_ids is not None:
             warnings.warn(
-                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
             )
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -815,7 +815,7 @@ class MPNetForMultipleChoice(MPNetPreTrainedModel):
         """
         if token_type_ids is not None:
             warnings.warn(
-                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
             )
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -911,7 +911,7 @@ class MPNetForTokenClassification(MPNetPreTrainedModel):
         """
         if token_type_ids is not None:
             warnings.warn(
-                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
             )
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -1031,7 +1031,7 @@ class MPNetForQuestionAnswering(MPNetPreTrainedModel):
 
         if token_type_ids is not None:
             warnings.warn(
-                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
             )
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict

--- a/src/transformers/models/mpnet/modeling_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_mpnet.py
@@ -17,6 +17,8 @@
 
 
 import math
+import warnings
+from logging import warning
 
 import torch
 from torch import nn
@@ -523,6 +525,11 @@ class MPNetModel(MPNetPreTrainedModel):
         return_dict=None,
         **kwargs,
     ):
+        if "token_type_ids" in kwargs:
+            warnings.warn(
+                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+            )
+
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -612,12 +619,16 @@ class MPNetForMaskedLM(MPNetPreTrainedModel):
             config.vocab_size]`` (see ``input_ids`` docstring) Tokens with indices set to ``-100`` are ignored
             (masked), the loss is only computed for the tokens with labels in ``[0, ..., config.vocab_size]``
         """
+        if token_type_ids is not None:
+            warnings.warn(
+                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+            )
+
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         outputs = self.mpnet(
             input_ids,
             attention_mask=attention_mask,
-            token_type_ids=token_type_ids,
             position_ids=position_ids,
             head_mask=head_mask,
             inputs_embeds=inputs_embeds,
@@ -716,12 +727,16 @@ class MPNetForSequenceClassification(MPNetPreTrainedModel):
             config.num_labels - 1]`. If :obj:`config.num_labels == 1` a regression loss is computed (Mean-Square loss),
             If :obj:`config.num_labels > 1` a classification loss is computed (Cross-Entropy).
         """
+        if token_type_ids is not None:
+            warnings.warn(
+                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+            )
+
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         outputs = self.mpnet(
             input_ids,
             attention_mask=attention_mask,
-            token_type_ids=token_type_ids,
             position_ids=position_ids,
             head_mask=head_mask,
             inputs_embeds=inputs_embeds,
@@ -799,12 +814,16 @@ class MPNetForMultipleChoice(MPNetPreTrainedModel):
             num_choices-1]`` where :obj:`num_choices` is the size of the second dimension of the input tensors. (See
             :obj:`input_ids` above)
         """
+        if token_type_ids is not None:
+            warnings.warn(
+                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+            )
+
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         num_choices = input_ids.shape[1] if input_ids is not None else inputs_embeds.shape[1]
 
         flat_input_ids = input_ids.view(-1, input_ids.size(-1)) if input_ids is not None else None
         flat_position_ids = position_ids.view(-1, position_ids.size(-1)) if position_ids is not None else None
-        flat_token_type_ids = token_type_ids.view(-1, token_type_ids.size(-1)) if token_type_ids is not None else None
         flat_attention_mask = attention_mask.view(-1, attention_mask.size(-1)) if attention_mask is not None else None
         flat_inputs_embeds = (
             inputs_embeds.view(-1, inputs_embeds.size(-2), inputs_embeds.size(-1))
@@ -815,7 +834,6 @@ class MPNetForMultipleChoice(MPNetPreTrainedModel):
         outputs = self.mpnet(
             flat_input_ids,
             position_ids=flat_position_ids,
-            token_type_ids=flat_token_type_ids,
             attention_mask=flat_attention_mask,
             head_mask=head_mask,
             inputs_embeds=flat_inputs_embeds,
@@ -892,12 +910,16 @@ class MPNetForTokenClassification(MPNetPreTrainedModel):
             Labels for computing the token classification loss. Indices should be in ``[0, ..., config.num_labels -
             1]``.
         """
+        if token_type_ids is not None:
+            warnings.warn(
+                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+            )
+
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         outputs = self.mpnet(
             input_ids,
             attention_mask=attention_mask,
-            token_type_ids=token_type_ids,
             position_ids=position_ids,
             head_mask=head_mask,
             inputs_embeds=inputs_embeds,
@@ -1008,12 +1030,16 @@ class MPNetForQuestionAnswering(MPNetPreTrainedModel):
             sequence are not taken into account for computing the loss.
         """
 
+        if token_type_ids is not None:
+            warnings.warn(
+                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+            )
+
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         outputs = self.mpnet(
             input_ids,
             attention_mask=attention_mask,
-            token_type_ids=token_type_ids,
             position_ids=position_ids,
             head_mask=head_mask,
             inputs_embeds=inputs_embeds,

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -551,7 +551,6 @@ class TFMPNetMainLayer(tf.keras.layers.Layer):
         """
         raise NotImplementedError
 
-    # Copied from transformers.models.bert.modeling_tf_bert.TFBertMainLayer.call
     def call(
         self,
         input_ids=None,

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -752,7 +752,6 @@ class TFMPNetModel(TFMPNetPreTrainedModel):
         self,
         input_ids=None,
         attention_mask=None,
-        token_type_ids=None,
         position_ids=None,
         head_mask=None,
         inputs_embeds=None,
@@ -762,11 +761,6 @@ class TFMPNetModel(TFMPNetPreTrainedModel):
         training=False,
         **kwargs,
     ):
-        if token_type_ids is not None:
-            warnings.warn(
-                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
-            )
-
         inputs = input_processing(
             func=self.call,
             config=self.config,
@@ -883,7 +877,6 @@ class TFMPNetForMaskedLM(TFMPNetPreTrainedModel, TFMaskedLanguageModelingLoss):
         self,
         input_ids=None,
         attention_mask=None,
-        token_type_ids=None,
         position_ids=None,
         head_mask=None,
         inputs_embeds=None,
@@ -900,11 +893,7 @@ class TFMPNetForMaskedLM(TFMPNetPreTrainedModel, TFMaskedLanguageModelingLoss):
             config.vocab_size]`` (see ``input_ids`` docstring) Tokens with indices set to ``-100`` are ignored
             (masked), the loss is only computed for the tokens with labels in ``[0, ..., config.vocab_size]``
         """
-        if token_type_ids is not None:
-            warnings.warn(
-                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
-            )
-
+        
         inputs = input_processing(
             func=self.call,
             config=self.config,
@@ -1009,7 +998,6 @@ class TFMPNetForSequenceClassification(TFMPNetPreTrainedModel, TFSequenceClassif
         self,
         input_ids=None,
         attention_mask=None,
-        token_type_ids=None,
         position_ids=None,
         head_mask=None,
         inputs_embeds=None,
@@ -1026,11 +1014,7 @@ class TFMPNetForSequenceClassification(TFMPNetPreTrainedModel, TFSequenceClassif
             config.num_labels - 1]`. If :obj:`config.num_labels == 1` a regression loss is computed (Mean-Square loss),
             If :obj:`config.num_labels > 1` a classification loss is computed (Cross-Entropy).
         """
-        if token_type_ids is not None:
-            warnings.warn(
-                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
-            )
-
+        
         inputs = input_processing(
             func=self.call,
             config=self.config,
@@ -1120,7 +1104,6 @@ class TFMPNetForMultipleChoice(TFMPNetPreTrainedModel, TFMultipleChoiceLoss):
         self,
         input_ids=None,
         attention_mask=None,
-        token_type_ids=None,
         position_ids=None,
         head_mask=None,
         inputs_embeds=None,
@@ -1142,7 +1125,6 @@ class TFMPNetForMultipleChoice(TFMPNetPreTrainedModel, TFMultipleChoiceLoss):
             config=self.config,
             input_ids=input_ids,
             attention_mask=attention_mask,
-            token_type_ids=token_type_ids,
             position_ids=position_ids,
             head_mask=head_mask,
             inputs_embeds=inputs_embeds,
@@ -1254,7 +1236,6 @@ class TFMPNetForTokenClassification(TFMPNetPreTrainedModel, TFTokenClassificatio
         self,
         input_ids=None,
         attention_mask=None,
-        token_type_ids=None,
         position_ids=None,
         head_mask=None,
         inputs_embeds=None,
@@ -1270,11 +1251,7 @@ class TFMPNetForTokenClassification(TFMPNetPreTrainedModel, TFTokenClassificatio
             Labels for computing the token classification loss. Indices should be in ``[0, ..., config.num_labels -
             1]``.
         """
-        if token_type_ids is not None:
-            warnings.warn(
-                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
-            )
-
+        
         inputs = input_processing(
             func=self.call,
             config=self.config,
@@ -1358,7 +1335,6 @@ class TFMPNetForQuestionAnswering(TFMPNetPreTrainedModel, TFQuestionAnsweringLos
         self,
         input_ids=None,
         attention_mask=None,
-        token_type_ids=None,
         position_ids=None,
         head_mask=None,
         inputs_embeds=None,
@@ -1380,11 +1356,7 @@ class TFMPNetForQuestionAnswering(TFMPNetPreTrainedModel, TFQuestionAnsweringLos
             Positions are clamped to the length of the sequence (:obj:`sequence_length`). Position outside of the
             sequence are not taken into account for computing the loss.
         """
-        if token_type_ids is not None:
-            warnings.warn(
-                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
-            )
-
+        
         inputs = input_processing(
             func=self.call,
             config=self.config,

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -556,7 +556,6 @@ class TFMPNetMainLayer(tf.keras.layers.Layer):
         self,
         input_ids=None,
         attention_mask=None,
-        token_type_ids=None,
         position_ids=None,
         head_mask=None,
         inputs_embeds=None,
@@ -566,11 +565,6 @@ class TFMPNetMainLayer(tf.keras.layers.Layer):
         training=False,
         **kwargs,
     ):
-        if token_type_ids is not None:
-            warnings.warn(
-                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
-            )
-
         inputs = input_processing(
             func=self.call,
             config=self.config,
@@ -585,6 +579,7 @@ class TFMPNetMainLayer(tf.keras.layers.Layer):
             training=training,
             kwargs_call=kwargs,
         )
+        print(inputs)
         if inputs["input_ids"] is not None and inputs["inputs_embeds"] is not None:
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif inputs["input_ids"] is not None:
@@ -770,7 +765,7 @@ class TFMPNetModel(TFMPNetPreTrainedModel):
     ):
         if token_type_ids is not None:
             warnings.warn(
-                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
             )
 
         inputs = input_processing(
@@ -908,7 +903,7 @@ class TFMPNetForMaskedLM(TFMPNetPreTrainedModel, TFMaskedLanguageModelingLoss):
         """
         if token_type_ids is not None:
             warnings.warn(
-                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
             )
 
         inputs = input_processing(
@@ -1034,7 +1029,7 @@ class TFMPNetForSequenceClassification(TFMPNetPreTrainedModel, TFSequenceClassif
         """
         if token_type_ids is not None:
             warnings.warn(
-                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
             )
 
         inputs = input_processing(
@@ -1278,7 +1273,7 @@ class TFMPNetForTokenClassification(TFMPNetPreTrainedModel, TFTokenClassificatio
         """
         if token_type_ids is not None:
             warnings.warn(
-                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
             )
 
         inputs = input_processing(
@@ -1388,7 +1383,7 @@ class TFMPNetForQuestionAnswering(TFMPNetPreTrainedModel, TFQuestionAnsweringLos
         """
         if token_type_ids is not None:
             warnings.warn(
-                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+                "The argument `token_type_ids` is not used in this model and will be ignored. It will also be removed in a next release."
             )
 
         inputs = input_processing(

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -578,7 +578,7 @@ class TFMPNetMainLayer(tf.keras.layers.Layer):
             training=training,
             kwargs_call=kwargs,
         )
-        print(inputs)
+
         if inputs["input_ids"] is not None and inputs["inputs_embeds"] is not None:
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif inputs["input_ids"] is not None:
@@ -893,7 +893,7 @@ class TFMPNetForMaskedLM(TFMPNetPreTrainedModel, TFMaskedLanguageModelingLoss):
             config.vocab_size]`` (see ``input_ids`` docstring) Tokens with indices set to ``-100`` are ignored
             (masked), the loss is only computed for the tokens with labels in ``[0, ..., config.vocab_size]``
         """
-        
+
         inputs = input_processing(
             func=self.call,
             config=self.config,
@@ -1014,7 +1014,7 @@ class TFMPNetForSequenceClassification(TFMPNetPreTrainedModel, TFSequenceClassif
             config.num_labels - 1]`. If :obj:`config.num_labels == 1` a regression loss is computed (Mean-Square loss),
             If :obj:`config.num_labels > 1` a classification loss is computed (Cross-Entropy).
         """
-        
+
         inputs = input_processing(
             func=self.call,
             config=self.config,
@@ -1251,7 +1251,7 @@ class TFMPNetForTokenClassification(TFMPNetPreTrainedModel, TFTokenClassificatio
             Labels for computing the token classification loss. Indices should be in ``[0, ..., config.num_labels -
             1]``.
         """
-        
+
         inputs = input_processing(
             func=self.call,
             config=self.config,
@@ -1356,7 +1356,7 @@ class TFMPNetForQuestionAnswering(TFMPNetPreTrainedModel, TFQuestionAnsweringLos
             Positions are clamped to the length of the sequence (:obj:`sequence_length`). Position outside of the
             sequence are not taken into account for computing the loss.
         """
-        
+
         inputs = input_processing(
             func=self.call,
             config=self.config,

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -155,7 +155,7 @@ class TFMPNetEmbeddings(tf.keras.layers.Layer):
         Get token embeddings of inputs
 
         Args:
-            inputs: list of three int64 tensors with shape [batch_size, length]: (input_ids, position_ids)
+            inputs: list of two int64 tensors with shape [batch_size, length]: (input_ids, position_ids)
             mode: string, a valid value is one of "embedding" and "linear"
 
         Returns:

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -147,7 +147,6 @@ class TFMPNetEmbeddings(tf.keras.layers.Layer):
         self,
         input_ids=None,
         position_ids=None,
-        token_type_ids=None,
         inputs_embeds=None,
         mode="embedding",
         training=False,
@@ -156,7 +155,7 @@ class TFMPNetEmbeddings(tf.keras.layers.Layer):
         Get token embeddings of inputs
 
         Args:
-            inputs: list of three int64 tensors with shape [batch_size, length]: (input_ids, position_ids, token_type_ids)
+            inputs: list of three int64 tensors with shape [batch_size, length]: (input_ids, position_ids)
             mode: string, a valid value is one of "embedding" and "linear"
 
         Returns:
@@ -169,13 +168,13 @@ class TFMPNetEmbeddings(tf.keras.layers.Layer):
             https://github.com/tensorflow/models/blob/a009f4fb9d2fc4949e32192a944688925ef78659/official/transformer/v2/embedding_layer.py#L24
         """
         if mode == "embedding":
-            return self._embedding(input_ids, position_ids, token_type_ids, inputs_embeds, training=training)
+            return self._embedding(input_ids, position_ids, inputs_embeds, training=training)
         elif mode == "linear":
             return self._linear(input_ids)
         else:
             raise ValueError("mode {} is not valid.".format(mode))
 
-    def _embedding(self, input_ids, position_ids, token_type_ids, inputs_embeds, training=False):
+    def _embedding(self, input_ids, position_ids, inputs_embeds, training=False):
         """Applies embedding based on inputs tensor."""
         assert not (input_ids is None and inputs_embeds is None)
 
@@ -567,12 +566,16 @@ class TFMPNetMainLayer(tf.keras.layers.Layer):
         training=False,
         **kwargs,
     ):
+        if token_type_ids is not None:
+            warnings.warn(
+                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+            )
+
         inputs = input_processing(
             func=self.call,
             config=self.config,
             input_ids=input_ids,
             attention_mask=attention_mask,
-            token_type_ids=token_type_ids,
             position_ids=position_ids,
             head_mask=head_mask,
             inputs_embeds=inputs_embeds,
@@ -594,13 +597,9 @@ class TFMPNetMainLayer(tf.keras.layers.Layer):
         if inputs["attention_mask"] is None:
             inputs["attention_mask"] = tf.fill(input_shape, 1)
 
-        if inputs["token_type_ids"] is None:
-            inputs["token_type_ids"] = tf.fill(input_shape, 0)
-
         embedding_output = self.embeddings(
             inputs["input_ids"],
             inputs["position_ids"],
-            inputs["token_type_ids"],
             inputs["inputs_embeds"],
             training=inputs["training"],
         )
@@ -682,9 +681,9 @@ MPNET_START_DOCSTRING = r"""
 
         - a single Tensor with :obj:`input_ids` only and nothing else: :obj:`model(inputs_ids)`
         - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
-          :obj:`model([input_ids, attention_mask])` or :obj:`model([input_ids, attention_mask, token_type_ids])`
+          :obj:`model([input_ids, attention_mask])`
         - a dictionary with one or several input Tensors associated to the input names given in the docstring:
-          :obj:`model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+          :obj:`model({"input_ids": input_ids, "attention_mask": attention_mask})`
 
     Args:
         config (:class:`~transformers.MPNetConfig`): Model configuration class with all the parameters of the model.
@@ -710,14 +709,6 @@ MPNET_INPUTS_DOCSTRING = r"""
             - 0 for tokens that are **masked**.
 
             `What are attention masks? <../glossary.html#attention-mask>`__
-        token_type_ids (:obj:`Numpy array` or :obj:`tf.Tensor` of shape :obj:`({0})`, `optional`):
-            Segment token indices to indicate first and second portions of the inputs. Indices are selected in ``[0,
-            1]``:
-
-            - 0 corresponds to a `sentence A` token,
-            - 1 corresponds to a `sentence B` token.
-
-            `What are token type IDs? <../glossary.html#token-type-ids>`__
         position_ids (:obj:`Numpy array` or :obj:`tf.Tensor` of shape :obj:`({0})`, `optional`):
             Indices of positions of each input sequence tokens in the position embeddings. Selected in the range ``[0,
             config.max_position_embeddings - 1]``.
@@ -777,12 +768,16 @@ class TFMPNetModel(TFMPNetPreTrainedModel):
         training=False,
         **kwargs,
     ):
+        if token_type_ids is not None:
+            warnings.warn(
+                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+            )
+
         inputs = input_processing(
             func=self.call,
             config=self.config,
             input_ids=input_ids,
             attention_mask=attention_mask,
-            token_type_ids=token_type_ids,
             position_ids=position_ids,
             head_mask=head_mask,
             inputs_embeds=inputs_embeds,
@@ -795,7 +790,6 @@ class TFMPNetModel(TFMPNetPreTrainedModel):
         outputs = self.mpnet(
             input_ids=inputs["input_ids"],
             attention_mask=inputs["attention_mask"],
-            token_type_ids=inputs["token_type_ids"],
             position_ids=inputs["position_ids"],
             head_mask=inputs["head_mask"],
             inputs_embeds=inputs["inputs_embeds"],
@@ -912,12 +906,16 @@ class TFMPNetForMaskedLM(TFMPNetPreTrainedModel, TFMaskedLanguageModelingLoss):
             config.vocab_size]`` (see ``input_ids`` docstring) Tokens with indices set to ``-100`` are ignored
             (masked), the loss is only computed for the tokens with labels in ``[0, ..., config.vocab_size]``
         """
+        if token_type_ids is not None:
+            warnings.warn(
+                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+            )
+
         inputs = input_processing(
             func=self.call,
             config=self.config,
             input_ids=input_ids,
             attention_mask=attention_mask,
-            token_type_ids=token_type_ids,
             position_ids=position_ids,
             head_mask=head_mask,
             inputs_embeds=inputs_embeds,
@@ -931,7 +929,6 @@ class TFMPNetForMaskedLM(TFMPNetPreTrainedModel, TFMaskedLanguageModelingLoss):
         outputs = self.mpnet(
             inputs["input_ids"],
             attention_mask=inputs["attention_mask"],
-            token_type_ids=inputs["token_type_ids"],
             position_ids=inputs["position_ids"],
             head_mask=inputs["head_mask"],
             inputs_embeds=inputs["inputs_embeds"],
@@ -1035,12 +1032,16 @@ class TFMPNetForSequenceClassification(TFMPNetPreTrainedModel, TFSequenceClassif
             config.num_labels - 1]`. If :obj:`config.num_labels == 1` a regression loss is computed (Mean-Square loss),
             If :obj:`config.num_labels > 1` a classification loss is computed (Cross-Entropy).
         """
+        if token_type_ids is not None:
+            warnings.warn(
+                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+            )
+
         inputs = input_processing(
             func=self.call,
             config=self.config,
             input_ids=input_ids,
             attention_mask=attention_mask,
-            token_type_ids=token_type_ids,
             position_ids=position_ids,
             head_mask=head_mask,
             inputs_embeds=inputs_embeds,
@@ -1054,7 +1055,6 @@ class TFMPNetForSequenceClassification(TFMPNetPreTrainedModel, TFSequenceClassif
         outputs = self.mpnet(
             inputs["input_ids"],
             attention_mask=inputs["attention_mask"],
-            token_type_ids=inputs["token_type_ids"],
             position_ids=inputs["position_ids"],
             head_mask=inputs["head_mask"],
             inputs_embeds=inputs["inputs_embeds"],
@@ -1171,9 +1171,6 @@ class TFMPNetForMultipleChoice(TFMPNetPreTrainedModel, TFMultipleChoiceLoss):
         flat_attention_mask = (
             tf.reshape(inputs["attention_mask"], (-1, seq_length)) if inputs["attention_mask"] is not None else None
         )
-        flat_token_type_ids = (
-            tf.reshape(inputs["token_type_ids"], (-1, seq_length)) if inputs["token_type_ids"] is not None else None
-        )
         flat_position_ids = (
             tf.reshape(inputs["position_ids"], (-1, seq_length)) if inputs["position_ids"] is not None else None
         )
@@ -1185,7 +1182,6 @@ class TFMPNetForMultipleChoice(TFMPNetPreTrainedModel, TFMultipleChoiceLoss):
         outputs = self.mpnet(
             flat_input_ids,
             flat_attention_mask,
-            flat_token_type_ids,
             flat_position_ids,
             inputs["head_mask"],
             flat_inputs_embeds,
@@ -1280,12 +1276,16 @@ class TFMPNetForTokenClassification(TFMPNetPreTrainedModel, TFTokenClassificatio
             Labels for computing the token classification loss. Indices should be in ``[0, ..., config.num_labels -
             1]``.
         """
+        if token_type_ids is not None:
+            warnings.warn(
+                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+            )
+
         inputs = input_processing(
             func=self.call,
             config=self.config,
             input_ids=input_ids,
             attention_mask=attention_mask,
-            token_type_ids=token_type_ids,
             position_ids=position_ids,
             head_mask=head_mask,
             inputs_embeds=inputs_embeds,
@@ -1299,7 +1299,6 @@ class TFMPNetForTokenClassification(TFMPNetPreTrainedModel, TFTokenClassificatio
         outputs = self.mpnet(
             input_ids=inputs["input_ids"],
             attention_mask=inputs["attention_mask"],
-            token_type_ids=inputs["token_type_ids"],
             position_ids=inputs["position_ids"],
             head_mask=inputs["head_mask"],
             inputs_embeds=inputs["inputs_embeds"],
@@ -1387,12 +1386,16 @@ class TFMPNetForQuestionAnswering(TFMPNetPreTrainedModel, TFQuestionAnsweringLos
             Positions are clamped to the length of the sequence (:obj:`sequence_length`). Position outside of the
             sequence are not taken into account for computing the loss.
         """
+        if token_type_ids is not None:
+            warnings.warn(
+                "The argument `token_type_ids` is not used is this model and will be ignored. It will also be removed in a next release."
+            )
+
         inputs = input_processing(
             func=self.call,
             config=self.config,
             input_ids=input_ids,
             attention_mask=attention_mask,
-            token_type_ids=token_type_ids,
             position_ids=position_ids,
             head_mask=head_mask,
             inputs_embeds=inputs_embeds,
@@ -1407,7 +1410,6 @@ class TFMPNetForQuestionAnswering(TFMPNetPreTrainedModel, TFQuestionAnsweringLos
         outputs = self.mpnet(
             inputs["input_ids"],
             attention_mask=inputs["attention_mask"],
-            token_type_ids=inputs["token_type_ids"],
             position_ids=inputs["position_ids"],
             head_mask=inputs["head_mask"],
             inputs_embeds=inputs["inputs_embeds"],

--- a/src/transformers/models/mpnet/tokenization_mpnet.py
+++ b/src/transformers/models/mpnet/tokenization_mpnet.py
@@ -122,6 +122,7 @@ class MPNetTokenizer(PreTrainedTokenizer):
     pretrained_vocab_files_map = PRETRAINED_VOCAB_FILES_MAP
     pretrained_init_configuration = PRETRAINED_INIT_CONFIGURATION
     max_model_input_sizes = PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES
+    model_input_names = ["attention_mask"]
 
     def __init__(
         self,

--- a/src/transformers/models/mpnet/tokenization_mpnet_fast.py
+++ b/src/transformers/models/mpnet/tokenization_mpnet_fast.py
@@ -102,6 +102,7 @@ class MPNetTokenizerFast(PreTrainedTokenizerFast):
     pretrained_init_configuration = PRETRAINED_INIT_CONFIGURATION
     max_model_input_sizes = PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES
     slow_tokenizer_class = MPNetTokenizer
+    model_input_names = ["attention_mask"]
 
     def __init__(
         self,


### PR DESCRIPTION
# What does this PR do?

This PR adds a warning when the argument `token_type_ids` is given a show a message saying that this argument is never used. I just supressed the internal appearance of this argument without modifying the method signatures in order to do not integrates a breaking change.

Should I update the Tokenizer to make it returns only `attention_mask`?
