### PR TITLE
Handle padding in decoder_inputs_id when using generate

### DIFF
--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -1221,7 +1221,7 @@ class GenerationMixin:
                 output_attentions=output_attentions,
                 output_hidden_states=output_hidden_states,
             )
-            if outputs.logits.size(1) == 1:
+            if outputs.logits.size(1) == 1 or pad_token_id is None:
                 mask_pad_indices = torch.zeros(
                     [outputs.logits.size(0)], dtype=torch.long, device=outputs.logits.device
                 )
@@ -1260,9 +1260,12 @@ class GenerationMixin:
                 next_tokens = next_tokens * unfinished_sequences + (pad_token_id) * (1 - unfinished_sequences)
 
             # set next token before padding index and increase length by one
-            input_ids = torch.cat([input_ids, input_ids.new_full([input_ids.shape[0], 1], pad_token_id)], dim=-1)
-            mask_pad_indices[mask_pad_indices == 0] = -1
-            input_ids[torch.arange(input_ids.size(0)), mask_pad_indices] = next_tokens
+            if pad_token_id is None:
+                input_ids = torch.cat([input_ids, next_tokens[:, None]], dim=-1)
+            else:
+                input_ids = torch.cat([input_ids, input_ids.new_full([input_ids.shape[0], 1], pad_token_id)], dim=-1)
+                mask_pad_indices[mask_pad_indices == 0] = -1
+                input_ids[torch.arange(input_ids.size(0)), mask_pad_indices] = next_tokens
 
             # update sequence length
             if eos_token_id is not None:
@@ -1442,7 +1445,7 @@ class GenerationMixin:
                 output_attentions=output_attentions,
                 output_hidden_states=output_hidden_states,
             )
-            if outputs.logits.size(1) == 1:
+            if outputs.logits.size(1) == 1 or pad_token_id is None:
                 mask_pad_indices = torch.zeros(
                     [outputs.logits.size(0)], dtype=torch.long, device=outputs.logits.device
                 )
@@ -1483,9 +1486,12 @@ class GenerationMixin:
                 next_tokens = next_tokens * unfinished_sequences + (pad_token_id) * (1 - unfinished_sequences)
 
             # set next token before padding index and increase length by one
-            input_ids = torch.cat([input_ids, input_ids.new_full([input_ids.shape[0], 1], pad_token_id)], dim=-1)
-            mask_pad_indices[mask_pad_indices == 0] = -1
-            input_ids[torch.arange(input_ids.size(0)), mask_pad_indices] = next_tokens
+            if pad_token_id is None:
+                input_ids = torch.cat([input_ids, next_tokens[:, None]], dim=-1)
+            else:
+                input_ids = torch.cat([input_ids, input_ids.new_full([input_ids.shape[0], 1], pad_token_id)], dim=-1)
+                mask_pad_indices[mask_pad_indices == 0] = -1
+                input_ids[torch.arange(input_ids.size(0)), mask_pad_indices] = next_tokens
             cur_len = cur_len + 1
 
             # update sequence length
@@ -1681,7 +1687,7 @@ class GenerationMixin:
                 output_hidden_states=output_hidden_states,
             )
 
-            if outputs.logits.size(1) == 1:
+            if outputs.logits.size(1) == 1 or pad_token_id is None:
                 mask_pad_indices = torch.zeros(
                     [outputs.logits.size(0)], dtype=torch.long, device=outputs.logits.device
                 )
@@ -1744,11 +1750,14 @@ class GenerationMixin:
             beam_idx = beam_outputs["next_beam_indices"]
 
             # set next token before padding index and increase length by one
-            input_ids = torch.cat(
-                [input_ids[beam_idx, :], input_ids.new_full([input_ids.shape[0], 1], pad_token_id)], dim=-1
-            )
-            mask_pad_indices[mask_pad_indices == 0] = -1
-            input_ids[torch.arange(input_ids.size(0)), mask_pad_indices] = beam_next_tokens
+            if pad_token_id is None:
+                input_ids = torch.cat([input_ids[beam_idx, :], beam_next_tokens.unsqueeze(-1)], dim=-1)
+            else:
+                input_ids = torch.cat(
+                    [input_ids[beam_idx, :], input_ids.new_full([input_ids.shape[0], 1], pad_token_id)], dim=-1
+                )
+                mask_pad_indices[mask_pad_indices == 0] = -1
+                input_ids[torch.arange(input_ids.size(0)), mask_pad_indices] = beam_next_tokens
             cur_len = cur_len + 1
 
             model_kwargs = self._update_model_kwargs_for_generation(
@@ -1952,7 +1961,7 @@ class GenerationMixin:
                 output_attentions=output_attentions,
                 output_hidden_states=output_hidden_states,
             )
-            if outputs.logits.size(1) == 1:
+            if outputs.logits.size(1) == 1 or pad_token_id is None:
                 mask_pad_indices = torch.zeros(
                     [outputs.logits.size(0)], dtype=torch.long, device=outputs.logits.device
                 )
@@ -2019,11 +2028,14 @@ class GenerationMixin:
             beam_idx = beam_outputs["next_beam_indices"]
 
             # set next token before padding index and increase length by one
