### PR TITLE
EncoderDecoderConfigs should not create new objects

### DIFF
--- a/src/transformers/models/encoder_decoder/configuration_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/configuration_encoder_decoder.py
@@ -71,24 +71,25 @@ class EncoderDecoderConfig(PretrainedConfig):
     model_type = "encoder-decoder"
     is_composition = True
 
-    def __init__(
-            self,
-            encoder: PretrainedConfig,
-            decoder: PretrainedConfig,
-            **kwargs
-    ):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        assert (
+            "encoder" in kwargs and "decoder" in kwargs
+        ), "Config has to be initialized with encoder and decoder config"
+        encoder_config = kwargs.pop("encoder")
+        encoder_model_type = encoder_config.pop("model_type")
+        decoder_config = kwargs.pop("decoder")
+        decoder_model_type = decoder_config.pop("model_type")
 
-        self.encoder = encoder
-        self.decoder = decoder
+        from ..auto.configuration_auto import AutoConfig
+
+        self.encoder = AutoConfig.for_model(encoder_model_type, **encoder_config)
+        self.decoder = AutoConfig.for_model(decoder_model_type, **decoder_config)
         self.is_encoder_decoder = True
 
     @classmethod
     def from_encoder_decoder_configs(
-        cls, 
-        encoder_config: PretrainedConfig, 
-        decoder_config: PretrainedConfig, 
-        **kwargs
+        cls, encoder_config: PretrainedConfig, decoder_config: PretrainedConfig, **kwargs
     ) -> PretrainedConfig:
         r"""
         Instantiate a :class:`~transformers.EncoderDecoderConfig` (or a derived class) from a pre-trained encoder model
@@ -101,7 +102,7 @@ class EncoderDecoderConfig(PretrainedConfig):
         decoder_config.is_decoder = True
         decoder_config.add_cross_attention = True
 
-        return cls(encoder=encoder_config, decoder=decoder_config, **kwargs)
+        return cls(encoder=encoder_config.to_dict(), decoder=decoder_config.to_dict(), **kwargs)
 
     def to_dict(self):
         """

--- a/src/transformers/models/encoder_decoder/configuration_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/configuration_encoder_decoder.py
@@ -71,25 +71,24 @@ class EncoderDecoderConfig(PretrainedConfig):
     model_type = "encoder-decoder"
     is_composition = True
 
-    def __init__(self, **kwargs):
+    def __init__(
+            self,
+            encoder: PretrainedConfig,
+            decoder: PretrainedConfig,
+            **kwargs
+    ):
         super().__init__(**kwargs)
-        assert (
-            "encoder" in kwargs and "decoder" in kwargs
-        ), "Config has to be initialized with encoder and decoder config"
-        encoder_config = kwargs.pop("encoder")
-        encoder_model_type = encoder_config.pop("model_type")
-        decoder_config = kwargs.pop("decoder")
-        decoder_model_type = decoder_config.pop("model_type")
 
-        from ..auto.configuration_auto import AutoConfig
-
-        self.encoder = AutoConfig.for_model(encoder_model_type, **encoder_config)
-        self.decoder = AutoConfig.for_model(decoder_model_type, **decoder_config)
+        self.encoder = encoder
+        self.decoder = decoder
         self.is_encoder_decoder = True
 
     @classmethod
     def from_encoder_decoder_configs(
-        cls, encoder_config: PretrainedConfig, decoder_config: PretrainedConfig, **kwargs
+        cls, 
+        encoder_config: PretrainedConfig, 
+        decoder_config: PretrainedConfig, 
+        **kwargs
     ) -> PretrainedConfig:
         r"""
         Instantiate a :class:`~transformers.EncoderDecoderConfig` (or a derived class) from a pre-trained encoder model
@@ -102,7 +101,7 @@ class EncoderDecoderConfig(PretrainedConfig):
         decoder_config.is_decoder = True
         decoder_config.add_cross_attention = True
 
-        return cls(encoder=encoder_config.to_dict(), decoder=decoder_config.to_dict(), **kwargs)
+        return cls(encoder=encoder_config, decoder=decoder_config, **kwargs)
 
     def to_dict(self):
         """

--- a/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
@@ -15,7 +15,7 @@
 """ Classes to support Encoder-Decoder architectures """
 
 
-from typing import Optional
+from typing import Optional, Tuple
 
 from ...configuration_utils import PretrainedConfig
 from ...file_utils import add_start_docstrings, add_start_docstrings_to_model_forward, replace_return_docstrings
@@ -175,6 +175,12 @@ class EncoderDecoderModel(PreTrainedModel):
 
         self.encoder = encoder
         self.decoder = decoder
