### PR TITLE
TensorFlow tests: having from_pt set to True requires torch to be installed.

### DIFF
--- a/tests/test_modeling_tf_blenderbot.py
+++ b/tests/test_modeling_tf_blenderbot.py
@@ -309,7 +309,7 @@ class TFBlenderbot400MIntegrationTests(unittest.TestCase):
 
     @cached_property
     def model(self):
-        model = TFAutoModelForSeq2SeqLM.from_pretrained(self.model_name, from_pt=True)
+        model = TFAutoModelForSeq2SeqLM.from_pretrained(self.model_name)
         return model
 
     @slow

--- a/tests/test_modeling_tf_marian.py
+++ b/tests/test_modeling_tf_marian.py
@@ -350,7 +350,7 @@ class AbstractMarianIntegrationTest(unittest.TestCase):
     @cached_property
     def model(self):
         warnings.simplefilter("error")
-        model: TFMarianMTModel = TFAutoModelForSeq2SeqLM.from_pretrained(self.model_name, from_pt=True)
+        model: TFMarianMTModel = TFAutoModelForSeq2SeqLM.from_pretrained(self.model_name)
         assert isinstance(model, TFMarianMTModel)
         c = model.config
         self.assertListEqual(c.bad_words_ids, [[c.pad_token_id]])

--- a/tests/test_modeling_tf_rag.py
+++ b/tests/test_modeling_tf_rag.py
@@ -562,7 +562,7 @@ class TFRagModelIntegrationTests(unittest.TestCase):
         )
 
     def token_model_nq_checkpoint(self, retriever):
-        return TFRagTokenForGeneration.from_pretrained("facebook/rag-token-nq", from_pt=True, retriever=retriever)
+        return TFRagTokenForGeneration.from_pretrained("facebook/rag-token-nq", retriever=retriever)
 
     def get_rag_config(self):
         question_encoder_config = AutoConfig.from_pretrained("facebook/dpr-question_encoder-single-nq-base")
@@ -799,7 +799,7 @@ class TFRagModelIntegrationTests(unittest.TestCase):
     def test_rag_token_greedy_search(self):
         tokenizer = RagTokenizer.from_pretrained("facebook/rag-token-nq")
         retriever = RagRetriever.from_pretrained("facebook/rag-token-nq", index_name="exact", use_dummy_dataset=True)
-        rag_token = TFRagTokenForGeneration.from_pretrained("facebook/rag-token-nq", retriever=retriever, from_pt=True)
+        rag_token = TFRagTokenForGeneration.from_pretrained("facebook/rag-token-nq", retriever=retriever)
 
         # check first two questions
         input_dict = tokenizer(
@@ -833,7 +833,7 @@ class TFRagModelIntegrationTests(unittest.TestCase):
         # NOTE: gold labels comes from num_beam=4, so this is effectively beam-search test
         tokenizer = RagTokenizer.from_pretrained("facebook/rag-token-nq")
         retriever = RagRetriever.from_pretrained("facebook/rag-token-nq", index_name="exact", use_dummy_dataset=True)
-        rag_token = TFRagTokenForGeneration.from_pretrained("facebook/rag-token-nq", retriever=retriever, from_pt=True)
+        rag_token = TFRagTokenForGeneration.from_pretrained("facebook/rag-token-nq", retriever=retriever)
 
         input_dict = tokenizer(
             self.test_data_questions,
@@ -877,9 +877,7 @@ class TFRagModelIntegrationTests(unittest.TestCase):
         retriever = RagRetriever.from_pretrained(
             "facebook/rag-sequence-nq", index_name="exact", use_dummy_dataset=True
         )
-        rag_sequence = TFRagSequenceForGeneration.from_pretrained(
-            "facebook/rag-sequence-nq", retriever=retriever, from_pt=True
-        )
+        rag_sequence = TFRagSequenceForGeneration.from_pretrained("facebook/rag-sequence-nq", retriever=retriever)
 
         input_dict = tokenizer(
             self.test_data_questions,
@@ -923,9 +921,7 @@ class TFRagModelIntegrationTests(unittest.TestCase):
         retriever = RagRetriever.from_pretrained(
             "facebook/rag-sequence-nq", index_name="exact", use_dummy_dataset=True
         )
-        rag_sequence = TFRagSequenceForGeneration.from_pretrained(
-            "facebook/rag-sequence-nq", retriever=retriever, from_pt=True
-        )
+        rag_sequence = TFRagSequenceForGeneration.from_pretrained("facebook/rag-sequence-nq", retriever=retriever)
         input_dict = tokenizer(
             self.test_data_questions,
             return_tensors="tf",


### PR DESCRIPTION
Some tests were executed without having torch installed, while they require torch. Namely, all the tests that have a `from_pt=True` requirement require torch to be installed.

This is a draft PR as several of the requirements to merge this PR are not met:
- The Marian models do not have their tensorflow variant available on the hub
- Neither do the RAG models

The easy option is to only set `@requires_torch`, but since we have no slow test suite that runs both PT + TF that's not a good workaround.

How do you want to proceed @patrickvonplaten ?
