### PR TITLE
[Deepspeed] zero3 tests band aid

### DIFF
--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -115,6 +115,11 @@ class TrainerIntegrationDeepSpeed(TestCasePlus, TrainerIntegrationCommon):
         with io.open(self.ds_config_file[ZERO3], "r", encoding="utf-8") as f:
             self.ds_config_dict[ZERO3] = json.load(f)
 
+    def tearDown(self):
+        # XXX: Fixme - this is a temporary band-aid since this global variable impacts other tests
+        import transformers
+        transformers.integrations._is_deepspeed_zero3_enabled = None
+
     def get_config_dict(self, stage):
         """ As the tests modify the dict, always make a copy """
         config = deepcopy(self.ds_config_dict[stage])

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -118,6 +118,7 @@ class TrainerIntegrationDeepSpeed(TestCasePlus, TrainerIntegrationCommon):
     def tearDown(self):
         # XXX: Fixme - this is a temporary band-aid since this global variable impacts other tests
         import transformers
+
         transformers.integrations._is_deepspeed_zero3_enabled = None
 
     def get_config_dict(self, stage):


### PR DESCRIPTION
Currently Deepspeed integration is bleeding its global state which can impact other transformers runs in the same process w/o deepspeed, This only impacts tests that don't spawn a new process for deepspeed, which is not the norm.

This PR is just a temporary band-aid to restore the state on the test level - and I need to rethink of how to not use a global state or have the state tied to the deepspeed object which when destructed would automatically restore the state.

The main issue here is that the Trainer gets init'ed after the model, which is an important issue that I started the discussion on here:
https://github.com/huggingface/transformers/issues/10893

An example of the failing sequence is:
```
CUDA_VISIBLE_DEVICES=0 RUN_SLOW=1 pyt tests/deepspeed \
/test_deepspeed.py::TrainerIntegrationDeepSpeed::test_early_get_last_lr_1_zero3 tests/extended \
/test_trainer_ext.py::TestTrainerExt::test_run_seq2seq_no_dist
```



@LysandreJik