### PR TITLE
Enable option for subword regularization in more tokenizers.

### DIFF
--- a/src/transformers/models/albert/tokenization_albert.py
+++ b/src/transformers/models/albert/tokenization_albert.py
@@ -18,7 +18,7 @@
 import os
 import unicodedata
 from shutil import copyfile
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import sentencepiece as spm
 
@@ -139,7 +139,7 @@ class AlbertTokenizer(PreTrainedTokenizer):
         pad_token="<pad>",
         cls_token="[CLS]",
         mask_token="[MASK]",
-        sp_model_kwargs=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
         # Mask token behave like a normal word, i.e. include the space before it
@@ -209,7 +209,7 @@ class AlbertTokenizer(PreTrainedTokenizer):
 
         return outputs
 
-    def _tokenize(self, text):
+    def _tokenize(self, text: str) -> List[str]:
         """Tokenize a string."""
         text = self.preprocess_text(text)
         pieces = self.sp_model.encode(text, out_type=str)

--- a/src/transformers/models/albert/tokenization_albert.py
+++ b/src/transformers/models/albert/tokenization_albert.py
@@ -209,14 +209,10 @@ class AlbertTokenizer(PreTrainedTokenizer):
 
         return outputs
 
-    def _tokenize(self, text, sample=False):
+    def _tokenize(self, text):
         """Tokenize a string."""
         text = self.preprocess_text(text)
-
-        if not sample:
-            pieces = self.sp_model.encode(text, out_type=str)
-        else:
-            pieces = self.sp_model.SampleEncodeAsPieces(text, 64, 0.1)
+        pieces = self.sp_model.encode(text, out_type=str)
         new_pieces = []
         for piece in pieces:
             if len(piece) > 1 and piece[-1] == str(",") and piece[-2].isdigit():

--- a/src/transformers/models/albert/tokenization_albert.py
+++ b/src/transformers/models/albert/tokenization_albert.py
@@ -102,6 +102,20 @@ class AlbertTokenizer(PreTrainedTokenizer):
         mask_token (:obj:`str`, `optional`, defaults to :obj:`"[MASK]"`):
             The token used for masking values. This is the token used when training this model with masked language
             modeling. This is the token which the model will try to predict.
+        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+            Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
+            <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
+
+            - ``enable_sampling``: Enable subword regularization.
+            - ``nbest_size``: Sampling parameters for unigram. Invalid for BPE-Dropout.
+
+              - ``nbest_size = {0,1}``: No sampling is performed.
+              - ``nbest_size > 1``: samples from the nbest_size results.
+              - ``nbest_size < 0``: assuming that nbest_size is infinite and samples from the all hypothesis (lattice)
+                using forward-filtering-and-backward-sampling algorithm.
+
+            - ``alpha``: Smoothing parameter for unigram sampling, and dropout probability of merge operations for
+              BPE-dropout.
 
     Attributes:
         sp_model (:obj:`SentencePieceProcessor`):
@@ -125,10 +139,13 @@ class AlbertTokenizer(PreTrainedTokenizer):
         pad_token="<pad>",
         cls_token="[CLS]",
         mask_token="[MASK]",
+        sp_model_kwargs=None,
         **kwargs
     ):
         # Mask token behave like a normal word, i.e. include the space before it
         mask_token = AddedToken(mask_token, lstrip=True, rstrip=False) if isinstance(mask_token, str) else mask_token
+
+        self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
         super().__init__(
             do_lower_case=do_lower_case,
@@ -141,6 +158,7 @@ class AlbertTokenizer(PreTrainedTokenizer):
             pad_token=pad_token,
             cls_token=cls_token,
             mask_token=mask_token,
+            sp_model_kwargs=self.sp_model_kwargs,
             **kwargs,
         )
 
@@ -149,7 +167,7 @@ class AlbertTokenizer(PreTrainedTokenizer):
         self.keep_accents = keep_accents
         self.vocab_file = vocab_file
 
-        self.sp_model = spm.SentencePieceProcessor()
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(vocab_file)
 
     @property
@@ -168,7 +186,12 @@ class AlbertTokenizer(PreTrainedTokenizer):
 
     def __setstate__(self, d):
         self.__dict__ = d
-        self.sp_model = spm.SentencePieceProcessor()
+
+        # for backward compatibility
+        if not hasattr(self, "sp_model_kwargs"):
+            self.sp_model_kwargs = {}
+
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(self.vocab_file)
 
     def preprocess_text(self, inputs):
@@ -191,7 +214,7 @@ class AlbertTokenizer(PreTrainedTokenizer):
         text = self.preprocess_text(text)
 
         if not sample:
-            pieces = self.sp_model.EncodeAsPieces(text)
+            pieces = self.sp_model.encode(text, out_type=str)
         else:
             pieces = self.sp_model.SampleEncodeAsPieces(text, 64, 0.1)
         new_pieces = []

--- a/src/transformers/models/albert/tokenization_albert.py
+++ b/src/transformers/models/albert/tokenization_albert.py
@@ -141,7 +141,7 @@ class AlbertTokenizer(PreTrainedTokenizer):
         mask_token="[MASK]",
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
-    ):
+    ) -> None:
         # Mask token behave like a normal word, i.e. include the space before it
         mask_token = AddedToken(mask_token, lstrip=True, rstrip=False) if isinstance(mask_token, str) else mask_token
 

--- a/src/transformers/models/albert/tokenization_albert.py
+++ b/src/transformers/models/albert/tokenization_albert.py
@@ -102,7 +102,7 @@ class AlbertTokenizer(PreTrainedTokenizer):
         mask_token (:obj:`str`, `optional`, defaults to :obj:`"[MASK]"`):
             The token used for masking values. This is the token used when training this model with masked language
             modeling. This is the token which the model will try to predict.
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/src/transformers/models/barthez/tokenization_barthez.py
+++ b/src/transformers/models/barthez/tokenization_barthez.py
@@ -17,7 +17,7 @@
 
 import os
 from shutil import copyfile
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import sentencepiece as spm
 
@@ -124,7 +124,7 @@ class BarthezTokenizer(PreTrainedTokenizer):
         unk_token="<unk>",
         pad_token="<pad>",
         mask_token="<mask>",
-        sp_model_kwargs=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
         # Mask token behave like a normal word, i.e. include the space before it
@@ -237,7 +237,7 @@ class BarthezTokenizer(PreTrainedTokenizer):
         vocab.update(self.added_tokens_encoder)
         return vocab
 
-    def _tokenize(self, text):
+    def _tokenize(self, text: str) -> List[str]:
         return self.sp_model.encode(text, out_type=str)
 
     def _convert_token_to_id(self, token):

--- a/src/transformers/models/barthez/tokenization_barthez.py
+++ b/src/transformers/models/barthez/tokenization_barthez.py
@@ -89,6 +89,20 @@ class BarthezTokenizer(PreTrainedTokenizer):
             modeling. This is the token which the model will try to predict.
         additional_special_tokens (:obj:`List[str]`, `optional`, defaults to :obj:`["<s>NOTUSED", "</s>NOTUSED"]`):
             Additional special tokens used by the tokenizer.
+        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+            Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
+            <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
+
+            - ``enable_sampling``: Enable subword regularization.
+            - ``nbest_size``: Sampling parameters for unigram. Invalid for BPE-Dropout.
+
+              - ``nbest_size = {0,1}``: No sampling is performed.
+              - ``nbest_size > 1``: samples from the nbest_size results.
+              - ``nbest_size < 0``: assuming that nbest_size is infinite and samples from the all hypothesis (lattice)
+                using forward-filtering-and-backward-sampling algorithm.
+
+            - ``alpha``: Smoothing parameter for unigram sampling, and dropout probability of merge operations for
+              BPE-dropout.
 
     Attributes:
         sp_model (:obj:`SentencePieceProcessor`):
@@ -110,10 +124,13 @@ class BarthezTokenizer(PreTrainedTokenizer):
         unk_token="<unk>",
         pad_token="<pad>",
         mask_token="<mask>",
+        sp_model_kwargs=None,
         **kwargs
     ):
         # Mask token behave like a normal word, i.e. include the space before it
         mask_token = AddedToken(mask_token, lstrip=True, rstrip=False) if isinstance(mask_token, str) else mask_token
+
+        sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
         super().__init__(
             bos_token=bos_token,
@@ -123,11 +140,12 @@ class BarthezTokenizer(PreTrainedTokenizer):
             cls_token=cls_token,
             pad_token=pad_token,
             mask_token=mask_token,
+            sp_model_kwargs=sp_model_kwargs,
             **kwargs,
         )
 
         self.vocab_file = vocab_file
-        self.sp_model = spm.SentencePieceProcessor()
+        self.sp_model = spm.SentencePieceProcessor(**sp_model_kwargs)
         self.sp_model.Load(str(vocab_file))
 
         self.fairseq_tokens_to_ids = {"<s>": 0, "<pad>": 1, "</s>": 2, "<unk>": 3}
@@ -220,7 +238,7 @@ class BarthezTokenizer(PreTrainedTokenizer):
         return vocab
 
     def _tokenize(self, text):
-        return self.sp_model.EncodeAsPieces(text)
+        return self.sp_model.encode(text, out_type=str)
 
     def _convert_token_to_id(self, token):
         """Converts a token (str) in an id using the vocab."""

--- a/src/transformers/models/barthez/tokenization_barthez.py
+++ b/src/transformers/models/barthez/tokenization_barthez.py
@@ -126,7 +126,7 @@ class BarthezTokenizer(PreTrainedTokenizer):
         mask_token="<mask>",
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
-    ):
+    ) -> None:
         # Mask token behave like a normal word, i.e. include the space before it
         mask_token = AddedToken(mask_token, lstrip=True, rstrip=False) if isinstance(mask_token, str) else mask_token
 

--- a/src/transformers/models/barthez/tokenization_barthez.py
+++ b/src/transformers/models/barthez/tokenization_barthez.py
@@ -130,7 +130,7 @@ class BarthezTokenizer(PreTrainedTokenizer):
         # Mask token behave like a normal word, i.e. include the space before it
         mask_token = AddedToken(mask_token, lstrip=True, rstrip=False) if isinstance(mask_token, str) else mask_token
 
-        sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
+        self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
         super().__init__(
             bos_token=bos_token,
@@ -140,12 +140,12 @@ class BarthezTokenizer(PreTrainedTokenizer):
             cls_token=cls_token,
             pad_token=pad_token,
             mask_token=mask_token,
-            sp_model_kwargs=sp_model_kwargs,
+            sp_model_kwargs=self.sp_model_kwargs,
             **kwargs,
         )
 
         self.vocab_file = vocab_file
-        self.sp_model = spm.SentencePieceProcessor(**sp_model_kwargs)
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(str(vocab_file))
 
         self.fairseq_tokens_to_ids = {"<s>": 0, "<pad>": 1, "</s>": 2, "<unk>": 3}
@@ -261,7 +261,12 @@ class BarthezTokenizer(PreTrainedTokenizer):
 
     def __setstate__(self, d):
         self.__dict__ = d
-        self.sp_model = spm.SentencePieceProcessor()
+
+        # for backward compatibility
+        if not hasattr(self, "sp_model_kwargs"):
+            self.sp_model_kwargs = {}
+
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(self.vocab_file)
 
     def convert_tokens_to_string(self, tokens):

