### PR TITLE
Make convert_to_onnx runable as script again

### DIFF
--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -19,9 +19,9 @@ from typing import Dict, List, Optional, Tuple
 
 from packaging.version import Version, parse
 
-from .file_utils import ModelOutput, is_tf_available, is_torch_available
-from .pipelines import Pipeline, pipeline
-from .tokenization_utils import BatchEncoding
+from transformers.file_utils import ModelOutput, is_tf_available, is_torch_available
+from transformers.pipelines import Pipeline, pipeline
+from transformers.tokenization_utils import BatchEncoding
 
 
 # This is the minimal required version to


### PR DESCRIPTION
# What does this PR do?

When rewroking the inits, `convert_graph_to_onnx.py` got its import replaced by relative imports which broke the fact it can be run as a script. This PR fixes that.