### PR TITLE
[examples] better model example

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -231,7 +231,7 @@ class Trainer:
 
     """
 
-    from .trainer_pt_utils import _get_learning_rate, log_metrics, metrics_format, save_metrics
+    from .trainer_pt_utils import _get_learning_rate, log_metrics, metrics_format, save_metrics, save_state
 
     def __init__(
         self,

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -599,12 +599,16 @@ def log_metrics(self, split, metrics):
     """
     Log metrics in a specially formatted way
 
+    Under distributed environment this is done only for a process with rank 0.
+
     Args:
         split (:obj:`str`):
             Mode/split name: one of ``train``, ``eval``, ``test``
         metrics (:obj:`Dict[str, float]`):
             The metrics returned from train/evaluate/predictmetrics: metrics dict
     """
+    if not self.is_world_process_zero():
+        return
 
     logger.info(f"***** {split} metrics *****")
     metrics_formatted = self.metrics_format(metrics)
@@ -614,16 +618,48 @@ def log_metrics(self, split, metrics):
         logger.info(f"  {key: <{k_width}} = {metrics_formatted[key]:>{v_width}}")
 
 
-def save_metrics(self, split, metrics):
+def save_metrics(self, split, metrics, combined=True):
     """
     Save metrics into a json file for that split, e.g. ``train_results.json``.
+
+    Under distributed environment this is done only for a process with rank 0.
 
     Args:
         split (:obj:`str`):
             Mode/split name: one of ``train``, ``eval``, ``test``, ``all``
         metrics (:obj:`Dict[str, float]`):
             The metrics returned from train/evaluate/predict
+        combined (:obj:`bool`, `optional`, defaults to :obj:`True`):
+            Creates combined metrics by updating ``all_results.json`` with metrics of this file
     """
+    if not self.is_world_process_zero():
+        return
+
     path = os.path.join(self.args.output_dir, f"{split}_results.json")
     with open(path, "w") as f:
         json.dump(metrics, f, indent=4, sort_keys=True)
+
+    if combined:
+        path = os.path.join(self.args.output_dir, "all_results.json")
+        if os.path.exists(path):
+            with open(path, "r") as f:
+                all_metrics = json.load(f)
+        else:
+            all_metrics = {}
+
+        all_metrics.update(metrics)
+        with open(path, "w") as f:
+            json.dump(all_metrics, f, indent=4, sort_keys=True)
+
+
+def save_state(self):
+    """
+    Saves the Trainer state, since Trainer.save_model saves only the tokenizer with the model
+
+    Under distributed environment this is done only for a process with rank 0.
+    """
+    if not self.is_world_process_zero():
+        return
+
+    path = os.path.join(self.args.output_dir, "trainer_state.json")
+    self.state.save_to_json(path)

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -630,7 +630,7 @@ def save_metrics(self, split, metrics, combined=True):
         metrics (:obj:`Dict[str, float]`):
             The metrics returned from train/evaluate/predict
         combined (:obj:`bool`, `optional`, defaults to :obj:`True`):
-            Creates combined metrics by updating ``all_results.json`` with metrics of this file
+            Creates combined metrics by updating ``all_results.json`` with metrics of this call
     """
     if not self.is_world_process_zero():
         return


### PR DESCRIPTION
As a continued effort to make examples easy to read and synchronizing them all to use the same look and feel, this PR tries to improve `run_seq2seq.py` as a model and then future PRs will sync other examples with it.

* [x] makes the helper methods work for rank0 internally - simplifying the caller
* [x] abstracts the helper `trainer.state.save_to_json` into a simple method
* [x] automatically aggregates all metrics into `all_metrics.json` w/o requiring any extra code on the caller side 

Anything else?

@sgugger 