### PR TITLE
Adding new argument `max_new_tokens` for generate.

### DIFF
--- a/tests/test_generation_stopping_criteria.py
+++ b/tests/test_generation_stopping_criteria.py
@@ -12,6 +12,7 @@ if is_torch_available():
 
     from transformers.generation_stopping_criteria import (
         MaxLengthCriteria,
+        MaxNewTokensCriteria,
         MaxTimeCriteria,
         StoppingCriteriaList,
         validate_stopping_criteria,
@@ -57,6 +58,21 @@ class StoppingCriteriaTestCase(unittest.TestCase):
 
         input_ids, scores = self._get_tensors(10)
         self.assertTrue(criteria(input_ids, scores))
+
+    def test_max_new_tokens_criteria(self):
+        criteria = MaxNewTokensCriteria(start_length=5, max_new_tokens=5)
+
+        input_ids, scores = self._get_tensors(5)
+        self.assertFalse(criteria(input_ids, scores))
+
+        input_ids, scores = self._get_tensors(9)
+        self.assertFalse(criteria(input_ids, scores))
+
+        input_ids, scores = self._get_tensors(10)
+        self.assertTrue(criteria(input_ids, scores))
+
+        criteria_list = StoppingCriteriaList([criteria])
+        self.assertEqual(criteria_list.max_length, 10)
 
     def test_max_time_criteria(self):
         input_ids, scores = self._get_tensors(5)

--- a/tests/test_generation_utils.py
+++ b/tests/test_generation_utils.py
@@ -1626,18 +1626,15 @@ class GenerationIntegrationTests(unittest.TestCase):
 
         # Encoder decoder call
         max_new_tokens = 3
-        with torch.no_grad():
-            outputs = bart_model.generate(input_ids, max_new_tokens=max_new_tokens)
+        outputs = bart_model.generate(input_ids, max_new_tokens=max_new_tokens)
         # 1 BOS + 3 new tokens
         self.assertEqual(list(outputs.shape), [1, 4])
 
         # Decoder only call
-        with torch.no_grad():
-            outputs = bart_model.generate(decoder_input_ids=input_ids, max_new_tokens=max_new_tokens)
+        outputs = bart_model.generate(decoder_input_ids=input_ids, max_new_tokens=max_new_tokens)
         # 15 + 3 new tokens
         self.assertEqual(list(outputs.shape), [1, 18])
 
-        with torch.no_grad():
-            # max_new_tokens and max_length serve the same purpose and should not be used together.
-            with self.assertWarns(UserWarning):
-                outputs = bart_model.generate(decoder_input_ids=input_ids, max_new_tokens=10, max_length=20)
+        # max_new_tokens and max_length serve the same purpose and should not be used together.
+        with self.assertWarns(UserWarning):
+            outputs = bart_model.generate(decoder_input_ids=input_ids, max_new_tokens=10, max_length=20)

--- a/tests/test_generation_utils.py
+++ b/tests/test_generation_utils.py
@@ -1636,3 +1636,8 @@ class GenerationIntegrationTests(unittest.TestCase):
             outputs = bart_model.generate(decoder_input_ids=input_ids, max_new_tokens=max_new_tokens)
         # 15 + 3 new tokens
         self.assertEqual(list(outputs.shape), [1, 18])
+
+        with torch.no_grad():
+            # max_new_tokens and max_length serve the same purpose and should not be used together.
+            with self.assertWarns(UserWarning):
+                outputs = bart_model.generate(decoder_input_ids=input_ids, max_new_tokens=10, max_length=20)

--- a/tests/test_generation_utils.py
+++ b/tests/test_generation_utils.py
@@ -1615,3 +1615,24 @@ class GenerationIntegrationTests(unittest.TestCase):
 
         # BeamSearchScorer max_length should not influence "real" max_length
         self.assertEqual(generated_ids.tolist(), generated_ids_no_max_len.tolist())
+
+    def test_max_new_tokens(self):
+        article = """Justin Timberlake and Jessica Biel, welcome to parenthood."""
+        bart_tokenizer = BartTokenizer.from_pretrained("sshleifer/bart-tiny-random")
+        bart_model = BartForConditionalGeneration.from_pretrained("sshleifer/bart-tiny-random").to(torch_device)
+        input_ids = bart_tokenizer(article, return_tensors="pt").input_ids.to(torch_device)
+
+        self.assertEqual(list(input_ids.shape), [1, 15])
+
+        # Encoder decoder call
+        max_new_tokens = 3
+        with torch.no_grad():
+            outputs = bart_model.generate(input_ids, max_new_tokens=max_new_tokens)
+        # 1 BOS + 3 new tokens
+        self.assertEqual(list(outputs.shape), [1, 4])
+
+        # Decoder only call
+        with torch.no_grad():
+            outputs = bart_model.generate(decoder_input_ids=input_ids, max_new_tokens=max_new_tokens)
+        # 15 + 3 new tokens
+        self.assertEqual(list(outputs.shape), [1, 18])


### PR DESCRIPTION
# What does this PR do?

This is a proposal to add a new argument `max_new_tokens` to `generate`.
This include a `MaxNewTokensCriteria` that enables callers that don't
know about the token length ahead (like pipelines callers) to manage
more easily the length of their generated output.

`max_length` is a hard to use argument for generate:

- It means different things in `encoder-decoder` context and
`decoder-only` context
  - `encoder-decoder`: max_length = max_new_tokens - 1 (in case of bos)
  - `decoder-only`: max_length = input_ids.shape[-1] + max_new_tokens
- It is hard to understand from a pipeline point of view where `tokens`
do not exist yet.


This is a proposal to add a new argument `max_new_tokens` to `generate`.
This include a `MaxNewTokensCriteria` which is a bit redundant with
respect to `MaxLengthCriteria`. It is a consistency concern for now but debattable.



<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@LysandreJik  @patrickvonplaten 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->