### PR TITLE
Dont use sigmoid when num_labels==1

### DIFF
--- a/src/transformers/pipelines/text_classification.py
+++ b/src/transformers/pipelines/text_classification.py
@@ -65,7 +65,7 @@ class TextClassificationPipeline(Pipeline):
         outputs = super().__call__(*args, **kwargs)
 
         if self.model.config.num_labels == 1:
-            scores = 1.0 / (1.0 + np.exp(-outputs))
+            scores = outputs
         else:
             scores = np.exp(outputs) / np.exp(outputs).sum(-1, keepdims=True)
         if self.return_all_scores:


### PR DESCRIPTION
It seems like we use MSELoss when num_labels==1 in config, i.e. a single column regression problem. But in text_classification pipeline, this is considered as a classification problem and uses sigmoid. This PR fixes that issue. 