### PR TITLE
Default to accuracy metric in run_glue_no_trainer

### DIFF
--- a/examples/pytorch/text-classification/run_glue_no_trainer.py
+++ b/examples/pytorch/text-classification/run_glue_no_trainer.py
@@ -367,6 +367,8 @@ def main():
     # Get the metric function
     if args.task_name is not None:
         metric = load_metric("glue", args.task_name)
+    else:
+        metric = load_metric("accuracy")
 
     # Train!
     total_batch_size = args.per_device_train_batch_size * accelerator.num_processes * args.gradient_accumulation_steps


### PR DESCRIPTION
# What does this PR do?

In `run_glue_no_trainer`, the metric is not properly initialized when no task name is passed, this PR fixes that.

Fixes #11403