### PR TITLE
Fix datasets set_format

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -439,7 +439,8 @@ class Trainer:
             f"The following columns {dset_description}don't have a corresponding argument in "
             f"`{self.model.__class__.__name__}.forward` and have been ignored: {', '.join(ignored_columns)}."
         )
-        dataset.set_format(type=dataset.format["type"], columns=columns)
+
+        dataset.set_format(type=dataset.format["type"], columns=columns, format_kwargs=dataset.format["format_kwargs"])
 
     def _get_train_sampler(self) -> Optional[torch.utils.data.sampler.Sampler]:
         if isinstance(self.train_dataset, torch.utils.data.IterableDataset) or not isinstance(


### PR DESCRIPTION
# What does this PR do?

This PR fixes a problem in `Trainer` when user provide a dataset using the new functionality in the upcoming v2 of `datasets` `set_transform` (see [here](https://github.com/huggingface/datasets/issues/1867) for more details). This is a hotfix that is not perfect and we will need to take some time to make this column ignoring more general (probably after batch creation) but I will look deeper into this at the end of next week.