### PR TITLE
[seq2seq] fix logger format for non-main process

### DIFF
--- a/examples/seq2seq/finetune_trainer.py
+++ b/examples/seq2seq/finetune_trainer.py
@@ -175,11 +175,11 @@ def main():
         bool(training_args.parallel_mode == ParallelMode.DISTRIBUTED),
         training_args.fp16,
     )
+    transformers.utils.logging.enable_default_handler()
+    transformers.utils.logging.enable_explicit_format()
     # Set the verbosity to info of the Transformers logger (on main process only):
     if is_main_process(training_args.local_rank):
         transformers.utils.logging.set_verbosity_info()
-        transformers.utils.logging.enable_default_handler()
-        transformers.utils.logging.enable_explicit_format()
     logger.info("Training/evaluation parameters %s", training_args)
 
     # Set seed


### PR DESCRIPTION
Currently, in `finetune_trainer.py` non-main process doesn't have any formatting at all, so we end up with:

```
[WARNING|modeling_t5.py:1645] 2021-01-30 20:01:37,246 >> [p0] got MPU
[WARNING|modeling_t5.py:1646] 2021-01-30 20:01:37,246 >> [p0] DP group [0]
[p1] got MPU
[p1] DP group [1]
```

as you can see the 2nd process in DDP misses formatting in logger.

this PR fixes it.

I looked in the take-over version `run_seq2seq.py` if it needed to be fixed too and it doesn't have these function calls, not sure why.  They appear to be needed, unless they get called elsewhere.

@sgugger, @patil-suraj 
