### PR TITLE
[Trainer] implement gradient_accumulation_steps support in DeepSpeed integration

### DIFF
--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -838,7 +838,7 @@ While normally DeepSpeed gets gradient accumulation configured with:
 .. code-block:: json
 
     {
-        ""gradient_accumulation_steps": 3,
+        "gradient_accumulation_steps": 3,
     }
 
 in this case, to enable gradient accumulation, pass the command line `--gradient_accumulation_steps` argument as normal

--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -830,6 +830,28 @@ Here is an example of the ``amp`` configuration:
     }
 
 
+Gradient Accumulation
+=======================================================================================================================
+
+While normally DeepSpeed gets gradient accumulation configured with:
+
+.. code-block:: json
+
+    {
+        ""gradient_accumulation_steps": 3,
+    }
+
+in this case, to enable gradient accumulation, pass the command line `--gradient_accumulation_steps` argument as normal
+and it will get injected into the DeepSpeed configuration.
+
+If you try to add it directly to the configuration file, you will receive an error from the Trainer - this is because
+this setting is needed by the Trainer too, and so this approach ensures that there is a single way of setting this
+value and thus avoid potential subtle errors.
+
+
+
+
+
 
 Gradient Clipping
 =======================================================================================================================

--- a/examples/tests/deepspeed/ds_config.json
+++ b/examples/tests/deepspeed/ds_config.json
@@ -3,6 +3,7 @@
         "enabled": true,
         "loss_scale": 0,
         "loss_scale_window": 1000,
+        "initial_scale_power": 32,
         "hysteresis": 2,
         "min_loss_scale": 1
     },

--- a/examples/tests/deepspeed/test_deepspeed.py
+++ b/examples/tests/deepspeed/test_deepspeed.py
@@ -107,10 +107,10 @@ class TrainerIntegrationDeepSpeed(TestCasePlus):
             )
             baseline_result = trainer_baseline.train()
             baseline_loss = baseline_result.training_loss
-            baseline_a = trainer_baseline.model.a
-            baseline_b = trainer_baseline.model.b
+            baseline_a = trainer_baseline.model.a.item()
+            baseline_b = trainer_baseline.model.b.item()
             # make sure the optimizer kicked in - if it hasn't changed from the original value of a then make train_len bigger
-            self.assertNotEqual(baseline_a.item(), a)
+            self.assertNotEqual(baseline_a, a)
 
         with mockenv_context(**self.dist_env_1_gpu):
             trainer_deepspeed = get_regression_trainer(
@@ -124,13 +124,13 @@ class TrainerIntegrationDeepSpeed(TestCasePlus):
             )
             deepspeed_result = trainer_deepspeed.train()
             deepspeed_loss = deepspeed_result.training_loss
-            deepspeed_a = trainer_deepspeed.model.a
-            deepspeed_b = trainer_deepspeed.model.b
+            deepspeed_a = trainer_deepspeed.model.a.item()
+            deepspeed_b = trainer_deepspeed.model.b.item()
             self.assertNotEqual(deepspeed_a, a)
 
         # training with half the batch size but accumulation steps as 2 should give the same weights
-        self.assertEqual(baseline_a.item(), deepspeed_a.item())
-        self.assertEqual(baseline_b.item(), deepspeed_b.item())
+        self.assertEqual(baseline_a, deepspeed_a)
+        self.assertEqual(baseline_b, deepspeed_b)
 
         # see the note above how to get identical loss on a small bs
         self.assertAlmostEqual(baseline_loss, deepspeed_loss, places=5)

--- a/examples/tests/deepspeed/test_deepspeed.py
+++ b/examples/tests/deepspeed/test_deepspeed.py
@@ -23,12 +23,17 @@ from transformers.testing_utils import (
     TestCasePlus,
     execute_subprocess_async,
     get_gpu_count,
-    mockenv,
+    mockenv_context,
     require_torch_gpu,
     require_torch_multi_gpu,
     slow,
 )
 from transformers.trainer_utils import set_seed
+
+
+bindir = os.path.abspath(os.path.dirname(__file__))
+sys.path.append(f"{bindir}/../../../tests")
+from test_trainer import get_regression_trainer  # noqa
 
 
 set_seed(42)
@@ -51,31 +56,95 @@ def require_deepspeed(test_case):
         return test_case
 
 
