### PR TITLE
Ignore unexpected weights from PT conversion

### DIFF
--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -919,7 +919,11 @@ Bert Model with two heads on top as done during the pretraining:
 )
 class TFBertForPreTraining(TFBertPreTrainedModel, TFBertPreTrainingLoss):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
-    _keys_to_ignore_on_load_unexpected = [r"cls.predictions.decoder.weight"]
+    _keys_to_ignore_on_load_unexpected = [
+        r"position_ids",
+        r"cls.predictions.decoder.weight",
+        r"cls.predictions.decoder.bias",
+    ]
 
     def __init__(self, config: BertConfig, *inputs, **kwargs):
         super().__init__(config, *inputs, **kwargs)


### PR DESCRIPTION
Some weights resulting from the conversion from a PyTorch model to a TensorFlow model are throwing an unnecessary warning.

To see for yourself, the following code throws a warning before the PR:

```py
from transformers import BertForPreTraining, BertConfig, TFBertForPreTraining

pt = BertForPreTraining(BertConfig())
pt.save_pretrained("here")
tf = TFBertForPreTraining.from_pretrained("here", from_pt=True)
```

Fix https://github.com/huggingface/transformers/issues/10348