### PR TITLE
Fairscale FSDP fix model save

### DIFF
--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -321,7 +321,7 @@ Notes:
 
 Known caveats:
 
-- This feature is incompatible with evaluation, you can only train your model with it.
+- This feature is incompatible with :obj:`--predict_with_generate` in the `run_seq2seq.py` script.
 - Using :obj:`--sharded_ddp zero_dp_3` requires wrapping each layer of the model in the special container
   :obj:`FullyShardedDataParallelism` of fairscale. This is not done automatically by any of the example scripts of the
   :class:`~transformers.Trainer`.

--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -321,7 +321,7 @@ Notes:
 
 Known caveats:
 
-- This feature is incompatible with :obj:`--predict_with_generate` in the `run_seq2seq.py` script.
+- This feature is incompatible with evaluation, you can only train your model with it.
 - Using :obj:`--sharded_ddp zero_dp_3` requires wrapping each layer of the model in the special container
   :obj:`FullyShardedDataParallelism` of fairscale. This is not done automatically by any of the example scripts of the
   :class:`~transformers.Trainer`.

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1495,11 +1495,13 @@ class Trainer:
         """
         if is_torch_tpu_available():
             self._save_tpu(output_dir)
-        else:
-            if self.is_world_process_zero():
-                self._save(output_dir)
-            if self.args.local_rank != -1:
-                dist.barrier()
+        elif (
+            ShardedDDPOption.ZERO_DP_2 in self.args.sharded_ddp or ShardedDDPOption.ZERO_DP_3 in self.args.sharded_ddp
+        ):
+            state_dict = self.model.state_dict()
+            self._save(output_dir, state_dict=state_dict)
+        elif self.is_world_process_zero():
+            self._save(output_dir)
 
     def _save_tpu(self, output_dir: Optional[str] = None):
         output_dir = output_dir if output_dir is not None else self.args.output_dir
@@ -1529,7 +1531,7 @@ class Trainer:
         if self.tokenizer is not None and self.is_world_process_zero():
             self.tokenizer.save_pretrained(output_dir)
 
-    def _save(self, output_dir: Optional[str] = None):
+    def _save(self, output_dir: Optional[str] = None, state_dict=None):
         # If we are executing this function, we are the process zero, so we don't check for that.
         output_dir = output_dir if output_dir is not None else self.args.output_dir
         os.makedirs(output_dir, exist_ok=True)
@@ -1538,13 +1540,16 @@ class Trainer:
         # They can then be reloaded using `from_pretrained()`
         if not isinstance(self.model, PreTrainedModel):
             if isinstance(unwrap_model(self.model), PreTrainedModel):
-                unwrap_model(self.model).save_pretrained(output_dir, state_dict=self.model.state_dict())
+                if state_dict is None:
+                    state_dict = self.model.state_dict()
+                unwrap_model(self.model).save_pretrained(output_dir, state_dict=state_dict)
             else:
                 logger.info("Trainer.model is not a `PreTrainedModel`, only saving its state dict.")
-                state_dict = self.model.state_dict()
+                if state_dict is None:
+                    state_dict = self.model.state_dict()
                 torch.save(state_dict, os.path.join(output_dir, WEIGHTS_NAME))
         else:
-            self.model.save_pretrained(output_dir)
+            self.model.save_pretrained(output_dir, state_dict=state_dict)
         if self.tokenizer is not None:
             self.tokenizer.save_pretrained(output_dir)
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1499,7 +1499,8 @@ class Trainer:
             ShardedDDPOption.ZERO_DP_2 in self.args.sharded_ddp or ShardedDDPOption.ZERO_DP_3 in self.args.sharded_ddp
         ):
             state_dict = self.model.state_dict()
-            self._save(output_dir, state_dict=state_dict)
+            if self.is_world_process_zero():
+                self._save(output_dir, state_dict=state_dict)
         elif self.is_world_process_zero():
             self._save(output_dir)
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes the fact training with fairscale fully-sharded wrapper was hanging: it looks like recent changes in fairscale make a synchronization during the model state dict call, which results in the training hanging if we don't call that state_dict method on all processes. This PR addresses that.