### PR TITLE
Allow --arg Value for booleans in HfArgumentParser

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -15,7 +15,7 @@
 import dataclasses
 import json
 import sys
-from argparse import ArgumentParser
+from argparse import ArgumentParser, ArgumentTypeError
 from enum import Enum
 from pathlib import Path
 from typing import Any, Iterable, List, NewType, Optional, Tuple, Union
@@ -23,6 +23,18 @@ from typing import Any, Iterable, List, NewType, Optional, Tuple, Union
 
 DataClass = NewType("DataClass", Any)
 DataClassType = NewType("DataClassType", Any)
+
+
+# From https://stackoverflow.com/questions/15008758/parsing-boolean-values-with-argparse
+def string_to_bool(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ("yes", "true", "t", "y", "1"):
+        return True
+    elif v.lower() in ("no", "false", "f", "n", "0"):
+        return False
+    else:
+        raise ArgumentTypeError("Boolean value expected.")
 
 
 class HfArgumentParser(ArgumentParser):
@@ -85,11 +97,20 @@ class HfArgumentParser(ArgumentParser):
                 if field.default is not dataclasses.MISSING:
                     kwargs["default"] = field.default
             elif field.type is bool or field.type is Optional[bool]:
-                if field.type is bool or (field.default is not None and field.default is not dataclasses.MISSING):
-                    kwargs["action"] = "store_false" if field.default is True else "store_true"
                 if field.default is True:
-                    field_name = f"--no_{field.name}"
-                    kwargs["dest"] = field.name
+                    self.add_argument(f"--no_{field.name}", action="store_false", dest=field.name, **kwargs)
+
+                # Hack because type=bool in argparse does not behave as we want.
+                kwargs["type"] = string_to_bool
+                if field.type is bool or (field.default is not None and field.default is not dataclasses.MISSING):
+                    # Default value is True if we have no default when of type bool.
+                    default = True if field.default is dataclasses.MISSING else field.default
+                    # This is the value that will get picked if we don't include --field_name in any way
+                    kwargs["default"] = default
+                    # This tells argparse we accept 0 or 1 value after --field_name
+                    kwargs["nargs"] = "?"
+                    # This is the value that will get picked if we do --field_name (without value)
+                    kwargs["const"] = True
             elif hasattr(field.type, "__origin__") and issubclass(field.type.__origin__, List):
                 kwargs["nargs"] = "+"
                 kwargs["type"] = field.type.__args__[0]

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -34,7 +34,9 @@ def string_to_bool(v):
     elif v.lower() in ("no", "false", "f", "n", "0"):
         return False
     else:
-        raise ArgumentTypeError("Boolean value expected.")
+        raise ArgumentTypeError(
+            f"Truthy value expected: got {v} but expected one of yes/no, true/false, t/f, y/n, 1/0 (case insensitive)."
+        )
 
 
 class HfArgumentParser(ArgumentParser):

--- a/tests/test_hf_argparser.py
+++ b/tests/test_hf_argparser.py
@@ -93,7 +93,7 @@ class HfArgumentParserTest(unittest.TestCase):
         expected.add_argument("--foo", type=int, required=True)
         expected.add_argument("--bar", type=float, required=True)
         expected.add_argument("--baz", type=str, required=True)
-        expected.add_argument("--flag", type=string_to_bool, default=True, const=False, nargs="?")
+        expected.add_argument("--flag", type=string_to_bool, default=True, const=True, nargs="?")
         self.argparsersEqual(parser, expected)
 
     def test_with_default(self):

--- a/tests/test_hf_argparser.py
+++ b/tests/test_hf_argparser.py
@@ -20,6 +20,7 @@ from enum import Enum
 from typing import List, Optional
 
 from transformers import HfArgumentParser, TrainingArguments
+from transformers.hf_argparser import string_to_bool
 
 
 def list_field(default=None, metadata=None):
@@ -44,6 +45,7 @@ class WithDefaultExample:
 class WithDefaultBoolExample:
     foo: bool = False
     baz: bool = True
+    opt: Optional[bool] = None
 
 
 class BasicEnum(Enum):
@@ -91,7 +93,7 @@ class HfArgumentParserTest(unittest.TestCase):
         expected.add_argument("--foo", type=int, required=True)
         expected.add_argument("--bar", type=float, required=True)
         expected.add_argument("--baz", type=str, required=True)
-        expected.add_argument("--flag", action="store_true")
+        expected.add_argument("--flag", type=string_to_bool, default=True, const=False, nargs="?")
         self.argparsersEqual(parser, expected)
 
     def test_with_default(self):
@@ -106,15 +108,26 @@ class HfArgumentParserTest(unittest.TestCase):
         parser = HfArgumentParser(WithDefaultBoolExample)
 
         expected = argparse.ArgumentParser()
-        expected.add_argument("--foo", action="store_true")
+        expected.add_argument("--foo", type=string_to_bool, default=False, const=True, nargs="?")
         expected.add_argument("--no_baz", action="store_false", dest="baz")
+        expected.add_argument("--baz", type=string_to_bool, default=True, const=True, nargs="?")
+        expected.add_argument("--opt", type=string_to_bool, default=None)
         self.argparsersEqual(parser, expected)
 
         args = parser.parse_args([])
-        self.assertEqual(args, Namespace(foo=False, baz=True))
+        self.assertEqual(args, Namespace(foo=False, baz=True, opt=None))
 
         args = parser.parse_args(["--foo", "--no_baz"])
-        self.assertEqual(args, Namespace(foo=True, baz=False))
+        self.assertEqual(args, Namespace(foo=True, baz=False, opt=None))
+
+        args = parser.parse_args(["--foo", "--baz"])
+        self.assertEqual(args, Namespace(foo=True, baz=True, opt=None))
+
+        args = parser.parse_args(["--foo", "True", "--baz", "True", "--opt", "True"])
+        self.assertEqual(args, Namespace(foo=True, baz=True, opt=True))
+
+        args = parser.parse_args(["--foo", "False", "--baz", "False", "--opt", "False"])
+        self.assertEqual(args, Namespace(foo=False, baz=False, opt=False))
 
     def test_with_enum(self):
         parser = HfArgumentParser(EnumExample)


### PR DESCRIPTION
# What does this PR do?

The primary reason I dived into this PR is because when launching a training with sagemaker, bool arguments need to be passed along with something (e.g. we can't do `--do_train`, we have to do `--do_train True` because the arguments are passed as a dict). This is refused by the current argparser.

This PR changes a little bit the way `HfArgumentParser` handles bool fields in dataclasses. Up until now:
- a bool arg `foo` with `True` as a default gives a flag `--no_foo` that stores `False` in foo
- a bool arg `bar` with no default value or `False` as a default value gives a flag `bar` that stores `True` in bar
- an optional bool arg `opt` gives the same as a bool if its default is True or False. If the default is None, it gives a flag `--opt` that requires an argument that accepts anything and stores the value as a string (which is obviously a bug)

After this PR, the following happens:
- a bool arg `foo` with `True` as a default gives a flag `--no_foo` that stores `False` in foo, it also gives a flag `--foo` that can be used as is (will store `True` in foo), or by using any truthy/falsy value (`--foo yes`, `--foo True`, `--foo no`...) that will store the result as a proper bool.
- a bool arg  `bar` with no default value or `False` gives a flag `bar` that can be used as is (will store `True` in bar), or by using any truthy/falsy value (`--bar yes`, `--bar True`, `--bar no`...) that will store the result as a proper bool.
- an optional bool arg `opt` gives the same as a bool if its default is True or False. If the default is None, it gives a flag `--opt` that requires an argument that accepts a truthy value and stores the value as a proper bool.

In all cases above, when a truthy value is expected but something else is passed (that is not `true`, `false`, `yes`, `no`, `1`, `0`, `t`, `f`, `y`, `n`), an error is raised.

So no breaking changes at all and all bool values can be used with an argument so that sagemaker is happy. Tests are updated and improved to check the behaviors summarized above are all correct.