--- a/src/transformers/models/barthez/tokenization_barthez.py
+++ b/src/transformers/models/barthez/tokenization_barthez.py
@@ -89,7 +89,7 @@ class BarthezTokenizer(PreTrainedTokenizer):
             modeling. This is the token which the model will try to predict.
         additional_special_tokens (:obj:`List[str]`, `optional`, defaults to :obj:`["<s>NOTUSED", "</s>NOTUSED"]`):
             Additional special tokens used by the tokenizer.
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`:
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/src/transformers/models/barthez/tokenization_barthez.py
+++ b/src/transformers/models/barthez/tokenization_barthez.py
@@ -89,7 +89,7 @@ class BarthezTokenizer(PreTrainedTokenizer):
             modeling. This is the token which the model will try to predict.
         additional_special_tokens (:obj:`List[str]`, `optional`, defaults to :obj:`["<s>NOTUSED", "</s>NOTUSED"]`):
             Additional special tokens used by the tokenizer.
-        sp_model_kwargs (:obj:`dict`, `optional`:
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/src/transformers/models/bert_generation/tokenization_bert_generation.py
+++ b/src/transformers/models/bert_generation/tokenization_bert_generation.py
@@ -90,7 +90,7 @@ class BertGenerationTokenizer(PreTrainedTokenizer):
         sep_token="<::::>",
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
-    ):
+    ) -> None:
         self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
         # Add extra_ids to the special token list

--- a/src/transformers/models/bert_generation/tokenization_bert_generation.py
+++ b/src/transformers/models/bert_generation/tokenization_bert_generation.py
@@ -17,7 +17,7 @@
 
 import os
 from shutil import copyfile
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import sentencepiece as spm
 
@@ -88,7 +88,7 @@ class BertGenerationTokenizer(PreTrainedTokenizer):
         unk_token="<unk>",
         pad_token="<pad>",
         sep_token="<::::>",
-        sp_model_kwargs=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
         self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
@@ -133,7 +133,7 @@ class BertGenerationTokenizer(PreTrainedTokenizer):
         self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(self.vocab_file)
 
-    def _tokenize(self, text):
+    def _tokenize(self, text: str) -> List[str]:
         """Take as input a string and return a list of strings (tokens) for words/sub-words"""
         return self.sp_model.encode(text, out_type=str)
 

--- a/src/transformers/models/bert_generation/tokenization_bert_generation.py
+++ b/src/transformers/models/bert_generation/tokenization_bert_generation.py
@@ -58,6 +58,20 @@ class BertGenerationTokenizer(PreTrainedTokenizer):
             token instead.
         pad_token (:obj:`str`, `optional`, defaults to :obj:`"<pad>"`):
             The token used for padding, for example when batching sequences of different lengths.
+        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+            Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
+            <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
+
+            - ``enable_sampling``: Enable subword regularization.
+            - ``nbest_size``: Sampling parameters for unigram. Invalid for BPE-Dropout.
+
+              - ``nbest_size = {0,1}``: No sampling is performed.
+              - ``nbest_size > 1``: samples from the nbest_size results.
+              - ``nbest_size < 0``: assuming that nbest_size is infinite and samples from the all hypothesis (lattice)
+                using forward-filtering-and-backward-sampling algorithm.
+
+            - ``alpha``: Smoothing parameter for unigram sampling, and dropout probability of merge operations for
+              BPE-dropout.
     """
 
     vocab_files_names = VOCAB_FILES_NAMES
@@ -74,8 +88,11 @@ class BertGenerationTokenizer(PreTrainedTokenizer):
         unk_token="<unk>",
         pad_token="<pad>",
         sep_token="<::::>",
+        sp_model_kwargs=None,
         **kwargs
     ):
+        self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
+
         # Add extra_ids to the special token list
         super().__init__(
             bos_token=bos_token,
@@ -83,12 +100,13 @@ class BertGenerationTokenizer(PreTrainedTokenizer):
             unk_token=unk_token,
             pad_token=pad_token,
             sep_token=sep_token,
+            sp_model_kwargs=self.sp_model_kwargs,
             **kwargs,
         )
 
         self.vocab_file = vocab_file
 
-        self.sp_model = spm.SentencePieceProcessor()
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(vocab_file)
 
     @property
@@ -107,16 +125,17 @@ class BertGenerationTokenizer(PreTrainedTokenizer):
 
     def __setstate__(self, d):
         self.__dict__ = d
-        self.sp_model = spm.SentencePieceProcessor()
+
+        # for backward compatibility
+        if not hasattr(self, "sp_model_kwargs"):
+            self.sp_model_kwargs = {}
+
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(self.vocab_file)
 
-    def _tokenize(self, text, sample=False):
+    def _tokenize(self, text):
         """Take as input a string and return a list of strings (tokens) for words/sub-words"""
-        if not sample:
-            pieces = self.sp_model.EncodeAsPieces(text)
-        else:
-            pieces = self.sp_model.SampleEncodeAsPieces(text, 64, 0.1)
-        return pieces
+        return self.sp_model.encode(text, out_type=str)
 
     def _convert_token_to_id(self, token):
         """Converts a token (str) in an id using the vocab."""

--- a/src/transformers/models/bert_generation/tokenization_bert_generation.py
+++ b/src/transformers/models/bert_generation/tokenization_bert_generation.py
@@ -58,7 +58,7 @@ class BertGenerationTokenizer(PreTrainedTokenizer):
             token instead.
         pad_token (:obj:`str`, `optional`, defaults to :obj:`"<pad>"`):
             The token used for padding, for example when batching sequences of different lengths.
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/src/transformers/models/big_bird/tokenization_big_bird.py
+++ b/src/transformers/models/big_bird/tokenization_big_bird.py
@@ -17,9 +17,10 @@
 
 import os
 from shutil import copyfile
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import sentencepiece as spm
+from google.protobuf.any_pb2 import Any
 
 from ...tokenization_utils import AddedToken, PreTrainedTokenizer
 from ...utils import logging
@@ -106,7 +107,7 @@ class BigBirdTokenizer(PreTrainedTokenizer):
         sep_token="[SEP]",
         mask_token="[MASK]",
         cls_token="[CLS]",
-        sp_model_kwargs=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
         bos_token = AddedToken(bos_token, lstrip=False, rstrip=False) if isinstance(bos_token, str) else bos_token
@@ -162,7 +163,7 @@ class BigBirdTokenizer(PreTrainedTokenizer):
         self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(self.vocab_file)
 
-    def _tokenize(self, text):
+    def _tokenize(self, text: str) -> List[str]:
         """Take as input a string and return a list of strings (tokens) for words/sub-words"""
         return self.sp_model.encode(text, out_type=str)
 

--- a/src/transformers/models/big_bird/tokenization_big_bird.py
+++ b/src/transformers/models/big_bird/tokenization_big_bird.py
@@ -109,7 +109,7 @@ class BigBirdTokenizer(PreTrainedTokenizer):
         cls_token="[CLS]",
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
-    ):
+    ) -> None:
         bos_token = AddedToken(bos_token, lstrip=False, rstrip=False) if isinstance(bos_token, str) else bos_token
         eos_token = AddedToken(eos_token, lstrip=False, rstrip=False) if isinstance(eos_token, str) else eos_token
         unk_token = AddedToken(unk_token, lstrip=False, rstrip=False) if isinstance(unk_token, str) else unk_token

--- a/src/transformers/models/big_bird/tokenization_big_bird.py
+++ b/src/transformers/models/big_bird/tokenization_big_bird.py
@@ -17,10 +17,9 @@
 
 import os
 from shutil import copyfile
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import sentencepiece as spm
-from google.protobuf.any_pb2 import Any
 
 from ...tokenization_utils import AddedToken, PreTrainedTokenizer
 from ...utils import logging

--- a/src/transformers/models/big_bird/tokenization_big_bird.py
+++ b/src/transformers/models/big_bird/tokenization_big_bird.py
@@ -75,7 +75,7 @@ class BigBirdTokenizer(PreTrainedTokenizer):
         mask_token (:obj:`str`, `optional`, defaults to :obj:`"[MASK]"`):
             The token used for masking values. This is the token used when training this model with masked language
             modeling. This is the token which the model will try to predict.
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/src/transformers/models/camembert/tokenization_camembert.py
+++ b/src/transformers/models/camembert/tokenization_camembert.py
@@ -123,7 +123,7 @@ class CamembertTokenizer(PreTrainedTokenizer):
         additional_special_tokens=["<s>NOTUSED", "</s>NOTUSED"],
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
-    ):
+    ) -> None:
         # Mask token behave like a normal word, i.e. include the space before it
         mask_token = AddedToken(mask_token, lstrip=True, rstrip=False) if isinstance(mask_token, str) else mask_token
 

--- a/src/transformers/models/camembert/tokenization_camembert.py
+++ b/src/transformers/models/camembert/tokenization_camembert.py
@@ -127,7 +127,7 @@ class CamembertTokenizer(PreTrainedTokenizer):
         # Mask token behave like a normal word, i.e. include the space before it
         mask_token = AddedToken(mask_token, lstrip=True, rstrip=False) if isinstance(mask_token, str) else mask_token
 
-        sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
+        self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
         super().__init__(
             bos_token=bos_token,
@@ -138,10 +138,10 @@ class CamembertTokenizer(PreTrainedTokenizer):
             pad_token=pad_token,
             mask_token=mask_token,
             additional_special_tokens=additional_special_tokens,
-            sp_model_kwargs=sp_model_kwargs,
+            sp_model_kwargs=self.sp_model_kwargs,
             **kwargs,
         )
-        self.sp_model = spm.SentencePieceProcessor(**sp_model_kwargs)
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(str(vocab_file))
         self.vocab_file = vocab_file
         # HACK: These tokens were added by fairseq but don't seem to be actually used when duplicated in the actual
@@ -261,7 +261,12 @@ class CamembertTokenizer(PreTrainedTokenizer):
 
     def __setstate__(self, d):
         self.__dict__ = d
-        self.sp_model = spm.SentencePieceProcessor()
+
+        # for backward compatibility
+        if not hasattr(self, "sp_model_kwargs"):
+            self.sp_model_kwargs = {}
+
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(self.vocab_file)
 
     def convert_tokens_to_string(self, tokens):

--- a/src/transformers/models/camembert/tokenization_camembert.py
+++ b/src/transformers/models/camembert/tokenization_camembert.py
@@ -17,7 +17,7 @@
 
 import os
 from shutil import copyfile
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import sentencepiece as spm
 
@@ -121,7 +121,7 @@ class CamembertTokenizer(PreTrainedTokenizer):
         pad_token="<pad>",
         mask_token="<mask>",
         additional_special_tokens=["<s>NOTUSED", "</s>NOTUSED"],
-        sp_model_kwargs=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
         # Mask token behave like a normal word, i.e. include the space before it
@@ -236,7 +236,7 @@ class CamembertTokenizer(PreTrainedTokenizer):
         vocab.update(self.added_tokens_encoder)
         return vocab
 
-    def _tokenize(self, text):
+    def _tokenize(self, text: str) -> List[str]:
         return self.sp_model.encode(text, out_type=str)
 
     def _convert_token_to_id(self, token):

--- a/src/transformers/models/camembert/tokenization_camembert.py
+++ b/src/transformers/models/camembert/tokenization_camembert.py
@@ -85,6 +85,20 @@ class CamembertTokenizer(PreTrainedTokenizer):
             modeling. This is the token which the model will try to predict.
         additional_special_tokens (:obj:`List[str]`, `optional`, defaults to :obj:`["<s>NOTUSED", "</s>NOTUSED"]`):
             Additional special tokens used by the tokenizer.
+        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+            Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
+            <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
+
+            - ``enable_sampling``: Enable subword regularization.
+            - ``nbest_size``: Sampling parameters for unigram. Invalid for BPE-Dropout.
+
+              - ``nbest_size = {0,1}``: No sampling is performed.
+              - ``nbest_size > 1``: samples from the nbest_size results.
+              - ``nbest_size < 0``: assuming that nbest_size is infinite and samples from the all hypothesis (lattice)
+                using forward-filtering-and-backward-sampling algorithm.
+
+            - ``alpha``: Smoothing parameter for unigram sampling, and dropout probability of merge operations for
+              BPE-dropout.
 
     Attributes:
         sp_model (:obj:`SentencePieceProcessor`):
@@ -107,10 +121,13 @@ class CamembertTokenizer(PreTrainedTokenizer):
         pad_token="<pad>",
         mask_token="<mask>",
         additional_special_tokens=["<s>NOTUSED", "</s>NOTUSED"],
+        sp_model_kwargs=None,
         **kwargs
     ):
         # Mask token behave like a normal word, i.e. include the space before it
         mask_token = AddedToken(mask_token, lstrip=True, rstrip=False) if isinstance(mask_token, str) else mask_token
+
+        sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
         super().__init__(
             bos_token=bos_token,
@@ -121,9 +138,10 @@ class CamembertTokenizer(PreTrainedTokenizer):
             pad_token=pad_token,
             mask_token=mask_token,
             additional_special_tokens=additional_special_tokens,
+            sp_model_kwargs=sp_model_kwargs,
             **kwargs,
         )
-        self.sp_model = spm.SentencePieceProcessor()
+        self.sp_model = spm.SentencePieceProcessor(**sp_model_kwargs)
         self.sp_model.Load(str(vocab_file))
         self.vocab_file = vocab_file
         # HACK: These tokens were added by fairseq but don't seem to be actually used when duplicated in the actual
@@ -219,7 +237,7 @@ class CamembertTokenizer(PreTrainedTokenizer):
         return vocab
 
     def _tokenize(self, text):
-        return self.sp_model.EncodeAsPieces(text)
+        return self.sp_model.encode(text, out_type=str)
 
     def _convert_token_to_id(self, token):
         """Converts a token (str) in an id using the vocab."""

--- a/src/transformers/models/camembert/tokenization_camembert.py
+++ b/src/transformers/models/camembert/tokenization_camembert.py
@@ -85,7 +85,7 @@ class CamembertTokenizer(PreTrainedTokenizer):
             modeling. This is the token which the model will try to predict.
         additional_special_tokens (:obj:`List[str]`, `optional`, defaults to :obj:`["<s>NOTUSED", "</s>NOTUSED"]`):
             Additional special tokens used by the tokenizer.
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
@@ -16,7 +16,7 @@
 
 import os
 import unicodedata
-from typing import Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import sentencepiece as sp
 import six
@@ -106,7 +106,7 @@ class DebertaV2Tokenizer(PreTrainedTokenizer):
         pad_token="[PAD]",
         cls_token="[CLS]",
         mask_token="[MASK]",
-        sp_model_kwargs=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
         sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
@@ -145,7 +145,7 @@ class DebertaV2Tokenizer(PreTrainedTokenizer):
         vocab.update(self.get_added_vocab())
         return vocab
 
-    def _tokenize(self, text):
+    def _tokenize(self, text: str) -> List[str]:
         """Take as input a string and return a list of strings (tokens) for words/sub-words"""
         if self.do_lower_case:
             text = text.lower()

--- a/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
@@ -252,6 +252,29 @@ class DebertaV2Tokenizer(PreTrainedTokenizer):
 
 
 class SPMTokenizer:
+    r"""
+    Constructs a tokenizer based on `SentencePiece <https://github.com/google/sentencepiece>`__.
+
+    Args:
+        vocab_file (:obj:`str`):
+            `SentencePiece <https://github.com/google/sentencepiece>`__ file (generally has a `.spm` extension) that
+            contains the vocabulary necessary to instantiate a tokenizer.
+        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+            Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
+            <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
+
+            - ``enable_sampling``: Enable subword regularization.
+            - ``nbest_size``: Sampling parameters for unigram. Invalid for BPE-Dropout.
+
+              - ``nbest_size = {0,1}``: No sampling is performed.
+              - ``nbest_size > 1``: samples from the nbest_size results.
+              - ``nbest_size < 0``: assuming that nbest_size is infinite and samples from the all hypothesis (lattice)
+                using forward-filtering-and-backward-sampling algorithm.
+
+            - ``alpha``: Smoothing parameter for unigram sampling, and dropout probability of merge operations for
+              BPE-dropout.
+    """
+
     def __init__(self, vocab_file, split_by_punct=False, sp_model_kwargs=None):
         self.split_by_punct = split_by_punct
         self.vocab_file = vocab_file

--- a/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
@@ -108,7 +108,7 @@ class DebertaV2Tokenizer(PreTrainedTokenizer):
         mask_token="[MASK]",
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
-    ):
+    ) -> None:
         sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
         super().__init__(

--- a/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
@@ -303,6 +303,11 @@ class SPMTokenizer:
 
     def __setstate__(self, d):
         self.__dict__ = d
+
+        # for backward compatibility
+        if not hasattr(self, "sp_model_kwargs"):
+            self.sp_model_kwargs = {}
+
         self.spm = sp.SentencePieceProcessor(**self.sp_model_kwargs)
         self.spm.Load(self.vocab_file)
 

--- a/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
@@ -275,7 +275,7 @@ class SPMTokenizer:
               BPE-dropout.
     """
 
-    def __init__(self, vocab_file, split_by_punct=False, sp_model_kwargs=None):
+    def __init__(self, vocab_file, split_by_punct=False, sp_model_kwargs: Optional[Dict[str, Any]] = None):
         self.split_by_punct = split_by_punct
         self.vocab_file = vocab_file
         self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs

--- a/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
@@ -109,7 +109,7 @@ class DebertaV2Tokenizer(PreTrainedTokenizer):
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
     ) -> None:
-        sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
+        self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
         super().__init__(
             do_lower_case=do_lower_case,
@@ -119,7 +119,7 @@ class DebertaV2Tokenizer(PreTrainedTokenizer):
             cls_token=cls_token,
             mask_token=mask_token,
             split_by_punct=split_by_punct,
-            sp_model_kwargs=sp_model_kwargs,
+            sp_model_kwargs=self.sp_model_kwargs,
             **kwargs,
         )
 
@@ -130,7 +130,7 @@ class DebertaV2Tokenizer(PreTrainedTokenizer):
             )
         self.do_lower_case = do_lower_case
         self.split_by_punct = split_by_punct
-        self._tokenizer = SPMTokenizer(vocab_file, split_by_punct=split_by_punct, sp_model_kwargs=sp_model_kwargs)
+        self._tokenizer = SPMTokenizer(vocab_file, split_by_punct=split_by_punct, sp_model_kwargs=self.sp_model_kwargs)
 
     @property
     def vocab_size(self):

--- a/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
@@ -75,7 +75,7 @@ class DebertaV2Tokenizer(PreTrainedTokenizer):
         mask_token (:obj:`str`, `optional`, defaults to :obj:`"[MASK]"`):
             The token used for masking values. This is the token used when training this model with masked language
             modeling. This is the token which the model will try to predict.
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 
@@ -259,7 +259,7 @@ class SPMTokenizer:
         vocab_file (:obj:`str`):
             `SentencePiece <https://github.com/google/sentencepiece>`__ file (generally has a `.spm` extension) that
             contains the vocabulary necessary to instantiate a tokenizer.
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -274,7 +274,7 @@ class M2M100Tokenizer(PreTrainedTokenizer):
 
     def __setstate__(self, d: Dict) -> None:
         self.__dict__ = d
-        self.sp_model = load_spm(self.spm_file), self.sp_model_kwargs
+        self.sp_model = load_spm(self.spm_file, self.sp_model_kwargs)
 
     def save_vocabulary(self, save_directory: str, filename_prefix: Optional[str] = None) -> Tuple[str]:
         save_dir = Path(save_directory)

--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -134,7 +134,7 @@ class M2M100Tokenizer(PreTrainedTokenizer):
         unk_token="<unk>",
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs,
-    ):
+    ) -> None:
         self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
         super().__init__(

--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -16,7 +16,7 @@ import json
 from contextlib import contextmanager
 from pathlib import Path
 from shutil import copyfile
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import sentencepiece
 

--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -132,7 +132,7 @@ class M2M100Tokenizer(PreTrainedTokenizer):
         sep_token="</s>",
         pad_token="<pad>",
         unk_token="<unk>",
-        sp_model_kwargs=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs,
     ):
         self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs

--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -348,7 +348,7 @@ class M2M100Tokenizer(PreTrainedTokenizer):
         return self.lang_token_to_id[lang_token]
 
 
-def load_spm(path: str, sp_model_kwargs: Dict) -> sentencepiece.SentencePieceProcessor:
+def load_spm(path: str, sp_model_kwargs: Dict[str, Any]) -> sentencepiece.SentencePieceProcessor:
     spm = sentencepiece.SentencePieceProcessor(**sp_model_kwargs)
     spm.Load(str(path))
     return spm

--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -274,6 +274,11 @@ class M2M100Tokenizer(PreTrainedTokenizer):
 
     def __setstate__(self, d: Dict) -> None:
         self.__dict__ = d
+
+        # for backward compatibility
+        if not hasattr(self, "sp_model_kwargs"):
+            self.sp_model_kwargs = {}
+
         self.sp_model = load_spm(self.spm_file, self.sp_model_kwargs)
 
     def save_vocabulary(self, save_directory: str, filename_prefix: Optional[str] = None) -> Tuple[str]:

--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -135,7 +135,7 @@ class M2M100Tokenizer(PreTrainedTokenizer):
         sp_model_kwargs=None,
         **kwargs,
     ):
-        sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
+        self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
         super().__init__(
             src_lang=src_lang,
@@ -145,7 +145,7 @@ class M2M100Tokenizer(PreTrainedTokenizer):
             sep_token=sep_token,
             unk_token=unk_token,
             pad_token=pad_token,
-            sp_model_kwargs=sp_model_kwargs,
+            sp_model_kwargs=self.sp_model_kwargs,
             **kwargs,
         )
 
@@ -153,7 +153,7 @@ class M2M100Tokenizer(PreTrainedTokenizer):
         self.encoder = load_json(vocab_file)
         self.decoder = {v: k for k, v in self.encoder.items()}
         self.spm_file = spm_file
-        self.sp_model = load_spm(spm_file, sp_model_kwargs)
+        self.sp_model = load_spm(spm_file, self.sp_model_kwargs)
 
         self.encoder_size = len(self.encoder)
 

--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -86,7 +86,7 @@ class M2M100Tokenizer(PreTrainedTokenizer):
             token instead.
         pad_token (:obj:`str`, `optional`, defaults to :obj:`"<pad>"`):
             The token used for padding, for example when batching sequences of different lengths.
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/src/transformers/models/marian/tokenization_marian.py
+++ b/src/transformers/models/marian/tokenization_marian.py
@@ -18,7 +18,7 @@ import warnings
 from contextlib import contextmanager
 from pathlib import Path
 from shutil import copyfile
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import sentencepiece
 
@@ -82,6 +82,20 @@ class MarianTokenizer(PreTrainedTokenizer):
             The maximum sentence length the model accepts.
         additional_special_tokens (:obj:`List[str]`, `optional`, defaults to :obj:`["<eop>", "<eod>"]`):
             Additional special tokens used by the tokenizer.
+        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+            Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
+            <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
+
+            - ``enable_sampling``: Enable subword regularization.
+            - ``nbest_size``: Sampling parameters for unigram. Invalid for BPE-Dropout.
+
+              - ``nbest_size = {0,1}``: No sampling is performed.
+              - ``nbest_size > 1``: samples from the nbest_size results.
+              - ``nbest_size < 0``: assuming that nbest_size is infinite and samples from the all hypothesis (lattice)
+                using forward-filtering-and-backward-sampling algorithm.
+
+            - ``alpha``: Smoothing parameter for unigram sampling, and dropout probability of merge operations for
+              BPE-dropout.
 
     Examples::
 
@@ -115,8 +129,11 @@ class MarianTokenizer(PreTrainedTokenizer):
         eos_token="</s>",
         pad_token="<pad>",
         model_max_length=512,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
+        self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
+
         super().__init__(
             # bos_token=bos_token,  unused. Start decoding with config.decoder_start_token_id
             source_lang=source_lang,
@@ -125,6 +142,7 @@ class MarianTokenizer(PreTrainedTokenizer):
             eos_token=eos_token,
             pad_token=pad_token,
             model_max_length=model_max_length,
+            sp_model_kwargs=self.sp_model_kwargs,
             **kwargs,
         )
         assert Path(source_spm).exists(), f"cannot find spm source {source_spm}"
@@ -140,8 +158,8 @@ class MarianTokenizer(PreTrainedTokenizer):
         self.spm_files = [source_spm, target_spm]
 
         # load SentencePiece model for pre-processing
-        self.spm_source = load_spm(source_spm)
-        self.spm_target = load_spm(target_spm)
+        self.spm_source = load_spm(source_spm, self.sp_model_kwargs)
+        self.spm_target = load_spm(target_spm, self.sp_model_kwargs)
         self.current_spm = self.spm_source
 
         # Multilingual target side: default to using first supported language code.
@@ -172,7 +190,7 @@ class MarianTokenizer(PreTrainedTokenizer):
 
     def _tokenize(self, text: str) -> List[str]:
         code, text = self.remove_language_code(text)
-        pieces = self.current_spm.EncodeAsPieces(text)
+        pieces = self.current_spm.encode(text, out_type=str)
         return code + pieces
 
     def _convert_id_to_token(self, index: int) -> str:
@@ -283,7 +301,12 @@ class MarianTokenizer(PreTrainedTokenizer):
 
     def __setstate__(self, d: Dict) -> None:
         self.__dict__ = d
-        self.spm_source, self.spm_target = (load_spm(f) for f in self.spm_files)
+
+        # for backward compatibility
+        if not hasattr(self, "sp_model_kwargs"):
+            self.sp_model_kwargs = {}
+
+        self.spm_source, self.spm_target = (load_spm(f, self.sp_model_kwargs) for f in self.spm_files)
         self.current_spm = self.spm_source
         self._setup_normalizer()
 
