### PR TITLE
[doc] [testing] extend the pytest -k section with more examples

### DIFF
--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -159,8 +159,8 @@ To run only tests whose name contains ``adam``:
 
    pytest -k adam tests/test_optimization.py
 
-Logical ``and`` and ``or`` can be used to indicate whether all keywords should match or either. ``not`` can be 
-used to negate.
+Logical ``and`` and ``or`` can be used to indicate whether all keywords should match or either. ``not`` can be used to
+negate.
 
 To run all tests except those whose name contains ``adam``:
 
@@ -180,15 +180,15 @@ For example to run both ``test_adafactor`` and ``test_adam_w`` you can use:
 
    pytest -k "test_adam_w or test_adam_w" tests/test_optimization.py
 
-Note that we use ``or`` here, since we want either of the keywords to match to include both. 
+Note that we use ``or`` here, since we want either of the keywords to match to include both.
 
 If you want to include only tests that include both patterns, ``and`` is to be used:
 
 .. code-block:: bash
 
    pytest -k "test and ada" tests/test_optimization.py
-   
-   
+
+
 
 Run only modified tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -151,7 +151,6 @@ As mentioned earlier you can see what tests are contained inside the ``Optimizat
 
    pytest tests/test_optimization.py::OptimizationTest --collect-only -q
 
-
 You can run tests by keyword expressions.
 
 To run only tests whose name contains ``adam``:
@@ -159,6 +158,9 @@ To run only tests whose name contains ``adam``:
 .. code-block:: bash
 
    pytest -k adam tests/test_optimization.py
+
+Logical ``and`` and ``or`` can be used to indicate whether all keywords should match or either. ``not`` can be 
+used to negate.
 
 To run all tests except those whose name contains ``adam``:
 
@@ -168,12 +170,25 @@ To run all tests except those whose name contains ``adam``:
 
 And you can combine the two patterns in one:
 
-
 .. code-block:: bash
 
    pytest -k "ada and not adam" tests/test_optimization.py
 
+For example to run both ``test_adafactor`` and ``test_adam_w`` you can use:
 
+.. code-block:: bash
+
+   pytest -k "test_adam_w or test_adam_w" tests/test_optimization.py
+
+Note that we use ``or`` here, since we want either of the keywords to match to include both. 
+
+If you want to include only tests that include both patterns, ``and`` is to be used:
+
+.. code-block:: bash
+
+   pytest -k "test and ada" tests/test_optimization.py
+   
+   
 
 Run only modified tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR adds more examples on using `pytest -k` - I always forget that I want to use `-k A OR B` when I want several tests - I keep trying AND and it doesn't match any.

@sgugger 