### PR TITLE
[Tests] RAG

### DIFF
--- a/tests/test_modeling_rag.py
+++ b/tests/test_modeling_rag.py
@@ -840,13 +840,6 @@ class RagModelIntegrationTests(unittest.TestCase):
             "when is the last time the philadelphia won the superbowl",
             "what is the most current adobe flash player version",
             "how many episodes are there in dragon ball z",
-            "what is the first step in the evolution of the eye",
-            "where is gall bladder situated in human body",
-            "what is the main mineral in lithium batteries",
-            "who is the president of usa right now",
-            "where do the greasers live in the outsiders",
-            "panda is a national animal of which country",
-            "what is the name of manchester united stadium",
         ]
 
     @slow
@@ -885,13 +878,6 @@ class RagModelIntegrationTests(unittest.TestCase):
             " 1980",
             " 7.0",
             " 8",
-            " reticular formation",
-            " walls of the abdomen",
-            " spodumene",
-            " obama",
-            " new orleans",
-            " japan",
-            " old trafford",
         ]
         self.assertListEqual(outputs, EXPECTED_OUTPUTS)
 
@@ -942,13 +928,6 @@ class RagModelIntegrationTests(unittest.TestCase):
             " 1980",
             " 7.0",
             " 8",
-            " reticular formation",
-            " walls of the abdomen",
-            " spodumene",
-            " obama",
-            " new orleans",
-            " japan",
-            " old trafford",
         ]
         self.assertListEqual(outputs, EXPECTED_OUTPUTS)
 
@@ -986,13 +965,6 @@ class RagModelIntegrationTests(unittest.TestCase):
             " the 1970s",
             " 7.1. 2",
             " 13",
-            " step by step",
-            " stomach",
-            " spodumene",
-            " obama",
-            " northern new jersey",
-            " india",
-            " united stadium",
         ]
         self.assertListEqual(outputs, EXPECTED_OUTPUTS)
 

--- a/tests/test_modeling_tf_rag.py
+++ b/tests/test_modeling_tf_rag.py
@@ -786,13 +786,6 @@ class TFRagModelIntegrationTests(unittest.TestCase):
             "when is the last time the philadelphia won the superbowl",
             "what is the most current adobe flash player version",
             "how many episodes are there in dragon ball z",
-            "what is the first step in the evolution of the eye",
-            "where is gall bladder situated in human body",
-            "what is the main mineral in lithium batteries",
-            "who is the president of usa right now",
-            "where do the greasers live in the outsiders",
-            "panda is a national animal of which country",
-            "what is the name of manchester united stadium",
         ]
 
     @slow
@@ -861,13 +854,6 @@ class TFRagModelIntegrationTests(unittest.TestCase):
             " the 1970s",
             " 7.1. 2",
             " 13",
-            " evolution",
-            " stomach",
-            " spodumene",
-            " obama",
-            " northern new jersey",
-            " india",
-            " united stadium",
         ]
         self.assertListEqual(outputs, EXPECTED_OUTPUTS)
 
@@ -907,13 +893,6 @@ class TFRagModelIntegrationTests(unittest.TestCase):
             " 1980",
             " 7.0",
             " 8",
-            " reticular formation",
-            " walls of the abdomen",
-            " spodumene",
-            " obama",
-            " new orleans",
-            " japan",
-            " old trafford",
         ]
         self.assertListEqual(outputs, EXPECTED_OUTPUTS)
 
@@ -961,13 +940,6 @@ class TFRagModelIntegrationTests(unittest.TestCase):
             " 1980",
             " 7.0",
             " 8",
-            " reticular formation",
-            " walls of the abdomen",
-            " spodumene",
-            " obama",
-            " new orleans",
-            " japan",
-            " old trafford",
         ]
         self.assertListEqual(outputs, EXPECTED_OUTPUTS)
 


### PR DESCRIPTION
This PR shortens the RAG tests by simply reducing the batch size to 8. It's not ideal because RAG is a fairly complex model and IMO, it's good that we have such "big" integration tests. Maybe we should move those tests to a different `@require_large_gpu` decorator?