@@ -308,8 +331,8 @@ class MarianTokenizer(PreTrainedTokenizer):
             return self._special_token_mask(token_ids_0 + token_ids_1) + [1]
 
 
-def load_spm(path: str) -> sentencepiece.SentencePieceProcessor:
-    spm = sentencepiece.SentencePieceProcessor()
+def load_spm(path: str, sp_model_kwargs) -> sentencepiece.SentencePieceProcessor:
+    spm = sentencepiece.SentencePieceProcessor(**sp_model_kwargs)
     spm.Load(path)
     return spm
 

--- a/src/transformers/models/marian/tokenization_marian.py
+++ b/src/transformers/models/marian/tokenization_marian.py
@@ -131,7 +131,7 @@ class MarianTokenizer(PreTrainedTokenizer):
         model_max_length=512,
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
-    ):
+    ) -> None:
         self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
         super().__init__(

--- a/src/transformers/models/marian/tokenization_marian.py
+++ b/src/transformers/models/marian/tokenization_marian.py
@@ -82,7 +82,7 @@ class MarianTokenizer(PreTrainedTokenizer):
             The maximum sentence length the model accepts.
         additional_special_tokens (:obj:`List[str]`, `optional`, defaults to :obj:`["<eop>", "<eod>"]`):
             Additional special tokens used by the tokenizer.
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/src/transformers/models/marian/tokenization_marian.py
+++ b/src/transformers/models/marian/tokenization_marian.py
@@ -331,7 +331,7 @@ class MarianTokenizer(PreTrainedTokenizer):
             return self._special_token_mask(token_ids_0 + token_ids_1) + [1]
 
 
-def load_spm(path: str, sp_model_kwargs) -> sentencepiece.SentencePieceProcessor:
+def load_spm(path: str, sp_model_kwargs: Dict[str, Any]) -> sentencepiece.SentencePieceProcessor:
     spm = sentencepiece.SentencePieceProcessor(**sp_model_kwargs)
     spm.Load(path)
     return spm

--- a/src/transformers/models/mbart/tokenization_mbart50.py
+++ b/src/transformers/models/mbart/tokenization_mbart50.py
@@ -124,7 +124,7 @@ class MBart50Tokenizer(PreTrainedTokenizer):
         mask_token="<mask>",
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
-    ):
+    ) -> None:
         # Mask token behave like a normal word, i.e. include the space before it
         mask_token = AddedToken(mask_token, lstrip=True, rstrip=False) if isinstance(mask_token, str) else mask_token
 

--- a/src/transformers/models/mbart/tokenization_mbart50.py
+++ b/src/transformers/models/mbart/tokenization_mbart50.py
@@ -16,7 +16,7 @@
 import os
 from contextlib import contextmanager
 from shutil import copyfile
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import sentencepiece as spm
 
@@ -122,7 +122,7 @@ class MBart50Tokenizer(PreTrainedTokenizer):
         unk_token="<unk>",
         pad_token="<pad>",
         mask_token="<mask>",
-        sp_model_kwargs=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
         # Mask token behave like a normal word, i.e. include the space before it

--- a/src/transformers/models/mbart/tokenization_mbart50.py
+++ b/src/transformers/models/mbart/tokenization_mbart50.py
@@ -76,7 +76,7 @@ class MBart50Tokenizer(PreTrainedTokenizer):
         mask_token (:obj:`str`, `optional`, defaults to :obj:`"<mask>"`):
             The token used for masking values. This is the token used when training this model with masked language
             modeling. This is the token which the model will try to predict.
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/src/transformers/models/pegasus/tokenization_pegasus.py
+++ b/src/transformers/models/pegasus/tokenization_pegasus.py
@@ -77,6 +77,20 @@ class PegasusTokenizer(PreTrainedTokenizer):
             tokenizer
             <https://github.com/google-research/pegasus/blob/939830367bcf411193d2b5eca2f2f90f3f9260ca/pegasus/ops/pretrain_parsing_ops.cc#L66>`__
             that uses the tokens 2 - 104 only for pretraining
+        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+            Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
+            <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
+
+            - ``enable_sampling``: Enable subword regularization.
+            - ``nbest_size``: Sampling parameters for unigram. Invalid for BPE-Dropout.
+
+              - ``nbest_size = {0,1}``: No sampling is performed.
+              - ``nbest_size > 1``: samples from the nbest_size results.
+              - ``nbest_size < 0``: assuming that nbest_size is infinite and samples from the all hypothesis (lattice)
+                using forward-filtering-and-backward-sampling algorithm.
+
+            - ``alpha``: Smoothing parameter for unigram sampling, and dropout probability of merge operations for
+              BPE-dropout.
     """
     vocab_files_names = VOCAB_FILES_NAMES
 
@@ -95,6 +109,7 @@ class PegasusTokenizer(PreTrainedTokenizer):
         mask_token_sent="<mask_1>",
         additional_special_tokens=None,
         offset=103,  # entries 2 - 104 are only used for pretraining
+        sp_model_kwargs=None,
         **kwargs
     ):
         self.offset = offset
@@ -123,6 +138,8 @@ class PegasusTokenizer(PreTrainedTokenizer):
             additional_special_tokens = [mask_token_sent] if mask_token_sent is not None else []
             additional_special_tokens += [f"<unk_{i}>" for i in range(2, self.offset)]
 
+        self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
+
         super().__init__(
             eos_token=eos_token,
             unk_token=unk_token,
@@ -131,11 +148,12 @@ class PegasusTokenizer(PreTrainedTokenizer):
             mask_token_sent=mask_token_sent,
             offset=offset,
             additional_special_tokens=additional_special_tokens,
+            sp_model_kwargs=self.sp_model_kwargs,
             **kwargs,
         )
         self.mask_token_sent = mask_token_sent
         self.vocab_file = vocab_file
-        self.sp_model = spm.SentencePieceProcessor()
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(vocab_file)
 
         # add special tokens to encoder dict
@@ -175,16 +193,17 @@ class PegasusTokenizer(PreTrainedTokenizer):
 
     def __setstate__(self, d):
         self.__dict__ = d
-        self.sp_model = spm.SentencePieceProcessor()
+
+        # for backward compatibility
+        if not hasattr(self, "sp_model_kwargs"):
+            self.sp_model_kwargs = {}
+
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(self.vocab_file)
 
-    def _tokenize(self, text, sample=False):
+    def _tokenize(self, text):
         """Take as input a string and return a list of strings (tokens) for words/sub-words"""
-        if not sample:
-            pieces = self.sp_model.EncodeAsPieces(text)
-        else:
-            pieces = self.sp_model.SampleEncodeAsPieces(text, 64, 0.1)
-        return pieces
+        return self.sp_model.encode(text, out_type=str)
 
     def _convert_token_to_id(self, token: str) -> int:
         """Converts a token (str) to an id using the vocab."""

--- a/src/transformers/models/pegasus/tokenization_pegasus.py
+++ b/src/transformers/models/pegasus/tokenization_pegasus.py
@@ -113,7 +113,6 @@ class PegasusTokenizer(PreTrainedTokenizer):
         **kwargs
     ) -> None:
         self.offset = offset
-
         if additional_special_tokens is not None:
             assert isinstance(
                 additional_special_tokens, list

--- a/src/transformers/models/pegasus/tokenization_pegasus.py
+++ b/src/transformers/models/pegasus/tokenization_pegasus.py
@@ -111,7 +111,7 @@ class PegasusTokenizer(PreTrainedTokenizer):
         offset=103,  # entries 2 - 104 are only used for pretraining
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
-    ):
+    ) -> None:
         self.offset = offset
 
         if additional_special_tokens is not None:

--- a/src/transformers/models/pegasus/tokenization_pegasus.py
+++ b/src/transformers/models/pegasus/tokenization_pegasus.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import os
 from shutil import copyfile
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import sentencepiece as spm
 
@@ -109,7 +109,7 @@ class PegasusTokenizer(PreTrainedTokenizer):
         mask_token_sent="<mask_1>",
         additional_special_tokens=None,
         offset=103,  # entries 2 - 104 are only used for pretraining
-        sp_model_kwargs=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
         self.offset = offset
@@ -201,7 +201,7 @@ class PegasusTokenizer(PreTrainedTokenizer):
         self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(self.vocab_file)
 
-    def _tokenize(self, text):
+    def _tokenize(self, text: str) -> List[str]:
         """Take as input a string and return a list of strings (tokens) for words/sub-words"""
         return self.sp_model.encode(text, out_type=str)
 

--- a/src/transformers/models/pegasus/tokenization_pegasus.py
+++ b/src/transformers/models/pegasus/tokenization_pegasus.py
@@ -77,7 +77,7 @@ class PegasusTokenizer(PreTrainedTokenizer):
             tokenizer
             <https://github.com/google-research/pegasus/blob/939830367bcf411193d2b5eca2f2f90f3f9260ca/pegasus/ops/pretrain_parsing_ops.cc#L66>`__
             that uses the tokens 2 - 104 only for pretraining
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/src/transformers/models/reformer/tokenization_reformer.py
+++ b/src/transformers/models/reformer/tokenization_reformer.py
@@ -17,7 +17,7 @@
 
 import os
 from shutil import copyfile
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import sentencepiece as spm
 
@@ -95,7 +95,7 @@ class ReformerTokenizer(PreTrainedTokenizer):
         eos_token="</s>",
         unk_token="<unk>",
         additional_special_tokens=[],
-        sp_model_kwargs=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
         self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
@@ -136,7 +136,7 @@ class ReformerTokenizer(PreTrainedTokenizer):
         self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(self.vocab_file)
 
-    def _tokenize(self, text):
+    def _tokenize(self, text: str) -> List[str]:
         """Take as input a string and return a list of strings (tokens) for words/sub-words"""
         return self.sp_model.encode(text, out_type=str)
 

--- a/src/transformers/models/reformer/tokenization_reformer.py
+++ b/src/transformers/models/reformer/tokenization_reformer.py
@@ -97,7 +97,7 @@ class ReformerTokenizer(PreTrainedTokenizer):
         additional_special_tokens=[],
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
-    ):
+    ) -> None:
         self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
         super().__init__(

--- a/src/transformers/models/reformer/tokenization_reformer.py
+++ b/src/transformers/models/reformer/tokenization_reformer.py
@@ -68,7 +68,7 @@ class ReformerTokenizer(PreTrainedTokenizer):
             The token used for padding, for example when batching sequences of different lengths.
         additional_special_tokens (:obj:`List[str]`, `optional`):
             Additional special tokens used by the tokenizer.
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
@@ -240,6 +240,11 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
 
     def __setstate__(self, d: Dict) -> None:
         self.__dict__ = d
+
+        # for backward compatibility
+        if not hasattr(self, "sp_model_kwargs"):
+            self.sp_model_kwargs = {}
+
         self.sp_model = load_spm(self.spm_file, self.sp_model_kwargs)
 
     def save_vocabulary(self, save_directory: str, filename_prefix: Optional[str] = None) -> Tuple[str]:

--- a/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
@@ -260,7 +260,7 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
         return (str(vocab_save_path), str(spm_save_path))
 
 
-def load_spm(path: str, sp_model_kwargs: Dict) -> sentencepiece.SentencePieceProcessor:
+def load_spm(path: str, sp_model_kwargs: Dict[str, Any]) -> sentencepiece.SentencePieceProcessor:
     spm = sentencepiece.SentencePieceProcessor(**sp_model_kwargs)
     spm.Load(str(path))
     return spm

--- a/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
@@ -119,7 +119,7 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
         lang_codes=None,
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs,
-    ):
+    ) -> None:
         self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
         super().__init__(

--- a/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
@@ -117,7 +117,7 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
         do_lower_case=False,
         tgt_lang=None,
         lang_codes=None,
-        sp_model_kwargs=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs,
     ):
         self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs

--- a/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
@@ -260,7 +260,7 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
         return (str(vocab_save_path), str(spm_save_path))
 
 
-def load_spm(path: str, sp_model_kwargs: dict) -> sentencepiece.SentencePieceProcessor:
+def load_spm(path: str, sp_model_kwargs: Dict) -> sentencepiece.SentencePieceProcessor:
     spm = sentencepiece.SentencePieceProcessor(**sp_model_kwargs)
     spm.Load(str(path))
     return spm

--- a/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
@@ -17,7 +17,7 @@
 import json
 from pathlib import Path
 from shutil import copyfile
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import sentencepiece
 

--- a/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
@@ -120,7 +120,7 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
         sp_model_kwargs=None,
         **kwargs,
     ):
-        sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
+        self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
         super().__init__(
             bos_token=bos_token,
@@ -131,7 +131,7 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
             do_lower_case=do_lower_case,
             tgt_lang=tgt_lang,
             lang_codes=lang_codes,
-            sp_model_kwargs=sp_model_kwargs,
+            sp_model_kwargs=self.sp_model_kwargs,
             **kwargs,
         )
         self.do_upper_case = do_upper_case
@@ -140,7 +140,7 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
         self.encoder = load_json(vocab_file)
         self.decoder = {v: k for k, v in self.encoder.items()}
         self.spm_file = spm_file
-        self.sp_model = load_spm(spm_file, sp_model_kwargs)
+        self.sp_model = load_spm(spm_file, self.sp_model_kwargs)
 
         if lang_codes is not None:
             self.lang_codes = lang_codes

--- a/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
@@ -79,6 +79,21 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
             Whether or not to lowercase the input when tokenizing.
         tgt_lang (:obj:`str`, `optional`):
             A string representing the target language.
+        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+            Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
+            <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
+
+            - ``enable_sampling``: Enable subword regularization.
+            - ``nbest_size``: Sampling parameters for unigram. Invalid for BPE-Dropout.
+
+              - ``nbest_size = {0,1}``: No sampling is performed.
+              - ``nbest_size > 1``: samples from the nbest_size results.
+              - ``nbest_size < 0``: assuming that nbest_size is infinite and samples from the all hypothesis (lattice)
+                using forward-filtering-and-backward-sampling algorithm.
+
+            - ``alpha``: Smoothing parameter for unigram sampling, and dropout probability of merge operations for
+              BPE-dropout.
+
         **kwargs
             Additional keyword arguments passed along to :class:`~transformers.PreTrainedTokenizer`
     """
@@ -102,8 +117,11 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
         do_lower_case=False,
         tgt_lang=None,
         lang_codes=None,
+        sp_model_kwargs=None,
         **kwargs,
     ):
+        sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
+
         super().__init__(
             bos_token=bos_token,
             eos_token=eos_token,
@@ -113,6 +131,7 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
             do_lower_case=do_lower_case,
             tgt_lang=tgt_lang,
             lang_codes=lang_codes,
+            sp_model_kwargs=sp_model_kwargs,
             **kwargs,
         )
         self.do_upper_case = do_upper_case
@@ -121,7 +140,7 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
         self.encoder = load_json(vocab_file)
         self.decoder = {v: k for k, v in self.encoder.items()}
         self.spm_file = spm_file
-        self.sp_model = load_spm(spm_file)
+        self.sp_model = load_spm(spm_file, sp_model_kwargs)
 
         if lang_codes is not None:
             self.lang_codes = lang_codes
@@ -155,7 +174,7 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
         self.prefix_tokens = [lang_code_id]
 
     def _tokenize(self, text: str) -> List[str]:
-        return self.sp_model.EncodeAsPieces(text)
+        return self.sp_model.encode(text, out_type=str)
 
     def _convert_token_to_id(self, token):
         return self.encoder.get(token, self.encoder[self.unk_token])
@@ -221,7 +240,7 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
 
     def __setstate__(self, d: Dict) -> None:
         self.__dict__ = d
-        self.sp_model = load_spm(self.spm_file)
+        self.sp_model = load_spm(self.spm_file, self.sp_model_kwargs)
 
     def save_vocabulary(self, save_directory: str, filename_prefix: Optional[str] = None) -> Tuple[str]:
         save_dir = Path(save_directory)
@@ -241,8 +260,8 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
         return (str(vocab_save_path), str(spm_save_path))
 
 
-def load_spm(path: str) -> sentencepiece.SentencePieceProcessor:
-    spm = sentencepiece.SentencePieceProcessor()
+def load_spm(path: str, sp_model_kwargs: dict) -> sentencepiece.SentencePieceProcessor:
+    spm = sentencepiece.SentencePieceProcessor(**sp_model_kwargs)
     spm.Load(str(path))
     return spm
 

--- a/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/tokenization_speech_to_text.py
@@ -79,7 +79,7 @@ class Speech2TextTokenizer(PreTrainedTokenizer):
             Whether or not to lowercase the input when tokenizing.
         tgt_lang (:obj:`str`, `optional`):
             A string representing the target language.
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/src/transformers/models/t5/tokenization_t5.py
+++ b/src/transformers/models/t5/tokenization_t5.py
@@ -19,7 +19,7 @@ import os
 import re
 import warnings
 from shutil import copyfile
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import sentencepiece as spm
 
@@ -114,7 +114,7 @@ class T5Tokenizer(PreTrainedTokenizer):
         pad_token="<pad>",
         extra_ids=100,
         additional_special_tokens=None,
-        sp_model_kwargs=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
         # Add extra_ids to the special token list
@@ -257,7 +257,7 @@ class T5Tokenizer(PreTrainedTokenizer):
         self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(self.vocab_file)
 
-    def _tokenize(self, text):
+    def _tokenize(self, text: str) -> List[str]:
         """Take as input a string and return a list of strings (tokens) for words/sub-words"""
         return self.sp_model.encode(text, out_type=str)
 

--- a/src/transformers/models/t5/tokenization_t5.py
+++ b/src/transformers/models/t5/tokenization_t5.py
@@ -116,7 +116,7 @@ class T5Tokenizer(PreTrainedTokenizer):
         additional_special_tokens=None,
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
-    ):
+    ) -> None:
         # Add extra_ids to the special token list
         if extra_ids > 0 and additional_special_tokens is None:
             additional_special_tokens = [f"<extra_id_{i}>" for i in range(extra_ids)]

