### PR TITLE
Multiple fixes in SageMakerTrainer

### DIFF
--- a/src/transformers/sagemaker/trainer_sm.py
+++ b/src/transformers/sagemaker/trainer_sm.py
@@ -89,7 +89,7 @@ class SageMakerTrainer(Trainer):
         if self.is_model_parallel_enabled:
             return smp.rank() == 0 and smp.local_rank() == 0 and smp.mp_rank() == 0 and smp.dp_rank() == 0
         else:
-            return super.is_world_process_zero()
+            return super().is_world_process_zero()
 
     def _get_train_sampler(self):
         if self.is_model_parallel_enabled:

--- a/src/transformers/sagemaker/trainer_sm.py
+++ b/src/transformers/sagemaker/trainer_sm.py
@@ -11,21 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os
+import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import numpy as np
 import torch
 from torch import nn
 from torch.utils.data.dataset import Dataset
 from torch.utils.data.distributed import DistributedSampler
 
-from ..trainer import Trainer
+from ..file_utils import WEIGHTS_NAME, is_torch_tpu_available
+from ..modeling_utils import PreTrainedModel
+from ..trainer import Trainer, _model_unwrap
 from ..trainer_pt_utils import (
     DistributedLengthGroupedSampler,
     SequentialDistributedSampler,
     nested_detach,
     nested_numpify,
+    reissue_pt_warnings,
 )
+from ..trainer_utils import PREFIX_CHECKPOINT_DIR
 from ..utils import logging
 from .training_args_sm import is_smdistributed_available
 

--- a/src/transformers/sagemaker/trainer_sm.py
+++ b/src/transformers/sagemaker/trainer_sm.py
@@ -132,6 +132,8 @@ class SageMakerTrainer(Trainer):
             return super().training_step(model, inputs)
 
     def _gather_and_numpify(self, tensors, name):
+        if tensors is None:
+            return
         if self.is_model_parallel_enabled:
             tensors = smp_gather(tensors)
             return nested_numpify(tensors)

--- a/src/transformers/sagemaker/trainer_sm.py
+++ b/src/transformers/sagemaker/trainer_sm.py
@@ -197,7 +197,7 @@ class SageMakerTrainer(Trainer):
             opt_state_dict = self.optimizer.state_dict()
             # Save it and the scheduler on the main process
             if self.is_world_process_zero():
-                torch.save(opt_state_dict.state_dict(), os.path.join(output_dir, "optimizer.pt"))
+                torch.save(opt_state_dict, os.path.join(output_dir, "optimizer.pt"))
                 with warnings.catch_warnings(record=True) as caught_warnings:
                     torch.save(self.lr_scheduler.state_dict(), os.path.join(output_dir, "scheduler.pt"))
                 reissue_pt_warnings(caught_warnings)

--- a/src/transformers/sagemaker/training_args_sm.py
+++ b/src/transformers/sagemaker/training_args_sm.py
@@ -85,6 +85,13 @@ class SageMakerTrainingArguments(TrainingArguments):
         return device
 
     @property
+    def world_size(self):
+        if is_smdistributed_available() and self.mp_parameters != "":
+            return smp.dp_size()
+
+        return super().world_size
+
+    @property
     def place_model_on_device(self):
         return not (is_smdistributed_available() and self.mp_parameters != "")
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -915,9 +915,6 @@ class Trainer:
         self.state = TrainerState()
         self.state.is_hyper_param_search = trial is not None
 
-        # Check if saved optimizer or scheduler states exist
-        self._load_optimizer_and_scheduler(resume_from_checkpoint)
-
         model = self._wrap_model(self.model_wrapped)
 
         # for the rest of this function `model` is the outside model, whether it was wrapped or not
@@ -926,6 +923,9 @@ class Trainer:
 
         if delay_optimizer_creation:
             self.create_optimizer_and_scheduler(num_training_steps=max_steps)
+
+        # Check if saved optimizer or scheduler states exist
+        self._load_optimizer_and_scheduler(resume_from_checkpoint)
 
         # important: at this point:
         # self.model         is the Transformers Model

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1776,12 +1776,7 @@ class Trainer:
         preds_host: Union[torch.Tensor, List[torch.Tensor]] = None
         labels_host: Union[torch.Tensor, List[torch.Tensor]] = None
 
-        world_size = 1
-        if is_torch_tpu_available():
-            world_size = xm.xrt_world_size()
-        elif self.args.local_rank != -1:
-            world_size = dist.get_world_size()
-        world_size = max(1, world_size)
+        world_size = max(1, self.args.world_size)
 
         eval_losses_gatherer = DistributedTensorGatherer(world_size, num_examples, make_multiple_of=batch_size)
         if not prediction_loss_only:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -36,6 +36,9 @@ if is_torch_available():
 if is_torch_tpu_available():
     import torch_xla.core.xla_model as xm
 
+if is_sagemaker_distributed_available():
+    import smdistributed.dataparallel.torch.distributed as sm_dist
+
 
 logger = logging.get_logger(__name__)
 
@@ -623,10 +626,8 @@ class TrainingArguments:
             device = xm.xla_device()
             self._n_gpu = 0
         elif is_sagemaker_distributed_available():
-            import smdistributed.dataparallel.torch.distributed as dist
-
-            dist.init_process_group()
-            self.local_rank = dist.get_local_rank()
+            sm_dist.init_process_group()
+            self.local_rank = sm_dist.get_local_rank()
             device = torch.device("cuda", self.local_rank)
             self._n_gpu = 1
         elif self.deepspeed:
@@ -716,6 +717,20 @@ class TrainingArguments:
             return ParallelMode.NOT_DISTRIBUTED
         else:
             return ParallelMode.NOT_PARALLEL
+
+    @property
+    @torch_required
+    def world_size(self):
+        """
+        The number of processes used in parallel.
+        """
+        if is_torch_tpu_available():
+            return xm.xrt_world_size()
+        elif is_sagemaker_distributed_available():
+            return sm_dist.get_world_size()
+        elif self.args.local_rank != -1:
+            return torch.distributed.get_world_size()
+        return 1
 
     @property
     def place_model_on_device(self):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -728,7 +728,7 @@ class TrainingArguments:
             return xm.xrt_world_size()
         elif is_sagemaker_distributed_available():
             return sm_dist.get_world_size()
-        elif self.args.local_rank != -1:
+        elif self.local_rank != -1:
             return torch.distributed.get_world_size()
         return 1
 


### PR DESCRIPTION
# What does this PR do?

This PR adds quite a few fixes to the `SageMakerTrainer` to make sure example scripts run fully. In particular it fixes:
- save made the training hanging forever
- predict didn't work
- evaluation required using `drop_last=True` which is not something anyone wants.

The goal is now to test a little bit more that functionality before merging the `SageMakerTrainer` into the main `Trainer` (otherwise one can't use model parallelism in seq2seq examples or QA example). The plan is to have them merged in the v4.5.0.