### PR TITLE
[fsmt] token_type_ids isn't used

### DIFF
--- a/src/transformers/models/fsmt/tokenization_fsmt.py
+++ b/src/transformers/models/fsmt/tokenization_fsmt.py
@@ -177,6 +177,7 @@ class FSMTTokenizer(PreTrainedTokenizer):
     pretrained_vocab_files_map = PRETRAINED_VOCAB_FILES_MAP
     pretrained_init_configuration = PRETRAINED_INIT_CONFIGURATION
     max_model_input_sizes = PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES
+    model_input_names = ["attention_mask"]
 
     def __init__(
         self,


### PR DESCRIPTION
This PR fixes a bug discovered in https://github.com/huggingface/transformers/issues/9722

`token_type_ids` was returned by default by the tokenizer, but it isn't used by the model.

The original fsmt port was a frankenstein of bart for the model and xlm for the tokenizer, hence the discrepancy.

I thought the tests had common onnx tests, but it doesn't seem to be the case. I added a local test in the related PR:  https://github.com/huggingface/transformers/pull/9738

With this fix `convert_graph_to_onnx.convert` still fails with:
```
RuntimeError: Exporting the operator triu to ONNX opset version 12 is not supported. Please open a bug to request ONNX export support for the missing operator
```
but that's a totally different issue. Fixed in https://github.com/huggingface/transformers/pull/9738

Fixes: https://github.com/huggingface/transformers/issues/9722

@LysandreJik, @patrickvonplaten 