--- a/src/transformers/models/t5/tokenization_t5.py
+++ b/src/transformers/models/t5/tokenization_t5.py
@@ -81,7 +81,7 @@ class T5Tokenizer(PreTrainedTokenizer):
             <https://github.com/google-research/text-to-text-transfer-transformer/blob/9fd7b14a769417be33bc6c850f9598764913c833/t5/data/preprocessors.py#L2117>`__).
         additional_special_tokens (:obj:`List[str]`, `optional`):
             Additional special tokens used by the tokenizer.
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/src/transformers/models/xlm_prophetnet/tokenization_xlm_prophetnet.py
+++ b/src/transformers/models/xlm_prophetnet/tokenization_xlm_prophetnet.py
@@ -16,7 +16,9 @@
 import collections
 import os
 from shutil import copyfile
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
+
+from google.protobuf.any_pb2 import Any
 
 from ...tokenization_utils import PreTrainedTokenizer
 from ...utils import logging
@@ -131,7 +133,7 @@ class XLMProphetNetTokenizer(PreTrainedTokenizer):
         pad_token="[PAD]",
         cls_token="[CLS]",
         mask_token="[MASK]",
-        sp_model_kwargs=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
         self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
@@ -264,7 +266,7 @@ class XLMProphetNetTokenizer(PreTrainedTokenizer):
         vocab.update(self.added_tokens_encoder)
         return vocab
 
-    def _tokenize(self, text):
+    def _tokenize(self, text: str) -> str:
         return self.sp_model.encode(text, out_type=str)
 
     def _convert_token_to_id(self, token):

--- a/src/transformers/models/xlm_prophetnet/tokenization_xlm_prophetnet.py
+++ b/src/transformers/models/xlm_prophetnet/tokenization_xlm_prophetnet.py
@@ -135,7 +135,7 @@ class XLMProphetNetTokenizer(PreTrainedTokenizer):
         mask_token="[MASK]",
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
-    ):
+    ) -> None:
         self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
         super().__init__(

--- a/src/transformers/models/xlm_prophetnet/tokenization_xlm_prophetnet.py
+++ b/src/transformers/models/xlm_prophetnet/tokenization_xlm_prophetnet.py
@@ -96,6 +96,20 @@ class XLMProphetNetTokenizer(PreTrainedTokenizer):
             modeling. This is the token which the model will try to predict.
         additional_special_tokens (:obj:`List[str]`, `optional`, defaults to :obj:`["<s>NOTUSED", "</s>NOTUSED"]`):
             Additional special tokens used by the tokenizer.
+        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+            Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
+            <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
+
+            - ``enable_sampling``: Enable subword regularization.
+            - ``nbest_size``: Sampling parameters for unigram. Invalid for BPE-Dropout.
+
+              - ``nbest_size = {0,1}``: No sampling is performed.
+              - ``nbest_size > 1``: samples from the nbest_size results.
+              - ``nbest_size < 0``: assuming that nbest_size is infinite and samples from the all hypothesis (lattice)
+                using forward-filtering-and-backward-sampling algorithm.
+
+            - ``alpha``: Smoothing parameter for unigram sampling, and dropout probability of merge operations for
+              BPE-dropout.
 
     Attributes:
         sp_model (:obj:`SentencePieceProcessor`):
@@ -117,8 +131,11 @@ class XLMProphetNetTokenizer(PreTrainedTokenizer):
         pad_token="[PAD]",
         cls_token="[CLS]",
         mask_token="[MASK]",
+        sp_model_kwargs=None,
         **kwargs
     ):
+        self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
+
         super().__init__(
             bos_token=bos_token,
             eos_token=eos_token,
@@ -127,6 +144,7 @@ class XLMProphetNetTokenizer(PreTrainedTokenizer):
             pad_token=pad_token,
             cls_token=cls_token,
             mask_token=mask_token,
+            sp_model_kwargs=self.sp_model_kwargs,
             **kwargs,
         )
 
@@ -139,7 +157,7 @@ class XLMProphetNetTokenizer(PreTrainedTokenizer):
             )
             raise
 
-        self.sp_model = spm.SentencePieceProcessor()
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(str(vocab_file))
         self.vocab_file = vocab_file
 
@@ -177,7 +195,12 @@ class XLMProphetNetTokenizer(PreTrainedTokenizer):
                 "pip install sentencepiece"
             )
             raise
-        self.sp_model = spm.SentencePieceProcessor()
+
+        # for backward compatibility
+        if not hasattr(self, "sp_model_kwargs"):
+            self.sp_model_kwargs = {}
+
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(self.vocab_file)
 
     def get_special_tokens_mask(
@@ -242,7 +265,7 @@ class XLMProphetNetTokenizer(PreTrainedTokenizer):
         return vocab
 
     def _tokenize(self, text):
-        return self.sp_model.EncodeAsPieces(text)
+        return self.sp_model.encode(text, out_type=str)
 
     def _convert_token_to_id(self, token):
         """Converts a token (str) in an id using the vocab."""

--- a/src/transformers/models/xlm_prophetnet/tokenization_xlm_prophetnet.py
+++ b/src/transformers/models/xlm_prophetnet/tokenization_xlm_prophetnet.py
@@ -98,7 +98,7 @@ class XLMProphetNetTokenizer(PreTrainedTokenizer):
             modeling. This is the token which the model will try to predict.
         additional_special_tokens (:obj:`List[str]`, `optional`, defaults to :obj:`["<s>NOTUSED", "</s>NOTUSED"]`):
             Additional special tokens used by the tokenizer.
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/src/transformers/models/xlm_prophetnet/tokenization_xlm_prophetnet.py
+++ b/src/transformers/models/xlm_prophetnet/tokenization_xlm_prophetnet.py
@@ -16,9 +16,7 @@
 import collections
 import os
 from shutil import copyfile
-from typing import Dict, List, Optional, Tuple
-
-from google.protobuf.any_pb2 import Any
+from typing import Any, Dict, List, Optional, Tuple
 
 from ...tokenization_utils import PreTrainedTokenizer
 from ...utils import logging

--- a/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
@@ -131,7 +131,7 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
         mask_token="<mask>",
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
-    ):
+    ) -> None:
         # Mask token behave like a normal word, i.e. include the space before it
         mask_token = AddedToken(mask_token, lstrip=True, rstrip=False) if isinstance(mask_token, str) else mask_token
 

--- a/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
@@ -17,7 +17,7 @@
 
 import os
 from shutil import copyfile
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import sentencepiece as spm
 
@@ -129,7 +129,7 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
         unk_token="<unk>",
         pad_token="<pad>",
         mask_token="<mask>",
-        sp_model_kwargs=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
         # Mask token behave like a normal word, i.e. include the space before it
@@ -271,7 +271,7 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
         vocab.update(self.added_tokens_encoder)
         return vocab
 
-    def _tokenize(self, text):
+    def _tokenize(self, text: str) -> List[str]:
         return self.sp_model.encode(text, out_type=str)
 
     def _convert_token_to_id(self, token):

--- a/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/tokenization_xlm_roberta.py
@@ -94,7 +94,7 @@ class XLMRobertaTokenizer(PreTrainedTokenizer):
             modeling. This is the token which the model will try to predict.
         additional_special_tokens (:obj:`List[str]`, `optional`, defaults to :obj:`["<s>NOTUSED", "</s>NOTUSED"]`):
             Additional special tokens used by the tokenizer.
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/src/transformers/models/xlnet/tokenization_xlnet.py
+++ b/src/transformers/models/xlnet/tokenization_xlnet.py
@@ -140,7 +140,7 @@ class XLNetTokenizer(PreTrainedTokenizer):
         additional_special_tokens=["<eop>", "<eod>"],
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
-    ):
+    ) -> None:
         # Mask token behave like a normal word, i.e. include the space before it
         mask_token = AddedToken(mask_token, lstrip=True, rstrip=False) if isinstance(mask_token, str) else mask_token
 

--- a/src/transformers/models/xlnet/tokenization_xlnet.py
+++ b/src/transformers/models/xlnet/tokenization_xlnet.py
@@ -18,7 +18,7 @@
 import os
 import unicodedata
 from shutil import copyfile
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import sentencepiece as spm
 
@@ -138,7 +138,7 @@ class XLNetTokenizer(PreTrainedTokenizer):
         cls_token="<cls>",
         mask_token="<mask>",
         additional_special_tokens=["<eop>", "<eod>"],
-        sp_model_kwargs=None,
+        sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
         # Mask token behave like a normal word, i.e. include the space before it
@@ -211,7 +211,7 @@ class XLNetTokenizer(PreTrainedTokenizer):
 
         return outputs
 
-    def _tokenize(self, text):
+    def _tokenize(self, text: str) -> List[str]:
         """Tokenize a string."""
         text = self.preprocess_text(text)
         pieces = self.sp_model.encode(text, out_type=str)

--- a/src/transformers/models/xlnet/tokenization_xlnet.py
+++ b/src/transformers/models/xlnet/tokenization_xlnet.py
@@ -99,7 +99,7 @@ class XLNetTokenizer(PreTrainedTokenizer):
             modeling. This is the token which the model will try to predict.
         additional_special_tokens (:obj:`List[str]`, `optional`, defaults to :obj:`["<eop>", "<eod>"]`):
             Additional special tokens used by the tokenizer.
-        sp_model_kwargs (:obj:`dict`, `optional`, defaults to :obj:`None`):
+        sp_model_kwargs (:obj:`dict`, `optional`):
             Will be passed to the ``SentencePieceProcessor.__init__()`` method. The `Python wrapper for SentencePiece
             <https://github.com/google/sentencepiece/tree/master/python>`__ can be used, among other things, to set:
 

--- a/tests/test_tokenization_albert.py
+++ b/tests/test_tokenization_albert.py
@@ -150,7 +150,7 @@ class AlbertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             for expected, decoded in zip(expected_decoded_sequence, decoded_sequences):
                 self.assertEqual(expected, decoded)
 
-    def test_subword_regularization_tokenizer(self):
+    def test_subword_regularization_tokenizer(self) -> None:
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = AlbertTokenizer(
             SAMPLE_VOCAB, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
@@ -158,7 +158,7 @@ class AlbertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.check_subword_sampling(tokenizer, ignore_case=True)
 
-    def test_pickle_subword_regularization_tokenizer(self):
+    def test_pickle_subword_regularization_tokenizer(self) -> None:
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}

--- a/tests/test_tokenization_albert.py
+++ b/tests/test_tokenization_albert.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import itertools
 import os
 import pickle
 import unittest
@@ -157,22 +156,7 @@ class AlbertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        # Subword regularization augments training data with subword sampling.
-        # This has a random component. We test if the tokenizer generates different
-        # results when subword regularization is enabled.
-        tokens_list = []
-        for _ in range(5):
-            tokens_list.append(tokenizer.tokenize("This is a test for subword regularization."))
-
-        # the list of different pairs of tokens_list
-        combinations = itertools.combinations(tokens_list, 2)
-
-        all_equal = True
-        for combination in combinations:
-            if combination[0] != combination[1]:
-                all_equal = False
-
-        self.assertFalse(all_equal)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -180,8 +164,10 @@ class AlbertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         tokenizer = AlbertTokenizer(SAMPLE_VOCAB, sp_model_kwargs=sp_model_kwargs)
         tokenizer_bin = pickle.dumps(tokenizer)
+        del tokenizer
         tokenizer_new = pickle.loads(tokenizer_bin)
 
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))

--- a/tests/test_tokenization_albert.py
+++ b/tests/test_tokenization_albert.py
@@ -156,7 +156,7 @@ class AlbertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+        self.check_subword_sampling(tokenizer)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -170,4 +170,4 @@ class AlbertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+        self.check_subword_sampling(tokenizer_new)

--- a/tests/test_tokenization_albert.py
+++ b/tests/test_tokenization_albert.py
@@ -156,7 +156,7 @@ class AlbertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.check_subword_sampling(tokenizer)
+        self.check_subword_sampling(tokenizer, ignore_case=True)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -170,4 +170,4 @@ class AlbertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new)
+        self.check_subword_sampling(tokenizer_new, ignore_case=True)

--- a/tests/test_tokenization_albert.py
+++ b/tests/test_tokenization_albert.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import os
-import pickle
 import unittest
 
 from transformers import AlbertTokenizer, AlbertTokenizerFast

--- a/tests/test_tokenization_albert.py
+++ b/tests/test_tokenization_albert.py
@@ -33,6 +33,7 @@ class AlbertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     rust_tokenizer_class = AlbertTokenizerFast
     test_rust_tokenizer = True
     test_sentencepiece = True
+    test_sentencepiece_ignore_case = True
 
     def setUp(self):
         super().setUp()

--- a/tests/test_tokenization_albert.py
+++ b/tests/test_tokenization_albert.py
@@ -33,6 +33,7 @@ class AlbertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     tokenizer_class = AlbertTokenizer
     rust_tokenizer_class = AlbertTokenizerFast
     test_rust_tokenizer = True
+    test_sentencepiece = True
 
     def setUp(self):
         super().setUp()
@@ -149,25 +150,3 @@ class AlbertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
             for expected, decoded in zip(expected_decoded_sequence, decoded_sequences):
                 self.assertEqual(expected, decoded)
-
-    def test_subword_regularization_tokenizer(self) -> None:
-        # Subword regularization is only available for the slow tokenizer.
-        tokenizer = AlbertTokenizer(
-            SAMPLE_VOCAB, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        )
-
-        self.check_subword_sampling(tokenizer, ignore_case=True)
-
-    def test_pickle_subword_regularization_tokenizer(self) -> None:
-        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
-        # Subword regularization is only available for the slow tokenizer.
-        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = AlbertTokenizer(SAMPLE_VOCAB, sp_model_kwargs=sp_model_kwargs)
-        tokenizer_bin = pickle.dumps(tokenizer)
-        del tokenizer
-        tokenizer_new = pickle.loads(tokenizer_bin)
-
-        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
-        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
-        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new, ignore_case=True)

--- a/tests/test_tokenization_barthez.py
+++ b/tests/test_tokenization_barthez.py
@@ -15,6 +15,7 @@
 
 
 import itertools
+import pickle
 import unittest
 
 from transformers import BarthezTokenizer, BarthezTokenizerFast, BatchEncoding
@@ -99,3 +100,15 @@ class BarthezTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 all_equal = False
 
         self.assertFalse(all_equal)
+
+    def test_pickle_subword_regularization_tokenizer(self):
+        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
+        # Subword regularization is only available for the slow tokenizer.
+        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        tokenizer = self.tokenizer_class.from_pretrained("moussaKam/mbarthez", sp_model_kwargs=sp_model_kwargs)
+        tokenizer_bin = pickle.dumps(tokenizer)
+        tokenizer_new = pickle.loads(tokenizer_bin)
+
+        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
+        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
+        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)

--- a/tests/test_tokenization_barthez.py
+++ b/tests/test_tokenization_barthez.py
@@ -75,3 +75,26 @@ class BarthezTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         ids = tokenizer.encode(sequence)
         rust_ids = rust_tokenizer.encode(sequence)
         self.assertListEqual(ids, rust_ids)
+
+    def test_subword_regularization_tokenizer(self):
+        # Subword regularization is only available for the slow tokenizer.
+        tokenizer = BarthezTokenizer.from_pretrained(
+            "moussaKam/mbarthez", sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        )
+
+        # Subword regularization augments training data with subword sampling.
+        # This has a random component. We test if the tokenizer generates different
+        # results when subword regularization is enabled.
+        tokens_list = []
+        for _ in range(5):
+            tokens_list.append(tokenizer.tokenize("This is a test for subword regularization."))
+
+        # the list of different pairs of tokens_list
+        combinations = itertools.combinations(tokens_list, 2)
+
+        all_equal = True
+        for combination in combinations:
+            if combination[0] != combination[1]:
+                all_equal = False
+
+        self.assertFalse(all_equal)

--- a/tests/test_tokenization_barthez.py
+++ b/tests/test_tokenization_barthez.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+import itertools
 import unittest
 
 from transformers import BarthezTokenizer, BarthezTokenizerFast, BatchEncoding
@@ -78,7 +79,7 @@ class BarthezTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     def test_subword_regularization_tokenizer(self):
         # Subword regularization is only available for the slow tokenizer.
-        tokenizer = tokenizer_class.from_pretrained(
+        tokenizer = self.tokenizer_class.from_pretrained(
             "moussaKam/mbarthez", sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 

--- a/tests/test_tokenization_barthez.py
+++ b/tests/test_tokenization_barthez.py
@@ -26,7 +26,7 @@ from .test_tokenization_common import TokenizerTesterMixin
 
 @require_tokenizers
 @require_sentencepiece
-@slow
+@slow  # see https://github.com/huggingface/transformers/issues/11457
 class BarthezTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     tokenizer_class = BarthezTokenizer

--- a/tests/test_tokenization_barthez.py
+++ b/tests/test_tokenization_barthez.py
@@ -78,7 +78,7 @@ class BarthezTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     def test_subword_regularization_tokenizer(self):
         # Subword regularization is only available for the slow tokenizer.
-        tokenizer = BarthezTokenizer.from_pretrained(
+        tokenizer = tokenizer_class.from_pretrained(
             "moussaKam/mbarthez", sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 

--- a/tests/test_tokenization_barthez.py
+++ b/tests/test_tokenization_barthez.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import itertools
 import pickle
 import unittest
 
@@ -84,22 +82,7 @@ class BarthezTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             "moussaKam/mbarthez", sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        # Subword regularization augments training data with subword sampling.
-        # This has a random component. We test if the tokenizer generates different
-        # results when subword regularization is enabled.
-        tokens_list = []
-        for _ in range(5):
-            tokens_list.append(tokenizer.tokenize("This is a test for subword regularization."))
-
-        # the list of different pairs of tokens_list
-        combinations = itertools.combinations(tokens_list, 2)
-
-        all_equal = True
-        for combination in combinations:
-            if combination[0] != combination[1]:
-                all_equal = False
-
-        self.assertFalse(all_equal)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -107,8 +90,10 @@ class BarthezTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         tokenizer = self.tokenizer_class.from_pretrained("moussaKam/mbarthez", sp_model_kwargs=sp_model_kwargs)
         tokenizer_bin = pickle.dumps(tokenizer)
+        del tokenizer
         tokenizer_new = pickle.loads(tokenizer_bin)
 
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))

--- a/tests/test_tokenization_barthez.py
+++ b/tests/test_tokenization_barthez.py
@@ -82,7 +82,7 @@ class BarthezTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             "moussaKam/mbarthez", sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+        self.check_subword_sampling(tokenizer)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -96,4 +96,4 @@ class BarthezTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+        self.check_subword_sampling(tokenizer_new)

--- a/tests/test_tokenization_barthez.py
+++ b/tests/test_tokenization_barthez.py
@@ -76,7 +76,7 @@ class BarthezTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         rust_ids = rust_tokenizer.encode(sequence)
         self.assertListEqual(ids, rust_ids)
 
-    def test_subword_regularization_tokenizer(self):
+    def test_subword_regularization_tokenizer(self) -> None:
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.tokenizer_class.from_pretrained(
             "moussaKam/mbarthez", sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
@@ -84,7 +84,7 @@ class BarthezTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.check_subword_sampling(tokenizer)
 
-    def test_pickle_subword_regularization_tokenizer(self):
+    def test_pickle_subword_regularization_tokenizer(self) -> None:
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}

--- a/tests/test_tokenization_barthez.py
+++ b/tests/test_tokenization_barthez.py
@@ -30,6 +30,7 @@ class BarthezTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     tokenizer_class = BarthezTokenizer
     rust_tokenizer_class = BarthezTokenizerFast
     test_rust_tokenizer = True
+    test_sentencepiece = True
 
     def setUp(self):
         super().setUp()
@@ -75,25 +76,3 @@ class BarthezTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         ids = tokenizer.encode(sequence)
         rust_ids = rust_tokenizer.encode(sequence)
         self.assertListEqual(ids, rust_ids)
-
-    def test_subword_regularization_tokenizer(self) -> None:
-        # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.tokenizer_class.from_pretrained(
-            "moussaKam/mbarthez", sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        )
-
-        self.check_subword_sampling(tokenizer)
-
-    def test_pickle_subword_regularization_tokenizer(self) -> None:
-        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
-        # Subword regularization is only available for the slow tokenizer.
-        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = self.tokenizer_class.from_pretrained("moussaKam/mbarthez", sp_model_kwargs=sp_model_kwargs)
-        tokenizer_bin = pickle.dumps(tokenizer)
-        del tokenizer
-        tokenizer_new = pickle.loads(tokenizer_bin)
-
-        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
-        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
-        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new)

