### PR TITLE
Fix backward compatibility with EvaluationStrategy

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -526,6 +526,8 @@ class TrainingArguments:
                 "using `EvaluationStrategy` for `evaluation_strategy` is deprecated and will be removed in version 5 of 🤗 Transformers. Use `IntervalStrategy` instead",
                 FutureWarning,
             )
+            # Go back to the underlying string or we won't be able to instantiate `IntervalStrategy` on it.
+            self.evaluation_strategy = self.evaluation_strategy.value
 
         self.evaluation_strategy = IntervalStrategy(self.evaluation_strategy)
         self.logging_strategy = IntervalStrategy(self.logging_strategy)


### PR DESCRIPTION
# What does this PR do?

As mentioned in #10666, the switch from `EvaluationStrategy` to `IntervalStrategy` is not fully backward compatible. This PR fixes that.