### PR TITLE
Fix DPRReaderTokenizer's attention_mask

### DIFF
--- a/src/transformers/models/dpr/tokenization_dpr.py
+++ b/src/transformers/models/dpr/tokenization_dpr.py
@@ -251,7 +251,9 @@ class CustomDPRReaderTokenizerMixin:
             ]
         }
         if return_attention_mask is not False:
-            attention_mask = [input_ids != self.pad_token_id for input_ids in encoded_inputs["input_ids"]]
+            attention_mask = []
+            for input_ids in encoded_inputs["input_ids"]:
+                attention_mask.append([int(input_id != self.pad_token_id) for input_id in input_ids])
             encoded_inputs["attention_mask"] = attention_mask
         return self.pad(encoded_inputs, padding=padding, max_length=max_length, return_tensors=return_tensors)
 

--- a/src/transformers/models/dpr/tokenization_dpr_fast.py
+++ b/src/transformers/models/dpr/tokenization_dpr_fast.py
@@ -252,7 +252,9 @@ class CustomDPRReaderTokenizerMixin:
             ]
         }
         if return_attention_mask is not False:
-            attention_mask = [input_ids != self.pad_token_id for input_ids in encoded_inputs["input_ids"]]
+            attention_mask = []
+            for input_ids in encoded_inputs["input_ids"]:
+                attention_mask.append([int(input_id != self.pad_token_id) for input_id in input_ids])
             encoded_inputs["attention_mask"] = attention_mask
         return self.pad(encoded_inputs, padding=padding, max_length=max_length, return_tensors=return_tensors)
 

--- a/tests/test_modeling_dpr.py
+++ b/tests/test_modeling_dpr.py
@@ -263,52 +263,28 @@ class DPRModelIntegrationTest(unittest.TestCase):
 
     @slow
     def test_reader_inference(self):
-        tokenizer = DPRReaderTokenizer.from_pretrained('facebook/dpr-reader-single-nq-base')
-        model = DPRReader.from_pretrained('facebook/dpr-reader-single-nq-base')
+        tokenizer = DPRReaderTokenizer.from_pretrained("facebook/dpr-reader-single-nq-base")
+        model = DPRReader.from_pretrained("facebook/dpr-reader-single-nq-base")
 
-        encoded_inputs = tokenizer(questions="What is love ?",
-                                   titles="Haddaway",
-                                   texts="What Is Love is a song recorded by the artist Haddaway",
-                                   padding=True,
-                                   return_tensors='pt')
+        encoded_inputs = tokenizer(
+            questions="What is love ?",
+            titles="Haddaway",
+            texts="What Is Love is a song recorded by the artist Haddaway",
+            padding=True,
+            return_tensors="pt",
+        )
 
         outputs = model(**encoded_inputs)
 
         # compare the actual values for a slice.
         expected_start_logits = torch.tensor(
-            [
-                [
-                    -10.3005,
-                    -10.7765,
-                    -11.4872,
-                    -11.6841,
-                    -11.9312,
-                    -10.3002,
-                    -9.8544,
-                    -11.7378,
-                    -12.0821,
-                    -10.2975
-                ]
-            ],
+            [[-10.3005, -10.7765, -11.4872, -11.6841, -11.9312, -10.3002, -9.8544, -11.7378, -12.0821, -10.2975]],
             dtype=torch.float,
             device=torch_device,
         )
 
         expected_end_logits = torch.tensor(
-            [
-                [
-                    -11.0684,
-                    -11.7041,
-                    -11.5397,
-                    -10.3465,
-                    -10.8791,
-                    -6.8443,
-                    -11.9959,
-                    -11.0364,
-                    -10.0096,
-                    -6.8405
-                ]
-            ],
+            [[-11.0684, -11.7041, -11.5397, -10.3465, -10.8791, -6.8443, -11.9959, -11.0364, -10.0096, -6.8405]],
             dtype=torch.float,
             device=torch_device,
         )

--- a/tests/test_modeling_dpr.py
+++ b/tests/test_modeling_dpr.py
@@ -26,7 +26,7 @@ from .test_modeling_common import ModelTesterMixin, ids_tensor, random_attention
 if is_torch_available():
     import torch
 
-    from transformers import DPRConfig, DPRContextEncoder, DPRQuestionEncoder, DPRReader
+    from transformers import DPRConfig, DPRContextEncoder, DPRQuestionEncoder, DPRReader, DPRReaderTokenizer
     from transformers.models.dpr.modeling_dpr import (
         DPR_CONTEXT_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST,
         DPR_QUESTION_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST,
@@ -260,3 +260,57 @@ class DPRModelIntegrationTest(unittest.TestCase):
             device=torch_device,
         )
         self.assertTrue(torch.allclose(output[:, :10], expected_slice, atol=1e-4))
+
+    @slow
+    def test_reader_inference(self):
+        tokenizer = DPRReaderTokenizer.from_pretrained('facebook/dpr-reader-single-nq-base')
+        model = DPRReader.from_pretrained('facebook/dpr-reader-single-nq-base')
+
+        encoded_inputs = tokenizer(questions="What is love ?",
+                                   titles="Haddaway",
+                                   texts="What Is Love is a song recorded by the artist Haddaway",
+                                   padding=True,
+                                   return_tensors='pt')
+
+        outputs = model(**encoded_inputs)
+
+        # compare the actual values for a slice.
+        expected_start_logits = torch.tensor(
+            [
+                [
+                    -10.3005,
+                    -10.7765,
+                    -11.4872,
+                    -11.6841,
+                    -11.9312,
+                    -10.3002,
+                    -9.8544,
+                    -11.7378,
+                    -12.0821,
+                    -10.2975
+                ]
+            ],
+            dtype=torch.float,
+            device=torch_device,
+        )
+
+        expected_end_logits = torch.tensor(
+            [
+                [
+                    -11.0684,
+                    -11.7041,
+                    -11.5397,
+                    -10.3465,
+                    -10.8791,
+                    -6.8443,
+                    -11.9959,
+                    -11.0364,
+                    -10.0096,
+                    -6.8405
+                ]
+            ],
+            dtype=torch.float,
+            device=torch_device,
+        )
+        self.assertTrue(torch.allclose(outputs.start_logits[:, :10], expected_start_logits, atol=1e-4))
+        self.assertTrue(torch.allclose(outputs.end_logits[:, :10], expected_end_logits, atol=1e-4))


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue with the `attention_mask` not being properly generated by the DPRReaderTokenizer. Please see  issue #9555 for more details.

I added an integration test that checks the DPRReader following a similar example in the test file.

I have some test failures due to 
```
"AttributeError: Can't pickle local object 'measure_peak_memory_cpu.<locals>.MemoryMeasureProcess'"
```
and 
```
"AttributeError: module 'wandb' has no attribute 'ensure_configured'"
```
which seem to be unrelated to my code changes.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@LysandreJik and @lhoestq would probably be best positioned to review.
