### PR TITLE
the change from single mask to multi mask support for pytorch

### DIFF
--- a/src/transformers/pipelines/fill_mask.py
+++ b/src/transformers/pipelines/fill_mask.py
@@ -1,7 +1,7 @@
+import itertools
 from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
-import itertools
 
 from ..file_utils import add_end_docstrings, is_tf_available, is_torch_available
 from ..modelcard import ModelCard
@@ -173,15 +173,15 @@ class FillMaskPipeline(Pipeline):
                     sort_inds = list(reversed(values.argsort(dim=-1)))
                     values = values[..., sort_inds]
                     predictions = target_inds[sort_inds]
-            
+
             values_indices = [[i for i in range(value.size()[0])] for value in values_all]
             values_combinatorial_val = list(itertools.product(*values_all))
             values_combinatorial_ind = list(itertools.product(*values_indices))
             values_combinatorial = []
             for values_comb_val, values_comb_ind in zip(values_combinatorial_val, values_combinatorial_ind):
                 values_combinatorial.append([np.prod(values_comb_val), list(values_comb_ind)])
-            values_combinatorial = sorted(values_combinatorial, key=lambda x:x[0], reverse=True)[0:self.top_k]
-            
+            values_combinatorial = sorted(values_combinatorial, key=lambda x: x[0], reverse=True)[0 : self.top_k]
+
             for value_combinatorial in values_combinatorial:
                 tokens = input_ids.numpy()
                 tokens_collated = []
@@ -193,12 +193,12 @@ class FillMaskPipeline(Pipeline):
                 result.append(
                     {
                         "sequence": self.tokenizer.decode(tokens, skip_special_tokens=True),
-                        "score" : value_combinatorial[0],
-                        "tokens" : tokens_collated,
-                        "tokens_strs" : [self.tokenizer.decode(token) for token in tokens_collated]
+                        "score": value_combinatorial[0],
+                        "tokens": tokens_collated,
+                        "tokens_strs": [self.tokenizer.decode(token) for token in tokens_collated],
                     }
                 )
-                  
+
             # Append
             results += [result]
 

--- a/src/transformers/pipelines/fill_mask.py
+++ b/src/transformers/pipelines/fill_mask.py
@@ -190,14 +190,24 @@ class FillMaskPipeline(Pipeline):
                     tokens[masked_index] = predictions_all[mask_iter].tolist()[element_index]
                     tokens_collated.append(predictions_all[mask_iter].tolist()[element_index])
                 tokens = tokens[np.where(tokens != self.tokenizer.pad_token_id)]
-                result.append(
-                    {
-                        "sequence": self.tokenizer.decode(tokens, skip_special_tokens=True),
-                        "score": value_combinatorial[0],
-                        "tokens": tokens_collated,
-                        "tokens_strs": [self.tokenizer.decode(token) for token in tokens_collated],
-                    }
-                )
+                if len(tokens_collated) == 1:
+                    result.append(
+                        {
+                            "sequence": self.tokenizer.decode(tokens, skip_special_tokens=True),
+                            "score": value_combinatorial[0],
+                            "token": tokens_collated[0],
+                            "token_str": self.tokenizer.decode(tokens_collated[0])
+                        }
+                    )
+                else:
+                    result.append(
+                        {
+                            "sequence": self.tokenizer.decode(tokens, skip_special_tokens=True),
+                            "score": value_combinatorial[0],
+                            "tokens": tokens_collated,
+                            "tokens_strs": [self.tokenizer.decode(token) for token in tokens_collated],
+                        }
+                    )
 
             # Append
             results += [result]


### PR DESCRIPTION
# What does this PR do?

A draft PR for the Feature request to change from single mask to multi mask support for the fill mask pipeline.

As discussed this is one a draft PR to discuss the changes that need to be made to the output format to jointly support multiple and single mask in one pipeline call. The PR implements the change for Pytorch and code has not been pushed in yet for  when the keyword argument is called.

The pipeline tests are expected to fail since the output format changed.
#10158 

Example code that tests this feature is below.  
```
import json
from transformers import pipeline
unmasker = pipeline('fill-mask', model='bert-base-uncased')
t = unmasker("hi [MASK] morning I'm a [MASK] model.")
print(json.dumps(t, indent=4))
```
@LysandreJik 