### PR TITLE
Move integrations imports before any ML framework imports

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -39,15 +39,15 @@ else:
 
 from typing import TYPE_CHECKING
 
+
 # Integrations: import before any ML framework
-from .integrations import (
-    is_comet_available,
-    is_optuna_available,
-    is_ray_available,
-    is_ray_tune_available,
-    is_tensorboard_available,
-    is_wandb_available,
-)
+from .integrations (is_comet_available,  # isort:skip
+                    is_optuna_available,
+                    is_ray_available,
+                    is_ray_tune_available,
+                    is_tensorboard_available,
+                    is_wandb_available)
+
 
 # Check the dependencies satisfy the minimal versions required.
 from . import dependency_versions_check

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -1474,6 +1474,16 @@ if TYPE_CHECKING:
     )
     from .hf_argparser import HfArgumentParser
 
+    # Integrations
+    from .integrations import (
+        is_comet_available,
+        is_optuna_available,
+        is_ray_available,
+        is_ray_tune_available,
+        is_tensorboard_available,
+        is_wandb_available,
+    )
+
     # Model Cards
     from .modelcard import ModelCard
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -41,13 +41,17 @@ from typing import TYPE_CHECKING
 
 
 # Integrations: import before any ML framework
-from .integrations (is_comet_available,  # isort:skip
-                    is_optuna_available,
-                    is_ray_available,
-                    is_ray_tune_available,
-                    is_tensorboard_available,
-                    is_wandb_available)
+# isort: off
+from .integrations import (
+    is_comet_available,
+    is_optuna_available,
+    is_ray_available,
+    is_ray_tune_available,
+    is_tensorboard_available,
+    is_wandb_available,
+)
 
+# isort: on
 
 # Check the dependencies satisfy the minimal versions required.
 from . import dependency_versions_check

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -39,6 +39,16 @@ else:
 
 from typing import TYPE_CHECKING
 
+# Integrations: import before any ML framework
+from .integrations import (
+    is_comet_available,
+    is_optuna_available,
+    is_ray_available,
+    is_ray_tune_available,
+    is_tensorboard_available,
+    is_wandb_available,
+)
+
 # Check the dependencies satisfy the minimal versions required.
 from . import dependency_versions_check
 from .file_utils import (
@@ -1459,16 +1469,6 @@ if TYPE_CHECKING:
         is_vision_available,
     )
     from .hf_argparser import HfArgumentParser
-
-    # Integrations
-    from .integrations import (
-        is_comet_available,
-        is_optuna_available,
-        is_ray_available,
-        is_ray_tune_available,
-        is_tensorboard_available,
-        is_wandb_available,
-    )
 
     # Model Cards
     from .modelcard import ModelCard

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -45,7 +45,7 @@ if _has_comet:
         _has_comet = False
 
 
-from .dependency_versions_check import dep_version_check
+from .dependency_versions_check import dep_version_check  # noqa: E402
 from .file_utils import ENV_VARS_TRUE_VALUES, is_torch_tpu_available  # noqa: E402
 from .trainer_callback import TrainerCallback  # noqa: E402
 from .trainer_utils import PREFIX_CHECKPOINT_DIR, BestRun, IntervalStrategy  # noqa: E402

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -24,13 +24,6 @@ import weakref
 from copy import deepcopy
 from pathlib import Path
 
-from .dependency_versions_check import dep_version_check
-from .utils import logging
-
-
-logger = logging.get_logger(__name__)
-
-
 # comet_ml requires to be imported before any ML frameworks
 _has_comet = importlib.util.find_spec("comet_ml") is not None and os.getenv("COMET_MODE", "").upper() != "DISABLED"
 if _has_comet:
@@ -45,6 +38,13 @@ if _has_comet:
             _has_comet = False
     except (ImportError, ValueError):
         _has_comet = False
+
+
+from .dependency_versions_check import dep_version_check
+from .utils import logging
+
+
+logger = logging.get_logger(__name__)
 
 from .file_utils import ENV_VARS_TRUE_VALUES, is_torch_tpu_available  # noqa: E402
 from .trainer_callback import TrainerCallback  # noqa: E402

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 from .utils import logging
 
+
 logger = logging.get_logger(__name__)
 
 # comet_ml requires to be imported before any ML frameworks
@@ -45,7 +46,6 @@ if _has_comet:
 
 
 from .dependency_versions_check import dep_version_check
-
 from .file_utils import ENV_VARS_TRUE_VALUES, is_torch_tpu_available  # noqa: E402
 from .trainer_callback import TrainerCallback  # noqa: E402
 from .trainer_utils import PREFIX_CHECKPOINT_DIR, BestRun, IntervalStrategy  # noqa: E402

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -24,11 +24,15 @@ import weakref
 from copy import deepcopy
 from pathlib import Path
 
+from .utils import logging
+
+logger = logging.get_logger(__name__)
+
 # comet_ml requires to be imported before any ML frameworks
 _has_comet = importlib.util.find_spec("comet_ml") is not None and os.getenv("COMET_MODE", "").upper() != "DISABLED"
 if _has_comet:
     try:
-        import comet_ml  # noqa: F401
+        import comet_ml  # noqa: F401,E402
 
         if hasattr(comet_ml, "config") and comet_ml.config.get_config("comet.api_key"):
             _has_comet = True
@@ -41,10 +45,6 @@ if _has_comet:
 
 
 from .dependency_versions_check import dep_version_check
-from .utils import logging
-
-
-logger = logging.get_logger(__name__)
 
 from .file_utils import ENV_VARS_TRUE_VALUES, is_torch_tpu_available  # noqa: E402
 from .trainer_callback import TrainerCallback  # noqa: E402


### PR DESCRIPTION
## Fixes

Current transformers breaks compatibility with comet_ml because it needs to be imported before any ML frameworks (such as torch). This PR simply moves the imports earlier in the flow.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

- integrations and imports: @sgugger
