### PR TITLE
ONNX export: move sample input to same device as model when inferring shapes

### DIFF
--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -195,6 +195,9 @@ def infer_shapes(nlp: Pipeline, framework: str) -> Tuple[List[str], List[str], D
 
     tokens = nlp.tokenizer("This is a sample output", return_tensors=framework)
     seq_len = tokens.input_ids.shape[-1]
+    if framework == "pt":
+        # Make sure both the model and inputs are on the same device
+        tokens = tokens.to(nlp.device)
     outputs = nlp.model(**tokens) if framework == "pt" else nlp.model(tokens)
     if isinstance(outputs, ModelOutput):
         outputs = outputs.to_tuple()


### PR DESCRIPTION
# What does this PR do?

Training a model on a GPU and exporting it afterwards to ONNX has raised a `RuntimeError`, because the model and the [sample input](https://github.com/huggingface/transformers/blob/1a3e0c4fe6868b4eb1105dfe601a79d7e5d11a0f/src/transformers/convert_graph_to_onnx.py#L196) in [`transformers.convert_graph_to_onnx.infer_shapes()`](https://github.com/huggingface/transformers/blob/1a3e0c4fe6868b4eb1105dfe601a79d7e5d11a0f/src/transformers/convert_graph_to_onnx.py#L161-L222) were not on the same device. This PR moves the output to the same device as the model.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests) Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@mfuntowicz (according to `git blame`)
