### PR TITLE
[trainer] fix ignored columns logger

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -434,7 +434,7 @@ class Trainer:
             self._signature_columns += ["label", "label_ids"]
         columns = [k for k in self._signature_columns if k in dataset.column_names]
         ignored_columns = list(set(dataset.column_names) - set(self._signature_columns))
-        if len(ignored_columns):
+        if len(ignored_columns) > 0:
             dset_description = "" if description is None else f"in the {description} set "
             logger.info(
                 f"The following columns {dset_description} don't have a corresponding argument in "

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -434,11 +434,12 @@ class Trainer:
             self._signature_columns += ["label", "label_ids"]
         columns = [k for k in self._signature_columns if k in dataset.column_names]
         ignored_columns = list(set(dataset.column_names) - set(self._signature_columns))
-        dset_description = "" if description is None else f"in the {description} set "
-        logger.info(
-            f"The following columns {dset_description}don't have a corresponding argument in "
-            f"`{self.model.__class__.__name__}.forward` and have been ignored: {', '.join(ignored_columns)}."
-        )
+        if len(ignored_columns):
+            dset_description = "" if description is None else f"in the {description} set "
+            logger.info(
+                f"The following columns {dset_description} don't have a corresponding argument in "
+                f"`{self.model.__class__.__name__}.forward` and have been ignored: {', '.join(ignored_columns)}."
+            )
 
         dataset.set_format(type=dataset.format["type"], columns=columns, format_kwargs=dataset.format["format_kwargs"])
 


### PR DESCRIPTION
This PR fixes a confusing log entry that says:
```
The following columns in the evaluation set don't have a corresponding argument in `T5ForConditionalGeneration.forward` and have been ignored: .
```
when everything is in order.

@sgugger 