### PR TITLE
Avoid using no_sync on SageMaker DP

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -805,7 +805,7 @@ class TrainingArguments:
         """
         Whether or not to use no_sync for the gradients when doing gradient accumulation.
         """
-        return not (self.deepspeed or is_sagemaker_mp_enabled())
+        return not (self.deepspeed or is_sagemaker_dp_enabled() or is_sagemaker_mp_enabled())
 
     def to_dict(self):
         """


### PR DESCRIPTION
# What does this PR do?

As reported on the [forums](https://discuss.huggingface.co/t/distributeddataparallel-object-has-no-attribute-no-sync/5469), SageMaker DP is incompatible with gradient accumulation for now. This PR fixes that.