### PR TITLE
[ci] don't fail when there are no zombies

### DIFF
--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -31,7 +31,7 @@ jobs:
       - run: nvidia-smi
 
       - name: Kill any run-away pytest processes
-        run: pkill -f tests; pkill -f examples
+        run: (pkill -f tests; pkill -f examples) || echo "no zombies"
 
       - name: Loading cache.
         uses: actions/cache@v2
@@ -106,7 +106,7 @@ jobs:
       - run: nvidia-smi
 
       - name: Kill any run-away pytest processes
-        run: pkill -f tests; pkill -f examples
+        run: (pkill -f tests; pkill -f examples) || echo "no zombies"
 
       - name: Loading cache.
         uses: actions/cache@v2
@@ -179,7 +179,7 @@ jobs:
       - run: nvidia-smi
 
       - name: Kill any run-away pytest processes
-        run: pkill -f tests; pkill -f examples
+        run: (pkill -f tests; pkill -f examples) || echo "no zombies"
 
       - name: Loading cache.
         uses: actions/cache@v2
@@ -243,7 +243,7 @@ jobs:
       - run: nvidia-smi
 
       - name: Kill any run-away pytest processes
-        run: pkill -f tests; pkill -f examples
+        run: (pkill -f tests; pkill -f examples) || echo "no zombies"
 
       - name: Loading cache.
         uses: actions/cache@v2

--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -35,7 +35,7 @@ jobs:
       - run: nvidia-smi
 
       - name: Kill any run-away pytest processes
-        run: pkill -f tests; pkill -f examples
+        run: (pkill -f tests; pkill -f examples) || echo "no zombies"
 
       - name: Create new python env (on self-hosted runners we have to handle isolation ourselves)
         if: steps.cache.outputs.cache-hit != 'true'
@@ -133,7 +133,7 @@ jobs:
       - run: nvidia-smi
 
       - name: Kill any run-away pytest processes
-        run: pkill -f tests; pkill -f examples
+        run: (pkill -f tests; pkill -f examples) || echo "no zombies"
 
 
       - name: Create new python env (on self-hosted runners we have to handle isolation ourselves)
@@ -217,7 +217,7 @@ jobs:
       - run: nvidia-smi
 
       - name: Kill any run-away pytest processes
-        run: pkill -f tests; pkill -f examples
+        run: (pkill -f tests; pkill -f examples) || echo "no zombies"
 
       - name: Create new python env (on self-hosted runners we have to handle isolation ourselves)
         if: steps.cache.outputs.cache-hit != 'true'
@@ -316,7 +316,7 @@ jobs:
       - run: nvidia-smi
 
       - name: Kill any run-away pytest processes
-        run: pkill -f tests; pkill -f examples
+        run: (pkill -f tests; pkill -f examples) || echo "no zombies"
 
       - name: Create new python env (on self-hosted runners we have to handle isolation ourselves)
         if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
fixes:
```
Run pkill -f tests; pkill -f examples
4
Error: Process completed with exit code 1.
```

Didn't think that it'd `exit(1)` when there is nothing to kill

@sgugger 