### PR TITLE
Enabling multilingual models for translation pipelines.

### DIFF
--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -296,7 +296,7 @@ class M2M100Tokenizer(PreTrainedTokenizer):
             raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
         self.src_lang = src_lang
         inputs = self(raw_inputs, add_special_tokens=True, return_tensors="pt", **extra_kwargs)
-        tgt_lang_id = self.convert_tokens_to_ids(tgt_lang)
+        tgt_lang_id = self.get_lang_id(tgt_lang)
         inputs["forced_bos_token_id"] = tgt_lang_id
         return inputs
 

--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -290,6 +290,15 @@ class M2M100Tokenizer(PreTrainedTokenizer):
         self.set_src_lang_special_tokens(self.src_lang)
         return super().prepare_seq2seq_batch(src_texts, tgt_texts, **kwargs)
 
+    def _build_translation_inputs(self, raw_inputs, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs):
+        if src_lang is None or tgt_lang is None:
+            raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
+        self.src_lang = src_lang
+        inputs = self(raw_inputs, add_special_tokens=True, return_tensors="pt", **extra_kwargs)
+        tgt_lang_id = self.convert_tokens_to_ids(tgt_lang)
+        inputs["forced_bos_token_id"] = tgt_lang_id
+        return inputs
+
     @contextmanager
     def as_target_tokenizer(self):
         """

--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -291,6 +291,7 @@ class M2M100Tokenizer(PreTrainedTokenizer):
         return super().prepare_seq2seq_batch(src_texts, tgt_texts, **kwargs)
 
     def _build_translation_inputs(self, raw_inputs, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs):
+        """Used by translation pipeline, to prepare inputs for the generate function"""
         if src_lang is None or tgt_lang is None:
             raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
         self.src_lang = src_lang

--- a/src/transformers/models/mbart/tokenization_mbart.py
+++ b/src/transformers/models/mbart/tokenization_mbart.py
@@ -189,6 +189,7 @@ class MBartTokenizer(XLMRobertaTokenizer):
         return self.prefix_tokens + token_ids_0 + token_ids_1 + self.suffix_tokens
 
     def _build_translation_inputs(self, raw_inputs, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs):
+        """Used by translation pipeline, to prepare inputs for the generate function"""
         if src_lang is None or tgt_lang is None:
             raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
         self.src_lang = src_lang

--- a/src/transformers/models/mbart/tokenization_mbart.py
+++ b/src/transformers/models/mbart/tokenization_mbart.py
@@ -188,6 +188,15 @@ class MBartTokenizer(XLMRobertaTokenizer):
         # We don't expect to process pairs, but leave the pair logic for API consistency
         return self.prefix_tokens + token_ids_0 + token_ids_1 + self.suffix_tokens
 
+    def _build_translation_inputs(self, raw_inputs, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs):
+        if src_lang is None or tgt_lang is None:
+            raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
+        self.src_lang = src_lang
+        inputs = self(raw_inputs, add_special_tokens=True, return_tensors="pt", **extra_kwargs)
+        tgt_lang_id = self.convert_tokens_to_ids(tgt_lang)
+        inputs["forced_bos_token_id"] = tgt_lang_id
+        return inputs
+
     def prepare_seq2seq_batch(
         self,
         src_texts: List[str],

--- a/src/transformers/models/mbart/tokenization_mbart50.py
+++ b/src/transformers/models/mbart/tokenization_mbart50.py
@@ -280,6 +280,15 @@ class MBart50Tokenizer(PreTrainedTokenizer):
         # We don't expect to process pairs, but leave the pair logic for API consistency
         return self.prefix_tokens + token_ids_0 + token_ids_1 + self.suffix_tokens
 
+    def _build_translation_inputs(self, raw_inputs, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs):
+        if src_lang is None or tgt_lang is None:
+            raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
+        self.src_lang = src_lang
+        inputs = self(raw_inputs, add_special_tokens=True, return_tensors="pt", **extra_kwargs)
+        tgt_lang_id = self.convert_tokens_to_ids(tgt_lang)
+        inputs["forced_bos_token_id"] = tgt_lang_id
+        return inputs
+
     def prepare_seq2seq_batch(
         self,
         src_texts: List[str],

--- a/src/transformers/models/mbart/tokenization_mbart50.py
+++ b/src/transformers/models/mbart/tokenization_mbart50.py
@@ -281,6 +281,7 @@ class MBart50Tokenizer(PreTrainedTokenizer):
         return self.prefix_tokens + token_ids_0 + token_ids_1 + self.suffix_tokens
 
     def _build_translation_inputs(self, raw_inputs, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs):
+        """Used by translation pipeline, to prepare inputs for the generate function"""
         if src_lang is None or tgt_lang is None:
             raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
         self.src_lang = src_lang

--- a/src/transformers/models/mbart/tokenization_mbart50_fast.py
+++ b/src/transformers/models/mbart/tokenization_mbart50_fast.py
@@ -273,11 +273,11 @@ class MBart50TokenizerFast(PreTrainedTokenizerFast):
             special_tokens=list(zip(prefix_tokens_str + suffix_tokens_str, self.prefix_tokens + self.suffix_tokens)),
         )
 
-    def _build_translation_inputs(self, raw_inputs, src_lang: Optional[str], tgt_lang: Optional[str], truncation):
+    def _build_translation_inputs(self, raw_inputs, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs):
         if src_lang is None or tgt_lang is None:
             raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
         self.src_lang = src_lang
-        inputs = self(raw_inputs, add_special_tokens=True, return_tensors="pt", truncation=truncation)
+        inputs = self(raw_inputs, add_special_tokens=True, return_tensors="pt", **extra_kwargs)
         tgt_lang_id = self.convert_tokens_to_ids(tgt_lang)
         inputs["forced_bos_token_id"] = tgt_lang_id
         return inputs

--- a/src/transformers/models/mbart/tokenization_mbart50_fast.py
+++ b/src/transformers/models/mbart/tokenization_mbart50_fast.py
@@ -273,6 +273,18 @@ class MBart50TokenizerFast(PreTrainedTokenizerFast):
             special_tokens=list(zip(prefix_tokens_str + suffix_tokens_str, self.prefix_tokens + self.suffix_tokens)),
         )
 
+    def _build_translation_inputs(self, raw_inputs, src_lang: Optional[str], tgt_lang: Optional[str], truncation):
+        if src_lang is None or tgt_lang is None:
+            raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
+        self.src_lang = src_lang
+        inputs = self(raw_inputs, add_special_tokens=True, return_tensors="pt", truncation=truncation)
+        tgt_lang_id = self.convert_tokens_to_ids(tgt_lang)
+        import torch
+
+        inputs["decoder_input_ids"] = torch.LongTensor([self.bos_token_id, tgt_lang_id])
+        print(inputs)
+        return inputs
+
     def save_vocabulary(self, save_directory: str, filename_prefix: Optional[str] = None) -> Tuple[str]:
         if not os.path.isdir(save_directory):
             logger.error(f"Vocabulary path ({save_directory}) should be a directory")

--- a/src/transformers/models/mbart/tokenization_mbart50_fast.py
+++ b/src/transformers/models/mbart/tokenization_mbart50_fast.py
@@ -279,10 +279,7 @@ class MBart50TokenizerFast(PreTrainedTokenizerFast):
         self.src_lang = src_lang
         inputs = self(raw_inputs, add_special_tokens=True, return_tensors="pt", truncation=truncation)
         tgt_lang_id = self.convert_tokens_to_ids(tgt_lang)
-        import torch
-
-        inputs["decoder_input_ids"] = torch.LongTensor([self.bos_token_id, tgt_lang_id])
-        print(inputs)
+        inputs["forced_bos_token_id"] = tgt_lang_id
         return inputs
 
     def save_vocabulary(self, save_directory: str, filename_prefix: Optional[str] = None) -> Tuple[str]:

--- a/src/transformers/models/mbart/tokenization_mbart50_fast.py
+++ b/src/transformers/models/mbart/tokenization_mbart50_fast.py
@@ -274,6 +274,7 @@ class MBart50TokenizerFast(PreTrainedTokenizerFast):
         )
 
     def _build_translation_inputs(self, raw_inputs, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs):
+        """Used by translation pipeline, to prepare inputs for the generate function"""
         if src_lang is None or tgt_lang is None:
             raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
         self.src_lang = src_lang

--- a/src/transformers/models/mbart/tokenization_mbart_fast.py
+++ b/src/transformers/models/mbart/tokenization_mbart_fast.py
@@ -193,6 +193,7 @@ class MBartTokenizerFast(XLMRobertaTokenizerFast):
         return self.prefix_tokens + token_ids_0 + token_ids_1 + self.suffix_tokens
 
     def _build_translation_inputs(self, raw_inputs, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs):
+        """Used by translation pipeline, to prepare inputs for the generate function"""
         if src_lang is None or tgt_lang is None:
             raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
         self.src_lang = src_lang

--- a/src/transformers/models/mbart/tokenization_mbart_fast.py
+++ b/src/transformers/models/mbart/tokenization_mbart_fast.py
@@ -192,6 +192,15 @@ class MBartTokenizerFast(XLMRobertaTokenizerFast):
         # We don't expect to process pairs, but leave the pair logic for API consistency
         return self.prefix_tokens + token_ids_0 + token_ids_1 + self.suffix_tokens
 
+    def _build_translation_inputs(self, raw_inputs, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs):
+        if src_lang is None or tgt_lang is None:
+            raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
+        self.src_lang = src_lang
+        inputs = self(raw_inputs, add_special_tokens=True, return_tensors="pt", **extra_kwargs)
+        tgt_lang_id = self.convert_tokens_to_ids(tgt_lang)
+        inputs["forced_bos_token_id"] = tgt_lang_id
+        return inputs
+
     def prepare_seq2seq_batch(
         self,
         src_texts: List[str],

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -614,7 +614,10 @@ class Pipeline(_ScikitCompat):
         Return:
             :obj:`Dict[str, torch.Tensor]`: The same as :obj:`inputs` but on the proper device.
         """