+        
+        # we can not stop the users from calling the encoder or decoder individually,
+        # we need to link the individual configs with the encoderdecoderconfig to ensure consistency
+        self.config.encoder = self.encoder.config
+        self.config.decoder = self.decoder.config
+        
         assert (
             self.encoder.get_output_embeddings() is None
         ), "The encoder {} should not have a LM Head. Please use a model without LM Head"

--- a/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
@@ -15,7 +15,7 @@
 """ Classes to support Encoder-Decoder architectures """
 
 
-from typing import Optional, Tuple
+from typing import Optional
 
 from ...configuration_utils import PretrainedConfig
 from ...file_utils import add_start_docstrings, add_start_docstrings_to_model_forward, replace_return_docstrings
@@ -464,32 +464,8 @@ class EncoderDecoderModel(PreTrainedModel):
         }
         return input_dict
 
-    def resize_token_embeddings(
-        self,
-        new_num_tokens_encoder: Optional[int] = None,
-        new_num_tokens_decoder: Optional[int] = None
-    ) -> Tuple[torch.nn.Embedding, torch.nn.Embedding]:
-        """
-        Resizes token embeddings matrices of the model if :obj:`new_num_tokens_encoder != config.encoder.vocab_size` or :obj:`new_num_tokens_decoder != config.decoder.vocab_size`.
-        Takes care of tying weights embeddings afterwards if the model class has a :obj:`tie_weights()` method.
-        Arguments:
-            new_num_tokens_encoder (:obj:`int`, `optional`):
-                The number of new tokens in the encoder embedding matrix. Increasing the size will add newly initialized
-                vectors at the end. Reducing the size will remove vectors from the end. If not provided or :obj:`None`,
-                just returns a pointer to the input tokens :obj:`torch.nn.Embedding` module of the model without doing
-                anything.
-            new_num_tokens_decoder (:obj:`int`, `optional`):
-                The number of new tokens in the decoder embedding matrix. Increasing the size will add newly initialized
-                vectors at the end. Reducing the size will remove vectors from the end. If not provided or :obj:`None`,
-                just returns a pointer to the input tokens :obj:`torch.nn.Embedding` module of the model without doing
-                anything.
-        Return:
-            :obj: `Tuple[torch.nn.Embedding, torch.nn.Embedding]`: Tuple with pointers to the encoder and decoder tokens Embeddings Modules of the model.
-        """
-        model_embeds_encoder = self.encoder.resize_token_embeddings(new_num_tokens_encoder)
-        model_embeds_decoder = self.decoder.resize_token_embeddings(new_num_tokens_decoder)
-        
-        return model_embeds_encoder, model_embeds_decoder
+    def resize_token_embeddings(self, *args, **kwargs):
+        raise NotImplementedError("Resizing the embedding layers via the EncoderDecoderModel directly is not supported. Please use the respective methods of the wrapped objects (model.encoder.resize_token_embeddings(...) or model.decoder.resize_token_embeddings(...))")
 
     def _reorder_cache(self, past, beam_idx):
         # apply decoder cache reordering here

--- a/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
@@ -470,7 +470,10 @@ class EncoderDecoderModel(PreTrainedModel):
         return input_dict
 
     def resize_token_embeddings(self, *args, **kwargs):
-        raise NotImplementedError("Resizing the embedding layers via the EncoderDecoderModel directly is not supported. Please use the respective methods of the wrapped objects (model.encoder.resize_token_embeddings(...) or model.decoder.resize_token_embeddings(...))")
+        raise NotImplementedError(
+            "Resizing the embedding layers via the EncoderDecoderModel directly is not supported." 
+            "Please use the respective methods of the wrapped objects (model.encoder.resize_token_embeddings(...) or model.decoder.resize_token_embeddings(...))"
+        )
 
     def _reorder_cache(self, past, beam_idx):
         # apply decoder cache reordering here

--- a/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
@@ -175,17 +175,21 @@ class EncoderDecoderModel(PreTrainedModel):
 
         self.encoder = encoder
         self.decoder = decoder
-        
+
         if self.encoder.config.to_dict() != self.config.encoder.to_dict():
-            logger.warning(f"Config of the encoder: {self.encoder.__class__} is overwritten by shared encoder config: {self.config.encoder}")
+            logger.warning(
+                f"Config of the encoder: {self.encoder.__class__} is overwritten by shared encoder config: {self.config.encoder}"
+            )
         if self.decoder.config.to_dict() != self.config.decoder.to_dict():
