### PR TITLE
[DeepSpeed in notebooks] Jupyter + Colab

### DIFF
--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -437,7 +437,7 @@ The problem with notebooks is that there is no normal ``deepspeed`` launcher to 
 have to emulate it.
 
 Here is how you'd have to adjust your training code in the notebook to use DeepSpeed. This example uses
-`Seq2SeqTrainer`, but the same applies to `Trainer` or any subclass of it:
+``Seq2SeqTrainer``, but the same applies to ``Trainer`` or any subclass of it:
 
 .. code-block:: python
 

--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -433,18 +433,19 @@ Notes:
 Deployment in Notebooks
 =======================================================================================================================
 
-The problem with notebooks is that there is no normal ``deepspeed`` launcher to rely on, so we have to emulate it.
+The problem with notebooks is that there is no normal ``deepspeed`` launcher to rely on, so under certain setups we
+have to emulate it.
 
-Here is how you'd have to adjust your training code to have DeepSpeed working:
+Here is how you'd have to adjust your training code in the notebook to use DeepSpeed. This example uses
+`Seq2SeqTrainer`, but the same applies to `Trainer` or any subclass of it:
 
 .. code-block:: python
 
     import os
 
     # deepspeed requires a distributed environment even if one process is used
-    # emulating distributed env with a single gpu 0 (for multiple-gpus need a process per gpu)
+    # this seems to be required on colab.google.com, but works fine without it in normal jupyter notebook
     os.environ['RANK'] = "0"
-    local_rank = 0
 
     # You can also tweak the following if need be
     # os.environ['CUDA_VISIBLE_DEVICES'] = "0"
@@ -462,9 +463,6 @@ Here is how you'd have to adjust your training code to have DeepSpeed working:
 
     trainer = Seq2SeqTrainer(...)
     trainer.train()
-
-
-You may need to adjust ``localhost`` and the port number if the suggested ones don't work on your setup.
 
 If you want to create the config file on the fly in the notebook in the current directory, you could have a dedicated
 cell with:

--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -443,8 +443,9 @@ Here is how you'd have to adjust your training code in the notebook to use DeepS
 
     import os
 
-    # deepspeed requires a distributed environment even if one process is used
-    # this seems to be required on colab.google.com, but works fine without it in normal jupyter notebook
+    # DeepSpeed requires a distributed environment even when only one process is used.
+    # The following seems to be required on colab.research.google.com, but works fine
+    # without it in a normal jupyter notebook.
     os.environ['RANK'] = "0"
 
     # You can also tweak the following if need be

--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -456,7 +456,7 @@ Here is how you'd have to adjust your training code in the notebook to use DeepS
 
     training_args = Seq2SeqTrainingArguments(
         [... normal args ...]
-        # deepspeed-in-jupyter-notebook-special-args
+        # deepspeed-in-notebook-special-args
         local_rank=0,
         deepspeed="ds_config.json"
     )

--- a/examples/tests/deepspeed/test_deepspeed.py
+++ b/examples/tests/deepspeed/test_deepspeed.py
@@ -56,9 +56,9 @@ def require_deepspeed(test_case):
 @require_torch_gpu
 class TestDeepSpeed(TestCasePlus):
 
-    # setup that is normally needed in the colab notebook (but it works fine in jupyter notebook w/o it)
-    @mockenv(RANK="0")
-    def test_notebook_no_launcher(self):
+    # this setup emulates a notebook where a launcher needs to be emulated by hand
+    @mockenv(MASTER_ADDR="localhost", MASTER_PORT="109999", RANK="0", LOCAL_RANK="0", WORLD_SIZE="1")
+    def test_fake_notebook_no_launcher(self):
         sys.path.append(self.tests_dir_str)
         from test_trainer import get_regression_trainer
 

--- a/examples/tests/deepspeed/test_deepspeed.py
+++ b/examples/tests/deepspeed/test_deepspeed.py
@@ -14,13 +14,16 @@
 
 import json
 import os
