### PR TITLE
Rename zero-shot pipeline multi_class argument

### DIFF
--- a/examples/research_projects/zero-shot-distillation/distill_classifier.py
+++ b/examples/research_projects/zero-shot-distillation/distill_classifier.py
@@ -49,7 +49,7 @@ class TeacherModelArguments:
     teacher_batch_size: Optional[int] = field(
         default=32, metadata={"help": "Batch size for generating teacher predictions."}
     )
-    multi_class: Optional[bool] = field(
+    multi_label: Optional[bool] = field(
         default=False,
         metadata={
             "help": (
@@ -163,7 +163,7 @@ def get_teacher_predictions(
     hypothesis_template: str,
     batch_size: int,
     temperature: float,
-    multi_class: bool,
+    multi_label: bool,
     use_fast_tokenizer: bool,
     no_cuda: bool,
     fp16: bool,
@@ -203,7 +203,7 @@ def get_teacher_predictions(
     logits = torch.cat(logits, dim=0)  # N*K x 3
     nli_logits = logits.reshape(len(examples), len(class_names), -1)[..., [contr_id, entail_id]]  # N x K x 2
 
-    if multi_class:
+    if multi_label:
         # softmax over (contr, entail) logits for each class independently
         nli_prob = (nli_logits / temperature).softmax(-1)
     else:
@@ -285,7 +285,7 @@ def main():
         teacher_args.hypothesis_template,
         teacher_args.teacher_batch_size,
         teacher_args.temperature,
-        teacher_args.multi_class,
+        teacher_args.multi_label,
         data_args.use_fast_tokenizer,
         training_args.no_cuda,
         training_args.fp16,

--- a/tests/test_pipelines_zero_shot.py
+++ b/tests/test_pipelines_zero_shot.py
@@ -140,7 +140,7 @@ class ZeroShotClassificationPipelineTests(CustomInputPipelineCommonMixin, unitte
                 {
                     "sequences": "The dominant sequence transduction models are based on complex recurrent or convolutional neural networks in an encoder-decoder configuration. The best performing models also connect the encoder and decoder through an attention mechanism. We propose a new simple network architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence and convolutions entirely. Experiments on two machine translation tasks show these models to be superior in quality while being more parallelizable and requiring significantly less time to train. Our model achieves 28.4 BLEU on the WMT 2014 English-to-German translation task, improving over the existing best results, including ensembles by over 2 BLEU. On the WMT 2014 English-to-French translation task, our model establishes a new single-model state-of-the-art BLEU score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the training costs of the best models from the literature. We show that the Transformer generalizes well to other tasks by applying it successfully to English constituency parsing both with large and limited training data.",
                     "candidate_labels": ["machine learning", "statistics", "translation", "vision"],
-                    "multi_class": True,
+                    "multi_label": True,
                 },
             ]
 


### PR DESCRIPTION
Renames the `multi_class` argument to `multi_label` in the `ZeroShotClassificationPipeline` and adds a deprecation warning to the former. Typically, "multi-label classification" is used to refer to this type of classification (where each class is evaluated independently).

The name is changed in the zero-shot distillation script as well. Resolves #6668.