### PR TITLE
[trainer] solve "scheduler before optimizer step" warning

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1161,7 +1161,7 @@ class Trainer:
                         self.scaler.step(self.optimizer)
                         self.scaler.update()
                         scale_after = self.scaler.get_scale()
-                        optimizer_was_run = scale_before == scale_after
+                        optimizer_was_run = scale_before <= scale_after
                     else:
                         self.optimizer.step()
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1151,17 +1151,21 @@ class Trainer:
                             )
 
                     # Optimizer step
+                    optimizer_was_run = True
                     if self.deepspeed:
                         pass  # called outside the loop
                     elif is_torch_tpu_available():
                         xm.optimizer_step(self.optimizer)
                     elif self.use_amp:
+                        scale_before = self.scaler.get_scale()
                         self.scaler.step(self.optimizer)
                         self.scaler.update()
+                        scale_after = self.scaler.get_scale()
+                        optimizer_was_run = scale_before == scale_after
                     else:
                         self.optimizer.step()
 
-                    if not self.deepspeed:
+                    if optimizer_was_run and not self.deepspeed :
                         self.lr_scheduler.step()
 
                     model.zero_grad()

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1165,7 +1165,7 @@ class Trainer:
                     else:
                         self.optimizer.step()
 
-                    if optimizer_was_run and not self.deepspeed :
+                    if optimizer_was_run and not self.deepspeed:
                         self.lr_scheduler.step()
 
                     model.zero_grad()


### PR DESCRIPTION
As discussed in https://github.com/huggingface/transformers/issues/11106 fp16 scaler leads to a warning:

> torch/optim/lr_scheduler.py:132: UserWarning: Detected call of lr_scheduler.step() before optimizer.step(). In PyTorch 1.1.0 and later, you should call them in the opposite order: optimizer.step() before lr_scheduler.step(). Failure to do this will result in PyTorch skipping the first value of the learning rate schedule. See more details at https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate
> warnings.warn("Detected call of lr_scheduler.step() before optimizer.step().

because the optimizer may get skipped until the right scale is found, so we shouldn't run `lr_scheduler.step()` when that happens.

@ptrblck provided a workaround here:
https://discuss.pytorch.org/t/model-weights-not-getting-updated-when-using-autocast/117286/10?u=ptrblck

This is also reported at pytoch: https://github.com/pytorch/pytorch/issues/55585

So the solution is we check the scale before and after and if it changed, then the optimizer wasn't run and we skip the scheduler step then.

Fixes: https://github.com/huggingface/transformers/issues/11106

@sgugger 