### PR TITLE
[trainer metrics] fix cpu mem metrics; reformat runtime metric

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -228,7 +228,7 @@ extras["speech"] = deps_list("soundfile", "torchaudio")
 
 extras["sentencepiece"] = deps_list("sentencepiece", "protobuf")
 extras["testing"] = (
-    deps_list("pytest", "pytest-xdist", "timeout-decorator", "parameterized", "datasets", "pytest-sugar", "black")
+    deps_list("pytest", "pytest-xdist", "timeout-decorator", "parameterized", "psutil", "datasets", "pytest-sugar", "black")
     + extras["retrieval"]
     + extras["modelcreation"]
 )
@@ -269,7 +269,6 @@ install_requires = [
     deps["filelock"],  # filesystem locks, e.g., to prevent parallel downloads
     deps["numpy"],
     deps["packaging"],  # utilities from PyPA to e.g., compare versions
-    deps["psutil"],  # memory tracking
     deps["regex"],  # for OpenAI GPT
     deps["requests"],  # for downloading models over HTTPS
     deps["sacremoses"],  # for XLM

--- a/setup.py
+++ b/setup.py
@@ -228,7 +228,7 @@ extras["speech"] = deps_list("soundfile", "torchaudio")
 
 extras["sentencepiece"] = deps_list("sentencepiece", "protobuf")
 extras["testing"] = (
-    deps_list("pytest", "pytest-xdist", "timeout-decorator", "parameterized", "psutil", "datasets", "pytest-sugar", "black")
+    deps_list("pytest", "pytest-xdist", "timeout-decorator", "parameterized", "datasets", "pytest-sugar", "black")
     + extras["retrieval"]
     + extras["modelcreation"]
 )
@@ -269,6 +269,7 @@ install_requires = [
     deps["filelock"],  # filesystem locks, e.g., to prevent parallel downloads
     deps["numpy"],
     deps["packaging"],  # utilities from PyPA to e.g., compare versions
+    deps["psutil"],  # memory tracking
     deps["regex"],  # for OpenAI GPT
     deps["requests"],  # for downloading models over HTTPS
     deps["sacremoses"],  # for XLM

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -16,6 +16,7 @@
 Torch utilities for the Trainer class.
 """
 
+import datetime
 import json
 import math
 import os
@@ -615,6 +616,15 @@ def _get_learning_rate(self):
     return last_lr
 
 
+def _secs2timedelta(secs):
+    """
+    convert seconds to hh:mm:ss.msec, msecs rounded to 2 decimals
+    """
+
+    msec = int(abs(secs - int(secs)) * 100)
+    return f"{datetime.timedelta(seconds=int(secs))}.{msec:02d}"
+
+
 def metrics_format(self, metrics: Dict[str, float]) -> Dict[str, float]:
     """
     Reformat Trainer metrics values to a human-readable format
@@ -631,6 +641,8 @@ def metrics_format(self, metrics: Dict[str, float]) -> Dict[str, float]:
     for k, v in metrics_copy.items():
         if "_mem_" in k:
             metrics_copy[k] = f"{ v >> 20 }MB"
+        elif "_runtime" in k:
+            metrics_copy[k] = _secs2timedelta(v)
         elif k == "total_flos":
             metrics_copy[k] = f"{ int(v) >> 30 }GF"
         elif type(metrics_copy[k]) == float:

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -754,7 +754,7 @@ def save_metrics(self, split, metrics, combined=True):
         combined (:obj:`bool`, `optional`, defaults to :obj:`True`):
             Creates combined metrics by updating ``all_results.json`` with metrics of this call
 
-    To understand the metrics please read the docstring of :obj:`transformers.Trainer.log_metrics()`. The only
+    To understand the metrics please read the docstring of :meth:`~transformers.Trainer.log_metrics`. The only
     difference is that raw unformatted numbers are saved in the current method.
 
     """

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -662,6 +662,72 @@ def log_metrics(self, split, metrics):
             Mode/split name: one of ``train``, ``eval``, ``test``
         metrics (:obj:`Dict[str, float]`):
             The metrics returned from train/evaluate/predictmetrics: metrics dict
+
+    Notes on memory reports:
+
+    In order to get memory usage report you need to install ``psutil``. You can do that with ``pip install psutil``.
+
+    Now when this method is run, you will see a report that will include: ::
+
+        init_mem_cpu_alloc_delta   =     1301MB
+        init_mem_cpu_peaked_delta  =      154MB
+        init_mem_gpu_alloc_delta   =      230MB
+        init_mem_gpu_peaked_delta  =        0MB
+        train_mem_cpu_alloc_delta  =     1345MB
+        train_mem_cpu_peaked_delta =        0MB
+        train_mem_gpu_alloc_delta  =      693MB
+        train_mem_gpu_peaked_delta =        7MB
+
+    **Understanding the reports:**
+
+    - the first segment, e.g., ``train__``, tells you which stage the metrics are for. Reports starting with ``init_``
+      will be added to the first stage that gets run. So that if only evaluation is run, the memory usage for the
+      ``__init__`` will be reported along with the ``eval_`` metrics.
+    - the third segment, is either ``cpu`` or ``gpu``, tells you whether it's the general RAM or the gpu0 memory
+      metric.
+    - ``*_alloc_delta`` - is the difference in the used/allocated memory counter between the end and the start of the
+      stage - it can be negative if a function released more memory than it allocated.
+    - ``*_peaked_delta`` - is any extra memory that was consumed and then freed - relative to the current allocated
+      memory counter - it is never negative. When you look at the metrics of any stage you add up ``alloc_delta`` +
+      ``peaked_delta`` and you know how much memory was needed to complete that stage.
+
+    The reporting happens only for process of rank 0 and gpu 0 (if there is a gpu). Typically this is enough since the
+    main process does the bulk of work, but it could be not quite so if model parallel is used and then other GPUs may
+    use a different amount of gpu memory. This is also not the same under DataParallel where gpu0 may require much more
+    memory than the rest since it stores the gradient and optimizer states for all participating GPUS. Perhaps in the
+    future these reports will evolve to measure those too.
+
+    The CPU RAM metric measures RSS (Resident Set Size) includes both the memory which is unique to the process and the
+    memory shared with other processes. It is important to note that it does not include swapped out memory, so the
+    reports could be imprecise.
+
+    The CPU peak memory is measured using a sampling thread. Due to python's GIL it may miss some of the peak memory if
+    that thread didn't get a chance to run when the highest memory was used. Therefore this report can be less than
+    reality. Using ``tracemalloc`` would have reported the exact peak memory, but it doesn't report memory allocations
+    outside of python. So if some C++ CUDA extension allocated its own memory it won't be reported. And therefore it
+    was dropped in favor of the memory sampling approach, which reads the current process memory usage.
+
+    The GPU allocated and peak memory reporting is done with ``torch.cuda.memory_allocated()`` and
+    ``torch.cuda.max_memory_allocated()``. This metric reports only "deltas" for pytorch-specific allocations, as
+    ``torch.cuda`` memory management system doesn't track any memory allocated outside of pytorch. For example, the
+    very first cuda call typically loads CUDA kernels, which may take from 0.5 to 2GB of GPU memory.
+
+    Note that this tracker doesn't account for memory allocations outside of :class:`~transformers.Trainer`'s
+    ``__init__``, ``train``, ``evaluate`` and ``predict`` calls.
+
+    Because ``evaluation`` calls may happen during ``train``, we can't handle nested invocations because
+    ``torch.cuda.max_memory_allocated`` is a single counter, so if it gets reset by a nested eval call, ``train``'s
+    tracker will report incorrect info. If this `pytorch issue <https://github.com/pytorch/pytorch/issues/16266>`__
+    gets resolved it will be possible to change this class to be re-entrant. Until then we will only track the outer
+    level of ``train``, ``evaluate`` and ``predict`` methods. Which means that if ``eval`` is called during ``train``,
+    it's the latter that will account for its memory usage and that of the former.
+
+    This also means that if any other tool that is used along the :class:`~transformers.Trainer` calls
+    ``torch.cuda.reset_peak_memory_stats``, the gpu peak memory stats could be invalid. And the
+    :class:`~transformers.Trainer` will disrupt the normal behavior of any such tools that rely on calling
+    ``torch.cuda.reset_peak_memory_stats`` themselves.
+
+    For best performance you may want to consider turning the memory profiling off for production runs.
     """
     if not self.is_world_process_zero():
         return
@@ -687,6 +753,10 @@ def save_metrics(self, split, metrics, combined=True):
             The metrics returned from train/evaluate/predict
         combined (:obj:`bool`, `optional`, defaults to :obj:`True`):
             Creates combined metrics by updating ``all_results.json`` with metrics of this call
+
+    To understand the metrics please read the docstring of :obj:`transformers.Trainer.log_metrics()`. The only
+    difference is that raw unformatted numbers are saved in the current method.
+
     """
     if not self.is_world_process_zero():
         return

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -17,7 +17,6 @@ Utilities for the Trainer and TFTrainer class. Should be independent from PyTorc
 """
 
 import copy
-import datetime
 import gc
 import inspect
 import os
@@ -226,15 +225,6 @@ def total_processes_number(local_rank):
     return 1
 
 
-def secs2timedelta(secs):
-    """
-    convert seconds to hh:mm:ss.msec, msecs rounded to 2 decimals
-    """
-
-    msec = int(abs(secs - int(secs)) * 100)
-    return f"{datetime.timedelta(seconds=int(secs))}.{msec:02d}"
-
-
 def speed_metrics(split, start_time, num_samples=None):
     """
     Measure and return speed performance metrics.
@@ -249,7 +239,7 @@ def speed_metrics(split, start_time, num_samples=None):
     - num_samples: number of samples processed
     """
     runtime = time.time() - start_time
-    result = {f"{split}_runtime": secs2timedelta(runtime)}
+    result = {f"{split}_runtime": runtime}
     if num_samples is not None:
         samples_per_second = 1 / (runtime / num_samples)
         result[f"{split}_samples_per_second"] = round(samples_per_second, 3)

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -345,7 +345,6 @@ class TrainerMemoryTracker:
         self.skip_memory_metrics = skip_memory_metrics
 
         if not is_psutil_available():
-            die
             # soft dependency on psutil
             self.skip_memory_metrics = True
 

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -273,7 +273,7 @@ class TrainerMemoryTracker:
 
     At the moment GPU tracking is only for ``pytorch``, but can be extended to support ``tensorflow``.
 
-    To understand this class' intricacies please read the documentation of :obj:`transformers.Trainer.log_metrics()`.
+    To understand this class' intricacies please read the documentation of :meth:`~transformers.Trainer.log_metrics`.
 
     """
 

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -239,7 +239,7 @@ def speed_metrics(split, start_time, num_samples=None):
     - num_samples: number of samples processed
     """
     runtime = time.time() - start_time
-    result = {f"{split}_runtime": runtime}
+    result = {f"{split}_runtime": round(runtime, 4)}
     if num_samples is not None:
         samples_per_second = 1 / (runtime / num_samples)
         result[f"{split}_samples_per_second"] = round(samples_per_second, 3)


### PR DESCRIPTION
This PR improves and fixes trainer metrics:

* reworks the general ram memory tracking replacing `tracemalloc`, with "sampling" via `psutil` - in particular for peak tracking using a thread. `tracemalloc` proved to not track anything but python memory allocations, so we were missing most of the general RAM from reports. Now we are reporting much more. (other than swapped out memory).
* adds important details to memory metrics docs
* moves `psutil` dependency from just-for-tests to the core. I tried to find a built-in python equivalent, but the closest that I found is `resource.getrusage(resource.RUSAGE_SELF).ru_maxrss` which doesn't report what we need and it's not cross-platform.
* reformats secs to be in `hh:mm:ss.msec` format so it's much easier to read the runtime metric

Discovered the `tracemalloc` limitation while tracking a huge memory leak in DeepSpeed when re-using deepspeed in the same process. My tests were consuming hundreds of MBs of general RAM and the metrics were reporting nothing.

before:
```
BS=4; PYTHONPATH=src USE_TF=0 python examples/seq2seq/run_translation.py --model_name_or_path \
t5-small --output_dir /tmp/zero3 --overwrite_output_dir --max_train_samples 64 --max_val_samples 64 \
--max_source_length 128 --max_target_length 128 --val_max_target_length 128 --do_train \
--num_train_epochs 1 --per_device_train_batch_size $BS --per_device_eval_batch_size $BS \
--learning_rate 3e-3 --warmup_steps 500 --predict_with_generate --logging_steps 0 --save_steps 0 \
--eval_steps 0 --group_by_length --adafactor --dataset_name wmt16 --dataset_config ro-en \
--source_lang en --target_lang ro --source_prefix "translate English to Romanian: "

***** train metrics *****
  epoch                      =    1.0
  init_mem_cpu_alloc_delta   =    3MB
  init_mem_cpu_peaked_delta  =    0MB
  init_mem_gpu_alloc_delta   =  230MB
  init_mem_gpu_peaked_delta  =    0MB
  train_mem_cpu_alloc_delta  =   60MB
  train_mem_cpu_peaked_delta =    0MB
  train_mem_gpu_alloc_delta  =  232MB
  train_mem_gpu_peaked_delta =  472MB
  train_runtime              = 5.5261
  train_samples              =     64
  train_samples_per_second   =  1.448
```

after this PR:

```
***** train metrics *****
  epoch                      =        1.0
  init_mem_cpu_alloc_delta   =     1298MB
  init_mem_cpu_peaked_delta  =      154MB
  init_mem_gpu_alloc_delta   =      230MB
  init_mem_gpu_peaked_delta  =        0MB
  train_mem_cpu_alloc_delta  =     3446MB
  train_mem_cpu_peaked_delta =        0MB
  train_mem_gpu_alloc_delta  =      232MB
  train_mem_gpu_peaked_delta =      472MB
  train_runtime              = 0:00:05.66
  train_samples              =         64
  train_samples_per_second   =      1.412
```

@sgugger, @LysandreJik 