### PR TITLE
fix deprecated reference `tokenizer.max_len` in glue.py

### DIFF
--- a/src/transformers/data/processors/glue.py
+++ b/src/transformers/data/processors/glue.py
@@ -116,7 +116,7 @@ def _glue_convert_examples_to_features(
     output_mode=None,
 ):
     if max_length is None:
-        max_length = tokenizer.max_len
+        max_length = tokenizer.model_max_length
 
     if task is not None:
         processor = glue_processors[task]()


### PR DESCRIPTION
This is to fix deprecated reference to `tokenizer.max_len` with `tokenizer.model_max_length` - similar to [issue 8739](https://github.com/huggingface/transformers/issues/8739) and [PR 8604](https://github.com/huggingface/transformers/pull/8604). 
See error example [in Colab here](https://colab.research.google.com/gist/poedator/f8776349e5c625ce287fc6fcd312fa1e/tokenizer-max_len-error-in-transformers_glue.ipynb).  it causes `AttributeError: 'BertTokenizer' object has no attribute 'max_len'`
The error happens when `glue_convert_examples_to_features()` is called without `max_length` parameter specified. In that case [line 119](https://github.com/huggingface/transformers/blob/master/src/transformers/data/processors/glue.py#L119) with wrong reference gets called. This simple fix should  do it.
