### PR TITLE
support passing path to a `config` variable in AutoClass

### DIFF
--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -831,8 +831,9 @@ class AutoModel:
         """
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
+            config_path = config if config is not None else pretrained_model_name_or_path
             config, kwargs = AutoConfig.from_pretrained(
-                pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
+                config_path, return_unused_kwargs=True, **kwargs
             )
 
         if type(config) in MODEL_MAPPING.keys():
@@ -925,8 +926,9 @@ class AutoModelForPreTraining:
         """
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
+            config_path = config if config is not None else pretrained_model_name_or_path
             config, kwargs = AutoConfig.from_pretrained(
-                pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
+                config_path, return_unused_kwargs=True, **kwargs
             )
 
         if type(config) in MODEL_FOR_PRETRAINING_MAPPING.keys():
@@ -1036,8 +1038,9 @@ class AutoModelWithLMHead:
         )
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
+            config_path = config if config is not None else pretrained_model_name_or_path
             config, kwargs = AutoConfig.from_pretrained(
-                pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
+                config_path, return_unused_kwargs=True, **kwargs
             )
 
         if type(config) in MODEL_WITH_LM_HEAD_MAPPING.keys():
@@ -1129,8 +1132,9 @@ class AutoModelForCausalLM:
         """
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
+            config_path = config if config is not None else pretrained_model_name_or_path
             config, kwargs = AutoConfig.from_pretrained(
-                pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
+                config_path, return_unused_kwargs=True, **kwargs
             )
 
         if type(config) in MODEL_FOR_CAUSAL_LM_MAPPING.keys():
@@ -1222,8 +1226,9 @@ class AutoModelForMaskedLM:
         """
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
+            config_path = config if config is not None else pretrained_model_name_or_path
             config, kwargs = AutoConfig.from_pretrained(
-                pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
+                config_path, return_unused_kwargs=True, **kwargs
             )
 
         if type(config) in MODEL_FOR_MASKED_LM_MAPPING.keys():
@@ -1318,8 +1323,9 @@ class AutoModelForSeq2SeqLM:
         """
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
+            config_path = config if config is not None else pretrained_model_name_or_path
             config, kwargs = AutoConfig.from_pretrained(
-                pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
+                config_path, return_unused_kwargs=True, **kwargs
             )
 
         if type(config) in MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.keys():
@@ -1416,8 +1422,9 @@ class AutoModelForSequenceClassification:
         """
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
+            config_path = config if config is not None else pretrained_model_name_or_path
             config, kwargs = AutoConfig.from_pretrained(
-                pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
+                config_path, return_unused_kwargs=True, **kwargs
             )
 
         if type(config) in MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.keys():
@@ -1513,8 +1520,9 @@ class AutoModelForQuestionAnswering:
         """
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
+            config_path = config if config is not None else pretrained_model_name_or_path
             config, kwargs = AutoConfig.from_pretrained(
-                pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
+                config_path, return_unused_kwargs=True, **kwargs
             )
 
         if type(config) in MODEL_FOR_QUESTION_ANSWERING_MAPPING.keys():
@@ -1613,8 +1621,9 @@ class AutoModelForTableQuestionAnswering:
         """
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
+            config_path = config if config is not None else pretrained_model_name_or_path
             config, kwargs = AutoConfig.from_pretrained(
-                pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
+                config_path, return_unused_kwargs=True, **kwargs
             )
 
         if type(config) in MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING.keys():
@@ -1711,8 +1720,9 @@ class AutoModelForTokenClassification:
         """
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
+            config_path = config if config is not None else pretrained_model_name_or_path
             config, kwargs = AutoConfig.from_pretrained(
-                pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
+                config_path, return_unused_kwargs=True, **kwargs
             )
 
         if type(config) in MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.keys():
@@ -1811,8 +1821,9 @@ class AutoModelForMultipleChoice:
         """
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
+            config_path = config if config is not None else pretrained_model_name_or_path
             config, kwargs = AutoConfig.from_pretrained(
-                pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
+                config_path, return_unused_kwargs=True, **kwargs
             )
 
         if type(config) in MODEL_FOR_MULTIPLE_CHOICE_MAPPING.keys():
