### PR TITLE
Fix comment in modeling_t5.py

### DIFF
--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -904,6 +904,7 @@ class T5Stack(T5PreTrainedModel):
         if past_key_values is None:
             past_key_values = [None] * len(self.block)
 
+        # We can provide a self-attention mask of dimensions [batch_size, from_seq_length, to_seq_length]
         # ourselves in which case we just need to make it broadcastable to all heads.
         extended_attention_mask = self.get_extended_attention_mask(attention_mask, input_shape, inputs_embeds.device)
 


### PR DESCRIPTION
# What does this PR do?
This PR completes an incomplete comment in the modeling_t5.py file. 

`# ourselves in which case we just need to make it broadcastable to all heads.`
to 
```
# We can provide a self-attention mask of dimensions [batch_size, from_seq_length, to_seq_length] 
# ourselves in which case we just need to make it broadcastable to all heads.
```
