### PR TITLE
W2v2 test require torch

### DIFF
--- a/tests/test_feature_extraction_wav2vec2.py
+++ b/tests/test_feature_extraction_wav2vec2.py
@@ -21,7 +21,7 @@ import unittest
 import numpy as np
 
 from transformers import WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST, Wav2Vec2Config, Wav2Vec2FeatureExtractor
-from transformers.testing_utils import slow, require_torch
+from transformers.testing_utils import require_torch, slow
 
 from .test_sequence_feature_extraction_common import SequenceFeatureExtractionTestMixin
 

--- a/tests/test_feature_extraction_wav2vec2.py
+++ b/tests/test_feature_extraction_wav2vec2.py
@@ -21,7 +21,7 @@ import unittest
 import numpy as np
 
 from transformers import WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST, Wav2Vec2Config, Wav2Vec2FeatureExtractor
-from transformers.testing_utils import slow
+from transformers.testing_utils import slow, require_torch
 
 from .test_sequence_feature_extraction_common import SequenceFeatureExtractionTestMixin
 
@@ -134,6 +134,7 @@ class Wav2Vec2FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         _check_zero_mean_unit_variance(input_values[2])
 
     @slow
+    @require_torch
     def test_pretrained_checkpoints_are_set_correctly(self):
         # this test makes sure that models that are using
         # group norm don't have their feature extractor return the

--- a/tests/test_tokenization_wav2vec2.py
+++ b/tests/test_tokenization_wav2vec2.py
@@ -30,7 +30,7 @@ from transformers import (
     Wav2Vec2Tokenizer,
 )
 from transformers.models.wav2vec2.tokenization_wav2vec2 import VOCAB_FILES_NAMES
-from transformers.testing_utils import slow
+from transformers.testing_utils import slow, require_torch
 
 from .test_tokenization_common import TokenizerTesterMixin
 
@@ -340,6 +340,7 @@ class Wav2Vec2TokenizerTest(unittest.TestCase):
         self.assertListEqual(processed.attention_mask.sum(-1).tolist(), [800, 1000, 1200])
 
     @slow
+    @require_torch
     def test_pretrained_checkpoints_are_set_correctly(self):
         # this test makes sure that models that are using
         # group norm don't have their tokenizer return the

--- a/tests/test_tokenization_wav2vec2.py
+++ b/tests/test_tokenization_wav2vec2.py
@@ -30,7 +30,7 @@ from transformers import (
     Wav2Vec2Tokenizer,
 )
 from transformers.models.wav2vec2.tokenization_wav2vec2 import VOCAB_FILES_NAMES
-from transformers.testing_utils import slow, require_torch
+from transformers.testing_utils import require_torch, slow
 
 from .test_tokenization_common import TokenizerTesterMixin
 


### PR DESCRIPTION
The object `WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST` requires torch to be installed to not be `None`. This adds the required `@require_torch`.