### PR TITLE
wrong parentclass in documentation

### DIFF
--- a/src/transformers/models/roberta/tokenization_roberta.py
+++ b/src/transformers/models/roberta/tokenization_roberta.py
@@ -81,7 +81,7 @@ class RobertaTokenizer(GPT2Tokenizer):
         When used with ``is_split_into_words=True``, this tokenizer will add a space before each word (even the first
         one).
 
-    This tokenizer inherits from :class:`~transformers.PreTrainedTokenizerFast` which contains most of the main
+    This tokenizer inherits from :class:`~transformers.PreTrainedTokenizer` which contains most of the main
     methods. Users should refer to this superclass for more information regarding those methods.
 
     Args:


### PR DESCRIPTION
# What does this PR do?

The documentation linked to the parent class PreTrainedTokenizerFast but it should be the slow tokenizer class


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.


@sgugger
