### PR TITLE
Don't duplicate logs in TensorBoard and handle --use_env

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -521,9 +521,11 @@ class TensorBoardCallback(TrainerCallback):
                 self.tb_writer.add_hparams(args.to_sanitized_dict(), metric_dict={})
 
     def on_log(self, args, state, control, logs=None, **kwargs):
-        if state.is_world_process_zero:
-            if self.tb_writer is None:
-                self._init_summary_writer(args)
+        if not state.is_world_process_zero:
+            return
+
+        if self.tb_writer is None:
+            self._init_summary_writer(args)
 
         if self.tb_writer is not None:
             logs = rewrite_logs(logs)

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -531,6 +531,12 @@ class TrainingArguments:
     )
 
     def __post_init__(self):
+        # Handle --use_env option in torch.distributed.launch (local_rank not passed as an arg then).
+        # This needs to happen before any call to self.device or self.n_gpu.
+        env_local_rank = int(os.environ.get("LOCAL_RANK", -1))
+        if env_local_rank != -1 and env_local_rank != self.local_rank:
+            self.local_rank = env_local_rank
+
         # expand paths, if not os.makedirs("~/bar") will make directory
         # in the current directory instead of the actual home
         #  see https://github.com/huggingface/transformers/issues/10628


### PR DESCRIPTION
# What does this PR do?

This PR fixes a few bugs in the `Trainer` and `TrainingArguments`. First it cleans up the `TensorBoardCallback` to make sure the logs are not duplicated (I think they were not for some convoluted logic with the `tb_writer` never set but now I'm sure).

The second part is more important and handles support for when a user launches a training script using `Trainer` with the `--use_env` option (for instance when using `accelerate launch`). In this case the argument `local_rank` is not passed directly, it's just set in the environment and we did not detect it.