### PR TITLE
offline mode for firewalled envs (part 2)

### DIFF
--- a/examples/research_projects/bertabs/run_summarization.py
+++ b/examples/research_projects/bertabs/run_summarization.py
@@ -9,10 +9,8 @@ import torch
 from torch.utils.data import DataLoader, SequentialSampler
 from tqdm import tqdm
 
-from filelock import FileLock
 from modeling_bertabs import BertAbs, build_predictor
 from transformers import BertTokenizer
-from transformers.file_utils import is_offline_mode
 
 from .utils_summarization import (
     CNNDMDataset,
@@ -50,16 +48,7 @@ def evaluate(args):
 
         import rouge
 
-        try:
-            nltk.data.find("tokenizers/punkt")
-        except (LookupError, OSError):
-            if is_offline_mode():
-                raise LookupError(
-                    "Offline mode: run this script without TRANSFORMERS_OFFLINE first to download nltk data files"
-                )
-            with FileLock(".lock") as lock:  # noqa
-                nltk.download("punkt", quiet=True)
-
+        nltk.download("punkt")
         rouge_evaluator = rouge.Rouge(
             metrics=["rouge-n", "rouge-l"],
             max_n=2,

--- a/examples/research_projects/bertabs/run_summarization.py
+++ b/examples/research_projects/bertabs/run_summarization.py
@@ -52,7 +52,7 @@ def evaluate(args):
 
         try:
             nltk.data.find("tokenizers/punkt")
-        except LookupError:
+        except (LookupError, OSError):
             if is_offline_mode():
                 raise LookupError(
                     "Offline mode: run this script without TRANSFORMERS_OFFLINE first to download nltk data files"

--- a/examples/research_projects/bertabs/run_summarization.py
+++ b/examples/research_projects/bertabs/run_summarization.py
@@ -9,8 +9,10 @@ import torch
 from torch.utils.data import DataLoader, SequentialSampler
 from tqdm import tqdm
 
+from filelock import FileLock
 from modeling_bertabs import BertAbs, build_predictor
 from transformers import BertTokenizer
+from transformers.file_utils import is_offline_mode
 
 from .utils_summarization import (
     CNNDMDataset,
@@ -48,7 +50,16 @@ def evaluate(args):
 
         import rouge
 
-        nltk.download("punkt")
+        try:
+            nltk.data.find("tokenizers/punkt")
+        except LookupError:
+            if is_offline_mode():
+                raise LookupError(
+                    "Offline mode: run this script without TRANSFORMERS_OFFLINE first to download nltk data files"
+                )
+            with FileLock(".lock") as lock:  # noqa
+                nltk.download("punkt", quiet=True)
+
         rouge_evaluator = rouge.Rouge(
             metrics=["rouge-n", "rouge-l"],
             max_n=2,

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -35,6 +35,7 @@ from .file_utils import (
     cached_path,
     hf_bucket_url,
     is_flax_available,
+    is_offline_mode,
     is_remote_url,
     is_tf_available,
     is_torch_available,
@@ -341,6 +342,10 @@ class PreTrainedFeatureExtractor:
         use_auth_token = kwargs.pop("use_auth_token", None)
         local_files_only = kwargs.pop("local_files_only", False)
         revision = kwargs.pop("revision", None)
+
+        if is_offline_mode() and not local_files_only:
+            logger.info("Offline mode: forcing local_files_only=True")
+            local_files_only = True
 
         pretrained_model_name_or_path = str(pretrained_model_name_or_path)
         if os.path.isdir(pretrained_model_name_or_path):

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -1105,6 +1105,10 @@ def cached_path(
     if isinstance(cache_dir, Path):
         cache_dir = str(cache_dir)
 
+    if is_offline_mode() and not local_files_only:
+        logger.info("Offline mode: forcing local_files_only=True")
+        local_files_only = True
+
     if is_remote_url(url_or_filename):
         # URL, so get it from the cache (downloading if necessary)
         output_path = get_from_cache(

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -28,7 +28,7 @@ from flax.traverse_util import flatten_dict, unflatten_dict
 from jax.random import PRNGKey
 
 from .configuration_utils import PretrainedConfig
-from .file_utils import FLAX_WEIGHTS_NAME, WEIGHTS_NAME, cached_path, hf_bucket_url, is_remote_url
+from .file_utils import FLAX_WEIGHTS_NAME, WEIGHTS_NAME, cached_path, hf_bucket_url, is_offline_mode, is_remote_url
 from .utils import logging
 
 
@@ -228,6 +228,10 @@ class FlaxPreTrainedModel(ABC):
         local_files_only = kwargs.pop("local_files_only", False)
         use_auth_token = kwargs.pop("use_auth_token", None)
         revision = kwargs.pop("revision", None)
+
+        if is_offline_mode() and not local_files_only:
+            logger.info("Offline mode: forcing local_files_only=True")
+            local_files_only = True
 
         # Load config if we don't provide a configuration
         if not isinstance(config, PretrainedConfig):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -36,6 +36,7 @@ from .file_utils import (
     ModelOutput,
     cached_path,
     hf_bucket_url,
+    is_offline_mode,
     is_remote_url,
 )
 from .generation_tf_utils import TFGenerationMixin
@@ -1150,6 +1151,10 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin):
         use_auth_token = kwargs.pop("use_auth_token", None)
         revision = kwargs.pop("revision", None)
         mirror = kwargs.pop("mirror", None)
+
+        if is_offline_mode() and not local_files_only:
+            logger.info("Offline mode: forcing local_files_only=True")
+            local_files_only = True
 
         # Load config if we don't provide a configuration
         if not isinstance(config, PretrainedConfig):


### PR DESCRIPTION
In https://github.com/huggingface/transformers/pull/10407 I noticed I missed a few places where `local_files_only` should be overridden for the offline mode, so this PR completes the process.

Also rewrote the test to be more readable. Could test TF/Flax too but I don't have tiny models to run quick tests on.

@LysandreJik, @sgugger 