### PR TITLE
Fix Longformer and LED

### DIFF
--- a/src/transformers/models/led/modeling_tf_led.py
+++ b/src/transformers/models/led/modeling_tf_led.py
@@ -1665,7 +1665,6 @@ class TFLEDEncoder(tf.keras.layers.Layer):
     def compute_hidden_states(self, hidden_states, padding_len):
         return hidden_states[:, :-padding_len] if padding_len > 0 else hidden_states
 
-    @tf.function
     def _pad_to_window_size(
         self,
         input_ids,
@@ -1685,26 +1684,28 @@ class TFLEDEncoder(tf.keras.layers.Layer):
         batch_size, seq_len = input_shape[:2]
         padding_len = (attention_window - seq_len % attention_window) % attention_window
 
-        if padding_len > 0:
+        if tf.math.greater(padding_len, 0):
             logger.info(
                 "Input ids are automatically padded from {} to {} to be a multiple of `config.attention_window`: {}".format(
                     seq_len, seq_len + padding_len, attention_window
                 )
             )
 
-            paddings = tf.convert_to_tensor([[0, 0], [0, padding_len]])
+        paddings = tf.convert_to_tensor([[0, 0], [0, padding_len]])
 
-            if input_ids is not None:
-                input_ids = tf.pad(input_ids, paddings, constant_values=pad_token_id)
+        if input_ids is not None:
+            input_ids = tf.pad(input_ids, paddings, constant_values=pad_token_id)
 
-            if inputs_embeds is not None:
+        if inputs_embeds is not None:
+
+            def pad_embeddings():
                 input_ids_padding = tf.fill((batch_size, padding_len), pad_token_id)
                 inputs_embeds_padding = self.embed_tokens(input_ids_padding)
-                inputs_embeds = tf.concat([inputs_embeds, inputs_embeds_padding], axis=-2)
+                return tf.concat([inputs_embeds, inputs_embeds_padding], axis=-2)
 
-            attention_mask = tf.pad(
-                attention_mask, paddings, constant_values=False
-            )  # no attention on the padding tokens
+            inputs_embeds = tf.cond(tf.math.greater(padding_len, 0), pad_embeddings, lambda: inputs_embeds)
+
+        attention_mask = tf.pad(attention_mask, paddings, constant_values=False)  # no attention on the padding tokens
 
         return (
             padding_len,

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -1836,7 +1836,7 @@ class TFLongformerMainLayer(tf.keras.layers.Layer):
         batch_size, seq_len = input_shape[:2]
         padding_len = (attention_window - seq_len % attention_window) % attention_window
 
-        if padding_len > 0:
+        if tf.math.greater(padding_len, 0):
             logger.info(
                 "Input ids are automatically padded from {} to {} to be a multiple of `config.attention_window`: {}".format(
                     seq_len, seq_len + padding_len, attention_window
@@ -1859,7 +1859,7 @@ class TFLongformerMainLayer(tf.keras.layers.Layer):
                 inputs_embeds_padding = self.embeddings(input_ids_padding)
                 return tf.concat([inputs_embeds, inputs_embeds_padding], axis=-2)
 
-            inputs_embeds = tf.cond(padding_len > 0, pad_embeddings, lambda: inputs_embeds)
+            inputs_embeds = tf.cond(tf.math.greater(padding_len, 0), pad_embeddings, lambda: inputs_embeds)
 
         attention_mask = tf.pad(attention_mask, paddings, constant_values=False)  # no attention on the padding tokens
         token_type_ids = tf.pad(token_type_ids, paddings, constant_values=0)  # pad with token_type_id = 0

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -870,6 +870,36 @@ class TFModelTesterMixin:
                 inputs["decoder_inputs_embeds"] = model.get_input_embeddings()(decoder_input_ids)
 
             model(inputs)
+    
+    def test_graph_mode_with_inputs_embeds(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+
+            inputs = copy.deepcopy(self._prepare_for_class(inputs_dict, model_class))
+            if not self.is_encoder_decoder:
+                input_ids = inputs["input_ids"]
+                del inputs["input_ids"]
+            else:
+                encoder_input_ids = inputs["input_ids"]
+                decoder_input_ids = inputs.get("decoder_input_ids", encoder_input_ids)
+                del inputs["input_ids"]
+                inputs.pop("decoder_input_ids", None)
+
+            if not self.is_encoder_decoder:
+                inputs["inputs_embeds"] = model.get_input_embeddings()(input_ids)
+            else:
+                inputs["inputs_embeds"] = model.get_input_embeddings()(encoder_input_ids)
+                inputs["decoder_inputs_embeds"] = model.get_input_embeddings()(decoder_input_ids)
+            
+            @tf.function
+            def run_in_graph_mode():
+                return model(inputs)
+            
+            outputs = run_in_graph_mode()
+            self.assertIsNotNone(outputs)
+
 
     def test_numpy_arrays_inputs(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -870,7 +870,7 @@ class TFModelTesterMixin:
                 inputs["decoder_inputs_embeds"] = model.get_input_embeddings()(decoder_input_ids)
 
             model(inputs)
-    
+
     def test_graph_mode_with_inputs_embeds(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
@@ -892,14 +892,13 @@ class TFModelTesterMixin:
             else:
                 inputs["inputs_embeds"] = model.get_input_embeddings()(encoder_input_ids)
                 inputs["decoder_inputs_embeds"] = model.get_input_embeddings()(decoder_input_ids)
-            
+
             @tf.function
             def run_in_graph_mode():
                 return model(inputs)
-            
+
             outputs = run_in_graph_mode()
             self.assertIsNotNone(outputs)
-
 
     def test_numpy_arrays_inputs(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
# What does this PR do?

This PR fix TF Longformer and LED when `inputs_embeds`/`decoder_inputs_embeds` are used as main input instead of `input_ids`/`decoder_input_ids`.

Here a quick test that shows the bug for Longformer:
```python
from transformers.models.longformer.modeling_tf_longformer import TFLongformerMainLayer
from tensorflow.keras.layers import Input, Dense
from tensorflow.keras.models import Model
from transformers import LongformerConfig
import tensorflow as tf
import numpy as np

class CustomLongFormer(tf.keras.layers.Layer):
    def __init__(self, name='longformer', **kwargs):
        super().__init__(name=name, **kwargs)
        config = LongformerConfig(attention_window=4, num_hidden_layers=1, vocab_size=10)
        self.longformer = TFLongformerMainLayer(config)

    def call(self, inputs):
        x = self.longformer(inputs)[0]
        return x


longformer = CustomLongFormer()
inputs_embeds = Input(shape=(None, None), dtype='float32', name="inputs_embeds")
output = longformer({"inputs_embeds": inputs_embeds})
output = Dense(9, activation='softmax')(output)
model = Model({"inputs_embeds": inputs_embeds}, output)
model.compile(optimizer='adam', loss='sparse_categorical_crossentropy')

x = np.array([np.random.uniform(0,1, (3, 768))] * 100)
y = np.array([[1]*3] * 100)
model.fit(x=x, y=y, epochs=10, batch_size=4, validation_split=0.1)
```

And the one for LED:
```python
from transformers.models.led.modeling_tf_led import TFLEDMainLayer
from tensorflow.keras.layers import Input, Dense
from tensorflow.keras.models import Model
from transformers import LEDConfig
import tensorflow as tf
import numpy as np

class CustomLED(tf.keras.layers.Layer):
    def __init__(self, name='longformer', **kwargs):
        super().__init__(name=name, **kwargs)
        config = LEDConfig(attention_window=4, num_hidden_layers=1, vocab_size=10)
        self.led = TFLEDMainLayer(config)

    def call(self, inputs):
        x = self.led(inputs)[0]
        return x


led = CustomLED()
inputs_embeds = Input(shape=(None, None), dtype='float32', name="inputs_embeds")
decoder_inputs_embeds = Input(shape=(None, None), dtype='float32', name="decoder_inputs_embeds")
output = led({"inputs_embeds": inputs_embeds, "decoder_inputs_embeds": decoder_inputs_embeds})
output = Dense(9, activation='softmax')(output)
model = Model({"inputs_embeds": inputs_embeds, "decoder_inputs_embeds": decoder_inputs_embeds}, output)
model.compile(optimizer='adam', loss='sparse_categorical_crossentropy')

x = np.array([np.random.uniform(0,1, (3, 1024))] * 100)
y = np.array([[1]*3] * 100)
model.fit(x={"inputs_embeds": x, "decoder_inputs_embeds": x}, y=y, epochs=10, batch_size=4, validation_split=0.1)
```

The reason is because the graph compiled is different than the one when the usual `input_ids`/`decoder_input_ids` are used. Knowing that we are not testing this case (in graph execution) other models might be involved in a similar bug. Hence, I put in my TODO list to create a test that will test if all the models can be used with different combinaison of inputs in graph mode.

# Fix issue
#9864 