### PR TITLE
ConvBERT: minor fixes for conversion script

### DIFF
--- a/src/transformers/models/convbert/convert_convbert_original_tf1_checkpoint_to_pytorch.py
+++ b/src/transformers/models/convbert/convert_convbert_original_tf1_checkpoint_to_pytorch.py
@@ -16,8 +16,8 @@
 
 import argparse
 
-from ...utils import logging
-from .modeling_convbert import ConvBertConfig, ConvBertModel, load_tf_weights_in_convbert
+from transformers import ConvBertConfig, ConvBertModel, load_tf_weights_in_convbert
+from transformers.utils import logging
 
 
 logging.set_verbosity_info()
@@ -49,4 +49,4 @@ if __name__ == "__main__":
         "--pytorch_dump_path", default=None, type=str, required=True, help="Path to the output PyTorch model."
     )
     args = parser.parse_args()
-    convert_orig_tf1_checkpoint_to_pytorch(args.tf_checkpoint_path, args.conv_bert_config_file, args.pytorch_dump_path)
+    convert_orig_tf1_checkpoint_to_pytorch(args.tf_checkpoint_path, args.convbert_config_file, args.pytorch_dump_path)


### PR DESCRIPTION
Hi,

the conversion script for ConvBERT throws the following error message when using it:

```bash
Traceback (most recent call last):
  File "convert_convbert_original_tf1_checkpoint_to_pytorch.py", line 19, in <module>
    from ...utils import logging
ImportError: attempted relative import with no known parent package
```

I fixed that error, as well as using the correct name for the configuration file argument.

Additionally, I just found that the configuration files from the [YituTech](https://huggingface.co/YituTech) organization for ConvBERT from aren't correct, because they use:

```json
"model_type": "conv_bert",
```

instead of:

```json
"model_type": "convbert",
```

(This currently results in a `KeyError: 'conv_bert'` error).