### PR TITLE
pin_memory -> dataloader_pin_memory

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -485,7 +485,7 @@ class Trainer:
             collate_fn=self.data_collator,
             drop_last=self.args.dataloader_drop_last,
             num_workers=self.args.dataloader_num_workers,
-            pin_memory=self.args.pin_memory,
+            pin_memory=self.args.dataloader_pin_memory,
         )
 
     def _get_eval_sampler(self, eval_dataset: Dataset) -> Optional[torch.utils.data.sampler.Sampler]:
@@ -523,7 +523,7 @@ class Trainer:
             collate_fn=self.data_collator,
             drop_last=self.args.dataloader_drop_last,
             num_workers=self.args.dataloader_num_workers,
-            pin_memory=self.args.pin_memory,
+            pin_memory=self.args.dataloader_pin_memory,
         )
 
     def get_test_dataloader(self, test_dataset: Dataset) -> DataLoader:
@@ -550,7 +550,7 @@ class Trainer:
             batch_size=self.args.eval_batch_size,
             collate_fn=self.data_collator,
             drop_last=self.args.dataloader_drop_last,
-            pin_memory=self.args.pin_memory,
+            pin_memory=self.args.dataloader_pin_memory,
         )
 
     def create_optimizer_and_scheduler(self, num_training_steps: int):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -244,7 +244,7 @@ class TrainingArguments:
             When using distributed training, the value of the flag :obj:`find_unused_parameters` passed to
             :obj:`DistributedDataParallel`. Will default to :obj:`False` if gradient checkpointing is used, :obj:`True`
             otherwise.
-        pin_memory (:obj:`bool`, `optional`, defaults to :obj:`True`)):
+        dataloader_pin_memory (:obj:`bool`, `optional`, defaults to :obj:`True`)):
             Whether you want to pin memory in data loaders or not. Will default to :obj:`True`.
     """
 
@@ -438,7 +438,9 @@ class TrainingArguments:
             "`DistributedDataParallel`."
         },
     )
-    pin_memory: bool = field(default=True, metadata={"help": "Whether or not to pin memory for data loaders."})
+    dataloader_pin_memory: bool = field(
+        default=True, metadata={"help": "Whether or not to pin memory for data loaders."}
+    )
     _n_gpu: int = field(init=False, repr=False, default=-1)
 
     def __post_init__(self):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -439,7 +439,7 @@ class TrainingArguments:
         },
     )
     dataloader_pin_memory: bool = field(
-        default=True, metadata={"help": "Whether or not to pin memory for data loaders."}
+        default=True, metadata={"help": "Whether or not to pin memory for DataLoader."}
     )
     _n_gpu: int = field(init=False, repr=False, default=-1)
 


### PR DESCRIPTION
Ref: https://github.com/huggingface/transformers/pull/9857#issuecomment-769256215

This PR adds a new argument `dataloader_pin_memory` to `TrainingArguments`. You can use this to pin memory in `DataLoader`.