### PR TITLE
[trainer] implement support for full fp16 in evaluation/predict

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -164,7 +164,8 @@ class TrainingArguments:
             :obj:`"apex"`. :obj:`"auto"` will use AMP or APEX depending on the PyTorch version detected, while the
             other choices will force the requested backend.
         fp16_full_eval (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            Whether to use full 16-bit precision evaluation instead of 32-bit. This will be faster and save memory but can harm metric values.
+            Whether to use full 16-bit precision evaluation instead of 32-bit. This will be faster and save memory but
+            can harm metric values.
         local_rank (:obj:`int`, `optional`, defaults to -1):
             Rank of the process during distributed training.
         tpu_num_cores (:obj:`int`, `optional`):
@@ -495,7 +496,9 @@ class TrainingArguments:
             self.run_name = self.output_dir
 
         if is_torch_available() and self.device.type != "cuda" and (self.fp16 or self.fp16_full_eval):
-            raise ValueError("Mixed precision training with AMP or APEX (`--fp16`) and FP16 evaluation can only be used on CUDA devices.")
+            raise ValueError(
+                "Mixed precision training with AMP or APEX (`--fp16`) and FP16 evaluation can only be used on CUDA devices."
+            )
         if self.report_to is None:
             logger.info(
                 "The default value for the training argument `--report_to` will change in v5 (from all installed "

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -155,7 +155,7 @@ class TrainingArguments:
             :func:`~transformers.Trainer.model_init` function to instantiate the model if it has some randomly
             initialized parameters.
         fp16 (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            Whether to use 16-bit (mixed) precision training (through NVIDIA Apex) instead of 32-bit training.
+            Whether to use 16-bit (mixed) precision training instead of 32-bit training.
         fp16_opt_level (:obj:`str`, `optional`, defaults to 'O1'):
             For :obj:`fp16` training, Apex AMP optimization level selected in ['O0', 'O1', 'O2', and 'O3']. See details
             on the `Apex documentation <https://nvidia.github.io/apex/amp.html>`__.
@@ -163,6 +163,8 @@ class TrainingArguments:
             The backend to use for mixed precision training. Must be one of :obj:`"auto"`, :obj:`"amp"` or
             :obj:`"apex"`. :obj:`"auto"` will use AMP or APEX depending on the PyTorch version detected, while the
             other choices will force the requested backend.
+        fp16_full_eval (:obj:`bool`, `optional`, defaults to :obj:`False`):
+            Whether to use full 16-bit precision evaluation instead of 32-bit.
         local_rank (:obj:`int`, `optional`, defaults to -1):
             Rank of the process during distributed training.
         tpu_num_cores (:obj:`int`, `optional`):
@@ -353,7 +355,7 @@ class TrainingArguments:
 
     fp16: bool = field(
         default=False,
-        metadata={"help": "Whether to use 16-bit (mixed) precision (through NVIDIA Apex) instead of 32-bit"},
+        metadata={"help": "Whether to use 16-bit (mixed) precision instead of 32-bit"},
     )
     fp16_opt_level: str = field(
         default="O1",
@@ -367,6 +369,10 @@ class TrainingArguments:
     fp16_backend: str = field(
         default="auto",
         metadata={"help": "The backend to be used for mixed precision.", "choices": ["auto", "amp", "apex"]},
+    )
+    fp16_full_eval: bool = field(
+        default=False,
+        metadata={"help": "Whether to use full 16-bit precision evaluation instead of 32-bit"},
     )
     local_rank: int = field(default=-1, metadata={"help": "For distributed training: local_rank"})
 
@@ -488,7 +494,7 @@ class TrainingArguments:
         if self.run_name is None:
             self.run_name = self.output_dir
 
-        if is_torch_available() and self.device.type != "cuda" and self.fp16:
+        if is_torch_available() and self.device.type != "cuda" and (self.fp16 or self.fp16_full_eval):
             raise ValueError("Mixed precision training with AMP or APEX (`--fp16`) can only be used on CUDA devices.")
         if self.report_to is None:
             logger.info(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -164,7 +164,7 @@ class TrainingArguments:
             :obj:`"apex"`. :obj:`"auto"` will use AMP or APEX depending on the PyTorch version detected, while the
             other choices will force the requested backend.
         fp16_full_eval (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            Whether to use full 16-bit precision evaluation instead of 32-bit.
+            Whether to use full 16-bit precision evaluation instead of 32-bit. This will be faster and save memory but can harm metric values.
         local_rank (:obj:`int`, `optional`, defaults to -1):
             Rank of the process during distributed training.
         tpu_num_cores (:obj:`int`, `optional`):
@@ -495,7 +495,7 @@ class TrainingArguments:
             self.run_name = self.output_dir
 
         if is_torch_available() and self.device.type != "cuda" and (self.fp16 or self.fp16_full_eval):
-            raise ValueError("Mixed precision training with AMP or APEX (`--fp16`) can only be used on CUDA devices.")
+            raise ValueError("Mixed precision training with AMP or APEX (`--fp16`) and FP16 evaluation can only be used on CUDA devices.")
         if self.report_to is None:
             logger.info(
                 "The default value for the training argument `--report_to` will change in v5 (from all installed "


### PR DESCRIPTION
This PR allows users to use `model.half()` in evaluation/predict, which may or may not deliver results identical to fp32 eval. The outcome depends on how the model was trained and the application. e.g. if I use `--label_smoothing` with t5-small I get `eval loss = nan`, but bleu scores are exactly the same as with fp32.

### Need

Besides users asking for it in the past, the real need that prompted me to implement this is based on this Issue:  https://github.com/huggingface/transformers/issues/10161. To explain - DeepSpeed trains in fp16, while keeping master copy of fp32 weights on cpu, which allows fitting a model like t5-11b (45GB in params) onto a 40GB gpu (only 22.5GB in fp16). But then the user wants to eval and deepspeed is of no use here at the moment. So we need to give a way to users to run full fp16 in eval, which is what this PR proposes.

This PR:
* [x] adds `is_in_train` public Trainer attribute which helps to tell whether `evaluation` is running on its own, or called from `train`
* [x] adds `--fp16_full_eval` to enable the full fp16 mode under eval/predict (while `full-fp16` would read better, I picked the name starting with `--fp16_` to align/group well with other3 `--fp16_*` args.
* [x] adds the first test that measures gpu mem deltas - let's hope it proves to work across different gpus 

The logic is a bit tricky since we must not `model.to(device)` before `model.half()` or otherwise the model loading will OOM, but I hope I was able to keep it simple and not error-prone. Perhaps instead of replaying `place_on_device` logic at the end of `train` in the deepspeed clean up section - it'd be better to re-play the full logic in the `predict_loop`? So that each stage can decide at its beginning how and when to put the model on device. 

A few small related fixes:
* [x] fixes `_wrap_model` to do nothing under deepspeed
* [x] fixes `--fp16` help to remove apex-only comment, as it's outdated.

Questions:
* [ ] Should I add a log, saying that half is used at `model.half()` activation
* [ ] I put it inside `prediction_step` which seems to be the right place, it won't run if it's a re-entrant eval-inside-train
* [ ] as the `inputs` are `ints` I don't think we need to switch them to `half()` as well.

@sgugger 