### PR TITLE
Wav2Vec2 CommonVoice training - Save the processor before training starts

### DIFF
--- a/examples/research_projects/wav2vec2/run_common_voice.py
+++ b/examples/research_projects/wav2vec2/run_common_voice.py
@@ -476,12 +476,13 @@ def main():
             checkpoint = model_args.model_name_or_path
         else:
             checkpoint = None
-        train_result = trainer.train(resume_from_checkpoint=checkpoint)
-        trainer.save_model()
 
-        # save the feature_extractor and the tokenizer
+        # Save the feature_extractor and the tokenizer
         if is_main_process(training_args.local_rank):
             processor.save_pretrained(training_args.output_dir)
+
+        train_result = trainer.train(resume_from_checkpoint=checkpoint)
+        trainer.save_model()
 
         metrics = train_result.metrics
         max_train_samples = (


### PR DESCRIPTION
# What does this PR do?

Currently, the Wav2Vec2 processor is saved at the end of training. However, the vocabulary is non-deterministic and varies between runs. Thus, if the training is killed before it's done, the processor is not saved, meaning that the checkpoints do not contain the processor configuration files, making them unusable for resuming training or for evaluating on the checkpoint. Hence, this PR saves the processor before the training begins.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@patrickvonplaten @patil-suraj 
