### PR TITLE
Specify minimum version for sacrebleu

### DIFF
--- a/examples/_tests_requirements.txt
+++ b/examples/_tests_requirements.txt
@@ -2,7 +2,7 @@ tensorboard
 scikit-learn
 seqeval
 psutil
-sacrebleu
+sacrebleu >= 1.4.12
 rouge-score
 tensorflow_datasets
 matplotlib

--- a/examples/seq2seq/requirements.txt
+++ b/examples/seq2seq/requirements.txt
@@ -1,6 +1,6 @@
 datasets >= 1.1.3
 sentencepiece != 0.1.92
 protobuf
-sacrebleu
+sacrebleu >= 1.4.12
 rouge-score
 nltk


### PR DESCRIPTION
The `_tests_requirements.txt` require an install of sacrebleu without any version specified. However, some `sacrebleu` versions don't have the same API. I've had problems with version `1.2.10`, and @lhoestq confirmed the issue is not present in `1.4.12`.

The error was the following:

```
    def _compute(
        self,
        predictions,
        references,
        smooth_method="exp",
        smooth_value=None,
        force=False,
        lowercase=False,
        tokenize=scb.DEFAULT_TOKENIZER,
        use_effective_order=False,
    ):
        references_per_prediction = len(references[0])
        if any(len(refs) != references_per_prediction for refs in references):
            raise ValueError("Sacrebleu requires the same number of references for each prediction")
        transformed_references = [[refs[i] for refs in references] for i in range(references_per_prediction)]
>       output = scb.corpus_bleu(
            sys_stream=predictions,
            ref_streams=transformed_references,
            smooth_method=smooth_method,
            smooth_value=smooth_value,
            force=force,
            lowercase=lowercase,
            tokenize=tokenize,
            use_effective_order=use_effective_order,
        )
E       TypeError: corpus_bleu() got an unexpected keyword argument 'smooth_method'
/mnt/cache/modules/datasets_modules/metrics/sacrebleu/b390045b3d1dd4abf6a95c4a2a11ee3bcc2b7620b076204d0ddc353fa649fd86/sacrebleu.py:114: TypeError
```

Full stack trace:

```
E             File "/__w/transformers/transformers/src/transformers/trainer_seq2seq.py", line 74, in evaluate
E               return super().evaluate(eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
E             File "/__w/transformers/transformers/src/transformers/trainer.py", line 1650, in evaluate
E               output = self.prediction_loop(
E             File "/__w/transformers/transformers/src/transformers/trainer.py", line 1823, in prediction_loop
E               metrics = self.compute_metrics(EvalPrediction(predictions=preds, label_ids=label_ids))
E             File "/__w/transformers/transformers/examples/seq2seq/run_seq2seq.py", line 563, in compute_metrics
E               result = metric.compute(predictions=decoded_preds, references=decoded_labels)
E             File "/opt/conda/lib/python3.8/site-packages/datasets/metric.py", line 403, in compute
E               output = self._compute(predictions=predictions, references=references, **kwargs)
E             File "/mnt/cache/modules/datasets_modules/metrics/sacrebleu/b390045b3d1dd4abf6a95c4a2a11ee3bcc2b7620b076204d0ddc353fa649fd86/sacrebleu.py", line 114, in _compute
E               output = scb.corpus_bleu(
```

I'm unsure about the minimum version required here, I just know that 1.2.10 doesn't work. Please advise if you think a better minimum version would be better.