-            input_ids = torch.cat(
-                [input_ids[beam_idx, :], input_ids.new_full([input_ids.shape[0], 1], pad_token_id)], dim=-1
-            )
-            mask_pad_indices[mask_pad_indices == 0] = -1
-            input_ids[torch.arange(input_ids.size(0)), mask_pad_indices] = beam_next_tokens
+            if pad_token_id is None:
+                input_ids = torch.cat([input_ids[beam_idx, :], beam_next_tokens.unsqueeze(-1)], dim=-1)
+            else:
+                input_ids = torch.cat(
+                    [input_ids[beam_idx, :], input_ids.new_full([input_ids.shape[0], 1], pad_token_id)], dim=-1
+                )
+                mask_pad_indices[mask_pad_indices == 0] = -1
+                input_ids[torch.arange(input_ids.size(0)), mask_pad_indices] = beam_next_tokens
             cur_len = cur_len + 1
 
             model_kwargs = self._update_model_kwargs_for_generation(
@@ -2234,7 +2246,7 @@ class GenerationMixin:
                 output_attentions=output_attentions,
                 output_hidden_states=output_hidden_states,
             )
-            if outputs.logits.size(1) == 1:
+            if outputs.logits.size(1) == 1 or pad_token_id is None:
                 mask_pad_indices = torch.zeros(
                     [outputs.logits.size(0)], dtype=torch.long, device=outputs.logits.device
                 )
@@ -2304,23 +2316,26 @@ class GenerationMixin:
                 beam_next_tokens = beam_outputs["next_beam_tokens"]
                 beam_idx = beam_outputs["next_beam_indices"]
 
-                # input_ids[batch_group_indices] = group_input_ids[beam_idx]
-                # group_input_ids = torch.cat([group_input_ids[beam_idx, :], beam_next_tokens.unsqueeze(-1)], dim=-1)
+                input_ids[batch_group_indices] = group_input_ids[beam_idx]
 
                 # set next token before padding index and increase length by one
-                group_input_ids = torch.cat(
-                    [
-                        group_input_ids[beam_idx, :],
-                        group_input_ids.new_full([group_input_ids.shape[0], 1], pad_token_id),
-                    ],
-                    dim=-1,
-                )
-                mask_pad_indices[mask_pad_indices == 0] = -1
-                group_input_ids[
-                    torch.arange(group_input_ids.size(0)), mask_pad_indices[batch_group_indices]
-                ] = beam_next_tokens
+                if pad_token_id is None:
+                    group_input_ids = torch.cat([group_input_ids[beam_idx, :], beam_next_tokens.unsqueeze(-1)], dim=-1)
+                else:
+                    group_input_ids = torch.cat(
+                        [
+                            group_input_ids[beam_idx, :],
+                            group_input_ids.new_full([group_input_ids.shape[0], 1], pad_token_id),
+                        ],
+                        dim=-1,
+                    )
+                    mask_pad_indices[mask_pad_indices == 0] = -1
+                    group_input_ids[
+                        torch.arange(group_input_ids.size(0)), mask_pad_indices[batch_group_indices]
+                    ] = beam_next_tokens
+                    mask_pad_indices[mask_pad_indices == -1] = 0
+
                 current_tokens[batch_group_indices] = beam_next_tokens
-                mask_pad_indices[mask_pad_indices == -1] = 0
 
                 # (beam_idx // group_size) -> batch_idx
                 # (beam_idx % group_size) -> offset of idx inside the group
@@ -2352,11 +2367,13 @@ class GenerationMixin:
             if model_kwargs["past"] is not None:
                 model_kwargs["past"] = self._reorder_cache(model_kwargs["past"], reordering_indices)
 
-            # input_ids = torch.cat([input_ids, current_tokens.unsqueeze(-1)], dim=-1)
             # set next token before padding index and increase length by one
-            input_ids = torch.cat([input_ids, input_ids.new_full([input_ids.shape[0], 1], pad_token_id)], dim=-1)
-            mask_pad_indices[mask_pad_indices == 0] = -1
-            input_ids[torch.arange(input_ids.size(0)), mask_pad_indices] = current_tokens
+            if pad_token_id is None:
+                input_ids = torch.cat([input_ids, current_tokens.unsqueeze(-1)], dim=-1)
+            else:
+                input_ids = torch.cat([input_ids, input_ids.new_full([input_ids.shape[0], 1], pad_token_id)], dim=-1)
+                mask_pad_indices[mask_pad_indices == 0] = -1
+                input_ids[torch.arange(input_ids.size(0)), mask_pad_indices] = current_tokens
             cur_len = cur_len + 1
             if beam_scorer.is_done:
                 break


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #10478 for pytorch version of `generate()` in generate_utils.py

As described in the issue, when `decoder_input_ids` have different lengths and require padding, generation continues after the padding tokens. This PR modifies that behavior so that tokens are generated before the padding for each element in the batch.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

I am adding those who I see more often in the git blame of the file:
@patrickvonplaten, @patil-suraj, @yjernite

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @
 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @jplu

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- nlp datasets: [different repo](https://github.com/huggingface/nlp)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->

This is my first PR, so let me use it to thank everyone involved in this library for all the cool work :)