### PR TITLE
update QuickTour docs to reflect model output object

### DIFF
--- a/docs/source/main_classes/output.rst
+++ b/docs/source/main_classes/output.rst
@@ -13,8 +13,8 @@
 Model outputs
 -----------------------------------------------------------------------------------------------------------------------
 
-All models have outputs that are instances of subclasses of :class:`~transformers.file_utils.ModelOutput`. Those
-are data structures containing all the information returned by the model, but that can also be used as tuples or
+All models have outputs that are instances of subclasses of :class:`~transformers.file_utils.ModelOutput`. Those are
+data structures containing all the information returned by the model, but that can also be used as tuples or
 dictionaries.
 
 Let's see of this looks on an example:

--- a/docs/source/main_classes/output.rst
+++ b/docs/source/main_classes/output.rst
@@ -13,7 +13,7 @@
 Model outputs
 -----------------------------------------------------------------------------------------------------------------------
 
-PyTorch models have outputs that are instances of subclasses of :class:`~transformers.file_utils.ModelOutput`. Those
+All models have outputs that are instances of subclasses of :class:`~transformers.file_utils.ModelOutput`. Those
 are data structures containing all the information returned by the model, but that can also be used as tuples or
 dictionaries.
 

--- a/docs/source/quicktour.rst
+++ b/docs/source/quicktour.rst
@@ -238,23 +238,21 @@ keys directly to tensors, for a PyTorch model, you need to unpack the dictionary
     >>> ## TENSORFLOW CODE
     >>> tf_outputs = tf_model(tf_batch)
 
-In 🤗 Transformers, all outputs are tuples (with only one element potentially). Here, we get a tuple with just the final
-activations of the model.
+In 🤗 Transformers, all outputs are objects that contain the model's final activations along with other metadata.  These objects are described in greater detail :doc:`here <main_classes/output>`.  For now, let's inspect the output ourselves:
 
 .. code-block::
 
     >>> ## PYTORCH CODE
     >>> print(pt_outputs)
-    (tensor([[-4.0833,  4.3364],
-            [ 0.0818, -0.0418]], grad_fn=<AddmmBackward>),)
+    SequenceClassifierOutput(loss=None, logits=tensor([[-4.0833,  4.3364],
+        [ 0.0818, -0.0418]], grad_fn=<AddmmBackward>), hidden_states=None, attentions=None)
     >>> ## TENSORFLOW CODE
     >>> print(tf_outputs)
-    (<tf.Tensor: shape=(2, 2), dtype=float32, numpy=
-    array([[-4.0832963 ,  4.336414  ],
-           [ 0.08181786, -0.04179301]], dtype=float32)>,)
+    TFSequenceClassifierOutput(loss=None, logits=<tf.Tensor: shape=(2, 2), dtype=float32, numpy=
+    array([[-4.0832963 ,  4.3364143 ],
+           [ 0.081807  , -0.04178282]], dtype=float32)>, hidden_states=None, attentions=None)
 
-The model can return more than just the final activations, which is why the output is a tuple. Here we only asked for
-the final activations, so we get a tuple with one element.
+Notice how the output object has a ``logits`` attribute.  You can use this to access the model's final activations.
 
 .. note::
 
@@ -267,10 +265,10 @@ Let's apply the SoftMax activation to get predictions.
 
     >>> ## PYTORCH CODE
     >>> import torch.nn.functional as F
-    >>> pt_predictions = F.softmax(pt_outputs[0], dim=-1)
+    >>> pt_predictions = F.softmax(pt_outputs.logits, dim=-1)
     >>> ## TENSORFLOW CODE
     >>> import tensorflow as tf
-    >>> tf_predictions = tf.nn.softmax(tf_outputs[0], axis=-1)
+    >>> tf.nn.softmax(tf_outputs.logits, axis=-1)
 
 We can see we get the numbers from before:
 

--- a/docs/source/quicktour.rst
+++ b/docs/source/quicktour.rst
@@ -238,7 +238,8 @@ keys directly to tensors, for a PyTorch model, you need to unpack the dictionary
     >>> ## TENSORFLOW CODE
     >>> tf_outputs = tf_model(tf_batch)
 
-In 🤗 Transformers, all outputs are objects that contain the model's final activations along with other metadata.  These objects are described in greater detail :doc:`here <main_classes/output>`.  For now, let's inspect the output ourselves:
+In 🤗 Transformers, all outputs are objects that contain the model's final activations along with other metadata. These
+objects are described in greater detail :doc:`here <main_classes/output>`. For now, let's inspect the output ourselves:
 
 .. code-block::
 
@@ -252,7 +253,7 @@ In 🤗 Transformers, all outputs are objects that contain the model's final act
     array([[-4.0832963 ,  4.3364143 ],
            [ 0.081807  , -0.04178282]], dtype=float32)>, hidden_states=None, attentions=None)
 
-Notice how the output object has a ``logits`` attribute.  You can use this to access the model's final activations.
+Notice how the output object has a ``logits`` attribute. You can use this to access the model's final activations.
 
 .. note::
 


### PR DESCRIPTION
Currently, the [Quick tour](https://huggingface.co/transformers/quicktour.html#) docs shows model output as tuples when you print them out.  In the current version of 🤗, the user sees an object that inherits from the `ModelOutput` class.  Yes, you can still access this object as a tuple, but this might be confusing for many readers, especially since this is the very first document that many people see when using 🤗 .

This PR does the following things:

1. Changes code examples in the Quick Tour to show the output object, not the tuple.  
2. Minor modification in the `Model Output` doc as _both_ PyTorch and Tensorflow models return an object that is an instance of a subclass of `ModelOutput`.
 
@sgugger

P.S. I am planning to go through all of the documentation very carefully like this, please let me know if there is anything along these lines that I can pay more attention to that is needed. 
