### PR TITLE
Pass along seed to DistributedSampler

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -547,6 +547,7 @@ class Trainer:
                     rank=self.args.process_index,
                     lengths=lengths,
                     model_input_name=model_input_name,
+                    seed=self.args.seed,
                 )
 
         else:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -562,10 +562,14 @@ class Trainer:
                     batch_size=self.args.per_device_train_batch_size,
                     num_replicas=self.args.world_size,
                     rank=self.args.process_index,
+                    seed=self.args.seed,
                 )
             else:
                 return DistributedSampler(
-                    self.train_dataset, num_replicas=self.args.world_size, rank=self.args.process_index
+                    self.train_dataset,
+                    num_replicas=self.args.world_size,
+                    rank=self.args.process_index,
+                    seed=self.args.seed,
                 )
 
     def get_train_dataloader(self) -> DataLoader:


### PR DESCRIPTION
# What does this PR do?

This PR passes along the seed to `DistributedSampler` otherwise it always uses 0 for setting its RNG. See #11389 for more context.

Fixes #11389