@@ -1911,8 +1922,9 @@ class AutoModelForNextSentencePrediction:
         """
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
+            config_path = config if config is not None else pretrained_model_name_or_path
             config, kwargs = AutoConfig.from_pretrained(
-                pretrained_model_name_or_path, return_unused_kwargs=True, **kwargs
+                config_path, return_unused_kwargs=True, **kwargs
             )
 
         if type(config) in MODEL_FOR_NEXT_SENTENCE_PREDICTION_MAPPING.keys():

--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -700,13 +700,18 @@ AUTO_MODEL_PRETRAINED_DOCSTRING = r"""
                       a PyTorch model using the provided conversion scripts and loading the PyTorch model afterwards.
             model_args (additional positional arguments, `optional`):
                 Will be passed along to the underlying model ``__init__()`` method.
-            config (:class:`~transformers.PretrainedConfig`, `optional`):
-                Configuration for the model to use instead of an automatically loaded configuration. Configuration can
+            config (:obj:`Union[PretrainedConfig, str, os.PathLike]`, `optional`):
+                Can be either:
+
+                    - an instance of a class derived from :class:`~transformers.PretrainedConfig`,
+                    - a string or path valid as input to :func:`~transformers.PretrainedConfig.from_pretrained`.
+
+                Configuration for the model to use instead of an automatically loaded configuation. Configuration can
                 be automatically loaded when:
 
                     - The model is a model provided by the library (loaded with the `model id` string of a pretrained
                       model).
-                    - The model was saved using :meth:`~transformers.PreTrainedModel.save_pretrained` and is reloaded
+                    - The model was saved using :func:`~transformers.PreTrainedModel.save_pretrained` and is reloaded
                       by supplying the save directory.
                     - The model is loaded by supplying a local directory as ``pretrained_model_name_or_path`` and a
                       configuration JSON file named `config.json` is found in the directory.

--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -837,9 +837,7 @@ class AutoModel:
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
             config_path = config if config is not None else pretrained_model_name_or_path
