### PR TITLE
Disable temporarily too slow tests (Longformer/LED)

### DIFF
--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -517,7 +517,7 @@ class TF{{cookiecutter.camelcase_modelname}}Encoder(tf.keras.layers.Layer):
         )
 
 
-# Copied from transformers.models.bert.modeling_tf_bert.TFBertPredictionHead with Bert->{{cookiecutter.camelcase_modelname}}
+# Copied from transformers.models.bert.modeling_tf_bert.TFBertPredictionHeadTransform with Bert->{{cookiecutter.camelcase_modelname}}
 class TF{{cookiecutter.camelcase_modelname}}PredictionHeadTransform(tf.keras.layers.Layer):
     def __init__(self, config: {{cookiecutter.camelcase_modelname}}Config, **kwargs):
         super().__init__(**kwargs)

--- a/tests/test_modeling_tf_led.py
+++ b/tests/test_modeling_tf_led.py
@@ -377,6 +377,22 @@ class TFLEDModelTest(TFModelTesterMixin, unittest.TestCase):
         # Need to check with PVP how to properly fix this
         pass
 
+    @slow
+    def test_saved_model_with_hidden_states_output(self):
+        # Temporarily disable this test in order to find
+        # how to better handle it without timing out the CI
+        pass
+
+    def test_saved_model_creation(self):
+        # This test is too long (>30sec) and makes fail the CI
+        pass
+
+    @slow
+    def test_saved_model_creation_extended(self):
+        # Temporarily disable this test in order to find
+        # how to better handle it without timing out the CI
+        pass
+
 
 def _assert_tensors_equal(a, b, atol=1e-12, prefix=""):
     """If tensors not close, or a and b arent both tensors, raise a nice Assertion error."""

--- a/tests/test_modeling_tf_led.py
+++ b/tests/test_modeling_tf_led.py
@@ -353,10 +353,6 @@ class TFLEDModelTest(TFModelTesterMixin, unittest.TestCase):
             self.assertEqual(model.config.output_hidden_states, True)
             check_encoder_attentions_output(outputs)
 
-    def test_saved_model_creation(self):
-        # This test is too long (>30sec) and makes fail the CI
-        pass
-
     def test_mixed_precision(self):
         # TODO JP: Make LED float16 compliant
         pass

--- a/tests/test_modeling_tf_longformer.py
+++ b/tests/test_modeling_tf_longformer.py
@@ -351,8 +351,20 @@ class TFLongformerModelTest(TFModelTesterMixin, unittest.TestCase):
         # Need to check with PVP how to properly fix this
         pass
 
+    @slow
+    def test_saved_model_with_hidden_states_output(self):
+        # Temporarily disable this test in order to find
+        # how to better handle it without timing out the CI
+        pass
+
     def test_saved_model_creation(self):
         # This test is too long (>30sec) and makes fail the CI
+        pass
+
+    @slow
+    def test_saved_model_creation_extended(self):
+        # Temporarily disable this test in order to find
+        # how to better handle it without timing out the CI
         pass
 
     def test_mixed_precision(self):


### PR DESCRIPTION
# What does this PR do?

The tests about SavedModel takes way too long for Longformer and LED. To do not timeout the CI, we disable them and will see how to better handle them.