### PR TITLE
Update `PreTrainedTokenizerBase` to check/handle batch length for `text_pair` parameter

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2281,7 +2281,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         if is_batched:
             if isinstance(text_pair, str):
                 text_pair = [text_pair] * len(text)
-            else:
+            if text_pair is not None:
                 assert len(text) == len(
                     text_pair
                 ), f"batch length of `text`: {len(text)} does not match batch length of `text_pair`: {len(text_pair)}"

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2279,6 +2279,8 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         )
 
         if is_batched:
+            if isinstance(text_pair, str): 
+                text_pair = [text_pair]
             batch_text_or_text_pairs = list(zip(text, text_pair)) if text_pair is not None else text
             return self.batch_encode_plus(
                 batch_text_or_text_pairs=batch_text_or_text_pairs,

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2280,9 +2280,13 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
 
         if is_batched:
             if isinstance(text_pair, str):
-                text_pair = [text_pair] * len(text)
-if text_pair is not None and len(text) != len(text_pair):
-    raise ValueError(f"batch length of `text`: {len(text)} does not match batch length of `text_pair`: {len(text_pair)}.")
+                raise TypeError(
+                    "when tokenizing batches of text, `text_pair` must be a list or tuple with the same length as `text`."
+                )
+            if text_pair is not None and len(text) != len(text_pair):
+                raise ValueError(
+                    f"batch length of `text`: {len(text)} does not match batch length of `text_pair`: {len(text_pair)}."
+                )
             batch_text_or_text_pairs = list(zip(text, text_pair)) if text_pair is not None else text
             return self.batch_encode_plus(
                 batch_text_or_text_pairs=batch_text_or_text_pairs,

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2279,8 +2279,12 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         )
 
         if is_batched:
-            if isinstance(text_pair, str): 
-                text_pair = [text_pair]
+            if isinstance(text_pair, str):
+                text_pair = [text_pair] * len(text)
+            else:
+                assert len(text) == len(
+                    text_pair
+                ), f"batch length of `text`: {len(text)} does not match batch length of `text_pair`: {len(text_pair)}"
             batch_text_or_text_pairs = list(zip(text, text_pair)) if text_pair is not None else text
             return self.batch_encode_plus(
                 batch_text_or_text_pairs=batch_text_or_text_pairs,

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2281,10 +2281,8 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         if is_batched:
             if isinstance(text_pair, str):
                 text_pair = [text_pair] * len(text)
-            if text_pair is not None:
-                assert len(text) == len(
-                    text_pair
-                ), f"batch length of `text`: {len(text)} does not match batch length of `text_pair`: {len(text_pair)}"
+if text_pair is not None and len(text) != len(text_pair):
+    raise ValueError(f"batch length of `text`: {len(text)} does not match batch length of `text_pair`: {len(text_pair)}.")
             batch_text_or_text_pairs = list(zip(text, text_pair)) if text_pair is not None else text
             return self.batch_encode_plus(
                 batch_text_or_text_pairs=batch_text_or_text_pairs,


### PR DESCRIPTION
Consider the following example:

```py
from transformers import AutoTokenizer, AutoModelForQuestionAnswering
import torch
tokenizer = AutoTokenizer.from_pretrained("bert-large-uncased-whole-word-masking-finetuned-squad")
text = r"""
🤗 Transformers (formerly known as pytorch-transformers and pytorch-pretrained-bert) provides general-purpose
architectures (BERT, GPT-2, RoBERTa, XLM, DistilBert, XLNet…) for Natural Language Understanding (NLU) and Natural
Language Generation (NLG) with over 32+ pretrained models in 100+ languages and deep interoperability between
TensorFlow 2.0 and PyTorch.
"""
questions = [
    "How many pretrained models are available in 🤗 Transformers?",
    "What does 🤗 Transformers provide?",
    "🤗 Transformers provides interoperability between which frameworks?"
]

inp = tokenizer(text=questions, 
                text_pair=text, 
                add_special_tokens=True, 
                padding=True, 
                truncation=True,
                return_tensors="pt")

print(inp.input_ids.shape)
```

**The error in the above example is that the parameter `text_pair` is a string, but is supposed to be a `List[str]` to match the batch size of `text`.**

Currently, this silently fails because when  `text_pair` is a string it is treated as an iterable causing `zip(text, text_pair)` to erroneously build the wrong inputs to the model.  This PR adds the following:

1.  If `text_pair` is a string but the user passes in a batch of `text`, we convert the input for them automatically (For example when you want to ask multiple questions of the same passage). 
2.  Adds error checking to see if the batch length of `text` matches the batch length of `text_pair` ONLY when a batch of inputs is used.


@LysandreJik @sgugger