+import sys
 import unittest
 
 from transformers.integrations import is_deepspeed_available
 from transformers.testing_utils import (
+    CaptureStd,
     TestCasePlus,
     execute_subprocess_async,
     get_gpu_count,
+    mockenv,
     require_torch_gpu,
     require_torch_multi_gpu,
     slow,
@@ -52,6 +55,20 @@ def require_deepspeed(test_case):
 @require_deepspeed
 @require_torch_gpu
 class TestDeepSpeed(TestCasePlus):
+
+    # setup that is normally needed in the colab notebook (but it works fine in jupyter notebook w/o it)
+    @mockenv(RANK="0")
+    def test_notebook_no_launcher(self):
+        sys.path.append(self.tests_dir_str)
+        from test_trainer import get_regression_trainer
+
+        del sys.path[-1]  # restore
+        ds_config_file = f"{self.test_file_dir_str}/ds_config.json"
+        with CaptureStd() as cs:
+            trainer = get_regression_trainer(local_rank=0, deepspeed=ds_config_file)
+            trainer.train()
+        assert "DeepSpeed info" in cs.out, "expected DeepSpeed logger output but got none"
+
     @require_torch_multi_gpu
     def test_basic_distributed(self):
         self.run_quick(distributed=True)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -239,6 +239,9 @@ class Trainer:
         self.hp_name = None
         self.deepspeed = None
 
+        # force device and distributed setup init explicitly
+        args._setup_devices
+
         if model is None:
             if model_init is not None:
                 self.model_init = model_init

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -556,16 +556,17 @@ class TrainingArguments:
             # python -m torch.distributed.launch --nproc_per_node=2 ./program.py
             from .integrations import is_deepspeed_available
 
-            # workaround for setups like notebooks where the launcher can't be used,
-            # but deepspeed requires a dist env.
-            if self.local_rank == -1:
-                self.local_rank = 0
-
             if not is_deepspeed_available():
                 raise ImportError("--deepspeed requires deepspeed: `pip install deepspeed`.")
             import deepspeed
 
             deepspeed.init_distributed()
+
+            # workaround for setups like notebooks where the launcher can't be used,
+            # but deepspeed requires a dist env.
+            # env LOCAL_RANK could be set manually by the user, or via init_distributed if mpi4py is installed
+            self.local_rank = int(os.environ.get("LOCAL_RANK", "-1"))
+
             device = torch.device("cuda", self.local_rank)
             self._n_gpu = 1
         elif self.local_rank == -1:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -556,6 +556,11 @@ class TrainingArguments:
             # python -m torch.distributed.launch --nproc_per_node=2 ./program.py
             from .integrations import is_deepspeed_available
 
+            # workaround for setups like notebooks where the launcher can't be used,
+            # but deepspeed requires a dist env.
+            if self.local_rank == -1:
+                self.local_rank = 0
+
             if not is_deepspeed_available():
                 raise ImportError("--deepspeed requires deepspeed: `pip install deepspeed`.")
             import deepspeed


### PR DESCRIPTION
This PR addresses issues raised in https://github.com/huggingface/transformers/issues/10011 when the user tried to use DeepSpeed in a notebook (most likely colab).

This PR:

* forces device and distributed setup init from TrainingArguments explicitly at the beginning of Trainer's `__init__`. This is needed since until now the init was happening as a side effect of someone calling `device` or `n_gpus`, which doesn't happen if someone runs their own version of `Trainer` w/ deepspeed - which is the case with notebooks - so we are missing out on DeepSpeed init and things weren't working. Let's do it explicitly, and not as a side-effect, so everything is loud and clear.
* sets up `self.local_rank` based on LOCAL_RANK env var under deepspeed to save users a hassle - deepspeed must have `local_rank>-1`. I guess the fake launcher env setup could be folded into the init as well, but then the user loses control over the port number and they may need to edit it, so for now leaving it outside - but will ask deepspeed to provide a wrapper function to make it easy for the user. perhaps once the wrapper is available it could be automated completely. Alternatively, if they make `mpi4py` a dependency then fake launcher env setup won't be needed at all.
* documents how to run DeepSpeed in the notebook env
* adds a test that mocks a notebook environment and runs deepspeed w/o a launcher

I may wait to hear about the follow up to https://github.com/microsoft/DeepSpeed/issues/748 to merge this, if it looks quick, but otherwise I will revise the setup doc in a future PR. The main changes of this PR besides the doc are required anyway.

@sgugger 