### PR TITLE
[Flax] Add general conversion script

### DIFF
--- a/src/transformers/modeling_flax_pytorch_utils.py
+++ b/src/transformers/modeling_flax_pytorch_utils.py
@@ -48,7 +48,7 @@ def load_pytorch_checkpoint_in_flax_state_dict(flax_model, pytorch_checkpoint_pa
     logger.info("Loading PyTorch weights from {}".format(pt_path))
 
     pt_state_dict = torch.load(pt_path, map_location="cpu")
-    logger.info("PyTorch checkpoint contains {:,} parameters".format(sum(t.numel() for t in pt_state_dict.values())))
+    logger.info("PyTorch checkpoint contains {sum(t.numel() for t in pt_state_dict.values())):,} parameters."
 
     flax_state_dict = convert_pytorch_state_dict_to_flax(pt_state_dict, flax_model)
 

--- a/src/transformers/modeling_flax_pytorch_utils.py
+++ b/src/transformers/modeling_flax_pytorch_utils.py
@@ -1,0 +1,485 @@
+# coding=utf-8
+# Copyright 2018 The Google AI Language Team Authors and The HuggingFace Inc. team.
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" PyTorch - TF 2.0 general utilities."""
+
+
+import os
+import re
+
+import numpy
+
+from .utils import logging
+
+
+logger = logging.get_logger(__name__)
+
+#def convert_state_dict_from_pt(model_class, state: Dict, config: PretrainedConfig):
+#    """
+#    Converts a PyTorch parameter state dict to an equivalent Flax parameter state dict
+#    """
+#    state = {k: v.numpy() for k, v in state.items()}
+#    state = model_class.convert_from_pytorch(state, config)
+#    state = unflatten_dict({tuple(k.split(".")): v for k, v in state.items()})
+#    return state
+
+
+def convert_tf_weight_name_to_pt_weight_name(tf_name, start_prefix_to_remove=""):
+    """
+    Convert a TF 2.0 model variable name in a pytorch model weight name.
+
+    Conventions for TF2.0 scopes -> PyTorch attribute names conversions:
+
+        - '$1___$2' is replaced by $2 (can be used to duplicate or remove layers in TF2.0 vs PyTorch)
+        - '_._' is replaced by a new level separation (can be used to convert TF2.0 lists in PyTorch nn.ModulesList)
+
+    return tuple with:
+
+        - pytorch model weight name
+        - transpose: boolean indicating whether TF2.0 and PyTorch weights matrices are transposed with regards to each
+          other
+    """
+    tf_name = tf_name.replace(":0", "")  # device ids
+    tf_name = re.sub(
+        r"/[^/]*___([^/]*)/", r"/\1/", tf_name
+    )  # '$1___$2' is replaced by $2 (can be used to duplicate or remove layers in TF2.0 vs PyTorch)
+    tf_name = tf_name.replace(
+        "_._", "/"
+    )  # '_._' is replaced by a level separation (can be used to convert TF2.0 lists in PyTorch nn.ModulesList)
+    tf_name = re.sub(r"//+", "/", tf_name)  # Remove empty levels at the end
+    tf_name = tf_name.split("/")  # Convert from TF2.0 '/' separators to PyTorch '.' separators
+    # Some weights have a single name withtout "/" such as final_logits_bias in BART
+    if len(tf_name) > 1:
+        tf_name = tf_name[1:]  # Remove level zero
+
+    # When should we transpose the weights
+    transpose = bool(
+        tf_name[-1] in ["kernel", "pointwise_kernel", "depthwise_kernel"]
+        or "emb_projs" in tf_name
+        or "out_projs" in tf_name
+    )
+
+    # Convert standard TF2.0 names in PyTorch names
+    if tf_name[-1] == "kernel" or tf_name[-1] == "embeddings" or tf_name[-1] == "gamma":
+        tf_name[-1] = "weight"
+    if tf_name[-1] == "beta":
+        tf_name[-1] = "bias"
+
+    # The SeparableConv1D TF layer contains two weights that are translated to PyTorch Conv1D here
+    if tf_name[-1] == "pointwise_kernel" or tf_name[-1] == "depthwise_kernel":
+        tf_name[-1] = tf_name[-1].replace("_kernel", ".weight")
+
+    # Remove prefix if needed
+    tf_name = ".".join(tf_name)
+    if start_prefix_to_remove:
+        tf_name = tf_name.replace(start_prefix_to_remove, "", 1)
+
+    return tf_name, transpose
+
+
+#####################
+# PyTorch => Flax #
+#####################
+
+
+def load_pytorch_checkpoint_in_flax_state_dict(flax_model, pytorch_checkpoint_path, allow_missing_keys=False):
+    """Load pytorch checkpoints in a flax model"""
+    try:
+        import flax  # noqa: F401
+        import torch  # noqa: F401
+    except ImportError:
+        logger.error(
+            "Loading a PyTorch model in Flax, requires both PyTorch and  Flax to be installed. Please see "
+            "https://pytorch.org/ and https://flax.readthedocs.io/en/latest/installation.html for installation instructions."
+        )
+        raise
+
+    pt_path = os.path.abspath(pytorch_checkpoint_path)
+    logger.info("Loading PyTorch weights from {}".format(pt_path))
+
+    pt_state_dict = torch.load(pt_path, map_location="cpu")
+    logger.info("PyTorch checkpoint contains {:,} parameters".format(sum(t.numel() for t in pt_state_dict.values())))
+
+    flax_state_dict = convert_pytorch_state_dict_to_flax(pt_state_dict, flax_model)
+
+    return flax_state_dict
+
+
+def convert_pytorch_state_dict_to_flax(pt_state_dict, flax_model):
+
+    # convert pytorch tensor to numpy
+    pt_state_dict = {k: v.numpy() for k, v in pt_state_dict.items()}
+    import ipdb; ipdb.set_trace()
+
+    # Need to change some parameters name to match Flax names so that we don't have to fork any layer
+    for key, tensor in pt_state.items():
+        # Key parts
+        key_parts = set(key.split("."))
+
+        # Every dense layer has "kernel" parameters instead of "weight"
+        if "dense.weight" in key:
+            del jax_state[key]
+            key = key.replace("weight", "kernel")
+            jax_state[key] = tensor
+
+        if "decoder.weight" in key:
+            del jax_state[key]
+            key = key.replace("weight", "kernel")
+            jax_state[key] = tensor.T
+
+        # SelfAttention needs also to replace "weight" by "kernel"
+        if {"query", "key", "value"} & key_parts:
+
+            # Flax SelfAttention decomposes the heads (num_head, size // num_heads)
+            if "bias" in key:
+                jax_state[key] = tensor.reshape((config.num_attention_heads, -1))
+            elif "weight":
+                del jax_state[key]
+                key = key.replace("weight", "kernel")
+                tensor = tensor.reshape((config.num_attention_heads, -1, config.hidden_size)).transpose((2, 0, 1))
+                jax_state[key] = tensor
+
+        # SelfAttention output is not a separate layer, remove one nesting
+        if "attention.output.dense" in key:
+            del jax_state[key]
+            key = key.replace("attention.output.dense", "attention.self.out")
+            jax_state[key] = tensor
+
+        # SelfAttention output is not a separate layer, remove nesting on layer norm
+        if "attention.output.LayerNorm" in key:
+            del jax_state[key]
+            key = key.replace("attention.output.LayerNorm", "attention.LayerNorm")
+            jax_state[key] = tensor
+
+        # There are some transposed parameters w.r.t their PyTorch counterpart
+        if "intermediate.dense.kernel" in key or "output.dense.kernel" in key or "transform.dense.kernel" in key:
+            jax_state[key] = tensor.T
+
+        # Self Attention output projection needs to be transposed
+        if "out.kernel" in key:
+            jax_state[key] = tensor.reshape((config.hidden_size, config.num_attention_heads, -1)).transpose(
+                1, 2, 0
+            )
+
+        # Pooler needs to transpose its kernel
+        if "pooler.dense.kernel" in key:
+            jax_state[key] = tensor.T
+
+        # Hack to correctly load some pytorch models
+        if "predictions.bias" in key:
+            del jax_state[key]
+            jax_state[".".join(key.split(".")[:2]) + ".decoder.bias"] = tensor
+
+        # Handle LayerNorm conversion
+        if "LayerNorm" in key:
+            del jax_state[key]
+
+            # Replace LayerNorm by layer_norm
+            new_key = key.replace("LayerNorm", "layer_norm")
+
+            if "weight" in key:
+                new_key = new_key.replace("weight", "gamma")
+            elif "bias" in key:
+                new_key = new_key.replace("bias", "beta")
+
+            jax_state[new_key] = tensor
+
+
+    flax_state_dict = unflatten_dict({tuple(k.split(".")): v for k, v in flax_state_dict.items()})
+
+    return flax_state_dict
+
+
+
+
+
+
+    if tf_inputs is None:
+        tf_inputs = flax_model.dummy_inputs
+
+    if tf_inputs is not None:
+        flax_model(tf_inputs, training=False)  # Make sure model is built
+
+    # Adapt state dict - TODO remove this and update the AWS weights files instead
+    # Convert old format to new format if needed from a PyTorch state_dict
+    old_keys = []
+    new_keys = []
+    for key in pt_state_dict.keys():
+        new_key = None
+        if "gamma" in key:
+            new_key = key.replace("gamma", "weight")
+        if "beta" in key:
+            new_key = key.replace("beta", "bias")
+        if new_key:
+            old_keys.append(key)
+            new_keys.append(new_key)
+    for old_key, new_key in zip(old_keys, new_keys):
+        pt_state_dict[new_key] = pt_state_dict.pop(old_key)
+
+    # Make sure we are able to load PyTorch base models as well as derived models (with heads)
+    # TF models always have a prefix, some of PyTorch models (base ones) don't
+    start_prefix_to_remove = ""
+    if not any(s.startswith(flax_model.base_model_prefix) for s in pt_state_dict.keys()):
+        start_prefix_to_remove = flax_model.base_model_prefix + "."
+
+    symbolic_weights = flax_model.trainable_weights + flax_model.non_trainable_weights
+    tf_loaded_numel = 0
+    weight_value_tuples = []
+    all_pytorch_weights = set(list(pt_state_dict.keys()))
+    missing_keys = []
+    for symbolic_weight in symbolic_weights:
+        sw_name = symbolic_weight.name
+        name, transpose = convert_tf_weight_name_to_pt_weight_name(
+            sw_name, start_prefix_to_remove=start_prefix_to_remove
+        )
+
+        # Find associated numpy array in pytorch model state dict
+        if name not in pt_state_dict:
+            if allow_missing_keys:
+                missing_keys.append(name)
+                continue
+            elif flax_model._keys_to_ignore_on_load_missing is not None:
+                # authorized missing keys don't have to be loaded
+                if any(re.search(pat, name) is not None for pat in flax_model._keys_to_ignore_on_load_missing):
+                    continue
+
+            raise AttributeError("{} not found in PyTorch model".format(name))
+
+        array = pt_state_dict[name].numpy()
+
+        if transpose:
+            array = numpy.transpose(array)
+
+        if len(symbolic_weight.shape) < len(array.shape):
+            array = numpy.squeeze(array)
+        elif len(symbolic_weight.shape) > len(array.shape):
+            array = numpy.expand_dims(array, axis=0)
+
+        if list(symbolic_weight.shape) != list(array.shape):
+            try:
+                array = numpy.reshape(array, symbolic_weight.shape)
+            except AssertionError as e:
+                e.args += (symbolic_weight.shape, array.shape)
+                raise e
+
+        try:
+            assert list(symbolic_weight.shape) == list(array.shape)
+        except AssertionError as e:
+            e.args += (symbolic_weight.shape, array.shape)
+            raise e
+
+        tf_loaded_numel += array.size
+        # logger.warning("Initialize TF weight {}".format(symbolic_weight.name))
+
+        weight_value_tuples.append((symbolic_weight, array))
+        all_pytorch_weights.discard(name)
+
+    K.batch_set_value(weight_value_tuples)
+
+    if tf_inputs is not None:
+        flax_model(tf_inputs, training=False)  # Make sure restore ops are run
+
+    logger.info("Loaded {:,} parameters in the TF 2.0 model.".format(tf_loaded_numel))
+
+    unexpected_keys = list(all_pytorch_weights)
+
+    if flax_model._keys_to_ignore_on_load_missing is not None:
+        for pat in flax_model._keys_to_ignore_on_load_missing:
+            missing_keys = [k for k in missing_keys if re.search(pat, k) is None]
+    if flax_model._keys_to_ignore_on_load_unexpected is not None:
+        for pat in flax_model._keys_to_ignore_on_load_unexpected:
+            unexpected_keys = [k for k in unexpected_keys if re.search(pat, k) is None]
+
+    if len(unexpected_keys) > 0:
+        logger.warning(
+            f"Some weights of the PyTorch model were not used when "
+            f"initializing the TF 2.0 model {flax_model.__class__.__name__}: {unexpected_keys}\n"
+            f"- This IS expected if you are initializing {flax_model.__class__.__name__} from a PyTorch model trained on another task "
+            f"or with another architecture (e.g. initializing a TFBertForSequenceClassification model from a BertForPreTraining model).\n"
+            f"- This IS NOT expected if you are initializing {flax_model.__class__.__name__} from a PyTorch model that you expect "
+            f"to be exactly identical (e.g. initializing a TFBertForSequenceClassification model from a BertForSequenceClassification model)."
+        )
+    else:
+        logger.warning(f"All PyTorch model weights were used when initializing {flax_model.__class__.__name__}.\n")
+    if len(missing_keys) > 0:
+        logger.warning(
+            f"Some weights or buffers of the TF 2.0 model {flax_model.__class__.__name__} were not initialized from the PyTorch model "
+            f"and are newly initialized: {missing_keys}\n"
+            f"You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference."
+        )
+    else:
+        logger.warning(
+            f"All the weights of {flax_model.__class__.__name__} were initialized from the PyTorch model.\n"
+            f"If your task is similar to the task the model of the checkpoint was trained on, "
+            f"you can already use {flax_model.__class__.__name__} for predictions without further training."
+        )
+
+    return flax_model
+
+
+#####################
+# TF 2.0 => PyTorch #
+#####################
+
+
+def load_tf2_checkpoint_in_pytorch_model(pt_model, tf_checkpoint_path, tf_inputs=None, allow_missing_keys=False):
+    """
+    Load TF 2.0 HDF5 checkpoint in a PyTorch model We use HDF5 to easily do transfer learning (see
+    https://github.com/tensorflow/tensorflow/blob/ee16fcac960ae660e0e4496658a366e2f745e1f0/tensorflow/python/keras/engine/network.py#L1352-L1357).
+    """
+    try:
+        import tensorflow as tf  # noqa: F401
+        import torch  # noqa: F401
+    except ImportError:
+        logger.error(
+            "Loading a TensorFlow model in PyTorch, requires both PyTorch and TensorFlow to be installed. Please see "
+            "https://pytorch.org/ and https://www.tensorflow.org/install/ for installation instructions."
+        )
+        raise
+
+    import transformers
+
+    from .modeling_tf_utils import load_tf_weights
+
+    logger.info("Loading TensorFlow weights from {}".format(tf_checkpoint_path))
+
+    # Instantiate and load the associated TF 2.0 model
+    flax_model_class_name = "TF" + pt_model.__class__.__name__  # Add "TF" at the beginning
+    flax_model_class = getattr(transformers, flax_model_class_name)
+    flax_model = flax_model_class(pt_model.config)
+
+    if tf_inputs is None:
+        tf_inputs = flax_model.dummy_inputs
+
+    if tf_inputs is not None:
+        flax_model(tf_inputs, training=False)  # Make sure model is built
+
+    load_tf_weights(flax_model, tf_checkpoint_path)
+
+    return load_flax_model_in_pytorch_model(pt_model, flax_model, allow_missing_keys=allow_missing_keys)
+
+
+def load_flax_model_in_pytorch_model(pt_model, flax_model, allow_missing_keys=False):
+    """Load TF 2.0 model in a pytorch model"""
+    weights = flax_model.weights
+
+    return load_tf2_weights_in_pytorch_model(pt_model, weights, allow_missing_keys=allow_missing_keys)
+
+
+def load_tf2_weights_in_pytorch_model(pt_model, tf_weights, allow_missing_keys=False):
+    """Load TF2.0 symbolic weights in a PyTorch model"""
+    try:
+        import tensorflow as tf  # noqa: F401
+        import torch  # noqa: F401
+    except ImportError:
+        logger.error(
+            "Loading a TensorFlow model in PyTorch, requires both PyTorch and TensorFlow to be installed. Please see "
+            "https://pytorch.org/ and https://www.tensorflow.org/install/ for installation instructions."
+        )
+        raise
+
+    new_pt_params_dict = {}
+    current_pt_params_dict = dict(pt_model.named_parameters())
+
+    # Make sure we are able to load PyTorch base models as well as derived models (with heads)
+    # TF models always have a prefix, some of PyTorch models (base ones) don't
+    start_prefix_to_remove = ""
+    if not any(s.startswith(pt_model.base_model_prefix) for s in current_pt_params_dict.keys()):
+        start_prefix_to_remove = pt_model.base_model_prefix + "."
+
+    # Build a map from potential PyTorch weight names to TF 2.0 Variables
+    tf_weights_map = {}
+    for tf_weight in tf_weights:
+        pt_name, transpose = convert_tf_weight_name_to_pt_weight_name(
+            tf_weight.name, start_prefix_to_remove=start_prefix_to_remove
+        )
+        tf_weights_map[pt_name] = (tf_weight.numpy(), transpose)
+
+    all_tf_weights = set(list(tf_weights_map.keys()))
+    loaded_pt_weights_data_ptr = {}
+    missing_keys_pt = []
+    for pt_weight_name, pt_weight in current_pt_params_dict.items():
+        # Handle PyTorch shared weight ()not duplicated in TF 2.0
+        if pt_weight.data_ptr() in loaded_pt_weights_data_ptr:
+            new_pt_params_dict[pt_weight_name] = loaded_pt_weights_data_ptr[pt_weight.data_ptr()]
+            continue
+
+        # Find associated numpy array in pytorch model state dict
+        if pt_weight_name not in tf_weights_map:
+            if allow_missing_keys:
+                missing_keys_pt.append(pt_weight_name)
+                continue
+
+            raise AttributeError("{} not found in TF 2.0 model".format(pt_weight_name))
+
+        array, transpose = tf_weights_map[pt_weight_name]
+
+        if transpose:
+            array = numpy.transpose(array)
+
+        if len(pt_weight.shape) < len(array.shape):
+            array = numpy.squeeze(array)
+        elif len(pt_weight.shape) > len(array.shape):
+            array = numpy.expand_dims(array, axis=0)
+
+        if list(pt_weight.shape) != list(array.shape):
+            try:
+                array = numpy.reshape(array, pt_weight.shape)
+            except AssertionError as e:
+                e.args += (pt_weight.shape, array.shape)
+                raise e
+
+        try:
+            assert list(pt_weight.shape) == list(array.shape)
+        except AssertionError as e:
+            e.args += (pt_weight.shape, array.shape)
+            raise e
+
+        # logger.warning("Initialize PyTorch weight {}".format(pt_weight_name))
+
+        new_pt_params_dict[pt_weight_name] = torch.from_numpy(array)
+        loaded_pt_weights_data_ptr[pt_weight.data_ptr()] = torch.from_numpy(array)
+        all_tf_weights.discard(pt_weight_name)
+
+    missing_keys, unexpected_keys = pt_model.load_state_dict(new_pt_params_dict, strict=False)
+    missing_keys += missing_keys_pt
+
+    if len(unexpected_keys) > 0:
+        logger.warning(
+            f"Some weights of the TF 2.0 model were not used when "
+            f"initializing the PyTorch model {pt_model.__class__.__name__}: {unexpected_keys}\n"
+            f"- This IS expected if you are initializing {pt_model.__class__.__name__} from a TF 2.0 model trained on another task "
+            f"or with another architecture (e.g. initializing a BertForSequenceClassification model from a TFBertForPreTraining model).\n"
+            f"- This IS NOT expected if you are initializing {pt_model.__class__.__name__} from a TF 2.0 model that you expect "
+            f"to be exactly identical (e.g. initializing a BertForSequenceClassification model from a TFBertForSequenceClassification model)."
+        )
+    else:
+        logger.warning(f"All TF 2.0 model weights were used when initializing {pt_model.__class__.__name__}.\n")
+    if len(missing_keys) > 0:
+        logger.warning(
+            f"Some weights of {pt_model.__class__.__name__} were not initialized from the TF 2.0 model "
+            f"and are newly initialized: {missing_keys}\n"
+            f"You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference."
+        )
+    else:
+        logger.warning(
+            f"All the weights of {pt_model.__class__.__name__} were initialized from the TF 2.0 model.\n"
+            f"If your task is similar to the task the model of the checkpoint was trained on, "
+            f"you can already use {pt_model.__class__.__name__} for predictions without further training."
+        )
+
+    logger.info("Weights or buffers not loaded from TF 2.0 model: {}".format(all_tf_weights))
+
+    return pt_model

--- a/src/transformers/modeling_flax_pytorch_utils.py
+++ b/src/transformers/modeling_flax_pytorch_utils.py
@@ -1,6 +1,5 @@
 # coding=utf-8
-# Copyright 2018 The Google AI Language Team Authors and The HuggingFace Inc. team.
-# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+# Copyright 2021 The HuggingFace Inc. team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/transformers/modeling_flax_pytorch_utils.py
+++ b/src/transformers/modeling_flax_pytorch_utils.py
@@ -17,76 +17,14 @@
 
 
 import os
-import re
 
-import numpy
+from flax.core.frozen_dict import unfreeze
+from flax.traverse_util import flatten_dict, unflatten_dict
 
 from .utils import logging
 
 
 logger = logging.get_logger(__name__)
-
-#def convert_state_dict_from_pt(model_class, state: Dict, config: PretrainedConfig):
-#    """
-#    Converts a PyTorch parameter state dict to an equivalent Flax parameter state dict
-#    """
-#    state = {k: v.numpy() for k, v in state.items()}
-#    state = model_class.convert_from_pytorch(state, config)
-#    state = unflatten_dict({tuple(k.split(".")): v for k, v in state.items()})
-#    return state
-
-
-def convert_tf_weight_name_to_pt_weight_name(tf_name, start_prefix_to_remove=""):
-    """
-    Convert a TF 2.0 model variable name in a pytorch model weight name.
-
-    Conventions for TF2.0 scopes -> PyTorch attribute names conversions:
-
-        - '$1___$2' is replaced by $2 (can be used to duplicate or remove layers in TF2.0 vs PyTorch)
-        - '_._' is replaced by a new level separation (can be used to convert TF2.0 lists in PyTorch nn.ModulesList)
-
-    return tuple with:
-
-        - pytorch model weight name
-        - transpose: boolean indicating whether TF2.0 and PyTorch weights matrices are transposed with regards to each
-          other
-    """
-    tf_name = tf_name.replace(":0", "")  # device ids
-    tf_name = re.sub(
-        r"/[^/]*___([^/]*)/", r"/\1/", tf_name
-    )  # '$1___$2' is replaced by $2 (can be used to duplicate or remove layers in TF2.0 vs PyTorch)
-    tf_name = tf_name.replace(
-        "_._", "/"
-    )  # '_._' is replaced by a level separation (can be used to convert TF2.0 lists in PyTorch nn.ModulesList)
-    tf_name = re.sub(r"//+", "/", tf_name)  # Remove empty levels at the end
-    tf_name = tf_name.split("/")  # Convert from TF2.0 '/' separators to PyTorch '.' separators
-    # Some weights have a single name withtout "/" such as final_logits_bias in BART
-    if len(tf_name) > 1:
-        tf_name = tf_name[1:]  # Remove level zero
-
-    # When should we transpose the weights
-    transpose = bool(
-        tf_name[-1] in ["kernel", "pointwise_kernel", "depthwise_kernel"]
-        or "emb_projs" in tf_name
-        or "out_projs" in tf_name
-    )
-
-    # Convert standard TF2.0 names in PyTorch names
-    if tf_name[-1] == "kernel" or tf_name[-1] == "embeddings" or tf_name[-1] == "gamma":
-        tf_name[-1] = "weight"
-    if tf_name[-1] == "beta":
-        tf_name[-1] = "bias"
-
-    # The SeparableConv1D TF layer contains two weights that are translated to PyTorch Conv1D here
-    if tf_name[-1] == "pointwise_kernel" or tf_name[-1] == "depthwise_kernel":
-        tf_name[-1] = tf_name[-1].replace("_kernel", ".weight")
-
-    # Remove prefix if needed
-    tf_name = ".".join(tf_name)
-    if start_prefix_to_remove:
-        tf_name = tf_name.replace(start_prefix_to_remove, "", 1)
-
-    return tf_name, transpose
 
 
 #####################
@@ -97,8 +35,9 @@ def convert_tf_weight_name_to_pt_weight_name(tf_name, start_prefix_to_remove="")
 def load_pytorch_checkpoint_in_flax_state_dict(flax_model, pytorch_checkpoint_path, allow_missing_keys=False):
     """Load pytorch checkpoints in a flax model"""
     try:
-        import flax  # noqa: F401
         import torch  # noqa: F401
+
+        import flax  # noqa: F401
     except ImportError:
         logger.error(
             "Loading a PyTorch model in Flax, requires both PyTorch and  Flax to be installed. Please see "
@@ -118,368 +57,55 @@ def load_pytorch_checkpoint_in_flax_state_dict(flax_model, pytorch_checkpoint_pa
 
 
 def convert_pytorch_state_dict_to_flax(pt_state_dict, flax_model):
+    def is_sub_tuple(main_tuple, sub_tuple):
+        return ".".join(main_tuple) in ".".join(sub_tuple)
 
     # convert pytorch tensor to numpy
     pt_state_dict = {k: v.numpy() for k, v in pt_state_dict.items()}
-    import ipdb; ipdb.set_trace()
+
+    random_flax_state_dict = flatten_dict(unfreeze(flax_model.params))
+    flax_state_dict = {}
+
+    remove_base_model_prefix = (flax_model.base_model_prefix not in flax_model.params) and (
+        flax_model.base_model_prefix in set([k.split(".")[0] for k in pt_state_dict.keys()])
+    )
+    add_base_model_prefix = (flax_model.base_model_prefix in flax_model.params) and (
+        flax_model.base_model_prefix not in set([k.split(".")[0] for k in pt_state_dict.keys()])
+    )
 
     # Need to change some parameters name to match Flax names so that we don't have to fork any layer
-    for key, tensor in pt_state.items():
-        # Key parts
-        key_parts = set(key.split("."))
-
-        # Every dense layer has "kernel" parameters instead of "weight"
-        if "dense.weight" in key:
-            del jax_state[key]
-            key = key.replace("weight", "kernel")
-            jax_state[key] = tensor
-
-        if "decoder.weight" in key:
-            del jax_state[key]
-            key = key.replace("weight", "kernel")
-            jax_state[key] = tensor.T
-
-        # SelfAttention needs also to replace "weight" by "kernel"
-        if {"query", "key", "value"} & key_parts:
-
-            # Flax SelfAttention decomposes the heads (num_head, size // num_heads)
-            if "bias" in key:
-                jax_state[key] = tensor.reshape((config.num_attention_heads, -1))
-            elif "weight":
-                del jax_state[key]
-                key = key.replace("weight", "kernel")
-                tensor = tensor.reshape((config.num_attention_heads, -1, config.hidden_size)).transpose((2, 0, 1))
-                jax_state[key] = tensor
-
-        # SelfAttention output is not a separate layer, remove one nesting
-        if "attention.output.dense" in key:
-            del jax_state[key]
-            key = key.replace("attention.output.dense", "attention.self.out")
-            jax_state[key] = tensor
-
-        # SelfAttention output is not a separate layer, remove nesting on layer norm
-        if "attention.output.LayerNorm" in key:
-            del jax_state[key]
-            key = key.replace("attention.output.LayerNorm", "attention.LayerNorm")
-            jax_state[key] = tensor
-
-        # There are some transposed parameters w.r.t their PyTorch counterpart
-        if "intermediate.dense.kernel" in key or "output.dense.kernel" in key or "transform.dense.kernel" in key:
-            jax_state[key] = tensor.T
-
-        # Self Attention output projection needs to be transposed
-        if "out.kernel" in key:
-            jax_state[key] = tensor.reshape((config.hidden_size, config.num_attention_heads, -1)).transpose(
-                1, 2, 0
-            )
-
-        # Pooler needs to transpose its kernel
-        if "pooler.dense.kernel" in key:
-            jax_state[key] = tensor.T
-
-        # Hack to correctly load some pytorch models
-        if "predictions.bias" in key:
-            del jax_state[key]
-            jax_state[".".join(key.split(".")[:2]) + ".decoder.bias"] = tensor
-
-        # Handle LayerNorm conversion
-        if "LayerNorm" in key:
-            del jax_state[key]
-
-            # Replace LayerNorm by layer_norm
-            new_key = key.replace("LayerNorm", "layer_norm")
-
-            if "weight" in key:
-                new_key = new_key.replace("weight", "gamma")
-            elif "bias" in key:
-                new_key = new_key.replace("bias", "beta")
-
-            jax_state[new_key] = tensor
-
-
-    flax_state_dict = unflatten_dict({tuple(k.split(".")): v for k, v in flax_state_dict.items()})
-
-    return flax_state_dict
-
-
-
-
-
-
-    if tf_inputs is None:
-        tf_inputs = flax_model.dummy_inputs
-
-    if tf_inputs is not None:
-        flax_model(tf_inputs, training=False)  # Make sure model is built
-
-    # Adapt state dict - TODO remove this and update the AWS weights files instead
-    # Convert old format to new format if needed from a PyTorch state_dict
-    old_keys = []
-    new_keys = []
-    for key in pt_state_dict.keys():
-        new_key = None
-        if "gamma" in key:
-            new_key = key.replace("gamma", "weight")
-        if "beta" in key:
-            new_key = key.replace("beta", "bias")
-        if new_key:
-            old_keys.append(key)
-            new_keys.append(new_key)
-    for old_key, new_key in zip(old_keys, new_keys):
-        pt_state_dict[new_key] = pt_state_dict.pop(old_key)
-
-    # Make sure we are able to load PyTorch base models as well as derived models (with heads)
-    # TF models always have a prefix, some of PyTorch models (base ones) don't
-    start_prefix_to_remove = ""
-    if not any(s.startswith(flax_model.base_model_prefix) for s in pt_state_dict.keys()):
-        start_prefix_to_remove = flax_model.base_model_prefix + "."
-
-    symbolic_weights = flax_model.trainable_weights + flax_model.non_trainable_weights
-    tf_loaded_numel = 0
-    weight_value_tuples = []
-    all_pytorch_weights = set(list(pt_state_dict.keys()))
-    missing_keys = []
-    for symbolic_weight in symbolic_weights:
-        sw_name = symbolic_weight.name
-        name, transpose = convert_tf_weight_name_to_pt_weight_name(
-            sw_name, start_prefix_to_remove=start_prefix_to_remove
-        )
-
-        # Find associated numpy array in pytorch model state dict
-        if name not in pt_state_dict:
-            if allow_missing_keys:
-                missing_keys.append(name)
-                continue
-            elif flax_model._keys_to_ignore_on_load_missing is not None:
-                # authorized missing keys don't have to be loaded
-                if any(re.search(pat, name) is not None for pat in flax_model._keys_to_ignore_on_load_missing):
-                    continue
-
-            raise AttributeError("{} not found in PyTorch model".format(name))
-
-        array = pt_state_dict[name].numpy()
-
-        if transpose:
-            array = numpy.transpose(array)
-
-        if len(symbolic_weight.shape) < len(array.shape):
-            array = numpy.squeeze(array)
-        elif len(symbolic_weight.shape) > len(array.shape):
-            array = numpy.expand_dims(array, axis=0)
-
-        if list(symbolic_weight.shape) != list(array.shape):
-            try:
-                array = numpy.reshape(array, symbolic_weight.shape)
-            except AssertionError as e:
-                e.args += (symbolic_weight.shape, array.shape)
-                raise e
-
-        try:
-            assert list(symbolic_weight.shape) == list(array.shape)
-        except AssertionError as e:
-            e.args += (symbolic_weight.shape, array.shape)
-            raise e
-
-        tf_loaded_numel += array.size
-        # logger.warning("Initialize TF weight {}".format(symbolic_weight.name))
-
-        weight_value_tuples.append((symbolic_weight, array))
-        all_pytorch_weights.discard(name)
-
-    K.batch_set_value(weight_value_tuples)
-
-    if tf_inputs is not None:
-        flax_model(tf_inputs, training=False)  # Make sure restore ops are run
-
-    logger.info("Loaded {:,} parameters in the TF 2.0 model.".format(tf_loaded_numel))
-
-    unexpected_keys = list(all_pytorch_weights)
-
-    if flax_model._keys_to_ignore_on_load_missing is not None:
-        for pat in flax_model._keys_to_ignore_on_load_missing:
-            missing_keys = [k for k in missing_keys if re.search(pat, k) is None]
-    if flax_model._keys_to_ignore_on_load_unexpected is not None:
-        for pat in flax_model._keys_to_ignore_on_load_unexpected:
-            unexpected_keys = [k for k in unexpected_keys if re.search(pat, k) is None]
-
-    if len(unexpected_keys) > 0:
-        logger.warning(
-            f"Some weights of the PyTorch model were not used when "
-            f"initializing the TF 2.0 model {flax_model.__class__.__name__}: {unexpected_keys}\n"
-            f"- This IS expected if you are initializing {flax_model.__class__.__name__} from a PyTorch model trained on another task "
-            f"or with another architecture (e.g. initializing a TFBertForSequenceClassification model from a BertForPreTraining model).\n"
-            f"- This IS NOT expected if you are initializing {flax_model.__class__.__name__} from a PyTorch model that you expect "
-            f"to be exactly identical (e.g. initializing a TFBertForSequenceClassification model from a BertForSequenceClassification model)."
-        )
-    else:
-        logger.warning(f"All PyTorch model weights were used when initializing {flax_model.__class__.__name__}.\n")
-    if len(missing_keys) > 0:
-        logger.warning(
-            f"Some weights or buffers of the TF 2.0 model {flax_model.__class__.__name__} were not initialized from the PyTorch model "
-            f"and are newly initialized: {missing_keys}\n"
-            f"You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference."
-        )
-    else:
-        logger.warning(
-            f"All the weights of {flax_model.__class__.__name__} were initialized from the PyTorch model.\n"
-            f"If your task is similar to the task the model of the checkpoint was trained on, "
-            f"you can already use {flax_model.__class__.__name__} for predictions without further training."
-        )
-
-    return flax_model
-
-
-#####################
-# TF 2.0 => PyTorch #
-#####################
-
-
-def load_tf2_checkpoint_in_pytorch_model(pt_model, tf_checkpoint_path, tf_inputs=None, allow_missing_keys=False):
-    """
-    Load TF 2.0 HDF5 checkpoint in a PyTorch model We use HDF5 to easily do transfer learning (see
-    https://github.com/tensorflow/tensorflow/blob/ee16fcac960ae660e0e4496658a366e2f745e1f0/tensorflow/python/keras/engine/network.py#L1352-L1357).
-    """
-    try:
-        import tensorflow as tf  # noqa: F401
-        import torch  # noqa: F401
-    except ImportError:
-        logger.error(
-            "Loading a TensorFlow model in PyTorch, requires both PyTorch and TensorFlow to be installed. Please see "
-            "https://pytorch.org/ and https://www.tensorflow.org/install/ for installation instructions."
-        )
-        raise
-
-    import transformers
-
-    from .modeling_tf_utils import load_tf_weights
-
-    logger.info("Loading TensorFlow weights from {}".format(tf_checkpoint_path))
-
-    # Instantiate and load the associated TF 2.0 model
-    flax_model_class_name = "TF" + pt_model.__class__.__name__  # Add "TF" at the beginning
-    flax_model_class = getattr(transformers, flax_model_class_name)
-    flax_model = flax_model_class(pt_model.config)
-
-    if tf_inputs is None:
-        tf_inputs = flax_model.dummy_inputs
-
-    if tf_inputs is not None:
-        flax_model(tf_inputs, training=False)  # Make sure model is built
-
-    load_tf_weights(flax_model, tf_checkpoint_path)
-
-    return load_flax_model_in_pytorch_model(pt_model, flax_model, allow_missing_keys=allow_missing_keys)
-
-
-def load_flax_model_in_pytorch_model(pt_model, flax_model, allow_missing_keys=False):
-    """Load TF 2.0 model in a pytorch model"""
-    weights = flax_model.weights
-
-    return load_tf2_weights_in_pytorch_model(pt_model, weights, allow_missing_keys=allow_missing_keys)
-
-
-def load_tf2_weights_in_pytorch_model(pt_model, tf_weights, allow_missing_keys=False):
-    """Load TF2.0 symbolic weights in a PyTorch model"""
-    try:
-        import tensorflow as tf  # noqa: F401
-        import torch  # noqa: F401
-    except ImportError:
-        logger.error(
-            "Loading a TensorFlow model in PyTorch, requires both PyTorch and TensorFlow to be installed. Please see "
-            "https://pytorch.org/ and https://www.tensorflow.org/install/ for installation instructions."
-        )
-        raise
-
-    new_pt_params_dict = {}
-    current_pt_params_dict = dict(pt_model.named_parameters())
-
-    # Make sure we are able to load PyTorch base models as well as derived models (with heads)
-    # TF models always have a prefix, some of PyTorch models (base ones) don't
-    start_prefix_to_remove = ""
-    if not any(s.startswith(pt_model.base_model_prefix) for s in current_pt_params_dict.keys()):
-        start_prefix_to_remove = pt_model.base_model_prefix + "."
-
-    # Build a map from potential PyTorch weight names to TF 2.0 Variables
-    tf_weights_map = {}
-    for tf_weight in tf_weights:
-        pt_name, transpose = convert_tf_weight_name_to_pt_weight_name(
-            tf_weight.name, start_prefix_to_remove=start_prefix_to_remove
-        )
-        tf_weights_map[pt_name] = (tf_weight.numpy(), transpose)
-
-    all_tf_weights = set(list(tf_weights_map.keys()))
-    loaded_pt_weights_data_ptr = {}
-    missing_keys_pt = []
-    for pt_weight_name, pt_weight in current_pt_params_dict.items():
-        # Handle PyTorch shared weight ()not duplicated in TF 2.0
-        if pt_weight.data_ptr() in loaded_pt_weights_data_ptr:
-            new_pt_params_dict[pt_weight_name] = loaded_pt_weights_data_ptr[pt_weight.data_ptr()]
-            continue
-
-        # Find associated numpy array in pytorch model state dict
-        if pt_weight_name not in tf_weights_map:
-            if allow_missing_keys:
-                missing_keys_pt.append(pt_weight_name)
-                continue
-
-            raise AttributeError("{} not found in TF 2.0 model".format(pt_weight_name))
-
-        array, transpose = tf_weights_map[pt_weight_name]
-
-        if transpose:
-            array = numpy.transpose(array)
-
-        if len(pt_weight.shape) < len(array.shape):
-            array = numpy.squeeze(array)
-        elif len(pt_weight.shape) > len(array.shape):
-            array = numpy.expand_dims(array, axis=0)
-
-        if list(pt_weight.shape) != list(array.shape):
-            try:
-                array = numpy.reshape(array, pt_weight.shape)
-            except AssertionError as e:
-                e.args += (pt_weight.shape, array.shape)
-                raise e
-
-        try:
-            assert list(pt_weight.shape) == list(array.shape)
-        except AssertionError as e:
-            e.args += (pt_weight.shape, array.shape)
-            raise e
-
-        # logger.warning("Initialize PyTorch weight {}".format(pt_weight_name))
-
-        new_pt_params_dict[pt_weight_name] = torch.from_numpy(array)
-        loaded_pt_weights_data_ptr[pt_weight.data_ptr()] = torch.from_numpy(array)
-        all_tf_weights.discard(pt_weight_name)
-
-    missing_keys, unexpected_keys = pt_model.load_state_dict(new_pt_params_dict, strict=False)
-    missing_keys += missing_keys_pt
-
-    if len(unexpected_keys) > 0:
-        logger.warning(
-            f"Some weights of the TF 2.0 model were not used when "
-            f"initializing the PyTorch model {pt_model.__class__.__name__}: {unexpected_keys}\n"
-            f"- This IS expected if you are initializing {pt_model.__class__.__name__} from a TF 2.0 model trained on another task "
-            f"or with another architecture (e.g. initializing a BertForSequenceClassification model from a TFBertForPreTraining model).\n"
-            f"- This IS NOT expected if you are initializing {pt_model.__class__.__name__} from a TF 2.0 model that you expect "
-            f"to be exactly identical (e.g. initializing a BertForSequenceClassification model from a TFBertForSequenceClassification model)."
-        )
-    else:
-        logger.warning(f"All TF 2.0 model weights were used when initializing {pt_model.__class__.__name__}.\n")
-    if len(missing_keys) > 0:
-        logger.warning(
-            f"Some weights of {pt_model.__class__.__name__} were not initialized from the TF 2.0 model "
-            f"and are newly initialized: {missing_keys}\n"
-            f"You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference."
-        )
-    else:
-        logger.warning(
-            f"All the weights of {pt_model.__class__.__name__} were initialized from the TF 2.0 model.\n"
-            f"If your task is similar to the task the model of the checkpoint was trained on, "
-            f"you can already use {pt_model.__class__.__name__} for predictions without further training."
-        )
-
-    logger.info("Weights or buffers not loaded from TF 2.0 model: {}".format(all_tf_weights))
-
-    return pt_model
+    for pt_key, pt_tensor in pt_state_dict.items():
+
+        pt_tuple_key = tuple(pt_key.split("."))
+
+        has_base_model_prefix = pt_tuple_key[0] == flax_model.base_model_prefix
+        require_base_model_prefix = (flax_model.base_model_prefix,) + pt_tuple_key in random_flax_state_dict
+
+        if remove_base_model_prefix and has_base_model_prefix:
+            pt_tuple_key = pt_tuple_key[1:]
+        elif add_base_model_prefix and require_base_model_prefix:
+            pt_tuple_key = (flax_model.base_model_prefix,) + pt_tuple_key
+
+        if pt_tuple_key[-1] == "weight" and pt_tuple_key not in random_flax_state_dict:
+            pt_tuple_key = pt_tuple_key[:-1] + ("kernel",)
+            pt_tensor = pt_tensor.T
+        elif pt_tuple_key[-1] == "gamma":
+            pt_tuple_key = pt_tuple_key[:-1] + ("weight",)
+        elif pt_tuple_key[-1] == "beta":
+            pt_tuple_key = pt_tuple_key[:-1] + ("bias",)
+
+        # THIS WOULD BE NEEDED IF ATTENTION FN IS USED
+        #        elif flax_model.attention_layers_names is not None and any(is_sub_tuple(pt_tuple_key, attn_layer_name) for attn_layer_name in flax_model.attention_layers_names):
+        #
+        #            if pt_tuple_key[1:] in flax_model.pt_to_flax_look_up:
+        #                pt_tuple_key = pt_tuple_key[:1] + flax_model.pt_to_flax_look_up[pt_tuple_key[1:]]
+        #            elif pt_tuple_key in flax_model.pt_to_flax_look_up:
+        #                pt_tuple_key = flax_model.pt_to_flax_look_up[pt_tuple_key]
+
+        if pt_tuple_key in random_flax_state_dict:
+            if random_flax_state_dict[pt_tuple_key].shape != pt_tensor.shape:
+                raise ValueError("TODO (PVP): Fill in...")
+
+        flax_state_dict[pt_tuple_key] = pt_tensor
+
+    return unflatten_dict(flax_state_dict)

--- a/src/transformers/modeling_flax_pytorch_utils.py
+++ b/src/transformers/modeling_flax_pytorch_utils.py
@@ -35,8 +35,6 @@ def load_pytorch_checkpoint_in_flax_state_dict(flax_model, pytorch_checkpoint_pa
     """Load pytorch checkpoints in a flax model"""
     try:
         import torch  # noqa: F401
-
-        import flax  # noqa: F401
     except ImportError:
         logger.error(
             "Loading a PyTorch model in Flax, requires both PyTorch and  Flax to be installed. Please see "

--- a/src/transformers/modeling_flax_pytorch_utils.py
+++ b/src/transformers/modeling_flax_pytorch_utils.py
@@ -94,13 +94,20 @@ def convert_pytorch_state_dict_to_flax(pt_state_dict, flax_model):
         elif pt_tuple_key[-1] == "beta":
             pt_tuple_key = pt_tuple_key[:-1] + ("bias",)
 
-        # THIS WOULD BE NEEDED IF ATTENTION FN IS USED
+        # THIS AND MORE WOULD BE NEEDED IF ATTENTION FN IS USED
         #        elif flax_model.attention_layers_names is not None and any(is_sub_tuple(pt_tuple_key, attn_layer_name) for attn_layer_name in flax_model.attention_layers_names):
         #
         #            if pt_tuple_key[1:] in flax_model.pt_to_flax_look_up:
         #                pt_tuple_key = pt_tuple_key[:1] + flax_model.pt_to_flax_look_up[pt_tuple_key[1:]]
         #            elif pt_tuple_key in flax_model.pt_to_flax_look_up:
         #                pt_tuple_key = flax_model.pt_to_flax_look_up[pt_tuple_key]
+        #
+        #        if pt_tuple_key[-2] in ["key", "query", "value"]:
+        # do reshape
+        # ...
+        #        elif pt_tuple_key[-2] == "out":
+        # do different reshape
+        # ...
 
         if pt_tuple_key in random_flax_state_dict:
             if random_flax_state_dict[pt_tuple_key].shape != pt_tensor.shape:

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -330,6 +330,10 @@ class FlaxPreTrainedModel(ABC):
         for missing_key in missing_keys:
             state[missing_key] = random_state[missing_key]
 
+        # remove unexpected keys to not be saved again
+        for unexpected_key in unexpected_keys:
+            del state[unexpected_key]
+
         if len(unexpected_keys) > 0:
             logger.warning(
                 f"Some weights of the model checkpoint at {pretrained_model_name_or_path} were not used when "

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -122,11 +122,6 @@ class FlaxPreTrainedModel(ABC):
             )
         self._params = freeze(params)
 
-    #    @staticmethod
-    #    @abstractmethod
-    #    def convert_from_pytorch(pt_state: Dict, config: PretrainedConfig) -> Dict:
-    #        raise NotImplementedError()
-
     @classmethod
     def from_pretrained(
         cls,

--- a/src/transformers/models/bert/modeling_flax_bert.py
+++ b/src/transformers/models/bert/modeling_flax_bert.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Dict, Tuple
+from typing import Callable, Tuple
 
 import numpy as np
 
@@ -21,7 +21,7 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 from flax.core.frozen_dict import FrozenDict
-from flax.linen.attention import dot_product_attention
+from flax.linen import dot_product_attention
 from jax import lax
 from jax.random import PRNGKey
 

--- a/src/transformers/models/bert/modeling_flax_bert.py
+++ b/src/transformers/models/bert/modeling_flax_bert.py
@@ -283,9 +283,9 @@ class FlaxBertSelfOutput(nn.Module):
         self.LayerNorm = FlaxBertLayerNorm(hidden_size=self.config.hidden_size)
         self.dropout = nn.Dropout(rate=self.config.hidden_dropout_prob)
 
-    def __call__(self, hidden_states, input_tensor):
+    def __call__(self, hidden_states, input_tensor, deterministic: bool = True):
         hidden_states = self.dense(hidden_states)
-        hidden_states = self.dropout(hidden_states)
+        hidden_states = self.dropout(hidden_states, deterministic=deterministic)
         hidden_states = self.LayerNorm(hidden_states + input_tensor)
         return hidden_states
 
@@ -303,7 +303,7 @@ class FlaxBertAttention(nn.Module):
         # FLAX expects: attention_mask.shape == (*batch_sizes, 1, 1, kv_length) such that it is broadcastable
         # with attn_weights.shape == (*batch_sizes, num_heads, q_length, kv_length)
         attn_output = self.self(hidden_states, attention_mask, deterministic=deterministic)
-        hidden_states = self.output(attn_output, hidden_states)
+        hidden_states = self.output(attn_output, hidden_states, deterministic=deterministic)
         return hidden_states
 
 

--- a/src/transformers/models/bert/modeling_flax_bert.py
+++ b/src/transformers/models/bert/modeling_flax_bert.py
@@ -21,6 +21,8 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 from flax.core.frozen_dict import FrozenDict
+from flax.linen.attention import dot_product_attention
+from jax import lax
 from jax.random import PRNGKey
 
 from ...file_utils import add_start_docstrings, add_start_docstrings_to_model_forward
@@ -100,7 +102,7 @@ class FlaxBertLayerNorm(nn.Module):
     hidden_size: int
     epsilon: float = 1e-6
     dtype: jnp.dtype = jnp.float32  # the dtype of the computation
-    bias: bool = True  # If True, bias (beta) is added.
+    use_bias: bool = True  # If True, bias (beta) is added.
     scale: bool = True  # If True, multiply by scale (gamma). When the next layer is linear
     # (also e.g. nn.relu), this can be disabled since the scaling will be
     # done by the next layer.
@@ -108,8 +110,8 @@ class FlaxBertLayerNorm(nn.Module):
     bias_init: Callable[..., np.ndarray] = jax.nn.initializers.zeros
 
     def setup(self):
-        self.gamma = self.param("gamma", self.scale_init, (self.hidden_size,))
-        self.beta = self.param("beta", self.scale_init, (self.hidden_size,))
+        self.gamma = self.param("weight", self.scale_init, (self.hidden_size,))
+        self.beta = self.param("bias", self.scale_init, (self.hidden_size,))
 
     def __call__(self, x):
         """
@@ -132,7 +134,7 @@ class FlaxBertLayerNorm(nn.Module):
             mul = mul * jnp.asarray(self.gamma)
         y = (x - mean) * mul
 
-        if self.bias:
+        if self.use_bias:
             y = y + jnp.asarray(self.beta)
         return y
 
@@ -184,7 +186,7 @@ class FlaxBertEmbeddings(nn.Module):
             name="token_type_embeddings",
             dtype=self.dtype,
         )
-        self.layer_norm = FlaxBertLayerNorm(hidden_size=self.config.hidden_size, name="layer_norm", dtype=self.dtype)
+        self.LayerNorm = FlaxBertLayerNorm(hidden_size=self.config.hidden_size, name="LayerNorm", dtype=self.dtype)
         self.dropout = nn.Dropout(rate=self.config.hidden_dropout_prob)
 
     def __call__(self, input_ids, token_type_ids, position_ids, attention_mask, deterministic: bool = True):
@@ -197,12 +199,119 @@ class FlaxBertEmbeddings(nn.Module):
         hidden_states = inputs_embeds + jnp.broadcast_to(position_embeds, inputs_embeds.shape) + token_type_embeddings
 
         # Layer Norm
-        hidden_states = self.layer_norm(hidden_states)
+        hidden_states = self.LayerNorm(hidden_states)
         hidden_states = self.dropout(hidden_states, deterministic=deterministic)
         return hidden_states
 
 
+class FlaxBertSelfAttention(nn.Module):
+    config: BertConfig
+    dtype: jnp.dtype = jnp.float32  # the dtype of the computation
+
+    def setup(self):
+        assert self.config.hidden_size % self.config.num_attention_heads == 0, "Error"
+        self.query = nn.Dense(
+            self.config.hidden_size,
+            name="query",
+            dtype=self.dtype,
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range, self.dtype),
+        )
+        self.key = nn.Dense(
+            self.config.hidden_size,
+            name="key",
+            dtype=self.dtype,
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range, self.dtype),
+        )
+        self.value = nn.Dense(
+            self.config.hidden_size,
+            name="value",
+            dtype=self.dtype,
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range, self.dtype),
+        )
+
+    def __call__(self, hidden_states, attention_mask, deterministic=True):
+        head_dim = self.config.hidden_size // self.config.num_attention_heads
+
+        query_states = self.query(hidden_states).reshape(
+            hidden_states.shape[:2] + (self.config.num_attention_heads, head_dim)
+        )
+        value_states = self.value(hidden_states).reshape(
+            hidden_states.shape[:2] + (self.config.num_attention_heads, head_dim)
+        )
+        key_states = self.key(hidden_states).reshape(
+            hidden_states.shape[:2] + (self.config.num_attention_heads, head_dim)
+        )
+
+        # Convert the boolean attention mask to an attention bias.
+        if attention_mask is not None:
+            # attention mask in the form of attention bias
+            attention_mask = jnp.expand_dims(attention_mask, axis=(-3, -2))
+            attention_bias = lax.select(
+                attention_mask > 0,
+                jnp.full(attention_mask.shape, 0.0).astype(self.dtype),
+                jnp.full(attention_mask.shape, -1e10).astype(self.dtype),
+            )
+        else:
+            attention_bias = None
+
+        dropout_rng = None
+        if not deterministic and self.dropout_rate > 0.0:
+            dropout_rng = self.make_rng("dropout")
+
+        attn_output = dot_product_attention(
+            query_states,
+            key_states,
+            value_states,
+            bias=attention_bias,
+            dropout_rng=dropout_rng,
+            dropout_rate=self.config.attention_probs_dropout_prob,
+            broadcast_dropout=True,
+            deterministic=deterministic,
+            dtype=self.dtype,
+            precision=None,
+        )
+
+        return attn_output.reshape(attn_output.shape[:2] + (-1,))
+
+
+class FlaxBertSelfOutput(nn.Module):
+    config: BertConfig
+    dtype: jnp.dtype = jnp.float32  # the dtype of the computation
+
+    def setup(self):
+        self.dense = nn.Dense(
+            self.config.hidden_size,
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range, self.dtype),
+            dtype=self.dtype,
+            name="dense",
+        )
+        self.LayerNorm = FlaxBertLayerNorm(hidden_size=self.config.hidden_size, name="LayerNorm", dtype=self.dtype)
+
+    def __call__(self, hidden_states, input_tensor):
+        hidden_states = self.dense(hidden_states)
+        # TODO: add Dropout
+        hidden_states = self.LayerNorm(hidden_states + input_tensor)
+        return hidden_states
+
+
 class FlaxBertAttention(nn.Module):
+    config: BertConfig
+    dtype: jnp.dtype = jnp.float32  # the dtype of the computation
+
+    def setup(self):
+        self.self_attention = FlaxBertSelfAttention(self.config, dtype=self.dtype, name="self")
+        self.output = FlaxBertSelfOutput(self.config, dtype=self.dtype, name="output")
+
+    def __call__(self, hidden_states, attention_mask, deterministic=True):
+        # Attention mask comes in as attention_mask.shape == (*batch_sizes, kv_length)
+        # FLAX expects: attention_mask.shape == (*batch_sizes, 1, 1, kv_length) such that it is broadcastable
+        # with attn_weights.shape == (*batch_sizes, num_heads, q_length, kv_length)
+        attn_output = self.self_attention(hidden_states, attention_mask, deterministic=deterministic)
+        hidden_states = self.output(attn_output, hidden_states)
+        return hidden_states
+
+
+class OldFlaxBertAttention(nn.Module):
     config: BertConfig
     dtype: jnp.dtype = jnp.float32  # the dtype of the computation
 
@@ -216,7 +325,7 @@ class FlaxBertAttention(nn.Module):
             name="self",
             dtype=self.dtype,
         )
-        self.layer_norm = FlaxBertLayerNorm(hidden_size=self.config.hidden_size, name="layer_norm", dtype=self.dtype)
+        self.LayerNorm = FlaxBertLayerNorm(hidden_size=self.config.hidden_size, name="LayerNorm", dtype=self.dtype)
 
     def __call__(self, hidden_states, attention_mask, deterministic=True):
         # Attention mask comes in as attention_mask.shape == (*batch_sizes, kv_length)
@@ -225,7 +334,7 @@ class FlaxBertAttention(nn.Module):
         attention_mask = jnp.expand_dims(attention_mask, axis=(-3, -2))
         self_attn_output = self.self_attention(hidden_states, attention_mask, deterministic=deterministic)
 
-        hidden_states = self.layer_norm(self_attn_output + hidden_states)
+        hidden_states = self.LayerNorm(self_attn_output + hidden_states)
         return hidden_states
 
 
@@ -260,12 +369,12 @@ class FlaxBertOutput(nn.Module):
             dtype=self.dtype,
         )
         self.dropout = nn.Dropout(rate=self.config.hidden_dropout_prob)
-        self.layer_norm = FlaxBertLayerNorm(hidden_size=self.config.hidden_size, name="layer_norm", dtype=self.dtype)
+        self.LayerNorm = FlaxBertLayerNorm(hidden_size=self.config.hidden_size, name="LayerNorm", dtype=self.dtype)
 
     def __call__(self, hidden_states, attention_output, deterministic: bool = True):
         hidden_states = self.dense(hidden_states)
         hidden_states = self.dropout(hidden_states, deterministic=deterministic)
-        hidden_states = self.layer_norm(hidden_states + attention_output)
+        hidden_states = self.LayerNorm(hidden_states + attention_output)
         return hidden_states
 
 
@@ -336,12 +445,12 @@ class FlaxBertPredictionHeadTransform(nn.Module):
     def setup(self):
         self.dense = nn.Dense(self.config.hidden_size, name="dense", dtype=self.dtype)
         self.activation = ACT2FN[self.config.hidden_act]
-        self.layer_norm = FlaxBertLayerNorm(hidden_size=self.config.hidden_size, name="layer_norm", dtype=self.dtype)
+        self.LayerNorm = FlaxBertLayerNorm(hidden_size=self.config.hidden_size, name="LayerNorm", dtype=self.dtype)
 
     def __call__(self, hidden_states):
         hidden_states = self.dense(hidden_states)
         hidden_states = self.activation(hidden_states)
-        return self.layer_norm(hidden_states)
+        return self.LayerNorm(hidden_states)
 
 
 class FlaxBertLMPredictionHead(nn.Module):
@@ -405,84 +514,25 @@ class FlaxBertPreTrainedModel(FlaxPreTrainedModel):
 
         return self.module.init(rngs, input_ids, attention_mask, token_type_ids, position_ids)["params"]
 
-    @staticmethod
-    def convert_from_pytorch(pt_state: Dict, config: BertConfig) -> Dict:
-        jax_state = dict(pt_state)
 
-        # Need to change some parameters name to match Flax names so that we don't have to fork any layer
-        for key, tensor in pt_state.items():
-            # Key parts
-            key_parts = set(key.split("."))
-
-            # Every dense layer has "kernel" parameters instead of "weight"
-            if "dense.weight" in key:
-                del jax_state[key]
-                key = key.replace("weight", "kernel")
-                jax_state[key] = tensor
-
-            if "decoder.weight" in key:
-                del jax_state[key]
-                key = key.replace("weight", "kernel")
-                jax_state[key] = tensor.T
-
-            # SelfAttention needs also to replace "weight" by "kernel"
-            if {"query", "key", "value"} & key_parts:
-
-                # Flax SelfAttention decomposes the heads (num_head, size // num_heads)
-                if "bias" in key:
-                    jax_state[key] = tensor.reshape((config.num_attention_heads, -1))
-                elif "weight":
-                    del jax_state[key]
-                    key = key.replace("weight", "kernel")
-                    tensor = tensor.reshape((config.num_attention_heads, -1, config.hidden_size)).transpose((2, 0, 1))
-                    jax_state[key] = tensor
-
-            # SelfAttention output is not a separate layer, remove one nesting
-            if "attention.output.dense" in key:
-                del jax_state[key]
-                key = key.replace("attention.output.dense", "attention.self.out")
-                jax_state[key] = tensor
-
-            # SelfAttention output is not a separate layer, remove nesting on layer norm
-            if "attention.output.LayerNorm" in key:
-                del jax_state[key]
-                key = key.replace("attention.output.LayerNorm", "attention.LayerNorm")
-                jax_state[key] = tensor
-
-            # There are some transposed parameters w.r.t their PyTorch counterpart
-            if "intermediate.dense.kernel" in key or "output.dense.kernel" in key or "transform.dense.kernel" in key:
-                jax_state[key] = tensor.T
-
-            # Self Attention output projection needs to be transposed
-            if "out.kernel" in key:
-                jax_state[key] = tensor.reshape((config.hidden_size, config.num_attention_heads, -1)).transpose(
-                    1, 2, 0
-                )
-
-            # Pooler needs to transpose its kernel
-            if "pooler.dense.kernel" in key:
-                jax_state[key] = tensor.T
-
-            # Hack to correctly load some pytorch models
-            if "predictions.bias" in key:
-                del jax_state[key]
-                jax_state[".".join(key.split(".")[:2]) + ".decoder.bias"] = tensor
-
-            # Handle LayerNorm conversion
-            if "LayerNorm" in key:
-                del jax_state[key]
-
-                # Replace LayerNorm by layer_norm
-                new_key = key.replace("LayerNorm", "layer_norm")
-
-                if "weight" in key:
-                    new_key = new_key.replace("weight", "gamma")
-                elif "bias" in key:
-                    new_key = new_key.replace("bias", "beta")
-
-                jax_state[new_key] = tensor
-
-        return jax_state
+#    @property
+#    def pt_to_flax_attention_weight_name(self):
+#        pt_to_flax_look_up = {}
+#        for i in range(self.config.num_hidden_layers):
+#            prefix = ("encoder", "layer", str(i), "attention")
+#            pt_to_flax_look_up.update(
+#                {
+#                    prefix + ("output", "dense", "kernel"): prefix + ("self", "out", "kernel"),
+#                    prefix + ("output", "dense", "bias"): prefix + ("self", "out", "bias"),
+#                    prefix + ("output", "LayerNorm", "gamma"): prefix + ("LayerNorm", "kernel"),
+#                    prefix + ("output", "LayerNorm", "beta"): prefix + ("LayerNorm", "bias"),
+#                }
+#            )
+#        return pt_to_flax_look_up
+#
+#    @property
+#    def attention_layers_names(self):
+#        return set(("encoder", "layer", str(i), "attention") for i in range(self.config.num_hidden_layers))
 
 
 @add_start_docstrings(

--- a/src/transformers/models/roberta/modeling_flax_roberta.py
+++ b/src/transformers/models/roberta/modeling_flax_roberta.py
@@ -304,9 +304,9 @@ class FlaxRobertaSelfOutput(nn.Module):
         self.LayerNorm = FlaxRobertaLayerNorm(hidden_size=self.config.hidden_size)
         self.dropout = nn.Dropout(rate=self.config.hidden_dropout_prob)
 
-    def __call__(self, hidden_states, input_tensor):
+    def __call__(self, hidden_states, input_tensor, deterministic: bool = True):
         hidden_states = self.dense(hidden_states)
-        hidden_states = self.dropout(hidden_states)
+        hidden_states = self.dropout(hidden_states, deterministic=deterministic)
         hidden_states = self.LayerNorm(hidden_states + input_tensor)
         return hidden_states
 
@@ -325,7 +325,7 @@ class FlaxRobertaAttention(nn.Module):
         # FLAX expects: attention_mask.shape == (*batch_sizes, 1, 1, kv_length) such that it is broadcastable
         # with attn_weights.shape == (*batch_sizes, num_heads, q_length, kv_length)
         attn_output = self.self(hidden_states, attention_mask, deterministic=deterministic)
-        hidden_states = self.output(attn_output, hidden_states)
+        hidden_states = self.output(attn_output, hidden_states, deterministic=deterministic)
         return hidden_states
 
 

--- a/tests/test_modeling_flax_bert.py
+++ b/tests/test_modeling_flax_bert.py
@@ -115,6 +115,6 @@ class FlaxBertModelTest(FlaxModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_class_name in self.all_model_classes:
-            model = model_class_name.from_pretrained("bert-base-cased")
+            model = model_class_name.from_pretrained("bert-base-cased", from_pt=True)
             outputs = model(np.ones((1, 1)))
             self.assertIsNotNone(outputs)

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -27,7 +27,7 @@ if is_flax_available():
 
     import jax
     import jax.numpy as jnp
-    from transformers.modeling_flax_utils import convert_state_dict_from_pt
+    from transformers.modeling_flax_pytorch_utils import convert_pytorch_state_dict_to_flax
 
     os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.12"  # assumed parallelism: 8
 
@@ -79,8 +79,8 @@ class FlaxModelTesterMixin:
                 pt_model_class = getattr(transformers, pt_model_class_name)
                 pt_model = pt_model_class(config).eval()
 
-                fx_state = convert_state_dict_from_pt(model_class, pt_model.state_dict(), config)
                 fx_model = model_class(config, dtype=jnp.float32)
+                fx_state = convert_pytorch_state_dict_to_flax(pt_model.state_dict(), fx_model)
                 fx_model.params = fx_state
 
                 pt_inputs = {k: torch.tensor(v.tolist()) for k, v in inputs_dict.items()}

--- a/tests/test_modeling_flax_roberta.py
+++ b/tests/test_modeling_flax_roberta.py
@@ -115,6 +115,6 @@ class FlaxRobertaModelTest(FlaxModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_class_name in self.all_model_classes:
-            model = model_class_name.from_pretrained("roberta-base")
+            model = model_class_name.from_pretrained("roberta-base", from_pt=True)
             outputs = model(np.ones((1, 1)))
             self.assertIsNotNone(outputs)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR changes the weight architecture of `FlaxBertModel` so that it corresponds 1-to-1 to PyTorch's version of `BertModel`. This means that some weights had to be renamed (*e.g.* "layer_norm" -> "LayerNorm" since PyTorch uses "LayerNorm") and also some new `flax.linen.Modules`, such as `FlaxBertSelfOutput` had to be created.

As can be seen, the PT=>Flax conversion function is now kept very general and can be applied to all models so that we can fully delete any model-specific conversion logic.

The PR has one drawback however:

Flax official [SelfAttention Module](https://flax.readthedocs.io/en/latest/_autosummary/flax.linen.SelfAttention.html#flax-linen-selfattention) cannot be used anymore since it doesn't give us enough flexibility to convert PyTorch weights to flax weights without having a model-specific conversion function. FlaxBERT's new attention modules fully correspond to PyTorchBERT's attention modules and are IMO still kept quite short by relying on Flax's [`dot_product_attention` function](https://flax.readthedocs.io/en/latest/_autosummary/flax.linen.dot_product_attention.html). Another drawback is that for auto-regressive Transformers models we will have to manually add all the code corresponding to cached / auto-regressive attention to the attention module (which we do for PyTorch anyways) instead of being able to use already existing code of `nn.linen.SelfAttention` -> see here: https://github.com/google/flax/blob/e31063da71bd7a4df137b000df6a48b0cea35a2b/flax/linen/attention.py#L202.

All in all, rewriting parts of `flax.linen.SelfAttention` is the right choice here though because it allows us to have a much cleaner conversion function with very little downside IMO (slightly higher maintenance because we need to copy-paste a bit more code).

@LysandreJik @sgugger - could you check if you agree more or less with my solution here (below I left some comments to showcase the trade-offs a bit better). I'll clean the code & upload the new weight structure then :-)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors which may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- nlp datasets: [different repo](https://github.com/huggingface/nlp)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