--- a/tests/test_tokenization_barthez.py
+++ b/tests/test_tokenization_barthez.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pickle
 import unittest
 
 from transformers import BarthezTokenizer, BarthezTokenizerFast, BatchEncoding

--- a/tests/test_tokenization_bert_generation.py
+++ b/tests/test_tokenization_bert_generation.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import os
+import pickle
 import unittest
 
 from transformers import BertGenerationTokenizer
@@ -111,6 +111,28 @@ class BertGenerationTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 ".",
             ],
         )
+
+    def test_subword_regularization_tokenizer(self):
+        # Subword regularization is only available for the slow tokenizer.
+        tokenizer = self.tokenizer_class(
+            SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        )
+
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+
+    def test_pickle_subword_regularization_tokenizer(self):
+        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
+        # Subword regularization is only available for the slow tokenizer.
+        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
+        tokenizer_bin = pickle.dumps(tokenizer)
+        del tokenizer
+        tokenizer_new = pickle.loads(tokenizer_bin)
+
+        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
+        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
+        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
 
     @cached_property
     def big_tokenizer(self):

--- a/tests/test_tokenization_bert_generation.py
+++ b/tests/test_tokenization_bert_generation.py
@@ -112,7 +112,7 @@ class BertGenerationTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             ],
         )
 
-    def test_subword_regularization_tokenizer(self):
+    def test_subword_regularization_tokenizer(self) -> None:
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.tokenizer_class(
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
@@ -120,7 +120,7 @@ class BertGenerationTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.check_subword_sampling(tokenizer)
 
-    def test_pickle_subword_regularization_tokenizer(self):
+    def test_pickle_subword_regularization_tokenizer(self) -> None:
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}

--- a/tests/test_tokenization_bert_generation.py
+++ b/tests/test_tokenization_bert_generation.py
@@ -118,7 +118,7 @@ class BertGenerationTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+        self.check_subword_sampling(tokenizer)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -132,7 +132,7 @@ class BertGenerationTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+        self.check_subword_sampling(tokenizer_new)
 
     @cached_property
     def big_tokenizer(self):

--- a/tests/test_tokenization_bert_generation.py
+++ b/tests/test_tokenization_bert_generation.py
@@ -33,6 +33,7 @@ SAMPLE_VOCAB = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixture
 class BertGenerationTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     tokenizer_class = BertGenerationTokenizer
+    test_sentencepiece = True
 
     def setUp(self):
         super().setUp()
@@ -111,28 +112,6 @@ class BertGenerationTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 ".",
             ],
         )
-
-    def test_subword_regularization_tokenizer(self) -> None:
-        # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.tokenizer_class(
-            SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        )
-
-        self.check_subword_sampling(tokenizer)
-
-    def test_pickle_subword_regularization_tokenizer(self) -> None:
-        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
-        # Subword regularization is only available for the slow tokenizer.
-        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
-        tokenizer_bin = pickle.dumps(tokenizer)
-        del tokenizer
-        tokenizer_new = pickle.loads(tokenizer_bin)
-
-        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
-        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
-        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new)
 
     @cached_property
     def big_tokenizer(self):

--- a/tests/test_tokenization_bert_generation.py
+++ b/tests/test_tokenization_bert_generation.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import os
-import pickle
 import unittest
 
 from transformers import BertGenerationTokenizer

--- a/tests/test_tokenization_big_bird.py
+++ b/tests/test_tokenization_big_bird.py
@@ -138,7 +138,7 @@ class BigBirdTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             ],
         )
 
-    def test_subword_regularization_tokenizer(self):
+    def test_subword_regularization_tokenizer(self) -> None:
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.tokenizer_class(
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
@@ -146,7 +146,7 @@ class BigBirdTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.check_subword_sampling(tokenizer)
 
-    def test_pickle_subword_regularization_tokenizer(self):
+    def test_pickle_subword_regularization_tokenizer(self) -> None:
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}

--- a/tests/test_tokenization_big_bird.py
+++ b/tests/test_tokenization_big_bird.py
@@ -15,6 +15,7 @@
 
 
 import os
+import pickle
 import unittest
 
 from transformers import BigBirdTokenizer, BigBirdTokenizerFast
@@ -40,7 +41,7 @@ class BigBirdTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        tokenizer = BigBirdTokenizer(SAMPLE_VOCAB, keep_accents=True)
+        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True)
         tokenizer.save_pretrained(self.tmpdirname)
 
     def test_rust_and_python_full_tokenizers(self):
@@ -136,6 +137,28 @@ class BigBirdTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 ".",
             ],
         )
+
+    def test_subword_regularization_tokenizer(self):
+        # Subword regularization is only available for the slow tokenizer.
+        tokenizer = self.tokenizer_class(
+            SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        )
+
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+
+    def test_pickle_subword_regularization_tokenizer(self):
+        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
+        # Subword regularization is only available for the slow tokenizer.
+        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
+        tokenizer_bin = pickle.dumps(tokenizer)
+        del tokenizer
+        tokenizer_new = pickle.loads(tokenizer_bin)
+
+        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
+        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
+        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
 
     @cached_property
     def big_tokenizer(self):

--- a/tests/test_tokenization_big_bird.py
+++ b/tests/test_tokenization_big_bird.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import os
-import pickle
 import unittest
 
 from transformers import BigBirdTokenizer, BigBirdTokenizerFast

--- a/tests/test_tokenization_big_bird.py
+++ b/tests/test_tokenization_big_bird.py
@@ -144,7 +144,7 @@ class BigBirdTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+        self.check_subword_sampling(tokenizer)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -158,7 +158,7 @@ class BigBirdTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+        self.check_subword_sampling(tokenizer_new)
 
     @cached_property
     def big_tokenizer(self):

--- a/tests/test_tokenization_big_bird.py
+++ b/tests/test_tokenization_big_bird.py
@@ -37,6 +37,7 @@ class BigBirdTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     tokenizer_class = BigBirdTokenizer
     rust_tokenizer_class = BigBirdTokenizerFast
     test_rust_tokenizer = True
+    test_sentencepiece = True
 
     def setUp(self):
         super().setUp()
@@ -137,28 +138,6 @@ class BigBirdTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 ".",
             ],
         )
-
-    def test_subword_regularization_tokenizer(self) -> None:
-        # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.tokenizer_class(
-            SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        )
-
-        self.check_subword_sampling(tokenizer)
-
-    def test_pickle_subword_regularization_tokenizer(self) -> None:
-        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
-        # Subword regularization is only available for the slow tokenizer.
-        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
-        tokenizer_bin = pickle.dumps(tokenizer)
-        del tokenizer
-        tokenizer_new = pickle.loads(tokenizer_bin)
-
-        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
-        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
-        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new)
 
     @cached_property
     def big_tokenizer(self):

--- a/tests/test_tokenization_camembert.py
+++ b/tests/test_tokenization_camembert.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import itertools
 import os
 import pickle
 import unittest
@@ -97,22 +95,7 @@ class CamembertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        # Subword regularization augments training data with subword sampling.
-        # This has a random component. We test if the tokenizer generates different
-        # results when subword regularization is enabled.
-        tokens_list = []
-        for _ in range(5):
-            tokens_list.append(tokenizer.tokenize("This is a test for subword regularization."))
-
-        # the list of different pairs of tokens_list
-        combinations = itertools.combinations(tokens_list, 2)
-
-        all_equal = True
-        for combination in combinations:
-            if combination[0] != combination[1]:
-                all_equal = False
-
-        self.assertFalse(all_equal)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -120,8 +103,10 @@ class CamembertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
         tokenizer_bin = pickle.dumps(tokenizer)
+        del tokenizer
         tokenizer_new = pickle.loads(tokenizer_bin)
 
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))

--- a/tests/test_tokenization_camembert.py
+++ b/tests/test_tokenization_camembert.py
@@ -89,7 +89,7 @@ class CamembertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         rust_ids = rust_tokenizer.encode(sequence)
         self.assertListEqual(ids, rust_ids)
 
-    def test_subword_regularization_tokenizer(self):
+    def test_subword_regularization_tokenizer(self) -> None:
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.tokenizer_class(
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
@@ -97,7 +97,7 @@ class CamembertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.check_subword_sampling(tokenizer)
 
-    def test_pickle_subword_regularization_tokenizer(self):
+    def test_pickle_subword_regularization_tokenizer(self) -> None:
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}

--- a/tests/test_tokenization_camembert.py
+++ b/tests/test_tokenization_camembert.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+import itertools
 import os
 import unittest
 
@@ -88,3 +89,26 @@ class CamembertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         ids = tokenizer.encode(sequence)
         rust_ids = rust_tokenizer.encode(sequence)
         self.assertListEqual(ids, rust_ids)
+
+    def test_subword_regularization_tokenizer(self):
+        # Subword regularization is only available for the slow tokenizer.
+        tokenizer = self.tokenizer_class(
+            SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        )
+
+        # Subword regularization augments training data with subword sampling.
+        # This has a random component. We test if the tokenizer generates different
+        # results when subword regularization is enabled.
+        tokens_list = []
+        for _ in range(5):
+            tokens_list.append(tokenizer.tokenize("This is a test for subword regularization."))
+
+        # the list of different pairs of tokens_list
+        combinations = itertools.combinations(tokens_list, 2)
+
+        all_equal = True
+        for combination in combinations:
+            if combination[0] != combination[1]:
+                all_equal = False
+
+        self.assertFalse(all_equal)

--- a/tests/test_tokenization_camembert.py
+++ b/tests/test_tokenization_camembert.py
@@ -16,6 +16,7 @@
 
 import itertools
 import os
+import pickle
 import unittest
 
 from transformers import CamembertTokenizer, CamembertTokenizerFast
@@ -112,3 +113,15 @@ class CamembertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 all_equal = False
 
         self.assertFalse(all_equal)
+
+    def test_pickle_subword_regularization_tokenizer(self):
+        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
+        # Subword regularization is only available for the slow tokenizer.
+        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
+        tokenizer_bin = pickle.dumps(tokenizer)
+        tokenizer_new = pickle.loads(tokenizer_bin)
+
+        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
+        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
+        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)

--- a/tests/test_tokenization_camembert.py
+++ b/tests/test_tokenization_camembert.py
@@ -95,7 +95,7 @@ class CamembertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+        self.check_subword_sampling(tokenizer)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -109,4 +109,4 @@ class CamembertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+        self.check_subword_sampling(tokenizer_new)

--- a/tests/test_tokenization_camembert.py
+++ b/tests/test_tokenization_camembert.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import os
-import pickle
 import unittest
 
 from transformers import CamembertTokenizer, CamembertTokenizerFast

--- a/tests/test_tokenization_camembert.py
+++ b/tests/test_tokenization_camembert.py
@@ -37,6 +37,7 @@ class CamembertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     tokenizer_class = CamembertTokenizer
     rust_tokenizer_class = CamembertTokenizerFast
     test_rust_tokenizer = True
+    test_sentencepiece = True
 
     def setUp(self):
         super().setUp()
@@ -88,25 +89,3 @@ class CamembertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         ids = tokenizer.encode(sequence)
         rust_ids = rust_tokenizer.encode(sequence)
         self.assertListEqual(ids, rust_ids)
-
-    def test_subword_regularization_tokenizer(self) -> None:
-        # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.tokenizer_class(
-            SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        )
-
-        self.check_subword_sampling(tokenizer)
-
-    def test_pickle_subword_regularization_tokenizer(self) -> None:
-        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
-        # Subword regularization is only available for the slow tokenizer.
-        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
-        tokenizer_bin = pickle.dumps(tokenizer)
-        del tokenizer
-        tokenizer_new = pickle.loads(tokenizer_bin)
-
-        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
-        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
-        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -15,6 +15,7 @@
 
 
 import inspect
+import itertools
 import os
 import pickle
 import re
@@ -1726,6 +1727,29 @@ class TokenizerTesterMixin:
 
             # add pad_token_id to pass subsequent tests
             tokenizer.add_special_tokens({"pad_token": "<PAD>"})
+
+    @staticmethod
+    def does_subword_sampling(tokenizer, default_text: str = None):
+        """
+        Check if the tokenizer generates different results when subword regularization is enabled.
+
+        Subword regularization augments training data with subword sampling.
+        This has a random component.
+        """
+        default_text = "This is a test for subword regularization." if default_text is None else default_text
+
+        tokens_list = []
+        for _ in range(5):
+            tokens_list.append(tokenizer.tokenize(default_text))
+
+        # the list of different pairs of tokens_list
+        combinations = itertools.combinations(tokens_list, 2)
+
+        for combination in combinations:
+            if combination[0] != combination[1]:
+                return True  # subword sampling found
+
+        return False  # no subword sampling found
 
     @require_torch
     @slow

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1728,8 +1728,7 @@ class TokenizerTesterMixin:
             # add pad_token_id to pass subsequent tests
             tokenizer.add_special_tokens({"pad_token": "<PAD>"})
 
-    @staticmethod
-    def does_subword_sampling(tokenizer, default_text: str = None):
+    def check_subword_sampling(self, tokenizer, default_text: str = None):
         """
         Check if the tokenizer generates different results when subword regularization is enabled.
 
@@ -1745,11 +1744,16 @@ class TokenizerTesterMixin:
         # the list of different pairs of tokens_list
         combinations = itertools.combinations(tokens_list, 2)
 
+        # check of sampling is done
+        subword_sampling_found = False
         for combination in combinations:
             if combination[0] != combination[1]:
-                return True  # subword sampling found
+                subword_sampling_found = True
+        self.assertTrue(subword_sampling_found)
 
-        return False  # no subword sampling found
+        # check if converting back to original text works
+        for tokens in tokens_list:
+            self.assertEqual(tokenizer.convert_tokens_to_string(tokens), default_text)
 
     @require_torch
     @slow

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1728,18 +1728,26 @@ class TokenizerTesterMixin:
             # add pad_token_id to pass subsequent tests
             tokenizer.add_special_tokens({"pad_token": "<PAD>"})
 
-    def check_subword_sampling(self, tokenizer, default_text: str = None):
+    def check_subword_sampling(self, tokenizer, text: str = None, skip_back_convert_check=False):
         """
         Check if the tokenizer generates different results when subword regularization is enabled.
 
         Subword regularization augments training data with subword sampling.
         This has a random component.
+
+        Args:
+            tokenizer: The tokenizer to check.
+            text: The text to use for the checks.
+            skip_back_convert_check:
+                Option to skip the test if the tokens can be converted back to the original text.
+                This is useful for the Marian tokenizer which uses different tokenizers for
+                source and target language.
         """
-        default_text = "This is a test for subword regularization." if default_text is None else default_text
+        text = "This is a test for subword regularization." if text is None else text
 
         tokens_list = []
         for _ in range(5):
-            tokens_list.append(tokenizer.tokenize(default_text))
+            tokens_list.append(tokenizer.tokenize(text))
 
         # the list of different pairs of tokens_list
         combinations = itertools.combinations(tokens_list, 2)
@@ -1752,8 +1760,9 @@ class TokenizerTesterMixin:
         self.assertTrue(subword_sampling_found)
 
         # check if converting back to original text works
-        for tokens in tokens_list:
-            self.assertEqual(tokenizer.convert_tokens_to_string(tokens), default_text)
+        if not skip_back_convert_check:
+            for tokens in tokens_list:
+                self.assertEqual(tokenizer.convert_tokens_to_string(tokens), text)
 
     @require_torch
     @slow

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1728,7 +1728,8 @@ class TokenizerTesterMixin:
             # add pad_token_id to pass subsequent tests
             tokenizer.add_special_tokens({"pad_token": "<PAD>"})
 
-    def check_subword_sampling(self, tokenizer, text: str = None, skip_back_convert_check=False):
+    def check_subword_sampling(self, tokenizer, text: str = None, skip_back_convert_check=False,
+                               ignore_case=False):
         """
         Check if the tokenizer generates different results when subword regularization is enabled.
 
@@ -1742,6 +1743,7 @@ class TokenizerTesterMixin:
                 Option to skip the test if the tokens can be converted back to the original text.
                 This is useful for the Marian tokenizer which uses different tokenizers for
                 source and target language.
+            ignore_case Ignore the case when comparing tokeinzer results.
         """
         text = "This is a test for subword regularization." if text is None else text
 
@@ -1762,7 +1764,10 @@ class TokenizerTesterMixin:
         # check if converting back to original text works
         if not skip_back_convert_check:
             for tokens in tokens_list:
-                self.assertEqual(tokenizer.convert_tokens_to_string(tokens), text)
+                if ignore_case:
+                    self.assertEqual(text.lower(), tokenizer.convert_tokens_to_string(tokens).lower())
+                else:
+                    self.assertEqual(text, tokenizer.convert_tokens_to_string(tokens))
 
     @require_torch
     @slow

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1728,8 +1728,7 @@ class TokenizerTesterMixin:
             # add pad_token_id to pass subsequent tests
             tokenizer.add_special_tokens({"pad_token": "<PAD>"})
 
-    def check_subword_sampling(self, tokenizer, text: str = None, skip_back_convert_check=False,
-                               ignore_case=False):
+    def check_subword_sampling(self, tokenizer, text: str = None, skip_back_convert_check=False, ignore_case=False):
         """
         Check if the tokenizer generates different results when subword regularization is enabled.
 

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1728,7 +1728,13 @@ class TokenizerTesterMixin:
             # add pad_token_id to pass subsequent tests
             tokenizer.add_special_tokens({"pad_token": "<PAD>"})
 
