### PR TITLE
Fix version control with anchors

### DIFF
--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -128,7 +128,7 @@ function addVersionControl() {
     const parts = location.toString().split('/');
     let versionIndex = parts.length - 2;
     // Index page may not have a last part with filename.html so we need to go up
-    if (parts[parts.length - 1] != "" && ! parts[parts.length - 1].match(/\.html|^search.html?/)) {
+    if (parts[parts.length - 1] != "" && ! parts[parts.length - 1].match(/\.html/)) {
         versionIndex = parts.length - 1;
     }
     // Main classes and models are nested so we need to go deeper

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -128,7 +128,7 @@ function addVersionControl() {
     const parts = location.toString().split('/');
     let versionIndex = parts.length - 2;
     // Index page may not have a last part with filename.html so we need to go up
-    if (parts[parts.length - 1] != "" && ! parts[parts.length - 1].match(/\.html$|^search.html?/)) {
+    if (parts[parts.length - 1] != "" && ! parts[parts.length - 1].match(/\.html|^search.html?/)) {
         versionIndex = parts.length - 1;
     }
     // Main classes and models are nested so we need to go deeper


### PR DESCRIPTION
# What does this PR do?

In urls containing an anchor (such as https://huggingface.co/transformers/master/installation.html#caching-models), the version controller was not finding the right version (basically because the page wasn't ending with .html). This PR fixes that.

Fixes #10559