### PR TITLE
Fix Trainer with remove_unused_columns=False

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -482,7 +482,7 @@ class Trainer:
 
     def _remove_unused_columns(self, dataset: "datasets.Dataset", description: Optional[str] = None):
         if not self.args.remove_unused_columns:
-            return
+            return datset
         if self._signature_columns is None:
             # Inspect model forward signature to keep only the arguments it accepts.
             signature = inspect.signature(self.model.forward)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -482,7 +482,7 @@ class Trainer:
 
     def _remove_unused_columns(self, dataset: "datasets.Dataset", description: Optional[str] = None):
         if not self.args.remove_unused_columns:
-            return datset
+            return dataset
         if self._signature_columns is None:
             # Inspect model forward signature to keep only the arguments it accepts.
             signature = inspect.signature(self.model.forward)


### PR DESCRIPTION
# What does this PR do?

A bug was introduced by mistake in #11343 when `remove_unused_columns=False`. This PR fixes that.
Fixes #11381