### PR TITLE
Make a base init in FeatureExtractionMixin

### DIFF
--- a/src/transformers/feature_extraction_sequence_utils.py
+++ b/src/transformers/feature_extraction_sequence_utils.py
@@ -56,13 +56,7 @@ class SequenceFeatureExtractor(FeatureExtractionMixin):
         self.padding_side = kwargs.pop("padding_side", "right")
         self.return_attention_mask = kwargs.pop("return_attention_mask", True)
 
-        # Additional attributes without default values
-        for key, value in kwargs.items():
-            try:
-                setattr(self, key, value)
-            except AttributeError as err:
-                logger.error(f"Can't set {key} with value {value} for {self}")
-                raise err
+        super().__init__(**kwargs)
 
     def pad(
         self,

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -197,6 +197,16 @@ class FeatureExtractionMixin:
     extractors.
     """
 
+    def __init__(self, **kwargs):
+        """Set elements of `kwargs` as attributes."""
+        # Additional attributes without default values
+        for key, value in kwargs.items():
+            try:
+                setattr(self, key, value)
+            except AttributeError as err:
+                logger.error(f"Can't set {key} with value {value} for {self}")
+                raise err
+
     @classmethod
     def from_pretrained(
         cls, pretrained_model_name_or_path: Union[str, os.PathLike], **kwargs


### PR DESCRIPTION
# What does this PR do?

This PR adds a base init to `FeatureExtractionMixin` so that high up in the hierarchy, remaining kwargs are set as attributes. Without this, adding new fields to the config of a feature extractor inheriting directly from `FeatureExtractionMixin`, like `ViTFeatureExtractor`, will fail so we won't be able to add fields (like the model type for easy use with an Auto API) without breaking backward compatibility.