-        return {name: tensor.to(self.device) for name, tensor in inputs.items()}
+        return {
+            name: tensor.to(self.device) if isinstance(tensor, torch.Tensor) else tensor
+            for name, tensor in inputs.items()
+        }
 
     def check_model_type(self, supported_models: Union[List[str], dict]):
         """

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -289,8 +289,8 @@ class TranslationPipeline(Text2TextGenerationPipeline):
             clean_up_tokenization_spaces (:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to clean up the potential extra spaces in the text output.
             src_lang (:obj:`str`, `optional`, defaults to :obj:`None`):
-                The language of the input. Might be required for multilingual models. Will not have any effect
-                for single pair translation models
+                The language of the input. Might be required for multilingual models. Will not have any effect for
+                single pair translation models
             tgt_lang (:obj:`str`, `optional`, defaults to :obj:`None`):
                 The language of the desired output. Might be required for multilingual models. Will not have any effect
                 for single pair translation models

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -69,8 +69,7 @@ class Text2TextGenerationPipeline(Pipeline):
                 f" `args[0]`: {args[0]} have the wrong format. The should be either of type `str` or type `list`"
             )
         inputs = super()._parse_and_tokenize(*args, padding=padding, truncation=truncation)
-        # This is produced by tokenizers but is an invalid
-        # generate kwargs
+        # This is produced by tokenizers but is an invalid generate kwargs
         if "token_type_ids" in inputs:
             del inputs["token_type_ids"]
         return inputs

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -289,9 +289,11 @@ class TranslationPipeline(Text2TextGenerationPipeline):
             clean_up_tokenization_spaces (:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to clean up the potential extra spaces in the text output.
             src_lang (:obj:`str`, `optional`, defaults to :obj:`None`):
-                The language of the input. Might be required for multilingual models
+                The language of the input. Might be required for multilingual models. Will not have any effect
+                for single pair translation models
             tgt_lang (:obj:`str`, `optional`, defaults to :obj:`None`):
-                The language of the desired output. Might be required for multilingual models
+                The language of the desired output. Might be required for multilingual models. Will not have any effect
+                for single pair translation models
             generate_kwargs:
                 Additional keyword arguments to pass along to the generate method of the model (see the generate method
                 corresponding to your framework `here <./model.html#generative-models>`__).

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -68,7 +68,12 @@ class Text2TextGenerationPipeline(Pipeline):
             raise ValueError(
                 f" `args[0]`: {args[0]} have the wrong format. The should be either of type `str` or type `list`"
             )
-        return super()._parse_and_tokenize(*args, padding=padding, truncation=truncation)
+        inputs =  super()._parse_and_tokenize(*args, padding=padding, truncation=truncation)
+        # This is produced by tokenizers but is an invalid
+        # generate kwargs
+        if 'token_type_ids' in inputs:
+            del inputs['token_type_ids']
+        return inputs
 
     def __call__(
         self,
@@ -249,7 +254,7 @@ class TranslationPipeline(Text2TextGenerationPipeline):
             if task and len(tokens) == 4:
                 # translation, XX, to YY
                 self.src_lang = tokens[1]
-                self.tgt_lang = tokens[2]
+                self.tgt_lang = tokens[3]
 
     def check_inputs(self, input_length: int, min_length: int, max_length: int):
         if input_length > 0.9 * max_length:

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -125,9 +125,9 @@ class Text2TextGenerationPipeline(Pipeline):
         max_length = generate_kwargs.get("max_length", self.model.config.max_length)
         self.check_inputs(input_length, min_length, max_length)
 
+        generate_kwargs.update(inputs)
+
         generations = self.model.generate(
-            inputs["input_ids"],
-            attention_mask=inputs["attention_mask"],
             **generate_kwargs,
         )
         results = []

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -68,11 +68,11 @@ class Text2TextGenerationPipeline(Pipeline):
             raise ValueError(
                 f" `args[0]`: {args[0]} have the wrong format. The should be either of type `str` or type `list`"
             )
-        inputs =  super()._parse_and_tokenize(*args, padding=padding, truncation=truncation)
+        inputs = super()._parse_and_tokenize(*args, padding=padding, truncation=truncation)
         # This is produced by tokenizers but is an invalid
         # generate kwargs
-        if 'token_type_ids' in inputs:
-            del inputs['token_type_ids']
+        if "token_type_ids" in inputs:
+            del inputs["token_type_ids"]
         return inputs
 
     def __call__(

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from ..file_utils import add_end_docstrings, is_tf_available, is_torch_available
 from ..tokenization_utils import TruncationStrategy
 from ..utils import logging
@@ -50,6 +52,24 @@ class Text2TextGenerationPipeline(Pipeline):
         """
         return True
 
