### PR TITLE
[Wav2Vec2] Improve Tokenizer & Model for batched inference

### DIFF
--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -114,6 +114,9 @@ class Wav2Vec2GroupNormConvLayer(nn.Module):
     def forward(self, hidden_states):
         hidden_states = self.conv(hidden_states)
         hidden_states = self.dropout(hidden_states)
+        import ipdb
+
+        ipdb.set_trace()
         hidden_states = self.layer_norm(hidden_states)
         hidden_states = self.activation(hidden_states)
         return hidden_states
@@ -191,7 +194,6 @@ class Wav2Vec2FeatureProjection(nn.Module):
         self.dropout = nn.Dropout(config.feat_extract_dropout)
 
     def forward(self, hidden_states):
-        hidden_states = hidden_states.transpose(1, 2)
         hidden_states = self.layer_norm(hidden_states)
         hidden_states = self.projection(hidden_states)
         hidden_states = self.dropout(hidden_states)
@@ -387,9 +389,11 @@ class Wav2Vec2EncoderLayer(nn.Module):
         self.feed_forward = Wav2Vec2FeedForward(config)
         self.final_layer_norm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
 
-    def forward(self, hidden_states, output_attentions=False):
+    def forward(self, hidden_states, attention_mask=None, output_attentions=False):
         attn_residual = hidden_states
-        hidden_states, attn_weights, _ = self.attention(hidden_states, output_attentions=output_attentions)
+        hidden_states, attn_weights, _ = self.attention(
+            hidden_states, attention_mask=attention_mask, output_attentions=output_attentions
+        )
         hidden_states = self.dropout(hidden_states)
         hidden_states = attn_residual + hidden_states
 
@@ -414,10 +418,12 @@ class Wav2Vec2EncoderLayerStableLayerNorm(nn.Module):
         self.feed_forward = Wav2Vec2FeedForward(config)
         self.final_layer_norm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
 
-    def forward(self, hidden_states, output_attentions=False):
+    def forward(self, hidden_states, attention_mask=None, output_attentions=False):
         attn_residual = hidden_states
         hidden_states = self.layer_norm(hidden_states)
-        hidden_states, attn_weights, _ = self.attention(hidden_states, output_attentions=output_attentions)
+        hidden_states, attn_weights, _ = self.attention(
+            hidden_states, attention_mask=attention_mask, output_attentions=output_attentions
+        )
         hidden_states = self.dropout(hidden_states)
         hidden_states = attn_residual + hidden_states
         hidden_states = hidden_states + self.feed_forward(self.final_layer_norm(hidden_states))
@@ -438,12 +444,23 @@ class Wav2Vec2Encoder(nn.Module):
     def forward(
         self,
         hidden_states,
+        attention_mask=None,
         output_attentions=False,
         output_hidden_states=False,
         return_dict=True,
     ):
         all_hidden_states = () if output_hidden_states else None
         all_self_attentions = () if output_attentions else None
+
+        if attention_mask is not None:
+            # make sure padded tokens output 0
+            hidden_states[~attention_mask] = 0.0
+
+            # extend attention_mask
+            attention_mask = (1.0 - attention_mask[:, None, None, :].to(dtype=hidden_states.dtype)) * -10000.0
+            attention_mask = attention_mask.expand(
+                attention_mask.shape[0], 1, attention_mask.shape[-1], attention_mask.shape[-1]
+            )
 
         position_embeddings = self.pos_conv_embed(hidden_states)
         hidden_states = hidden_states + position_embeddings
@@ -454,7 +471,9 @@ class Wav2Vec2Encoder(nn.Module):
             if output_hidden_states:
                 all_hidden_states = all_hidden_states + (hidden_states,)
 
-            hidden_states, attn_weights = layer(hidden_states, output_attentions=output_attentions)
+            hidden_states, attn_weights = layer(
+                hidden_states, attention_mask=attention_mask, output_attentions=output_attentions
+            )
 
             if output_attentions:
                 all_self_attentions = all_self_attentions + (attn_weights,)
