### PR TITLE
[Trainer] memory tracker metrics

### DIFF
--- a/examples/seq2seq/run_seq2seq.py
+++ b/examples/seq2seq/run_seq2seq.py
@@ -606,7 +606,7 @@ def main():
         logger.info("*** Evaluate ***")
 
         metrics = trainer.evaluate(
-            max_length=data_args.val_max_target_length, num_beams=data_args.num_beams, metric_key_prefix="val"
+            max_length=data_args.val_max_target_length, num_beams=data_args.num_beams, metric_key_prefix="eval"
         )
         max_val_samples = data_args.max_val_samples if data_args.max_val_samples is not None else len(eval_dataset)
         metrics["val_samples"] = min(max_val_samples, len(eval_dataset))

--- a/examples/seq2seq/run_seq2seq.py
+++ b/examples/seq2seq/run_seq2seq.py
@@ -609,7 +609,7 @@ def main():
             max_length=data_args.val_max_target_length, num_beams=data_args.num_beams, metric_key_prefix="eval"
         )
         max_val_samples = data_args.max_val_samples if data_args.max_val_samples is not None else len(eval_dataset)
-        metrics["val_samples"] = min(max_val_samples, len(eval_dataset))
+        metrics["eval_samples"] = min(max_val_samples, len(eval_dataset))
 
         if trainer.is_world_process_zero():
             metrics_formatted = trainer.metrics_format(metrics)
@@ -618,7 +618,7 @@ def main():
             v_width = max(len(str(x)) for x in metrics_formatted.values())
             for key in sorted(metrics_formatted.keys()):
                 logger.info(f"  {key: <{k_width}} = {metrics_formatted[key]:>{v_width}}")
-            save_json(metrics, os.path.join(training_args.output_dir, "val_results.json"))
+            save_json(metrics, os.path.join(training_args.output_dir, "eval_results.json"))
             all_metrics.update(metrics)
 
     if training_args.do_predict:

--- a/examples/seq2seq/run_seq2seq.py
+++ b/examples/seq2seq/run_seq2seq.py
@@ -588,9 +588,12 @@ def main():
         )
         metrics["train_samples"] = min(max_train_samples, len(train_dataset))
         if trainer.is_world_process_zero():
+            metrics_formatted = trainer.metrics_format(metrics)
             logger.info("***** train metrics *****")
-            for key in sorted(metrics.keys()):
-                logger.info(f"  {key} = {metrics[key]}")
+            k_width = max(len(str(x)) for x in metrics_formatted.keys())
+            v_width = max(len(str(x)) for x in metrics_formatted.values())
+            for key in sorted(metrics_formatted.keys()):
+                logger.info(f"  {key: <{k_width}} = {metrics_formatted[key]:>{v_width}}")
             save_json(metrics, os.path.join(training_args.output_dir, "train_results.json"))
             all_metrics.update(metrics)
 
@@ -605,14 +608,16 @@ def main():
         metrics = trainer.evaluate(
             max_length=data_args.val_max_target_length, num_beams=data_args.num_beams, metric_key_prefix="val"
         )
-        metrics = {k: round(v, 4) for k, v in metrics.items()}
         max_val_samples = data_args.max_val_samples if data_args.max_val_samples is not None else len(eval_dataset)
         metrics["val_samples"] = min(max_val_samples, len(eval_dataset))
 
         if trainer.is_world_process_zero():
+            metrics_formatted = trainer.metrics_format(metrics)
             logger.info("***** val metrics *****")
-            for key in sorted(metrics.keys()):
-                logger.info(f"  {key} = {metrics[key]}")
+            k_width = max(len(str(x)) for x in metrics_formatted.keys())
+            v_width = max(len(str(x)) for x in metrics_formatted.values())
+            for key in sorted(metrics_formatted.keys()):
+                logger.info(f"  {key: <{k_width}} = {metrics_formatted[key]:>{v_width}}")
             save_json(metrics, os.path.join(training_args.output_dir, "val_results.json"))
             all_metrics.update(metrics)
 
@@ -628,12 +633,14 @@ def main():
         metrics = test_results.metrics
         max_test_samples = data_args.max_test_samples if data_args.max_test_samples is not None else len(test_dataset)
         metrics["test_samples"] = min(max_test_samples, len(test_dataset))
-        metrics = {k: round(v, 4) for k, v in metrics.items()}
 
         if trainer.is_world_process_zero():
