### PR TITLE
Fix WAND_DISABLED test

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -25,6 +25,7 @@ import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
+from .file_utils import ENV_VARS_TRUE_VALUES
 from .trainer_utils import SchedulerType
 from .utils import logging
 
@@ -54,7 +55,7 @@ from .trainer_utils import PREFIX_CHECKPOINT_DIR, BestRun, EvaluationStrategy  #
 
 # Integration functions:
 def is_wandb_available():
-    if os.getenv("WANDB_DISABLED"):
+    if os.getenv("WANDB_DISABLED").upper() in ENV_VARS_TRUE_VALUES:
         return False
     return importlib.util.find_spec("wandb") is not None
 

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -25,7 +25,6 @@ import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
-from .file_utils import ENV_VARS_TRUE_VALUES
 from .trainer_utils import SchedulerType
 from .utils import logging
 

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -54,7 +54,7 @@ from .trainer_utils import PREFIX_CHECKPOINT_DIR, BestRun, EvaluationStrategy  #
 
 # Integration functions:
 def is_wandb_available():
-    if os.getenv("WANDB_DISABLED").upper() in ENV_VARS_TRUE_VALUES:
+    if os.getenv("WANDB_DISABLED", "").upper() in ENV_VARS_TRUE_VALUES:
         return False
     return importlib.util.find_spec("wandb") is not None
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -106,7 +106,7 @@ class TrainingArguments:
         learning_rate (:obj:`float`, `optional`, defaults to 5e-5):
             The initial learning rate for :class:`~transformers.AdamW` optimizer.
         weight_decay (:obj:`float`, `optional`, defaults to 0):
-            The weight decay to apply (if not zero) to all layers except all bias and LayerNorm weights in 
+            The weight decay to apply (if not zero) to all layers except all bias and LayerNorm weights in
             :class:`~transformers.AdamW` optimizer.
         adam_beta1 (:obj:`float`, `optional`, defaults to 0.9):
             The beta1 hyperparameter for the :class:`~transformers.AdamW` optimizer.


### PR DESCRIPTION
# What does this PR do?

As reported in #9699, the test for the WAND_DISABLED environment variable is not working right now. This PR fixes that.

Fixes #9699
