### PR TITLE
[GPTNeo] create local attention mask ones

### DIFF
--- a/src/transformers/models/gpt_neo/modeling_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/modeling_gpt_neo.py
@@ -192,6 +192,57 @@ class GPTNeoAttentionMixin:
             padded_tensor = padded_tensor.transpose(-2, -1)
         return padded_tensor
 
+    @staticmethod
+    def _split_seq_length_dim_to(tensors, dim_factor_1, dim_factor_2, hidden_size):
+        """
+        Splits sequence length dim of tensors into `dim_factor_1` and `dim_factor_2` dims
+        """
+        batch_size = tensors.shape[0]
+        split_dim_shape = (batch_size, dim_factor_1, dim_factor_2)
+
+        if len(tensors.shape) == 3:
+            return torch.reshape(tensors, split_dim_shape + (hidden_size,))
+        elif len(tensors.shape) == 2:
+            return torch.reshape(tensors, split_dim_shape)
+        else:
+            raise ValueError(f"Input vector rank should be one of [2, 3], but is: {len(tensors.shape)}")
+
+    @staticmethod
+    def create_local_attention_mask(batch_size, seq_length, window_size, device, attention_mask=None):
+        block_length, num_blocks = GPTNeoAttentionMixin._get_block_length_and_num_blocks(seq_length, window_size)
+        indices = torch.arange(seq_length, dtype=torch.long, device=device).repeat(batch_size, 1)
+
+        query_indices = GPTNeoAttentionMixin._split_seq_length_dim_to(indices, num_blocks, block_length, None)
+        key_indices = GPTNeoAttentionMixin._look_back(indices, block_length, window_size, is_key_value=False)
+
+        # create mask tensor such that each block contains a causal_mask for that block
+        causal_mask = torch.ge(query_indices.unsqueeze(-1), key_indices.unsqueeze(-2))
+
+        if attention_mask is None:
+            attention_mask = torch.ones(batch_size, seq_length, dtype=torch.long, device=device)
+
+        # A block can also be padded becuase of the _look_back operation
+        # look back into the attention_block such that it will also get padded the same way
+        # and have 0s in the padded position
+        attention_mask = GPTNeoAttentionMixin._look_back(attention_mask, block_length, window_size, is_key_value=False)
+        attention_mask = attention_mask.unsqueeze(-2)  # Add an extra dimension to account for hidden_dim
+
+        # Multiply the causal_mask with attention_mask so the padded positions (by _look_back operation)
+        # will contain 0s.
+        # This also makes sure that other positions ignored by the attention_mask will also be ignored
+        # in the causal_mask.
+        causal_mask = causal_mask * attention_mask
+
+        # In GPT Neo's local attention each window can attend to at most window_size tokens
+        # rest of the tokens should be ignored.
+        relative_position = key_indices.unsqueeze(-2) - query_indices.unsqueeze(-1)
+        visible = torch.gt(relative_position, -window_size)
+
+        causal_mask = causal_mask * visible
+        causal_mask = causal_mask.unsqueeze(-3).bool()  # Add an extra dimension to account for num_heads
+
+        return causal_mask
+
     def _split_heads(self, tensor, num_heads, attn_head_size):
         """
         Splits hidden_size dim into attn_head_size and num_heads
@@ -217,20 +268,6 @@ class GPTNeoAttentionMixin:
             raise ValueError(f"Input tensor rank should be one of [4, 5], but is: {len(tensor.shape)}")
         new_shape = tensor.size()[:-2] + (num_heads * attn_head_size,)
         return tensor.view(new_shape)
-
-    def _split_seq_length_dim_to(self, tensors, dim_factor_1, dim_factor_2, hidden_size):
-        """
-        Splits sequence length dim of tensors into `dim_factor_1` and `dim_factor_2` dims
-        """
-        batch_size = tensors.shape[0]
-        split_dim_shape = (batch_size, dim_factor_1, dim_factor_2)
-
-        if len(tensors.shape) == 3:
-            return torch.reshape(tensors, split_dim_shape + (hidden_size,))
-        elif len(tensors.shape) == 2:
-            return torch.reshape(tensors, split_dim_shape)
-        else:
-            raise ValueError(f"Input vector rank should be one of [2, 3], but is: {len(tensors.shape)}")
 
     def _attn(self, query, key, value, causal_mask, masked_bias, attn_dropout, attention_mask=None, head_mask=None):
         # Keep the attention weights computation in fp32 to avoid overflow issues
@@ -289,8 +326,8 @@ class GPTNeoSelfAttention(nn.Module, GPTNeoAttentionMixin):
     def forward(
         self,
         hidden_states,
-        layer_past=None,
         attention_mask=None,
+        layer_past=None,
         head_mask=None,
         use_cache=False,
         output_attentions=False,
@@ -394,8 +431,8 @@ class GPTNeoLocalSelfAttention(nn.Module, GPTNeoAttentionMixin):
     def forward(
         self,
         hidden_states,
+        attention_mask,
         layer_past=None,
-        attention_mask=None,
         head_mask=None,
         use_cache=False,
         output_attentions=False,
@@ -437,18 +474,16 @@ class GPTNeoLocalSelfAttention(nn.Module, GPTNeoAttentionMixin):
         key = self._split_heads(key, self.num_heads, self.head_dim)
         value = self._split_heads(value, self.num_heads, self.head_dim)
 
-        mask = self._create_attention_mask(
-            batch_size, full_seq_length, num_blocks, block_length, hidden_states.device, attention_mask
-        )
         if layer_past is not None:
-            mask = mask[:, -1:, :, -1:, :]  # only take the mask for the last block
+            # only take the mask for the last block
+            attention_mask = attention_mask[:, -1:, :, -1:, :]
 
         # attn
         attn_output, attn_weights = self._attn(
             query,
             key,
             value,
-            causal_mask=mask,
+            causal_mask=attention_mask,
             masked_bias=self.masked_bias,
             attn_dropout=self.attn_dropout,
             head_mask=head_mask,
@@ -495,8 +530,8 @@ class GPTNeoAttention(nn.Module):
     ):
         outputs = self.attention(
             hidden_states,
-            layer_past=layer_past,
             attention_mask=attention_mask,
+            layer_past=layer_past,
             head_mask=head_mask,
             use_cache=use_cache,
             output_attentions=output_attentions,
@@ -765,8 +800,9 @@ class GPTNeoModel(GPTNeoPreTrainedModel):
             past_key_values = tuple([None] * len(self.h))
         else:
             past_length = past_key_values[0][0].size(-2)
+
+        device = input_ids.device if input_ids is not None else inputs_embeds.device
         if position_ids is None:
-            device = input_ids.device if input_ids is not None else inputs_embeds.device
             position_ids = torch.arange(past_length, input_shape[-1] + past_length, dtype=torch.long, device=device)
             position_ids = position_ids.unsqueeze(0).view(-1, input_shape[-1])
 
@@ -790,6 +826,13 @@ class GPTNeoModel(GPTNeoPreTrainedModel):
             global_attention_mask = (1.0 - global_attention_mask) * -10000.0
         else:
             global_attention_mask = None
+
+        # Local causal attention mask
+        batch_size, seq_length = input_shape
+        full_seq_length = seq_length + past_length
+        local_attention_mask = GPTNeoAttentionMixin.create_local_attention_mask(
+            batch_size, full_seq_length, self.config.window_size, device, attention_mask
+        )
 
         # Prepare head mask if needed
         # 1.0 in head_mask indicate we keep the head
@@ -815,7 +858,7 @@ class GPTNeoModel(GPTNeoPreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         for i, (block, layer_past) in enumerate(zip(self.h, past_key_values)):
             attn_type = self.config.attention_layers[i]
-            attn_mask = global_attention_mask if attn_type == "global" else attention_mask
+            attn_mask = global_attention_mask if attn_type == "global" else local_attention_mask
 
             if output_hidden_states:
                 all_hidden_states = all_hidden_states + (hidden_states,)


### PR DESCRIPTION
# What does this PR do?

This PR refactors GPT Neo such that the causal attention mask for the local attention layer is only computed once per batch in the `GPTNeoModel` class and then shared between the layers instead of re-computing it in each layer.

I've verified that all slow tests are passing.

#### Benchmarks

This PR does not change memory/speed for the forward pass

On master
```
====================       INFERENCE - SPEED - RESULT       ====================
--------------------------------------------------------------------------------
          Model Name             Batch Size     Seq Length     Time in s   
--------------------------------------------------------------------------------
/home/suraj/projects/gpt-neo-c       2               32            0.021     
/home/suraj/projects/gpt-neo-c       2              128            0.059     
/home/suraj/projects/gpt-neo-c       2              512            0.227
/home/suraj/projects/gpt-neo-c       2              1024           0.464        
/home/suraj/projects/gpt-neo-c       4               32            0.033     
/home/suraj/projects/gpt-neo-c       4              128            0.113     
/home/suraj/projects/gpt-neo-c       4              512            0.449
/home/suraj/projects/gpt-neo-c       2              1024           N/A        
--------------------------------------------------------------------------------

====================      INFERENCE - MEMORY - RESULT       ====================
--------------------------------------------------------------------------------
          Model Name             Batch Size     Seq Length    Memory in MB 
--------------------------------------------------------------------------------
/home/suraj/projects/gpt-neo-c       2               32             6136     
/home/suraj/projects/gpt-neo-c       2              128             6268     
/home/suraj/projects/gpt-neo-c       2              512             6790
/home/suraj/projects/gpt-neo-c       2              1024            7472          
/home/suraj/projects/gpt-neo-c       4               32             6204     
/home/suraj/projects/gpt-neo-c       4              128             6428     
/home/suraj/projects/gpt-neo-c       4              512             7456
/home/suraj/projects/gpt-neo-c       4              1024            N/A         
--------------------------------------------------------------------------------
```

On this PR
```
===================       INFERENCE - SPEED - RESULT       ====================
--------------------------------------------------------------------------------
          Model Name             Batch Size     Seq Length     Time in s   
--------------------------------------------------------------------------------
/home/suraj/projects/gpt-neo-c       2               32            0.021     
/home/suraj/projects/gpt-neo-c       2              128            0.058     
/home/suraj/projects/gpt-neo-c       2              512            0.222
/home/suraj/projects/gpt-neo-c       2              1024           0.453      
/home/suraj/projects/gpt-neo-c       4               32            0.032     
/home/suraj/projects/gpt-neo-c       4              128            0.11     
/home/suraj/projects/gpt-neo-c       4              512            0.439
/home/suraj/projects/gpt-neo-c       4              1024          N/A           
--------------------------------------------------------------------------------

====================      INFERENCE - MEMORY - RESULT       ====================
--------------------------------------------------------------------------------
          Model Name             Batch Size     Seq Length    Memory in MB 
--------------------------------------------------------------------------------
/home/suraj/projects/gpt-neo-c       2               32             6136     
/home/suraj/projects/gpt-neo-c       2              128             6268     
/home/suraj/projects/gpt-neo-c       2              512             6790
/home/suraj/projects/gpt-neo-c       2              1024            7476     
/home/suraj/projects/gpt-neo-c       4               32             6204     
/home/suraj/projects/gpt-neo-c       4              128             6428     
/home/suraj/projects/gpt-neo-c       4              512             7460 
/home/suraj/projects/gpt-neo-c       4              1024            N/A    
--------------------------------------------------------------------------------
```

I did a micro-benchmark using the 125M model for generation and this PR does give a small speed-up when generating longer sequences.

On master 

```
%timeit model.generate(**enc, do_sample=False, max_length=512, min_length=512)
4.63 s ± 25.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit -n 10 model.generate(**enc, do_sample=False, max_length=1024, min_length=1024)
9.63 s ± 549 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

On this PR
```
%timeit model.generate(**enc, do_sample=False, max_length=512, min_length=512)
4.25 s ± 189 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit -n 10 model.generate(**enc, do_sample=False, max_length=1024, min_length=1024)

9 s ± 437 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

 