### PR TITLE
[CI] build docs faster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,7 +306,7 @@ jobs:
                   key: v0.4-build_doc-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: cd docs && make html SPHINXOPTS="-W"
+            - run: cd docs && make html SPHINXOPTS="-W -j 4"
             - store_artifacts:
                 path: ./docs/_build
 


### PR DESCRIPTION
I assume the CI machine should have at least 4 cores, so let's build docs faster.

@sgugger, @LysandreJik 