### PR TITLE
[run_clm] clarify why we get the tokenizer warning on long input

### DIFF
--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -323,7 +323,9 @@ def main():
             output = tokenizer(examples[text_column_name])
         # clm input could be much much longer than block_size
         if "Token indices sequence length is longer than the" in cl.out:
-            tok_logger.warning("^^^^^^^^^^^^^^^^ Please ignore the warning above - this long input will be chunked into smaller bits before being passed to the model.")
+            tok_logger.warning(
+                "^^^^^^^^^^^^^^^^ Please ignore the warning above - this long input will be chunked into smaller bits before being passed to the model."
+            )
         return output
 
     tokenized_datasets = datasets.map(

--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -323,7 +323,7 @@ def main():
             output = tokenizer(examples[text_column_name])
         # clm input could be much much longer than block_size
         if "Token indices sequence length is longer than the" in cl.out:
-            tok_logger.warning("^^^^^^^^^^^^^^^^ Please ignore the warning above - it's just a long input")
+            tok_logger.warning("^^^^^^^^^^^^^^^^ Please ignore the warning above - this long input will be chunked in smaller bits before being passed to the model.")
         return output
 
     tokenized_datasets = datasets.map(

--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -323,7 +323,7 @@ def main():
             output = tokenizer(examples[text_column_name])
         # clm input could be much much longer than block_size
         if "Token indices sequence length is longer than the" in cl.out:
-            tok_logger.warning("^^^^^^^^^^^^^^^^ Please ignore the warning above - this long input will be chunked in smaller bits before being passed to the model.")
+            tok_logger.warning("^^^^^^^^^^^^^^^^ Please ignore the warning above - this long input will be chunked into smaller bits before being passed to the model.")
         return output
 
     tokenized_datasets = datasets.map(

--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -43,6 +43,7 @@ from transformers import (
     default_data_collator,
     set_seed,
 )
+from transformers.testing_utils import CaptureLogger
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
 from transformers.utils import check_min_version
 
@@ -317,7 +318,13 @@ def main():
     text_column_name = "text" if "text" in column_names else column_names[0]
 
     def tokenize_function(examples):
-        return tokenizer(examples[text_column_name])
+        tok_logger = transformers.utils.logging.get_logger("transformers.tokenization_utils_base")
+        with CaptureLogger(tok_logger) as cl:
+            output = tokenizer(examples[text_column_name])
+        # clm input could be much much longer than block_size
+        if "Token indices sequence length is longer than the" in cl.out:
+            tok_logger.warning("^^^^^^^^^^^^^^^^ Please ignore the warning above - it's just a long input")
+        return output
 
     tokenized_datasets = datasets.map(
         tokenize_function,


### PR DESCRIPTION
Solving https://github.com/huggingface/transformers/issues/11108 this PR adds a clarification of why the warning is printed by the tokenizer when `run_clm.py` sends a huge input to tokenize against a short `block_size`. It's not great, but at least now the user will know that the warning is not warranted to be a warning in this particular situation.

> [WARNING|tokenization_utils_base.py:3138] 2021-04-06 21:29:29,790 >> Token indices sequence length is longer than the specified maximum sequence length for this model (1462828 > 1024). Running this sequence through the model will result in indexing errors

So after this PR the we end up an extra warning:

```
[WARNING|tokenization_utils_base.py:3143] 2021-04-07 21:09:22,144 >> Token indices sequence length is longer than the specified maximum sequence length for this model (1462828 > 1024). Running this sequence through the model will result in indexing errors
[WARNING|run_clm.py:326] 2021-04-07 21:13:14,300 >> ^^^^^^^^^^^^^^^^ Please ignore the warning above - it's just a long input
```

The correct solution would be to redesign the API to notify the tokenizer that in some cases the input doesn't have to be less than `block_size`.

Fixes: https://github.com/huggingface/transformers/issues/11108

@sgugger 