### PR TITLE
Fix p_mask cls token masking in question-answering pipeline

### DIFF
--- a/src/transformers/pipelines/question_answering.py
+++ b/src/transformers/pipelines/question_answering.py
@@ -268,7 +268,7 @@ class QuestionAnsweringPipeline(Pipeline):
                 )
 
                 # keep the cls_token unmasked (some models use it to indicate unanswerable questions)
-                if self.tokenizer.cls_token_id:
+                if self.tokenizer.cls_token_id is not None:
                     cls_index = np.nonzero(encoded_inputs["input_ids"] == self.tokenizer.cls_token_id)
                     p_mask[cls_index] = 0
 


### PR DESCRIPTION
# What does this PR do?
It fixes a really small bug described in detail in the issue - it only adds a condition to the if statement responsible for unmasking the `cls_token_id` in the `p_mask` used in the question answering pipeline.

Fixes #10810 

## Who can review?
Anyone in the community is free to review the PR once the tests have passed. 