### PR TITLE
Fix overflowing bad word ids

### DIFF
--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -417,7 +417,9 @@ class NoBadWordsLogitsProcessor(LogitsProcessor):
         banned_mask_list = []
         for idx, batch_banned_tokens in enumerate(banned_tokens):
             for token in batch_banned_tokens:
-                banned_mask_list.append([idx, token])
+                # Eliminates invalid bad word IDs that are over the vocabulary size.
+                if token <= scores.shape[1]:
+                    banned_mask_list.append([idx, token])
         if not banned_mask_list:
             return scores
 

--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -22,6 +22,10 @@ import numpy as np
 import torch
 
 from .file_utils import add_start_docstrings
+from .utils.logging import get_logger
+
+
+logger = get_logger(__name__)
 
 
 LOGITS_PROCESSOR_INPUTS_DOCSTRING = r"""
@@ -420,6 +424,11 @@ class NoBadWordsLogitsProcessor(LogitsProcessor):
                 # Eliminates invalid bad word IDs that are over the vocabulary size.
                 if token <= scores.shape[1]:
                     banned_mask_list.append([idx, token])
+                else:
+                    logger.error(
+                        f"An invalid bad word ID is defined: {token}. This ID is not contained in the"
+                        f"vocabulary, and is therefore ignored."
+                    )
         if not banned_mask_list:
             return scores
 


### PR DESCRIPTION
As of now, bad word IDs are not checked when added to the configuration/passed as inputs to the generate method.

This is an issue when an invalid bad word ID is defined: if the vocab size is 30k, then defining a bad word ID for `30001` crashes the generation function with the following error:
```
    torch.sparse.LongTensor(banned_mask.t(), indices, scores.size()).to(scores.device).to_dense().bool()
RuntimeError: size is inconsistent with indices: for dim 1, size is 30000 but found index 30001
```

Please let me know if you think this should raise a better error instead, rather than a warning.