+            metrics_formatted = trainer.metrics_format(metrics)
             logger.info("***** test metrics *****")
-            for key in sorted(metrics.keys()):
-                logger.info(f"  {key} = {metrics[key]}")
+            k_width = max(len(str(x)) for x in metrics_formatted.keys())
+            v_width = max(len(str(x)) for x in metrics_formatted.values())
+            for key in sorted(metrics_formatted.keys()):
+                logger.info(f"  {key: <{k_width}} = {metrics_formatted[key]:>{v_width}}")
             save_json(metrics, os.path.join(training_args.output_dir, "test_results.json"))
             all_metrics.update(metrics)
 

--- a/examples/tests/deepspeed/test_deepspeed.py
+++ b/examples/tests/deepspeed/test_deepspeed.py
@@ -88,8 +88,8 @@ class TestDeepSpeed(TestCasePlus):
             extra_args_str="--do_eval",
             remove_args_str="--do_train",
         )
-        val_metrics = load_json(os.path.join(output_dir, "val_results.json"))
-        assert "val_bleu" in val_metrics
+        val_metrics = load_json(os.path.join(output_dir, "eval_results.json"))
+        assert "eval_bleu" in val_metrics
 
     # XXX: need to do better validation beyond just that the run was successful
     def run_quick(self, distributed=True, extra_args_str=None, remove_args_str=None):

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -236,6 +236,15 @@ def is_torch_available():
     return _torch_available
 
 
+def is_torch_cuda_available():
+    if is_torch_available():
+        import torch
+
+        return torch.cuda.is_available()
+    else:
+        return False
+
+
 def is_tf_available():
     return _tf_available
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -391,7 +391,7 @@ class Trainer:
         self.control = self.callback_handler.on_init_end(self.args, self.state, self.control)
 
         # very last
-        self.mem.stop()
+        self.mem.stop("init")
 
     def add_callback(self, callback):
         """
@@ -1073,7 +1073,7 @@ class Trainer:
             self.store_flos()
             metrics["total_flos"] = self.state.total_flos
 
-        self.mem.stop()
+        self.mem.stop("train")
         self.mem.update_metrics("train", metrics)
         self.log(metrics)
 
@@ -1593,7 +1593,7 @@ class Trainer:
             xm.master_print(met.metrics_report())
 
         self.control = self.callback_handler.on_evaluate(self.args, self.state, self.control, output.metrics)
-        self.mem.stop()
+        self.mem.stop("eval")
         self.mem.update_metrics("eval", output.metrics)
         return output.metrics
 
@@ -1644,7 +1644,7 @@ class Trainer:
         )
         output.metrics.update(speed_metrics(metric_key_prefix, start_time, len(test_dataset)))
 
-        self.mem.stop()
+        self.mem.stop("test")
         self.mem.update_metrics("test", output.metrics)
         return output
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -400,7 +400,7 @@ class Trainer:
         self.control = self.callback_handler.on_init_end(self.args, self.state, self.control)
 
         # very last
-        self._memory_tracker.stop_n_update_metrics()
+        self._memory_tracker.stop_and_update_metrics()
 
     def add_callback(self, callback):
         """
@@ -1083,7 +1083,7 @@ class Trainer:
             self.model_wrapped = self.model
             gc.collect()  # force memory release
 
-        self._memory_tracker.stop_n_update_metrics(metrics)
+        self._memory_tracker.stop_and_update_metrics(metrics)
 
         return TrainOutput(self.state.global_step, self._total_loss_scalar / self.state.global_step, metrics)
 
@@ -1602,7 +1602,7 @@ class Trainer:
 
         self.control = self.callback_handler.on_evaluate(self.args, self.state, self.control, output.metrics)
 
-        self._memory_tracker.stop_n_update_metrics(output.metrics)
+        self._memory_tracker.stop_and_update_metrics(output.metrics)
 
         return output.metrics
 
@@ -1653,7 +1653,7 @@ class Trainer:
         )
         output.metrics.update(speed_metrics(metric_key_prefix, start_time, len(test_dataset)))
 
-        self._memory_tracker.stop_n_update_metrics(output.metrics)
+        self._memory_tracker.stop_and_update_metrics(output.metrics)
 
         return output
 

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -281,10 +281,10 @@ class TrainerMemoryTracker:
 
     Because ``evaluation`` calls may happen during ``train``, we can't handle nested invocations because
     ``torch.cuda.max_memory_allocated`` is a single counter, so if it gets reset by a nested eval call, ``train``'s
