### PR TITLE
Specify dataset dtype

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -500,7 +500,7 @@ class TrainerIntegrationTest(unittest.TestCase):
         self.check_trained_model(trainer.model)
 
         # Can return tensors.
-        train_dataset.set_format(type="torch")
+        train_dataset.set_format(type="torch", dtype=torch.float32)
         model = RegressionModel()
         trainer = Trainer(model, args, train_dataset=train_dataset)
         trainer.train()


### PR DESCRIPTION
There was an issue in `datasets` <1.3.0 where the datasets type wouldn't be kept. Since this bug was patched, we have to specify the correct type for the dataset.

Co-authored-by: Quentin Lhoest <lhoest.q@gmail.com>