-            logger.warning(f"Config of the decoder: {self.decoder.__class__} is overwritten by shared decoder config: {self.config.decoder}")        
-        
+            logger.warning(
+                f"Config of the decoder: {self.decoder.__class__} is overwritten by shared decoder config: {self.config.decoder}"
+            )
+
         # make sure that the individual model's config refers to the shared config
         # so that the updates to the config will be synced
         self.encoder.config = self.config.encoder
         self.decoder.config = self.config.decoder
-        
+
         assert (
             self.encoder.get_output_embeddings() is None
         ), "The encoder {} should not have a LM Head. Please use a model without LM Head"
@@ -471,7 +475,7 @@ class EncoderDecoderModel(PreTrainedModel):
 
     def resize_token_embeddings(self, *args, **kwargs):
         raise NotImplementedError(
-            "Resizing the embedding layers via the EncoderDecoderModel directly is not supported." 
+            "Resizing the embedding layers via the EncoderDecoderModel directly is not supported."
             "Please use the respective methods of the wrapped objects (model.encoder.resize_token_embeddings(...) or model.decoder.resize_token_embeddings(...))"
         )
 

--- a/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
@@ -176,8 +176,8 @@ class EncoderDecoderModel(PreTrainedModel):
         self.encoder = encoder
         self.decoder = decoder
         
-        # we can not stop the users from calling the encoder or decoder individually,
-        # we need to link the individual configs with the encoderdecoderconfig to ensure consistency
+        # make sure that the individual model's config refers to the shared config
+        # so that the updates to the config will be synced
         self.config.encoder = self.encoder.config
         self.config.decoder = self.decoder.config
         

--- a/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
@@ -458,6 +458,33 @@ class EncoderDecoderModel(PreTrainedModel):
         }
         return input_dict
 
+    def resize_token_embeddings(
+        self,
+        new_num_tokens_encoder: Optional[int] = None,
+        new_num_tokens_decoder: Optional[int] = None
+    ) -> Tuple[torch.nn.Embedding, torch.nn.Embedding]:
+        """
+        Resizes token embeddings matrices of the model if :obj:`new_num_tokens_encoder != config.encoder.vocab_size` or :obj:`new_num_tokens_decoder != config.decoder.vocab_size`.
+        Takes care of tying weights embeddings afterwards if the model class has a :obj:`tie_weights()` method.
+        Arguments:
+            new_num_tokens_encoder (:obj:`int`, `optional`):
+                The number of new tokens in the encoder embedding matrix. Increasing the size will add newly initialized
+                vectors at the end. Reducing the size will remove vectors from the end. If not provided or :obj:`None`,
+                just returns a pointer to the input tokens :obj:`torch.nn.Embedding` module of the model without doing
+                anything.
+            new_num_tokens_decoder (:obj:`int`, `optional`):
+                The number of new tokens in the decoder embedding matrix. Increasing the size will add newly initialized
+                vectors at the end. Reducing the size will remove vectors from the end. If not provided or :obj:`None`,
+                just returns a pointer to the input tokens :obj:`torch.nn.Embedding` module of the model without doing
+                anything.
+        Return:
+            :obj: `Tuple[torch.nn.Embedding, torch.nn.Embedding]`: Tuple with pointers to the encoder and decoder tokens Embeddings Modules of the model.
+        """
+        model_embeds_encoder = self.encoder.resize_token_embeddings(new_num_tokens_encoder)
+        model_embeds_decoder = self.decoder.resize_token_embeddings(new_num_tokens_decoder)
+        
+        return model_embeds_encoder, model_embeds_decoder
+
     def _reorder_cache(self, past, beam_idx):
         # apply decoder cache reordering here
         return self.decoder._reorder_cache(past, beam_idx)

--- a/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
@@ -176,10 +176,15 @@ class EncoderDecoderModel(PreTrainedModel):
         self.encoder = encoder
         self.decoder = decoder
         
+        if self.encoder.config.to_dict() != self.config.encoder.to_dict():
+            logger.warning(f"Config of the encoder: {self.encoder.__class__} is overwritten by shared encoder config: {self.config.encoder}")
+        if self.decoder.config.to_dict() != self.config.decoder.to_dict():
+            logger.warning(f"Config of the decoder: {self.decoder.__class__} is overwritten by shared decoder config: {self.config.decoder}")        
+        
         # make sure that the individual model's config refers to the shared config
         # so that the updates to the config will be synced
