### PR TITLE
Fix Trainer and Args to mention AdamW, not Adam.

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -587,8 +587,8 @@ class Trainer:
             else:
                 optimizer_cls = AdamW
                 optimizer_kwargs = {
-                    "betas": (self.args.adam_beta1, self.args.adam_beta2),
-                    "eps": self.args.adam_epsilon,
+                    "betas": (self.args.adamw_beta1, self.args.adamw_beta2),
+                    "eps": self.args.adamw_epsilon,
                 }
             optimizer_kwargs["lr"] = self.args.learning_rate
             if self.sharded_dpp:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -587,8 +587,8 @@ class Trainer:
             else:
                 optimizer_cls = AdamW
                 optimizer_kwargs = {
-                    "betas": (self.args.adamw_beta1, self.args.adamw_beta2),
-                    "eps": self.args.adamw_epsilon,
+                    "betas": (self.args.adam_beta1, self.args.adam_beta2),
+                    "eps": self.args.adam_epsilon,
                 }
             optimizer_kwargs["lr"] = self.args.learning_rate
             if self.sharded_dpp:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -104,15 +104,15 @@ class TrainingArguments:
             left unset, the whole predictions are accumulated on GPU/TPU before being moved to the CPU (faster but
             requires more memory).
         learning_rate (:obj:`float`, `optional`, defaults to 5e-5):
-            The initial learning rate for Adam.
+            The initial learning rate for AdamW.
         weight_decay (:obj:`float`, `optional`, defaults to 0):
             The weight decay to apply (if not zero).
-        adam_beta1 (:obj:`float`, `optional`, defaults to 0.9):
-            The beta1 hyperparameter for the Adam optimizer.
-        adam_beta2 (:obj:`float`, `optional`, defaults to 0.999):
-            The beta2 hyperparameter for the Adam optimizer.
-        adam_epsilon (:obj:`float`, `optional`, defaults to 1e-8):
-            The epsilon hyperparameter for the Adam optimizer.
+        adamw_beta1 (:obj:`float`, `optional`, defaults to 0.9):
+            The beta1 hyperparameter for the AdamW optimizer.
+        adamw_beta2 (:obj:`float`, `optional`, defaults to 0.999):
+            The beta2 hyperparameter for the AdamW optimizer.
+        adamw_epsilon (:obj:`float`, `optional`, defaults to 1e-8):
+            The epsilon hyperparameter for the AdamW optimizer.
         max_grad_norm (:obj:`float`, `optional`, defaults to 1.0):
             Maximum gradient norm (for gradient clipping).
         num_train_epochs(:obj:`float`, `optional`, defaults to 3.0):
@@ -290,9 +290,9 @@ class TrainingArguments:
 
     learning_rate: float = field(default=5e-5, metadata={"help": "The initial learning rate for Adam."})
     weight_decay: float = field(default=0.0, metadata={"help": "Weight decay if we apply some."})
-    adam_beta1: float = field(default=0.9, metadata={"help": "Beta1 for Adam optimizer"})
-    adam_beta2: float = field(default=0.999, metadata={"help": "Beta2 for Adam optimizer"})
-    adam_epsilon: float = field(default=1e-8, metadata={"help": "Epsilon for Adam optimizer."})
+    adamw_beta1: float = field(default=0.9, metadata={"help": "Beta1 for AdamW optimizer"})
+    adamw_beta2: float = field(default=0.999, metadata={"help": "Beta2 for AdamW optimizer"})
+    adamw_epsilon: float = field(default=1e-8, metadata={"help": "Epsilon for AdamW optimizer."})
     max_grad_norm: float = field(default=1.0, metadata={"help": "Max gradient norm."})
 
     num_train_epochs: float = field(default=3.0, metadata={"help": "Total number of training epochs to perform."})
@@ -407,7 +407,7 @@ class TrainingArguments:
     label_smoothing_factor: float = field(
         default=0.0, metadata={"help": "The label smoothing epsilon to apply (zero means no label smoothing)."}
     )
