### PR TITLE
[docs] How to solve "Title level inconsistent" sphinx error

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -296,3 +296,5 @@ This tells you which characters have already been assigned for each level.
 So using this particular example's output -- if your current section's header uses `=` as its underline character, you now know you're at level 4, and if you want to add a sub-section header you know you want `"` as it'd level 5.
 
 If you needed to add yet another sub-level, then pick a character that is not used already. That is you must pick a character that is not in the output of that script.
+
+Here is the full list of characters that can be used in this context: `= - ` : ' " ~ ^ _ * + # < >`

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ pip install -e ".[docs]"
 ---
 **NOTE**
 
-You only need to generate the documentation to inspect it locally (if you're planning changes and want to 
+You only need to generate the documentation to inspect it locally (if you're planning changes and want to
 check how they look like before committing for instance). You don't have to commit the built documentation.
 
 ---
@@ -65,7 +65,7 @@ make html
 ```
 
 A folder called ``_build/html`` should have been created. You can now open the file ``_build/html/index.html`` in your
-browser. 
+browser.
 
 ---
 **NOTE**
@@ -95,15 +95,15 @@ following these steps:
   expand them).
 - Click on "details" next to the `ci/circleci: build_doc` check.
 - In the new window, click on the "Artifacts" tab.
-- Locate the file "docs/_build/html/index.html" (or any specific page you want to check) and click on it to get a 
+- Locate the file "docs/_build/html/index.html" (or any specific page you want to check) and click on it to get a
   preview.
 
 ## Writing Documentation - Specification
 
 The `huggingface/transformers` documentation follows the
 [Google documentation](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) style. It is
-mostly written in ReStructuredText 
-([Sphinx simple documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html), 
+mostly written in ReStructuredText
+([Sphinx simple documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html),
 [Sourceforge complete documentation](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html)).
 
 
@@ -121,8 +121,8 @@ four.
 ### Adding a new model
 
 When adding a new model:
- 
-- Create a file `xxx.rst` under `./source/model_doc` (don't hesitate to copy an existing file as template). 
+
+- Create a file `xxx.rst` under `./source/model_doc` (don't hesitate to copy an existing file as template).
 - Link that file in `./source/index.rst` on the `model_doc` toc-tree.
 - Write a short overview of the model:
     - Overview with paper & authors
@@ -130,8 +130,8 @@ When adding a new model:
     - Tips and tricks and how to use it best
 - Add the classes that should be linked in the model. This generally includes the configuration, the tokenizer, and
   every model of that class (the base model, alongside models with additional heads), both in PyTorch and TensorFlow.
-  The order is generally: 
-    - Configuration, 
+  The order is generally:
+    - Configuration,
     - Tokenizer
     - PyTorch base model
     - PyTorch head models
@@ -179,7 +179,7 @@ Links should be done as so (note the double underscore at the end): \`text for t
 
 #### Defining arguments in a method
 
-Arguments should be defined with the `Args:` prefix, followed by a line return and an indentation. 
+Arguments should be defined with the `Args:` prefix, followed by a line return and an indentation.
 The argument should be followed by its type, with its shape if it is a tensor, and a line return.
 Another indentation is necessary before writing the description of the argument.
 
@@ -216,9 +216,9 @@ then its documentation should look like this:
 
 Note that we always omit the "defaults to :obj:\`None\`" when None is the default for any argument. Also note that even
 if the first line describing your argument type and its default gets long, you can't break it on several lines. You can
-however write as many lines as you want in the indented description (see the example above with `input_ids`). 
+however write as many lines as you want in the indented description (see the example above with `input_ids`).
 
-#### Writing a multi-line code block 
+#### Writing a multi-line code block
 
 Multi-line code blocks can be useful for displaying examples. They are done like so:
 
@@ -237,7 +237,7 @@ the results stay consistent with the library.
 
 #### Writing a return block
 
-Arguments should be defined with the `Args:` prefix, followed by a line return and an indentation. 
+Arguments should be defined with the `Args:` prefix, followed by a line return and an indentation.
 The first line should be the type of the return, followed by a line return. No need to indent further for the elements
 building the return.
 
@@ -258,3 +258,41 @@ Here's an example for a single value return:
     Returns:
         :obj:`List[int]`: A list of integers in the range [0, 1] --- 1 for a special token, 0 for a sequence token.
 ```
+
+#### Adding a new section
+
+In ReST section headers are designated as such with the help of a line of underlying characters, e.g.,:
+
+```
+Section 1
+^^^^^^^^^^^^^^^^^^
+
+Sub-section 1
+~~~~~~~~~~~~~~~~~~
+```
+
+ReST allows the use of any characters to designate different section levels, as long as they are used consistently within the same document. For details see [sections doc](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections). Because there is no standard different documents often end up using different characters for the same levels which makes it very difficult to know which character to use when creating a new section.
+
+Specifically, if when running `make docs` you get an error like:
+```
+docs/source/main_classes/trainer.rst:127:Title level inconsistent:
+```
+you picked an inconsistent character for some of the levels.
+
+But how do you know which characters you must use for an already existing level or when adding a new level?
+
+You can use this helper script:
+```
+perl -ne '/^(.)\1{100,}/ && do { $h{$1}=++$c if !$h{$1} }; END { %h = reverse %h ; print "$_ $h{$_}\n" for sort keys %h}' docs/source/main_classes/trainer.rst
+1 -
+2 ~
+3 ^
+4 =
+5 "
+```
+
+This tells you which characters have already been assigned for each level.
+
+So using this particular example's output -- if your current section's header uses `=` as its underline character, you now know you're at level 4, and if you want to add a sub-section header you know you want `"` as it'd level 5.
+
+If you needed to add yet another sub-level, then pick a character that is not used already. That is you must pick a character that is not in the output of that script.


### PR DESCRIPTION
This PR documents an easy solution to the "Title level inconsistent" puzzle when adding a new sub-section to an `.rst` doc.

@sgugger 