-    def check_subword_sampling(self, tokenizer, text: str = None, skip_back_convert_check=False, ignore_case=False):
+    def check_subword_sampling(
+        self,
+        tokenizer: PreTrainedTokenizer,
+        text: str = None,
+        skip_back_convert_check: bool = False,
+        ignore_case: bool = False,
+    ) -> None:
         """
         Check if the tokenizer generates different results when subword regularization is enabled.
 
@@ -1742,7 +1748,7 @@ class TokenizerTesterMixin:
                 Option to skip the test if the tokens can be converted back to the original text.
                 This is useful for the Marian tokenizer which uses different tokenizers for
                 source and target language.
-            ignore_case Ignore the case when comparing tokeinzer results.
+            ignore_case: Ignore the case when comparing tokeinzer results.
         """
         text = "This is a test for subword regularization." if text is None else text
 

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -100,9 +100,13 @@ class TokenizerTesterMixin:
     from_pretrained_filter = None
     from_pretrained_vocab_key = "vocab_file"
     test_seq2seq = True
+
+    # set to True to test a sentencepiece tokenizer
     test_sentencepiece = False
+
+    # set to True to ignore casing when testing a sentencepiece tokenizer
+    # test_sentencepiece must also be set to True
     test_sentencepiece_ignore_case = False
-    test_sentencepiece_skip_back_convert_check = False
 
     def setUp(self) -> None:
         # Tokenizer.filter makes it possible to filter which Tokenizer to case based on all the
@@ -1797,12 +1801,11 @@ class TokenizerTesterMixin:
         self.assertTrue(subword_sampling_found)
 
         # check if converting back to original text works
-        if not self.test_sentencepiece_skip_back_convert_check:
-            for tokens in tokens_list:
-                if self.test_sentencepiece_ignore_case:
-                    self.assertEqual(text, tokenizer.convert_tokens_to_string(tokens).lower())
-                else:
-                    self.assertEqual(text, tokenizer.convert_tokens_to_string(tokens))
+        for tokens in tokens_list:
+            if self.test_sentencepiece_ignore_case:
+                self.assertEqual(text, tokenizer.convert_tokens_to_string(tokens).lower())
+            else:
+                self.assertEqual(text, tokenizer.convert_tokens_to_string(tokens))
 
     @require_torch
     @slow

--- a/tests/test_tokenization_deberta_v2.py
+++ b/tests/test_tokenization_deberta_v2.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import itertools
 import os
 import pickle
 import unittest
@@ -169,22 +167,7 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        # Subword regularization augments training data with subword sampling.
-        # This has a random component. We test if the tokenizer generates different
-        # results when subword regularization is enabled.
-        tokens_list = []
-        for _ in range(5):
-            tokens_list.append(tokenizer.tokenize("This is a test for subword regularization."))
-
-        # the list of different pairs of tokens_list
-        combinations = itertools.combinations(tokens_list, 2)
-
-        all_equal = True
-        for combination in combinations:
-            if combination[0] != combination[1]:
-                all_equal = False
-
-        self.assertFalse(all_equal)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -192,6 +175,7 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
         tokenizer_bin = pickle.dumps(tokenizer)
+        del tokenizer
         tokenizer_new = pickle.loads(tokenizer_bin)
 
         self.assertTrue(hasattr(tokenizer_new, "_tokenizer"))
@@ -199,3 +183,4 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new._tokenizer.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new._tokenizer.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new._tokenizer.sp_model_kwargs, sp_model_kwargs)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))

--- a/tests/test_tokenization_deberta_v2.py
+++ b/tests/test_tokenization_deberta_v2.py
@@ -161,7 +161,7 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             for expected, decoded in zip(expected_decoded_sequences, decoded_sequences):
                 self.assertEqual(expected, decoded)
 
-    def test_subword_regularization_tokenizer(self):
+    def test_subword_regularization_tokenizer(self) -> None:
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.tokenizer_class(
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
@@ -169,7 +169,7 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.check_subword_sampling(tokenizer, text="this is a test for subword regularization", ignore_case=True)
 
-    def test_pickle_subword_regularization_tokenizer(self):
+    def test_pickle_subword_regularization_tokenizer(self) -> None:
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}

--- a/tests/test_tokenization_deberta_v2.py
+++ b/tests/test_tokenization_deberta_v2.py
@@ -167,7 +167,7 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.check_subword_sampling(tokenizer)
+        self.check_subword_sampling(tokenizer, ignore_case=True)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -183,4 +183,4 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new._tokenizer.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new._tokenizer.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new._tokenizer.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new)
+        self.check_subword_sampling(tokenizer_new, ignore_case=True)

--- a/tests/test_tokenization_deberta_v2.py
+++ b/tests/test_tokenization_deberta_v2.py
@@ -167,7 +167,7 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+        self.check_subword_sampling(tokenizer)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -183,4 +183,4 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new._tokenizer.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new._tokenizer.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new._tokenizer.sp_model_kwargs, sp_model_kwargs)
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+        self.check_subword_sampling(tokenizer_new)

--- a/tests/test_tokenization_deberta_v2.py
+++ b/tests/test_tokenization_deberta_v2.py
@@ -167,7 +167,7 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.check_subword_sampling(tokenizer, ignore_case=True)
+        self.check_subword_sampling(tokenizer, text="this is a test for subword regularization", ignore_case=True)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -183,4 +183,4 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new._tokenizer.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new._tokenizer.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new._tokenizer.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new, ignore_case=True)
+        self.check_subword_sampling(tokenizer_new, text="this is a test for subword regularization", ignore_case=True)

--- a/tests/test_tokenization_deberta_v2.py
+++ b/tests/test_tokenization_deberta_v2.py
@@ -16,6 +16,7 @@
 
 import itertools
 import os
+import pickle
 import unittest
 
 from transformers import DebertaV2Tokenizer
@@ -184,3 +185,17 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 all_equal = False
 
         self.assertFalse(all_equal)
+
+    def test_pickle_subword_regularization_tokenizer(self):
+        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
+        # Subword regularization is only available for the slow tokenizer.
+        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
+        tokenizer_bin = pickle.dumps(tokenizer)
+        tokenizer_new = pickle.loads(tokenizer_bin)
+
+        self.assertTrue(hasattr(tokenizer_new, "_tokenizer"))
+        self.assertIsNotNone(tokenizer_new._tokenizer)
+        self.assertIsNotNone(tokenizer_new._tokenizer.sp_model_kwargs)
+        self.assertTrue(isinstance(tokenizer_new._tokenizer.sp_model_kwargs, dict))
+        self.assertEqual(tokenizer_new._tokenizer.sp_model_kwargs, sp_model_kwargs)

--- a/tests/test_tokenization_deberta_v2.py
+++ b/tests/test_tokenization_deberta_v2.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+import itertools
 import os
 import unittest
 
@@ -160,3 +161,26 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
             for expected, decoded in zip(expected_decoded_sequences, decoded_sequences):
                 self.assertEqual(expected, decoded)
+
+    def test_subword_regularization_tokenizer(self):
+        # Subword regularization is only available for the slow tokenizer.
+        tokenizer = self.tokenizer_class(
+            SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        )
+
+        # Subword regularization augments training data with subword sampling.
+        # This has a random component. We test if the tokenizer generates different
+        # results when subword regularization is enabled.
+        tokens_list = []
+        for _ in range(5):
+            tokens_list.append(tokenizer.tokenize("This is a test for subword regularization."))
+
+        # the list of different pairs of tokens_list
+        combinations = itertools.combinations(tokens_list, 2)
+
+        all_equal = True
+        for combination in combinations:
+            if combination[0] != combination[1]:
+                all_equal = False
+
+        self.assertFalse(all_equal)

--- a/tests/test_tokenization_deberta_v2.py
+++ b/tests/test_tokenization_deberta_v2.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import os
-import pickle
 import unittest
 
 from transformers import DebertaV2Tokenizer

--- a/tests/test_tokenization_deberta_v2.py
+++ b/tests/test_tokenization_deberta_v2.py
@@ -33,6 +33,8 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     tokenizer_class = DebertaV2Tokenizer
     rust_tokenizer_class = None
     test_rust_tokenizer = False
+    test_sentencepiece = True
+    test_sentencepiece_ignore_case = True
 
     def setUp(self):
         super().setUp()
@@ -160,27 +162,3 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
             for expected, decoded in zip(expected_decoded_sequences, decoded_sequences):
                 self.assertEqual(expected, decoded)
-
-    def test_subword_regularization_tokenizer(self) -> None:
-        # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.tokenizer_class(
-            SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        )
-
-        self.check_subword_sampling(tokenizer, text="this is a test for subword regularization", ignore_case=True)
-
-    def test_pickle_subword_regularization_tokenizer(self) -> None:
-        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
-        # Subword regularization is only available for the slow tokenizer.
-        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
-        tokenizer_bin = pickle.dumps(tokenizer)
-        del tokenizer
-        tokenizer_new = pickle.loads(tokenizer_bin)
-
-        self.assertTrue(hasattr(tokenizer_new, "_tokenizer"))
-        self.assertIsNotNone(tokenizer_new._tokenizer)
-        self.assertIsNotNone(tokenizer_new._tokenizer.sp_model_kwargs)
-        self.assertTrue(isinstance(tokenizer_new._tokenizer.sp_model_kwargs, dict))
-        self.assertEqual(tokenizer_new._tokenizer.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new, text="this is a test for subword regularization", ignore_case=True)

--- a/tests/test_tokenization_m2m_100.py
+++ b/tests/test_tokenization_m2m_100.py
@@ -90,7 +90,7 @@ class M2M100TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         text = tokenizer.convert_tokens_to_string(tokens)
         self.assertEqual(text, "This is a test")
 
-    def test_subword_regularization_tokenizer(self):
+    def test_subword_regularization_tokenizer(self) -> None:
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.get_tokenizer(
             sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1},
@@ -98,7 +98,7 @@ class M2M100TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.check_subword_sampling(tokenizer)
 
-    def test_pickle_subword_regularization_tokenizer(self):
+    def test_pickle_subword_regularization_tokenizer(self) -> None:
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}

--- a/tests/test_tokenization_m2m_100.py
+++ b/tests/test_tokenization_m2m_100.py
@@ -93,10 +93,7 @@ class M2M100TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     def test_subword_regularization_tokenizer(self):
         # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.tokenizer_class(
-            SAMPLE_SP,
-            spm_file=self.tmpdirname,
-            keep_accents=True,
+        tokenizer = self.get_tokenizer(
             sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1},
         )
 

--- a/tests/test_tokenization_m2m_100.py
+++ b/tests/test_tokenization_m2m_100.py
@@ -15,6 +15,7 @@
 
 import itertools
 import os
+import pickle
 import tempfile
 import unittest
 from pathlib import Path
@@ -113,6 +114,18 @@ class M2M100TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 all_equal = False
 
         self.assertFalse(all_equal)
+
+    def test_pickle_subword_regularization_tokenizer(self):
+        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
+        # Subword regularization is only available for the slow tokenizer.
+        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        tokenizer = self.get_tokenizer(sp_model_kwargs=sp_model_kwargs)
+        tokenizer_bin = pickle.dumps(tokenizer)
+        tokenizer_new = pickle.loads(tokenizer_bin)
+
+        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
+        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
+        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
 
 
 @require_torch

--- a/tests/test_tokenization_m2m_100.py
+++ b/tests/test_tokenization_m2m_100.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+import itertools
 import os
 import tempfile
 import unittest
@@ -88,6 +90,29 @@ class M2M100TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         text = tokenizer.convert_tokens_to_string(tokens)
         self.assertEqual(text, "This is a test")
+
+    def test_subword_regularization_tokenizer(self):
+        # Subword regularization is only available for the slow tokenizer.
+        tokenizer = self.tokenizer_class(
+            SAMPLE_SP, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        )
+
+        # Subword regularization augments training data with subword sampling.
+        # This has a random component. We test if the tokenizer generates different
+        # results when subword regularization is enabled.
+        tokens_list = []
+        for _ in range(5):
+            tokens_list.append(tokenizer.tokenize("This is a test for subword regularization."))
+
+        # the list of different pairs of tokens_list
+        combinations = itertools.combinations(tokens_list, 2)
+
+        all_equal = True
+        for combination in combinations:
+            if combination[0] != combination[1]:
+                all_equal = False
+
+        self.assertFalse(all_equal)
 
 
 @require_torch

--- a/tests/test_tokenization_m2m_100.py
+++ b/tests/test_tokenization_m2m_100.py
@@ -96,7 +96,7 @@ class M2M100TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1},
         )
 
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+        self.check_subword_sampling(tokenizer)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -110,7 +110,7 @@ class M2M100TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+        self.check_subword_sampling(tokenizer_new)
 
 
 @require_torch

--- a/tests/test_tokenization_m2m_100.py
+++ b/tests/test_tokenization_m2m_100.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import itertools
 import os
 import pickle
 import tempfile
@@ -98,22 +96,7 @@ class M2M100TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1},
         )
 
-        # Subword regularization augments training data with subword sampling.
-        # This has a random component. We test if the tokenizer generates different
-        # results when subword regularization is enabled.
-        tokens_list = []
-        for _ in range(5):
-            tokens_list.append(tokenizer.tokenize("This is a test for subword regularization."))
-
-        # the list of different pairs of tokens_list
-        combinations = itertools.combinations(tokens_list, 2)
-
-        all_equal = True
-        for combination in combinations:
-            if combination[0] != combination[1]:
-                all_equal = False
-
-        self.assertFalse(all_equal)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -121,11 +104,13 @@ class M2M100TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         tokenizer = self.get_tokenizer(sp_model_kwargs=sp_model_kwargs)
         tokenizer_bin = pickle.dumps(tokenizer)
+        del tokenizer
         tokenizer_new = pickle.loads(tokenizer_bin)
 
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
 
 
 @require_torch

--- a/tests/test_tokenization_m2m_100.py
+++ b/tests/test_tokenization_m2m_100.py
@@ -94,7 +94,10 @@ class M2M100TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     def test_subword_regularization_tokenizer(self):
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.tokenizer_class(
-            SAMPLE_SP, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+            SAMPLE_SP,
+            spm_file=self.tmpdirname,
+            keep_accents=True,
+            sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1},
         )
 
         # Subword regularization augments training data with subword sampling.

--- a/tests/test_tokenization_m2m_100.py
+++ b/tests/test_tokenization_m2m_100.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import pickle
 import tempfile
 import unittest
 from pathlib import Path

--- a/tests/test_tokenization_m2m_100.py
+++ b/tests/test_tokenization_m2m_100.py
@@ -46,6 +46,7 @@ class M2M100TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     tokenizer_class = M2M100Tokenizer
     test_rust_tokenizer = False
     test_seq2seq = False
+    test_sentencepiece = True
 
     def setUp(self):
         super().setUp()
@@ -89,28 +90,6 @@ class M2M100TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         text = tokenizer.convert_tokens_to_string(tokens)
         self.assertEqual(text, "This is a test")
-
-    def test_subword_regularization_tokenizer(self) -> None:
-        # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.get_tokenizer(
-            sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1},
-        )
-
-        self.check_subword_sampling(tokenizer)
-
-    def test_pickle_subword_regularization_tokenizer(self) -> None:
-        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
-        # Subword regularization is only available for the slow tokenizer.
-        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = self.get_tokenizer(sp_model_kwargs=sp_model_kwargs)
-        tokenizer_bin = pickle.dumps(tokenizer)
-        del tokenizer
-        tokenizer_new = pickle.loads(tokenizer_bin)
-
-        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
-        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
-        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new)
 
 
 @require_torch

--- a/tests/test_tokenization_marian.py
+++ b/tests/test_tokenization_marian.py
@@ -15,6 +15,7 @@
 
 
 import os
+import pickle
 import tempfile
 import unittest
 from pathlib import Path
@@ -101,3 +102,25 @@ class MarianTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         batch_smaller = tok(["I am a tiny frog", "I am a small frog"], padding=True, return_tensors=FRAMEWORK)
         self.assertIsInstance(batch_smaller, BatchEncoding)
         self.assertEqual(batch_smaller.input_ids.shape, (2, 10))
+
+    def test_subword_regularization_tokenizer(self):
+        # Subword regularization is only available for the slow tokenizer.
+        tokenizer = self.tokenizer_class.from_pretrained(
+            f"{ORG_NAME}opus-mt-en-de", sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        )
+
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+
+    def test_pickle_subword_regularization_tokenizer(self):
+        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
+        # Subword regularization is only available for the slow tokenizer.
+        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        tokenizer = self.tokenizer_class.from_pretrained(f"{ORG_NAME}opus-mt-en-de", sp_model_kwargs=sp_model_kwargs)
+        tokenizer_bin = pickle.dumps(tokenizer)
+        del tokenizer
+        tokenizer_new = pickle.loads(tokenizer_bin)
+
+        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
+        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
+        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))

--- a/tests/test_tokenization_marian.py
+++ b/tests/test_tokenization_marian.py
@@ -123,4 +123,4 @@ class MarianTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+        self.check_subword_sampling(tokenizer_new)

--- a/tests/test_tokenization_marian.py
+++ b/tests/test_tokenization_marian.py
@@ -103,7 +103,7 @@ class MarianTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsInstance(batch_smaller, BatchEncoding)
         self.assertEqual(batch_smaller.input_ids.shape, (2, 10))
 
-    def test_subword_regularization_tokenizer(self):
+    def test_subword_regularization_tokenizer(self) -> None:
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.tokenizer_class.from_pretrained(
             f"{ORG_NAME}opus-mt-en-de", sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
@@ -111,7 +111,7 @@ class MarianTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.check_subword_sampling(tokenizer, skip_back_convert_check=True)
 
-    def test_pickle_subword_regularization_tokenizer(self):
+    def test_pickle_subword_regularization_tokenizer(self) -> None:
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}