-        self.config.encoder = self.encoder.config
-        self.config.decoder = self.decoder.config
+        self.encoder.config = self.config.encoder
+        self.decoder.config = self.config.decoder
         
         assert (
             self.encoder.get_output_embeddings() is None

--- a/tests/test_modeling_encoder_decoder.py
+++ b/tests/test_modeling_encoder_decoder.py
@@ -34,6 +34,7 @@ if is_torch_available():
     import torch
 
     from transformers import (
+        AutoConfig,
         AutoTokenizer,
         BartForCausalLM,
         BertGenerationDecoder,
@@ -884,3 +885,37 @@ class BartEncoderDecoderModelTest(EncoderDecoderMixin, unittest.TestCase):
 
     def test_encoder_decoder_model_shared_weights(self):
         pass
+
+@require_torch
+class EncoderDecoderModelTest(unittest.TestCase):
+    def get_from_encoderdecoder_pretrained_model(self):
+        return EncoderDecoderModel.from_encoder_decoder_pretrained("bert-base-uncased", "bert-base-uncased")
+    
+    def get_decoder_config(self):
+        config = AutoConfig.from_pretrained('bert-base-uncased')
+        config.is_decoder = True 
+        config.add_cross_attention= True  
+        return config
+    
+    def get_encoderdecoder_model(self):
+        return EncoderDecoderModel.from_pretrained('patrickvonplaten/bert2bert-cnn_dailymail-fp16')
+    
+    def get_encoder_decoder_models(self):
+        encoder_model = BertModel.from_pretrained('bert-base-uncased')
+        decoder_model = BertLMHeadModel.from_pretrained('bert-base-uncased', config = self.get_decoder_config())
+        return {'encoder':encoder_model, 'decoder': decoder_model}
+
+    def _check_configuration_tie(self, model):
+        assert id(model.decoder.config) == id(model.config.decoder)
+        assert id(model.encoder.config) == id(model.config.encoder)
+
+    @slow
+    def test_configuration_tie(self):
+        model = self.get_from_encoderdecoder_pretrained_model()
+        self._check_configuration_tie(model)
+        
+        model = EncoderDecoderModel(**self.get_encoder_decoder_models())
+        self._check_configuration_tie(model)
+        
+        model = self.get_encoderdecoder_model()
+        self._check_configuration_tie(model)

--- a/tests/test_modeling_encoder_decoder.py
+++ b/tests/test_modeling_encoder_decoder.py
@@ -886,24 +886,25 @@ class BartEncoderDecoderModelTest(EncoderDecoderMixin, unittest.TestCase):
     def test_encoder_decoder_model_shared_weights(self):
         pass
 
+
 @require_torch
 class EncoderDecoderModelTest(unittest.TestCase):
     def get_from_encoderdecoder_pretrained_model(self):
         return EncoderDecoderModel.from_encoder_decoder_pretrained("bert-base-uncased", "bert-base-uncased")
-    
+
     def get_decoder_config(self):
-        config = AutoConfig.from_pretrained('bert-base-uncased')
-        config.is_decoder = True 
-        config.add_cross_attention= True  
+        config = AutoConfig.from_pretrained("bert-base-uncased")
+        config.is_decoder = True
+        config.add_cross_attention = True
         return config
-    
+
     def get_encoderdecoder_model(self):
-        return EncoderDecoderModel.from_pretrained('patrickvonplaten/bert2bert-cnn_dailymail-fp16')
-    
+        return EncoderDecoderModel.from_pretrained("patrickvonplaten/bert2bert-cnn_dailymail-fp16")
+
     def get_encoder_decoder_models(self):
-        encoder_model = BertModel.from_pretrained('bert-base-uncased')
-        decoder_model = BertLMHeadModel.from_pretrained('bert-base-uncased', config = self.get_decoder_config())
-        return {'encoder':encoder_model, 'decoder': decoder_model}
+        encoder_model = BertModel.from_pretrained("bert-base-uncased")
+        decoder_model = BertLMHeadModel.from_pretrained("bert-base-uncased", config=self.get_decoder_config())
+        return {"encoder": encoder_model, "decoder": decoder_model}
 
     def _check_configuration_tie(self, model):
         assert id(model.decoder.config) == id(model.config.decoder)
@@ -913,9 +914,9 @@ class EncoderDecoderModelTest(unittest.TestCase):
     def test_configuration_tie(self):
         model = self.get_from_encoderdecoder_pretrained_model()
         self._check_configuration_tie(model)
-        
+
         model = EncoderDecoderModel(**self.get_encoder_decoder_models())
         self._check_configuration_tie(model)
-        
+
         model = self.get_encoderdecoder_model()
         self._check_configuration_tie(model)


### PR DESCRIPTION
# What does this PR do?

1. Removes the creation of separate config objects (pre PR 3:encoderdecoderConfig, encoderConfig, decoderConfig) and uses the existing ones (encoderConfig and decoderConfig now part of the encoderdecoderConfig) 
2. Overwrite `resize_token_embeddings` from the parent class because it is not working for the EncoderDecoderModel and currently throws an error

Fixes #11285


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@patrickvonplaten @patil-suraj 