### PR TITLE
correct incorrect dimension comment in Longformer model

### DIFF
--- a/src/transformers/models/longformer/modeling_longformer.py
+++ b/src/transformers/models/longformer/modeling_longformer.py
@@ -814,7 +814,7 @@ class LongformerSelfAttention(nn.Module):
         # matrix multiplication
         # bcxd: batch_size * num_heads x chunks x 2window_overlap x head_dim
         # bcyd: batch_size * num_heads x chunks x 2window_overlap x head_dim
-        # bcxy: batch_size * num_heads x chunks x 2window_overlap x window_overlap
+        # bcxy: batch_size * num_heads x chunks x 2window_overlap x 2window_overlap
         diagonal_chunked_attention_scores = torch.einsum("bcxd,bcyd->bcxy", (query, key))  # multiply
 
         # convert diagonals into columns


### PR DESCRIPTION
This PR fixes a comment that incorrectly states the dimensions of a certain tensor in the `Longformer` model, confusing any reader trying to understand the code. The comment for the corresponding `TFLongformerX` is correct. 

- [x ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

Tagging @patrickvonplaten  (Longformer)

