### PR TITLE
Doc title in the template

### DIFF
--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/{{cookiecutter.lowercase_modelname}}.rst
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/{{cookiecutter.lowercase_modelname}}.rst
@@ -10,7 +10,7 @@
     an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
     specific language governing permissions and limitations under the License.
 
-{{cookiecutter.uppercase_modelname}}
+{{cookiecutter.modelname}}
 -----------------------------------------------------------------------------------------------------------------------
 
 Overview


### PR DESCRIPTION
# What does this PR do?

After reviewing a few PRs post-template, I'm noticing the doc pages are always misnamed -> they should use the cased name of the model, not the uppercase version.