### PR TITLE
Add `report_to` training arguments to control the integrations used

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -225,6 +225,21 @@ def run_hp_search_ray(trainer, n_trials: int, direction: str, **kwargs) -> BestR
     return best_run
 
 
+def get_available_reporting_integrations():
+    integrations = []
+    if is_azureml_available():
+        integrations.append("azure_ml")
+    if is_comet_available():
+        integrations.append("comet_ml")
+    if is_mlflow_available():
+        integrations.append("mlflow")
+    if is_tensorboard_available():
+        integrations.append("tensorboard")
+    if is_wandb_available():
+        integrations.append("wandb")
+    return integrations
+
+
 def rewrite_logs(d):
     new_d = {}
     eval_prefix = "eval_"
@@ -757,3 +772,21 @@ class MLflowCallback(TrainerCallback):
         # not let you start a new run before the previous one is killed
         if self._ml_flow.active_run is not None:
             self._ml_flow.end_run(status="KILLED")
+
+
+INTEGRATION_TO_CALLBACK = {
+    "azure_ml": AzureMLCallback,
+    "comet_ml": CometCallback,
+    "mlflow": MLflowCallback,
+    "tensorboard": TensorBoardCallback,
+    "wandb": WandbCallback,
+}
+
+
+def get_reporting_integration_callbacks(report_to):
+    for integration in report_to:
+        if integration not in INTEGRATION_TO_CALLBACK:
+            raise ValueError(
+                f"{integration} is not supported, only {', '.join(INTEGRATION_TO_CALLBACK.keys())} are supported."
+            )
+    return [INTEGRATION_TO_CALLBACK[integration] for integration in report_to]


### PR DESCRIPTION
# What does this PR do?

This PR introduces a new `report_to` training argument that controls which of the multiple reporting tools to use in a training round. Currently, `Trainer` automatically uses everything installed, which can cause trouble when:
- one platform is installed but not properly set up.
- one platform is installed but the user doesn't want to use it today.

In my opinion the current behavior is too magical and does not fit our philosophy. To avoid any breaking change, the current default for this `report_to` argument is to use everything installed, but I would like to switch this to an empty list at the next major release, so the user has to opt-in the platforms they want to use.
