### PR TITLE
Missing `return_dict` in Doc example

### DIFF
--- a/docs/source/task_summary.rst
+++ b/docs/source/task_summary.rst
@@ -243,7 +243,7 @@ Here is an example of question answering using a model and a tokenizer. The proc
     ...     input_ids = inputs["input_ids"].tolist()[0]
     ...
     ...     text_tokens = tokenizer.convert_ids_to_tokens(input_ids)
-    ...     outputs = model(**inputs)
+    ...     outputs = model(**inputs, return_dict=True)
     ...     answer_start_scores = outputs.start_logits
     ...     answer_end_scores = outputs.end_logits
     ...
@@ -287,7 +287,7 @@ Here is an example of question answering using a model and a tokenizer. The proc
     ...     input_ids = inputs["input_ids"].numpy()[0]
     ...
     ...     text_tokens = tokenizer.convert_ids_to_tokens(input_ids)
-    ...     outputs = model(inputs)
+    ...     outputs = model(inputs, return_dict=True)
     ...     answer_start_scores = outputs.start_logits
     ...     answer_end_scores = outputs.end_logits
     ...


### PR DESCRIPTION
# What does this PR do?
Fixes a crash in [Summary of the tasks](https://huggingface.co/transformers/task_summary.html) documentation, by adding `return_dict=True` to the model() function, as we need `start_logits` and `end_logits` afterwards.

## Fixes
[Issue 9043](https://github.com/huggingface/transformers/issues/9043) (reproduced in 4.2.1)

## Who can review?
@LysandreJik @sgugger
