### PR TITLE
[examples tests] various fixes

### DIFF
--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -425,6 +425,6 @@ class TrainerMemoryTracker:
 
 class ShardedDDPOption(ExplicitEnum):
     SIMPLE = "simple"
-    ZERO_DP_2 = "zero2"
-    ZERO_DP_3 = "zero3"
+    ZERO_DP_2 = "zero_dp_2"
+    ZERO_DP_3 = "zero_dp_3"
     OFFLOAD = "offload"


### PR DESCRIPTION
This PR is fixing slow examples tests that currently fail on scheduled CI

2 more tests will be fixed by https://github.com/huggingface/transformers/pull/10551

This PR:

Sharded DDP issues:
* fixes fully sharded ddp enum - and the corresponding tests
* 2 sharded ddp tests currently hang with master fairscale - add skip until this is sorted out - didn't want to step on @sgugger's toes - so for now just skipping


Tests:
* changes a large group of tests to check loss is not nan
* fix `test_run_seq2seq_slow` test 
   - missed by my PR https://github.com/huggingface/transformers/pull/10428
  - make it more resilient - was failing quality-wise on multi-gpu
* then we have an issue with apex - once run in a worker directly it breaks other tests running directly in the same pytest worker:

```
        # XXX: apex breaks the trainer if it's run twice e.g. run_seq2seq.main() from the same
        # program and it breaks other tests that run from the same pytest worker, therefore until this is
        # sorted out it must be run only in an external program, that is distributed=True in this
        # test and only under one or more gpus - if we want cpu will need to make a special test
        #
        # specifically to the problem traced it to self.optimizer.step() - if it's run 2nd time via
        # 2nd main() call it botches the future eval.
```
I'm not quite sure what happens but I think no-one will run into this in a normal situation, here we basically end up running:
```
main()
main()
```
in the same process. We have some internal state that doesn't get reset. 

So as I wrote above I used a workaround of running the apex integration test in a separate process so that it doesn't affect the rest of the test suite.

Of course if you have ideas on what the problem is and how to fix it I'm all ears. It's very simple to reproduce it:
```
    def test_run_seq2seq_apex(self):
        self.run_seq2seq_quick(distributed=True, extra_args_str="--fp16 --fp16_backend=apex")
        # test 2nd time - was getting eval_loss': nan'
        # to reproduce the problem set distributed=False
        self.run_seq2seq_quick(distributed=True, extra_args_str="--fp16 --fp16_backend=apex")
```

I can move it out into a separate PR if it's too much for one.

@LysandreJik, @sgugger 