### PR TITLE
added py7zr

### DIFF
--- a/examples/seq2seq/requirements.txt
+++ b/examples/seq2seq/requirements.txt
@@ -4,3 +4,4 @@ protobuf
 sacrebleu >= 1.4.12
 rouge-score
 nltk
+py7zr

--- a/examples/seq2seq/run_summarization.py
+++ b/examples/seq2seq/run_summarization.py
@@ -46,7 +46,7 @@ from transformers.utils import check_min_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-check_min_version("4.5.0.dev0")
+#check_min_version("4.5.0.dev0")
 
 logger = logging.getLogger(__name__)
 

--- a/examples/seq2seq/run_summarization.py
+++ b/examples/seq2seq/run_summarization.py
@@ -46,7 +46,7 @@ from transformers.utils import check_min_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-#check_min_version("4.5.0.dev0")
+check_min_version("4.5.0.dev0")
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# What does this PR do?

This PR adds `py7zr` to use `samsum` as a dataset. 

```python
[1,14]<stdout>:    use_auth_token=use_auth_token,
[1,14]<stdout>:  File "/opt/conda/lib/python3.6/site-packages/datasets/load.py", line 448, in prepare_module
[1,14]<stdout>:    f"To be able to use this {module_type}, you need to install the following dependencies"
[1,14]<stdout>:ImportError: To be able to use this dataset, you need to install the following dependencies['py7zr'] using 'pip install py7zr' for instance'
```