### PR TITLE
Fix test_trainer_distributed

### DIFF
--- a/tests/test_trainer_distributed.py
+++ b/tests/test_trainer_distributed.py
@@ -119,7 +119,7 @@ if __name__ == "__main__":
 
         p = trainer.predict(dataset)
         logger.info(p.metrics)
-        if p.metrics["eval_success"] is not True:
+        if p.metrics["test_success"] is not True:
             logger.error(p.metrics)
             exit(1)
 
@@ -133,7 +133,7 @@ if __name__ == "__main__":
 
         p = trainer.predict(dataset)
         logger.info(p.metrics)
-        if p.metrics["eval_success"] is not True:
+        if p.metrics["test_success"] is not True:
             logger.error(p.metrics)
             exit(1)
 


### PR DESCRIPTION
# What does this PR do?

#10861 introduced a change in the way metrics are prefixed byt default in `Trainer.predict`, which in turn made `tests/test_trainer_distributed.py` fail. This PR fixes that.
