### PR TITLE
Improve the speed of adding tokens from added_tokens.json

### DIFF
--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -101,8 +101,8 @@ def _is_start_of_word(text):
 
 
 def _insert_one_token_to_ordered_list(token_list: List[str], new_token: str):
-    """Inserts one token to an ordered list if it does not already exist.
-       Note: token_list must be sorted.
+    """
+    Inserts one token to an ordered list if it does not already exist. Note: token_list must be sorted.
     """
     insertion_idx = bisect.bisect_left(token_list, new_token)
     # Checks if new_token is already in the ordered token_list

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -16,6 +16,7 @@
  Tokenization classes for python tokenizers. For fast tokenizers (provided by HuggingFace's tokenizers library) see
  tokenization_utils_fast.py
 """
+import bisect
 import itertools
 import re
 import unicodedata
@@ -97,6 +98,19 @@ def _is_start_of_word(text):
     """Checks whether the first character in text is one of a punctuation, control or whitespace character."""
     first_char = text[0]
     return bool(_is_control(first_char) | _is_punctuation(first_char) | _is_whitespace(first_char))
+
+
+def _insert_one_token_to_ordered_list(token_list: List[str], new_token: str):
+    """Inserts one token to an ordered list if it does not already exist.
+       Note: token_list must be sorted.
+    """
+    insertion_idx = bisect.bisect_left(token_list, new_token)
+    # Checks if new_token is already in the ordered token_list
+    if insertion_idx < len(token_list) and token_list[insertion_idx] == new_token:
+        # new_token is in token_list, don't add
+        return
+    else:
+        token_list.insert(insertion_idx, new_token)
 
 
 @add_end_docstrings(INIT_TOKENIZER_DOCSTRING)
@@ -199,10 +213,16 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
 
         # Make sure we don't split on any special tokens (even they were already in the vocab before e.g. for Albert)
         if special_tokens:
-            self.unique_no_split_tokens = sorted(set(self.unique_no_split_tokens).union(set(new_tokens)))
+            if len(new_tokens) == 1:
+                _insert_one_token_to_ordered_list(self.unique_no_split_tokens, new_tokens[0])
+            else:
+                self.unique_no_split_tokens = sorted(set(self.unique_no_split_tokens).union(set(new_tokens)))
         else:
             # Or on the newly added tokens
-            self.unique_no_split_tokens = sorted(set(self.unique_no_split_tokens).union(set(tokens_to_add)))
+            if len(tokens_to_add) == 1:
+                _insert_one_token_to_ordered_list(self.unique_no_split_tokens, tokens_to_add[0])
+            else:
+                self.unique_no_split_tokens = sorted(set(self.unique_no_split_tokens).union(set(tokens_to_add)))
 
         return len(tokens_to_add)
 


### PR DESCRIPTION
# What does this PR do?

This PR significantly improves the speed of adding tokens from `added_tokens.json`, when it contains a large number of tokens (e.g., 20,000+). When adding one token at a time, it uses `bisect` to insert the token into `PreTrainedTokenizer.unique_no_split_tokens`. Please see a detailed description and motivation in this issue: https://github.com/huggingface/transformers/issues/10676

This change relies on the requirement that `unique_no_split_tokens` is sorted. (I'm not sure if this is a fair assumption, otherwise I can check if it's already sorted before the insertion.)

Fixes #10676


## Benchmark
MacOS Mojave (CPU: 2.6 GHz Intel Core i7)
python==3.7.9
torch==1.7.1+cpu
transformers==3.5.1 or transformers==4.4.2 (similar results)

```python
import json
from timeit import default_timer as timer
from transformers import DistilBertTokenizer

model_dir = '/home/username/saved_model'

# Load a pretrained model's tokenizer, save it to {model_dir}
tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-uncased')
tokenizer.save_pretrained(model_dir)
print('len(tokenizer) of a pretrained model distilbert-base-uncased:', len(tokenizer))

# Generate n values as token suffix, to randomize the insertion position of added tokens
low = 30522
high = 82181   # exclusive
random_suffix = list(range(low, high))
random.shuffle(random_suffix)

# Save the n new tokens with correct indices to added_tokens.json
added_tokens = {f'addedtoken{val}': low + idx for idx, val in enumerate(random_suffix)}
with open(f'{model_dir}/added_tokens.json', 'w') as f:
    json.dump(added_tokens, f)
print(f'saved {len(added_tokens)} tokens to added_tokens.json')

# Load the tokenizer from {model_dir}, and print the elapsed time
start = timer()
tokenizer = DistilBertTokenizer.from_pretrained(model_dir)
print('len(tokenizer) after loading from saved model:', len(tokenizer))
end = timer()
print('Elapsed (seconds):', round(end - start, 3))

# Make sure tokenizer.unique_no_split_tokens remains sorted
all_values = tokenizer.unique_no_split_tokens
assert all(all_values[i+1] > all_values[i] for i in range(len(all_values) - 1))
```

**If we save 21659 tokens in added_tokens.json**, output before the change:
```bash
len(tokenizer) of a pretrained model distilbert-base-uncased: 30522
saved 21659 tokens to added_tokens.json
len(tokenizer) after loading from saved model: 52181
*** Elapsed (seconds): 76.95
```

output after the change:
```bash
len(tokenizer) of a pretrained model distilbert-base-uncased: 30522
saved 21659 tokens to added_tokens.json
len(tokenizer) after loading from saved model: 52181
*** Elapsed (seconds): 0.308
```

**If we save 51659 tokens in added_tokens.json**, output before the change:
```bash
len(tokenizer) of a pretrained model distilbert-base-uncased: 30522
saved 51659 tokens to added_tokens.json
len(tokenizer) after loading from saved model: 82181
*** Elapsed (seconds): 527.795
```

output after the change:
```bash
len(tokenizer) of a pretrained model distilbert-base-uncased: 30522
saved 51659 tokens to added_tokens.json
len(tokenizer) after loading from saved model: 82181
*** Elapsed (seconds): 0.83
```

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

## Who can review?

@lhoestq @LysandreJik 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- nlp datasets: [different repo](https://github.com/huggingface/nlp)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
