### PR TITLE
Revert propagation

### DIFF
--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -85,6 +85,7 @@ def _configure_library_root_logger() -> None:
         library_root_logger = _get_library_root_logger()
         library_root_logger.addHandler(_default_handler)
         library_root_logger.setLevel(_get_default_logging_level())
+        library_root_logger.propagate = False
 
 
 def _reset_library_root_logger() -> None:


### PR DESCRIPTION
The proposition offered in https://github.com/huggingface/transformers/pull/10092 unfortunately can't be applied as having a default handler and propagation across handlers results in several logged items.

Reverting that PR here as seen offline with @lhoestq and leaving the docs regarding the default handler introduced in #10092.