### PR TITLE
 [deepspeed] test on one node 2 gpus max

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ _deps = [
     "cookiecutter==1.7.2",
     "dataclasses",
     "datasets",
-    "deepspeed>0.3.13",
+    "deepspeed>=0.3.14",
     "docutils==0.16.0",
     "fairscale>0.3",
     "faiss-cpu",

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -595,9 +595,7 @@ class TestDeepSpeedWithLauncher(TestCasePlus):
 
         ds_args = f"--deepspeed {self.test_file_dir_str}/ds_config_{stage}.json".split()
         script = [f"{self.examples_dir_str}/seq2seq/run_translation.py"]
-        # for now testing with just 2 gpus max
-        num_gpus = max(2, get_gpu_count()) if distributed else 1
-        launcher = f"deepspeed --num_nodes 1 --num_gpus {num_gpus}".split()
+        launcher = self.get_launcher(distributed)
 
         cmd = launcher + script + args + ds_args
         # keep for quick debug
@@ -633,9 +631,7 @@ class TestDeepSpeedWithLauncher(TestCasePlus):
         distributed = True
         ds_args = f"--deepspeed {self.test_file_dir_str}/ds_config_{stage}.json".split()
         script = [f"{self.examples_dir_str}/language-modeling/run_clm.py"]
-        # for now testing with just 2 gpus max
-        num_gpus = max(2, get_gpu_count()) if distributed else 1
-        launcher = f"deepspeed --num_nodes 1 --num_gpus {num_gpus}".split()
+        launcher = self.get_launcher(distributed)
 
         cmd = launcher + script + args + ds_args
         # keep for quick debug
@@ -643,3 +639,8 @@ class TestDeepSpeedWithLauncher(TestCasePlus):
         execute_subprocess_async(cmd, env=self.get_env())
 
         return output_dir
+
+    def get_launcher(self, distributed=False):
+        # for now testing with just 2 gpus max
+        num_gpus = max(2, get_gpu_count()) if distributed else 1
+        return f"deepspeed --num_nodes 1 --num_gpus {num_gpus}".split()

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -628,10 +628,9 @@ class TestDeepSpeedWithLauncher(TestCasePlus):
             --block_size 128
             """.split()
 
-        distributed = True
         ds_args = f"--deepspeed {self.test_file_dir_str}/ds_config_{stage}.json".split()
         script = [f"{self.examples_dir_str}/language-modeling/run_clm.py"]
-        launcher = self.get_launcher(distributed)
+        launcher = self.get_launcher(distributed=True)
 
         cmd = launcher + script + args + ds_args
         # keep for quick debug

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -595,8 +595,9 @@ class TestDeepSpeedWithLauncher(TestCasePlus):
 
         ds_args = f"--deepspeed {self.test_file_dir_str}/ds_config_{stage}.json".split()
         script = [f"{self.examples_dir_str}/seq2seq/run_translation.py"]
-        num_gpus = get_gpu_count() if distributed else 1
-        launcher = f"deepspeed --num_gpus {num_gpus}".split()
+        # for now testing with just 2 gpus max
+        num_gpus = max(2, get_gpu_count()) if distributed else 1
+        launcher = f"deepspeed --num_nodes 1 --num_gpus {num_gpus}".split()
 
         cmd = launcher + script + args + ds_args
         # keep for quick debug

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -641,6 +641,9 @@ class TestDeepSpeedWithLauncher(TestCasePlus):
         return output_dir
 
     def get_launcher(self, distributed=False):
-        # for now testing with just 2 gpus max
-        num_gpus = max(2, get_gpu_count()) if distributed else 1
+        # 1. explicitly set --num_nodes=1 just in case these tests end up run on a multi-node setup
+        # - it won't be able to handle that
+        # 2. for now testing with just 2 gpus max (since some quality tests may give different
+        # results with mode gpus because we use very little data)
+        num_gpus = min(2, get_gpu_count()) if distributed else 1
         return f"deepspeed --num_nodes 1 --num_gpus {num_gpus}".split()

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -632,8 +632,9 @@ class TestDeepSpeedWithLauncher(TestCasePlus):
         distributed = True
         ds_args = f"--deepspeed {self.test_file_dir_str}/ds_config_{stage}.json".split()
         script = [f"{self.examples_dir_str}/language-modeling/run_clm.py"]
-        num_gpus = get_gpu_count() if distributed else 1
-        launcher = f"deepspeed --num_gpus {num_gpus}".split()
+        # for now testing with just 2 gpus max
+        num_gpus = max(2, get_gpu_count()) if distributed else 1
+        launcher = f"deepspeed --num_nodes 1 --num_gpus {num_gpus}".split()
 
         cmd = launcher + script + args + ds_args
         # keep for quick debug


### PR DESCRIPTION
Deepspeed devs, who will be running our deepspeed tests as part of their tests, discovered that we had an unbound number of nodes and gpus in the tests so it was firing on multiple nodes and many gpus, so wasn't quite ready for it. So fixing it.