### PR TITLE
fix md file to avoid evaluation crash

### DIFF
--- a/examples/research_projects/wav2vec2/FINE_TUNE_XLSR_WAV2VEC2.md
+++ b/examples/research_projects/wav2vec2/FINE_TUNE_XLSR_WAV2VEC2.md
@@ -349,7 +349,7 @@ def speech_file_to_array_fn(batch):
 	return batch
 
 test_dataset = test_dataset.map(speech_file_to_array_fn)
-inputs = processor(test_dataset["speech"][:2], sampling_rate=16_000, return_tensors="pt", padding=True)
+inputs = processor(test_dataset[:2]["speech"], sampling_rate=16_000, return_tensors="pt", padding=True)
 
 with torch.no_grad():
 	logits = model(inputs.input_values, attention_mask=inputs.attention_mask).logits
@@ -357,7 +357,7 @@ with torch.no_grad():
 predicted_ids = torch.argmax(logits, dim=-1)
 
 print("Prediction:", processor.batch_decode(predicted_ids))
-print("Reference:", test_dataset["sentence"][:2])
+print("Reference:", test_dataset[:2]["sentence"])
 ```
 
 


### PR DESCRIPTION
# What does this PR do?

Fix the crash due to the memory usage in the instructions for model evaluation in `FINE_TUNE_XLSR_WAV2VEC2.md`.
The original version `test_dataset["speech"][:2]` load the whole speech array into memory which is too large.
Change it to `test_dataset[:2]["speech"]` runs smoothly and much faster.

## Before submitting
- [ ] This PR improves the docs

## Who can review?

@patrickvonplaten 
