### PR TITLE
Fix Wav2Vec2 classes imports

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -401,10 +401,13 @@ if is_torch_available():
     _import_structure["models.wav2vec2"].extend(
         [
             "WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST",
+            "Wav2Vec2CTCTokenizer",
+            "Wav2Vec2FeatureExtractor",
             "Wav2Vec2ForCTC",
             "Wav2Vec2ForMaskedLM",
             "Wav2Vec2Model",
             "Wav2Vec2PreTrainedModel",
+            "Wav2Vec2Processor",
         ]
     )
     _import_structure["models.m2m_100"].extend(
@@ -1931,10 +1934,13 @@ if TYPE_CHECKING:
         )
         from .models.wav2vec2 import (
             WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST,
+            Wav2Vec2CTCTokenizer,
+            Wav2Vec2FeatureExtractor,
             Wav2Vec2ForCTC,
             Wav2Vec2ForMaskedLM,
             Wav2Vec2Model,
             Wav2Vec2PreTrainedModel,
+            Wav2Vec2Processor,
         )
         from .models.xlm import (
             XLM_PRETRAINED_MODEL_ARCHIVE_LIST,

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -2385,6 +2385,20 @@ def load_tf_weights_in_transfo_xl(*args, **kwargs):
 WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST = None
 
 
+class Wav2Vec2CTCTokenizer:
+    def __init__(self, *args, **kwargs):
+        requires_pytorch(self)
+
+    @classmethod
+    def from_pretrained(self, *args, **kwargs):
+        requires_pytorch(self)
+
+
+class Wav2Vec2FeatureExtractor:
+    def __init__(self, *args, **kwargs):
+        requires_pytorch(self)
+
+
 class Wav2Vec2ForCTC:
     def __init__(self, *args, **kwargs):
         requires_pytorch(self)
@@ -2414,6 +2428,11 @@ class Wav2Vec2PreTrainedModel:
 
     @classmethod
     def from_pretrained(self, *args, **kwargs):
+        requires_pytorch(self)
+
+
+class Wav2Vec2Processor:
+    def __init__(self, *args, **kwargs):
         requires_pytorch(self)
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes imports for the following classes:

* Wav2Vec2CTCTokenizer
* Wav2Vec2FeatureExtractor
* Wav2Vec2Processor

In order to fine tune FB's Wav2Vec2 XLSR model, these classes need to be accessible. Importing using the instructions in the current [blog post](https://huggingface.co/blog/fine-tune-xlsr-wav2vec2) won't work, i.e. using `from transformers import Wav2Vec2CTCTokenizer` will fail. This PR fixes that.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@patrickvonplaten, I'd appreciate it if you could give this a look. Thanks!


