### PR TITLE
[DeepSpeed] fp32 support

### DIFF
--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -1507,6 +1507,25 @@ and ``total_num_steps`, ``warmup_max_lr``, ``warmup_num_steps`` and ``total_num_
 
 
 
+
+fp32 Training
+=======================================================================================================================
+
+Deepspeed supports the full fp32 and also the fp16 mixed precision training.
+
+Because of the much lower memory requirements and faster speed one gets with the fp16 mixed precision,
+the only time you will want to not use it is when the model you're using doesn't behave well in this mode, typically this happens when the model wasn't pretrained in fp16 mixed precision (e.g. often this happens with bf16-pretrained models). Such models often overflow or underflow leading to ``NaN`` loss. If this is your case then you will want to use the fp32 mode, by disabling the fp16 mode, like so:
+
+.. code-block:: json
+
+    {
+        "fp16": {
+            "enabled": "false",
+        }
+    }
+
+
+
 Automatic Mixed Precision
 =======================================================================================================================
 

--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -1513,8 +1513,11 @@ fp32 Training
 
 Deepspeed supports the full fp32 and also the fp16 mixed precision training.
 
-Because of the much lower memory requirements and faster speed one gets with the fp16 mixed precision,
-the only time you will want to not use it is when the model you're using doesn't behave well in this mode, typically this happens when the model wasn't pretrained in fp16 mixed precision (e.g. often this happens with bf16-pretrained models). Such models often overflow or underflow leading to ``NaN`` loss. If this is your case then you will want to use the fp32 mode, by disabling the fp16 mode, like so:
+Because of the much lower memory requirements and faster speed one gets with the fp16 mixed precision, the only time
+you will want to not use it is when the model you're using doesn't behave well in this mode, typically this happens
+when the model wasn't pretrained in fp16 mixed precision (e.g. often this happens with bf16-pretrained models). Such
+models often overflow or underflow leading to ``NaN`` loss. If this is your case then you will want to use the fp32
+mode, by disabling the fp16 mode, like so:
 
 .. code-block:: json
 

--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -1508,16 +1508,16 @@ and ``total_num_steps`, ``warmup_max_lr``, ``warmup_num_steps`` and ``total_num_
 
 
 
-fp32 Training
+fp32 Precision
 =======================================================================================================================
 
-Deepspeed supports the full fp32 and also the fp16 mixed precision training.
+Deepspeed supports the full fp32 and the fp16 mixed precision.
 
-Because of the much lower memory requirements and faster speed one gets with the fp16 mixed precision, the only time
-you will want to not use it is when the model you're using doesn't behave well in this mode, typically this happens
-when the model wasn't pretrained in fp16 mixed precision (e.g. often this happens with bf16-pretrained models). Such
-models often overflow or underflow leading to ``NaN`` loss. If this is your case then you will want to use the fp32
-mode, by disabling the fp16 mode, like so:
+Because of the much reduced memory needs and faster speed one gets with the fp16 mixed precision, the only time you
+will want to not use it is when the model you're using doesn't behave well under this training mode. Typically this
+happens when the model wasn't pretrained in the fp16 mixed precision (e.g. often this happens with bf16-pretrained
+models). Such models may overflow or underflow leading to ``NaN`` loss. If this is your case then you will want to use
+the full fp32 mode, by explicitly disabling the otherwise default fp16 mode with:
 
 .. code-block:: json
 
@@ -1526,6 +1526,13 @@ mode, by disabling the fp16 mode, like so:
             "enabled": "false",
         }
     }
+
+If you're using the Ampere-architecture based GPU, pytorch version 1.7 and higher will automatically switch to using
+the much more efficient tf32 format for some operations, but the results will still be in fp32. For details and
+benchmarks, please, see `TensorFloat-32(TF32) on Ampere devices
+<https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices>`__. The document includes
+instructions on how to disable this automatic conversion if for some reason you prefer not to use it.
+
 
 
 
@@ -1553,11 +1560,6 @@ and the :class:`~transformers.Trainer` will automatically enable or disable it b
 ``args.fp16_backend``. The rest of config values are up to you.
 
 This mode gets enabled when ``--fp16 --fp16_backend amp`` command line args are passed.
-
-.. note::
-
-   At the moment DeepSpeed doesn't supported fp32 mode, though it will become available soon. Until then it will be
-   always set to ``true``.
 
 You can also enable/disable this mode explicitly:
 

--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -1790,6 +1790,24 @@ stress on ``tensor([1.])``, or if you get an error where it says the parameter i
 larger multi-dimensional shape, this means that the parameter is partitioned and what you see is a ZeRO-3 placeholder.
 
 
+Troubleshooting
+=======================================================================================================================
+
+* ``deepspeed`` process gets killed at startup without a traceback
+
+If the ``deepspeed`` process gets killed at launch time without a traceback, that usually means that the program tried
+to allocate more CPU memory than your system has or your process is allowed to allocate and the OS kernel killed that
+process. This is because your configuration file most likely has either ``offload_optimizer`` or ``offload_param`` or
+both configured to offload to ``cpu`` (or under ZeRO-2 ``cpu_offload`` is enabled). If you have NVMe, experiment with
+offloading to NVMe if you're running under ZeRO-3.
+
+Work is being done to enable estimating how much memory is needed for a specific model: `PR
+<https://github.com/microsoft/DeepSpeed/pull/965>`__.
+
+
+
+
+
 
 Notes
 =======================================================================================================================

