### PR TITLE
[examples run_clm] fix _LazyModule hasher error

### DIFF
--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -317,8 +317,10 @@ def main():
         column_names = datasets["validation"].column_names
     text_column_name = "text" if "text" in column_names else column_names[0]
 
+    # since this will be hashed to avoid _LazyModule error in Hasher force logger loading before tokenize_function
+    tok_logger = transformers.utils.logging.get_logger("transformers.tokenization_utils_base")
+
     def tokenize_function(examples):
-        tok_logger = transformers.utils.logging.get_logger("transformers.tokenization_utils_base")
         with CaptureLogger(tok_logger) as cl:
             output = tokenizer(examples[text_column_name])
         # clm input could be much much longer than block_size

--- a/examples/language-modeling/run_clm.py
+++ b/examples/language-modeling/run_clm.py
@@ -317,7 +317,7 @@ def main():
         column_names = datasets["validation"].column_names
     text_column_name = "text" if "text" in column_names else column_names[0]
 
-    # since this will be hashed to avoid _LazyModule error in Hasher force logger loading before tokenize_function
+    # since this will be pickled to avoid _LazyModule error in Hasher force logger loading before tokenize_function
     tok_logger = transformers.utils.logging.get_logger("transformers.tokenization_utils_base")
 
     def tokenize_function(examples):


### PR DESCRIPTION
This PR fixes a problem I introduced in https://github.com/huggingface/transformers/pull/11145 and reported in https://github.com/huggingface/transformers/issues/11166 

`datasets.fingerprint.Hasher` fails to run 

```
hasher = Hasher()
hasher.update(tokenize_function)
```
getting:
```
TypeError: cannot pickle '_LazyModule' object
```

Because the logger object contains a lazy import.

The error was subtle as the exception was caught and not propagated but instead a warning was logged, which I didn't notice in the first place. Warnings aren't a great way to communicate problems. So we were getting now:

> [WARNING|tokenization_utils_base.py:3144] 2021-04-09 09:46:31,368 >> Token indices sequence length is longer than the specified maximum sequence length for this model (1462828 > 1024). Running this sequence through the model will result in indexing errors
> [WARNING|run_clm.py:326] 2021-04-09 09:46:31,368 >> ^^^^^^^^^^^^^^^^ Please ignore the warning above - this long input will be chunked into smaller bits before being passed to the model.
> 04/09/2021 09:46:31 - WARNING - datasets.fingerprint -   Parameter 'function'=<function main.<locals>.tokenize_function at 0x7f434d90da60> of the transform datasets.arrow_dataset.Dataset._map_single couldn't be hashed properly, a random hash was used instead. Make sure your transforms and parameters are serializable with pickle or dill for the dataset fingerprinting and caching to work. If you reuse this transform, the caching mechanism will consider it to be different from the previous calls and recompute everything. This warning is only showed once. Subsequent hashing failures won't be showed.

So I fixed this by moving the logger object fetching to outside of the function to be hashed and then it all works.

Fixes: https://github.com/huggingface/transformers/issues/11166 

@sgugger 
