### PR TITLE
Some styling of the training table in Notebooks

### DIFF
--- a/src/transformers/utils/notebook.py
+++ b/src/transformers/utils/notebook.py
@@ -33,15 +33,6 @@ def html_progress_bar(value, total, prefix, label, width=300):
     # docstyle-ignore
     return f"""
     <div>
-        <style>
-            /* Turns off some styling */
-            progress {{
-                /* gets rid of default border in Firefox and Opera. */
-                border: none;
-                /* Needs to be in here for Safari polyfill so background images work as expected. */
-                background-size: auto;
-            }}
-        </style>
       {prefix}
       <progress value='{value}' max='{total}' style='width:{width}px; height:20px; vertical-align: middle;'></progress>
       {label}
@@ -327,6 +318,8 @@ class NotebookProgressCallback(TrainerCallback):
             values["Validation Loss"] = metrics["eval_loss"]
             _ = metrics.pop("total_flos", None)
             _ = metrics.pop("epoch", None)
+            _ = metrics.pop("eval_runtime", None)
+            _ = metrics.pop("eval_samples_per_second", None)
             for k, v in metrics.items():
                 if k == "eval_loss":
                     values["Validation Loss"] = v


### PR DESCRIPTION
# What does this PR do?

This PR removes the custom styling of the progress bar, because the default one is actually prettier and it can cause some lag on some browsers (like Safari) to recompute the style at each update of the progress bar.

It also removes the timing metrics which do not make much sense form the table (there are still in the log history).