### PR TITLE
Add minimum version check in examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -64,7 +64,6 @@ To browse the examples corresponding to released versions of 🤗 Transformers, 
   - [v1.1.0](https://github.com/huggingface/transformers/tree/v1.1.0/examples)
   - [v1.0.0](https://github.com/huggingface/transformers/tree/v1.0.0/examples)
 </details>
-<br>
 
 Alternatively, you can find switch your cloned 🤗 Transformers to a specific version (for instance with v3.5.1) with
 ```bash

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,10 +33,44 @@ Then cd in the example folder of your choice and run
 pip install -r requirements.txt
 ```
 
-Alternatively, you can run the version of the examples as they were for your current version of Transformers via (for instance with v3.5.1):
+To browse the examples corresponding to released versions of 🤗 Transformers, click on the line below and then on your desired version of the library:
+
+<details>
+  <summary>Examples for older versions of 🤗 Transformers</summary>
+
+  - [v4.3.3](https://github.com/huggingface/transformers/tree/v4.3.3/examples)
+  - [v4.2.2](https://github.com/huggingface/transformers/tree/v4.2.2/examples)
+  - [v4.1.1](https://github.com/huggingface/transformers/tree/v4.1.1/examples)
+  - [v4.0.1](https://github.com/huggingface/transformers/tree/v4.0.1/examples)
+  - [v3.5.1](https://github.com/huggingface/transformers/tree/v3.5.1/examples)
+  - [v3.4.0](https://github.com/huggingface/transformers/tree/v3.4.0/examples)
+  - [v3.3.1](https://github.com/huggingface/transformers/tree/v3.3.1/examples)
+  - [v3.2.0](https://github.com/huggingface/transformers/tree/v3.2.0/examples)
+  - [v3.1.0](https://github.com/huggingface/transformers/tree/v3.1.0/examples)
+  - [v3.0.2](https://github.com/huggingface/transformers/tree/v3.0.2/examples)
+  - [v2.11.0](https://github.com/huggingface/transformers/tree/v2.11.0/examples)
+  - [v2.10.0](https://github.com/huggingface/transformers/tree/v2.10.0/examples)
+  - [v2.9.1](https://github.com/huggingface/transformers/tree/v2.9.1/examples)
+  - [v2.8.0](https://github.com/huggingface/transformers/tree/v2.8.0/examples)
+  - [v2.7.0](https://github.com/huggingface/transformers/tree/v2.7.0/examples)
+  - [v2.6.0](https://github.com/huggingface/transformers/tree/v2.6.0/examples)
+  - [v2.5.1](https://github.com/huggingface/transformers/tree/v2.5.1/examples)
+  - [v2.4.0](https://github.com/huggingface/transformers/tree/v2.4.0/examples)
+  - [v2.3.0](https://github.com/huggingface/transformers/tree/v2.3.0/examples)
+  - [v2.2.0](https://github.com/huggingface/transformers/tree/v2.2.0/examples)
+  - [v2.1.1](https://github.com/huggingface/transformers/tree/v2.1.0/examples)
+  - [v2.0.0](https://github.com/huggingface/transformers/tree/v2.0.0/examples)
+  - [v1.2.0](https://github.com/huggingface/transformers/tree/v1.2.0/examples)
+  - [v1.1.0](https://github.com/huggingface/transformers/tree/v1.1.0/examples)
+  - [v1.0.0](https://github.com/huggingface/transformers/tree/v1.0.0/examples)
+</details>
+<br>
+
+Alternatively, you can find switch your cloned 🤗 Transformers to a specific version (for instance with v3.5.1) with
 ```bash
 git checkout tags/v3.5.1
 ```
+and run the example command as usual afterward.
 
 ## The Big Table of Tasks
 
@@ -61,12 +95,6 @@ Coming soon!
 | [**`token-classification`**](https://github.com/huggingface/transformers/tree/master/examples/token-classification) | CoNLL NER       | ✅ | ✅ | ✅ | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/huggingface/notebooks/blob/master/examples/token_classification.ipynb)
 | [**`translation`**](https://github.com/huggingface/transformers/tree/master/examples/seq2seq)                       | WMT             | ✅  | - | - | -
 
-
-<!--
-## One-click Deploy to Cloud (wip)
-
-**Coming soon!**
--->
 
 ## Distributed training and mixed precision
 

--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -44,7 +44,10 @@ from transformers import (
     set_seed,
 )
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
+from transformers.utils import check_min_version
 
+
+check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)
 

--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -47,6 +47,7 @@ from transformers.trainer_utils import get_last_checkpoint, is_main_process
 from transformers.utils import check_min_version
 
 
+# Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)

--- a/examples/language-modeling/run_mlm.py
+++ b/examples/language-modeling/run_mlm.py
@@ -44,7 +44,10 @@ from transformers import (
     set_seed,
 )
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
+from transformers.utils import check_min_version
 
+
+check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)
 MODEL_CONFIG_CLASSES = list(MODEL_FOR_MASKED_LM_MAPPING.keys())

--- a/examples/language-modeling/run_mlm.py
+++ b/examples/language-modeling/run_mlm.py
@@ -47,6 +47,7 @@ from transformers.trainer_utils import get_last_checkpoint, is_main_process
 from transformers.utils import check_min_version
 
 
+# Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)

--- a/examples/language-modeling/run_plm.py
+++ b/examples/language-modeling/run_plm.py
@@ -43,6 +43,7 @@ from transformers.trainer_utils import get_last_checkpoint, is_main_process
 from transformers.utils import check_min_version
 
 
+# Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)

--- a/examples/language-modeling/run_plm.py
+++ b/examples/language-modeling/run_plm.py
@@ -40,7 +40,10 @@ from transformers import (
     set_seed,
 )
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
+from transformers.utils import check_min_version
 
+
+check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)
 

--- a/examples/multiple-choice/run_swag.py
+++ b/examples/multiple-choice/run_swag.py
@@ -42,7 +42,10 @@ from transformers import (
 from transformers.file_utils import PaddingStrategy
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
+from transformers.utils import check_min_version
 
+
+check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)
 

--- a/examples/multiple-choice/run_swag.py
+++ b/examples/multiple-choice/run_swag.py
@@ -45,6 +45,7 @@ from transformers.trainer_utils import get_last_checkpoint, is_main_process
 from transformers.utils import check_min_version
 
 
+# Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)

--- a/examples/question-answering/run_qa.py
+++ b/examples/question-answering/run_qa.py
@@ -45,6 +45,7 @@ from transformers.utils import check_min_version
 from utils_qa import postprocess_qa_predictions
 
 
+# Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)

--- a/examples/question-answering/run_qa.py
+++ b/examples/question-answering/run_qa.py
@@ -42,7 +42,10 @@ from transformers import (
 )
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
 from utils_qa import postprocess_qa_predictions
+from transformers.utils import check_min_version
 
+
+check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)
 

--- a/examples/question-answering/run_qa.py
+++ b/examples/question-answering/run_qa.py
@@ -41,8 +41,8 @@ from transformers import (
     set_seed,
 )
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
-from utils_qa import postprocess_qa_predictions
 from transformers.utils import check_min_version
+from utils_qa import postprocess_qa_predictions
 
 
 check_min_version("4.4.0.dev0")

--- a/examples/question-answering/run_qa_beam_search.py
+++ b/examples/question-answering/run_qa_beam_search.py
@@ -44,6 +44,7 @@ from transformers.utils import check_min_version
 from utils_qa import postprocess_qa_predictions_with_beam_search
 
 
+# Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)

--- a/examples/question-answering/run_qa_beam_search.py
+++ b/examples/question-answering/run_qa_beam_search.py
@@ -40,8 +40,8 @@ from transformers import (
     set_seed,
 )
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
-from utils_qa import postprocess_qa_predictions_with_beam_search
 from transformers.utils import check_min_version
+from utils_qa import postprocess_qa_predictions_with_beam_search
 
 
 check_min_version("4.4.0.dev0")

--- a/examples/question-answering/run_qa_beam_search.py
+++ b/examples/question-answering/run_qa_beam_search.py
@@ -41,7 +41,10 @@ from transformers import (
 )
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
 from utils_qa import postprocess_qa_predictions_with_beam_search
+from transformers.utils import check_min_version
 
+
+check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)
 

--- a/examples/seq2seq/run_summarization.py
+++ b/examples/seq2seq/run_summarization.py
@@ -46,6 +46,7 @@ from transformers.trainer_utils import get_last_checkpoint, is_main_process
 from transformers.utils import check_min_version
 
 
+# Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)

--- a/examples/seq2seq/run_summarization.py
+++ b/examples/seq2seq/run_summarization.py
@@ -43,7 +43,10 @@ from transformers import (
 )
 from transformers.file_utils import is_offline_mode
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
+from transformers.utils import check_min_version
 
+
+check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)
 

--- a/examples/seq2seq/run_translation.py
+++ b/examples/seq2seq/run_translation.py
@@ -42,7 +42,10 @@ from transformers import (
     set_seed,
 )
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
+from transformers.utils import check_min_version
 
+
+check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)
 

--- a/examples/seq2seq/run_translation.py
+++ b/examples/seq2seq/run_translation.py
@@ -45,6 +45,7 @@ from transformers.trainer_utils import get_last_checkpoint, is_main_process
 from transformers.utils import check_min_version
 
 
+# Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)

--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -25,6 +25,7 @@ from typing import Optional
 
 import numpy as np
 from datasets import load_dataset, load_metric
+from packaging import version
 
 import transformers
 from transformers import (
@@ -41,7 +42,10 @@ from transformers import (
     set_seed,
 )
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
+from transformers.utils import check_min_version
 
+
+check_min_version("4.4.0.dev0")
 
 task_to_keys = {
     "cola": ("sentence", None),

--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -25,7 +25,6 @@ from typing import Optional
 
 import numpy as np
 from datasets import load_dataset, load_metric
-from packaging import version
 
 import transformers
 from transformers import (

--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -44,6 +44,7 @@ from transformers.trainer_utils import get_last_checkpoint, is_main_process
 from transformers.utils import check_min_version
 
 
+# Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.4.0.dev0")
 
 task_to_keys = {

--- a/examples/text-classification/run_xnli.py
+++ b/examples/text-classification/run_xnli.py
@@ -41,7 +41,10 @@ from transformers import (
     set_seed,
 )
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
+from transformers.utils import check_min_version
 
+
+check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)
 

--- a/examples/text-classification/run_xnli.py
+++ b/examples/text-classification/run_xnli.py
@@ -44,6 +44,7 @@ from transformers.trainer_utils import get_last_checkpoint, is_main_process
 from transformers.utils import check_min_version
 
 
+# Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)

--- a/examples/token-classification/run_ner.py
+++ b/examples/token-classification/run_ner.py
@@ -41,7 +41,10 @@ from transformers import (
     set_seed,
 )
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
+from transformers.utils import check_min_version
 
+
+check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)
 

--- a/examples/token-classification/run_ner.py
+++ b/examples/token-classification/run_ner.py
@@ -44,6 +44,7 @@ from transformers.trainer_utils import get_last_checkpoint, is_main_process
 from transformers.utils import check_min_version
 
 
+# Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.4.0.dev0")
 
 logger = logging.getLogger(__name__)

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# coding=utf-8
+# Copyright 2021 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from packaging import version
+
+from .. import __version__
+
+def check_min_version(min_version):
+    if version.parse(__version__) < version.parse(min_version):
+        if "dev" in min_version:
+            error_message = (
+                "This example requires a source install from 🤗 Transformers (see "
+                "`https://huggingface.co/transformers/installation.html#installing-from-source`),"
+            )
+        else:
+            error_message = f"This example requires a minimum version of {min_version},"
+        error_message += f" but the version found is {__version__}.\n"
+        raise ImportError(
+            error_message
+            + (
+                "Check out https://huggingface.co/transformers/examples.html for the examples corresponding to other "
+                "versions of 🤗 Transformers."
+            )
+        )

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -18,6 +18,7 @@ from packaging import version
 
 from .. import __version__
 
+
 def check_min_version(min_version):
     if version.parse(__version__) < version.parse(min_version):
         if "dev" in min_version:


### PR DESCRIPTION
# What does this PR do?

This PR adds a minimum version check to all examples, in order to avoid the waves of issues created each time they use a functionality that was just released into `Trainer`. The script will immediately error if the version of Transformers does not match the required minimum version. At each release, a script will set that to the version released automatically (work in progress for a second PR with other release utils) so that the examples associated with one tag will require the minimum version of that tag.

The user can still remove that line to avoid the error (at their own risks). The error points out to:
- the instruction for a source install
- the examples README that now lists all examples folders with the various version tags.
