### PR TITLE
[setup] extras[docs] must include 'all'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,7 +348,7 @@ jobs:
                       - v0.4-{{ checksum "setup.py" }}
             - run: sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev
             - run: pip install --upgrade pip
-            - run: pip install ."[all, docs]"
+            - run: pip install ."[docs]"
             - save_cache:
                   key: v0.4-build_doc-{{ checksum "setup.py" }}
                   paths:
@@ -370,7 +370,7 @@ jobs:
                   keys:
                       - v0.4-deploy_doc-{{ checksum "setup.py" }}
                       - v0.4-{{ checksum "setup.py" }}
-            - run: pip install ."[all,docs]"
+            - run: pip install ."[docs]"
             - save_cache:
                   key: v0.4-deploy_doc-{{ checksum "setup.py" }}
                   paths:

--- a/setup.py
+++ b/setup.py
@@ -244,16 +244,6 @@ extras["testing"] = (
     + extras["modelcreation"]
 )
 
-extras["docs_specific"] = deps_list(
-    "docutils",
-    "recommonmark",
-    "sphinx",
-    "sphinx-markdown-tables",
-    "sphinx-rtd-theme",
-    "sphinx-copybutton",
-    "sphinxext-opengraph",
-)
-
 extras["quality"] = deps_list("black", "isort", "flake8")
 
 extras["all"] = (
@@ -266,6 +256,15 @@ extras["all"] = (
     + extras["vision"]
 )
 
+extras["docs_specific"] = deps_list(
+    "docutils",
+    "recommonmark",
+    "sphinx",
+    "sphinx-markdown-tables",
+    "sphinx-rtd-theme",
+    "sphinx-copybutton",
+    "sphinxext-opengraph",
+)
 # "docs" needs "all" to resolve all the references
 extras["docs"] = extras["all"] + extras["docs_specific"]
 

--- a/setup.py
+++ b/setup.py
@@ -243,6 +243,17 @@ extras["testing"] = (
     + extras["retrieval"]
     + extras["modelcreation"]
 )
+
+extras["docs_specific"] = deps_list(
+    "docutils",
+    "recommonmark",
+    "sphinx",
+    "sphinx-markdown-tables",
+    "sphinx-rtd-theme",
+    "sphinx-copybutton",
+    "sphinxext-opengraph",
+)
+
 extras["quality"] = deps_list("black", "isort", "flake8")
 
 extras["all"] = (
@@ -256,16 +267,6 @@ extras["all"] = (
 )
 
 # "docs" needs "all" to resolve all the references
-extras["docs_specific"] = deps_list(
-    "docutils",
-    "recommonmark",
-    "sphinx",
-    "sphinx-markdown-tables",
-    "sphinx-rtd-theme",
-    "sphinx-copybutton",
-    "sphinxext-opengraph",
-)
-
 extras["docs"] = extras["all"] + extras["docs_specific"]
 
 extras["dev"] = (

--- a/setup.py
+++ b/setup.py
@@ -255,18 +255,8 @@ extras["all"] = (
     + extras["vision"]
 )
 
-extras["dev"] = (
-    extras["all"]
-    + extras["testing"]
-    + extras["quality"]
-    + extras["ja"]
-    + extras["docs"]
-    + extras["sklearn"]
-    + extras["modelcreation"]
-)
-
 # "docs" needs "all" to resolve all the references
-extras["docs"] = extras["all"] + deps_list(
+extras["docs_specific"] = deps_list(
     "docutils",
     "recommonmark",
     "sphinx",
@@ -274,6 +264,18 @@ extras["docs"] = extras["all"] + deps_list(
     "sphinx-rtd-theme",
     "sphinx-copybutton",
     "sphinxext-opengraph",
+)
+
+extras["docs"] = extras["all"] + extras["docs_specific"]
+
+extras["dev"] = (
+    extras["all"]
+    + extras["testing"]
+    + extras["quality"]
+    + extras["ja"]
+    + extras["docs_specific"]
+    + extras["sklearn"]
+    + extras["modelcreation"]
 )
 
 extras["torchhub"] = deps_list(

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ To create the package for pypi.
 
 1. Run `make pre-release` (or `make pre-patch` for a patch release) then run `make fix-copies` to fix the index of the
    documentation.
-   
+
 2. Run Tests for Amazon Sagemaker. The documentation is located in `./tests/sagemaker/README.md`, otherwise @philschmid.
 
 3. Unpin specific versions from setup.py that use a git install.
@@ -243,15 +243,6 @@ extras["testing"] = (
     + extras["retrieval"]
     + extras["modelcreation"]
 )
-extras["docs"] = deps_list(
-    "docutils",
-    "recommonmark",
-    "sphinx",
-    "sphinx-markdown-tables",
-    "sphinx-rtd-theme",
-    "sphinx-copybutton",
-    "sphinxext-opengraph",
-)
 extras["quality"] = deps_list("black", "isort", "flake8")
 
 extras["all"] = (
@@ -272,6 +263,17 @@ extras["dev"] = (
     + extras["docs"]
     + extras["sklearn"]
     + extras["modelcreation"]
+)
+
+# "docs" needs "all" to resolve all the references
+extras["docs"] = extras["all"] + deps_list(
+    "docutils",
+    "recommonmark",
+    "sphinx",
+    "sphinx-markdown-tables",
+    "sphinx-rtd-theme",
+    "sphinx-copybutton",
+    "sphinxext-opengraph",
 )
 
 extras["torchhub"] = deps_list(


### PR DESCRIPTION
Currently `pip install -e .[docs]` doesn't necessarily lead to a successful `make docs`, so this PR makes `extras["docs"]` fully self-contained.

@sgugger, @LysandreJik  