### PR TITLE
fix typing error for HfArgumentParser for Optional[bool]

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -80,7 +80,7 @@ class HfArgumentParser(ArgumentParser):
                     "We will add compatibility when Python 3.9 is released."
                 )
             typestring = str(field.type)
-            for prim_type in (int, float, str):
+            for prim_type in (int, float, str, bool):
                 for collection in (List,):
                     if (
                         typestring == f"typing.Union[{collection[prim_type]}, NoneType]"

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -80,7 +80,7 @@ class HfArgumentParser(ArgumentParser):
                     "We will add compatibility when Python 3.9 is released."
                 )
             typestring = str(field.type)
-            for prim_type in (int, float, str, bool):
+            for prim_type in (int, float, str):
                 for collection in (List,):
                     if (
                         typestring == f"typing.Union[{collection[prim_type]}, NoneType]"
@@ -98,7 +98,7 @@ class HfArgumentParser(ArgumentParser):
                 kwargs["type"] = type(kwargs["choices"][0])
                 if field.default is not dataclasses.MISSING:
                     kwargs["default"] = field.default
-            elif field.type is bool or field.type is Optional[bool]:
+            elif field.type is bool or field.type == Optional[bool]:
                 if field.default is True:
                     self.add_argument(f"--no_{field.name}", action="store_false", dest=field.name, **kwargs)
 


### PR DESCRIPTION
`TrainingArguments` uses the `Optional[bool]` type for [a couple arguments](https://github.com/huggingface/transformers/blob/master/src/transformers/training_args.py#L443).  I ran into the following error when using transformers v4.3.3 with python 3.8:

`"TrainingArguments" TypeError: issubclass() arg 1 must be a class`