### PR TITLE
When resuming training from checkpoint, Trainer loads model

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -702,6 +702,18 @@ class Trainer:
             # Reinitializes optimizer and scheduler
             self.optimizer, self.lr_scheduler = None, None
 
+        if model_path is not None and os.path.isfile(os.path.join(model_path, WEIGHTS_NAME)):
+            logger.info(f"Loading model from {model_path}).")
+            if isinstance(self.model, PreTrainedModel):
+                self.model = self.model.from_pretrained(model_path)
+                if not self.is_model_parallel:
+                    self.model = self.model.to(self.args.device)
+            else:
+                state_dict = torch.load(os.path.join(model_path, WEIGHTS_NAME))
+                self.model.load_state_dict(state_dict)
+
+            self.model_wrapped = self.model
+
         # Keeping track whether we can can len() on the dataset or not
         train_dataset_is_sized = isinstance(self.train_dataset, collections.abc.Sized)
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -860,7 +860,7 @@ class Trainer:
         tr_loss = torch.tensor(0.0).to(self.args.device)
         # _total_loss_scalar is updated everytime .item() has to be called on tr_loss and stores the sum of all losses
         self._total_loss_scalar = 0.0
-        self._globalstep_last_logged = 0
+        self._globalstep_last_logged = self.state.global_step
         self._total_flos = self.state.total_flos
         model.zero_grad()
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -660,7 +660,7 @@ class TrainerIntegrationTest(unittest.TestCase):
 
             checkpoint = os.path.join(tmpdir, "checkpoint-5")
 
-            # Reinitialize traine
+            # Reinitialize trainer
             trainer = get_regression_trainer(
                 output_dir=tmpdir,
                 train_len=128,

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -578,9 +578,8 @@ class TrainerIntegrationTest(unittest.TestCase):
 
             checkpoint = os.path.join(tmpdir, "checkpoint-5")
 
-            # Reinitialize trainer and load model
-            model = RegressionPreTrainedModel.from_pretrained(checkpoint)
-            trainer = Trainer(model, trainer.args, train_dataset=trainer.train_dataset)
+            # Reinitialize trainer
+            trainer = get_regression_trainer(output_dir=tmpdir, train_len=128, save_steps=5, learning_rate=0.1)
 
             trainer.train(model_path=checkpoint)
             (a1, b1) = trainer.model.a.item(), trainer.model.b.item()
@@ -593,8 +592,7 @@ class TrainerIntegrationTest(unittest.TestCase):
             checkpoint = os.path.join(tmpdir, "checkpoint-15")
 
             # Reinitialize trainer and load model
-            model = RegressionPreTrainedModel.from_pretrained(checkpoint)
-            trainer = Trainer(model, trainer.args, train_dataset=trainer.train_dataset)
+            trainer = get_regression_trainer(output_dir=tmpdir, train_len=128, save_steps=5, learning_rate=0.1)
 
             trainer.train(model_path=checkpoint)
             (a1, b1) = trainer.model.a.item(), trainer.model.b.item()
@@ -615,10 +613,9 @@ class TrainerIntegrationTest(unittest.TestCase):
             checkpoint = os.path.join(tmpdir, "checkpoint-5")
 
             # Reinitialize trainer and load model
-            model = RegressionModel()
-            state_dict = torch.load(os.path.join(checkpoint, WEIGHTS_NAME))
-            model.load_state_dict(state_dict)
-            trainer = Trainer(model, trainer.args, train_dataset=trainer.train_dataset)
+            trainer = get_regression_trainer(
+                output_dir=tmpdir, train_len=128, save_steps=5, learning_rate=0.1, pretrained=False
+            )
 
             trainer.train(model_path=checkpoint)
             (a1, b1) = trainer.model.a.item(), trainer.model.b.item()
@@ -631,10 +628,9 @@ class TrainerIntegrationTest(unittest.TestCase):
             checkpoint = os.path.join(tmpdir, "checkpoint-15")
 
             # Reinitialize trainer and load model
-            model = RegressionModel()
-            state_dict = torch.load(os.path.join(checkpoint, WEIGHTS_NAME))
-            model.load_state_dict(state_dict)
-            trainer = Trainer(model, trainer.args, train_dataset=trainer.train_dataset)
+            trainer = get_regression_trainer(
+                output_dir=tmpdir, train_len=128, save_steps=5, learning_rate=0.1, pretrained=False
+            )
 
             trainer.train(model_path=checkpoint)
             (a1, b1) = trainer.model.a.item(), trainer.model.b.item()
@@ -664,9 +660,15 @@ class TrainerIntegrationTest(unittest.TestCase):
 
             checkpoint = os.path.join(tmpdir, "checkpoint-5")
 
-            # Reinitialize trainer and load model
-            model = RegressionPreTrainedModel.from_pretrained(checkpoint)
-            trainer = Trainer(model, trainer.args, train_dataset=trainer.train_dataset)
+            # Reinitialize traine
+            trainer = get_regression_trainer(
+                output_dir=tmpdir,
+                train_len=128,
+                gradient_accumulation_steps=2,
+                per_device_train_batch_size=4,
+                save_steps=5,
+                learning_rate=0.1,
+            )
 
             trainer.train(model_path=checkpoint)
             (a1, b1) = trainer.model.a.item(), trainer.model.b.item()


### PR DESCRIPTION
# What does this PR do?

Trainer was not reloading model when resuming training from a checkpoint, which was confusing for users (see #9099) and also was preventing the recent auto-reload from checkpoint to fully work.

This isn't a breaking change (if users were passing a model with the checkpoint already loaded, it is just loaded twice).