--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -1517,7 +1517,7 @@ Because of the much reduced memory needs and faster speed one gets with the fp16
 will want to not use it is when the model you're using doesn't behave well under this training mode. Typically this
 happens when the model wasn't pretrained in the fp16 mixed precision (e.g. often this happens with bf16-pretrained
 models). Such models may overflow or underflow leading to ``NaN`` loss. If this is your case then you will want to use
-the full fp32 mode, by explicitly disabling the otherwise default fp16 mode with:
+the full fp32 mode, by explicitly disabling the otherwise default fp16 mixed precision mode with:
 
 .. code-block:: json
 

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ _deps = [
     "cookiecutter==1.7.2",
     "dataclasses",
     "datasets",
-    "deepspeed>=0.3.15",
+    "deepspeed>=0.3.16",
     "docutils==0.16.0",
     "fairscale>0.3",
     "faiss-cpu",

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ _deps = [
     "cookiecutter==1.7.2",
     "dataclasses",
     "datasets",
-    "deepspeed>=0.3.16",
+    "deepspeed>=0.3.15",
     "docutils==0.16.0",
     "fairscale>0.3",
     "faiss-cpu",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -7,7 +7,7 @@ deps = {
     "cookiecutter": "cookiecutter==1.7.2",
     "dataclasses": "dataclasses",
     "datasets": "datasets",
-    "deepspeed": "deepspeed>=0.3.15",
+    "deepspeed": "deepspeed>=0.3.16",
     "docutils": "docutils==0.16.0",
     "fairscale": "fairscale>0.3",
     "faiss-cpu": "faiss-cpu",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -7,7 +7,7 @@ deps = {
     "cookiecutter": "cookiecutter==1.7.2",
     "dataclasses": "dataclasses",
     "datasets": "datasets",
-    "deepspeed": "deepspeed>=0.3.16",
+    "deepspeed": "deepspeed>=0.3.15",
     "docutils": "docutils==0.16.0",
     "fairscale": "fairscale>0.3",
     "faiss-cpu": "faiss-cpu",

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -374,10 +374,7 @@ class DeepSpeedConfigHF:
         # amp: similar to the pytorch native amp - it has a bunch of optional params but we won't set
         # any here unless the user did the work
         config_fp16 = config.get("fp16")
-        # XXX: at the moment fp16 can't be False, but the fp32 solution is in works - once it's PR'ed and
-        # merged and a new release is made, delete the next line and uncomment the one after it
-        _set_if_auto(config_fp16, "enabled", True)
-        # _set_if_auto(config_fp16, "enabled", fp16_backend == "amp")
+        _set_if_auto(config_fp16, "enabled", fp16_backend == "amp")
 
         # apex: delegates amp work to apex (which needs to be available), but it cannot be used with any
         # ZeRO features, so probably best to be avoided.

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1125,7 +1125,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # this immediately partitions the model across all gpus, to avoid the overhead in time
             # and memory copying it on CPU or each GPU first
 
-            with deepspeed.zero.Init(config=deepspeed_config()):
+            ds_config = deepspeed_config()
+            # XXX: Fixme - we shouldn't need to figure dtype out, it should be in the config file
+            dtype = torch.float16 if ds_config.get("fp16", {}).get("enabled", True) else torch.float
+            with deepspeed.zero.Init(dtype=dtype, config=ds_config):
                 model = cls(config, *model_args, **model_kwargs)
         else:
             model = cls(config, *model_args, **model_kwargs)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1124,11 +1124,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             logger.info("Detected DeepSpeed ZeRO-3: activating zero.init() for this model")
             # this immediately partitions the model across all gpus, to avoid the overhead in time
             # and memory copying it on CPU or each GPU first
-
-            ds_config = deepspeed_config()
-            # XXX: Fixme - we shouldn't need to figure dtype out, it should be in the config file
-            dtype = torch.float16 if ds_config.get("fp16", {}).get("enabled", True) else torch.float
-            with deepspeed.zero.Init(dtype=dtype, config=ds_config):
+            with deepspeed.zero.Init(config=deepspeed_config()):
                 model = cls(config, *model_args, **model_kwargs)
         else:
             model = cls(config, *model_args, **model_kwargs)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -44,7 +44,7 @@ from .file_utils import (
     replace_return_docstrings,
 )
 from .generation_utils import GenerationMixin
-from .integrations import is_deepspeed_zero3_enabled
+from .integrations import deepspeed_config, is_deepspeed_zero3_enabled
 from .utils import logging
 
 
@@ -1125,9 +1125,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # this immediately partitions the model across all gpus, to avoid the overhead in time
             # and memory copying it on CPU or each GPU first
 
-            # XXX: param_dict will be added in deepspeed==0.3.16 and probably replaced by deepspeed_config
-            # with deepspeed.zero.Init(param_dict=deepspeed_config()):
-            with deepspeed.zero.Init():
+            with deepspeed.zero.Init(config=deepspeed_config()):
                 model = cls(config, *model_args, **model_kwargs)
         else:
             model = cls(config, *model_args, **model_kwargs)


### PR DESCRIPTION
Things we need to sync with the upcoming `deepspeed==0.3.16` release:

- `zero.Init` now takes a config as an argument
- fp32-support integration, plus doc and tests
- start troubleshooting section

### Future TODO

will probably do in the next PR:
- switch `from_config()` to perform the same `zero.Init` as `from_pretrained` + add test.

###  Blocking events

PRs waiting to be merged before this PR can be merged:

- [x] https://github.com/microsoft/DeepSpeed/pull/1008 `zero.Init(config=ds_config)` new arg 
- [x] https://github.com/microsoft/DeepSpeed/pull/1004 fp32 support
- [x] new release is needed 0.3.16

@sgugger 