+@require_deepspeed
+@require_torch_gpu
+class TrainerIntegrationDeepSpeed(TestCasePlus):
+    """ This class is for testing directly via get_regression_trainer """
+
+    def setUp(self):
+        super().setUp()
+        self.dist_env_1_gpu = dict(
+            MASTER_ADDR="localhost", MASTER_PORT="10999", RANK="0", LOCAL_RANK="0", WORLD_SIZE="1"
+        )
+        self.ds_config_file = f"{self.test_file_dir_str}/ds_config.json"
+
+    def test_fake_notebook_no_launcher(self):
+
+        # this setup emulates a notebook where a launcher needs to be emulated by hand
+
+        with CaptureStd() as cs:
+            with mockenv_context(**self.dist_env_1_gpu):
+                trainer = get_regression_trainer(local_rank=0, deepspeed=self.ds_config_file)
+                trainer.train()
+        assert "DeepSpeed info" in cs.out, "expected DeepSpeed logger output but got none"
+
+    def test_grad_acum(self):
+
+        # this test measures that we get identical weights and similar loss with:
+        # 1. per_device_train_batch_size=8, gradient_accumulation_steps=1
+        # 2. per_device_train_batch_size=4, gradient_accumulation_steps=2
+        # since the 2nd should produce the effective batch of 1st, with the same results
+        #
+        # I can get an identical loss for a small train_len=32, plus the power of the initial
+        # dynamic loss scale value set to:
+        #   "fp16.initial_scale_power": 1
+        # plus having the same WarmupLR's warmup_min_lr == warmup_max_lr in the config file
+        # but for some reason going to train_len=64 the weights, weights start to mismatch with this setup.
+        # the culprit seems to be `initial_scale_power` - putting it back to its default 32 keeps the weights identical
+
+        train_len = 64
+        a = b = 0.0
+
+        with mockenv_context(**self.dist_env_1_gpu):
+            trainer_baseline = get_regression_trainer(
+                a=a,
+                b=b,
+                local_rank=0,
+                train_len=train_len,
+                deepspeed=self.ds_config_file,
+                per_device_train_batch_size=8,
+                gradient_accumulation_steps=1,
+            )
+            baseline_result = trainer_baseline.train()
+            baseline_loss = baseline_result.training_loss
+            baseline_a = trainer_baseline.model.a
+            baseline_b = trainer_baseline.model.b
+            # make sure the optimizer kicked in - if it hasn't changed from the original value of a then make train_len bigger
+            self.assertNotEqual(baseline_a.item(), a)
+
+        with mockenv_context(**self.dist_env_1_gpu):
+            trainer_deepspeed = get_regression_trainer(
+                a=a,
+                b=b,
+                local_rank=0,
+                train_len=train_len,
+                deepspeed=self.ds_config_file,
+                per_device_train_batch_size=4,
+                gradient_accumulation_steps=2,
+            )
+            deepspeed_result = trainer_deepspeed.train()
+            deepspeed_loss = deepspeed_result.training_loss
+            deepspeed_a = trainer_deepspeed.model.a
+            deepspeed_b = trainer_deepspeed.model.b
+            self.assertNotEqual(deepspeed_a, a)
+
+        # training with half the batch size but accumulation steps as 2 should give the same weights
+        self.assertEqual(baseline_a.item(), deepspeed_a.item())
+        self.assertEqual(baseline_b.item(), deepspeed_b.item())
+
+        # see the note above how to get identical loss on a small bs
+        self.assertAlmostEqual(baseline_loss, deepspeed_loss, places=5)
+
+
 @slow
 @require_deepspeed
 @require_torch_gpu
 class TestDeepSpeed(TestCasePlus):
-
-    # this setup emulates a notebook where a launcher needs to be emulated by hand
-    @mockenv(MASTER_ADDR="localhost", MASTER_PORT="10999", RANK="0", LOCAL_RANK="0", WORLD_SIZE="1")
-    def test_fake_notebook_no_launcher(self):
-        sys.path.append(self.tests_dir_str)
-        from test_trainer import get_regression_trainer
-
-        del sys.path[-1]  # restore
-        ds_config_file = f"{self.test_file_dir_str}/ds_config.json"
-        with CaptureStd() as cs:
-            trainer = get_regression_trainer(local_rank=0, deepspeed=ds_config_file)
-            trainer.train()
-        assert "DeepSpeed info" in cs.out, "expected DeepSpeed logger output but got none"
+    """ This class is for testing via an external script """
 
     @require_torch_multi_gpu
     def test_basic_distributed(self):
         self.run_quick(distributed=True)
-
-    @require_torch_multi_gpu
-    def test_grad_acum(self):
-        self.run_quick(distributed=True, extra_args_str="--gradient_accumulation_steps 2")
 
     def test_do_eval_no_train(self):
         # we should not fail if train is skipped


### PR DESCRIPTION
This PR:

Fixes in a bug:
- `lr_scheduler.step()` shouldn't be called under DeepSpeed - it's already called in its `optimizer.step()` internally - so it was moving through the scheduler rate change at twice the speed :(

Adds support for `gradient_accumulation_steps`:
* makes `gradient_accumulation_steps` work with deepspeed - for nuances see: https://github.com/microsoft/DeepSpeed/issues/776 - it required a lot of `if` / `if nots` - not helping the readability of the trainer  - and took a lot of trial and error to figure out - but what to do
* adds a corresponding doc 
* adds a first serious quality test for DeepSpeed that measures that `gradient_accumulation_steps` works - modelled after `test_trainer.py`'s own `test_gradient_accumulation` and extends it to compare loss as well, and also tests that the optimizer actually kicked in - with fp16 deepspeed it normally takes a few dozen steps before it kicks in with dynamic scaling enabled.
* extends `testing_utils` with a `mockenv_context` which is similar to `@mockenv`, but which can be used inside the test as context manager if multiple env vars need to be tested - `@mockenv` is only useful as a decorator. At the end I think I don't really need it as using the same env worked for all tests, but it might come handy if ports don't get released fast enough and then the test will use different ports - I'm concerned about CIs. And it's easier to re-use the class-wide env, rather hardcoding or creating a global variable - so it's just cleaner too.

Suggestion/Question:
* `get_regression_trainer` is very awesome! But importing it from a test file is not great - probably should move it and its components into a utilities file - `testing_utils.py` or create a new one `testing_training_utils.py` and in the future add other trainer-testing specific utils in there? Though this should be dealt with in a separate PR.

@sgugger 