### PR TITLE
enable loading Mbart50Tokenizer with AutoTokenizer 

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -133,6 +133,7 @@ else:
     DebertaV2Tokenizer = None
     MarianTokenizer = None
     MBartTokenizer = None
+    MBart50Tokenizer = None
     MT5Tokenizer = None
     PegasusTokenizer = None
     ReformerTokenizer = None
@@ -192,6 +193,7 @@ else:
     LongformerTokenizerFast = None
     LxmertTokenizerFast = None
     MBartTokenizerFast = None
+    MBart50TokenizerFast = None
     MobileBertTokenizerFast = None
     MPNetTokenizerFast = None
     MT5TokenizerFast = None

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -116,6 +116,7 @@ if is_sentencepiece_available():
     from ..m2m_100 import M2M100Tokenizer
     from ..marian.tokenization_marian import MarianTokenizer
     from ..mbart.tokenization_mbart import MBartTokenizer
+    from ..mbart.tokenization_mbart50 import MBart50Tokenizer
     from ..mt5 import MT5Tokenizer
     from ..pegasus.tokenization_pegasus import PegasusTokenizer
     from ..reformer.tokenization_reformer import ReformerTokenizer
@@ -159,6 +160,7 @@ if is_tokenizers_available():
     from ..led.tokenization_led_fast import LEDTokenizerFast
     from ..longformer.tokenization_longformer_fast import LongformerTokenizerFast
     from ..lxmert.tokenization_lxmert_fast import LxmertTokenizerFast
+    from ..mbart.tokenization_mbart50_fast import MBart50TokenizerFast
     from ..mbart.tokenization_mbart_fast import MBartTokenizerFast
     from ..mobilebert.tokenization_mobilebert_fast import MobileBertTokenizerFast
     from ..mpnet.tokenization_mpnet_fast import MPNetTokenizerFast
@@ -268,6 +270,8 @@ NO_CONFIG_TOKENIZER = [
     PhobertTokenizer,
     BarthezTokenizer,
     BarthezTokenizerFast,
+    MBart50Tokenizer,
+    MBart50TokenizerFast,
 ]
 
 


### PR DESCRIPTION
# What does this PR do?


Currently `MBart50Tokenizer`, `MBart50TokenizerFast` can't be loaded using `AutoTokenizer` because they use the `MBartConfig` which is associated with `MBartTokenizer`. 

This PR enables loading `MBart50Tokenizer(Fast)` by adding them to the `NO_CONFIG_TOKENIZER` list. I've also added the `tokenizer_type` argument in the respective models' config file on the hub.

cc @Narsil 