### PR TITLE
Run GA on every push even on forks

### DIFF
--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -7,9 +7,8 @@ on:
       - "tests/**"
       - ".github/**"
       - "templates/**"
-  pull_request_target:
-    branches:
-      - master
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
 
 jobs:
   run_tests_templates:


### PR DESCRIPTION
This PR updates the Github Actions YAML file so that PRs opened from forks run the GA tests on every commit.

Fixes https://github.com/huggingface/transformers/issues/10065