### PR TITLE
Add basic support for FP16 in SageMaker model parallelism

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -425,6 +425,13 @@ class Trainer:
                     )
                 self.use_apex = True
 
+        # FP16 + model parallelism in SageMaker: gradient clipping does not work for now so we raise a helpful error.
+        if is_sagemaker_mp_enabled() and self.use_amp and args.max_grad_norm is not None and args.max_grad_norm > 0:
+            raise ValueError(
+                "SageMaker Model Parallelism in mixed precision mode does not support gradient clipping yet. Use "
+                "pass along 'max_grad_norm': 0 in your hyperparameters."
+            )
+
         # Label smoothing
         if self.args.label_smoothing_factor != 0:
             self.label_smoother = LabelSmoother(epsilon=self.args.label_smoothing_factor)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -428,8 +428,8 @@ class Trainer:
         # FP16 + model parallelism in SageMaker: gradient clipping does not work for now so we raise a helpful error.
         if is_sagemaker_mp_enabled() and self.use_amp and args.max_grad_norm is not None and args.max_grad_norm > 0:
             raise ValueError(
-                "SageMaker Model Parallelism in mixed precision mode does not support gradient clipping yet. Use "
-                "pass along 'max_grad_norm': 0 in your hyperparameters."
+                "SageMaker Model Parallelism in mixed precision mode does not support gradient clipping yet. Pass "
+                "along 'max_grad_norm': 0 in your hyperparameters."
             )
 
         # Label smoothing

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -981,7 +981,10 @@ if is_sagemaker_mp_enabled():
         loss = outputs["loss"] if isinstance(outputs, dict) else outputs[0]
         loss /= gradient_accumulation_steps
         if scaler is not None:
+            print(f"Loss before {loss}")
             loss = scaler.scale(loss)
+            print(f"Loss after {loss}")
+
         model.backward(loss)
         return loss
 

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -982,7 +982,7 @@ if is_sagemaker_mp_enabled():
         loss /= gradient_accumulation_steps
         if scaler is not None:
             print(f"Loss before {loss}")
-            loss = scaler.scale(loss)
+            loss = scaler.scale(loss).squeeze()
             print(f"Loss after {loss}")
 
         model.backward(loss)

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -974,10 +974,14 @@ if is_sagemaker_mp_enabled():
     import smdistributed.modelparallel.torch as smp
 
     @smp.step()
-    def smp_forward_backward(model, inputs, gradient_accumulation_steps=1):
-        outputs = model(**inputs)
+    def smp_forward_backward(model, inputs, gradient_accumulation_steps=1, scaler=None):
+        with torch.cuda.amp.autocast(enabled=(scaler is not None)):
+            outputs = model(**inputs)
+
         loss = outputs["loss"] if isinstance(outputs, dict) else outputs[0]
         loss /= gradient_accumulation_steps
+        if scaler is not None:
+            loss = scaler.scale(loss)
         model.backward(loss)
         return loss
 

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -981,9 +981,7 @@ if is_sagemaker_mp_enabled():
         loss = outputs["loss"] if isinstance(outputs, dict) else outputs[0]
         loss /= gradient_accumulation_steps
         if scaler is not None:
-            print(f"Loss before {loss}")
             loss = scaler.scale(loss).squeeze()
-            print(f"Loss after {loss}")
 
         model.backward(loss)
         return loss


### PR DESCRIPTION
# What does this PR do?

**Note:** This is not full support yet as SageMaker Model Parallelism does not support gradient clipping, so a user has to change the default of `max_grad_norm` to 0 if they want to use it.

Otherwise, this adds support for mixed precision training in SageMaker Model Parallelism mode. The script has been tested on `run_glue.py` without error (as long as the caveat above is respected).
A defensive check is added so that the user gets an obvious error message if they don't change the default value of `max_grad_norm`.