### PR TITLE
Add new model to labels that should not stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,7 +6,8 @@ daysUntilClose: 7
 exemptLabels:
   - pinned
   - security
-  - Feature request
+  - "Feature request"
+  - "New model"
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
The `New model` label gets added to the labels that should not become stale.