### PR TITLE
Workflow fixes

### DIFF
--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -38,6 +38,7 @@ jobs:
           apt -y update && apt install -y libsndfile1-dev
           pip install --upgrade pip
           pip install .[sklearn,testing,onnxruntime,sentencepiece,speech]
+          pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-1.8.0+cu111.html
 
       - name: Are GPUs recognized by our DL frameworks
         run: |
@@ -121,6 +122,7 @@ jobs:
           apt -y update && apt install -y libsndfile1-dev
           pip install --upgrade pip
           pip install .[sklearn,testing,onnxruntime,sentencepiece,speech]
+          pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-1.8.0+cu111.html
 
       - name: Are GPUs recognized by our DL frameworks
         run: |
@@ -220,6 +222,13 @@ jobs:
         if: ${{ always() }}
         run: cat reports/tests_torch_cuda_extensions_gpu_failures_short.txt
 
+      - name: Test suite reports artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: run_tests_torch_cuda_extensions_gpu_test_reports
+          path: reports
+
   run_tests_torch_cuda_extensions_multi_gpu:
     runs-on: [self-hosted, docker-gpu, multi-gpu]
     container:
@@ -252,6 +261,13 @@ jobs:
       - name: Failure short reports
         if: ${{ always() }}
         run: cat reports/tests_torch_cuda_extensions_multi_gpu_failures_short.txt
+
+      - name: Test suite reports artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: run_tests_torch_cuda_extensions_multi_gpu_test_reports
+          path: reports
 
 
   send_results:

--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -33,7 +33,8 @@ jobs:
         run: |
           apt -y update && apt install -y libsndfile1-dev
           pip install --upgrade pip
-          pip install .[sklearn,testing,onnxruntime,sentencepiece,speech,deepspeed]
+          pip install .[sklearn,testing,onnxruntime,sentencepiece,speech]
+          pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-1.8.0+cu111.html
 
       - name: Are GPUs recognized by our DL frameworks
         run: |
@@ -155,7 +156,8 @@ jobs:
         run: |
           apt -y update && apt install -y libsndfile1-dev
           pip install --upgrade pip
-          pip install .[sklearn,testing,onnxruntime,sentencepiece,speech,deepspeed,fairscale]
+          pip install .[sklearn,testing,onnxruntime,sentencepiece,speech]
+          pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-1.8.0+cu111.html
 
       - name: Are GPUs recognized by our DL frameworks
         run: |
@@ -279,6 +281,13 @@ jobs:
         if: ${{ always() }}
         run: cat reports/tests_torch_cuda_extensions_gpu_failures_short.txt
 
+      - name: Test suite reports artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: run_tests_torch_cuda_extensions_gpu_test_reports
+          path: reports
+
   run_all_tests_torch_cuda_extensions_multi_gpu:
     runs-on: [self-hosted, docker-gpu, multi-gpu]
     container:
@@ -311,6 +320,13 @@ jobs:
       - name: Failure short reports
         if: ${{ always() }}
         run: cat reports/tests_torch_cuda_extensions_multi_gpu_failures_short.txt
+
+      - name: Test suite reports artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: run_tests_torch_cuda_extensions_multi_gpu_test_reports
+          path: reports
 
   send_results:
     name: Send results to webhook

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -7,7 +7,7 @@ deps = {
     "cookiecutter": "cookiecutter==1.7.2",
     "dataclasses": "dataclasses",
     "datasets": "datasets",
-    "deepspeed": "deepspeed>0.3.13",
+    "deepspeed": "deepspeed>=0.3.14",
     "docutils": "docutils==0.16.0",
     "fairscale": "fairscale>0.3",
     "faiss-cpu": "faiss-cpu",

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -128,6 +128,12 @@ if __name__ == "__main__":
                 "common": "run_all_tests_torch_multi_gpu_test_reports/tests_torch_multi_gpu_[].txt",
                 "pipeline": "run_all_tests_torch_multi_gpu_test_reports/tests_torch_pipeline_multi_gpu_[].txt",
             },
+            "Torch Cuda Extensions Single GPU": {
+                "common": "run_tests_torch_cuda_extensions_gpu_test_reports/tests_torch_cuda_extensions_gpu_[].txt"
+            },
+            "Torch Cuda Extensions Multi GPU": {
+                "common": "run_tests_torch_cuda_extensions_multi_gpu_test_reports/tests_torch_cuda_extensions_multi_gpu_[].txt"
+            },
         }
     else:
         file_paths = {
@@ -135,6 +141,12 @@ if __name__ == "__main__":
             "Torch Single GPU": {"common": "run_all_tests_torch_gpu_test_reports/tests_torch_gpu_[].txt"},
             "TF Multi GPU": {"common": "run_all_tests_tf_multi_gpu_test_reports/tests_tf_multi_gpu_[].txt"},
             "Torch Multi GPU": {"common": "run_all_tests_torch_multi_gpu_test_reports/tests_torch_multi_gpu_[].txt"},
+            "Torch Cuda Extensions Single GPU": {
+                "common": "run_tests_torch_cuda_extensions_gpu_test_reports/tests_torch_cuda_extensions_gpu_[].txt"
+            },
+            "Torch Cuda Extensions Multi GPU": {
+                "common": "run_tests_torch_cuda_extensions_multi_gpu_test_reports/tests_torch_cuda_extensions_multi_gpu_[].txt"
+            },
         }
 
     client = WebClient(token=os.environ["CI_SLACK_BOT_TOKEN"])


### PR DESCRIPTION
Fixes some workflow issues:
- Installs torch scatter in the CI with the appropriate pre-compiled version
- Removes DeepSpeed and Fairscale from the non-cuda-extension workflows
- Adds the forgotten reports for cuda-extension workflows
- Adds the result of the cuda-extension workflows to be sent to Slack

Also it updates the `deepspeed` dependency in the dependency table, because they seem mismatched on `master` (running `make fixup` fixed it for me)