### PR TITLE
[makefile] autogenerate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ extra_style_checks:
 	python utils/custom_init_isort.py
 	python utils/style_doc.py src/transformers docs/source --max_len 119
 
-# this target runs checks on all files
+# this target runs checks on all files and potentially modifies some of them
 style:
 	black $(check_dirs)
 	isort $(check_dirs)

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ modified_only_fixup:
 deps_table_update:
 	@python setup.py deps_table_update
 
+# autogenerating code
+
+autogenerate_code: deps_table_update
+	python utils/class_mapping_update.py
+
 # Check that source code meets quality standards
 
 extra_quality_checks:
@@ -37,20 +42,20 @@ quality:
 
 # Format source code automatically and check is there are any problems left that need manual fixing
 
-extra_style_checks: deps_table_update
+extra_style_checks:
 	python utils/custom_init_isort.py
 	python utils/style_doc.py src/transformers docs/source --max_len 119
-	python utils/class_mapping_update.py
 
 # this target runs checks on all files
 style:
 	black $(check_dirs)
 	isort $(check_dirs)
+	${MAKE} autogenerate_code
 	${MAKE} extra_style_checks
 
 # Super fast fix and check target that only works on relevant modified files since the branch was made
 
-fixup: modified_only_fixup extra_style_checks extra_quality_checks
+fixup: modified_only_fixup extra_style_checks autogenerate_code extra_quality_checks
 
 # Make marked copies of snippets of codes conform to the original
 
@@ -87,4 +92,3 @@ post-release:
 
 post-patch:
 	python utils/release.py --post_release --patch
-


### PR DESCRIPTION
As a follow up to https://github.com/huggingface/transformers/pull/10801 this PR proposes to group autogeneration code in a separate target. I think as the number of little things the makefile does this helps with clarity.

There is no functional change.

@sgugger, @LysandreJik 