### PR TITLE
[s2s examples] Replace -100 token ids with the tokenizer pad_id for compute_metrics

### DIFF
--- a/examples/seq2seq/utils.py
+++ b/examples/seq2seq/utils.py
@@ -82,10 +82,10 @@ def build_compute_metrics_fn(task_name: str, tokenizer: PreTrainedTokenizer) -> 
         return np.count_nonzero(tokens != tokenizer.pad_token_id)
 
     def decode_pred(pred: EvalPrediction) -> Tuple[List[str], List[str]]:
-        labels_ids = pred.label_ids
         pred_ids = pred.predictions
+        label_ids = pred.label_ids
         pred_str = tokenizer.batch_decode(pred_ids, skip_special_tokens=True)
-        labels_ids[labels_ids == -100] = tokenizer.pad_token_id
+        label_ids[label_ids == -100] = tokenizer.pad_token_id
         label_str = tokenizer.batch_decode(label_ids, skip_special_tokens=True)
         pred_str = lmap(str.strip, pred_str)
         label_str = lmap(str.strip, label_str)

--- a/examples/seq2seq/utils.py
+++ b/examples/seq2seq/utils.py
@@ -82,8 +82,11 @@ def build_compute_metrics_fn(task_name: str, tokenizer: PreTrainedTokenizer) -> 
         return np.count_nonzero(tokens != tokenizer.pad_token_id)
 
     def decode_pred(pred: EvalPrediction) -> Tuple[List[str], List[str]]:
-        pred_str = tokenizer.batch_decode(pred.predictions, skip_special_tokens=True)
-        label_str = tokenizer.batch_decode(pred.label_ids, skip_special_tokens=True)
+        labels_ids = pred.label_ids
+        pred_ids = pred.predictions
+        pred_str = tokenizer.batch_decode(pred_ids, skip_special_tokens=True)
+        labels_ids[labels_ids == -100] = tokenizer.pad_token_id
+        label_str = tokenizer.batch_decode(label_ids, skip_special_tokens=True)
         pred_str = lmap(str.strip, pred_str)
         label_str = lmap(str.strip, label_str)
         return pred_str, label_str


### PR DESCRIPTION
# What does this PR do?

This PR is a small fix that replaces the -100 token ids with the tokenizer pad_id when decoding sequences to compute metrics as was done in [this HF blog post](https://huggingface.co/blog/warm-starting-encoder-decoder)

## When does this problem occur?

When running `examples/seq2seq/finetune_trainer.py` with padding to the `max_seq_len`, an error is thrown at the evaluation step:

```
  File "/opt/conda/lib/python3.8/site-packages/transformers/trainer.py", line 1004, in _maybe_log_save_evaluate
    metrics = self.evaluate()
  File "/opt/conda/lib/python3.8/site-packages/transformers/trainer_seq2seq.py", line 96, in evaluate
    return super().evaluate(eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
  File "/opt/conda/lib/python3.8/site-packages/transformers/trainer.py", line 1442, in evaluate
    output = self.prediction_loop(
  File "/opt/conda/lib/python3.8/site-packages/transformers/trainer.py", line 1601, in prediction_loop
    metrics = self.compute_metrics(EvalPrediction(predictions=preds, label_ids=label_ids))
  File "/eai/transformers/examples/seq2seq/utils.py", line 98, in translation_metrics
    pred_str, label_str = decode_pred(pred)
  File "/eai/transformers/examples/seq2seq/utils.py", line 85, in decode_pred
    label_str = tokenizer.batch_decode(pred.label_ids, skip_special_tokens=True)
  File "/opt/conda/lib/python3.8/site-packages/transformers/tokenization_utils_base.py", line 3070, in batch_decode
    return [
  File "/opt/conda/lib/python3.8/site-packages/transformers/tokenization_utils_base.py", line 3071, in <listcomp>
    self.decode(
  File "/opt/conda/lib/python3.8/site-packages/transformers/tokenization_utils_base.py", line 3109, in decode
    return self._decode(
  File "/opt/conda/lib/python3.8/site-packages/transformers/tokenization_utils_fast.py", line 495, in _decode
    text = self._tokenizer.decode(token_ids, skip_special_tokens=skip_special_tokens)
OverflowError: out of range integral type conversion attempted
```

This is because in the prediction loop, the labels will be padded with -100 if the prediction or labels have different sequence length https://github.com/huggingface/transformers/blob/master/src/transformers/trainer.py#L1637.

