### PR TITLE
Some models have no tokenizers

### DIFF
--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -69,13 +69,14 @@ def merge_model_tokenizer_mappings(
     model_tokenizer_mapping = OrderedDict([])
 
     for configuration in configurations:
-        model = model_mapping[configuration]
-        tokenizer = tokenizer_mapping[configuration][0]
-        tokenizer_fast = tokenizer_mapping[configuration][1]
+        if configuration in model_mapping and configuration in tokenizer_mapping:
+            model = model_mapping[configuration]
+            tokenizer = tokenizer_mapping[configuration][0]
+            tokenizer_fast = tokenizer_mapping[configuration][1]
 
-        model_tokenizer_mapping.update({tokenizer: (configuration, model)})
-        if tokenizer_fast is not None:
-            model_tokenizer_mapping.update({tokenizer_fast: (configuration, model)})
+            model_tokenizer_mapping.update({tokenizer: (configuration, model)})
+            if tokenizer_fast is not None:
+                model_tokenizer_mapping.update({tokenizer_fast: (configuration, model)})
 
     return model_tokenizer_mapping
 


### PR DESCRIPTION
Some models have no tokenizer. This ensures we don't get a key error when looking for the tokenizer of a model that may not have it.

:warning: this means that we're missing a check to ensure that all tokenizers have an AutoTokenizer. As seen with @sgugger, this will be handled in a script from now on.