### PR TITLE
Enable option for subword regularization in `XLMRobertaTokenizer`

### DIFF
--- a/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
@@ -101,8 +101,8 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
             nbest_size = {0,1}: No sampling is performed.
             nbest_size > 1: samples from the nbest_size results.
             nbest_size < 0: assuming that nbest_size is infinite and samples
-                from the all hypothesis (lattice) using
-                forward-filtering-and-backward-sampling algorithm.
+            from the all hypothesis (lattice) using
+            forward-filtering-and-backward-sampling algorithm.
         alpha (:obj:`float`, `optional`, defaults to 0.1):
             Soothing parameter for unigram sampling, and dropout probability of
             merge operations for BPE-dropout.

--- a/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
@@ -98,10 +98,12 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
             Will be passed to the SentencePieceProcessor ``__init__()`` method. Can be used to set:
 
             - ``enable_sampling``: Enable subword regularization.
-            - ``nbest_size``: Sampling parameters for unigram. Invalid for BPE-Dropout. nbest_size = {0,1}: No sampling is performed.
-              nbest_size > 1: samples from the nbest_size results. nbest_size < 0: assuming that nbest_size is infinite
-              and samples from the all hypothesis (lattice) using forward-filtering-and-backward-sampling algorithm.
-            - ``alpha``: Smoothing parameter for unigram sampling, and dropout probability of merge operations for BPE-dropout.
+            - ``nbest_size``: Sampling parameters for unigram. Invalid for BPE-Dropout. nbest_size = {0,1}: No sampling
+              is performed. nbest_size > 1: samples from the nbest_size results. nbest_size < 0: assuming that
+              nbest_size is infinite and samples from the all hypothesis (lattice) using
+              forward-filtering-and-backward-sampling algorithm.
+            - ``alpha``: Smoothing parameter for unigram sampling, and dropout probability of merge operations for
+              BPE-dropout.
 
     Attributes:
         sp_model (:obj:`SentencePieceProcessor`):

--- a/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
@@ -104,7 +104,7 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
             from the all hypothesis (lattice) using
             forward-filtering-and-backward-sampling algorithm.
         alpha (:obj:`float`, `optional`, defaults to 0.1):
-            Soothing parameter for unigram sampling, and dropout probability of
+            Smoothing parameter for unigram sampling, and dropout probability of
             merge operations for BPE-dropout.
 
     Attributes:

--- a/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
@@ -105,6 +105,7 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
               - ``nbest_size > 1``: samples from the nbest_size results.
               - ``nbest_size < 0``: assuming that nbest_size is infinite and samples from the all hypothesis (lattice)
                 using forward-filtering-and-backward-sampling algorithm.
+
             - ``alpha``: Smoothing parameter for unigram sampling, and dropout probability of merge operations for
               BPE-dropout.
 

--- a/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
@@ -143,6 +143,9 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
             cls_token=cls_token,
             pad_token=pad_token,
             mask_token=mask_token,
+            enable_sampling=enable_sampling,
+            nbest_size=nbest_size,
+            alpha=alpha,
             **kwargs,
         )
 

--- a/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
@@ -95,7 +95,7 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
         additional_special_tokens (:obj:`List[str]`, `optional`, defaults to :obj:`["<s>NOTUSED", "</s>NOTUSED"]`):
             Additional special tokens used by the tokenizer.
         sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
-            Will be passed to the SentencePieceProcessor ``__init__()`` method. Can be used, among other things, to
+            Will be passed to the ``.SentencePieceProcessor.__init__()`` method. Can be used, among other things, to
             set:
 
             - ``enable_sampling``: Enable subword regularization.

--- a/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
@@ -95,14 +95,16 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
         additional_special_tokens (:obj:`List[str]`, `optional`, defaults to :obj:`["<s>NOTUSED", "</s>NOTUSED"]`):
             Additional special tokens used by the tokenizer.
         sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
-            Will be passed to the ``.SentencePieceProcessor.__init__()`` method. Can be used, among other things, to
-            set:
+            Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
+            <https://github.com/google/sentencepiece/tree/master/python>`_ can be used, among other things, to set:
 
             - ``enable_sampling``: Enable subword regularization.
-            - ``nbest_size``: Sampling parameters for unigram. Invalid for BPE-Dropout. nbest_size = {0,1}: No sampling
-              is performed. nbest_size > 1: samples from the nbest_size results. nbest_size < 0: assuming that
-              nbest_size is infinite and samples from the all hypothesis (lattice) using
-              forward-filtering-and-backward-sampling algorithm.
+            - ``nbest_size``: Sampling parameters for unigram. Invalid for BPE-Dropout.
+
+              - ``nbest_size = {0,1}``: No sampling is performed.
+              - ``nbest_size > 1``: samples from the nbest_size results.
+              - ``nbest_size < 0``: assuming that nbest_size is infinite and samples from the all hypothesis (lattice)
+                using forward-filtering-and-backward-sampling algorithm.
             - ``alpha``: Smoothing parameter for unigram sampling, and dropout probability of merge operations for
               BPE-dropout.
 

