### PR TITLE
[DeepSpeed] improve checkpoint loading code plus tests

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -21,9 +21,11 @@ import numbers
 import os
 import re
 import tempfile
+from copy import deepcopy
 from pathlib import Path
 from types import SimpleNamespace
 
+from .file_utils import WEIGHTS_NAME
 from .utils import logging
 from .utils.versions import require_version
 
@@ -269,15 +271,20 @@ def rewrite_logs(d):
     return new_d
 
 
-def init_deepspeed(trainer, num_training_steps):
+def init_deepspeed(trainer, num_training_steps, resume_from_checkpoint=None):
     """
-    Init DeepSpeed, after converting any relevant Trainer's args into DeepSpeed configuration
+    Init DeepSpeed, after updating the DeepSpeed configuration with any relevant Trainer's args.
+
+    If ``resume_from_checkpoint`` was passed then an attempt to resume from a previously saved
+    checkpoint will be made.
 
     Args:
         trainer: Trainer object
         num_training_steps: per single gpu
+        resume_from_checkpoint: path to a checkpoint if to resume from after normal DeepSpeedEngine load
 
     Returns: model, optimizer, lr_scheduler
+
     """
     import deepspeed
 
@@ -288,7 +295,9 @@ def init_deepspeed(trainer, num_training_steps):
     model = trainer.model
 
     if isinstance(args.deepspeed, dict):
-        config = args.deepspeed
+        # Don't modify user's data should they want to reuse it (e.g. in tests), because once we
+        # modified it, it will not be accepted here again, since some config params must be not set by users
+        config = deepcopy(args.deepspeed)
     elif isinstance(args.deepspeed, str):
         with io.open(ds_config_file, "r", encoding="utf-8") as f:
             config = json.load(f)
@@ -446,6 +455,18 @@ def init_deepspeed(trainer, num_training_steps):
         optimizer=optimizer,
         lr_scheduler=lr_scheduler,
     )
+
+    print(resume_from_checkpoint)
+
+    if resume_from_checkpoint is not None: # and os.path.isdir(resume_from_checkpoint):
+        print(f"Attempting to resume from {resume_from_checkpoint}")
+        logger.info(f"Attempting to resume from {resume_from_checkpoint}")
+        # this magically updates self.optimizer and self.lr_scheduler
+        load_path, _ = model.load_checkpoint(
+            resume_from_checkpoint, load_optimizer_states=True, load_lr_scheduler_states=True
+        )
+        if load_path is None:
+            raise ValueError(f"[deepspeed] failed to resume from checkpoint {resume_from_checkpoint}")
 
     return model, optimizer, lr_scheduler
 

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -25,7 +25,6 @@ from copy import deepcopy
 from pathlib import Path
 from types import SimpleNamespace
 
-from .file_utils import WEIGHTS_NAME
 from .utils import logging
 from .utils.versions import require_version
 
