### PR TITLE
Update to use datasets remove_cloumns method

### DIFF
--- a/examples/question-answering/requirements.txt
+++ b/examples/question-answering/requirements.txt
@@ -1,1 +1,1 @@
-datasets >= 1.2.1
+datasets >= 1.4.0

--- a/examples/question-answering/trainer_qa.py
+++ b/examples/question-answering/trainer_qa.py
@@ -16,12 +16,9 @@
 A subclass of `Trainer` specific to Question-Answering tasks
 """
 
-from transformers import Trainer, is_datasets_available, is_torch_tpu_available
+from transformers import Trainer, is_torch_tpu_available
 from transformers.trainer_utils import PredictionOutput
 
-
-if is_datasets_available():
-    import datasets
 
 if is_torch_tpu_available():
     import torch_xla.core.xla_model as xm

--- a/examples/question-answering/trainer_qa.py
+++ b/examples/question-answering/trainer_qa.py
@@ -54,10 +54,6 @@ class QuestionAnsweringTrainer(Trainer):
         finally:
             self.compute_metrics = compute_metrics
 
-        # We might have removed columns from the dataset so we put them back.
-        if isinstance(eval_dataset, datasets.Dataset):
-            eval_dataset.set_format(type=eval_dataset.format["type"], columns=list(eval_dataset.features.keys()))
-
         if self.post_process_function is not None and self.compute_metrics is not None:
             eval_preds = self.post_process_function(eval_examples, eval_dataset, output.predictions)
             metrics = self.compute_metrics(eval_preds)
@@ -93,10 +89,6 @@ class QuestionAnsweringTrainer(Trainer):
 
         if self.post_process_function is None or self.compute_metrics is None:
             return output
-
-        # We might have removed columns from the dataset so we put them back.
-        if isinstance(test_dataset, datasets.Dataset):
-            test_dataset.set_format(type=test_dataset.format["type"], columns=list(test_dataset.features.keys()))
 
         eval_preds = self.post_process_function(test_examples, test_dataset, output.predictions, "test")
         metrics = self.compute_metrics(eval_preds)


### PR DESCRIPTION
# What does this PR do?

This PR updates the command used in the `Trainer` to drop the columns not used by the model to take advantage of the latest (well not so latest since it landed in datasets 1.4.0) `remove_columns` method. This adds the advantage of not modifying in place the dataset (as was done before) so the user does not have unexpected changes in their original datasets.

In consequence, the little hack needed in the question answering examples is now unnecessary.