### PR TITLE
Extend trainer logging for sm

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -19,12 +19,12 @@ The Trainer class, to easily train a 🤗 Transformers from scratch or finetune 
 import collections
 import gc
 import inspect
-# import logging as native_logging
+from logging import StreamHandler
 import math
 import os
 import re
 import shutil
-# import sys
+import sys
 import time
 import warnings
 from pathlib import Path
@@ -60,7 +60,7 @@ from .file_utils import (
     is_datasets_available,
     is_in_notebook,
     is_sagemaker_distributed_available,
-    # is_training_run_on_sagemaker,
+    is_training_run_on_sagemaker,
     is_torch_tpu_available,
 )
 from .modeling_utils import PreTrainedModel, unwrap_model
@@ -153,7 +153,7 @@ else:
     import torch.distributed as dist
 
 # if is_training_run_on_sagemaker():
-#     logging.addHandler(native_logging.StreamHandler(sys.stdout))
+#     logging.addHandler(StreamHandler(sys.stdout))
 
 
 if TYPE_CHECKING:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -19,7 +19,6 @@ The Trainer class, to easily train a 🤗 Transformers from scratch or finetune 
 import collections
 import gc
 import inspect
-from logging import StreamHandler
 import math
 import os
 import re
@@ -27,6 +26,7 @@ import shutil
 import sys
 import time
 import warnings
+from logging import StreamHandler
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -60,8 +60,8 @@ from .file_utils import (
     is_datasets_available,
     is_in_notebook,
     is_sagemaker_distributed_available,
-    is_training_run_on_sagemaker,
     is_torch_tpu_available,
+    is_training_run_on_sagemaker,
 )
 from .modeling_utils import PreTrainedModel, unwrap_model
 from .optimization import Adafactor, AdamW, get_scheduler

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -19,12 +19,12 @@ The Trainer class, to easily train a 🤗 Transformers from scratch or finetune 
 import collections
 import gc
 import inspect
-import logging as native_logging
+# import logging as native_logging
 import math
 import os
 import re
 import shutil
-import sys
+# import sys
 import time
 import warnings
 from pathlib import Path
@@ -60,7 +60,7 @@ from .file_utils import (
     is_datasets_available,
     is_in_notebook,
     is_sagemaker_distributed_available,
-    is_training_run_on_sagemaker,
+    # is_training_run_on_sagemaker,
     is_torch_tpu_available,
 )
 from .modeling_utils import PreTrainedModel, unwrap_model
@@ -152,8 +152,8 @@ if is_sagemaker_distributed_available():
 else:
     import torch.distributed as dist
 
-if is_training_run_on_sagemaker():
-    logging.addHandler(native_logging.StreamHandler(sys.stdout))
+# if is_training_run_on_sagemaker():
+#     logging.addHandler(native_logging.StreamHandler(sys.stdout))
 
 
 if TYPE_CHECKING:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -19,10 +19,12 @@ The Trainer class, to easily train a 🤗 Transformers from scratch or finetune 
 import collections
 import gc
 import inspect
+import logging
 import math
 import os
 import re
 import shutil
+import sys
 import time
 import warnings
 from pathlib import Path
@@ -58,6 +60,7 @@ from .file_utils import (
     is_datasets_available,
     is_in_notebook,
     is_sagemaker_distributed_available,
+    is_training_run_on_sagemaker,
     is_torch_tpu_available,
 )
 from .modeling_utils import PreTrainedModel, unwrap_model
@@ -103,7 +106,7 @@ from .trainer_utils import (
     speed_metrics,
 )
 from .training_args import ParallelMode, TrainingArguments
-from .utils import logging
+from .utils import logging as hf_logging
 from .utils.modeling_auto_mapping import MODEL_FOR_QUESTION_ANSWERING_MAPPING_NAMES
 
 
@@ -149,10 +152,14 @@ if is_sagemaker_distributed_available():
 else:
     import torch.distributed as dist
 
+if is_training_run_on_sagemaker():
+   hf_logging.addHandler(logging.StreamHandler(sys.stdout))
+
+
 if TYPE_CHECKING:
     import optuna
 
-logger = logging.get_logger(__name__)
+logger = hf_logging.get_logger(__name__)
 
 
 class Trainer:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -19,7 +19,7 @@ The Trainer class, to easily train a 🤗 Transformers from scratch or finetune 
 import collections
 import gc
 import inspect
-import logging
+import logging as native_logging
 import math
 import os
 import re
@@ -106,7 +106,7 @@ from .trainer_utils import (
     speed_metrics,
 )
 from .training_args import ParallelMode, TrainingArguments
-from .utils import logging as hf_logging
+from .utils import logging
 from .utils.modeling_auto_mapping import MODEL_FOR_QUESTION_ANSWERING_MAPPING_NAMES
 
 
@@ -153,13 +153,13 @@ else:
     import torch.distributed as dist
 
 if is_training_run_on_sagemaker():
-   hf_logging.addHandler(logging.StreamHandler(sys.stdout))
+    logging.addHandler(native_logging.StreamHandler(sys.stdout))
 
 
 if TYPE_CHECKING:
     import optuna
 
-logger = hf_logging.get_logger(__name__)
+logger = logging.get_logger(__name__)
 
 
 class Trainer:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -152,8 +152,8 @@ if is_sagemaker_distributed_available():
 else:
     import torch.distributed as dist
 
-# if is_training_run_on_sagemaker():
-#     logging.addHandler(StreamHandler(sys.stdout))
+if is_training_run_on_sagemaker():
+    logging.add_handler(StreamHandler(sys.stdout))
 
 
 if TYPE_CHECKING:

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -209,7 +209,7 @@ def remove_handler(handler: logging.Handler) -> None:
 
     _configure_library_root_logger()
 
-    assert handler is not None
+    assert handler is not None and handler not in _get_library_root_logger().handlers
     _get_library_root_logger().removeHandler(handler)
 
 

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -204,6 +204,15 @@ def add_handler(handler: logging.Handler) -> None:
     _get_library_root_logger().addHandler(handler)
 
 
+def remove_handler(handler: logging.Handler) -> None:
+    """removes given handler from the HuggingFace Transformers's root logger."""
+
+    _configure_library_root_logger()
+
+    assert handler is not None
+    _get_library_root_logger().removeHandler(handler)
+
+
 def disable_propagation() -> None:
     """
     Disable propagation of the library log outputs. Note that log propagation is disabled by default.

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -194,7 +194,8 @@ def enable_default_handler() -> None:
     assert _default_handler is not None
     _get_library_root_logger().addHandler(_default_handler)
 
-def add_handler(handler:logging.Handler) -> None:
+
+def add_handler(handler: logging.Handler) -> None:
     """adds a handler to the HuggingFace Transformers's root logger."""
 
     _configure_library_root_logger()

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -194,6 +194,14 @@ def enable_default_handler() -> None:
     assert _default_handler is not None
     _get_library_root_logger().addHandler(_default_handler)
 
+def add_handler(handler:logging.Handler) -> None:
+    """adds a handler to the HuggingFace Transformers's root logger."""
+
+    _configure_library_root_logger()
+
+    assert handler is not None
+    _get_library_root_logger().addHandler(handler)
+
 
 def disable_propagation() -> None:
     """


### PR DESCRIPTION
# What does this PR do?

adds a helper function to `logging.py` to add a native logging handler if needed (`add_handler`). Adds in the `Trainer` a logging `StreamHandler(sys.stdout)` with `sys.stdout` when training is run on sagemaker to forward logs.