### PR TITLE
[run_seq2seq] fix nltk lookup

### DIFF
--- a/examples/seq2seq/run_seq2seq.py
+++ b/examples/seq2seq/run_seq2seq.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 
 try:
     nltk.data.find("tokenizers/punkt")
-except LookupError:
+except (LookupError, OSError):
     if is_offline_mode():
         raise LookupError(
             "Offline mode: run this script without TRANSFORMERS_OFFLINE first to download nltk data files"


### PR DESCRIPTION
Hmm, CI crashes every so often on 
```
try:
    nltk.data.find("tokenizers/punkt")
except LookupError:
```

introduced in this PR: https://github.com/huggingface/transformers/pull/10407

https://app.circleci.com/pipelines/github/huggingface/transformers/20635/workflows/989fde0b-e543-4620-9d9a-f213ad53dd9b/jobs/176742
```
__________________ ERROR collecting examples/test_examples.py __________________
examples/test_examples.py:51: in <module>
    import run_seq2seq
examples/seq2seq/run_seq2seq.py:54: in <module>
    nltk.data.find("tokenizers/punkt")
../.local/lib/python3.6/site-packages/nltk/data.py:539: in find
    return FileSystemPathPointer(p)
../.local/lib/python3.6/site-packages/nltk/compat.py:41: in _decorator
    return init_func(*args, **kwargs)
../.local/lib/python3.6/site-packages/nltk/data.py:315: in __init__
    raise IOError("No such file or directory: %r" % _path)
E   OSError: No such file or directory: '/home/circleci/nltk_data/tokenizers/punkt/PY3'
```
which is odd, re-running the job fixed the problem.

So trying to mend it with:

```
try:
    nltk.data.find("tokenizers/punkt")
except (LookupError, OSError):
```
not sure why the Exception was different here. 

@sgugger, @LysandreJik 
