### PR TITLE
Trainer iterable dataset

### DIFF
--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -598,7 +598,8 @@ class IterableDatasetShard(IterableDataset):
         :obj:`dataset` to generate your random numbers and call the
         :meth:`~transformers.trainer_pt_utils.IterableDatasetShard.set_epoch` method of this object. It will set the
         seed of this :obj:`generator` to :obj:`seed + epoch` on all processes before starting the iteration.
-        Alternatively, you can also subclass this class and override the :meth:`__iter__` method with your custom logic.
+        Alternatively, you can also subclass this class and override the :meth:`__iter__` method with your custom
+        logic.
 
     Args:
         dataset (:obj:`torch.utils.data.dataset.IterableDataset`):

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -579,23 +579,26 @@ class DistributedLengthGroupedSampler(DistributedSampler):
 class IterableDatasetShard(IterableDataset):
     """
     Wraps a PyTorch :obj:`IterableDataset` to generate samples for one of the processes only. Instances of this class
-    will always yield a number of samples that is a round multiple of the actual batch size (which is 
-    :obj:`batch_size x num_processes`). Depending on the value of the :obj:`drop_last` attribute, it will either stop the iteration at the first
-    batch that would be too small or loop with indices from the beginning.
-    
-    On two processes with an iterable dataset yielding of :obj:`[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]` with a batch 
+    will always yield a number of samples that is a round multiple of the actual batch size (which is :obj:`batch_size
+    x num_processes`). Depending on the value of the :obj:`drop_last` attribute, it will either stop the iteration at
+    the first batch that would be too small or loop with indices from the beginning.
+
+    On two processes with an iterable dataset yielding of :obj:`[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]` with a batch
     size of 2:
-    
-    - the shard on process 0 will yield :obj:`[0, 1, 4, 5, 8, 9]` so will see batches :obj:`[0, 1]`, :obj:`[4, 5]`, :obj:`[8, 9]`
-    - the shard on process 1 will yield :obj:`[2, 3, 6, 7, 10, 11]` so will see batches :obj:`[2, 3]`, :obj:`[6, 7]`, :obj:`[10, 11]`
-    
+
+    - the shard on process 0 will yield :obj:`[0, 1, 4, 5, 8, 9]` so will see batches :obj:`[0, 1]`, :obj:`[4, 5]`,
+      :obj:`[8, 9]`
+    - the shard on process 1 will yield :obj:`[2, 3, 6, 7, 10, 11]` so will see batches :obj:`[2, 3]`, :obj:`[6, 7]`,
+      :obj:`[10, 11]`
+
     .. warning:
 
         If your IterableDataset implements some randomization that needs to be applied the same way on all processes
-        (for instance, a shuffling), you should use a :obj:`torch.Generator` in a :obj:`generator` attribute of the :obj:`dataset` to generate
-        your random numbers and call the :meth:`~transformers.trainer_pt_utils.IterableDatasetShard.set_epoch` method
-        of this object. It will set the seed of this :obj:`generator` to :obj:`seed + epoch` on all processes before starting the iteration. Alternatively,
-        you can also subclass this class and override the :meth:`__iter__ method with your custom logic.
+        (for instance, a shuffling), you should use a :obj:`torch.Generator` in a :obj:`generator` attribute of the
+        :obj:`dataset` to generate your random numbers and call the
+        :meth:`~transformers.trainer_pt_utils.IterableDatasetShard.set_epoch` method of this object. It will set the
+        seed of this :obj:`generator` to :obj:`seed + epoch` on all processes before starting the iteration.
+        Alternatively, you can also subclass this class and override the :meth:`__iter__ method with your custom logic.
 
     Args:
         dataset (:obj:`torch.utils.data.dataset.IterableDataset`):
@@ -610,7 +613,8 @@ class IterableDatasetShard(IterableDataset):
         process_index (:obj:`int`, `optional`, defaults to 0):
             The index of the current process.
         seed (:obj:`int`, `optional`, defaults to 0):
-            A random seed that will be used for the random number generation in :meth:`~transformers.trainer_pt_utils.IterableDatasetShard.set_epoch`.
+            A random seed that will be used for the random number generation in
+            :meth:`~transformers.trainer_pt_utils.IterableDatasetShard.set_epoch`.
     """
 
     def __init__(
@@ -629,7 +633,7 @@ class IterableDatasetShard(IterableDataset):
         self.process_index = process_index
         self.seed = seed
         self.epoch = 0
-        
+
     def set_epoch(self, epoch):
         self.epoch = epoch
 

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -598,7 +598,7 @@ class IterableDatasetShard(IterableDataset):
         :obj:`dataset` to generate your random numbers and call the
         :meth:`~transformers.trainer_pt_utils.IterableDatasetShard.set_epoch` method of this object. It will set the
         seed of this :obj:`generator` to :obj:`seed + epoch` on all processes before starting the iteration.
-        Alternatively, you can also subclass this class and override the :meth:`__iter__ method with your custom logic.
+        Alternatively, you can also subclass this class and override the :meth:`__iter__` method with your custom logic.
 
     Args:
         dataset (:obj:`torch.utils.data.dataset.IterableDataset`):

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -28,7 +28,7 @@ from typing import Dict, Iterator, List, Optional, Union
 import numpy as np
 import torch
 from packaging import version
-from torch.utils.data.dataset import Dataset
+from torch.utils.data.dataset import Dataset, IterableDataset
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data.sampler import RandomSampler, Sampler
 
@@ -574,6 +574,91 @@ class DistributedLengthGroupedSampler(DistributedSampler):
         assert len(indices) == self.num_samples
 
         return iter(indices)
+
+
+class IterableDatasetShard(IterableDataset):
+    """
+    Wraps a PyTorch :obj:`IterableDataset` to generate samples for one of the processes only. Instances of this class
+    will always yield a number of samples that is a round multiple of the actual batch size (which is 
+    :obj:`batch_size x num_processes`). Depending on the value of the :obj:`drop_last` attribute, it will either stop the iteration at the first
+    batch that would be too small or loop with indices from the beginning.
+    
+    On two processes with an iterable dataset yielding of :obj:`[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]` with a batch 
+    size of 2:
+    
+    - the shard on process 0 will yield :obj:`[0, 1, 4, 5, 8, 9]` so will see batches :obj:`[0, 1]`, :obj:`[4, 5]`, :obj:`[8, 9]`
+    - the shard on process 1 will yield :obj:`[2, 3, 6, 7, 10, 11]` so will see batches :obj:`[2, 3]`, :obj:`[6, 7]`, :obj:`[10, 11]`
+    
+    .. warning:
+
+        If your IterableDataset implements some randomization that needs to be applied the same way on all processes
+        (for instance, a shuffling), you should use a :obj:`torch.Generator` in a :obj:`generator` attribute of the :obj:`dataset` to generate
+        your random numbers and call the :meth:`~transformers.trainer_pt_utils.IterableDatasetShard.set_epoch` method
+        of this object. It will set the seed of this :obj:`generator` to :obj:`seed + epoch` on all processes before starting the iteration. Alternatively,
+        you can also subclass this class and override the :meth:`__iter__ method with your custom logic.
+
+    Args:
+        dataset (:obj:`torch.utils.data.dataset.IterableDataset`):
+            The batch sampler to split in several shards.
+        batch_size (:obj:`int`, `optional`, defaults to 1):
+            The size of the batches per shard.
+        drop_last (:obj:`bool`, `optional`, defaults to :obj:`False`):
+            Whether or not to drop the last incomplete batch or complete the last batches by using the samples from the
+            beginning.
+        num_processes (:obj:`int`, `optional`, defaults to 1):
+            The number of processes running concurrently.
+        process_index (:obj:`int`, `optional`, defaults to 0):
+            The index of the current process.
+        seed (:obj:`int`, `optional`, defaults to 0):
+            A random seed that will be used for the random number generation in :meth:`~transformers.trainer_pt_utils.IterableDatasetShard.set_epoch`.
+    """
+
+    def __init__(
+        self,
+        dataset: IterableDataset,
+        batch_size: int = 1,
+        drop_last: bool = False,
+        num_processes: int = 1,
+        process_index: int = 0,
+        seed: int = 0,
+    ):
+        self.dataset = dataset
+        self.batch_size = batch_size
+        self.drop_last = drop_last
+        self.num_processes = num_processes
+        self.process_index = process_index
+        self.seed = seed
+        self.epoch = 0
+        
+    def set_epoch(self, epoch):
+        self.epoch = epoch
+
+    def __iter__(self):
+        if hasattr(self.dataset, "generator") and isinstance(self.dataset.generator, torch.Generator):
+            self.dataset.generator.manual_seed(self.seed + self.epoch)
+        real_batch_size = self.batch_size * self.num_processes
+        process_slice = range(self.process_index * self.batch_size, (self.process_index + 1) * self.batch_size)
+
+        first_batch = None
+        current_batch = []
+        for element in self.dataset:
+            current_batch.append(element)
+            # Wait to have a full batch before yielding elements.
+            if len(current_batch) == real_batch_size:
+                for i in process_slice:
+                    yield current_batch[i]
+                if first_batch is None:
+                    first_batch = current_batch.copy()
+                current_batch = []
+
+        # Finished if drop_last is True, otherwise complete the last batch with elements from the beginning.
+        if not self.drop_last and len(current_batch) > 0:
+            if first_batch is None:
+                first_batch = current_batch.copy()
+            while len(current_batch) < real_batch_size:
+                current_batch += first_batch
+            for i in process_slice:
+                yield current_batch[i]
 
 
 # In order to keep `trainer.py` compact and easy to understand, place any secondary PT Trainer


### PR DESCRIPTION
# What does this PR do?

This PR adds full support for `IterableDataset` training set in the main Trainer (just the training set, evaluation/prediction will require way more work). Up until now, the Trainer kind of support training dataset that are instances of `IterableDataset`, but in a distributed setting, the training will be on the same data on all processes, which is... not ideal. This PR fixes that and adds some tests.