+    def _parse_and_tokenize(self, *args, truncation):
+        prefix = self.model.config.prefix if self.model.config.prefix is not None else ""
+        if isinstance(args[0], list):
+            assert (
+                self.tokenizer.pad_token_id is not None
+            ), "Please make sure that the tokenizer has a pad_token_id when using a batch input"
+            args = ([prefix + arg for arg in args[0]],)
+            padding = True
+
+        elif isinstance(args[0], str):
+            args = (prefix + args[0],)
+            padding = False
+        else:
+            raise ValueError(
+                f" `args[0]`: {args[0]} have the wrong format. The should be either of type `str` or type `list`"
+            )
+        return super()._parse_and_tokenize(*args, padding=padding, truncation=truncation)
+
     def __call__(
         self,
         *args,
@@ -88,53 +108,41 @@ class Text2TextGenerationPipeline(Pipeline):
         """
         assert return_tensors or return_text, "You must specify return_tensors=True or return_text=True"
 
-        prefix = self.model.config.prefix if self.model.config.prefix is not None else ""
-        if isinstance(args[0], list):
-            assert (
-                self.tokenizer.pad_token_id is not None
-            ), "Please make sure that the tokenizer has a pad_token_id when using a batch input"
-            args = ([prefix + arg for arg in args[0]],)
-            padding = True
-
-        elif isinstance(args[0], str):
-            args = (prefix + args[0],)
-            padding = False
-        else:
-            raise ValueError(
-                f" `args[0]`: {args[0]} have the wrong format. The should be either of type `str` or type `list`"
-            )
-
         with self.device_placement():
-            inputs = self._parse_and_tokenize(*args, padding=padding, truncation=truncation)
+            inputs = self._parse_and_tokenize(*args, truncation=truncation)
+            return self._generate(inputs, return_tensors, return_text, clean_up_tokenization_spaces, generate_kwargs)
 
-            if self.framework == "pt":
-                inputs = self.ensure_tensor_on_device(**inputs)
-                input_length = inputs["input_ids"].shape[-1]
-            elif self.framework == "tf":
-                input_length = tf.shape(inputs["input_ids"])[-1].numpy()
+    def _generate(
+        self, inputs, return_tensors: bool, return_text: bool, clean_up_tokenization_spaces: bool, generate_kwargs
+    ):
+        if self.framework == "pt":
+            inputs = self.ensure_tensor_on_device(**inputs)
+            input_length = inputs["input_ids"].shape[-1]
+        elif self.framework == "tf":
+            input_length = tf.shape(inputs["input_ids"])[-1].numpy()
 
-            min_length = generate_kwargs.get("min_length", self.model.config.min_length)
-            max_length = generate_kwargs.get("max_length", self.model.config.max_length)
-            self.check_inputs(input_length, min_length, max_length)
+        min_length = generate_kwargs.get("min_length", self.model.config.min_length)
+        max_length = generate_kwargs.get("max_length", self.model.config.max_length)
+        self.check_inputs(input_length, min_length, max_length)
 
-            generations = self.model.generate(
-                inputs["input_ids"],
-                attention_mask=inputs["attention_mask"],
-                **generate_kwargs,
-            )
-            results = []
-            for generation in generations:
-                record = {}
-                if return_tensors:
-                    record[f"{self.return_name}_token_ids"] = generation
-                if return_text:
-                    record[f"{self.return_name}_text"] = self.tokenizer.decode(
-                        generation,
-                        skip_special_tokens=True,
-                        clean_up_tokenization_spaces=clean_up_tokenization_spaces,
-                    )
-                results.append(record)
-            return results
+        generations = self.model.generate(
+            inputs["input_ids"],
+            attention_mask=inputs["attention_mask"],
+            **generate_kwargs,
+        )
+        results = []
+        for generation in generations:
+            record = {}
+            if return_tensors:
+                record[f"{self.return_name}_token_ids"] = generation
+            if return_text:
+                record[f"{self.return_name}_text"] = self.tokenizer.decode(
+                    generation,
+                    skip_special_tokens=True,
+                    clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+                )
+            results.append(record)
+        return results
 
 
 @add_end_docstrings(PIPELINE_INIT_ARGS)
@@ -226,6 +234,22 @@ class TranslationPipeline(Text2TextGenerationPipeline):
 
     # Used in the return key of the pipeline.
     return_name = "translation"
+    src_lang: Optional[str] = None
+    tgt_lang: Optional[str] = None
+
+    def __init__(self, *args, src_lang=None, tgt_lang=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        if src_lang is not None:
+            self.src_lang = src_lang
+        if tgt_lang is not None:
+            self.tgt_lang = tgt_lang
+        if src_lang is None and tgt_lang is None:
+            task = kwargs.get("task", "")
+            tokens = task.split("_")
+            if task and len(tokens) == 4:
+                # translation, XX, to YY
+                self.src_lang = tokens[1]
+                self.tgt_lang = tokens[2]
 
     def check_inputs(self, input_length: int, min_length: int, max_length: int):
         if input_length > 0.9 * max_length:
@@ -233,8 +257,25 @@ class TranslationPipeline(Text2TextGenerationPipeline):
                 f"Your input_length: {input_length} is bigger than 0.9 * max_length: {max_length}. You might consider "
                 "increasing your max_length manually, e.g. translator('...', max_length=400)"
             )
+        return True
 
-    def __call__(self, *args, **kwargs):
+    def _parse_and_tokenize(self, *args, src_lang, tgt_lang, truncation):
+        if getattr(self.tokenizer, "_build_translation_inputs", None):
+            return self.tokenizer._build_translation_inputs(*args, src_lang, tgt_lang, truncation)
+        else:
+            return super()._parse_and_tokenize(*args, truncation=truncation)
+
+    def __call__(
+        self,
+        *args,
+        return_tensors=False,
+        return_text=True,
+        clean_up_tokenization_spaces=False,
+        truncation=TruncationStrategy.DO_NOT_TRUNCATE,
+        src_lang=None,
+        tgt_lang=None,
+        **generate_kwargs
+    ):
         r"""
         Translate the text(s) given as inputs.
 
@@ -247,6 +288,10 @@ class TranslationPipeline(Text2TextGenerationPipeline):
                 Whether or not to include the decoded texts in the outputs.
             clean_up_tokenization_spaces (:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to clean up the potential extra spaces in the text output.
+            src_lang (:obj:`str`, `optional`, defaults to :obj:`None`):
+                The language of the input. Might be required for multilingual models
+            tgt_lang (:obj:`str`, `optional`, defaults to :obj:`None`):
+                The language of the desired output. Might be required for multilingual models
             generate_kwargs:
                 Additional keyword arguments to pass along to the generate method of the model (see the generate method
                 corresponding to your framework `here <./model.html#generative-models>`__).
@@ -258,4 +303,10 @@ class TranslationPipeline(Text2TextGenerationPipeline):
             - **translation_token_ids** (:obj:`torch.Tensor` or :obj:`tf.Tensor`, present when ``return_tensors=True``)
               -- The token ids of the translation.
         """
-        return super().__call__(*args, **kwargs)
+        assert return_tensors or return_text, "You must specify return_tensors=True or return_text=True"
+        src_lang = src_lang if src_lang is not None else self.src_lang
+        tgt_lang = tgt_lang if tgt_lang is not None else self.tgt_lang
+
+        with self.device_placement():
+            inputs = self._parse_and_tokenize(*args, truncation=truncation, src_lang=src_lang, tgt_lang=tgt_lang)
+            return self._generate(inputs, return_tensors, return_text, clean_up_tokenization_spaces, generate_kwargs)

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -248,12 +248,13 @@ class TranslationPipeline(Text2TextGenerationPipeline):
         if tgt_lang is not None:
             self.tgt_lang = tgt_lang
         if src_lang is None and tgt_lang is None:
+            # Backward compatibility, direct arguments use is preferred.
             task = kwargs.get("task", "")
-            tokens = task.split("_")
-            if task and len(tokens) == 4:
+            items = task.split("_")
+            if task and len(items) == 4:
                 # translation, XX, to YY
-                self.src_lang = tokens[1]
-                self.tgt_lang = tokens[3]
+                self.src_lang = items[1]
+                self.tgt_lang = items[3]
 
     def check_inputs(self, input_length: int, min_length: int, max_length: int):
         if input_length > 0.9 * max_length:
@@ -265,7 +266,9 @@ class TranslationPipeline(Text2TextGenerationPipeline):
 
     def _parse_and_tokenize(self, *args, src_lang, tgt_lang, truncation):
         if getattr(self.tokenizer, "_build_translation_inputs", None):
-            return self.tokenizer._build_translation_inputs(*args, src_lang, tgt_lang, truncation)
+            return self.tokenizer._build_translation_inputs(
+                *args, src_lang=src_lang, tgt_lang=tgt_lang, truncation=truncation
+            )
         else:
             return super()._parse_and_tokenize(*args, truncation=truncation)
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1157,7 +1157,7 @@ def execute_subprocess_async(cmd, env=None, stdin=None, timeout=180, quiet=False
     return result
 
 
-def deep_round(obj, decimals=3):
+def nested_simplify(obj, decimals=3):
     """
     Simplifies an object by rounding float numbers, and downcasting tensors/numpy arrays to get simple equality test
     within tests.
@@ -1165,15 +1165,15 @@ def deep_round(obj, decimals=3):
     from transformers.tokenization_utils import BatchEncoding
 
     if isinstance(obj, list):
-        return [deep_round(item, decimals) for item in obj]
+        return [nested_simplify(item, decimals) for item in obj]
     elif isinstance(obj, (dict, BatchEncoding)):
-        return {deep_round(k, decimals): deep_round(v, decimals) for k, v in obj.items()}
+        return {nested_simplify(k, decimals): nested_simplify(v, decimals) for k, v in obj.items()}
     elif isinstance(obj, (str, int)):
         return obj
     elif is_torch_available() and isinstance(obj, torch.Tensor):
-        return deep_round(obj.tolist())
+        return nested_simplify(obj.tolist())
     elif is_tf_available() and tf.is_tensor(obj):
-        return deep_round(obj.numpy().tolist())
+        return nested_simplify(obj.numpy().tolist())
     elif isinstance(obj, float):
         return round(obj, decimals)
     else:

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1152,3 +1152,24 @@ def execute_subprocess_async(cmd, env=None, stdin=None, timeout=180, quiet=False
         raise RuntimeError(f"'{cmd_str}' produced no output.")
 
     return result
+
+
+def deep_round(obj, decimals=3):
+    """
+    Simplifies an object by rounding float numbers, and downcasting tensors/numpy arrays to get simple equality test
+    within tests.
+    """
+    from transformers.tokenization_utils import BatchEncoding
+
+    if isinstance(obj, list):
+        return [deep_round(item, decimals) for item in obj]
+    elif isinstance(obj, (dict, BatchEncoding)):
+        return {deep_round(k, decimals): deep_round(v, decimals) for k, v in obj.items()}
+    elif isinstance(obj, (str, int)):
+        return obj
+    elif is_torch_available() and isinstance(obj, torch.Tensor):
+        return deep_round(obj.tolist())
+    elif isinstance(obj, float):
+        return round(obj, decimals)
+    else:
+        raise Exception(f"Not supported: {type(obj)}")

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -360,6 +360,9 @@ if is_torch_available():
 else:
     torch_device = None
 
+if is_tf_available():
+    import tensorflow as tf
+
 
 def require_torch_gpu(test_case):
     """Decorator marking a test that requires CUDA and PyTorch. """
@@ -1169,6 +1172,8 @@ def deep_round(obj, decimals=3):
         return obj
     elif is_torch_available() and isinstance(obj, torch.Tensor):
         return deep_round(obj.tolist())
+    elif is_tf_available() and tf.is_tensor(obj):
+        return deep_round(obj.numpy().tolist())
     elif isinstance(obj, float):
         return round(obj, decimals)
     else:

--- a/tests/test_pipelines_translation.py
+++ b/tests/test_pipelines_translation.py
@@ -17,9 +17,13 @@ import unittest
 import pytest
 
 from transformers import pipeline
-from transformers.testing_utils import is_pipeline_test, require_torch, slow
+from transformers.testing_utils import is_pipeline_test, is_torch_available, require_torch, slow
 
 from .test_pipelines_common import MonoInputPipelineCommonMixin
+
+
+if is_torch_available():
+    from transformers.models.mbart import MBart50TokenizerFast, MBartForConditionalGeneration
 
 
 class TranslationEnToDePipelineTests(MonoInputPipelineCommonMixin, unittest.TestCase):
@@ -48,12 +52,38 @@ class TranslationNewFormatPipelineTests(unittest.TestCase):
             pipeline(task="translation_cn_to_ar")
 
         # but we do for this one
-        pipeline(task="translation_en_to_de")
+        translator = pipeline(task="translation_en_to_de")
+        self.assertEquals(translator.src_lang, "en")
+        self.assertEquals(translator.tgt_lang, "de")
+
+    @require_torch
+    @slow
+    def test_multilingual_translation(self):
+        model = MBartForConditionalGeneration.from_pretrained("facebook/mbart-large-50-many-to-many-mmt")
+        tokenizer = MBart50TokenizerFast.from_pretrained("facebook/mbart-large-50-many-to-many-mmt")
+
+        translator = pipeline(task="translation", model=model, tokenizer=tokenizer)
+        # Missing src_lang, tgt_lang
+        with self.assertRaises(ValueError):
+            translator("This is a test")
+
+        outputs = translator("This is a test", src_lang="en_XX", tgt_lang="ar_AR")
+        self.assertEqual(outputs, [{"translation_text": "یہ ایک امتحان ہے"}])
+
+        outputs = translator("This is a test", src_lang="en_XX", tgt_lang="hi_IN")
+        self.assertEqual(outputs, [{"translation_text": "This is a test."}])
+
+        # src_lang, tgt_lang can be defined at call time
+        translator = pipeline(task="translation", model=model, tokenizer=tokenizer, src_lang="en_XX", tgt_lang="ar_AR")
+        outputs = translator("This is a test")
+        self.assertEqual(outputs, [{"translation_text": "یہ ایک امتحان ہے"}])
 
     @require_torch
     def test_translation_on_odd_language(self):
         model = "patrickvonplaten/t5-tiny-random"
-        pipeline(task="translation_cn_to_ar", model=model)
+        translator = pipeline(task="translation_cn_to_ar", model=model)
+        self.assertEquals(translator.src_lang, "cn")
+        self.assertEquals(translator.tgt_lang, "ar")
 
     @require_torch
     def test_translation_default_language_selection(self):
@@ -61,6 +91,8 @@ class TranslationNewFormatPipelineTests(unittest.TestCase):
         with pytest.warns(UserWarning, match=r".*translation_en_to_de.*"):
             nlp = pipeline(task="translation", model=model)
         self.assertEqual(nlp.task, "translation_en_to_de")
+        self.assertEquals(nlp.src_lang, "en")
+        self.assertEquals(nlp.tgt_lang, "de")
 
     @require_torch
     def test_translation_with_no_language_no_model_fails(self):

--- a/tests/test_pipelines_translation.py
+++ b/tests/test_pipelines_translation.py
@@ -68,15 +68,15 @@ class TranslationNewFormatPipelineTests(unittest.TestCase):
             translator("This is a test")
 
         outputs = translator("This is a test", src_lang="en_XX", tgt_lang="ar_AR")
-        self.assertEqual(outputs, [{"translation_text": "یہ ایک امتحان ہے"}])
+        self.assertEqual(outputs, [{"translation_text": "هذا إختبار"}])
 
         outputs = translator("This is a test", src_lang="en_XX", tgt_lang="hi_IN")
-        self.assertEqual(outputs, [{"translation_text": "This is a test."}])
+        self.assertEqual(outputs, [{"translation_text": "यह एक परीक्षण है"}])
 
-        # src_lang, tgt_lang can be defined at call time
+        # src_lang, tgt_lang can be defined at pipeline call time
         translator = pipeline(task="translation", model=model, tokenizer=tokenizer, src_lang="en_XX", tgt_lang="ar_AR")
         outputs = translator("This is a test")
-        self.assertEqual(outputs, [{"translation_text": "یہ ایک امتحان ہے"}])
+        self.assertEqual(outputs, [{"translation_text": "هذا إختبار"}])
 
     @require_torch
     def test_translation_on_odd_language(self):

--- a/tests/test_tokenization_m2m_100.py
+++ b/tests/test_tokenization_m2m_100.py
@@ -20,7 +20,7 @@ from shutil import copyfile
 
 from transformers import M2M100Tokenizer, is_torch_available
 from transformers.file_utils import is_sentencepiece_available
-from transformers.testing_utils import deep_round, require_sentencepiece, require_tokenizers, require_torch
+from transformers.testing_utils import nested_simplify, require_sentencepiece, require_tokenizers, require_torch
 
 
 if is_sentencepiece_available():
@@ -197,12 +197,12 @@ class M2M100TokenizerIntegrationTest(unittest.TestCase):
         inputs = self.tokenizer._build_translation_inputs("A test", src_lang="en", tgt_lang="ar")
 
         self.assertEqual(
-            deep_round(inputs),
+            nested_simplify(inputs),
             {
                 # en_XX, A, test, EOS
                 "input_ids": [[128022, 58, 4183, 2]],
                 "attention_mask": [[1, 1, 1, 1]],
                 # ar_AR
-                "forced_bos_token_id": 44,
+                "forced_bos_token_id": 128006,
             },
         )

--- a/tests/test_tokenization_m2m_100.py
+++ b/tests/test_tokenization_m2m_100.py
@@ -20,7 +20,7 @@ from shutil import copyfile
 
 from transformers import M2M100Tokenizer, is_torch_available
 from transformers.file_utils import is_sentencepiece_available
-from transformers.testing_utils import require_sentencepiece, require_tokenizers, require_torch
+from transformers.testing_utils import deep_round, require_sentencepiece, require_tokenizers, require_torch
 
 
 if is_sentencepiece_available():
@@ -191,3 +191,18 @@ class M2M100TokenizerIntegrationTest(unittest.TestCase):
             self.assertListEqual(self.tokenizer.prefix_tokens, [self.tokenizer.get_lang_id("zh")])
             self.assertListEqual(self.tokenizer.suffix_tokens, [self.tokenizer.eos_token_id])
         self.assertListEqual(self.tokenizer.prefix_tokens, [self.tokenizer.get_lang_id(self.tokenizer.src_lang)])
+
+    @require_torch
+    def test_tokenizer_translation(self):
+        inputs = self.tokenizer._build_translation_inputs("A test", src_lang="en_XX", tgt_lang="ar_AR")
+
+        self.assertEqual(
+            deep_round(inputs),
+            {
+                # en_XX, A, test, EOS
+                "input_ids": [[250004, 62, 3034, 2]],
+                "attention_mask": [[1, 1, 1, 1]],
+                # ar_AR
+                "forced_bos_token_id": 250001,
+            },
+        )

--- a/tests/test_tokenization_m2m_100.py
+++ b/tests/test_tokenization_m2m_100.py
@@ -194,15 +194,15 @@ class M2M100TokenizerIntegrationTest(unittest.TestCase):
 
     @require_torch
     def test_tokenizer_translation(self):
-        inputs = self.tokenizer._build_translation_inputs("A test", src_lang="en_XX", tgt_lang="ar_AR")
+        inputs = self.tokenizer._build_translation_inputs("A test", src_lang="en", tgt_lang="ar")
 
         self.assertEqual(
             deep_round(inputs),
             {
                 # en_XX, A, test, EOS
-                "input_ids": [[250004, 62, 3034, 2]],
+                "input_ids": [[128022, 58, 4183, 2]],
                 "attention_mask": [[1, 1, 1, 1]],
                 # ar_AR
-                "forced_bos_token_id": 250001,
+                "forced_bos_token_id": 44,
             },
         )

--- a/tests/test_tokenization_mbart.py
+++ b/tests/test_tokenization_mbart.py
@@ -17,7 +17,7 @@ import tempfile
 import unittest
 
 from transformers import SPIECE_UNDERLINE, BatchEncoding, MBartTokenizer, MBartTokenizerFast, is_torch_available
-from transformers.testing_utils import deep_round, require_sentencepiece, require_tokenizers, require_torch
+from transformers.testing_utils import nested_simplify, require_sentencepiece, require_tokenizers, require_torch
 
 from .test_tokenization_common import TokenizerTesterMixin
 
@@ -238,7 +238,7 @@ class MBartEnroIntegrationTest(unittest.TestCase):
         inputs = self.tokenizer._build_translation_inputs("A test", src_lang="en_XX", tgt_lang="ar_AR")
 
         self.assertEqual(
-            deep_round(inputs),
+            nested_simplify(inputs),
             {
                 # A, test, EOS, en_XX
                 "input_ids": [[62, 3034, 2, 250004]],

--- a/tests/test_tokenization_mbart.py
+++ b/tests/test_tokenization_mbart.py
@@ -17,7 +17,7 @@ import tempfile
 import unittest
 
 from transformers import SPIECE_UNDERLINE, BatchEncoding, MBartTokenizer, MBartTokenizerFast, is_torch_available
-from transformers.testing_utils import require_sentencepiece, require_tokenizers, require_torch
+from transformers.testing_utils import deep_round, require_sentencepiece, require_tokenizers, require_torch
 
 from .test_tokenization_common import TokenizerTesterMixin
 
@@ -232,3 +232,18 @@ class MBartEnroIntegrationTest(unittest.TestCase):
 
         self.assertEqual(batch.input_ids.shape[1], 3)
         self.assertEqual(batch.decoder_input_ids.shape[1], 10)
+
+    @require_torch
+    def test_tokenizer_translation(self):
+        inputs = self.tokenizer._build_translation_inputs("A test", src_lang="en_XX", tgt_lang="ar_AR")
+
+        self.assertEqual(
+            deep_round(inputs),
+            {
+                # en_XX, A, test, EOS
+                "input_ids": [[250004, 62, 3034, 2]],
+                "attention_mask": [[1, 1, 1, 1]],
+                # ar_AR
+                "forced_bos_token_id": 250001,
+            },
+        )

--- a/tests/test_tokenization_mbart.py
+++ b/tests/test_tokenization_mbart.py
@@ -240,8 +240,8 @@ class MBartEnroIntegrationTest(unittest.TestCase):
         self.assertEqual(
             deep_round(inputs),
             {
-                # en_XX, A, test, EOS
-                "input_ids": [[250004, 62, 3034, 2]],
+                # A, test, EOS, en_XX
+                "input_ids": [[62, 3034, 2, 250004]],
                 "attention_mask": [[1, 1, 1, 1]],
                 # ar_AR
                 "forced_bos_token_id": 250001,

--- a/tests/test_tokenization_mbart50.py
+++ b/tests/test_tokenization_mbart50.py
@@ -17,7 +17,7 @@ import tempfile
 import unittest
 
 from transformers import SPIECE_UNDERLINE, BatchEncoding, MBart50Tokenizer, MBart50TokenizerFast, is_torch_available
-from transformers.testing_utils import deep_round, require_sentencepiece, require_tokenizers, require_torch
+from transformers.testing_utils import nested_simplify, require_sentencepiece, require_tokenizers, require_torch
 
 from .test_tokenization_common import TokenizerTesterMixin
 
@@ -200,7 +200,7 @@ class MBartOneToManyIntegrationTest(unittest.TestCase):
         inputs = self.tokenizer._build_translation_inputs("A test", src_lang="en_XX", tgt_lang="ar_AR")
 
         self.assertEqual(
-            deep_round(inputs),
+            nested_simplify(inputs),
             {
                 # en_XX, A, test, EOS
                 "input_ids": [[250004, 62, 3034, 2]],

--- a/tests/test_tokenization_mbart50.py
+++ b/tests/test_tokenization_mbart50.py
@@ -17,7 +17,7 @@ import tempfile
 import unittest
 
 from transformers import SPIECE_UNDERLINE, BatchEncoding, MBart50Tokenizer, MBart50TokenizerFast, is_torch_available
-from transformers.testing_utils import require_sentencepiece, require_tokenizers, require_torch
+from transformers.testing_utils import deep_round, require_sentencepiece, require_tokenizers, require_torch
 
 from .test_tokenization_common import TokenizerTesterMixin
 
@@ -194,3 +194,18 @@ class MBartOneToManyIntegrationTest(unittest.TestCase):
 
         self.assertEqual(batch.input_ids.shape[1], 3)
         self.assertEqual(batch.decoder_input_ids.shape[1], 10)
+
+    @require_torch
+    def test_tokenizer_translation(self):
+        inputs = self.tokenizer._build_translation_inputs("A test", src_lang="en_XX", tgt_lang="ar_AR")
+
+        self.assertEqual(
+            deep_round(inputs),
+            {
+                # en_XX, A, test, EOS
+                "input_ids": [[250004, 62, 3034, 2]],
+                "attention_mask": [[1, 1, 1, 1]],
+                # ar_AR
+                "forced_bos_token_id": 250001,
+            },
+        )


### PR DESCRIPTION
# What does this PR do?

Enables mutlilingual translation for pipelines.

Some models can target multiple languages/ language pairs. Before this PR, there was no simple way to exploit that within the Translation pipeline.

## Move away from `translation_XX_to_YY`.

Because src_lang, tgt_lang pairs can be used for a single model, we need to move away from this task naming scheme.
Currently it was done, as being able to use `src_lang` and `tgt_lang` both within `pipeline(.... src_lang=XX, tgt_lang=yy)` and at call time `translator = pipeline(...); translation("input string", src_lang=XX, tgt_lang=YY)`

 ## Rely on the model's tokenizer to build the inputs.

We now have at least 3 (m2m. mbart50, T5) different models that prepare input ids in a different manner. In order to avoid switches within a pipeline that would depend on a model, instead `tokenizer` can optionally implement `_build_translation_input_ids`.  That enables to put model specific logic within their model files and use all their custom methods over there.

This is in line with https://github.com/huggingface/transformers/pull/10002.

## Misc

- `ensure_tensor_on_device` now supports non tensor members
- Added a `deep_round` test utility to enable testing nested structures that contain tensors, floats and so on.


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors which may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @jplu

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- nlp datasets: [different repo](https://github.com/huggingface/nlp)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->