### PR TITLE
[trainer] [deepspeed] refactor deepspeed setup devices

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -522,6 +522,20 @@ class TrainingArguments:
             self.local_rank = dist.get_local_rank()
             device = torch.device("cuda", self.local_rank)
             self._n_gpu = 1
+        elif self.deepspeed:
+            # deepspeed performs its own DDP internally, and requires the program to be started with:
+            # deepspeed  ./program.py
+            # rather than:
+            # python -m torch.distributed.launch --nproc_per_node=2 ./program.py
+            from .integrations import is_deepspeed_available
+
+            if not is_deepspeed_available():
+                raise ImportError("--deepspeed requires deepspeed: `pip install deepspeed`.")
+            import deepspeed
+
+            deepspeed.init_distributed()
+            device = torch.device("cuda", self.local_rank)
+            self._n_gpu = 1
         elif self.local_rank == -1:
             # if n_gpu is > 1 we'll use nn.DataParallel.
             # If you only want to use a specific subset of GPUs use `CUDA_VISIBLE_DEVICES=0`
@@ -536,21 +550,7 @@ class TrainingArguments:
         else:
             # Here, we'll use torch.distributed.
             # Initializes the distributed backend which will take care of synchronizing nodes/GPUs
-            #
-            # deepspeed performs its own DDP internally, and requires the program to be started with:
-            # deepspeed  ./program.py
-            # rather than:
-            # python -m torch.distributed.launch --nproc_per_node=2 ./program.py
-            if self.deepspeed:
-                from .integrations import is_deepspeed_available
-
-                if not is_deepspeed_available():
-                    raise ImportError("--deepspeed requires deepspeed: `pip install deepspeed`.")
-                import deepspeed
-
-                deepspeed.init_distributed()
-            else:
-                torch.distributed.init_process_group(backend="nccl")
+            torch.distributed.init_process_group(backend="nccl")
             device = torch.device("cuda", self.local_rank)
             self._n_gpu = 1
 


### PR DESCRIPTION
Following the discussion at https://github.com/huggingface/transformers/pull/9798#pullrequestreview-578822445 as we now have multiple integrations with complex unique setups, @sgugger and I agreed that it's better to have a small duplication of a few lines of code but to make it much easier to understand what goes on for a specific integration, so rather than further refactoring the recently added sage branch, this PR creates a dedicated branch for DeepSpeed and thus simplifies the general case when straight DDP is used.

There is no functionality change - just a small code reshuffle.

@sgugger 
