### PR TITLE
Sm trainer smp init fix

### DIFF
--- a/src/transformers/sagemaker/trainer_sm.py
+++ b/src/transformers/sagemaker/trainer_sm.py
@@ -34,13 +34,13 @@ from ..trainer_pt_utils import (
 )
 from ..trainer_utils import PREFIX_CHECKPOINT_DIR
 from ..utils import logging
-from .training_args_sm import is_smdistributed_available
+from .training_args_sm import is_sagemaker_model_parallel_available
 
 
 logger = logging.get_logger(__name__)
 
 
-if is_smdistributed_available():
+if is_sagemaker_model_parallel_available():
     import smdistributed.modelparallel.torch as smp
 
     @smp.step()
@@ -79,7 +79,7 @@ if is_smdistributed_available():
 
 class SageMakerTrainer(Trainer):
     def __init__(self, args=None, **kwargs):
-        self.is_model_parallel_enabled = is_smdistributed_available() and args.mp_parameters != ""
+        self.is_model_parallel_enabled = is_sagemaker_model_parallel_available()
         super().__init__(args=args, **kwargs)
 
     def is_world_process_zero(self) -> bool:

--- a/src/transformers/sagemaker/training_args_sm.py
+++ b/src/transformers/sagemaker/training_args_sm.py
@@ -15,7 +15,7 @@
 import importlib.util
 import json
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import torch
 
@@ -61,6 +61,11 @@ if is_sagemaker_model_parallel_available():
 
 @dataclass
 class SageMakerTrainingArguments(TrainingArguments):
+    mp_parameters: str = field(
+        default="",
+        metadata={"help": "Used by the SageMaker launcher to send mp-specific args. Ignored in SageMakerTrainer"},
+    )
+
     @cached_property
     def _setup_devices(self) -> "torch.device":
         logger.info("PyTorch: setting up devices")

--- a/src/transformers/sagemaker/training_args_sm.py
+++ b/src/transformers/sagemaker/training_args_sm.py
@@ -15,7 +15,9 @@
 import importlib.util
 from dataclasses import dataclass, field
 
+import json
 import torch
+import os
 
 from transformers.file_utils import cached_property, is_sagemaker_distributed_available
 from transformers.training_args import TrainingArguments
@@ -24,13 +26,35 @@ from transformers.utils import logging
 
 logger = logging.get_logger(__name__)
 
+# TODO: should be moved to `file_utils` after refactoring of SageMakerTrainer
+def is_sagemaker_model_parallel_available():
+    # Get the sagemaker specific mp parameters from smp_options variable.
+    smp_options = os.getenv("SM_HP_MP_PARAMETERS", "{}")
+    try:
+        # Parse it and check the field "partitions" is included, it is required for model parallel.
+        smp_options = json.loads(smp_options)
+        if "partitions" not in smp_options:
+            return False
+    except json.JSONDecodeError:
+        return False
 
-def is_smdistributed_available():
+    # Get the sagemaker specific framework parameters from mpi_options variable.
+    mpi_options = os.getenv("SM_FRAMEWORK_PARAMS", "{}")
+    try:
+        # Parse it and check the field "sagemaker_distributed_dataparallel_enabled".
+        mpi_options = json.loads(mpi_options)
+        if not mpi_options.get("sagemaker_mpi_enabled", False):
+            return False
+    except json.JSONDecodeError:
+        return False
+    # Lastly, check if the `smdistributed` module is present.
     return importlib.util.find_spec("smdistributed") is not None
 
 
-if is_smdistributed_available():
+if is_sagemaker_model_parallel_available():
     import smdistributed.modelparallel.torch as smp
+
+    smp.init()
 
 
 @dataclass
@@ -39,18 +63,13 @@ class SageMakerTrainingArguments(TrainingArguments):
         default="", metadata={"help": "Used by the SageMaker launcher to send mp-specific args."}
     )
 
-    def __post_init__(self):
-        super().__post_init__()
-        if is_smdistributed_available() and self.mp_parameters != "":
-            smp.init()
-
     @cached_property
     def _setup_devices(self) -> "torch.device":
         logger.info("PyTorch: setting up devices")
         if self.no_cuda:
             device = torch.device("cpu")
             self._n_gpu = 0
-        elif is_smdistributed_available() and self.mp_parameters != "":
+        elif is_sagemaker_model_parallel_available():
             local_rank = smp.local_rank()
             device = torch.device("cuda", local_rank)
             self._n_gpu = 1
@@ -86,14 +105,14 @@ class SageMakerTrainingArguments(TrainingArguments):
 
     @property
     def world_size(self):
-        if is_smdistributed_available() and self.mp_parameters != "":
+        if is_sagemaker_model_parallel_available():
             return smp.dp_size()
 
         return super().world_size
 
     @property
     def place_model_on_device(self):
-        return not (is_smdistributed_available() and self.mp_parameters != "")
+        return not is_sagemaker_model_parallel_available()
 
     @property
     def _no_sync_in_gradient_accumulation(self):

--- a/src/transformers/sagemaker/training_args_sm.py
+++ b/src/transformers/sagemaker/training_args_sm.py
@@ -15,7 +15,7 @@
 import importlib.util
 import json
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import torch
 

--- a/src/transformers/sagemaker/training_args_sm.py
+++ b/src/transformers/sagemaker/training_args_sm.py
@@ -61,10 +61,6 @@ if is_sagemaker_model_parallel_available():
 
 @dataclass
 class SageMakerTrainingArguments(TrainingArguments):
-    mp_parameters: str = field(
-        default="", metadata={"help": "Used by the SageMaker launcher to send mp-specific args."}
-    )
-
     @cached_property
     def _setup_devices(self) -> "torch.device":
         logger.info("PyTorch: setting up devices")

--- a/src/transformers/sagemaker/training_args_sm.py
+++ b/src/transformers/sagemaker/training_args_sm.py
@@ -27,6 +27,8 @@ from transformers.utils import logging
 logger = logging.get_logger(__name__)
 
 # TODO: should be moved to `file_utils` after refactoring of SageMakerTrainer
+
+
 def is_sagemaker_model_parallel_available():
     # Get the sagemaker specific mp parameters from smp_options variable.
     smp_options = os.getenv("SM_HP_MP_PARAMETERS", "{}")

--- a/src/transformers/sagemaker/training_args_sm.py
+++ b/src/transformers/sagemaker/training_args_sm.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import importlib.util
+import json
+import os
 from dataclasses import dataclass, field
 
-import json
 import torch
-import os
 
 from transformers.file_utils import cached_property, is_sagemaker_distributed_available
 from transformers.training_args import TrainingArguments


### PR DESCRIPTION
# What does this PR do?

Fixes `SageMakerTrainer` `smp.init` for `smp 1.3`. It also removes the `is_smdistributed_available` for are more robust `is_sagemaker_model_parallel_available`. 
