### PR TITLE
Add example for registering callbacks with trainers

### DIFF
--- a/docs/source/main_classes/callback.rst
+++ b/docs/source/main_classes/callback.rst
@@ -74,6 +74,30 @@ TrainerCallback
 .. autoclass:: transformers.TrainerCallback
     :members:
 
+Here is an example of how to register a custom callback with the PyTorch :class:`~transformers.Trainer`:
+
+.. code-block:: python
+
+    class MyCallback(TrainerCallback):
+        "A callback that prints a message at the beginning of training"
+
+        def on_train_begin(self, args, state, control, **kwargs):
+            print("Starting training")
+
+    trainer = Trainer(
+        model,
+        args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        callbacks=[MyCallback]
+    )
+
+Another way to register a callback is to call ``trainer.add_callback()`` as follows:
+
+.. code-block:: python
+
+    trainer.add_callback(MyCallback)
+
 
 TrainerState
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/main_classes/callback.rst
+++ b/docs/source/main_classes/callback.rst
@@ -96,6 +96,7 @@ Another way to register a callback is to call ``trainer.add_callback()`` as foll
 
 .. code-block:: python
 
+    trainer = Trainer(...)
     trainer.add_callback(MyCallback)
 
 

--- a/docs/source/main_classes/callback.rst
+++ b/docs/source/main_classes/callback.rst
@@ -89,7 +89,7 @@ Here is an example of how to register a custom callback with the PyTorch :class:
         args,
         train_dataset=train_dataset,
         eval_dataset=eval_dataset,
-        callbacks=[MyCallback]
+        callbacks=[MyCallback]  # We can either pass the callback class this way or an instance of it (MyCallback())
     )
 
 Another way to register a callback is to call ``trainer.add_callback()`` as follows:
@@ -98,7 +98,8 @@ Another way to register a callback is to call ``trainer.add_callback()`` as foll
 
     trainer = Trainer(...)
     trainer.add_callback(MyCallback)
-
+    # Alternatively, we can pass an instance of the callback class
+    trainer.add_callback(MyCallback())
 
 TrainerState
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# What does this PR do?

Fixes the issue addressed in #9036 by adding an example for registering a custom callback with the Trainer.


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

Fixes: https://github.com/huggingface/transformers/issues/9036

## Who can review?

Anyone in the community is free to review the PR. But @sgugger seems the most appropriate.