--- a/tests/test_tokenization_marian.py
+++ b/tests/test_tokenization_marian.py
@@ -109,7 +109,7 @@ class MarianTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             f"{ORG_NAME}opus-mt-en-de", sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.check_subword_sampling(tokenizer)
+        self.check_subword_sampling(tokenizer, skip_back_convert_check=True)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -123,4 +123,4 @@ class MarianTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new)
+        self.check_subword_sampling(tokenizer_new, skip_back_convert_check=True)

--- a/tests/test_tokenization_marian.py
+++ b/tests/test_tokenization_marian.py
@@ -109,7 +109,7 @@ class MarianTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             f"{ORG_NAME}opus-mt-en-de", sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+        self.check_subword_sampling(tokenizer)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""

--- a/tests/test_tokenization_marian.py
+++ b/tests/test_tokenization_marian.py
@@ -51,6 +51,7 @@ class MarianTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     tokenizer_class = MarianTokenizer
     test_rust_tokenizer = False
+    test_sentencepiece = True
 
     def setUp(self):
         super().setUp()
@@ -102,25 +103,3 @@ class MarianTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         batch_smaller = tok(["I am a tiny frog", "I am a small frog"], padding=True, return_tensors=FRAMEWORK)
         self.assertIsInstance(batch_smaller, BatchEncoding)
         self.assertEqual(batch_smaller.input_ids.shape, (2, 10))
-
-    def test_subword_regularization_tokenizer(self) -> None:
-        # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.tokenizer_class.from_pretrained(
-            f"{ORG_NAME}opus-mt-en-de", sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        )
-
-        self.check_subword_sampling(tokenizer, skip_back_convert_check=True)
-
-    def test_pickle_subword_regularization_tokenizer(self) -> None:
-        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
-        # Subword regularization is only available for the slow tokenizer.
-        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = self.tokenizer_class.from_pretrained(f"{ORG_NAME}opus-mt-en-de", sp_model_kwargs=sp_model_kwargs)
-        tokenizer_bin = pickle.dumps(tokenizer)
-        del tokenizer
-        tokenizer_new = pickle.loads(tokenizer_bin)
-
-        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
-        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
-        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new, skip_back_convert_check=True)

--- a/tests/test_tokenization_marian.py
+++ b/tests/test_tokenization_marian.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import os
-import pickle
 import tempfile
 import unittest
 from pathlib import Path

--- a/tests/test_tokenization_mbart50.py
+++ b/tests/test_tokenization_mbart50.py
@@ -82,7 +82,7 @@ class MBartTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             # fmt: on
         )
 
-    def test_subword_regularization_tokenizer(self):
+    def test_subword_regularization_tokenizer(self) -> None:
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.tokenizer_class(
             SAMPLE_VOCAB,
@@ -94,7 +94,7 @@ class MBartTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.check_subword_sampling(tokenizer)
 
-    def test_pickle_subword_regularization_tokenizer(self):
+    def test_pickle_subword_regularization_tokenizer(self) -> None:
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}

--- a/tests/test_tokenization_mbart50.py
+++ b/tests/test_tokenization_mbart50.py
@@ -92,7 +92,7 @@ class MBartTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1},
         )
 
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+        self.check_subword_sampling(tokenizer)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -108,7 +108,7 @@ class MBartTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+        self.check_subword_sampling(tokenizer_new)
 
 
 @require_torch

--- a/tests/test_tokenization_mbart50.py
+++ b/tests/test_tokenization_mbart50.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import pickle
 import tempfile
 import unittest
 

--- a/tests/test_tokenization_mbart50.py
+++ b/tests/test_tokenization_mbart50.py
@@ -39,6 +39,7 @@ class MBartTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     tokenizer_class = MBart50Tokenizer
     rust_tokenizer_class = MBart50TokenizerFast
     test_rust_tokenizer = True
+    test_sentencepiece = True
 
     def setUp(self):
         super().setUp()
@@ -81,34 +82,6 @@ class MBartTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             [SPIECE_UNDERLINE + "I", SPIECE_UNDERLINE + "was", SPIECE_UNDERLINE + "b", "or", "n", SPIECE_UNDERLINE + "in", SPIECE_UNDERLINE + "", "<unk>", "2", "0", "0", "0", ",", SPIECE_UNDERLINE + "and", SPIECE_UNDERLINE + "this", SPIECE_UNDERLINE + "is", SPIECE_UNDERLINE + "f", "al", "s", "<unk>", "."],
             # fmt: on
         )
-
-    def test_subword_regularization_tokenizer(self) -> None:
-        # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.tokenizer_class(
-            SAMPLE_VOCAB,
-            src_lang="en_XX",
-            tgt_lang="ro_RO",
-            keep_accents=True,
-            sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1},
-        )
-
-        self.check_subword_sampling(tokenizer)
-
-    def test_pickle_subword_regularization_tokenizer(self) -> None:
-        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
-        # Subword regularization is only available for the slow tokenizer.
-        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = self.tokenizer_class(
-            SAMPLE_VOCAB, src_lang="en_XX", tgt_lang="ro_RO", keep_accents=True, sp_model_kwargs=sp_model_kwargs
-        )
-        tokenizer_bin = pickle.dumps(tokenizer)
-        del tokenizer
-        tokenizer_new = pickle.loads(tokenizer_bin)
-
-        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
-        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
-        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new)
 
 
 @require_torch

--- a/tests/test_tokenization_pegasus.py
+++ b/tests/test_tokenization_pegasus.py
@@ -103,7 +103,7 @@ class PegasusTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             "google/pegasus-large", sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+        self.check_subword_sampling(tokenizer)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -117,7 +117,7 @@ class PegasusTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+        self.check_subword_sampling(tokenizer_new)
 
 
 @require_sentencepiece

--- a/tests/test_tokenization_pegasus.py
+++ b/tests/test_tokenization_pegasus.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pickle
 import unittest
 
 from transformers import PegasusTokenizer, PegasusTokenizerFast

--- a/tests/test_tokenization_pegasus.py
+++ b/tests/test_tokenization_pegasus.py
@@ -97,7 +97,7 @@ class PegasusTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         assert targets["input_ids"].shape == (2, 5)
         assert len(batch) == 2  # input_ids, attention_mask.
 
-    def test_subword_regularization_tokenizer(self):
+    def test_subword_regularization_tokenizer(self) -> None:
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.tokenizer_class.from_pretrained(
             "google/pegasus-large", sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
@@ -105,7 +105,7 @@ class PegasusTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.check_subword_sampling(tokenizer)
 
-    def test_pickle_subword_regularization_tokenizer(self):
+    def test_pickle_subword_regularization_tokenizer(self) -> None:
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}

--- a/tests/test_tokenization_pegasus.py
+++ b/tests/test_tokenization_pegasus.py
@@ -32,6 +32,7 @@ class PegasusTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     tokenizer_class = PegasusTokenizer
     rust_tokenizer_class = PegasusTokenizerFast
     test_rust_tokenizer = True
+    test_sentencepiece = True
 
     def setUp(self):
         super().setUp()
@@ -97,28 +98,6 @@ class PegasusTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         assert targets["input_ids"].shape == (2, 5)
         assert len(batch) == 2  # input_ids, attention_mask.
 
-    def test_subword_regularization_tokenizer(self) -> None:
-        # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.tokenizer_class.from_pretrained(
-            "google/pegasus-large", sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        )
-
-        self.check_subword_sampling(tokenizer)
-
-    def test_pickle_subword_regularization_tokenizer(self) -> None:
-        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
-        # Subword regularization is only available for the slow tokenizer.
-        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = self.tokenizer_class.from_pretrained("google/pegasus-large", sp_model_kwargs=sp_model_kwargs)
-        tokenizer_bin = pickle.dumps(tokenizer)
-        del tokenizer
-        tokenizer_new = pickle.loads(tokenizer_bin)
-
-        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
-        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
-        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new)
-
 
 @require_sentencepiece
 @require_tokenizers
@@ -127,6 +106,7 @@ class BigBirdPegasusTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     tokenizer_class = PegasusTokenizer
     rust_tokenizer_class = PegasusTokenizerFast
     test_rust_tokenizer = True
+    test_sentencepiece = True
 
     def setUp(self):
         super().setUp()

--- a/tests/test_tokenization_reformer.py
+++ b/tests/test_tokenization_reformer.py
@@ -69,7 +69,7 @@ class ReformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+        self.check_subword_sampling(tokenizer)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -83,7 +83,7 @@ class ReformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+        self.check_subword_sampling(tokenizer_new)
 
     def test_padding(self, max_length=15):
         for tokenizer, pretrained_name, kwargs in self.tokenizers_list:

--- a/tests/test_tokenization_reformer.py
+++ b/tests/test_tokenization_reformer.py
@@ -63,7 +63,7 @@ class ReformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         rust_ids = rust_tokenizer.encode(sequence)
         self.assertListEqual(ids, rust_ids)
 
-    def test_subword_regularization_tokenizer(self):
+    def test_subword_regularization_tokenizer(self) -> None:
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.tokenizer_class(
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
@@ -71,7 +71,7 @@ class ReformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.check_subword_sampling(tokenizer)
 
-    def test_pickle_subword_regularization_tokenizer(self):
+    def test_pickle_subword_regularization_tokenizer(self) -> None:
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}

--- a/tests/test_tokenization_reformer.py
+++ b/tests/test_tokenization_reformer.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import os
+import pickle
 import unittest
 
 from transformers import SPIECE_UNDERLINE, ReformerTokenizer, ReformerTokenizerFast
@@ -62,6 +62,28 @@ class ReformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         ids = tokenizer.encode(sequence)
         rust_ids = rust_tokenizer.encode(sequence)
         self.assertListEqual(ids, rust_ids)
+
+    def test_subword_regularization_tokenizer(self):
+        # Subword regularization is only available for the slow tokenizer.
+        tokenizer = self.tokenizer_class(
+            SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        )
+
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+
+    def test_pickle_subword_regularization_tokenizer(self):
+        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
+        # Subword regularization is only available for the slow tokenizer.
+        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
+        tokenizer_bin = pickle.dumps(tokenizer)
+        del tokenizer
+        tokenizer_new = pickle.loads(tokenizer_bin)
+
+        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
+        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
+        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
 
     def test_padding(self, max_length=15):
         for tokenizer, pretrained_name, kwargs in self.tokenizers_list:

--- a/tests/test_tokenization_reformer.py
+++ b/tests/test_tokenization_reformer.py
@@ -34,6 +34,7 @@ class ReformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     rust_tokenizer_class = ReformerTokenizerFast
     test_rust_tokenizer = True
     test_seq2seq = False
+    test_sentencepiece = True
 
     def setUp(self):
         super().setUp()
@@ -62,28 +63,6 @@ class ReformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         ids = tokenizer.encode(sequence)
         rust_ids = rust_tokenizer.encode(sequence)
         self.assertListEqual(ids, rust_ids)
-
-    def test_subword_regularization_tokenizer(self) -> None:
-        # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.tokenizer_class(
-            SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        )
-
-        self.check_subword_sampling(tokenizer)
-
-    def test_pickle_subword_regularization_tokenizer(self) -> None:
-        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
-        # Subword regularization is only available for the slow tokenizer.
-        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
-        tokenizer_bin = pickle.dumps(tokenizer)
-        del tokenizer
-        tokenizer_new = pickle.loads(tokenizer_bin)
-
-        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
-        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
-        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new)
 
     def test_padding(self, max_length=15):
         for tokenizer, pretrained_name, kwargs in self.tokenizers_list:

--- a/tests/test_tokenization_reformer.py
+++ b/tests/test_tokenization_reformer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import pickle
 import unittest
 
 from transformers import SPIECE_UNDERLINE, ReformerTokenizer, ReformerTokenizerFast

--- a/tests/test_tokenization_speech_to_text.py
+++ b/tests/test_tokenization_speech_to_text.py
@@ -93,7 +93,10 @@ class SpeechToTextTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
     def test_subword_regularization_tokenizer(self):
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.tokenizer_class(
-            SAMPLE_SP, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+            SAMPLE_SP,
+            spm_file=self.tmpdirname,
+            keep_accents=True,
+            sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1},
         )
 
         # Subword regularization augments training data with subword sampling.

--- a/tests/test_tokenization_speech_to_text.py
+++ b/tests/test_tokenization_speech_to_text.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+import itertools
 import os
 import unittest
 from pathlib import Path
@@ -87,6 +89,29 @@ class SpeechToTextTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
             [SPIECE_UNDERLINE + "I", SPIECE_UNDERLINE + "was", SPIECE_UNDERLINE + "b", "or", "n", SPIECE_UNDERLINE + "in", SPIECE_UNDERLINE + "", "<unk>", "2", "0", "0", "0", ",", SPIECE_UNDERLINE + "and", SPIECE_UNDERLINE + "this", SPIECE_UNDERLINE + "is", SPIECE_UNDERLINE + "f", "al", "s", "<unk>", "."],
             # fmt: on
         )
+
+    def test_subword_regularization_tokenizer(self):
+        # Subword regularization is only available for the slow tokenizer.
+        tokenizer = self.tokenizer_class(
+            SAMPLE_SP, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        )
+
+        # Subword regularization augments training data with subword sampling.
+        # This has a random component. We test if the tokenizer generates different
+        # results when subword regularization is enabled.
+        tokens_list = []
+        for _ in range(5):
+            tokens_list.append(tokenizer.tokenize("This is a test for subword regularization."))
+
+        # the list of different pairs of tokens_list
+        combinations = itertools.combinations(tokens_list, 2)
+
+        all_equal = True
+        for combination in combinations:
+            if combination[0] != combination[1]:
+                all_equal = False
+
+        self.assertFalse(all_equal)
 
 
 @require_sentencepiece

--- a/tests/test_tokenization_speech_to_text.py
+++ b/tests/test_tokenization_speech_to_text.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import itertools
 import os
 import pickle
 import unittest
@@ -97,22 +95,7 @@ class SpeechToTextTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
             sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1},
         )
 
-        # Subword regularization augments training data with subword sampling.
-        # This has a random component. We test if the tokenizer generates different
-        # results when subword regularization is enabled.
-        tokens_list = []
-        for _ in range(5):
-            tokens_list.append(tokenizer.tokenize("This is a test for subword regularization."))
-
-        # the list of different pairs of tokens_list
-        combinations = itertools.combinations(tokens_list, 2)
-
-        all_equal = True
-        for combination in combinations:
-            if combination[0] != combination[1]:
-                all_equal = False
-
-        self.assertFalse(all_equal)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -122,11 +105,13 @@ class SpeechToTextTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
             sp_model_kwargs=sp_model_kwargs,
         )
         tokenizer_bin = pickle.dumps(tokenizer)
+        del tokenizer
         tokenizer_new = pickle.loads(tokenizer_bin)
 
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
 
 
 @require_sentencepiece

--- a/tests/test_tokenization_speech_to_text.py
+++ b/tests/test_tokenization_speech_to_text.py
@@ -92,10 +92,7 @@ class SpeechToTextTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
 
     def test_subword_regularization_tokenizer(self):
         # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.tokenizer_class(
-            SAMPLE_SP,
-            spm_file=self.tmpdirname,
-            keep_accents=True,
+        tokenizer = self.get_tokenizer(
             sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1},
         )
 

--- a/tests/test_tokenization_speech_to_text.py
+++ b/tests/test_tokenization_speech_to_text.py
@@ -15,6 +15,7 @@
 
 import itertools
 import os
+import pickle
 import unittest
 from pathlib import Path
 from shutil import copyfile
@@ -112,6 +113,20 @@ class SpeechToTextTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
                 all_equal = False
 
         self.assertFalse(all_equal)
+
+    def test_pickle_subword_regularization_tokenizer(self):
+        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
+        # Subword regularization is only available for the slow tokenizer.
+        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        tokenizer = self.get_tokenizer(
+            sp_model_kwargs=sp_model_kwargs,
+        )
+        tokenizer_bin = pickle.dumps(tokenizer)
+        tokenizer_new = pickle.loads(tokenizer_bin)
+
+        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
+        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
+        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
 
 
 @require_sentencepiece

--- a/tests/test_tokenization_speech_to_text.py
+++ b/tests/test_tokenization_speech_to_text.py
@@ -89,7 +89,7 @@ class SpeechToTextTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
             # fmt: on
         )
 
-    def test_subword_regularization_tokenizer(self):
+    def test_subword_regularization_tokenizer(self) -> None:
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.get_tokenizer(
             sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1},
@@ -97,7 +97,7 @@ class SpeechToTextTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.check_subword_sampling(tokenizer)
 
-    def test_pickle_subword_regularization_tokenizer(self):
+    def test_pickle_subword_regularization_tokenizer(self) -> None:
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}

--- a/tests/test_tokenization_speech_to_text.py
+++ b/tests/test_tokenization_speech_to_text.py
@@ -95,7 +95,7 @@ class SpeechToTextTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
             sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1},
         )
 
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+        self.check_subword_sampling(tokenizer)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -111,7 +111,7 @@ class SpeechToTextTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+        self.check_subword_sampling(tokenizer_new)
 
 
 @require_sentencepiece

--- a/tests/test_tokenization_speech_to_text.py
+++ b/tests/test_tokenization_speech_to_text.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import pickle
 import unittest
 from pathlib import Path
 from shutil import copyfile

--- a/tests/test_tokenization_speech_to_text.py
+++ b/tests/test_tokenization_speech_to_text.py
@@ -41,6 +41,7 @@ ES_CODE = 10
 class SpeechToTextTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
     tokenizer_class = Speech2TextTokenizer
     test_rust_tokenizer = False
+    test_sentencepiece = True
 
     def setUp(self):
         super().setUp()
@@ -88,30 +89,6 @@ class SpeechToTextTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
             [SPIECE_UNDERLINE + "I", SPIECE_UNDERLINE + "was", SPIECE_UNDERLINE + "b", "or", "n", SPIECE_UNDERLINE + "in", SPIECE_UNDERLINE + "", "<unk>", "2", "0", "0", "0", ",", SPIECE_UNDERLINE + "and", SPIECE_UNDERLINE + "this", SPIECE_UNDERLINE + "is", SPIECE_UNDERLINE + "f", "al", "s", "<unk>", "."],
             # fmt: on
         )
-
-    def test_subword_regularization_tokenizer(self) -> None:
-        # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.get_tokenizer(
-            sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1},
-        )
-
-        self.check_subword_sampling(tokenizer)
-
-    def test_pickle_subword_regularization_tokenizer(self) -> None:
-        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
-        # Subword regularization is only available for the slow tokenizer.
-        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = self.get_tokenizer(
-            sp_model_kwargs=sp_model_kwargs,
-        )
-        tokenizer_bin = pickle.dumps(tokenizer)
-        del tokenizer
-        tokenizer_new = pickle.loads(tokenizer_bin)
-
-        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
-        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
-        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new)
 
 
 @require_sentencepiece

