### PR TITLE
[versions] handle version requirement ranges

### DIFF
--- a/src/transformers/utils/versions.py
+++ b/src/transformers/utils/versions.py
@@ -40,6 +40,17 @@ ops = {
 }
 
 
+def _compare_versions(op, got_ver, want_ver, requirement, pkg, hint):
+    if got_ver is None:
+        raise ValueError("got_ver is None")
+    if want_ver is None:
+        raise ValueError("want_ver is None")
+    if not ops[op](version.parse(got_ver), version.parse(want_ver)):
+        raise ImportError(
+            f"{requirement} is required for a normal functioning of this module, but found {pkg}=={got_ver}.{hint}"
+        )
+
+
 def require_version(requirement: str, hint: Optional[str] = None) -> None:
     """
     Perform a runtime check of the dependency versions, using the exact same syntax used by pip.
@@ -62,22 +73,31 @@ def require_version(requirement: str, hint: Optional[str] = None) -> None:
     if re.match(r"^[\w_\-\d]+$", requirement):
         pkg, op, want_ver = requirement, None, None
     else:
-        match = re.findall(r"^([^!=<>\s]+)([\s!=<>]{1,2})(.+)", requirement)
+        # match = re.findall(r"^([^!=<>\s]+)([\s!=<>]{1,2})(.+)", requirement)
+        match = re.findall(r"^([^!=<>\s]+)([\s!=<>]{1,2}.+)", requirement)
         if not match:
             raise ValueError(
                 f"requirement needs to be in the pip package format, .e.g., package_a==1.23, or package_b>=1.23, but got {requirement}"
             )
-        pkg, op, want_ver = match[0]
-        if op not in ops:
-            raise ValueError(f"need one of {list(ops.keys())}, but got {op}")
+        pkg, want_full = match[0]
+        want_range = want_full.split(",")  # there could be multiple requirements
+        wanted = {}
+        for w in want_range:
+            match = re.findall(r"^([\s!=<>]{1,2})(.+)", w)
+            if not match:
+                raise ValueError(
+                    f"requirement needs to be in the pip package format, .e.g., package_a==1.23, or package_b>=1.23, but got {requirement}"
+                )
+            op, want_ver = match[0]
+            wanted[op] = want_ver
+            if op not in ops:
+                raise ValueError(f"{requirement}: need one of {list(ops.keys())}, but got {op}")
 
     # special case
     if pkg == "python":
         got_ver = ".".join([str(x) for x in sys.version_info[:3]])
-        if not ops[op](version.parse(got_ver), version.parse(want_ver)):
-            raise ImportError(
-                f"{requirement} is required for a normal functioning of this module, but found {pkg}=={got_ver}."
-            )
+        for op, want_ver in wanted.items():
+            _compare_versions(op, got_ver, want_ver, requirement, pkg, hint)
         return
 
     # check if any version is installed
@@ -88,11 +108,10 @@ def require_version(requirement: str, hint: Optional[str] = None) -> None:
             f"The '{requirement}' distribution was not found and is required by this application. {hint}"
         )
 
-    # check that the right version is installed if version number was provided
-    if want_ver is not None and not ops[op](version.parse(got_ver), version.parse(want_ver)):
-        raise ImportError(
-            f"{requirement} is required for a normal functioning of this module, but found {pkg}=={got_ver}.{hint}"
-        )
+    # check that the right version is installed if version number or a range was provided
+    if want_ver is not None:
+        for op, want_ver in wanted.items():
+            _compare_versions(op, got_ver, want_ver, requirement, pkg, hint)
 
 
 def require_version_core(requirement):

--- a/src/transformers/utils/versions.py
+++ b/src/transformers/utils/versions.py
@@ -62,18 +62,12 @@ def require_version(requirement: str, hint: Optional[str] = None) -> None:
         hint (:obj:`str`, `optional`): what suggestion to print in case of requirements not being met
     """
 
-    # note: while pkg_resources.require_version(requirement) is a much simpler way to do it, it
-    # fails if some of the dependencies of the dependencies are not matching, which is not necessarily
-    # bad, hence the more complicated check - which also should be faster, since it doesn't check
-    # dependencies of dependencies.
-
     hint = f"\n{hint}" if hint is not None else ""
 
     # non-versioned check
     if re.match(r"^[\w_\-\d]+$", requirement):
         pkg, op, want_ver = requirement, None, None
     else:
