### PR TITLE
HF emoji unicode doesn't work in console

### DIFF
--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -23,7 +23,7 @@ def check_min_version(min_version):
     if version.parse(__version__) < version.parse(min_version):
         if "dev" in min_version:
             error_message = (
-                "This example requires a source install from 🤗 Transformers (see "
+                "This example requires a source install from HuggingFace Transformers (see "
                 "`https://huggingface.co/transformers/installation.html#installing-from-source`),"
             )
         else:
@@ -33,6 +33,6 @@ def check_min_version(min_version):
             error_message
             + (
                 "Check out https://huggingface.co/transformers/examples.html for the examples corresponding to other "
-                "versions of 🤗 Transformers."
+                "versions of HuggingFace Transformers."
             )
         )


### PR DESCRIPTION
It doesn't look like using 🤗 is a great idea for printing to console. See attachment.

![snapshot_21](https://user-images.githubusercontent.com/10676103/113665185-e604cb00-9661-11eb-9b4b-d0f0423c6695.png)

This PR proposes to replace 🤗 with "HuggingFace" for an exception message.

@LysandreJik
