### PR TITLE
AdaFactor: avoid updating group["lr"] attributes

### DIFF
--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -546,7 +546,7 @@ class Adafactor(Optimizer):
 
                 state["step"] += 1
                 state["RMS"] = self._rms(p_data_fp32)
-                group["lr"] = self._get_lr(group, state)
+                lr = self._get_lr(group, state)
 
                 beta2t = 1.0 - math.pow(state["step"], group["decay_rate"])
                 update = (grad ** 2) + group["eps"][0]
@@ -567,7 +567,7 @@ class Adafactor(Optimizer):
                     update = exp_avg_sq.rsqrt().mul_(grad)
 
                 update.div_((self._rms(update) / group["clip_threshold"]).clamp_(min=1.0))
-                update.mul_(group["lr"])
+                update.mul_(lr)
 
                 if use_first_moment:
                     exp_avg = state["exp_avg"]
@@ -575,7 +575,7 @@ class Adafactor(Optimizer):
                     update = exp_avg
 
                 if group["weight_decay"] != 0:
-                    p_data_fp32.add_(-group["weight_decay"] * group["lr"], p_data_fp32)
+                    p_data_fp32.add_(-group["weight_decay"] * lr, p_data_fp32)
 
                 p_data_fp32.add_(-update)
 


### PR DESCRIPTION
This affects Adafactor with `relative_step=False` and `scale_parameter=True`.

Updating `group["lr"]` makes the result of ._get_lr() depends on the previous call, i.e., on the scale of other parameters. This isn't supposed to happen.

# What does this PR do?

I've observed weird behaviors when using Adafactor with `relative_step=False` and `scale_parameter=True` and an LR scheduler. I think the problem is that the code [updates the `lr` attribute of the current parameter group](https://github.com/huggingface/transformers/blob/490b39e6142ca8f2ccb84c5436402899ae54e44f/src/transformers/optimization.py#L549), and then uses the updated attribute to [calculate the next attribute](https://github.com/huggingface/transformers/blob/490b39e6142ca8f2ccb84c5436402899ae54e44f/src/transformers/optimization.py#L469). I don't think this is supposed to happen.  

A simple fix would be replacing the update operation with an assignment to a local variable. 

I'm not entirely sure if I understand the problem correctly, so I apologize in advance if this is a stupid PR. I'd appreciate it if someone could point out where I am wrong. Thanks!

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@moscow25  @sshleifer

