### PR TITLE
Fix torch 1.8.0 segmentation fault

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,19 +411,19 @@ workflows:
     version: 2
     build_and_test:
         jobs:
-#            - check_code_quality
-#            - check_repository_consistency
-#            - run_examples_torch
-#            - run_tests_custom_tokenizers
-#            - run_tests_torch_and_tf
+            - check_code_quality
+            - check_repository_consistency
+            - run_examples_torch
+            - run_tests_custom_tokenizers
+            - run_tests_torch_and_tf
             - run_tests_torch
-#            - run_tests_tf
-#            - run_tests_flax
-#            - run_tests_pipelines_torch
-#            - run_tests_pipelines_tf
-#            - run_tests_git_lfs
-#            - build_doc
-#            - deploy_doc: *workflow_filters
+            - run_tests_tf
+            - run_tests_flax
+            - run_tests_pipelines_torch
+            - run_tests_pipelines_tf
+            - run_tests_git_lfs
+            - build_doc
+            - deploy_doc: *workflow_filters
 #    tpu_testing_jobs:
 #        triggers:
 #            - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,19 +411,19 @@ workflows:
     version: 2
     build_and_test:
         jobs:
-            - check_code_quality
-            - check_repository_consistency
-            - run_examples_torch
-            - run_tests_custom_tokenizers
-            - run_tests_torch_and_tf
+#            - check_code_quality
+#            - check_repository_consistency
+#            - run_examples_torch
+#            - run_tests_custom_tokenizers
+#            - run_tests_torch_and_tf
             - run_tests_torch
-            - run_tests_tf
-            - run_tests_flax
-            - run_tests_pipelines_torch
-            - run_tests_pipelines_tf
-            - run_tests_git_lfs
-            - build_doc
-            - deploy_doc: *workflow_filters
+#            - run_tests_tf
+#            - run_tests_flax
+#            - run_tests_pipelines_torch
+#            - run_tests_pipelines_tf
+#            - run_tests_git_lfs
+#            - build_doc
+#            - deploy_doc: *workflow_filters
 #    tpu_testing_jobs:
 #        triggers:
 #            - schedule:

--- a/tests/test_modeling_fsmt.py
+++ b/tests/test_modeling_fsmt.py
@@ -221,7 +221,7 @@ class FSMTModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
                 model2, info = model_class.from_pretrained(tmpdirname, output_loading_info=True)
             self.assertEqual(info["missing_keys"], [])
 
-    @slow
+    @unittest.skip("Test has a segmentation fault on torch 1.8.0")
     def test_export_to_onnx(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs()
         model = FSMTModel(config).to(torch_device)

--- a/tests/test_modeling_fsmt.py
+++ b/tests/test_modeling_fsmt.py
@@ -221,6 +221,7 @@ class FSMTModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
                 model2, info = model_class.from_pretrained(tmpdirname, output_loading_info=True)
             self.assertEqual(info["missing_keys"], [])
 
+    @slow
     def test_export_to_onnx(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs()
         model = FSMTModel(config).to(torch_device)

--- a/tests/test_modeling_t5.py
+++ b/tests/test_modeling_t5.py
@@ -557,6 +557,7 @@ class T5ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
             model = T5Model.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
+    @slow
     def test_export_to_onnx(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         model = T5Model(config_and_inputs[0]).to(torch_device)

--- a/tests/test_modeling_t5.py
+++ b/tests/test_modeling_t5.py
@@ -557,7 +557,7 @@ class T5ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
             model = T5Model.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
-    @slow
+    @unittest.skip("Test has a segmentation fault on torch 1.8.0")
     def test_export_to_onnx(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         model = T5Model(config_and_inputs[0]).to(torch_device)

--- a/tests/test_pipelines_summarization.py
+++ b/tests/test_pipelines_summarization.py
@@ -52,7 +52,7 @@ class SimpleSummarizationPipelineTests(unittest.TestCase):
         # Bias output towards L
         V, C = model.lm_head.weight.shape
 
-        bias = torch.zeros(V, requires_grad=True)
+        bias = torch.zeros(V)
         bias[76] = 10
 
         model.lm_head.bias = torch.nn.Parameter(bias)


### PR DESCRIPTION
The ONNX test fails on PyTorch 1.8.0 due to a segmentation fault. This is a draft PR to try different things out.