### PR TITLE
Logging propagation

### DIFF
--- a/docs/source/main_classes/logging.rst
+++ b/docs/source/main_classes/logging.rst
@@ -65,6 +65,10 @@ Other functions
 
 .. autofunction:: transformers.logging.get_logger
 
+.. autofunction:: transformers.logging.enable_default_handler
+
+.. autofunction:: transformers.logging.disable_default_handler
+
 .. autofunction:: transformers.logging.enable_explicit_format
 
 .. autofunction:: transformers.logging.reset_format

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -85,7 +85,6 @@ def _configure_library_root_logger() -> None:
         library_root_logger = _get_library_root_logger()
         library_root_logger.addHandler(_default_handler)
         library_root_logger.setLevel(_get_default_logging_level())
-        library_root_logger.propagate = False
 
 
 def _reset_library_root_logger() -> None:


### PR DESCRIPTION
This PR enables logs propagation by default with transformers' logging system, in a similar fashion to https://github.com/huggingface/datasets/pull/1845.

Unlike `datasets` however, we will not remove the default handler in transformers' logging system: this handler is heavily used in all examples, and removing the default handler would prevent the formatting from being correctly applied to the examples.
Since this is the best practice shown in examples, I believe this change would be breaking for users that have copy/pasted this change across their codebases, and this change would therefore be breaking for these users.

Furthermore, any user that does not want the default handler may use the `disable_default_handler` method in order to disable that behavior. These two methods are added to the documentation in this PR.

cc @lhoestq @sgugger @patrickvonplaten 