### PR TITLE
Add fairscale and deepspeed back to the CI

### DIFF
--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -156,6 +156,8 @@ jobs:
           apt -y update && apt install -y libsndfile1-dev
           pip install --upgrade pip
           pip install .[sklearn,testing,onnxruntime,sentencepiece,speech]
+          pip install fairscale
+          pip install deepspeed
 
       - name: Are GPUs recognized by our DL frameworks
         run: |

--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -34,6 +34,7 @@ jobs:
           apt -y update && apt install -y libsndfile1-dev
           pip install --upgrade pip
           pip install .[sklearn,testing,onnxruntime,sentencepiece,speech]
+          pip install deepspeed
 
       - name: Are GPUs recognized by our DL frameworks
         run: |


### PR DESCRIPTION
Add fairscale and deepspeed back to the CI, they were erroneously removed in https://github.com/huggingface/transformers/pull/10681.

