### PR TITLE
Add a flag for find_unused_parameters

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -766,7 +766,7 @@ class Trainer:
             elif isinstance(model, PreTrainedModel):
                 # find_unused_parameters breaks checkpointing as per
                 # https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021
-                find_unused_parameters = getattr(model.config, "gradient_checkpointing", False)
+                find_unused_parameters = not getattr(model.config, "gradient_checkpointing", False)
             else:
                 find_unused_parameters = True
             model = torch.nn.parallel.DistributedDataParallel(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -761,18 +761,20 @@ class Trainer:
         elif is_sagemaker_distributed_available():
             model = DDP(model, device_ids=[dist.get_local_rank()], broadcast_buffers=False)
         elif self.args.local_rank != -1:
+            if self.args.ddp_find_unused_parameters is not None:
+                find_unused_parameters = self.args.ddp_find_unused_parameters
+            elif isinstance(model, PreTrainedModel):
+                # find_unused_parameters breaks checkpointing as per
+                # https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021
+                find_unused_parameters = getattr(model.config, "gradient_checkpointing", False)
+            else:
+                find_unused_parameters = True
             model = torch.nn.parallel.DistributedDataParallel(
                 model,
                 device_ids=[self.args.local_rank],
                 output_device=self.args.local_rank,
-                find_unused_parameters=(
-                    not getattr(model.config, "gradient_checkpointing", False)
-                    if isinstance(model, PreTrainedModel)
-                    else True
-                ),
+                find_unused_parameters=find_unused_parameters,
             )
-            # find_unused_parameters breaks checkpointing as per
-            # https://github.com/huggingface/transformers/pull/4659#issuecomment-643356021
 
         # for the rest of this function `model` is the outside model, whether it was wrapped or not
         if model is not self.model:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -240,6 +240,10 @@ class TrainingArguments:
         report_to (:obj:`List[str]`, `optional`, defaults to the list of integrations platforms installed):
             The list of integrations to report the results and logs to. Supported platforms are :obj:`"azure_ml"`,
             :obj:`"comet_ml"`, :obj:`"mlflow"`, :obj:`"tensorboard"` and :obj:`"wandb"`.
+        ddp_find_unused_parameters (:obj:`bool`, `optional`):
+            When using distributed training, the value of the flag :obj:`find_unused_parameters` passed to
+            :obj:`DistributedDataParallel`. Will defaut to :obj:`True` if gradient checkpointing is not used,
+            :obj:`False` otherwise.
     """
 
     output_dir: str = field(
@@ -424,6 +428,13 @@ class TrainingArguments:
     )
     report_to: Optional[List[str]] = field(
         default=None, metadata={"help": "The list of integrations to report the results and logs to."}
+    )
+    ddp_find_unused_parameters: Optional[bool] = field(
+        default=None,
+        metadata={
+            "help": "When using distributed training, the value of the flag `find_unused_parameters` passed to "
+            "`DistributedDataParallel`."
+        },
     )
     _n_gpu: int = field(init=False, repr=False, default=-1)
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -242,8 +242,8 @@ class TrainingArguments:
             :obj:`"comet_ml"`, :obj:`"mlflow"`, :obj:`"tensorboard"` and :obj:`"wandb"`.
         ddp_find_unused_parameters (:obj:`bool`, `optional`):
             When using distributed training, the value of the flag :obj:`find_unused_parameters` passed to
-            :obj:`DistributedDataParallel`. Will defaut to :obj:`True` if gradient checkpointing is not used,
-            :obj:`False` otherwise.
+            :obj:`DistributedDataParallel`. Will defaut to :obj:`False` if gradient checkpointing is used, :obj:`True`
+            otherwise.
     """
 
     output_dir: str = field(


### PR DESCRIPTION
# What does this PR do?

This PR adds a flag to control whether `find_unused_parameters` is set to `True` or not in DDP training, while keeping the current behavior as default to avoid any breaking change.
Fixes #9802