### PR TITLE
Changing model default for TableQuestionAnsweringPipeline.

### DIFF
--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -136,9 +136,9 @@ SUPPORTED_TASKS = {
         "tf": None,
         "default": {
             "model": {
-                "pt": "nielsr/tapas-base-finetuned-wtq",
-                "tokenizer": "nielsr/tapas-base-finetuned-wtq",
-                "tf": "nielsr/tapas-base-finetuned-wtq",
+                "pt": "google/tapas-base-finetuned-wtq",
+                "tokenizer": "google/tapas-base-finetuned-wtq",
+                "tf": "google/tapas-base-finetuned-wtq",
             },
         },
     },

--- a/tests/test_pipelines_table_question_answering.py
+++ b/tests/test_pipelines_table_question_answering.py
@@ -32,7 +32,7 @@ class TQAPipelineTests(CustomInputPipelineCommonMixin, unittest.TestCase):
         "lysandre/tiny-tapas-random-wtq",
         "lysandre/tiny-tapas-random-sqa",
     ]
-    large_models = ["nielsr/tapas-base-finetuned-wtq"]  # Models tested with the @slow decorator
+    large_models = ["google/tapas-base-finetuned-wtq"]  # Models tested with the @slow decorator
     valid_inputs = [
         {
             "table": {
@@ -214,8 +214,8 @@ class TQAPipelineTests(CustomInputPipelineCommonMixin, unittest.TestCase):
     def test_integration_sqa(self):
         tqa_pipeline = pipeline(
             "table-question-answering",
-            model="nielsr/tapas-base-finetuned-sqa",
-            tokenizer="nielsr/tapas-base-finetuned-sqa",
+            model="google/tapas-base-finetuned-sqa",
+            tokenizer="google/tapas-base-finetuned-sqa",
         )
         data = {
             "Actors": ["Brad Pitt", "Leonardo Di Caprio", "George Clooney"],

--- a/tests/test_pipelines_table_question_answering.py
+++ b/tests/test_pipelines_table_question_answering.py
@@ -190,22 +190,25 @@ class TQAPipelineTests(CustomInputPipelineCommonMixin, unittest.TestCase):
         results = tqa_pipeline(data, queries)
 
         expected_results = [
-            {"answer": "Transformers", "coordinates": [(0, 0)], "cells": ["Transformers"]},
-            {"answer": "Transformers", "coordinates": [(0, 0)], "cells": ["Transformers"]},
+            {"answer": "Transformers", "coordinates": [(0, 0)], "cells": ["Transformers"], "aggregator": "NONE"},
+            {"answer": "Transformers", "coordinates": [(0, 0)], "cells": ["Transformers"], "aggregator": "NONE"},
             {
-                "answer": "Transformers, Datasets, Tokenizers",
+                "answer": "COUNT > Transformers, Datasets, Tokenizers",
                 "coordinates": [(0, 0), (1, 0), (2, 0)],
                 "cells": ["Transformers", "Datasets", "Tokenizers"],
+                "aggregator": "COUNT",
             },
             {
-                "answer": "36542, 4512, 3934",
+                "answer": "AVERAGE > 36542, 4512, 3934",
                 "coordinates": [(0, 1), (1, 1), (2, 1)],
                 "cells": ["36542", "4512", "3934"],
+                "aggregator": "AVERAGE",
             },
             {
-                "answer": "36542, 4512, 3934",
+                "answer": "SUM > 36542, 4512, 3934",
                 "coordinates": [(0, 1), (1, 1), (2, 1)],
                 "cells": ["36542", "4512", "3934"],
+                "aggregator": "SUM",
             },
         ]
         self.assertListEqual(results, expected_results)


### PR DESCRIPTION
# What does this PR do?

Niels removed his tapas model from the Hub, so we need to update the default to `google` organization

- Discussion: https://discuss.huggingface.co/t/table-question-answering-is-not-an-available-task-under-pipeline/3284/6
- Had to update the slow test that was out-of-sync I think, @LysandreJik can you confirm ?



<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors which may be interested in your PR.

@LysandreJik
@thomwolf

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

 albert, bert, XLM: @LysandreJik
 GPT2: @LysandreJik, @patrickvonplaten
 tokenizers: @mfuntowicz
 Trainer: @sgugger
 Benchmarks: @patrickvonplaten
 Model Cards: @julien-c
 examples/distillation: @VictorSanh
 nlp datasets: [different repo](https://github.com/huggingface/nlp)
 rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
 Text Generation: @patrickvonplaten, @TevenLeScao
 Blenderbot, Bart, Marian, Pegasus: @patrickvonplaten
 T5: @patrickvonplaten
 Rag: @patrickvonplaten, @lhoestq
 EncoderDecoder: @patrickvonplaten
 Longformer, Reformer: @patrickvonplaten
 TransfoXL, XLNet: @TevenLeScao, @patrickvonplaten
 examples/seq2seq: @patil-suraj
 examples/bert-loses-patience: @JetRunner
 tensorflow: @jplu
 examples/token-classification: @stefan-it
 documentation: @sgugger
 FSMT: @stas00
 -->