### PR TITLE
[Trainer/Deepspeed] handle get_last_lr() before first step()

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1944,9 +1944,9 @@ class Trainer:
 
     def _get_learning_rate(self):
         if self.deepspeed:
-            # with deepspeed's fp16 and dynamic loss scale enabled the optimizer/scheduler steps
-            # may not run for the first few dozens steps while loss is overflowing, so
-            # `get_last_lr` will fail if called during that warm up stage, so handle it cleanly here:
+            # with deepspeed's fp16 and dynamic loss scale enabled the optimizer/scheduler steps may
+            # not run for the first few dozen steps while loss scale is too large, and thus during
+            # that time `get_last_lr` will fail if called during that warm up stage, so work around it:
             try:
                 last_lr = self.lr_scheduler.get_last_lr()[0]
             except AssertionError as e:


### PR DESCRIPTION
with deepspeed's fp16 and dynamic loss scale enabled the optimizer/scheduler steps may not run for the first few dozens steps while loss is overflowing, so `get_last_lr` will fail if called during that warm up stage, so this PR tries to catch that special warm situation and handle it by returning a fake LR=0, which is a good default because since there is no stepping it's effectively a 0.

I'm just not sure if I should warn - it ends up emitting like 20-30 of those: if the user picks `--logging_steps=`, e.g:

```
2021-02-23 12:53:06,798] [INFO] [stage2.py:1357:step] [deepscale] OVERFLOW! Rank 0 Skipping step. Attempted loss scale: 4294967296, reducing to 4294967296
[WARNING|trainer.py:1142] 2021-02-23 12:53:06,799 >> tried to get lr value before scheduler/optimizer started stepping, returning lr=0
{'loss': 11.0, 'learning_rate': 0, 'epoch': 0.0}                                                                                                                 
[2021-02-23 12:53:06,990] [INFO] [stage2.py:1357:step] [deepscale] OVERFLOW! Rank 0 Skipping step. Attempted loss scale: 4294967296, reducing to 2147483648.0
[WARNING|trainer.py:1142] 2021-02-23 12:53:06,992 >> tried to get lr value before scheduler/optimizer started stepping, returning lr=0
{'loss': 10.9922, 'learning_rate': 0, 'epoch': 0.0}                                                                                                              
                 
```

* [x] added a test too.

I first thought it should be handled by DeepSpeed https://github.com/microsoft/DeepSpeed/issues/782 but then realized that since pytorch optimizers won't be aware of this, we have to handle this in the trainer since we are the ones calling `get_last_lr()` sort of prematurely - (yet, we don't have a way to know that it's premature as we can't even called `lr_scheduler.step()` as it's being handled opaquely by DeepSpeed.

@sgugger 

Fixes: #https://github.com/huggingface/transformers/issues/10330#issuecomment-784457460