### PR TITLE
Fix some edge cases in report_to and add deprecation warnings

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -56,6 +56,10 @@ from .trainer_utils import PREFIX_CHECKPOINT_DIR, BestRun, EvaluationStrategy  #
 def is_wandb_available():
     # any value of WANDB_DISABLED disables wandb
     if os.getenv("WANDB_DISABLED", "").upper() in ENV_VARS_TRUE_VALUES:
+        logger.warn(
+            "Using the `WAND_DISABLED` environment variable is deprecated and will be removed in v5. Use the "
+            "--report_to flag to control the integrations used for logging result (for instance --report_to none)."
+        )
         return False
     return importlib.util.find_spec("wandb") is not None
 


### PR DESCRIPTION
# What does this PR do?

This PR adds two new values for the `report_to` TrainingArguments:
- "all" for all integrations installed
- "none" for none (necessary when using in the CLI and we can't pass an empty list)

It also starts warning the user (with an info to not be too spammy) of the upcoming change of default in v5.