-        # match = re.findall(r"^([^!=<>\s]+)([\s!=<>]{1,2})(.+)", requirement)
         match = re.findall(r"^([^!=<>\s]+)([\s!=<>]{1,2}.+)", requirement)
         if not match:
             raise ValueError(

--- a/tests/test_versions_utils.py
+++ b/tests/test_versions_utils.py
@@ -14,8 +14,6 @@
 
 import sys
 
-import numpy
-
 from transformers.testing_utils import TestCasePlus
 from transformers.utils.versions import (
     importlib_metadata,
@@ -25,7 +23,7 @@ from transformers.utils.versions import (
 )
 
 
-numpy_ver = numpy.__version__
+numpy_ver = importlib_metadata.version("numpy")
 python_ver = ".".join([str(x) for x in sys.version_info[:3]])
 
 

--- a/tests/test_versions_utils.py
+++ b/tests/test_versions_utils.py
@@ -52,6 +52,9 @@ class DependencyVersionCheckTest(TestCasePlus):
         # gt
         require_version_core("numpy>1.0.0")
 
+        # mix
+        require_version_core("numpy>1.0.0,<1000")
+
         # requirement w/o version
         require_version_core("numpy")
 


### PR DESCRIPTION
As discussed in https://github.com/huggingface/transformers/issues/11107 our `require_version` wasn't handling ranges like `"tokenizers>=0.10.1,<0.11"`. This PR fixes it.

I don't know if it fixes the problem reported in https://github.com/huggingface/transformers/issues/11107 as I can't reproduce it.

One odd thing though in `numpy`:
```
$ python -c "import numpy; print(numpy.__version__)"
1.19.2
$ python -c "from importlib.metadata import version; print(version('numpy'))"
1.18.5
$ pip uninstall numpy
Found existing installation: numpy 1.19.2
Uninstalling numpy-1.19.2:
  Would remove:
    /mnt/nvme1/anaconda3/envs/main-38/bin/f2py
    /mnt/nvme1/anaconda3/envs/main-38/bin/f2py3
    /mnt/nvme1/anaconda3/envs/main-38/bin/f2py3.8
    /mnt/nvme1/anaconda3/envs/main-38/lib/python3.8/site-packages/numpy-1.19.2.dist-info/*
    /mnt/nvme1/anaconda3/envs/main-38/lib/python3.8/site-packages/numpy/*
  Would not remove (might be manually added):
    /mnt/nvme1/anaconda3/envs/main-38/lib/python3.8/site-packages/numpy/core/tests/test_issue14735.py
    /mnt/nvme1/anaconda3/envs/main-38/lib/python3.8/site-packages/numpy/distutils/compat.py
    /mnt/nvme1/anaconda3/envs/main-38/lib/python3.8/site-packages/numpy/random/_bit_generator.cpython-38-x86_64-linux-gnu.so
    /mnt/nvme1/anaconda3/envs/main-38/lib/python3.8/site-packages/numpy/random/_bit_generator.pxd
Proceed (y/n)? y
  Successfully uninstalled numpy-1.19.2
$ python -c "from importlib.metadata import version; print(version('numpy'))"
1.18.5
$ python -c "import numpy; print(numpy.__version__)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AttributeError: module 'numpy' has no attribute '__version__'

$ pip install numpy -U
Requirement already satisfied: numpy in /mnt/nvme1/anaconda3/envs/main-38/lib/python3.8/site-packages (1.18.5)
Collecting numpy
  Downloading numpy-1.20.2-cp38-cp38-manylinux2010_x86_64.whl (15.4 MB)
     |████████████████████████████████| 15.4 MB 4.6 MB/s
Installing collected packages: numpy
  Attempting uninstall: numpy
    Found existing installation: numpy 1.18.5
    Uninstalling numpy-1.18.5:
      Successfully uninstalled numpy-1.18.5
$ python -c "import numpy; print(numpy.__version__)"
1.20.2
$  python -c "from importlib.metadata import version; print(version('numpy'))"
1.20.2
```

Perhaps it's just `numpy` and the extra files it leaves behind? I adjusted the test not to rely on `numpy.__version__` as it seems just invites failing tests. 

@sgugger, @LysandreJik 