--- a/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
@@ -95,7 +95,8 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
         additional_special_tokens (:obj:`List[str]`, `optional`, defaults to :obj:`["<s>NOTUSED", "</s>NOTUSED"]`):
             Additional special tokens used by the tokenizer.
         sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
-            Will be passed to the SentencePieceProcessor ``__init__()`` method. Can be used to set:
+            Will be passed to the SentencePieceProcessor ``__init__()`` method. Can be used, among other things, to
+            set:
 
             - ``enable_sampling``: Enable subword regularization.
             - ``nbest_size``: Sampling parameters for unigram. Invalid for BPE-Dropout. nbest_size = {0,1}: No sampling

--- a/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
@@ -97,15 +97,11 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
         enable_sampling (:obj:`bool`, `optional`, defaults to :obj:`False`):
             Enable subword regularization.
         nbest_size (:obj:`int`, `optional`, defaults to -1):
-            Sampling parameters for unigram. Invalid for BPE-Dropout.
-            nbest_size = {0,1}: No sampling is performed.
-            nbest_size > 1: samples from the nbest_size results.
-            nbest_size < 0: assuming that nbest_size is infinite and samples
-            from the all hypothesis (lattice) using
-            forward-filtering-and-backward-sampling algorithm.
+            Sampling parameters for unigram. Invalid for BPE-Dropout. nbest_size = {0,1}: No sampling is performed.
+            nbest_size > 1: samples from the nbest_size results. nbest_size < 0: assuming that nbest_size is infinite
+            and samples from the all hypothesis (lattice) using forward-filtering-and-backward-sampling algorithm.
         alpha (:obj:`float`, `optional`, defaults to 0.1):
-            Smoothing parameter for unigram sampling, and dropout probability of
-            merge operations for BPE-dropout.
+            Smoothing parameter for unigram sampling, and dropout probability of merge operations for BPE-dropout.
 
     Attributes:
         sp_model (:obj:`SentencePieceProcessor`):

--- a/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
@@ -96,7 +96,7 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
             Additional special tokens used by the tokenizer.
         sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
-            <https://github.com/google/sentencepiece/tree/master/python>`_ can be used, among other things, to set:
+            <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 
             - ``enable_sampling``: Enable subword regularization.
             - ``nbest_size``: Sampling parameters for unigram. Invalid for BPE-Dropout.

--- a/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
@@ -94,14 +94,14 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
             modeling. This is the token which the model will try to predict.
         additional_special_tokens (:obj:`List[str]`, `optional`, defaults to :obj:`["<s>NOTUSED", "</s>NOTUSED"]`):
             Additional special tokens used by the tokenizer.
-        enable_sampling (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            Enable subword regularization.
-        nbest_size (:obj:`int`, `optional`, defaults to -1):
-            Sampling parameters for unigram. Invalid for BPE-Dropout. nbest_size = {0,1}: No sampling is performed.
-            nbest_size > 1: samples from the nbest_size results. nbest_size < 0: assuming that nbest_size is infinite
-            and samples from the all hypothesis (lattice) using forward-filtering-and-backward-sampling algorithm.
-        alpha (:obj:`float`, `optional`, defaults to 0.1):
-            Smoothing parameter for unigram sampling, and dropout probability of merge operations for BPE-dropout.
+        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+            Will be passed to the SentencePieceProcessor ``__init__()`` method. Can be used to set:
+
+            - ``enable_sampling``: Enable subword regularization.
+            - ``nbest_size``: Sampling parameters for unigram. Invalid for BPE-Dropout. nbest_size = {0,1}: No sampling is performed.
+              nbest_size > 1: samples from the nbest_size results. nbest_size < 0: assuming that nbest_size is infinite
+              and samples from the all hypothesis (lattice) using forward-filtering-and-backward-sampling algorithm.
+            - ``alpha``: Smoothing parameter for unigram sampling, and dropout probability of merge operations for BPE-dropout.
 
     Attributes:
         sp_model (:obj:`SentencePieceProcessor`):
@@ -123,13 +123,13 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
         unk_token="<unk>",
         pad_token="<pad>",
         mask_token="<mask>",
-        enable_sampling=False,
-        nbest_size=-1,
-        alpha=0.1,
+        sp_model_kwargs=None,
         **kwargs
     ):
         # Mask token behave like a normal word, i.e. include the space before it
         mask_token = AddedToken(mask_token, lstrip=True, rstrip=False) if isinstance(mask_token, str) else mask_token
