### PR TITLE
Update Training Arguments Documentation: ignore_skip_data -> ignore_data_skip

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -243,7 +243,7 @@ class TrainingArguments:
             - :obj:`True` if :obj:`metric_for_best_model` is set to a value that isn't :obj:`"loss"` or
               :obj:`"eval_loss"`.
             - :obj:`False` if :obj:`metric_for_best_model` is not set, or set to :obj:`"loss"` or :obj:`"eval_loss"`.
-        ignore_skip_data (:obj:`bool`, `optional`, defaults to :obj:`False`):
+        ignore_data_skip (:obj:`bool`, `optional`, defaults to :obj:`False`):
             When resuming training, whether or not to skip the epochs and batches to get the data loading at the same
             stage as in the previous training. If set to :obj:`True`, the training will begin faster (as that skipping
             step can take a long time) but will not yield the same results as the interrupted training would have.


### PR DESCRIPTION
Currently, docs/docstring for TrainingArguments refers to `ignore_skip_data` as the argument for skipping dataloader replay on resume. However, actual argument is called `ignored_data_skip` which leads to errors if you just go off the docs.

(Separate note, doing a full replay for long runs is pretty annoying --> thinking about a way to eliminate this/speed up considerably, but would love to here what the Transformers team is up to in this regard!).

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors which may be interested in your PR.

Tagging @sgugger as this has to do with documentation.