### PR TITLE
Fix tests of TrainerCallback

### DIFF
--- a/tests/test_trainer_callback.py
+++ b/tests/test_trainer_callback.py
@@ -141,7 +141,6 @@ class TrainerCallbackTest(unittest.TestCase):
 
     def test_init_callback(self):
         trainer = self.get_trainer()
-        print(trainer.callback_handler.callbacks)
         expected_callbacks = DEFAULT_CALLBACKS.copy() + [ProgressCallback]
         self.check_callbacks_equality(trainer.callback_handler.callbacks, expected_callbacks)
 

--- a/tests/test_trainer_callback.py
+++ b/tests/test_trainer_callback.py
@@ -91,7 +91,7 @@ class TrainerCallbackTest(unittest.TestCase):
         config = RegressionModelConfig(a=a, b=b)
         model = RegressionPreTrainedModel(config)
 
-        args = TrainingArguments(self.output_dir, disable_tqdm=disable_tqdm, **kwargs)
+        args = TrainingArguments(self.output_dir, disable_tqdm=disable_tqdm, report_to=[], **kwargs)
         return Trainer(
             model,
             args,
@@ -141,6 +141,7 @@ class TrainerCallbackTest(unittest.TestCase):
 
     def test_init_callback(self):
         trainer = self.get_trainer()
+        print(trainer.callback_handler.callbacks)
         expected_callbacks = DEFAULT_CALLBACKS.copy() + [ProgressCallback]
         self.check_callbacks_equality(trainer.callback_handler.callbacks, expected_callbacks)
 


### PR DESCRIPTION
# What does this PR do?

When introducing the `report_to` argument, I must have messed something up. Bottomline is that the tests of `TrainerCallback` can fail depending on what is installed in the env (TensorBoard for instance), this PR fixes that.