--- a/tests/test_tokenization_t5.py
+++ b/tests/test_tokenization_t5.py
@@ -136,7 +136,6 @@ class T5TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
         self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
 
-
     @cached_property
     def t5_base_tokenizer(self):
         return T5Tokenizer.from_pretrained("t5-base")

--- a/tests/test_tokenization_t5.py
+++ b/tests/test_tokenization_t5.py
@@ -114,7 +114,7 @@ class T5TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             ],
         )
 
-    def test_subword_regularization_tokenizer(self):
+    def test_subword_regularization_tokenizer(self) -> None:
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.tokenizer_class(
             SAMPLE_VOCAB, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
@@ -122,7 +122,7 @@ class T5TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.check_subword_sampling(tokenizer)
 
-    def test_pickle_subword_regularization_tokenizer(self):
+    def test_pickle_subword_regularization_tokenizer(self) -> None:
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}

--- a/tests/test_tokenization_t5.py
+++ b/tests/test_tokenization_t5.py
@@ -120,7 +120,7 @@ class T5TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+        self.check_subword_sampling(tokenizer)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -134,7 +134,7 @@ class T5TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+        self.check_subword_sampling(tokenizer_new)
 
     @cached_property
     def t5_base_tokenizer(self):

--- a/tests/test_tokenization_t5.py
+++ b/tests/test_tokenization_t5.py
@@ -40,6 +40,7 @@ class T5TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     tokenizer_class = T5Tokenizer
     rust_tokenizer_class = T5TokenizerFast
     test_rust_tokenizer = True
+    test_sentencepiece = True
 
     def setUp(self):
         super().setUp()
@@ -113,28 +114,6 @@ class T5TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 ".",
             ],
         )
-
-    def test_subword_regularization_tokenizer(self) -> None:
-        # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.tokenizer_class(
-            SAMPLE_VOCAB, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        )
-
-        self.check_subword_sampling(tokenizer)
-
-    def test_pickle_subword_regularization_tokenizer(self) -> None:
-        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
-        # Subword regularization is only available for the slow tokenizer.
-        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, sp_model_kwargs=sp_model_kwargs)
-        tokenizer_bin = pickle.dumps(tokenizer)
-        del tokenizer
-        tokenizer_new = pickle.loads(tokenizer_bin)
-
-        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
-        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
-        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new)
 
     @cached_property
     def t5_base_tokenizer(self):

--- a/tests/test_tokenization_t5.py
+++ b/tests/test_tokenization_t5.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pickle
 import unittest
 
 from transformers import SPIECE_UNDERLINE, AddedToken, BatchEncoding, T5Tokenizer, T5TokenizerFast

--- a/tests/test_tokenization_t5.py
+++ b/tests/test_tokenization_t5.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import pickle
 import unittest
 
 from transformers import SPIECE_UNDERLINE, AddedToken, BatchEncoding, T5Tokenizer, T5TokenizerFast
@@ -113,6 +113,29 @@ class T5TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 ".",
             ],
         )
+
+    def test_subword_regularization_tokenizer(self):
+        # Subword regularization is only available for the slow tokenizer.
+        tokenizer = self.tokenizer_class(
+            SAMPLE_VOCAB, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        )
+
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+
+    def test_pickle_subword_regularization_tokenizer(self):
+        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
+        # Subword regularization is only available for the slow tokenizer.
+        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, sp_model_kwargs=sp_model_kwargs)
+        tokenizer_bin = pickle.dumps(tokenizer)
+        del tokenizer
+        tokenizer_new = pickle.loads(tokenizer_bin)
+
+        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
+        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
+        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+
 
     @cached_property
     def t5_base_tokenizer(self):

--- a/tests/test_tokenization_xlm_prophetnet.py
+++ b/tests/test_tokenization_xlm_prophetnet.py
@@ -116,7 +116,7 @@ class XLMProphetNetTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             ],
         )
 
-    def test_subword_regularization_tokenizer(self):
+    def test_subword_regularization_tokenizer(self) -> None:
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.tokenizer_class(
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
@@ -124,7 +124,7 @@ class XLMProphetNetTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.check_subword_sampling(tokenizer)
 
-    def test_pickle_subword_regularization_tokenizer(self):
+    def test_pickle_subword_regularization_tokenizer(self) -> None:
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}

--- a/tests/test_tokenization_xlm_prophetnet.py
+++ b/tests/test_tokenization_xlm_prophetnet.py
@@ -15,6 +15,7 @@
 
 
 import os
+import pickle
 import unittest
 
 from transformers.file_utils import cached_property
@@ -114,6 +115,28 @@ class XLMProphetNetTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 ".",
             ],
         )
+
+    def test_subword_regularization_tokenizer(self):
+        # Subword regularization is only available for the slow tokenizer.
+        tokenizer = self.tokenizer_class(
+            SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        )
+
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+
+    def test_pickle_subword_regularization_tokenizer(self):
+        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
+        # Subword regularization is only available for the slow tokenizer.
+        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
+        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
+        tokenizer_bin = pickle.dumps(tokenizer)
+        del tokenizer
+        tokenizer_new = pickle.loads(tokenizer_bin)
+
+        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
+        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
+        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
 
     @cached_property
     def big_tokenizer(self):

--- a/tests/test_tokenization_xlm_prophetnet.py
+++ b/tests/test_tokenization_xlm_prophetnet.py
@@ -122,7 +122,7 @@ class XLMProphetNetTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+        self.check_subword_sampling(tokenizer)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -136,7 +136,7 @@ class XLMProphetNetTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+        self.check_subword_sampling(tokenizer_new)
 
     @cached_property
     def big_tokenizer(self):

--- a/tests/test_tokenization_xlm_prophetnet.py
+++ b/tests/test_tokenization_xlm_prophetnet.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import os
-import pickle
 import unittest
 
 from transformers.file_utils import cached_property

--- a/tests/test_tokenization_xlm_prophetnet.py
+++ b/tests/test_tokenization_xlm_prophetnet.py
@@ -33,6 +33,7 @@ class XLMProphetNetTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     tokenizer_class = XLMProphetNetTokenizer
     test_rust_tokenizer = False
+    test_sentencepiece = True
 
     def setUp(self):
         super().setUp()
@@ -115,28 +116,6 @@ class XLMProphetNetTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 ".",
             ],
         )
-
-    def test_subword_regularization_tokenizer(self) -> None:
-        # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.tokenizer_class(
-            SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        )
-
-        self.check_subword_sampling(tokenizer)
-
-    def test_pickle_subword_regularization_tokenizer(self) -> None:
-        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
-        # Subword regularization is only available for the slow tokenizer.
-        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
-        tokenizer_bin = pickle.dumps(tokenizer)
-        del tokenizer
-        tokenizer_new = pickle.loads(tokenizer_bin)
-
-        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
-        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
-        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new)
 
     @cached_property
     def big_tokenizer(self):

--- a/tests/test_tokenization_xlm_roberta.py
+++ b/tests/test_tokenization_xlm_roberta.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import itertools
 import os
 import pickle
 import unittest
@@ -126,22 +124,7 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        # Subword regularization augments training data with subword sampling.
-        # This has a random component. We test if the tokenizer generates different
-        # results when subword regularization is enabled.
-        tokens_list = []
-        for _ in range(5):
-            tokens_list.append(tokenizer.tokenize("This is a test for subword regularization."))
-
-        # the list of different pairs of tokens_list
-        combinations = itertools.combinations(tokens_list, 2)
-
-        all_equal = True
-        for combination in combinations:
-            if combination[0] != combination[1]:
-                all_equal = False
-
-        self.assertFalse(all_equal)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -149,11 +132,13 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         tokenizer = XLMRobertaTokenizer(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
         tokenizer_bin = pickle.dumps(tokenizer)
+        del tokenizer
         tokenizer_new = pickle.loads(tokenizer_bin)
 
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
+        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
 
     @cached_property
     def big_tokenizer(self):

--- a/tests/test_tokenization_xlm_roberta.py
+++ b/tests/test_tokenization_xlm_roberta.py
@@ -122,7 +122,7 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     def test_subword_regularization_tokenizer(self):
         # Subword regularization is only available for the slow tokenizer.
-        tokenizer = tokenizer_class(
+        tokenizer = self.tokenizer_class(
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 

--- a/tests/test_tokenization_xlm_roberta.py
+++ b/tests/test_tokenization_xlm_roberta.py
@@ -130,7 +130,7 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = XLMRobertaTokenizer(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
+        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
         tokenizer_bin = pickle.dumps(tokenizer)
         del tokenizer
         tokenizer_new = pickle.loads(tokenizer_bin)

--- a/tests/test_tokenization_xlm_roberta.py
+++ b/tests/test_tokenization_xlm_roberta.py
@@ -118,7 +118,7 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             ],
         )
 
-    def test_subword_regularization_tokenizer(self):
+    def test_subword_regularization_tokenizer(self) -> None:
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.tokenizer_class(
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
@@ -126,7 +126,7 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.check_subword_sampling(tokenizer)
 
-    def test_pickle_subword_regularization_tokenizer(self):
+    def test_pickle_subword_regularization_tokenizer(self) -> None:
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}

--- a/tests/test_tokenization_xlm_roberta.py
+++ b/tests/test_tokenization_xlm_roberta.py
@@ -122,7 +122,7 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     def test_subword_regularization_tokenizer(self):
         # Subword regularization is only available for the slow tokenizer.
-        tokenizer = XLMRobertaTokenizer(
+        tokenizer = tokenizer_class(
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 

--- a/tests/test_tokenization_xlm_roberta.py
+++ b/tests/test_tokenization_xlm_roberta.py
@@ -124,7 +124,7 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+        self.check_subword_sampling(tokenizer)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -138,7 +138,7 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+        self.check_subword_sampling(tokenizer_new)
 
     @cached_property
     def big_tokenizer(self):

--- a/tests/test_tokenization_xlm_roberta.py
+++ b/tests/test_tokenization_xlm_roberta.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import os
-import pickle
 import unittest
 
 from transformers import SPIECE_UNDERLINE, XLMRobertaTokenizer, XLMRobertaTokenizerFast

--- a/tests/test_tokenization_xlm_roberta.py
+++ b/tests/test_tokenization_xlm_roberta.py
@@ -34,6 +34,7 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     tokenizer_class = XLMRobertaTokenizer
     rust_tokenizer_class = XLMRobertaTokenizerFast
     test_rust_tokenizer = True
+    test_sentencepiece = True
 
     def setUp(self):
         super().setUp()
@@ -117,28 +118,6 @@ class XLMRobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 ".",
             ],
         )
-
-    def test_subword_regularization_tokenizer(self) -> None:
-        # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.tokenizer_class(
-            SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        )
-
-        self.check_subword_sampling(tokenizer)
-
-    def test_pickle_subword_regularization_tokenizer(self) -> None:
-        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
-        # Subword regularization is only available for the slow tokenizer.
-        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
-        tokenizer_bin = pickle.dumps(tokenizer)
-        del tokenizer
-        tokenizer_new = pickle.loads(tokenizer_bin)
-
-        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
-        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
-        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new)
 
     @cached_property
     def big_tokenizer(self):

--- a/tests/test_tokenization_xlnet.py
+++ b/tests/test_tokenization_xlnet.py
@@ -108,7 +108,7 @@ class XLNetTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             ],
         )
 
-    def test_subword_regularization_tokenizer(self):
+    def test_subword_regularization_tokenizer(self) -> None:
         # Subword regularization is only available for the slow tokenizer.
         tokenizer = self.tokenizer_class(
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
@@ -116,7 +116,7 @@ class XLNetTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.check_subword_sampling(tokenizer)
 
-    def test_pickle_subword_regularization_tokenizer(self):
+    def test_pickle_subword_regularization_tokenizer(self) -> None:
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
         # Subword regularization is only available for the slow tokenizer.
         sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}

--- a/tests/test_tokenization_xlnet.py
+++ b/tests/test_tokenization_xlnet.py
@@ -114,7 +114,7 @@ class XLNetTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
         )
 
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer))
+        self.check_subword_sampling(tokenizer)
 
     def test_pickle_subword_regularization_tokenizer(self):
         """Google pickle __getstate__ __setstate__ if you are struggling with this."""
@@ -128,7 +128,7 @@ class XLNetTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
         self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
         self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.assertTrue(TokenizerTesterMixin.does_subword_sampling(tokenizer_new))
+        self.check_subword_sampling(tokenizer_new)
 
     def test_tokenizer_lower(self):
         tokenizer = XLNetTokenizer(SAMPLE_VOCAB, do_lower_case=True)

--- a/tests/test_tokenization_xlnet.py
+++ b/tests/test_tokenization_xlnet.py
@@ -33,6 +33,7 @@ class XLNetTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     tokenizer_class = XLNetTokenizer
     rust_tokenizer_class = XLNetTokenizerFast
     test_rust_tokenizer = True
+    test_sentencepiece = True
 
     def setUp(self):
         super().setUp()
@@ -107,28 +108,6 @@ class XLNetTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 ".",
             ],
         )
-
-    def test_subword_regularization_tokenizer(self) -> None:
-        # Subword regularization is only available for the slow tokenizer.
-        tokenizer = self.tokenizer_class(
-            SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs={"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        )
-
-        self.check_subword_sampling(tokenizer)
-
-    def test_pickle_subword_regularization_tokenizer(self) -> None:
-        """Google pickle __getstate__ __setstate__ if you are struggling with this."""
-        # Subword regularization is only available for the slow tokenizer.
-        sp_model_kwargs = {"enable_sampling": True, "alpha": 0.1, "nbest_size": -1}
-        tokenizer = self.tokenizer_class(SAMPLE_VOCAB, keep_accents=True, sp_model_kwargs=sp_model_kwargs)
-        tokenizer_bin = pickle.dumps(tokenizer)
-        del tokenizer
-        tokenizer_new = pickle.loads(tokenizer_bin)
-
-        self.assertIsNotNone(tokenizer_new.sp_model_kwargs)
-        self.assertTrue(isinstance(tokenizer_new.sp_model_kwargs, dict))
-        self.assertEqual(tokenizer_new.sp_model_kwargs, sp_model_kwargs)
-        self.check_subword_sampling(tokenizer_new)
 
     def test_tokenizer_lower(self):
         tokenizer = XLNetTokenizer(SAMPLE_VOCAB, do_lower_case=True)

--- a/tests/test_tokenization_xlnet.py
+++ b/tests/test_tokenization_xlnet.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import os
-import pickle
 import unittest
 
 from transformers import SPIECE_UNDERLINE, XLNetTokenizer, XLNetTokenizerFast


### PR DESCRIPTION
see https://github.com/huggingface/transformers/pull/11149#pullrequestreview-643686428

## To-do
### `AlbertTokenizer`
- [x] add `sp_model_kwargs` param with test
- [x] add pickle support with test
- [x] remove obscure function argument called `sample`
- [x] check
- [x] refactor test to follow DRY
### `BarthezTokenizer`
- [x] add `sp_model_kwargs` param with test
- [x] add pickle support with test
- [x] check
- [x] refactor test to follow DRY
- <s>remove obscure function argument called `sample`</s>
### `BertGenerationTokenizer`
- [x] add `sp_model_kwargs` param with test
- [x] add pickle support with test
- [x] remove obscure function argument called `sample`
- [x] check
- [x] refactor test to follow DRY
### `BigBirdTokenizer`
- [x] add `sp_model_kwargs` param with test
- [x] add pickle support with test
- [x] remove obscure function argument called `sample`
- [x] check
- [x] refactor test to follow DRY
### `CamembertTokenizer`
- [x] add `sp_model_kwargs` param with test
- [x] add pickle support with test
- [x] check
- [x] refactor test to follow DRY
- <s>remove obscure function argument called `sample`</s>
### `DebertaV2Tokenizer`
- [x] add `sp_model_kwargs` param with test
- [x] add pickle support with test
- [x] check
- [x] refactor test to follow DRY
- <s>remove obscure function argument called `sample`</s>
### `M2M100Tokenizer`
- [x] add `sp_model_kwargs` param with test
- [x] add pickle support with test
- [x] check
- [x] refactor test to follow DRY
- <s>remove obscure function argument called `sample`</s>
### `MarianTokenizer` - has src and target tokenizer
- [x] add `sp_model_kwargs` param with test
- [x] add pickle support with test
- [x] check
- [x] refactor test to follow DRY
- <s>remove obscure function argument called `sample`</s>
### `MBart50Tokenizer`
- [x] add `sp_model_kwargs` param with test
- [x] add pickle support with test
- [x] check
- [x] refactor test to follow DRY
- <s>remove obscure function argument called `sample`</s>
### `PegasusTokenizer`
- [x] add `sp_model_kwargs` param with test
- [x] add pickle support with test
- [x] remove obscure function argument called `sample`
- [x] check
- [x] refactor test to follow DRY
### `ReformerTokenizer`
- [x] add `sp_model_kwargs` param with test
- [x] add pickle support with test
- [x] remove obscure function argument called `sample`
- [x] check
- [x] refactor test to follow DRY
### `Speech2TextTokenizer`
- [x] add `sp_model_kwargs` param with test
- [x] add pickle support with test
- [x] check
- [x] refactor test to follow DRY
- <s>remove obscure function argument called `sample`</s>
### `T5Tokenizer`
- [x] add `sp_model_kwargs` param with test
- [x] add pickle support with test
- [x] remove obscure function argument called `sample`
- [x] check
- [x] refactor test to follow DRY
### `XLMProphetNetTokenizer`
- [x] add `sp_model_kwargs` param with test
- [x] add pickle support with test
- [x] check
- [x] refactor test to follow DRY
- <s>remove obscure function argument called `sample`</s>
### `XLNetTokenizer`
- [x] add `sp_model_kwargs` param with test
- [x] add pickle support with test
- [x] remove obscure function argument called `sample`
- [x] check
- [x] refactor test to follow DRY
### `XML RoBERTa`
- [x] refactor test to follow DRY
### General
- [x] check if we changed all tokenizers
- [x] add typing
- [x] check if tok. is used in other functions
- [x] also add changes to XLM RoBERTa tokenizer
### After review
- [x] fix type comments with default `None`
- [x] possibly remove `test_sentencepiece_skip_back_convert_check`