### PR TITLE
Pin HuggingFace Hub dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ _deps = [
     "flake8>=3.8.3",
     "flax>=0.3.2",
     "fugashi>=1.0",
-    "huggingface-hub>=0.0.8",
+    "huggingface-hub==0.0.8",
     "importlib_metadata",
     "ipadic>=1.0.0,<2.0",
     "isort>=5.5.4",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -16,7 +16,7 @@ deps = {
     "flake8": "flake8>=3.8.3",
     "flax": "flax>=0.3.2",
     "fugashi": "fugashi>=1.0",
-    "huggingface-hub": "huggingface-hub>=0.0.8",
+    "huggingface-hub": "huggingface-hub==0.0.8",
     "importlib_metadata": "importlib_metadata",
     "ipadic": "ipadic>=1.0.0,<2.0",
     "isort": "isort>=5.5.4",


### PR DESCRIPTION
There might be some breaking changes in the HuggingFace Hub library as development continues, so pin the dependency.