@@ -486,12 +505,17 @@ class Wav2Vec2EncoderStableLayerNorm(nn.Module):
     def forward(
         self,
         hidden_states,
+        attention_mask=None,
         output_attentions=False,
         output_hidden_states=False,
         return_dict=True,
     ):
         all_hidden_states = () if output_hidden_states else None
         all_self_attentions = () if output_attentions else None
+
+        if attention_mask is not None:
+            # make sure padded tokens are not attended to
+            hidden_states[attention_mask] = 0
 
         position_embeddings = self.pos_conv_embed(hidden_states)
         hidden_states = hidden_states + position_embeddings
@@ -501,7 +525,9 @@ class Wav2Vec2EncoderStableLayerNorm(nn.Module):
             if output_hidden_states:
                 all_hidden_states = all_hidden_states + (hidden_states,)
 
-            hidden_states, attn_weights = layer(hidden_states, output_attentions=output_attentions)
+            hidden_states, attn_weights = layer(
+                hidden_states, attention_mask=attention_mask, output_attentions=output_attentions
+            )
 
             if output_attentions:
                 all_self_attentions = all_self_attentions + (attn_weights,)
@@ -606,6 +632,7 @@ class Wav2Vec2Model(Wav2Vec2PreTrainedModel):
     def forward(
         self,
         input_values,
+        attention_mask=None,
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
@@ -641,10 +668,28 @@ class Wav2Vec2Model(Wav2Vec2PreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         hidden_states = self.feature_extractor(input_values)
+        hidden_states = hidden_states.transpose(1, 2)
+
+        if attention_mask is not None:
+            batch_size, input_length = attention_mask.shape
+            output_length = hidden_states.shape[1]
+
+            superfluous_padding = input_length % output_length
+
+            if superfluous_padding > 0:
+                attention_mask = attention_mask[:, :-superfluous_padding]
+
+            # attention_mask from shape [batch_size, input_length] to [batch_size, output_length]
+            # and only pad hidden_states that correspond to a fully padded input
+            attention_mask = attention_mask.bool().view(batch_size, output_length, -1).all(-1)
+
         hidden_states = self.feature_projection(hidden_states)
+
+        #        print("hidden_states", hidden_states[:, :3, :3])
 
         encoder_outputs = self.encoder(
             hidden_states,
+            attention_mask=attention_mask,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
@@ -681,6 +726,7 @@ class Wav2Vec2ForMaskedLM(Wav2Vec2PreTrainedModel):
     def forward(
         self,
         input_values,
+        attention_mask=None,
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
@@ -755,6 +801,7 @@ class Wav2Vec2ForCTC(Wav2Vec2PreTrainedModel):
     def forward(
         self,
         input_values,
+        attention_mask=None,
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
@@ -795,6 +842,7 @@ class Wav2Vec2ForCTC(Wav2Vec2PreTrainedModel):
 
         outputs = self.wav2vec2(
             input_values,
+            attention_mask=attention_mask,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -688,7 +688,7 @@ class Wav2Vec2Model(Wav2Vec2PreTrainedModel):
         hidden_states = hidden_states.transpose(1, 2)
 
         if attention_mask is not None:
-            # get real output lengths
+            # compute real output lengths according to convolution formula
             output_lengths = self._get_feat_extract_output_lengths(attention_mask.sum(-1))
 
             attention_mask = torch.zeros(

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -629,8 +629,8 @@ WAV_2_VEC_2_INPUTS_DOCSTRING = r"""
             `What are attention masks? <../glossary.html#attention-mask>`__
 
             .. warning::
-                :obj:`attention_mask` should only be passed if the corresponding tokenizer has set
-                ``config.return_attention_mask == True``. For all models whose tokenizer have set
+                :obj:`attention_mask` should only be passed if the corresponding tokenizer has
+                ``config.return_attention_mask == True``. For all models whose tokenizer has
                 ``config.return_attention_mask == False``, such as `wav2vec2-base
                 <https://huggingface.co/facebook/wav2vec2-base-960h>`__, :obj:`attention_mask` should **not** be passed
                 to avoid degraded performance when doing batched inference. For such models :obj:`input_values` should

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -614,6 +614,24 @@ WAV_2_VEC_2_INPUTS_DOCSTRING = r"""
             soundfile`). To prepare the array into `input_values`, the :class:`~transformers.Wav2Vec2Tokenizer` should
             be used for padding and conversion into a tensor of type `torch.FloatTensor`. See
             :meth:`transformers.Wav2Vec2Tokenizer.__call__` for details.
+        attention_mask (:obj:`torch.LongTensor` of shape :obj:`(batch_size, sequence_length)`, `optional`):
+            Mask to avoid performing convolution and attention on padding token indices. Mask values selected in ``[0,
+            1]``:
+
+            - 1 for tokens that are **not masked**,
+            - 0 for tokens that are **masked**.
+
+            `What are attention masks? <../glossary.html#attention-mask>`__
+
+            .. warning::
+                :obj:`attention_mask` should only be provided to the model if the corresponding tokenizer has set
+                ``config.return_attention_mask == True``. All models whose tokenizer have set
+                ``config.return_attention_mask == False``, such as `wav2vec2-base
+                <https://huggingface.co/facebook/wav2vec2-base-960h>`__, should **not** pass :obj:`attention_mask` to
+                avoid degraded performance when doing batched inference. For such models :obj:`input_values` should
+                simply be padded with 0 and passed without :obj:`attention_mask`. Be aware that these models also yield
+                slightly different results depending on whether the speech input is padded or not.
+
         output_attentions (:obj:`bool`, `optional`):
             Whether or not to return the attentions tensors of all attention layers. See ``attentions`` under returned
             tensors for more detail.

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -67,7 +67,6 @@ class Wav2Vec2NoLayerNormConvLayer(nn.Module):
 class Wav2Vec2LayerNormConvLayer(nn.Module):
     def __init__(self, config, layer_id=0):
         super().__init__()
-        self.id = layer_id
         self.in_conv_dim = config.conv_dim[layer_id] if layer_id > 0 else 1
         self.out_conv_dim = config.conv_dim[layer_id]
 

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -36,7 +36,10 @@ logger = logging.get_logger(__name__)
 _CONFIG_FOR_DOC = "Wav2Vec2Config"
 
 WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST = [
-    "facebook/wav2vec2-base-960h"
+    "facebook/wav2vec2-base-960h",
+    "facebook/wav2vec2-large-960h",
+    "facebook/wav2vec2-large-960h-lv60",
+    "facebook/wav2vec2-large-960h-lv60-self",
     # See all Wav2Vec2 models at https://huggingface.co/models?filter=wav2vec2
 ]
 
@@ -579,6 +582,8 @@ class Wav2Vec2PreTrainedModel(PreTrainedModel):
         """
 
         def _conv_out_length(input_length, kernel_size, stride):
+            # 1D convolutional layer output length formula taken
+            # from https://pytorch.org/docs/stable/generated/torch.nn.Conv1d.html
             return torch.floor((input_length - kernel_size) / stride + 1)
 
         for kernel_size, stride in zip(self.config.conv_kernel, self.config.conv_stride):
@@ -624,13 +629,13 @@ WAV_2_VEC_2_INPUTS_DOCSTRING = r"""
             `What are attention masks? <../glossary.html#attention-mask>`__
 
             .. warning::
-                :obj:`attention_mask` should only be provided to the model if the corresponding tokenizer has set
-                ``config.return_attention_mask == True``. All models whose tokenizer have set
+                :obj:`attention_mask` should only be passed if the corresponding tokenizer has set
+                ``config.return_attention_mask == True``. For all models whose tokenizer have set
                 ``config.return_attention_mask == False``, such as `wav2vec2-base
-                <https://huggingface.co/facebook/wav2vec2-base-960h>`__, should **not** pass :obj:`attention_mask` to
-                avoid degraded performance when doing batched inference. For such models :obj:`input_values` should
+                <https://huggingface.co/facebook/wav2vec2-base-960h>`__, :obj:`attention_mask` should **not** be passed
+                to avoid degraded performance when doing batched inference. For such models :obj:`input_values` should
                 simply be padded with 0 and passed without :obj:`attention_mask`. Be aware that these models also yield
-                slightly different results depending on whether the speech input is padded or not.
+                slightly different results depending on whether :obj:`input_values` is padded or not.
 
         output_attentions (:obj:`bool`, `optional`):
             Whether or not to return the attentions tensors of all attention layers. See ``attentions`` under returned

--- a/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
@@ -55,6 +55,9 @@ WAV2VEC2_KWARGS_DOCSTRING = r"""
             pad_to_multiple_of (:obj:`int`, `optional`):
                 If set will pad the sequence to a multiple of the provided value. This is especially useful to enable
                 the use of Tensor Cores on NVIDIA hardware with compute capability >= 7.5 (Volta).
+            normalize (:obj:`bool`, defaults to :obj:`True`):
+                Performs zero-mean and unit-variance on the input values
+
             return_tensors (:obj:`str` or :class:`~transformers.tokenization_utils_base.TensorType`, `optional`):
                 If set, will return tensors instead of list of python integers. Acceptable values are:
 
@@ -100,7 +103,7 @@ class Wav2Vec2Tokenizer(PreTrainedTokenizer):
             "facebook/wav2vec2-base-960h": "https://huggingface.co/facebook/wav2vec2-base-960h/resolve/main/tokenizer.json",
         },
     }
-    model_input_names = ["input_values"]
+    model_input_names = ["input_values", "attention_mask"]
 
     def __init__(
         self,
@@ -165,6 +168,7 @@ class Wav2Vec2Tokenizer(PreTrainedTokenizer):
         max_length: Optional[int] = None,
         pad_to_multiple_of: Optional[int] = None,
         return_tensors: Optional[Union[str, TensorType]] = None,
+        normalize: bool = True,
         verbose: bool = True,
         **kwargs
     ) -> BatchEncoding:
@@ -201,7 +205,7 @@ class Wav2Vec2Tokenizer(PreTrainedTokenizer):
             padding=padding,
             max_length=max_length,
             pad_to_multiple_of=pad_to_multiple_of,
-            return_attention_mask=False,
+            return_attention_mask=True,
             return_tensors=return_tensors,
             verbose=verbose,
         )

--- a/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
@@ -197,6 +197,10 @@ class Wav2Vec2Tokenizer(PreTrainedTokenizer):
         if not is_batched:
             raw_speech = [raw_speech]
 
+        # zero-mean and unit-variance normalization
+        if normalize:
+            raw_speech = [(x - np.mean(x)) / np.sqrt(np.var(x) + 1e-5) for x in raw_speech]
+
         # convert into correct format for padding
         encoded_inputs = BatchEncoding({"input_values": raw_speech})
 

--- a/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
@@ -55,9 +55,6 @@ WAV2VEC2_KWARGS_DOCSTRING = r"""
             pad_to_multiple_of (:obj:`int`, `optional`):
                 If set will pad the sequence to a multiple of the provided value. This is especially useful to enable
                 the use of Tensor Cores on NVIDIA hardware with compute capability >= 7.5 (Volta).
-            normalize (:obj:`bool`, defaults to :obj:`True`):
-                Performs zero-mean and unit-variance on the input values
-
             return_tensors (:obj:`str` or :class:`~transformers.tokenization_utils_base.TensorType`, `optional`):
                 If set, will return tensors instead of list of python integers. Acceptable values are:
 
@@ -91,26 +88,24 @@ class Wav2Vec2Tokenizer(PreTrainedTokenizer):
         word_delimiter_token (:obj:`str`, `optional`, defaults to :obj:`"|"`):
             The token used for defining the end of a word.
         do_lower_case (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            Whether or not to lowercase the input when tokenizing.
+            Whether or not to lowercase the output when decoding.
         do_normalize (:obj:`bool`, `optional`, defaults to :obj:`False`):
             Whether or not to zero-mean unit-variance normalize the input. Normalizing can help to significantly
             improve the performance for some models, *e.g.*, `wav2vec2-lv60
             <https://huggingface.co/models?search=lv60>`__.
         return_attention_mask (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            Whether :meth:`~transformers.Wav2Vec2Tokenizer.__call__` should return :obj:`attention_mask` for batched
-            inference.
+            Whether or not :meth:`~transformers.Wav2Vec2Tokenizer.__call__` should return :obj:`attention_mask`.
 
             .. note::
 
                 Wav2Vec2 models that have set ``config.feat_extract_norm == "group"``, such as `wav2vec2-base
                 <https://huggingface.co/facebook/wav2vec2-base-960h>`__, have **not** been trained using
-                :obj:`attention_mask` and therefore should **not** make use of :obj:`attention_mask` for batched
-                inference. For such, models :obj:`input_values` should simply be padded with 0 and no
-                :obj:`attention_mask` should be provided.
+                :obj:`attention_mask`. For such models, :obj:`input_values` should simply be padded with 0 and no
+                :obj:`attention_mask` should be passed.
 
-                Wav2Vec2 models that have set ``config.feat_extract_norm == "layer"``, such as `wav2vec2-lv60
-                <https://huggingface.co/facebook/wav2vec2-large-960h-lv60-self>`__ should make use of
-                :obj:`attention_mask` for batched inference.
+                For Wav2Vec2 models that have set ``config.feat_extract_norm == "layer"``, such as `wav2vec2-lv60
+                <https://huggingface.co/facebook/wav2vec2-large-960h-lv60-self>`__, :obj:`attention_mask` should be
+                passed for batched inference.
 
         **kwargs
             Additional keyword arguments passed along to :class:`~transformers.PreTrainedTokenizer`

--- a/tests/test_modeling_wav2vec2.py
+++ b/tests/test_modeling_wav2vec2.py
@@ -18,7 +18,7 @@
 import math
 import unittest
 
-from tests.test_modeling_common import floats_tensor
+from tests.test_modeling_common import floats_tensor, random_attention_mask
 from transformers import is_torch_available
 from transformers.testing_utils import require_datasets, require_soundfile, require_torch, slow, torch_device
 
@@ -93,6 +93,7 @@ class Wav2Vec2ModelTester:
 
     def prepare_config_and_inputs(self):
         input_values = floats_tensor([self.batch_size, self.seq_length], self.vocab_size)
+        attention_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         config = Wav2Vec2Config(
             hidden_size=self.hidden_size,
@@ -115,20 +116,53 @@ class Wav2Vec2ModelTester:
             vocab_size=self.vocab_size,
         )
 
-        return config, input_values
+        return config, input_values, attention_mask
 
-    def create_and_check_model(self, config, input_values):
+    def create_and_check_model(self, config, input_values, attention_mask):
         model = Wav2Vec2Model(config=config)
         model.to(torch_device)
         model.eval()
-        result = model(input_values)
+        result = model(input_values, attention_mask=attention_mask)
         self.parent.assertEqual(
             result.last_hidden_state.shape, (self.batch_size, self.output_seq_length, self.hidden_size)
         )
 
+    def create_and_check_batch_inference(self, config, input_values, *args):
+        model = Wav2Vec2Model(config=config)
+        model.to(torch_device)
+        model.eval()
+
+        input_values = input_values[:3]
+        attention_mask = torch.ones(input_values.shape, device=torch_device, dtype=torch.bool)
+
+        input_lengths = [input_values.shape[-1] // i for i in [1, 2, 4]]
+
+        #        input_values = input_values.view(2, 48, 32)
+        #        input_values = (input_values - torch.mean(input_values, -1, keepdim=True)) / torch.sqrt(torch.var(input_values, -1, keepdim=True, unbiased=False) + 1e-5)
+
+        #        self.layer_norm = torch.nn.GroupNorm(num_groups=48, num_channels=48, affine=True)
+
+        # pad input
+        for i in range(len(input_lengths)):
+            input_values[i, input_lengths[i] :] = 0.0
+            attention_mask[i, input_lengths[i] :] = 0.0
+
+        # normalize input values
+        #        input_values = (input_values - torch.mean(input_values, -1, keepdim=True)) / torch.sqrt(torch.var(input_values, -1, keepdim=True, unbiased=False) + 1e-5)
+        #
+        batch_outputs = model(input_values, attention_mask=attention_mask).last_hidden_state
+
+        for i in range(input_values.shape[0]):
+            input_slice = input_values[i : i + 1, : input_lengths[i]]
+            output = model(input_slice).last_hidden_state
+
+            batch_output = batch_outputs[i : i + 1, : output.shape[1]]
+            #            import ipdb; ipdb.set_trace()
+            self.parent.assertTrue(torch.allclose(output, batch_output, atol=1e-3))
+
     def prepare_config_and_inputs_for_common(self):
-        config, input_values = self.prepare_config_and_inputs()
-        inputs_dict = {"input_values": input_values}
+        config, input_values, attention_mask = self.prepare_config_and_inputs()
+        inputs_dict = {"input_values": input_values, "attention_mask": attention_mask}
         return config, inputs_dict
 
 
@@ -156,6 +190,10 @@ class Wav2Vec2ModelTest(ModelTesterMixin, unittest.TestCase):
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
+
+    def test_batched_inference(self):
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_batch_inference(*config_and_inputs)
 
     # Wav2Vec2 has no inputs_embeds
     def test_inputs_embeds(self):
@@ -221,6 +259,10 @@ class Wav2Vec2RobustModelTest(ModelTesterMixin, unittest.TestCase):
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
+
+    def test_batched_inference(self):
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_batch_inference(*config_and_inputs)
 
     # Wav2Vec2 has no inputs_embeds
     def test_inputs_embeds(self):
@@ -288,7 +330,7 @@ class Wav2Vec2ModelIntegrationTest(unittest.TestCase):
 
         return ds["speech"][:num_samples]
 
-    def test_inference_masked_lm_normal(self):
+    def test_inference_ctc_normal(self):
         model = Wav2Vec2ForCTC.from_pretrained("facebook/wav2vec2-base-960h")
         model.to(torch_device)
         tokenizer = Wav2Vec2Tokenizer.from_pretrained("facebook/wav2vec2-base-960h", do_lower_case=True)
@@ -306,19 +348,20 @@ class Wav2Vec2ModelIntegrationTest(unittest.TestCase):
         EXPECTED_TRANSCRIPTIONS = ["a man said to the universe sir i exist"]
         self.assertListEqual(predicted_trans, EXPECTED_TRANSCRIPTIONS)
 
-    def test_inference_masked_lm_normal_batched(self):
+    def test_inference_ctc_normal_batched(self):
         model = Wav2Vec2ForCTC.from_pretrained("facebook/wav2vec2-base-960h")
         model.to(torch_device)
         tokenizer = Wav2Vec2Tokenizer.from_pretrained("facebook/wav2vec2-base-960h", do_lower_case=True)
 
         input_speech = self._load_datasamples(2)
 
-        input_values = tokenizer(input_speech, return_tensors="pt", padding=True, truncation=True).input_values.to(
-            torch_device
-        )
+        inputs = tokenizer(input_speech, return_tensors="pt", padding=True, truncation=True)
+
+        input_values = inputs.input_values.to(torch_device)
+        attention_mask = inputs.attention_mask.to(torch_device)
 
         with torch.no_grad():
-            logits = model(input_values).logits
+            logits = model(input_values, attention_mask=attention_mask).logits
 
         predicted_ids = torch.argmax(logits, dim=-1)
         predicted_trans = tokenizer.batch_decode(predicted_ids)
@@ -329,18 +372,19 @@ class Wav2Vec2ModelIntegrationTest(unittest.TestCase):
         ]
         self.assertListEqual(predicted_trans, EXPECTED_TRANSCRIPTIONS)
 
-    def test_inference_masked_lm_robust_batched(self):
+    def test_inference_ctc_robust_batched(self):
         model = Wav2Vec2ForCTC.from_pretrained("facebook/wav2vec2-large-960h-lv60-self").to(torch_device)
         tokenizer = Wav2Vec2Tokenizer.from_pretrained("facebook/wav2vec2-large-960h-lv60-self", do_lower_case=True)
 
         input_speech = self._load_datasamples(4)
 
-        input_values = tokenizer(input_speech, return_tensors="pt", padding=True, truncation=True).input_values.to(
-            torch_device
-        )
+        inputs = tokenizer(input_speech, return_tensors="pt", padding=True, truncation=True)
+
+        input_values = inputs.input_values.to(torch_device)
+        attention_mask = inputs.attention_mask.to(torch_device)
 
         with torch.no_grad():
-            logits = model(input_values).logits
+            logits = model(input_values, attention_mask=attention_mask).logits
 
         predicted_ids = torch.argmax(logits, dim=-1)
         predicted_trans = tokenizer.batch_decode(predicted_ids)

--- a/tests/test_modeling_wav2vec2.py
+++ b/tests/test_modeling_wav2vec2.py
@@ -139,12 +139,7 @@ class Wav2Vec2ModelTester:
         input_values = input_values[:3]
         attention_mask = torch.ones(input_values.shape, device=torch_device, dtype=torch.bool)
 
-        input_lengths = [input_values.shape[-1] // i for i in [1, 2, 4]]
-
-        #        input_values = input_values.view(2, 48, 32)
-        #        input_values = (input_values - torch.mean(input_values, -1, keepdim=True)) / torch.sqrt(torch.var(input_values, -1, keepdim=True, unbiased=False) + 1e-5)
-
-        #        self.layer_norm = torch.nn.GroupNorm(num_groups=48, num_channels=48, affine=True)
+        input_lengths = [input_values.shape[-1] // i for i in [4, 2, 1]]
 
         # pad input
         for i in range(len(input_lengths)):
@@ -190,10 +185,6 @@ class Wav2Vec2ModelTest(ModelTesterMixin, unittest.TestCase):
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
-
-    def test_batched_inference(self):
-        config_and_inputs = self.model_tester.prepare_config_and_inputs()
-        self.model_tester.create_and_check_batch_inference(*config_and_inputs)
 
     # Wav2Vec2 has no inputs_embeds
     def test_inputs_embeds(self):
@@ -358,10 +349,9 @@ class Wav2Vec2ModelIntegrationTest(unittest.TestCase):
         inputs = tokenizer(input_speech, return_tensors="pt", padding=True, truncation=True)
 
         input_values = inputs.input_values.to(torch_device)
-        attention_mask = inputs.attention_mask.to(torch_device)
 
         with torch.no_grad():
-            logits = model(input_values, attention_mask=attention_mask).logits
+            logits = model(input_values).logits
 
         predicted_ids = torch.argmax(logits, dim=-1)
         predicted_trans = tokenizer.batch_decode(predicted_ids)

--- a/tests/test_tokenization_wav2vec2.py
+++ b/tests/test_tokenization_wav2vec2.py
@@ -23,7 +23,8 @@ import unittest
 
 import numpy as np
 
-from transformers.models.wav2vec2 import WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST, Wav2Vec2Config, Wav2Vec2Tokenizer
+from transformers import WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST
+from transformers.models.wav2vec2 import Wav2Vec2Config, Wav2Vec2Tokenizer
 from transformers.models.wav2vec2.tokenization_wav2vec2 import VOCAB_FILES_NAMES
 from transformers.testing_utils import slow
 

--- a/tests/test_tokenization_wav2vec2.py
+++ b/tests/test_tokenization_wav2vec2.py
@@ -23,12 +23,8 @@ import unittest
 
 import numpy as np
 
-from transformers.models.wav2vec2.tokenization_wav2vec2 import (
-    VOCAB_FILES_NAMES,
-    WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST,
-    Wav2Vec2Config,
-    Wav2Vec2Tokenizer,
-)
+from transformers.models.wav2vec2 import WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST, Wav2Vec2Config, Wav2Vec2Tokenizer
+from transformers.models.wav2vec2.tokenization_wav2vec2 import VOCAB_FILES_NAMES
 from transformers.testing_utils import slow
 
 

--- a/tests/test_tokenization_wav2vec2.py
+++ b/tests/test_tokenization_wav2vec2.py
@@ -23,7 +23,13 @@ import unittest
 
 import numpy as np
 
-from transformers.models.wav2vec2.tokenization_wav2vec2 import VOCAB_FILES_NAMES, Wav2Vec2Tokenizer
+from transformers.models.wav2vec2.tokenization_wav2vec2 import (
+    VOCAB_FILES_NAMES,
+    WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST,
+    Wav2Vec2Config,
+    Wav2Vec2Tokenizer,
+)
+from transformers.testing_utils import slow
 
 
 global_rng = random.Random()
@@ -299,3 +305,46 @@ class Wav2Vec2TokenizerTest(unittest.TestCase):
         for parameter_name, parameter in signature.parameters.items():
             if parameter.default != inspect.Parameter.empty:
                 self.assertIn(parameter_name, tokenizer.init_kwargs)
+
+    def test_zero_mean_unit_variance_normalization(self):
+        tokenizer = self.get_tokenizer(do_normalize=True)
+        speech_inputs = [floats_list((1, x))[0] for x in range(800, 1400, 200)]
+        processed = tokenizer(speech_inputs, padding="longest")
+        input_values = processed.input_values
+
+        def _check_zero_mean_unit_variance(input_vector):
+            self.assertTrue(np.abs(np.mean(input_vector)) < 1e-3)
+            self.assertTrue(np.abs(np.var(input_vector) - 1) < 1e-3)
+
+        _check_zero_mean_unit_variance(input_values[0, :800])
+        _check_zero_mean_unit_variance(input_values[1, :1000])
+        _check_zero_mean_unit_variance(input_values[2])
+
+    def test_return_attention_mask(self):
+        speech_inputs = [floats_list((1, x))[0] for x in range(800, 1400, 200)]
+
+        # default case -> no attention_mask is returned
+        tokenizer = self.get_tokenizer()
+        processed = tokenizer(speech_inputs)
+        self.assertNotIn("attention_mask", processed)
+
+        # wav2vec2-lv60 -> return attention_mask
+        tokenizer = self.get_tokenizer(return_attention_mask=True)
+        processed = tokenizer(speech_inputs, padding="longest")
+
+        self.assertIn("attention_mask", processed)
+        self.assertListEqual(list(processed.attention_mask.shape), list(processed.input_values.shape))
+        self.assertListEqual(processed.attention_mask.sum(-1).tolist(), [800, 1000, 1200])
+
+    @slow
+    def test_pretrained_checkpoints_are_set_correctly(self):
+        # this test makes sure that models that are using
+        # group norm don't have their tokenizer return the
+        # attention_mask
+        for model_id in WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST:
+            config = Wav2Vec2Config.from_pretrained(model_id)
+            tokenizer = Wav2Vec2Tokenizer.from_pretrained(model_id)
+
+            # only "layer" feature extraction norm should make use of
+            # attention_mask
+            self.assertEqual(tokenizer.return_attention_mask, config.feat_extract_norm == "layer")


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR improves batched inference for Wav2Vec2 models by:

- adding an `attention_mask`
- adding zero-mean unit-variance normalization to the tokenizer
- correctly setting returning `attention_mask` and doing normalization depending on which architecture is used

## Background

Some of Fairseq's Wav2Vec2 models apply Group Normalization over the time axis in the feature extractor. This means that the convolutional layers in the feature extractor can not 100% correctly treat padded input resulting in those models giving different results depending on whether the input is padded or not. See https://github.com/pytorch/fairseq/issues/3227 . Those models should never make use of `attention_mask` which is made sure by setting `return_attention_mask=False` in their corresponding tokenizer configs: https://huggingface.co/facebook/wav2vec2-base-960h/blob/main/tokenizer_config.json . Also some explicit warnigs have been added to both the tokenizer and model.

For the "newer" models however that have the improved layer norm architecture in the feature extraction: https://huggingface.co/facebook/wav2vec2-large-960h-lv60-self , normalization and correct padding via `attention_mask` gives some nice performance improvements and works correctly.

## Performance Evaluation

 I've evaluated both `wav2vec2-large-960h-lv60-self` and `wav2vec2-large-960h-lv60` on the test set of librispeech and got some nice improvements:

- `wav2vec2-large-960h-lv60-self`: 2.2 WER -> 1.8 WER
- `wav2vec2-large-960h-lv60`: 3.4 WER -> 2.2 WER 

So that the results now seem to match the paper's results very nicely.

Also, I checked that `wav2vec2-base-960h` should **not** use an `attention_mask` as the performance on librispeech test then drop heavily from ~4 WER to ~20 WER.

## TODO

Once this PR is merged, I can fully focus on adding the fine-tuning functionality and will also update the model cards with the new evaluation code & results.