-    tracker will report incorrect info. If this `pytorch issue <https://github.com/pytorch/pytorch/issues/16266>`__ gets
-    resolved it will be possible to change this class to be re-entrant. Until then we will only track the outer level
-    of ``train``, ``evaluate`` and ``predict`` methods. Which means that if ``eval`` is called during ``train``, it's
-    the latter that will account for its memory usage and that of the former.
+    tracker will report incorrect info. If this `pytorch issue <https://github.com/pytorch/pytorch/issues/16266>`__
+    gets resolved it will be possible to change this class to be re-entrant. Until then we will only track the outer
+    level of ``train``, ``evaluate`` and ``predict`` methods. Which means that if ``eval`` is called during ``train``,
+    it's the latter that will account for its memory usage and that of the former.
 
     This also means that if any other tool that is used along the :class:`~transformers.Trainer` calls
     ``torch.cuda.reset_peak_memory_stats``, the gpu peak memory stats could be invalid. And the

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -281,7 +281,7 @@ class TrainerMemoryTracker:
 
     Because ``evaluation`` calls may happen during ``train``, we can't handle nested invocations because
     ``torch.cuda.max_memory_allocated`` is a single counter, so if it gets reset by a nested eval call, ``train``'s
-    tracker will report incorrect info. If this pytorch issue https://github.com/pytorch/pytorch/issues/16266 gets
+    tracker will report incorrect info. If this `pytorch issue <https://github.com/pytorch/pytorch/issues/16266>`__ gets
     resolved it will be possible to change this class to be re-entrant. Until then we will only track the outer level
     of ``train``, ``evaluate`` and ``predict`` methods. Which means that if ``eval`` is called during ``train``, it's
     the latter that will account for its memory usage and that of the former.

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -245,6 +245,7 @@ class SchedulerType(ExplicitEnum):
 
 
 class TrainerMemoryTracker:
+
     def __init__(self, skip_memory_metrics=False):
         if is_torch_cuda_available():
             import torch
@@ -254,16 +255,27 @@ class TrainerMemoryTracker:
         else:
             self.torch = None
 
-        self.stage = "none"
+        self.cur_stage = None
         self.cpu = {}
         self.init_reported = False
         self.skip_memory_metrics = skip_memory_metrics
+
+    # notes: since eval calls may be intermixed with train calls, we can't handle nested invocations
+    # because torch.cuda.max_memory_allocated is a single counter, so if it gets reset by a nested
+    # eval call, train will report incorrect info. One day pytorch will fix this issue:
+    # https://github.com/pytorch/pytorch/issues/16266
+    # and then it will be possible to be re-entrant
+    # for now only track the outer level train / evaluation / predict functions
 
     def start(self, stage):
         if self.skip_memory_metrics:
             return
 
-        self.stage = stage
+        # deal with nested calls of eval during train - simply ignore those
+        if self.cur_stage is not None and self.cur_stage != stage:
+            return
+
+        self.cur_stage = stage
 
         if self.torch is not None:
             self.torch.cuda.reset_peak_memory_stats()
@@ -273,16 +285,20 @@ class TrainerMemoryTracker:
 
         # gpu
         if self.torch is not None:
-            self.gpu[self.stage] = {}
-            self.gpu[self.stage]["alloc"] = self.torch.cuda.memory_allocated()
-            self.gpu[self.stage]["peaked"] = 0
+            self.gpu[self.cur_stage] = {}
+            self.gpu[self.cur_stage]["alloc"] = self.torch.cuda.memory_allocated()
+            self.gpu[self.cur_stage]["peaked"] = 0
 
         # cpu
-        self.cpu[self.stage] = {}
+        self.cpu[self.cur_stage] = {}
         tracemalloc.start()
 
-    def stop(self):
+    def stop(self, stage):
         if self.skip_memory_metrics:
+            return
+
+        # deal with nested calls of eval during train - simply ignore those
+        if self.cur_stage is not None and self.cur_stage != stage:
             return
 
         if self.torch is not None:
@@ -294,19 +310,27 @@ class TrainerMemoryTracker:
         if self.torch is not None:
             mem_cur = self.torch.cuda.memory_allocated()
             # this is the difference between the start and the end allocated memory
