### PR TITLE
Partial local tokenizer load

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -1239,7 +1239,7 @@ def get_from_cache(
                 # the models might've been found if local_files_only=False
                 # Notify the user about that
                 if local_files_only:
-                    raise ValueError(
+                    raise FileNotFoundError(
                         "Cannot find the requested files in the cached path and outgoing traffic has been"
                         " disabled. To enable model look-ups and downloads online, set 'local_files_only'"
                         " to False."

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1730,26 +1730,38 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
 
         # Get files from url, cache, or disk depending on the case
         resolved_vocab_files = {}
+        unresolved_files = []
         for file_id, file_path in vocab_files.items():
             if file_path is None:
                 resolved_vocab_files[file_id] = None
             else:
                 try:
-                    resolved_vocab_files[file_id] = cached_path(
-                        file_path,
-                        cache_dir=cache_dir,
-                        force_download=force_download,
-                        proxies=proxies,
-                        resume_download=resume_download,
-                        local_files_only=local_files_only,
-                        use_auth_token=use_auth_token,
-                    )
+                    try:
+                        resolved_vocab_files[file_id] = cached_path(
+                            file_path,
+                            cache_dir=cache_dir,
+                            force_download=force_download,
+                            proxies=proxies,
+                            resume_download=resume_download,
+                            local_files_only=local_files_only,
+                            use_auth_token=use_auth_token,
+                        )
+                    except FileNotFoundError:
+                        if local_files_only:
+                            unresolved_files.append(file_id)
+
                 except requests.exceptions.HTTPError as err:
                     if "404 Client Error" in str(err):
                         logger.debug(err)
                         resolved_vocab_files[file_id] = None
                     else:
                         raise err
+
+        if len(unresolved_files) > 0:
+            logger.warning(
+                f"Can't load following files from cache: {unresolved_files} and cannot check if these "
+                f"files are necessary for the tokenizer to operate."
+            )
 
         if all(full_file_name is None for full_file_name in resolved_vocab_files.values()):
             msg = (
@@ -1760,6 +1772,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
             raise EnvironmentError(msg)
 
         for file_id, file_path in vocab_files.items():
+            if file_id not in resolved_vocab_files:
+                continue
+
             if file_path == resolved_vocab_files[file_id]:
                 logger.info("loading file {}".format(file_path))
             else:

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1746,9 +1746,11 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
                             local_files_only=local_files_only,
                             use_auth_token=use_auth_token,
                         )
-                    except FileNotFoundError:
+                    except FileNotFoundError as error:
                         if local_files_only:
                             unresolved_files.append(file_id)
+                        else:
+                            raise error
 
                 except requests.exceptions.HTTPError as err:
                     if "404 Client Error" in str(err):

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1758,7 +1758,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
                         raise err
 
         if len(unresolved_files) > 0:
-            logger.warning(
+            logger.info(
                 f"Can't load following files from cache: {unresolved_files} and cannot check if these "
                 f"files are necessary for the tokenizer to operate."
             )

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1760,7 +1760,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin):
         if len(unresolved_files) > 0:
             logger.info(
                 f"Can't load following files from cache: {unresolved_files} and cannot check if these "
-                f"files are necessary for the tokenizer to operate."
+                "files are necessary for the tokenizer to operate."
             )
 
         if all(full_file_name is None for full_file_name in resolved_vocab_files.values()):


### PR DESCRIPTION
This PR aims to allow partial loading of a cached tokenizer.

Fixes #9147 which explains the issue in a lot of detail.

Currently, if we download a tokenizer from the hub using the `from_pretrained` method:

```py
from transformers import BertTokenizer
tokenizer = BertTokenizer.from_pretrained("google/bert_uncased_L-2_H-128_A-2", local_files_only=True)
```

It caches the files to be reused later. Reloading the tokenizer while specifying `local_files_only=True`

```py
from transformers import BertTokenizer
tokenizer = BertTokenizer.from_pretrained("google/bert_uncased_L-2_H-128_A-2", local_files_only=True)
```

results in a failure as it tries to fetch all of the tokenizer files, even those that are necessary. It currently fails with a hard error.

This PR changes that error to an info log, and prints a single log containing all the files that were not loaded. I put it as an `info` and not as a `warning` or an `error`, because the situation where this is an actual issue is imo very rare; it is a real issue only when the initial `from_pretrained` managed to obtain only some of the necessary files, i.e., when the download was interrupted.

Running the last snippet results in the following warning:

```
Can't load following files from cache: ['added_tokens_file', 'special_tokens_map_file', 'tokenizer_config_file', 'tokenizer_file'] and cannot check if these files are necessary for the tokenizer to operate.
```