### PR TITLE
Add support for ZeRO-2/3 and ZeRO-offload in fairscale

### DIFF
--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -301,7 +301,7 @@ For example here is how you could use it for ``run_seq2seq.py`` with 2 GPUs:
 :obj:`zero_dp_2` is an optimized version of the simple wrapper, while :obj:`zero_dp_3` fully shards model weights,
 gradients and optimizer states.
 
-Both are compatible with adding :obj:`cpu_offload` to enable ZeRO-offload (activat it like this: :obj:`--sharded_ddp
+Both are compatible with adding :obj:`cpu_offload` to enable ZeRO-offload (activate it like this: :obj:`--sharded_ddp
 "zero_dp_2 cpu_offload"`).
 
 Notes:
@@ -309,15 +309,15 @@ Notes:
 - This feature requires distributed training (so multiple GPUs).
 - It is not implemented for TPUs.
 - It works with ``--fp16`` too, to make things even faster.
-- The ``cpu_offload`` additional option require ``--fp16``.
+- The ``cpu_offload`` additional option requires ``--fp16``.
 - This is an area of active development, so make sure you have a source install of fairscale to use this feature as
   some bugs you encounter may have been fixed there already.
 
 Known caveats:
 
-- This feature is incompatible with :obj:`--predict_with_generate` in the run_seq2seq script.
+- This feature is incompatible with :obj:`--predict_with_generate` in the `run_seq2seq.py` script.
 - Using :obj:`--sharded_ddp zero_dp_3` requires wrapping each layer of the model in the special container
-  :obj:`FullyShardedDataParallelism` of fairscale. This is not done automatically by any of the example script of the
+  :obj:`FullyShardedDataParallelism` of fairscale. This is not done automatically by any of the example scripts of the
   :class:`~transformers.Trainer`.
 
 

--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -241,6 +241,8 @@ provides support for the following features from `the ZeRO paper <https://arxiv.
 
 1. Optimizer State Sharding
 2. Gradient Sharding
+3. Model Parameters Sharding (new and very experimental)
+4. CPU offload (new and very experimental)
 
 You will need at least two GPUs to use this feature.
 
@@ -255,8 +257,9 @@ To deploy this feature:
    or find more details on `the FairScale's GitHub page
    <https://github.com/facebookresearch/fairscale/#installation>`__.
 
-2. Add ``--sharded_ddp`` to the command line arguments, and make sure you have added the distributed launcher ``-m
-   torch.distributed.launch --nproc_per_node=NUMBER_OF_GPUS_YOU_HAVE`` if you haven't been using it already.
+2. To use the first version of Sharded data-parallelism, add ``--sharded_ddp simple`` to the command line arguments,
+   and make sure you have added the distributed launcher ``-m torch.distributed.launch
+   --nproc_per_node=NUMBER_OF_GPUS_YOU_HAVE`` if you haven't been using it already.
 
 For example here is how you could use it for ``run_seq2seq.py`` with 2 GPUs:
 
@@ -268,16 +271,54 @@ For example here is how you could use it for ``run_seq2seq.py`` with 2 GPUs:
     --do_train --max_train_samples 500 --num_train_epochs 1 \
     --dataset_name wmt16 --dataset_config "ro-en" \
     --task translation_en_to_ro --source_prefix "translate English to Romanian: " \
-    --fp16 --sharded_ddp
+    --fp16 --sharded_ddp simple
 
 Notes:
 
 - This feature requires distributed training (so multiple GPUs).
 - It is not implemented for TPUs.
 - It works with ``--fp16`` too, to make things even faster.
-- One of the main benefits of enabling ``--sharded_ddp`` is that it uses a lot less GPU memory, so you should be able
-  to use significantly larger batch sizes using the same hardware (e.g. 3x and even bigger) which should lead to
+- One of the main benefits of enabling ``--sharded_ddp simple`` is that it uses a lot less GPU memory, so you should be
+  able to use significantly larger batch sizes using the same hardware (e.g. 3x and even bigger) which should lead to
   significantly shorter training time.
+
+3. To use the second version of Sharded data-parallelism, add ``--sharded_ddp zero_dp_2`` or ``--sharded_ddp zero_dp_3`
+   to the command line arguments, and make sure you have added the distributed launcher ``-m torch.distributed.launch
+   --nproc_per_node=NUMBER_OF_GPUS_YOU_HAVE`` if you haven't been using it already.
+
+For example here is how you could use it for ``run_seq2seq.py`` with 2 GPUs:
+
+.. code-block:: bash
+
+    python -m torch.distributed.launch --nproc_per_node=2 examples/seq2seq/run_seq2seq.py \
+    --model_name_or_path t5-small --per_device_train_batch_size 1   \
+    --output_dir output_dir --overwrite_output_dir \
+    --do_train --max_train_samples 500 --num_train_epochs 1 \
+    --dataset_name wmt16 --dataset_config "ro-en" \
+    --task translation_en_to_ro --source_prefix "translate English to Romanian: " \
+    --fp16 --sharded_ddp zero_dp_2
+
+:obj:`zero_dp_2` is an optimized version of the simple wrapper, while :obj:`zero_dp_3` fully shards model weights,
+gradients and optimizer states.
+
+Both are compatible with adding :obj:`cpu_offload` to enable ZeRO-offload (activat it like this: :obj:`--sharded_ddp
+"zero_dp_2 cpu_offload"`).
+
+Notes:
+
+- This feature requires distributed training (so multiple GPUs).
+- It is not implemented for TPUs.
+- It works with ``--fp16`` too, to make things even faster.
+- The ``cpu_offload`` additional option require ``--fp16``.
+- This is an area of active development, so make sure you have a source install of fairscale to use this feature as
+  some bugs you encounter may have been fixed there already.
+
+Known caveats:
+
+- This feature is incompatible with :obj:`--predict_with_generate` in the run_seq2seq script.
+- Using :obj:`--sharded_ddp zero_dp_3` requires wrapping each layer of the model in the special container
+  :obj:`FullyShardedDataParallelism` of fairscale. This is not done automatically by any of the example script of the
+  :class:`~transformers.Trainer`.
 
 
 DeepSpeed

--- a/examples/tests/trainer/test_trainer_ext.py
+++ b/examples/tests/trainer/test_trainer_ext.py
@@ -89,13 +89,13 @@ class TestTrainerExt(TestCasePlus):
     @require_torch_multi_gpu
     @require_fairscale
     def test_run_seq2seq_ddp_sharded_ddp(self):
-        self.run_seq2seq_quick(distributed=True, extra_args_str="--sharded_ddp")
+        self.run_seq2seq_quick(distributed=True, extra_args_str="--sharded_ddp simple")
 
     # test --sharded_ddp w/ --fp16
     @require_torch_multi_gpu
     @require_fairscale
     def test_run_seq2seq_ddp_sharded_ddp_fp16(self):
-        self.run_seq2seq_quick(distributed=True, extra_args_str="--sharded_ddp --fp16")
+        self.run_seq2seq_quick(distributed=True, extra_args_str="--sharded_ddp simple --fp16")
 
     @require_apex
     def test_run_seq2seq_apex(self):

--- a/examples/tests/trainer/test_trainer_ext.py
+++ b/examples/tests/trainer/test_trainer_ext.py
@@ -64,12 +64,13 @@ def require_apex(test_case):
 
 
 class TestTrainerExt(TestCasePlus):
-    def run_seq2seq_quick(self, distributed=False, extra_args_str=None):
-        output_dir = self.run_trainer(1, "12", MBART_TINY, 1, distributed, extra_args_str)
+    def run_seq2seq_quick(self, distributed=False, extra_args_str=None, eval=True, predict_with_generate=True):
+        output_dir = self.run_trainer(1, "12", MBART_TINY, 1, distributed, extra_args_str, predict_with_generate)
         logs = TrainerState.load_from_json(os.path.join(output_dir, "trainer_state.json")).log_history
         eval_metrics = [log for log in logs if "eval_loss" in log.keys()]
         first_step_stats = eval_metrics[0]
-        assert "eval_bleu" in first_step_stats
+        if predict_with_generate:
+            assert "eval_bleu" in first_step_stats
 
     @require_torch_non_multi_gpu
     def test_run_seq2seq_no_dist(self):
@@ -88,14 +89,28 @@ class TestTrainerExt(TestCasePlus):
     # test --sharded_ddp w/o --fp16
     @require_torch_multi_gpu
     @require_fairscale
-    def test_run_seq2seq_ddp_sharded_ddp(self):
+    def test_run_seq2seq_sharded_ddp(self):
         self.run_seq2seq_quick(distributed=True, extra_args_str="--sharded_ddp simple")
 
     # test --sharded_ddp w/ --fp16
     @require_torch_multi_gpu
     @require_fairscale
-    def test_run_seq2seq_ddp_sharded_ddp_fp16(self):
+    def test_run_seq2seq_sharded_ddp_fp16(self):
         self.run_seq2seq_quick(distributed=True, extra_args_str="--sharded_ddp simple --fp16")
+
+    # test --sharded_ddp zero2 w/o --fp16
+    @require_torch_multi_gpu
+    @require_fairscale
+    def test_run_seq2seq_fully_sharded_ddp(self):
+        self.run_seq2seq_quick(distributed=True, extra_args_str="--sharded_ddp zero2", predict_with_generate=False)
+
+    # test --sharded_ddp zero2 w/ --fp16
+    @require_torch_multi_gpu
+    @require_fairscale
+    def test_run_seq2seq_fully_sharded_ddp_fp16(self):
+        self.run_seq2seq_quick(
+            distributed=True, extra_args_str="--sharded_ddp zero2 --fp16", predict_with_generate=False
+        )
 
     @require_apex
     def test_run_seq2seq_apex(self):
@@ -131,6 +146,7 @@ class TestTrainerExt(TestCasePlus):
         num_train_epochs: int,
         distributed: bool = False,
         extra_args_str: str = None,
+        predict_with_generate: bool = True,
     ):
         data_dir = self.examples_dir / "test_data/wmt_en_ro"
         output_dir = self.get_auto_remove_tmp_dir()
@@ -155,7 +171,6 @@ class TestTrainerExt(TestCasePlus):
             --learning_rate 3e-3
             --warmup_steps 8
             --evaluation_strategy steps
-            --predict_with_generate
             --logging_steps 0
             --save_steps {str(eval_steps)}
             --eval_steps {str(eval_steps)}
@@ -165,7 +180,11 @@ class TestTrainerExt(TestCasePlus):
             --task translation
             --target_lang ro_RO
             --source_lang en_XX
-        """.split()
+        """
+        if predict_with_generate:
+            args += "--predict_with_generate"
+
+        args = args.split()
 
         if extra_args_str is not None:
             args.extend(extra_args_str.split())

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -765,7 +765,7 @@ class Trainer:
                 mixed_precision = self.args.fp16
                 cpu_offload = ShardedDDPOption.OFFLOAD in self.args.sharded_ddp
                 zero_3 = self.sharded_ddp == ShardedDDPOption.ZERO_DP_3
-                # Breaking the self.model convention but I see no way around it for now.
+                # XXX: Breaking the self.model convention but I see no way around it for now.
                 self.model = model = FullyShardedDDP(
                     model, mixed_precision=mixed_precision, reshard_after_forward=zero_3, cpu_offload=cpu_offload
                 ).to(self.args.device)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1569,7 +1569,7 @@ class Trainer:
         if not isinstance(self.model, PreTrainedModel):
             if isinstance(_model_unwrap(self.model), PreTrainedModel):
                 if xm.is_master_ordinal():
-                    _model_unwrap(self.model).config.save_pretrained(save_directory)
+                    _model_unwrap(self.model).config.save_pretrained(output_dir)
             else:
                 logger.info("Trainer.model is not a `PreTrainedModel`, only saving its state dict.")
             state_dict = self.model.state_dict()
@@ -1587,7 +1587,7 @@ class Trainer:
         # They can then be reloaded using `from_pretrained()`
         if not isinstance(self.model, PreTrainedModel):
             if isinstance(_model_unwrap(self.model), PreTrainedModel):
-                _model_unwrap(self.model).config.save_pretrained(save_directory)
+                _model_unwrap(self.model).config.save_pretrained(output_dir)
             else:
                 logger.info("Trainer.model is not a `PreTrainedModel`, only saving its state dict.")
             state_dict = self.model.state_dict()

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -421,3 +421,12 @@ class TrainerMemoryTracker:
         # init doesn't have metrics to update so we just save that data for later stages to retrieve
         if metrics is not None:
             self.update_metrics(stage, metrics)
+
+
+class ShardedDDPType(ExplicitEnum):
+    NO = "no"
+    SIMPLE = "simple"
+    ZERO_2 = "zero2"
+    ZERO_2_OFFLOAD = "zero2_offload"
+    ZERO_3 = "zero3"
+    ZERO_3_OFFLOAD = "zero3_offload"

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -423,10 +423,8 @@ class TrainerMemoryTracker:
             self.update_metrics(stage, metrics)
 
 
-class ShardedDDPType(ExplicitEnum):
-    NO = "no"
+class ShardedDDPOption(ExplicitEnum):
     SIMPLE = "simple"
-    ZERO_2 = "zero2"
-    ZERO_2_OFFLOAD = "zero2_offload"
-    ZERO_3 = "zero3"
-    ZERO_3_OFFLOAD = "zero3_offload"
+    ZERO_DP_2 = "zero2"
+    ZERO_DP_3 = "zero3"
+    OFFLOAD = "offload"

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -555,7 +555,7 @@ class TrainingArguments:
         if self.sharded_ddp == [ShardedDDPOption.OFFLOAD]:
             raise ValueError(
                 "`--sharded_ddp offload` can't work on its own. It needs to be added to `--sharded_ddp zero_dp_2` or "
-                "`--sharded_ddp zero_dp_3`"
+                "`--sharded_ddp zero_dp_3`". For example, `--sharded_ddp "zero_dp_2 offload"`.
             )
         elif len(self.sharded_ddp) > 1 and ShardedDDPOption.Simple in self.sharded_ddp:
             raise ValueError("`--sharded_ddp simple` is not compatible with any other option.")

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -458,7 +458,12 @@ class TrainingArguments:
     )
     sharded_ddp: str = field(
         default="",
-        metadata={"help": "Whether or not to use sharded DDP training (in distributed training only)."},
+        metadata={
+            "choices": ["simple", "zero_dp_2", "zero_dp_3", "zero_dp_2 offload", "zero_dp_3 offload"],
+            "help": "Whether or not to use sharded DDP training (in distributed training only). The base option "
+            "should be `simple`, `zero_dp_2` or `zero_dp_3` and you can add CPU-offload to `zero_dp_2` or `zero_dp_3` "
+            "like this: zero_dp_2 offload` or `zero_dp_3 offload`",
+        },
     )
     deepspeed: Optional[str] = field(
         default=None,
@@ -555,7 +560,7 @@ class TrainingArguments:
         if self.sharded_ddp == [ShardedDDPOption.OFFLOAD]:
             raise ValueError(
                 "`--sharded_ddp offload` can't work on its own. It needs to be added to `--sharded_ddp zero_dp_2` or "
-                "`--sharded_ddp zero_dp_3`". For example, `--sharded_ddp "zero_dp_2 offload"`.
+                '`--sharded_ddp zero_dp_3`. For example, `--sharded_ddp "zero_dp_2 offload"`.'
             )
         elif len(self.sharded_ddp) > 1 and ShardedDDPOption.Simple in self.sharded_ddp:
             raise ValueError("`--sharded_ddp simple` is not compatible with any other option.")


### PR DESCRIPTION
# What does this PR do?

This PR adds support for the new `FullyShardedDataParallel` introduced in fairscale. See [this PR](https://github.com/facebookresearch/fairscale/pull/413) for more details.

The PR changes a tiny bit the behavior of the `--sharded_ddp` flag/training argument to support a list of options. You can still use the TrainingArguments class with `sharded_dpp=True` but if launching a script, `--sharded_ddp` has to be replaced with `--sharded_ddp simple`. The `--sharded_ddp` was marked as an experimental API so I think this breaking change is fine if properly documented.

Other values supported are: `zero_dp_2`, `zero_dp_2 offload`, `zero_dp_3` and `zero_dp_3 offload`. To fully take advantage of the `zero_dp_3`/`zero_dp_3 offload` the model passed to the `Trainer` will need to have its internal layers wrapped inside the `FullyShardedDataParallel`, but this out of scope for this particular PR.

For all those new modes, the model simply needs to be wrapped inside `FullyShardedDataParallel` but the optimizer needs to be created after the model wrapping (to get the parameters shards).

Note that:
- `predict_with_generate` does not work with this integration
- `cpu_offload` does not work for now due to the bug mentioned in [this issue](https://github.com/facebookresearch/fairscale/issues/421). Once the issue is fixed, the option should work with the existing code.

One thing to think further is that this integration breaks the usual convention that `self.model` is the original model (`FullyShardedDataParallel` consumes the model to use less memory).