### PR TITLE
Ignore lm_head decoder bias warning

### DIFF
--- a/src/transformers/models/roberta/modeling_roberta.py
+++ b/src/transformers/models/roberta/modeling_roberta.py
@@ -827,7 +827,7 @@ class RobertaModel(RobertaPreTrainedModel):
     """RoBERTa Model with a `language modeling` head on top for CLM fine-tuning. """, ROBERTA_START_DOCSTRING
 )
 class RobertaForCausalLM(RobertaPreTrainedModel):
-    _keys_to_ignore_on_load_missing = [r"position_ids", r"predictions.decoder.bias"]
+    _keys_to_ignore_on_load_missing = [r"position_ids", r"lm_head.decoder.bias"]
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
 
     def __init__(self, config):
@@ -973,7 +973,7 @@ class RobertaForCausalLM(RobertaPreTrainedModel):
 
 @add_start_docstrings("""RoBERTa Model with a `language modeling` head on top. """, ROBERTA_START_DOCSTRING)
 class RobertaForMaskedLM(RobertaPreTrainedModel):
-    _keys_to_ignore_on_load_missing = [r"position_ids", r"predictions.decoder.bias"]
+    _keys_to_ignore_on_load_missing = [r"position_ids", r"lm_head.decoder.bias"]
     _keys_to_ignore_on_load_unexpected = [r"pooler"]
 
     def __init__(self, config):

--- a/src/transformers/models/xlm_roberta/modeling_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/modeling_xlm_roberta.py
@@ -70,7 +70,6 @@ class XLMRobertaModel(RobertaModel):
     documentation alongside usage examples.
     """
 
-    _keys_to_ignore_on_load_missing = [r"lm_head.decoder.bias", "position_ids"]
     config_class = XLMRobertaConfig
 
 
@@ -84,7 +83,6 @@ class XLMRobertaForCausalLM(RobertaForCausalLM):
     documentation alongside usage examples.
     """
 
-    _keys_to_ignore_on_load_missing = [r"lm_head.decoder.bias", "position_ids"]
     config_class = XLMRobertaConfig
 
 
@@ -98,7 +96,6 @@ class XLMRobertaForMaskedLM(RobertaForMaskedLM):
     documentation alongside usage examples.
     """
 
-    _keys_to_ignore_on_load_missing = [r"lm_head.decoder.bias", "position_ids"]
     config_class = XLMRobertaConfig
 
 
@@ -115,7 +112,6 @@ class XLMRobertaForSequenceClassification(RobertaForSequenceClassification):
     appropriate documentation alongside usage examples.
     """
 
-    _keys_to_ignore_on_load_missing = [r"lm_head.decoder.bias", "position_ids"]
     config_class = XLMRobertaConfig
 
 
@@ -132,7 +128,6 @@ class XLMRobertaForMultipleChoice(RobertaForMultipleChoice):
     appropriate documentation alongside usage examples.
     """
 
-    _keys_to_ignore_on_load_missing = [r"lm_head.decoder.bias", "position_ids"]
     config_class = XLMRobertaConfig
 
 
@@ -149,7 +144,6 @@ class XLMRobertaForTokenClassification(RobertaForTokenClassification):
     appropriate documentation alongside usage examples.
     """
 
-    _keys_to_ignore_on_load_missing = [r"lm_head.decoder.bias", "position_ids"]
     config_class = XLMRobertaConfig
 
 
@@ -166,5 +160,4 @@ class XLMRobertaForQuestionAnswering(RobertaForQuestionAnswering):
     appropriate documentation alongside usage examples.
     """
 
-    _keys_to_ignore_on_load_missing = [r"lm_head.decoder.bias", "position_ids"]
     config_class = XLMRobertaConfig

--- a/src/transformers/models/xlm_roberta/modeling_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/modeling_xlm_roberta.py
@@ -70,6 +70,7 @@ class XLMRobertaModel(RobertaModel):
     documentation alongside usage examples.
     """
 
+    _keys_to_ignore_on_load_missing = [r"lm_head.decoder.bias", "position_ids"]
     config_class = XLMRobertaConfig
 
 
@@ -83,6 +84,7 @@ class XLMRobertaForCausalLM(RobertaForCausalLM):
     documentation alongside usage examples.
     """
 
+    _keys_to_ignore_on_load_missing = [r"lm_head.decoder.bias", "position_ids"]
     config_class = XLMRobertaConfig
 
 
@@ -96,6 +98,7 @@ class XLMRobertaForMaskedLM(RobertaForMaskedLM):
     documentation alongside usage examples.
     """
 
+    _keys_to_ignore_on_load_missing = [r"lm_head.decoder.bias", "position_ids"]
     config_class = XLMRobertaConfig
 
 
@@ -112,6 +115,7 @@ class XLMRobertaForSequenceClassification(RobertaForSequenceClassification):
     appropriate documentation alongside usage examples.
     """
 
+    _keys_to_ignore_on_load_missing = [r"lm_head.decoder.bias", "position_ids"]
     config_class = XLMRobertaConfig
 
 
@@ -128,6 +132,7 @@ class XLMRobertaForMultipleChoice(RobertaForMultipleChoice):
     appropriate documentation alongside usage examples.
     """
 
+    _keys_to_ignore_on_load_missing = [r"lm_head.decoder.bias", "position_ids"]
     config_class = XLMRobertaConfig
 
 
@@ -144,6 +149,7 @@ class XLMRobertaForTokenClassification(RobertaForTokenClassification):
     appropriate documentation alongside usage examples.
     """
 
+    _keys_to_ignore_on_load_missing = [r"lm_head.decoder.bias", "position_ids"]
     config_class = XLMRobertaConfig
 
 
@@ -160,4 +166,5 @@ class XLMRobertaForQuestionAnswering(RobertaForQuestionAnswering):
     appropriate documentation alongside usage examples.
     """
 
+    _keys_to_ignore_on_load_missing = [r"lm_head.decoder.bias", "position_ids"]
     config_class = XLMRobertaConfig


### PR DESCRIPTION
Removes the warning that's currently happening when importing `xlm-roberta-base` with any of the XLM-R models.

Closes https://github.com/huggingface/transformers/issues/9579