+
+        sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
         super().__init__(
             bos_token=bos_token,
@@ -139,17 +139,11 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
             cls_token=cls_token,
             pad_token=pad_token,
             mask_token=mask_token,
-            enable_sampling=enable_sampling,
-            nbest_size=nbest_size,
-            alpha=alpha,
+            sp_model_kwargs=sp_model_kwargs,
             **kwargs,
         )
 
-        self.sp_model = spm.SentencePieceProcessor(
-            enable_sampling=enable_sampling,
-            nbest_size=nbest_size,
-            alpha=alpha,
-        )
+        self.sp_model = spm.SentencePieceProcessor(**sp_model_kwargs)
         self.sp_model.Load(str(vocab_file))
         self.vocab_file = vocab_file
 

--- a/tests/test_tokenization_xlm_roberta.py
+++ b/tests/test_tokenization_xlm_roberta.py
@@ -121,7 +121,9 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     def test_subword_regularization_tokenizer(self):
         # Subword regularization is only available for the slow tokenizer.
-        tokenizer = XLMRobertaTokenizer(SAMPLE_VOCAB, keep_accents=True, enable_sampling=True, alpha=0.1, nbest=-1)
+        tokenizer = XLMRobertaTokenizer(
+            SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        )
 
         # Subword regularization augments training data with subword sampling.
         # This has a random component. We test if the tokenizer generates different

--- a/tests/test_tokenization_xlm_roberta.py
+++ b/tests/test_tokenization_xlm_roberta.py
@@ -120,12 +120,12 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         )
 
     def test_subword_regularization_tokenizer(self):
+        # Subword regularization is only available for the slow tokenizer.
         tokenizer = XLMRobertaTokenizer(SAMPLE_VOCAB, keep_accents=True, enable_sampling=True, alpha=0.1, nbest=-1)
 
-        # Subword regularization are regularization augments training
-        # data with subword sampling. This has a random component.
-        # We test if the tokenizer generates different results when
-        # subword regularization is enabled.
+        # Subword regularization augments training data with subword sampling.
+        # This has a random component. We test if the tokenizer generates different
+        # results when subword regularization is enabled.
         tokens_list = []
         for _ in range(5):
             tokens_list.append(tokenizer.tokenize("This is a test for subword regularization."))

--- a/tests/test_tokenization_xlm_roberta.py
+++ b/tests/test_tokenization_xlm_roberta.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+import itertools
 import os
 import unittest
 
@@ -117,6 +118,27 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 ".",
             ],
         )
+
+    def test_subword_regularization_tokenizer(self):
+        tokenizer = XLMRobertaTokenizer(SAMPLE_VOCAB, keep_accents=True, enable_sampling=True, alpha=0.1, nbest=-1)
+
+        # Subword regularization are regularization augments training
+        # data with subword sampling. This has a random component.
+        # We test if the tokenizer generates different results when
+        # subword regularization is enabled.
+        tokens_list = []
+        for _ in range(5):
+            tokens_list.append(tokenizer.tokenize("This is a test for subword regularization."))
+
+        # the list of different pairs of tokens_list
+        combinations = itertools.combinations(tokens_list, 2)
+
+        all_equal = True
+        for combination in combinations:
+            if combination[0] != combination[1]:
+                all_equal = False
+
+        self.assertFalse(all_equal)
 
     @cached_property
     def big_tokenizer(self):


### PR DESCRIPTION
# What does this PR do?
I would like to use [subword regularization](https://github.com/google/sentencepiece#subword-regularization-and-bpe-dropout) from [google/sentencepiece](https://github.com/google/sentencepiece). The reason is that it might be used to improve downstream task performance.

Since `XLMRobertaTokenizer` already uses `SentencePieceProcessor` from `google/sentencepiece` there are only some minor modifications needed.

3 additional parameters are added to the constructor of `XLMRobertaTokenizer`. This are:
```python
        enable_sampling=False,
        nbest_size=-1,
        alpha=0.1,
```
The default values are selected so that this is no breaking change.

In the `_tokenize(self, text)` function there was a call to `self.sp_model.EncodeAsPieces(text)`. This call does ignore the parameters for subword regularization. That is why it had to be replaced by a call to `self.sp_model.encode(text, out_type=str)`.

Since `XLMRobertaTokenizerFast` is an independent implentation which does not use `google/sentencepiece` it is not in the scope of the PR to add subword regularization to the fast tokenizer.

## To-do
- [x] check if tests pass
- [x] check if tests can / should be added
- [x] add a link to a page where we can see all kwargs

## Who can review?
@LysandreJik @stefan-it 