### PR TITLE
[trainer] a few fixes

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -264,13 +264,14 @@ class Trainer:
         self.eval_dataset = eval_dataset
         self.tokenizer = tokenizer
 
-        # postpone switching to cuda when:
+        # postpone switching model to cuda when:
         # 1. MP - since we are trying to fit a much bigger than 1 gpu model
         # 2. fp16-enabled DeepSpeed loads the model in half the size and it doesn't need .to() anyway
-        if not self.is_model_parallel and not args.deepspeed:
+        if not (self.is_model_parallel or args.deepspeed):
             model = model.to(args.device)
-        else:
-            # Force n_gpu to 1 to avoid DataParallel.
+
+        # Force n_gpu to 1 to avoid DataParallel as MP will manage the GPUs
+        if self.is_model_parallel:
             self.args._n_gpu = 1
 
         # later use `self.model is self.model_wrapped` to check if it's wrapped or not


### PR DESCRIPTION
This PR:
- removes `model.to(device)` - it's not needed for DeepSpeed.  but primarily this allows loading models that otherwise won't load - e.g. loading 45GB (fp32) to a 40GB GPU when using Deepspeed with fp16 - as it loads only 22GB of it. But currently we load all 45GB right away and well nothing works
- decouples 2 unrelated logical things related to model parallel, which was very confusing in the previous if/else incarnation
- fixes a bug that left a deepspeed model to be  wrapped in DDP, but it shouldn't, like a few other bugs of the same kind I created as things just happened to work until they didn't. 

This PR enables t5-11b training on 1x 40GB gpu w/ Deepspeed  https://github.com/huggingface/transformers/issues/9996 

@sgugger