### PR TITLE
Stale bot updated

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,9 @@
 name: Stale Bot
 
 on:
+  push:
+     branches:
+       - stale*
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ on:
      branches:
        - stale*
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 15 * * *"
 
 jobs:
   close_stale_issues:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,9 +1,6 @@
 name: Stale Bot
 
 on:
-  push:
-     branches:
-       - stale*
   schedule:
     - cron: "0 15 * * *"
 

--- a/scripts/stale.py
+++ b/scripts/stale.py
@@ -44,21 +44,21 @@ def main():
             and (dt.utcnow() - issue.created_at).days >= 30
             and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
         ):
-            print(f"Would close issue {issue.number} since it has been 7 days of inactivity since bot mention.")
-            # issue.edit(state="closed")
+            # print(f"Would close issue {issue.number} since it has been 7 days of inactivity since bot mention.")
+            issue.edit(state="closed")
         elif (
             (dt.utcnow() - issue.updated_at).days > 23
             and (dt.utcnow() - issue.created_at).days >= 30
             and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
         ):
-            print(f"Would add stale comment to {issue.number}")
-            # issue.create_comment(
-            #     "This issue has been automatically marked as stale because it has not had "
-            #     "recent activity. If you think this still needs to be addressed "
-            #     "please comment on this thread.\n\nPlease note that issues that do not follow the "
-            #     "[contributing guidelines](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md) "
-            #     "are likely to be ignored."
-            # )
+            # print(f"Would add stale comment to {issue.number}")
+            issue.create_comment(
+                "This issue has been automatically marked as stale because it has not had "
+                "recent activity. If you think this still needs to be addressed "
+                "please comment on this thread.\n\nPlease note that issues that do not follow the "
+                "[contributing guidelines](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md) "
+                "are likely to be ignored."
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/stale.py
+++ b/scripts/stale.py
@@ -26,6 +26,7 @@ LABELS_TO_EXEMPT = [
     "good second issue",
     "feature request",
     "new model",
+    "wip",
 ]
 
 
@@ -35,32 +36,40 @@ def main():
     open_issues = repo.get_issues(state="open")
 
     for issue in open_issues:
+        comments = sorted([comment for comment in issue.get_comments()], key=lambda i: i.created_at, reverse=True)
+        last_comment = comments[0] if len(comments) > 0 else None
         if (
-            not issue.assignees
-            and (dt.utcnow() - issue.updated_at).days > 21
+            last_comment is not None and last_comment.user.login == "github-actions[bot]"
+            and not issue.assignees
+            and (dt.utcnow() - issue.updated_at).days > 7
             and (dt.utcnow() - issue.created_at).days >= 30
             and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
         ):
-            print("Closing", issue)
-            # issue.create_comment(
-            #     "This issue has been automatically marked as stale and been closed because it has not had "
-            #     "recent activity. Thank you for your contributions.\n\nIf you think this still needs to be addressed"
-            #     " please comment on this thread."
-            # )
-            # issue.add_to_labels("wontfix")
+            print(f"Would close issue {issue.number} since it has been 7 days of inactivity since bot mention.")
             # issue.edit(state="closed")
+        elif (
+            not issue.assignees
+            and (dt.utcnow() - issue.updated_at).days > 23
+            and (dt.utcnow() - issue.created_at).days >= 30
+            and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
+        ):
+            print(f"Would add stale comment to {issue.number}")
+            # issue.create_comment(
+            #     "This issue has been automatically marked as stale because it has not had "
+            #     "recent activity. If you think this still needs to be addressed "
+            #     "please comment on this thread.\n\nPlease note that issues that do not follow the "
+            #     "[contributing guidelines](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md) "
+            #     "are likely to be ignored."
+            # )
         elif (
             len(issue.assignees) > 0
             and (dt.utcnow() - issue.updated_at).days > 21
             and (dt.utcnow() - issue.created_at).days >= 30
+            and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
         ):
             for assignee in issue.assignees:
-                print(f"Issue {issue.number}. Pinging {assignee.name} with message")
-                print(f"Hey @{assignee.login}, could you take a second look at this issue?")
-
-                # issue.create_comment(
-                #    f"Hey @{assignee.login}, could you take a second look at this issue?"
-                # )
+                print(f"This issue has been stale for a while, ping @{assignee.login}")
+                # issue.create_comment(f"This issue has been stale for a while, ping @{assignee.login}")
 
 
 if __name__ == "__main__":

--- a/scripts/stale.py
+++ b/scripts/stale.py
@@ -68,7 +68,7 @@ def main():
             and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
         ):
             for assignee in issue.assignees:
-                print(f"This issue has been stale for a while, ping @{assignee.login}")
+                print(f"This issue ({issue.number}) has been stale for a while, ping @{assignee.login}")
                 # issue.create_comment(f"This issue has been stale for a while, ping @{assignee.login}")
 
 

--- a/scripts/stale.py
+++ b/scripts/stale.py
@@ -40,7 +40,6 @@ def main():
         last_comment = comments[0] if len(comments) > 0 else None
         if (
             last_comment is not None and last_comment.user.login == "github-actions[bot]"
-            and not issue.assignees
             and (dt.utcnow() - issue.updated_at).days > 7
             and (dt.utcnow() - issue.created_at).days >= 30
             and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
@@ -48,8 +47,7 @@ def main():
             print(f"Would close issue {issue.number} since it has been 7 days of inactivity since bot mention.")
             # issue.edit(state="closed")
         elif (
-            not issue.assignees
-            and (dt.utcnow() - issue.updated_at).days > 23
+            (dt.utcnow() - issue.updated_at).days > 23
             and (dt.utcnow() - issue.created_at).days >= 30
             and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
         ):
@@ -61,15 +59,6 @@ def main():
             #     "[contributing guidelines](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md) "
             #     "are likely to be ignored."
             # )
-        elif (
-            len(issue.assignees) > 0
-            and (dt.utcnow() - issue.updated_at).days > 21
-            and (dt.utcnow() - issue.created_at).days >= 30
-            and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
-        ):
-            for assignee in issue.assignees:
-                print(f"This issue ({issue.number}) has been stale for a while, ping @{assignee.login}")
-                # issue.create_comment(f"This issue has been stale for a while, ping @{assignee.login}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is an updated version of the stale bot.

**It is easier to review the file than the diff, you can find the file [here](https://github.com/huggingface/transformers/blob/d1e516ea0fe9e641a75a89e5a7522392f7dbd59d/scripts/stale.py).**

It sends a warning message after 23 days of inactivity, and closes the issue/PR if no activity is detected in the following 7 days.

It ignores the following labels (case insensitive):
- `Good First Issue`
- `Good Second Issue`
- `Feature Request`
- `New Model`
- `WIP`

If there are assignees on the issue/PR, then it puts the following comment: `f"This issue has been stale for a while, ping @{assignee.login}"`

I propose to leave the PR like it is, and I'll push an empty commit daily to check the result of the stale bot test (I'll remove other tests to ensure that we don't spend unnecessary CI credits). Once we verify that it works as expected for a few days, I propose to merge it.

You may check the results of the first run here: https://github.com/huggingface/transformers/runs/2045189559?check_suite_focus=true (Second commit was rate limited)