### PR TITLE
Replace pkg_resources with importlib_metadata

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -46,17 +46,11 @@ from tqdm.auto import tqdm
 
 import requests
 from filelock import FileLock
+from transformers.utils.versions import importlib_metadata
 
 from . import __version__
 from .hf_api import HfFolder
 from .utils import logging
-
-
-# The package importlib_metadata is in a different place, depending on the python version.
-if sys.version_info < (3, 8):
-    import importlib_metadata
-else:
-    import importlib.metadata as importlib_metadata
 
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name

--- a/tests/test_versions_utils.py
+++ b/tests/test_versions_utils.py
@@ -16,7 +16,13 @@ import sys
 
 import numpy
 
-import pkg_resources
+
+# The package importlib_metadata is in a different place, depending on the python version.
+if sys.version_info < (3, 8):
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
+
 from transformers.testing_utils import TestCasePlus
 from transformers.utils.versions import require_version, require_version_core, require_version_examples
 
@@ -57,7 +63,7 @@ class DependencyVersionCheckTest(TestCasePlus):
         for req in ["numpy==1.0.0", "numpy>=1000.0.0", f"numpy<{numpy_ver}"]:
             try:
                 require_version_core(req)
-            except pkg_resources.VersionConflict as e:
+            except ImportError as e:
                 self.assertIn(f"{req} is required", str(e))
                 self.assertIn("but found", str(e))
 
@@ -65,7 +71,7 @@ class DependencyVersionCheckTest(TestCasePlus):
         for req in ["numpipypie>1", "numpipypie2"]:
             try:
                 require_version_core(req)
-            except pkg_resources.DistributionNotFound as e:
+            except importlib_metadata.PackageNotFoundError as e:
                 self.assertIn(f"The '{req}' distribution was not found and is required by this application", str(e))
                 self.assertIn("Try: pip install transformers -U", str(e))
 
@@ -87,7 +93,7 @@ class DependencyVersionCheckTest(TestCasePlus):
         # the main functionality is tested in `test_core`, this is just the hint check
         try:
             require_version_examples("numpy>1000.4.5")
-        except pkg_resources.VersionConflict as e:
+        except ImportError as e:
             self.assertIn("is required", str(e))
             self.assertIn("pip install -r examples/requirements.txt", str(e))
 
@@ -100,6 +106,6 @@ class DependencyVersionCheckTest(TestCasePlus):
         for req in ["python>9.9.9", "python<3.0.0"]:
             try:
                 require_version_core(req)
-            except pkg_resources.VersionConflict as e:
+            except ImportError as e:
                 self.assertIn(f"{req} is required", str(e))
                 self.assertIn(f"but found python=={python_ver}", str(e))

--- a/tests/test_versions_utils.py
+++ b/tests/test_versions_utils.py
@@ -16,15 +16,13 @@ import sys
 
 import numpy
 
-
-# The package importlib_metadata is in a different place, depending on the python version.
-if sys.version_info < (3, 8):
-    import importlib_metadata
-else:
-    import importlib.metadata as importlib_metadata
-
 from transformers.testing_utils import TestCasePlus
-from transformers.utils.versions import require_version, require_version_core, require_version_examples
+from transformers.utils.versions import (
+    importlib_metadata,
+    require_version,
+    require_version_core,
+    require_version_examples,
+)
 
 
 numpy_ver = numpy.__version__


### PR DESCRIPTION
# What does this PR do?

Fixes #10964. The other reason for this change is that pkg_resources has been [deprecated](https://github.com/pypa/setuptools/commit/8fe85c22cee7fde5e6af571b30f864bad156a010) in favor of importlib_metadata.

`ImportError` looked like the best replacement for `pkg_resources.VersionConflict` since importlib has no equivalent exception, but I'm happy to change it to better suggestions.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. #10964
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation). n/a
- [x] Did you write any new necessary tests? n/a


## Who can review?

CC @stas00
