### PR TITLE
[Makefile] make sure to test against the local checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: deps_table_update modified_only_fixup extra_quality_checks quality style fixup fix-copies test test-examples docs
 
+# make sure to test the local checkout in scripts and not the pre-installed one (don't use quotes!)
+export PYTHONPATH = src
 
 check_dirs := examples tests src utils
 


### PR DESCRIPTION
Currently some scripts in `Makefile` run against the pre-installed `transformers` rather than the checkout it's supposed to test. This PR fixes that by setting ` PYTHONPATH="src"`.

I had to fix that as I was getting at the end of `make fixup`:
```
python utils/check_repo.py
2021-04-25 21:54:53.850434: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcudart.so.11.0
Checking all models are properly tested.
Traceback (most recent call last):
  File "utils/check_repo.py", line 481, in <module>
    check_repo_quality()
  File "utils/check_repo.py", line 473, in check_repo_quality
    check_all_models_are_tested()
  File "utils/check_repo.py", line 233, in check_all_models_are_tested
    modules = get_model_modules()
  File "utils/check_repo.py", line 147, in get_model_modules
    modeling_module = getattr(model_module, submodule)
  File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/file_utils.py", line 1666, in __getattr__
    value = self._get_module(name)
  File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/models/albert/__init__.py", line 120, in _get_module
    return importlib.import_module("." + module_name, self.__name__)
  File "/home/stas/anaconda3/envs/py38-pt18/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/models/albert/modeling_tf_albert.py", line 43, in <module>
    from ...modeling_tf_utils import (
  File "src/transformers/modeling_tf_utils.py", line 32, in <module>
    from .file_utils import (
ImportError: cannot import name 'PushToHubMixin' from 'transformers.file_utils' (/mnt/nvme1/code/huggingface/transformers-master/src/transformers/file_utils.py)
```

The errors are from the pre-installed `transformers` and not the clone I'm working on.

The CI failures are unrelated - this can be safely merged.

@sgugger 