@@ -275,8 +274,7 @@ def init_deepspeed(trainer, num_training_steps, resume_from_checkpoint=None):
     """
     Init DeepSpeed, after updating the DeepSpeed configuration with any relevant Trainer's args.
 
-    If ``resume_from_checkpoint`` was passed then an attempt to resume from a previously saved
-    checkpoint will be made.
+    If ``resume_from_checkpoint`` was passed then an attempt to resume from a previously saved checkpoint will be made.
 
     Args:
         trainer: Trainer object
@@ -458,7 +456,7 @@ def init_deepspeed(trainer, num_training_steps, resume_from_checkpoint=None):
 
     print(resume_from_checkpoint)
 
-    if resume_from_checkpoint is not None: # and os.path.isdir(resume_from_checkpoint):
+    if resume_from_checkpoint is not None:
         print(f"Attempting to resume from {resume_from_checkpoint}")
         logger.info(f"Attempting to resume from {resume_from_checkpoint}")
         # this magically updates self.optimizer and self.lr_scheduler

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -454,10 +454,7 @@ def init_deepspeed(trainer, num_training_steps, resume_from_checkpoint=None):
         lr_scheduler=lr_scheduler,
     )
 
-    print(resume_from_checkpoint)
-
-    if resume_from_checkpoint is not None:
-        print(f"Attempting to resume from {resume_from_checkpoint}")
+    if resume_from_checkpoint is not None:  # and os.path.isdir(resume_from_checkpoint):
         logger.info(f"Attempting to resume from {resume_from_checkpoint}")
         # this magically updates self.optimizer and self.lr_scheduler
         load_path, _ = model.load_checkpoint(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -878,7 +878,11 @@ class Trainer:
 
         if resume_from_checkpoint is not None and os.path.isfile(os.path.join(resume_from_checkpoint, WEIGHTS_NAME)):
             logger.info(f"Loading model from {resume_from_checkpoint}).")
-            if isinstance(self.model, PreTrainedModel):
+
+            if self.deepspeed:
+                # will be resumed in init_deepspeed
+                pass
+            elif isinstance(self.model, PreTrainedModel):
                 self.model = self.model.from_pretrained(resume_from_checkpoint)
                 model_reloaded = True
             else:
@@ -920,7 +924,9 @@ class Trainer:
 
         delay_optimizer_creation = self.sharded_ddp is not None and self.sharded_ddp != ShardedDDPOption.SIMPLE
         if self.args.deepspeed:
-            model, optimizer, lr_scheduler = init_deepspeed(self, num_training_steps=max_steps)
+            model, optimizer, lr_scheduler = init_deepspeed(
+                self, num_training_steps=max_steps, resume_from_checkpoint=resume_from_checkpoint
+            )
             self.model = model.module
             self.model_wrapped = model
             self.deepspeed = model  # DeepSpeedEngine object
@@ -1294,6 +1300,10 @@ class Trainer:
         if checkpoint is None:
             return
 
+        if self.deepspeed:
+            # deepspeed loads optimizer/lr_scheduler together with the model in init_deepspeed
+            return
+
         if os.path.isfile(os.path.join(checkpoint, "optimizer.pt")) and os.path.isfile(
             os.path.join(checkpoint, "scheduler.pt")
         ):
@@ -1317,10 +1327,6 @@ class Trainer:
                 with warnings.catch_warnings(record=True) as caught_warnings:
                     self.lr_scheduler.load_state_dict(torch.load(os.path.join(checkpoint, "scheduler.pt")))
                 reissue_pt_warnings(caught_warnings)
-
-        if self.deepspeed:
-            # Not sure how to check if there is a saved deepspeed checkpoint, but since it just return None if it fails to find a deepspeed checkpoint this is sort of a check-n-load function
-            self.deepspeed.load_checkpoint(checkpoint, load_optimizer_states=True, load_lr_scheduler_states=True)
 
     def hyperparameter_search(
         self,

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -24,6 +24,7 @@ import numpy as np
 from transformers import AutoTokenizer, IntervalStrategy, PretrainedConfig, TrainingArguments, is_torch_available
 from transformers.file_utils import WEIGHTS_NAME
 from transformers.testing_utils import (
+    TestCasePlus,
     get_tests_dir,
     require_datasets,
     require_optuna,
@@ -235,28 +236,7 @@ if is_torch_available():
         )
 
 
-@require_torch
-@require_sentencepiece
-@require_tokenizers
-class TrainerIntegrationTest(unittest.TestCase):
-    def setUp(self):
-        args = TrainingArguments(".")
-        self.n_epochs = args.num_train_epochs
-        self.batch_size = args.train_batch_size
-        trainer = get_regression_trainer(learning_rate=0.1)
-        trainer.train()
-        self.default_trained_model = (trainer.model.a, trainer.model.b)
-
-        trainer = get_regression_trainer(learning_rate=0.1, seed=314)
-        trainer.train()
-        self.alternate_trained_model = (trainer.model.a, trainer.model.b)
-
-    def check_trained_model(self, model, alternate_seed=False):
-        # Checks a training seeded with learning_rate = 0.1
-        (a, b) = self.alternate_trained_model if alternate_seed else self.default_trained_model
-        self.assertTrue(torch.allclose(model.a, a))
-        self.assertTrue(torch.allclose(model.b, b))
-
+class TrainerIntegrationCommon:
     def check_saved_checkpoints(self, output_dir, freq, total, is_pretrained=True):
         file_list = [WEIGHTS_NAME, "training_args.bin", "optimizer.pt", "scheduler.pt", "trainer_state.json"]
         if is_pretrained:
@@ -305,6 +285,30 @@ class TrainerIntegrationTest(unittest.TestCase):
             _ = log.pop("train_samples_per_second", None)
             _ = log1.pop("train_samples_per_second", None)
             self.assertEqual(log, log1)
+
+
+@require_torch
+@require_sentencepiece
+@require_tokenizers
+class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
+    def setUp(self):
+        super().setUp()
+        args = TrainingArguments(".")
+        self.n_epochs = args.num_train_epochs
+        self.batch_size = args.train_batch_size
+        trainer = get_regression_trainer(learning_rate=0.1)
+        trainer.train()
+        self.default_trained_model = (trainer.model.a, trainer.model.b)
+
+        trainer = get_regression_trainer(learning_rate=0.1, seed=314)
+        trainer.train()
+        self.alternate_trained_model = (trainer.model.a, trainer.model.b)
+
+    def check_trained_model(self, model, alternate_seed=False):
+        # Checks a training seeded with learning_rate = 0.1
+        (a, b) = self.alternate_trained_model if alternate_seed else self.default_trained_model
+        self.assertTrue(torch.allclose(model.a, a))
+        self.assertTrue(torch.allclose(model.b, b))
 
     def test_trainer_works_with_dict(self):
         # Edge case because Apex with mode O2 will change our models to return dicts. This test checks it doesn't break
@@ -607,6 +611,7 @@ class TrainerIntegrationTest(unittest.TestCase):
             # save_steps, the checkpoint will resume training at epoch 2 or more (so the data seen by the model
             # won't be the same since the training dataloader is shuffled).
             return
+
         with tempfile.TemporaryDirectory() as tmpdir:
             trainer = get_regression_trainer(output_dir=tmpdir, train_len=128, save_steps=5, learning_rate=0.1)
             trainer.train()


### PR DESCRIPTION
This PR further improves the DeepSpeed integration

* checkpoint resuming code has been cleaned up
* detailed checkpoint saving and resuming from checkpoint tests added
* a small reshuffle made in `test_trainer.py` to enable re-using helper functions in other test modules
* switched `test_trainer.py` to `TestCasePlus` so it's easier to deal with temp dirs during debug
* adjusted `init_deepspeed` to make a a deepcopy of the config dict passed to it, so that the user's copy isn't affected - needed at least for tests

Note that I made a failed attempt to load from resume point fatal under deepspeed. I'm not sure why the normal code just warns if a wrong path is passed. Unless I'm missing something, if a user expects to resume and it is not possible it should be fatal IMHO, so that they can correct their launching code.

@sgugger 