### PR TITLE
feat(wandb): logging and configuration improvements

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -240,34 +240,11 @@ Whenever you use `Trainer` or `TFTrainer` classes, your losses, evaluation metri
 
 Advanced configuration is possible by setting environment variables:
 
-<table>
-  <thead>
-    <tr>
-      <th>Environment Variables</th>
-      <th>Options</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>WANDB_LOG_MODEL</td>
-      <td>Log the model as artifact at the end of training (<b>false</b> by default)</td>
-    </tr>
-    <tr>
-      <td>WANDB_WATCH</td>
-      <td>
-        <ul>
-          <li><b>gradients</b> (default): Log histograms of the gradients</li>
-          <li><b>all</b>: Log histograms of gradients and parameters</li>
-          <li><b>false</b>: No gradient or parameter logging</li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td>WANDB_PROJECT</td>
-      <td>Organize runs by project</td>
-    </tr>
-  </tbody>
-</table>
+| Environment Variable | Value |
+|---|---|
+| WANDB_LOG_MODEL | Log the model as artifact (log the model as artifact at the end of training (`false` by default) |
+| WANDB_WATCH | one of `gradients` (default) to log histograms of gradients, `all` to log histograms of both gradients and parameters, or `false` for no histogram logging |
+| WANDB_PROJECT | Organize runs by project |
 
 Set run names with `run_name` argument present in scripts or as part of `TrainingArguments`.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -243,18 +243,18 @@ Advanced configuration is possible by setting environment variables:
 <table>
   <thead>
     <tr>
-      <th style="text-align:left">Environment Variables</th>
-      <th style="text-align:left">Options</th>
+      <th>Environment Variables</th>
+      <th>Options</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td style="text-align:left">WANDB_LOG_MODEL</td>
-      <td style="text-align:left">Log the model as artifact at the end of training (<b>false</b> by default)</td>
+      <td>WANDB_LOG_MODEL</td>
+      <td>Log the model as artifact at the end of training (<b>false</b> by default)</td>
     </tr>
     <tr>
-      <td style="text-align:left">WANDB_WATCH</td>
-      <td style="text-align:left">
+      <td>WANDB_WATCH</td>
+      <td>
         <ul>
           <li><b>gradients</b> (default): Log histograms of the gradients</li>
           <li><b>all</b>: Log histograms of gradients and parameters</li>
@@ -263,8 +263,8 @@ Advanced configuration is possible by setting environment variables:
       </td>
     </tr>
     <tr>
-      <td style="text-align:left">WANDB_PROJECT</td>
-      <td style="text-align:left">Organize runs by project</td>
+      <td>WANDB_PROJECT</td>
+      <td>Organize runs by project</td>
     </tr>
   </tbody>
 </table>

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -557,6 +557,7 @@ class WandbCallback(TrainerCallback):
         assert has_wandb, "WandbCallback requires wandb to be installed. Run `pip install wandb`."
         if has_wandb:
             import wandb
+
             self._wandb = wandb
         self._initialized = False
         # log outputs
@@ -571,8 +572,8 @@ class WandbCallback(TrainerCallback):
 
         Environment:
             WANDB_LOG_MODEL (:obj:`bool`, `optional`, defaults to :obj:`False`):
-                Whether or not to log model as artifact at the end of training.
-                Use along with `TrainingArguments.load_best_model_at_end` to upload best model.
+                Whether or not to log model as artifact at the end of training. Use along with
+                `TrainingArguments.load_best_model_at_end` to upload best model.
             WANDB_WATCH (:obj:`str`, `optional` defaults to :obj:`"gradients"`):
                 Can be :obj:`"gradients"`, :obj:`"all"` or :obj:`"false"`. Set to :obj:`"false"` to disable gradient
                 logging or :obj:`"all"` to log gradients and parameters.
@@ -613,7 +614,7 @@ class WandbCallback(TrainerCallback):
             # define default x-axis (for latest wandb versions)
             if getattr(self._wandb, "define_metric", None):
                 self._wandb.define_metric("train/global_step")
-                self._wandb.define_metric("*", step_metric='train/global_step', step_sync=True)
+                self._wandb.define_metric("*", step_metric="train/global_step", step_sync=True)
 
             # keep track of model topology and gradients, unsupported on TPU
             if not is_torch_tpu_available() and os.getenv("WANDB_WATCH") != "false":
@@ -665,7 +666,7 @@ class WandbCallback(TrainerCallback):
             self.setup(args, state, model)
         if state.is_world_process_zero:
             logs = rewrite_logs(logs)
-            self._wandb.log({**logs, 'train/global_step'=global_step)
+            self._wandb.log({**logs, "train/global_step": state.global_step})
 
 
 class CometCallback(TrainerCallback):

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -572,6 +572,7 @@ class WandbCallback(TrainerCallback):
         Environment:
             WANDB_LOG_MODEL (:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to log model as artifact at the end of training.
+                Use along with `TrainingArguments.load_best_model_at_end` to upload best model.
             WANDB_WATCH (:obj:`str`, `optional` defaults to :obj:`"gradients"`):
                 Can be :obj:`"gradients"`, :obj:`"all"` or :obj:`"false"`. Set to :obj:`"false"` to disable gradient
                 logging or :obj:`"all"` to log gradients and parameters.

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -611,11 +611,12 @@ class WandbCallback(TrainerCallback):
 
             self._wandb.init(
                 project=os.getenv("WANDB_PROJECT", "huggingface"),
-                config=combined_dict,
                 name=run_name,
-                reinit=reinit,
+                reinit=True if reinit else None,  # let wandb handle init logic (notebook vs script)
                 **init_args,
             )
+            # add config parameters (run may have been created manually)
+            self._wandb.config.update(combined_dict, allow_val_change=True)
 
             # keep track of model topology and gradients, unsupported on TPU
             if not is_torch_tpu_available() and os.getenv("WANDB_WATCH") != "false":

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -19,7 +19,6 @@ import io
 import json
 import numbers
 import os
-import re
 import tempfile
 from copy import deepcopy
 from pathlib import Path
@@ -643,8 +642,6 @@ class WandbCallback(TrainerCallback):
             fake_trainer = Trainer(args=args, model=model, tokenizer=tokenizer)
             with tempfile.TemporaryDirectory() as temp_dir:
                 fake_trainer.save_model(temp_dir)
-                # use run name and ensure it's a valid Artifact name
-                artifact_name = re.sub(r"[^a-zA-Z0-9_\.\-]", "", self._wandb.run.name)
                 metadata = (
                     {
                         k: v
@@ -657,7 +654,7 @@ class WandbCallback(TrainerCallback):
                         "train/total_floss": state.total_flos,
                     }
                 )
-                artifact = self._wandb.Artifact(name=f"run-{artifact_name}", type="model", metadata=metadata)
+                artifact = self._wandb.Artifact(name=f"model-{self._wandb.run.id}", type="model", metadata=metadata)
                 for f in Path(temp_dir).glob("*"):
                     if f.is_file():
                         with artifact.new_file(f.name, mode="wb") as fa:

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -557,16 +557,7 @@ class WandbCallback(TrainerCallback):
         assert has_wandb, "WandbCallback requires wandb to be installed. Run `pip install wandb`."
         if has_wandb:
             import wandb
-
-            wandb.ensure_configured()
-            if wandb.api.api_key is None:
-                has_wandb = False
-                logger.warning(
-                    "W&B installed but not logged in. Run `wandb login` or set the WANDB_API_KEY env variable."
-                )
-                self._wandb = None
-            else:
-                self._wandb = wandb
+            self._wandb = wandb
         self._initialized = False
         # log outputs
         self._log_model = os.getenv("WANDB_LOG_MODEL", "FALSE").upper() in ENV_VARS_TRUE_VALUES.union({"TRUE"})


### PR DESCRIPTION
# What does this PR do?

Following improvements to `wandb` integration:
* ensure unique artifact id → previously it was based on run name which could create duplicates and mismatches (as runs can be updated manually in the UI)
* allow manual calls to `wandb.init()` → previously it would have closed the run and started a new one
* when a wandb run already exists (manually created), adds automatically model config parameters
* simplify reinit logic → now explicitly closes a run for hp search and avoid use of reinit which can have complex side effects (different behavior in notebooks vs scripts)
* ensure we have no dropped values (when step is below a previous logged value) by logging the step as an independent `train/global_step` metric and set it as default x-axis in the UI (can be edited manually). Note: this auto-setting of x-axis will be activated in upcoming release of wandb
* get values committed immediately so they appear in the UI with no delay
* fixes compatibility with sagemaker

Fixes https://github.com/wandb/client/issues/1499, #8754, #10486


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors which may be interested in your PR.

Documentation: @sgugger