-    adafactor: bool = field(default=False, metadata={"help": "Whether or not to replace Adam by Adafactor."})
+    adafactor: bool = field(default=False, metadata={"help": "Whether or not to replace AdamW by Adafactor."})
     group_by_length: bool = field(
         default=False,
         metadata={"help": "Whether or not to group samples of roughly the same length together when batching."},

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -104,15 +104,15 @@ class TrainingArguments:
             left unset, the whole predictions are accumulated on GPU/TPU before being moved to the CPU (faster but
             requires more memory).
         learning_rate (:obj:`float`, `optional`, defaults to 5e-5):
-            The initial learning rate for AdamW.
+            The initial learning rate for `~tranformers.AdamW`.
         weight_decay (:obj:`float`, `optional`, defaults to 0):
             The weight decay to apply (if not zero).
-        adamw_beta1 (:obj:`float`, `optional`, defaults to 0.9):
-            The beta1 hyperparameter for the AdamW optimizer.
-        adamw_beta2 (:obj:`float`, `optional`, defaults to 0.999):
-            The beta2 hyperparameter for the AdamW optimizer.
-        adamw_epsilon (:obj:`float`, `optional`, defaults to 1e-8):
-            The epsilon hyperparameter for the AdamW optimizer.
+        adam_beta1 (:obj:`float`, `optional`, defaults to 0.9):
+            The beta1 hyperparameter for the `~tranformers.AdamW` optimizer.
+        adam_beta2 (:obj:`float`, `optional`, defaults to 0.999):
+            The beta2 hyperparameter for the `~tranformers.AdamW` optimizer.
+        adam_epsilon (:obj:`float`, `optional`, defaults to 1e-8):
+            The epsilon hyperparameter for the `~tranformers.AdamW` optimizer.
         max_grad_norm (:obj:`float`, `optional`, defaults to 1.0):
             Maximum gradient norm (for gradient clipping).
         num_train_epochs(:obj:`float`, `optional`, defaults to 3.0):
@@ -290,9 +290,9 @@ class TrainingArguments:
 
     learning_rate: float = field(default=5e-5, metadata={"help": "The initial learning rate for AdamW."})
     weight_decay: float = field(default=0.0, metadata={"help": "Weight decay for AdamW if we apply some."})
-    adamw_beta1: float = field(default=0.9, metadata={"help": "Beta1 for AdamW optimizer"})
-    adamw_beta2: float = field(default=0.999, metadata={"help": "Beta2 for AdamW optimizer"})
-    adamw_epsilon: float = field(default=1e-8, metadata={"help": "Epsilon for AdamW optimizer."})
+    adam_beta1: float = field(default=0.9, metadata={"help": "Beta1 for AdamW optimizer"})
+    adam_beta2: float = field(default=0.999, metadata={"help": "Beta2 for AdamW optimizer"})
+    adam_epsilon: float = field(default=1e-8, metadata={"help": "Epsilon for AdamW optimizer."})
     max_grad_norm: float = field(default=1.0, metadata={"help": "Max gradient norm."})
 
     num_train_epochs: float = field(default=3.0, metadata={"help": "Total number of training epochs to perform."})

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -106,7 +106,8 @@ class TrainingArguments:
         learning_rate (:obj:`float`, `optional`, defaults to 5e-5):
             The initial learning rate for :class:`~transformers.AdamW` optimizer.
         weight_decay (:obj:`float`, `optional`, defaults to 0):
-            The weight decay to apply (if not zero) to all layers except all bias and LayerNorm weights in :class:`~transformers.AdamW` optimizer.
+            The weight decay to apply (if not zero) to all layers except all bias and LayerNorm weights in 
+            :class:`~transformers.AdamW` optimizer.
         adam_beta1 (:obj:`float`, `optional`, defaults to 0.9):
             The beta1 hyperparameter for the :class:`~transformers.AdamW` optimizer.
         adam_beta2 (:obj:`float`, `optional`, defaults to 0.999):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -104,15 +104,15 @@ class TrainingArguments:
             left unset, the whole predictions are accumulated on GPU/TPU before being moved to the CPU (faster but
             requires more memory).
         learning_rate (:obj:`float`, `optional`, defaults to 5e-5):
-            The initial learning rate for `~tranformers.AdamW`.
+            The initial learning rate for :class:`~transformers.AdamW` optimizer.
         weight_decay (:obj:`float`, `optional`, defaults to 0):
-            The weight decay to apply (if not zero).
+            The weight decay to apply (if not zero) to all layers except all bias and LayerNorm weights in :class:`~transformers.AdamW` optimizer.
         adam_beta1 (:obj:`float`, `optional`, defaults to 0.9):
-            The beta1 hyperparameter for the `~tranformers.AdamW` optimizer.
+            The beta1 hyperparameter for the :class:`~transformers.AdamW` optimizer.
         adam_beta2 (:obj:`float`, `optional`, defaults to 0.999):
-            The beta2 hyperparameter for the `~tranformers.AdamW` optimizer.
+            The beta2 hyperparameter for the :class:`~transformers.AdamW` optimizer.
         adam_epsilon (:obj:`float`, `optional`, defaults to 1e-8):
-            The epsilon hyperparameter for the `~tranformers.AdamW` optimizer.
+            The epsilon hyperparameter for the :class:`~transformers.AdamW` optimizer.
         max_grad_norm (:obj:`float`, `optional`, defaults to 1.0):
             Maximum gradient norm (for gradient clipping).
         num_train_epochs(:obj:`float`, `optional`, defaults to 3.0):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -288,8 +288,8 @@ class TrainingArguments:
         metadata={"help": "Number of predictions steps to accumulate before moving the tensors to the CPU."},
     )
 
-    learning_rate: float = field(default=5e-5, metadata={"help": "The initial learning rate for Adam."})
-    weight_decay: float = field(default=0.0, metadata={"help": "Weight decay if we apply some."})
+    learning_rate: float = field(default=5e-5, metadata={"help": "The initial learning rate for AdamW."})
+    weight_decay: float = field(default=0.0, metadata={"help": "Weight decay for AdamW if we apply some."})
     adamw_beta1: float = field(default=0.9, metadata={"help": "Beta1 for AdamW optimizer"})
     adamw_beta2: float = field(default=0.999, metadata={"help": "Beta2 for AdamW optimizer"})
     adamw_epsilon: float = field(default=1e-8, metadata={"help": "Epsilon for AdamW optimizer."})


### PR DESCRIPTION
This PR fixed the issue with Docs and labels in Trainer and TrainingArguments Class for AdamW, current version mentions adam in several places.

Fixes #9628 

The Trainer class in  `trainer.py` uses AdamW as the default optimizer. The TrainingArguments class mentions it as Adam in the documentation, which was confusing.

I have also changed variable names to `adamw_beta1`, `adamw_beta2`, `adamw_epsilon` in `trainer.py`.

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

@LysandreJik 