-            config, kwargs = AutoConfig.from_pretrained(
-                config_path, return_unused_kwargs=True, **kwargs
-            )
+            config, kwargs = AutoConfig.from_pretrained(config_path, return_unused_kwargs=True, **kwargs)
 
         if type(config) in MODEL_MAPPING.keys():
             return MODEL_MAPPING[type(config)].from_pretrained(
@@ -932,9 +930,7 @@ class AutoModelForPreTraining:
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
             config_path = config if config is not None else pretrained_model_name_or_path
-            config, kwargs = AutoConfig.from_pretrained(
-                config_path, return_unused_kwargs=True, **kwargs
-            )
+            config, kwargs = AutoConfig.from_pretrained(config_path, return_unused_kwargs=True, **kwargs)
 
         if type(config) in MODEL_FOR_PRETRAINING_MAPPING.keys():
             return MODEL_FOR_PRETRAINING_MAPPING[type(config)].from_pretrained(
@@ -1044,9 +1040,7 @@ class AutoModelWithLMHead:
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
             config_path = config if config is not None else pretrained_model_name_or_path
-            config, kwargs = AutoConfig.from_pretrained(
-                config_path, return_unused_kwargs=True, **kwargs
-            )
+            config, kwargs = AutoConfig.from_pretrained(config_path, return_unused_kwargs=True, **kwargs)
 
         if type(config) in MODEL_WITH_LM_HEAD_MAPPING.keys():
             return MODEL_WITH_LM_HEAD_MAPPING[type(config)].from_pretrained(
@@ -1138,9 +1132,7 @@ class AutoModelForCausalLM:
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
             config_path = config if config is not None else pretrained_model_name_or_path
-            config, kwargs = AutoConfig.from_pretrained(
-                config_path, return_unused_kwargs=True, **kwargs
-            )
+            config, kwargs = AutoConfig.from_pretrained(config_path, return_unused_kwargs=True, **kwargs)
 
         if type(config) in MODEL_FOR_CAUSAL_LM_MAPPING.keys():
             return MODEL_FOR_CAUSAL_LM_MAPPING[type(config)].from_pretrained(
@@ -1232,9 +1224,7 @@ class AutoModelForMaskedLM:
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
             config_path = config if config is not None else pretrained_model_name_or_path
-            config, kwargs = AutoConfig.from_pretrained(
-                config_path, return_unused_kwargs=True, **kwargs
-            )
+            config, kwargs = AutoConfig.from_pretrained(config_path, return_unused_kwargs=True, **kwargs)
 
         if type(config) in MODEL_FOR_MASKED_LM_MAPPING.keys():
             return MODEL_FOR_MASKED_LM_MAPPING[type(config)].from_pretrained(
@@ -1329,9 +1319,7 @@ class AutoModelForSeq2SeqLM:
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
             config_path = config if config is not None else pretrained_model_name_or_path
-            config, kwargs = AutoConfig.from_pretrained(
-                config_path, return_unused_kwargs=True, **kwargs
-            )
+            config, kwargs = AutoConfig.from_pretrained(config_path, return_unused_kwargs=True, **kwargs)
 
         if type(config) in MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.keys():
             return MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING[type(config)].from_pretrained(
@@ -1428,9 +1416,7 @@ class AutoModelForSequenceClassification:
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
             config_path = config if config is not None else pretrained_model_name_or_path
-            config, kwargs = AutoConfig.from_pretrained(
-                config_path, return_unused_kwargs=True, **kwargs
-            )
+            config, kwargs = AutoConfig.from_pretrained(config_path, return_unused_kwargs=True, **kwargs)
 
         if type(config) in MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.keys():
             return MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING[type(config)].from_pretrained(
@@ -1526,9 +1512,7 @@ class AutoModelForQuestionAnswering:
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
             config_path = config if config is not None else pretrained_model_name_or_path
-            config, kwargs = AutoConfig.from_pretrained(
-                config_path, return_unused_kwargs=True, **kwargs
-            )
+            config, kwargs = AutoConfig.from_pretrained(config_path, return_unused_kwargs=True, **kwargs)
 
         if type(config) in MODEL_FOR_QUESTION_ANSWERING_MAPPING.keys():
             return MODEL_FOR_QUESTION_ANSWERING_MAPPING[type(config)].from_pretrained(
@@ -1627,9 +1611,7 @@ class AutoModelForTableQuestionAnswering:
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
             config_path = config if config is not None else pretrained_model_name_or_path
-            config, kwargs = AutoConfig.from_pretrained(
-                config_path, return_unused_kwargs=True, **kwargs
-            )
+            config, kwargs = AutoConfig.from_pretrained(config_path, return_unused_kwargs=True, **kwargs)
 
         if type(config) in MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING.keys():
             return MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING[type(config)].from_pretrained(
@@ -1726,9 +1708,7 @@ class AutoModelForTokenClassification:
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
             config_path = config if config is not None else pretrained_model_name_or_path
-            config, kwargs = AutoConfig.from_pretrained(
-                config_path, return_unused_kwargs=True, **kwargs
-            )
+            config, kwargs = AutoConfig.from_pretrained(config_path, return_unused_kwargs=True, **kwargs)
 
         if type(config) in MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.keys():
             return MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING[type(config)].from_pretrained(
@@ -1827,9 +1807,7 @@ class AutoModelForMultipleChoice:
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
             config_path = config if config is not None else pretrained_model_name_or_path
-            config, kwargs = AutoConfig.from_pretrained(
-                config_path, return_unused_kwargs=True, **kwargs
-            )
+            config, kwargs = AutoConfig.from_pretrained(config_path, return_unused_kwargs=True, **kwargs)
 
         if type(config) in MODEL_FOR_MULTIPLE_CHOICE_MAPPING.keys():
             return MODEL_FOR_MULTIPLE_CHOICE_MAPPING[type(config)].from_pretrained(
@@ -1928,9 +1906,7 @@ class AutoModelForNextSentencePrediction:
         config = kwargs.pop("config", None)
         if not isinstance(config, PretrainedConfig):
             config_path = config if config is not None else pretrained_model_name_or_path
-            config, kwargs = AutoConfig.from_pretrained(
-                config_path, return_unused_kwargs=True, **kwargs
-            )
+            config, kwargs = AutoConfig.from_pretrained(config_path, return_unused_kwargs=True, **kwargs)
 
         if type(config) in MODEL_FOR_NEXT_SENTENCE_PREDICTION_MAPPING.keys():
             return MODEL_FOR_NEXT_SENTENCE_PREDICTION_MAPPING[type(config)].from_pretrained(


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

It enables loading weights from a private server like the following.
```python
AutoModel.from_pretrained('https://myserver/model/pytorch_model.bin', config='path/to/local/config.json') 
```
**For the moment, the function to load weights from a private server like this way is supported in `PretrainedModel` but not in `AutoModel`.**
```python
BertModel.from_pretrained('https://myserver/model/pytorch_model.bin', config='path/to/local/config.json') # supported
AutoModel.from_pretrained('https://myserver/model/pytorch_model.bin', config='path/to/local/config.json') # not supported
```
To fix this issue, I copy and pasted code about `config_path` from `PretrainedModel` to `AutoModel`.

This features was requested in #10961 .

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors which may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
@LysandreJik 