### PR TITLE
Remove duplicated extras["retrieval"]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -228,7 +228,6 @@ extras["modelcreation"] = deps_list("cookiecutter")
 extras["serving"] = deps_list("pydantic", "uvicorn", "fastapi", "starlette")
 
 extras["sentencepiece"] = deps_list("sentencepiece", "protobuf")
-extras["retrieval"] = deps_list("faiss-cpu", "datasets")
 extras["testing"] = (
     deps_list("pytest", "pytest-xdist", "timeout-decorator", "parameterized", "psutil")
     + extras["retrieval"]


### PR DESCRIPTION
The `extras["retrieval"]` is defined a few lines above as:
https://github.com/huggingface/transformers/blob/28b26013abea3a49afeb46d36993a568ec98f39e/setup.py#L217-L222
and then it seems to be overridden just below, probably linking to `faiss-cpu` being included even on windows.

This PR removes the second assignment. 

cc @LysandreJik @sgugger @stas00 