### PR TITLE
RagTokenForGeneration: Fixed parameter name for logits_processor

### DIFF
--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1486,7 +1486,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
                 )
             return self.greedy_search(
                 input_ids,
-                pre_processor=pre_processor,
+                logits_processor=pre_processor,
                 max_length=max_length,
                 pad_token_id=pad_token_id,
                 eos_token_id=eos_token_id,
@@ -1509,7 +1509,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
             return self.beam_search(
                 input_ids,
                 beam_scorer,
-                pre_processor=pre_processor,
+                logits_processor=pre_processor,
                 max_length=max_length,
                 pad_token_id=pad_token_id,
                 eos_token_id=eos_token_id,


### PR DESCRIPTION
# What does this PR do?
The parameter name for the beam_search and greedy_search functions of the GenerationMixin is (now?) logits_processor not pre_processor.  This fix makes prefix_allowed_tokens_fn work (again?).

## Who can review?

 Rag: @patrickvonplaten, @lhoestq
 
