### PR TITLE
[model loading] don't init weights for pretrained models

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -769,7 +769,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         Initializes and prunes weights if needed.
         """
         # Initialize weights
-        self.apply(self._init_weights)
+        if not self.config.use_pretrained_weights:
+            self.apply(self._init_weights)
+        else:
+            logger.info("detected pretrained model - skipping _init_weights")
 
         # Prune heads if needed
         if self.config.pruned_heads:
@@ -1116,8 +1119,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         config.name_or_path = pretrained_model_name_or_path
 
-        # Instantiate model.
+        # weights are coming from state_dict so tell models not to init weights, since that
+        # randomization will be immediately overwritten by weights from state_dict
+        config.use_pretrained_weights = True
 
+        # Instantiate model.
         if is_deepspeed_zero3_enabled():
             import deepspeed
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -769,10 +769,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         Initializes and prunes weights if needed.
         """
         # Initialize weights
-        if not self.config.use_pretrained_weights:
-            self.apply(self._init_weights)
-        else:
+        if getattr(self.config, "use_pretrained_weights", False):
             logger.info("detected pretrained model - skipping _init_weights")
+        else:
+            self.apply(self._init_weights)
 
         # Prune heads if needed
         if self.config.pruned_heads:


### PR DESCRIPTION
Skip `_init_weights` for pretrained models since they get immediately replaced by pretrained weights. This leads to a much faster startup for huge models.

Fixes: https://github.com/huggingface/transformers/issues/9205

@sgugger, @patrickvonplaten 