### PR TITLE
[CI] make the examples sub-group of tests run always

### DIFF
--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -244,6 +244,7 @@ jobs:
         run: cat reports/tests_torch_multi_gpu_failures_short.txt
 
       - name: Run examples tests on multi-GPU
+        if: ${{ always() }}
         env:
           OMP_NUM_THREADS: 1
           RUN_SLOW: yes


### PR DESCRIPTION
the examples tests weren't running if some previous job failed. this fixes it to always run.

@LysandreJik 