-            self.gpu[self.stage]["alloc"] = mem_cur - self.gpu[self.stage]["alloc"]  # can be negative
+            self.gpu[self.cur_stage]["alloc"] = mem_cur - self.gpu[self.cur_stage]["alloc"]  # can be negative
             # this is the difference if any between the start and the peak
-            self.gpu[self.stage]["peaked"] = max(0, self.torch.cuda.max_memory_allocated() - mem_cur)
+            self.gpu[self.cur_stage]["peaked"] = max(0, self.torch.cuda.max_memory_allocated() - mem_cur)
 
         # cpu
         cpu_mem_used_delta, cpu_mem_used_peak = tracemalloc.get_traced_memory()
         tracemalloc.stop()  # reset accounting
-        self.cpu[self.stage]["alloc"] = cpu_mem_used_delta  # can be negative
-        self.cpu[self.stage]["peaked"] = max(0, cpu_mem_used_peak - cpu_mem_used_delta)
+        self.cpu[self.cur_stage]["alloc"] = cpu_mem_used_delta  # can be negative
+        self.cpu[self.cur_stage]["peaked"] = max(0, cpu_mem_used_peak - cpu_mem_used_delta)
+
+        # reset - cycle finished
+        self.cur_stage = None
 
     def update_metrics(self, stage, metrics):
         if self.skip_memory_metrics:
             return
+
+        # deal with nested calls of eval during train - simply ignore those
+        if self.cur_stage is not None and self.cur_stage != stage:
+            return
+
         # since we don't have a way to return init metrics, we push them into the first of train/val/predict
         stages = [stage]
         if not self.init_reported:
@@ -315,6 +339,7 @@ class TrainerMemoryTracker:
 
         for stage in stages:
             for t in ["alloc", "peaked"]:
-                metrics[f"{stage}_mem_cpu_{t}_delta"] = self.cpu[stage][t]
-                if self.torch is not None:
+                if stage in self.cpu and t in self.cpu[stage]:
+                    metrics[f"{stage}_mem_cpu_{t}_delta"] = self.cpu[stage][t]
+                if self.torch is not None and stage in self.gpu and t in self.gpu[stage]:
                     metrics[f"{stage}_mem_gpu_{t}_delta"] = self.gpu[stage][t]

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -257,7 +257,7 @@ class TrainerMemoryTracker:
         self._memory_tracker.start()
         code ...
         metrics = {"train_runtime": 10.5}
-        self._memory_tracker.stop_n_update_metrics(metrics)
+        self._memory_tracker.stop_and_update_metrics(metrics)
 
     At the moment gpu tracking is only for pytorch, but can be extended to support tensorflow.
 
@@ -404,7 +404,7 @@ class TrainerMemoryTracker:
                 if self.torch is not None and stage in self.gpu and t in self.gpu[stage]:
                     metrics[f"{stage}_mem_gpu_{t}_delta"] = self.gpu[stage][t]
 
-    def stop_n_update_metrics(self, metrics=None):
+    def stop_and_update_metrics(self, metrics=None):
         """ combine stop + update in one call for simpler code """
         if self.skip_memory_metrics:
             return

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -245,7 +245,6 @@ class SchedulerType(ExplicitEnum):
 
 
 class TrainerMemoryTracker:
-
     def __init__(self, skip_memory_metrics=False):
         if is_torch_cuda_available():
             import torch

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -249,6 +249,9 @@ class TrainingArguments:
             otherwise.
         dataloader_pin_memory (:obj:`bool`, `optional`, defaults to :obj:`True`)):
             Whether you want to pin memory in data loaders or not. Will default to :obj:`True`.
