### PR TITLE
[trainer] make failure to find a resume checkpoint fatal + tests

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -876,7 +876,10 @@ class Trainer:
             if resume_from_checkpoint is None:
                 raise ValueError(f"No valid checkpoint found in output directory ({self.args.output_dir})")
 
-        if resume_from_checkpoint is not None and os.path.isfile(os.path.join(resume_from_checkpoint, WEIGHTS_NAME)):
+        if resume_from_checkpoint is not None:
+            if not os.path.isfile(os.path.join(resume_from_checkpoint, WEIGHTS_NAME)):
+                raise ValueError(f"Can't find a valid checkpoint at {resume_from_checkpoint}")
+
             logger.info(f"Loading model from {resume_from_checkpoint}).")
 
             if self.deepspeed:


### PR DESCRIPTION
As a follow up to https://github.com/huggingface/transformers/pull/10760 this PR:
- makes a failure to find a valid checkpoint to resume from fatal - when an explicit `resume_from_checkpoint` was passed 
- extends `test_can_resume_training` to validate this change and also the boolean `resume_from_checkpoint` case.
- adds a small `test_can_resume_training` refactoring - so it's easy to see they are the same args on each invocation.

@sgugger 