### PR TITLE
Fix tokenizers training in notebooks

### DIFF
--- a/notebooks/01-training-tokenizers.ipynb
+++ b/notebooks/01-training-tokenizers.ipynb
@@ -229,7 +229,7 @@
     "\n",
     "# We initialize our trainer, giving him the details about the vocabulary we want to generate\n",
     "trainer = BpeTrainer(vocab_size=25000, show_progress=True, initial_alphabet=ByteLevel.alphabet())\n",
-    "tokenizer.train(trainer, [\"big.txt\"])\n",
+    "tokenizer.train(files=[\"big.txt\"], trainer=trainer)\n",
     "\n",
     "print(\"Trained vocab size: {}\".format(tokenizer.get_vocab_size()))"
    ]


### PR DESCRIPTION
The `train` method has been updated in `tokenizers` v0.10, and it includes a breaking change from the previous versions (reordered arguments). This modification ensures it works for all versions.

cc @sgugger @LysandreJik 