### PR TITLE
[trainer] no --deepspeed and --sharded_ddp together

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -338,7 +338,7 @@ class Trainer:
         self.sharded_dpp = False
         if args.sharded_ddp:
             if args.deepspeed:
-                raise ValueError("can't use --sharded_ddp together with --deepspeed.")
+                raise ValueError("Using --sharded_ddp together with --deepspeed is not possible, deactivate one of those flags.")
 
             if args.local_rank == -1:
                 raise ValueError("Using sharded DDP only works in distributed training.")

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -337,12 +337,13 @@ class Trainer:
         # Setup Sharded DDP training
         self.sharded_dpp = False
         if args.sharded_ddp:
+            if args.deepspeed:
+                raise ValueError("can't use --sharded_ddp together with --deepspeed.")
+
             if args.local_rank == -1:
                 raise ValueError("Using sharded DDP only works in distributed training.")
             elif not is_fairscale_available():
                 raise ImportError("Sharded DDP training requires fairscale: `pip install fairscale`.")
-            elif args.deepspeed:
-                raise ValueError("can't use --sharded_ddp together with --deepspeed.")
             else:
                 self.sharded_dpp = True
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -338,7 +338,9 @@ class Trainer:
         self.sharded_dpp = False
         if args.sharded_ddp:
             if args.deepspeed:
-                raise ValueError("Using --sharded_ddp together with --deepspeed is not possible, deactivate one of those flags.")
+                raise ValueError(
+                    "Using --sharded_ddp together with --deepspeed is not possible, deactivate one of those flags."
+                )
 
             if args.local_rank == -1:
                 raise ValueError("Using sharded DDP only works in distributed training.")


### PR DESCRIPTION
This PR fixes an invalid if branch, which fails to detect a concurrent use of `--deepspeed` and `--sharded_ddp`, which should never be used together.

@sgugger 