### PR TITLE
Compliancy with tf-nightly

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -89,10 +89,13 @@ if USE_TF in ENV_VARS_TRUE_AND_AUTO_VALUES and USE_TORCH not in ENV_VARS_TRUE_VA
             try:
                 _tf_version = importlib_metadata.version("tensorflow-cpu")
             except importlib_metadata.PackageNotFoundError:
-                _tf_version = None
-                _tf_available = False
+                try:
+                    _tf_version = importlib_metadata.version("tf-nightly")
+                except importlib_metadata.PackageNotFoundError:
+                    _tf_version = None
+                    _tf_available = False
     if _tf_available:
-        if version.parse(_tf_version) < version.parse("2"):
+        if version.parse(_tf_version) < version.parse("2.3"):
             logger.info(f"TensorFlow found but with version {_tf_version}. Transformers requires version 2 minimum.")
             _tf_available = False
         else:

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -90,12 +90,21 @@ if USE_TF in ENV_VARS_TRUE_AND_AUTO_VALUES and USE_TORCH not in ENV_VARS_TRUE_VA
                 _tf_version = importlib_metadata.version("tensorflow-cpu")
             except importlib_metadata.PackageNotFoundError:
                 try:
-                    _tf_version = importlib_metadata.version("tf-nightly")
+                    _tf_version = importlib_metadata.version("tensorflow-gpu")
                 except importlib_metadata.PackageNotFoundError:
-                    _tf_version = None
-                    _tf_available = False
+                    try:
+                        _tf_version = importlib_metadata.version("tf-nightly")
+                    except importlib_metadata.PackageNotFoundError:
+                        try:
+                            _tf_version = importlib_metadata.version("tf-nightly-cpu")
+                        except importlib_metadata.PackageNotFoundError:
+                            try:
+                                _tf_version = importlib_metadata.version("tf-nightly-gpu")
+                            except importlib_metadata.PackageNotFoundError:
+                                _tf_version = None
+                                _tf_available = False
     if _tf_available:
-        if version.parse(_tf_version) < version.parse("2.3"):
+        if version.parse(_tf_version) < version.parse("2"):
             logger.info(f"TensorFlow found but with version {_tf_version}. Transformers requires version 2 minimum.")
             _tf_available = False
         else:


### PR DESCRIPTION
# What does this PR do?

This PR makes the lib able to be used with the nightly builds of TensorFlow. And fix an issue with the min TensorFlow version.