### PR TITLE
[deepspeed] fix the backward for deepspeed

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1282,8 +1282,7 @@ class Trainer:
             with amp.scale_loss(loss, self.optimizer) as scaled_loss:
                 scaled_loss.backward()
         elif self.deepspeed:
-            # calling on DS engine (model_wrapped == DDP(Deepspeed(PretrainedModule)))
-            self.model_wrapped.module.backward(loss)
+            self.deepspeed.backward(loss)
         else:
             loss.backward()
 


### PR DESCRIPTION
This PR fixes a bug in my deepspeed integration - `backward` needs to be called on the deepspeed object.

@sgugger 

Fixes: https://github.com/huggingface/transformers/issues/9694
