### PR TITLE
Commit the last step on world_process_zero in WandbCallback

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -516,6 +516,7 @@ class WandbCallback(TrainerCallback):
             else:
                 self._wandb = wandb
         self._initialized = False
+        self._log_model = False
 
     def setup(self, args, state, model, reinit, **kwargs):
         """
@@ -583,7 +584,8 @@ class WandbCallback(TrainerCallback):
         if self._wandb is None:
             return
         # commit last step
-        self._wandb.log({})
+        if state.is_world_process_zero:
+            self._wandb.log({})
         if self._log_model and self._initialized and state.is_world_process_zero:
             from .trainer import Trainer
 

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -516,7 +516,8 @@ class WandbCallback(TrainerCallback):
             else:
                 self._wandb = wandb
         self._initialized = False
-        self._log_model = False
+        # log outputs
+        self._log_model = os.getenv("WANDB_LOG_MODEL", "FALSE").upper() in ENV_VARS_TRUE_VALUES.union({"TRUE"})
 
     def setup(self, args, state, model, reinit, **kwargs):
         """
@@ -569,9 +570,6 @@ class WandbCallback(TrainerCallback):
                 self._wandb.watch(
                     model, log=os.getenv("WANDB_WATCH", "gradients"), log_freq=max(100, args.logging_steps)
                 )
-
-            # log outputs
-            self._log_model = os.getenv("WANDB_LOG_MODEL", "FALSE").upper() in ENV_VARS_TRUE_VALUES.union({"TRUE"})
 
     def on_train_begin(self, args, state, control, model=None, **kwargs):
         if self._wandb is None:


### PR DESCRIPTION
# What does this PR do?

Only commit the last step on the first process (`is_world_process_zero == True`), to avoid calling `wandb.log()` without a prior call to `wandb.init()` (the latter being only called on the first process) with DDP.

Fixes (at least partially) #9623 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@borisdayma @sgugger 
