### PR TITLE
Bump numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ _deps = [
     "jax>=0.2.0",
     "jaxlib>=0.1.59",
     "keras2onnx",
-    "numpy",
+    "numpy>=1.17",
     "onnxconverter-common",
     "onnxruntime-tools>=1.4.2",
     "onnxruntime>=1.4.0",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -18,7 +18,7 @@ deps = {
     "jax": "jax>=0.2.0",
     "jaxlib": "jaxlib>=0.1.59",
     "keras2onnx": "keras2onnx",
-    "numpy": "numpy",
+    "numpy": "numpy>=1.17",
     "onnxconverter-common": "onnxconverter-common",
     "onnxruntime-tools": "onnxruntime-tools>=1.4.2",
     "onnxruntime": "onnxruntime>=1.4.0",


### PR DESCRIPTION
# What does this PR do?

As pointed out on the [forums](https://discuss.huggingface.co/t/typeerror-full-like-got-an-unexpected-keyword-argument-shape/2981), the method `np.full_like` used in the evaluation of the `Trainer` with the argument `shape=` does not work for all versions of numpy. According to the [numpy documentation]() it was introduced in version 1.17 only, so this PR bumps the setup to that version.

If for some reason we don't want to have a minimum version of numpy, I can try to find another way to do the same thing in `Trainer`.