+        skip_memory_metrics (:obj:`bool`, `optional`, defaults to :obj:`False`)):
+            Whether to skip adding of memory profiler reports to metrics. Defaults to :obj:`False`.
+
     """
 
     output_dir: Optional[str] = field(
@@ -444,6 +447,9 @@ class TrainingArguments:
     )
     dataloader_pin_memory: bool = field(
         default=True, metadata={"help": "Whether or not to pin memory for DataLoader."}
+    )
+    skip_memory_metrics: bool = field(
+        default=False, metadata={"help": "Whether or not to skip adding of memory profiler reports to metrics."}
     )
     _n_gpu: int = field(init=False, repr=False, default=-1)
 


### PR DESCRIPTION
This PR introduced memory usage metrics in Trainer:

* [x] adds `TrainerMemoryTracker` (pytorch only, no-op for tf), which records deltas of the first gpu and cpu of the main process - and records them for `init|train|eval|test` stages - if there is no gpu it reports cpu only.
* [x] adds `--skip_memory_metrics` to disable this new behavior - i.e. by default it'll print the memory metrics
* [x] adds `trainer.metrics_format` which will intelligently reformat the metrics to do the right thing - this is only for logger - moves manual rounding from the scripts into that helper method.
* [x] formats GFlops as GF number, so ` 2285698228224.0`, which is very unreadable and now it will be a nice `2128GF` (similar to `100MB`)
* [x] as a sample changes `run_seq2seq.py` to use  `trainer.metrics_format` - can replicate to other scripts in another PR.
* [x] changes the metrics logger in `run_seq2seq.py` to align data, so that it's easy to read the relative numbers e.g. allocated plus peak memory should be in the same column to make a quick read of the situation.
* [x] adds a new file_utils helper function `is_torch_cuda_available` to detect no gpu setups in one call.
* [x] adds a test 
* [x] consistently use the strange `train/eval/test` trio - it's very confusing - but at least it's consistent - I proposed to fix this `examples`-wide in https://github.com/huggingface/transformers/issues/10165

Request: I beg you to allow me to restore the original refactored metrics dump logic in `run_seq2seq.py` - the current repetition doesn't help the readability and it's just dumping a dict - nothing ML/NLP specific here, there is nothing to understand there IMHO. and then it'd be easy to replicate this to other examples. Thanks. This is the original (and will need to add to it a few formatting entries I added in this PR):

https://github.com/huggingface/transformers/blob/e94d63f6cbf5efe288e41d9840a96a5857090617/examples/legacy/seq2seq/finetune_trainer.py#L132-L145

A picture is worth a thousand words:
```
export BS=16; rm -r output_dir; PYTHONPATH=src USE_TF=0 CUDA_VISIBLE_DEVICES=0 python examples/seq2seq/run_seq2seq.py --model_name_or_path t5-small --output_dir output_dir --adam_eps 1e-06 --do_eval --do_train --do_predict --evaluation_strategy=steps  --label_smoothing 0.1 --learning_rate 3e-5 --logging_first_step --logging_steps 1000 --max_source_length 128 --max_target_length 128 --num_train_epochs 1 --overwrite_output_dir --per_device_eval_batch_size $BS --per_device_train_batch_size $BS --predict_with_generate --eval_steps 25000  --sortish_sampler --task translation_en_to_ro  --val_max_target_length 128 --warmup_steps 500 --max_train_samples 100 --max_val_samples 100 --max_test_samples 100  --dataset_name wmt16-en-ro-pre-processed --source_prefix "translate English to Romanian: "
```
gives:
```
02/16/2021 17:06:39 - INFO - __main__ -   ***** train metrics *****
02/16/2021 17:06:39 - INFO - __main__ -     epoch                      =    1.0
02/16/2021 17:06:39 - INFO - __main__ -     init_mem_cpu_alloc_delta   =    2MB
02/16/2021 17:06:39 - INFO - __main__ -     init_mem_cpu_peaked_delta  =    0MB
02/16/2021 17:06:39 - INFO - __main__ -     init_mem_gpu_alloc_delta   =  230MB
02/16/2021 17:06:39 - INFO - __main__ -     init_mem_gpu_peaked_delta  =    0MB
02/16/2021 17:06:39 - INFO - __main__ -     total_flos                 = 2128GF
02/16/2021 17:06:39 - INFO - __main__ -     train_mem_cpu_alloc_delta  =   55MB
02/16/2021 17:06:39 - INFO - __main__ -     train_mem_cpu_peaked_delta =    0MB
02/16/2021 17:06:39 - INFO - __main__ -     train_mem_gpu_alloc_delta  =  692MB
02/16/2021 17:06:39 - INFO - __main__ -     train_mem_gpu_peaked_delta =  661MB
02/16/2021 17:06:39 - INFO - __main__ -     train_runtime              = 2.3114
02/16/2021 17:06:39 - INFO - __main__ -     train_samples              =    100
02/16/2021 17:06:39 - INFO - __main__ -     train_samples_per_second   =  3.028

02/16/2021 17:06:43 - INFO - __main__ -   ***** val metrics *****
02/16/2021 17:13:05 - INFO - __main__ -     epoch                     =     1.0
02/16/2021 17:13:05 - INFO - __main__ -     eval_bleu                 = 24.6502
02/16/2021 17:13:05 - INFO - __main__ -     eval_gen_len              =    32.9
02/16/2021 17:13:05 - INFO - __main__ -     eval_loss                 =  3.7533
02/16/2021 17:13:05 - INFO - __main__ -     eval_mem_cpu_alloc_delta  =     0MB
02/16/2021 17:13:05 - INFO - __main__ -     eval_mem_cpu_peaked_delta =     0MB
02/16/2021 17:13:05 - INFO - __main__ -     eval_mem_gpu_alloc_delta  =     0MB
02/16/2021 17:13:05 - INFO - __main__ -     eval_mem_gpu_peaked_delta =   510MB
02/16/2021 17:13:05 - INFO - __main__ -     eval_runtime              =  3.9266
02/16/2021 17:13:05 - INFO - __main__ -     eval_samples              =     100
02/16/2021 17:13:05 - INFO - __main__ -     eval_samples_per_second   =  25.467

02/16/2021 17:06:48 - INFO - __main__ -     ***** test metrics *****
02/16/2021 17:06:48 - INFO - __main__ -     test_bleu                 = 27.146
02/16/2021 17:06:48 - INFO - __main__ -     test_gen_len              =  41.37
02/16/2021 17:06:48 - INFO - __main__ -     test_loss                 = 3.6682
02/16/2021 17:06:48 - INFO - __main__ -     test_mem_cpu_alloc_delta  =    0MB
02/16/2021 17:06:48 - INFO - __main__ -     test_mem_cpu_peaked_delta =    0MB
02/16/2021 17:06:48 - INFO - __main__ -     test_mem_gpu_alloc_delta  =    0MB
02/16/2021 17:06:48 - INFO - __main__ -     test_mem_gpu_peaked_delta =  645MB
02/16/2021 17:06:48 - INFO - __main__ -     test_runtime              = 5.1136
02/16/2021 17:06:48 - INFO - __main__ -     test_samples              =    100
02/16/2021 17:06:48 - INFO - __main__ -     test_samples_per_second   = 19.556
```

To understand the memory reports:
- `alloc_delta` - is the difference in the used/allocated memory counter between the end and the start of the stage - it can be negative if a function released more memory than it allocated
- `peaked_delta` - is any extra memory that was consumed and then freed - relative to the current allocated memory counter - it is never negative - this is the mysterious cause of OOM, since normally it doesn't register when everything fits into the memory.
- so when you look at the metrics of any stage you add up `alloc_delta` + `peaked_delta` and you know how much memory was needed to complete that stage. But the two numbers need to be separate.

We can change the names if you'd like, but if we do, let's make sure that allocated/used shows up before peaked  when alphabetically sorted - as they should be read in that order. 

Also it would be useful to have them of the same length so it's less noisy vertically. I was thinking perhaps to add `m` to `alloc`? Then it becomes perfect:
```
test_mem_cpu_malloc_delta =    0MB
test_mem_cpu_peaked_delta =    0MB
```
Logic behind `init`:
- since Trainer's `__init__` can consume a lot of memory, it's important that we trace it too, but since any of the stages can be skipped, I basically push it into the metrics of whichever stage gets to update metrics first, so it gets tacked on to that group of metrics. In the above example it happens to be `train`.

Logic behind nested calls:
- since eval calls may be intermixed with train calls, we can't handle nested invocations because `torch.cuda.max_memory_allocated` is a single counter, so if it gets reset by a nested eval call, train will report incorrect info. One day pytorch will fix this issue: https://github.com/pytorch/pytorch/issues/16266 and then it will be possible to be re-entrant, for now we will only track the outer level `train` / `evaluation` / `predict` functions.

After this addition we can already profile/detect regressions for specific training stages. But this doesn't give us the full picture as there other allocations outside of the trainer - i.e. in user's code. It's a start.

Down the road I may code a different version, based on pynvml, which gives somewhat different numbers, and has its own complications. But it gives you the exact gpu memory usage, so you know exactly how much memory is used or left. PyTorch only reports its internal allocations on the other hand.

@patrickvonplaten, this feature should give us already a partial way to track memory regression. So this could be the low hanging fruit you and I were discussing.

It also should be possible to extend the tracker to use TF, but I don't know anything about TF.

@sgugger, @patil-suraj, @LysandreJik, @patrickvonplaten 