### PR TITLE
[seq2seq] correctly handle mt5

### DIFF
--- a/examples/seq2seq/utils.py
+++ b/examples/seq2seq/utils.py
@@ -563,7 +563,7 @@ def freeze_embeds(model):
     """Freeze token embeddings and positional embeddings for bart, just token embeddings for t5."""
     model_type = model.config.model_type
 
-    if model_type == "t5":
+    if model_type in ["t5", "mt5"]:
         freeze_params(model.shared)
         for d in [model.encoder, model.decoder]:
             freeze_params(d.embed_tokens)


### PR DESCRIPTION
This PR fixes `seq2seq/utils.py` to handle `mt5` like it does `t5`.

Ideally there should be a test, which would require creating a tiny model for mt5, but I'm being told this code is going away anyway, so there is no point investing energy into it.

Fixes: https://github.com/huggingface/transformers/issues/9865

@patil-suraj, @sgugger 