### PR TITLE
solved coefficient issue for the TF version of gelu_fast

### DIFF
--- a/src/transformers/activations_tf.py
+++ b/src/transformers/activations_tf.py
@@ -57,8 +57,8 @@ def mish(x):
 
 def gelu_fast(x):
     x = tf.convert_to_tensor(x)
-    coeff1 = tf.cast(0.7978845608, x.dtype)
-    coeff2 = tf.cast(0.044715, x.dtype)
+    coeff1 = tf.cast(0.044715, x.dtype)
+    coeff2 = tf.cast(0.7978845608, x.dtype)
 
     return 0.5 * x * (1.0 + tf.tanh(x * coeff2 * (1.0 + coeff1 * x * x)))
 


### PR DESCRIPTION
# What does this PR do?

This PR solves a bug in the Tensorflow version of gelu_fast: the two coefficients being used to compute the approximation were swapped, making the computation inaccurate.