### PR TITLE
Adding support for `pipeline("automatic-speech-recognition")`.

### DIFF
--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -450,15 +450,15 @@ def pipeline(
             tokenizer = AutoTokenizer.from_pretrained(
                 tokenizer_identifier, revision=revision, use_fast=use_fast, _from_pipeline=task, **tokenizer_kwargs
             )
-        elif model_class == "config" and isinstance(model_id, str):
+        elif model_class == "config":
             if config is None:
-                config = AutoConfig.from_pretrained(model_id, revision=revision, _from_pipeline=task, **model_kwargs)
+                config = AutoConfig.from_pretrained(model, revision=revision, _from_pipeline=task, **model_kwargs)
             try:
                 import transformers
 
                 model_class = getattr(transformers, config.architectures[0])
             except Exception:
-                raise Exception(f"Could not load default model class for {model_id}")
+                raise Exception(f"Could not load default model class for {model}")
 
     if load_feature_extractor:
         # Try to infer feature extractor from model or config name (if provided as str)

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -450,15 +450,6 @@ def pipeline(
             tokenizer = AutoTokenizer.from_pretrained(
                 tokenizer_identifier, revision=revision, use_fast=use_fast, _from_pipeline=task, **tokenizer_kwargs
             )
-        elif model_class == "config":
-            if config is None:
-                config = AutoConfig.from_pretrained(model, revision=revision, _from_pipeline=task, **model_kwargs)
-            try:
-                import transformers
-
-                model_class = getattr(transformers, config.architectures[0])
-            except Exception:
-                raise Exception(f"Could not load default model class for {model}")
 
     if load_feature_extractor:
         # Try to infer feature extractor from model or config name (if provided as str)

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -95,8 +95,6 @@ if is_torch_available():
         AutoModelForTableQuestionAnswering,
         AutoModelForTokenClassification,
     )
-    from ..models.speech_to_text.modeling_speech_to_text import Speech2TextForConditionalGeneration
-    from ..models.wav2vec2.modeling_wav2vec2 import Wav2Vec2ForCTC
 if TYPE_CHECKING:
     from ..modeling_tf_utils import TFPreTrainedModel
     from ..modeling_utils import PreTrainedModel
@@ -112,8 +110,10 @@ TASK_ALIASES = {
 SUPPORTED_TASKS = {
     "automatic-speech-recognition": {
         "impl": AutomaticSpeechRecognitionPipeline,
-        "tf": None,
-        "pt": "config" if is_torch_available() else None,
+        "tf": (),
+        # Only load from `config.architectures`, AutoModelForCTC and AutoModelForConditionalGeneration
+        # do not exist yet.
+        "pt": () if is_torch_available() else (),
         "default": {"model": {"pt": "facebook/wav2vec2-base-960h"}},
     },
     "feature-extraction": {

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -104,11 +104,11 @@ def infer_framework_load_model(
             classes = []
             for architecture in config.architectures:
                 transformers_module = importlib.import_module("transformers")
-                if look_tf:
+                if look_pt:
                     _class = getattr(transformers_module, architecture, None)
                     if _class is not None:
                         classes.append(_class)
-                if look_pt:
+                if look_tf:
                     _class = getattr(transformers_module, f"TF{architecture}", None)
                     if _class is not None:
                         classes.append(_class)

--- a/tests/test_pipelines_automatic_speech_recognition.py
+++ b/tests/test_pipelines_automatic_speech_recognition.py
@@ -16,13 +16,14 @@ import unittest
 
 from transformers import AutoFeatureExtractor, AutoTokenizer, Speech2TextForConditionalGeneration, Wav2Vec2ForCTC
 from transformers.pipelines import AutomaticSpeechRecognitionPipeline, pipeline
-from transformers.testing_utils import require_datasets, require_torch, require_torchaudio, slow
+from transformers.testing_utils import is_pipeline_test, require_datasets, require_torch, require_torchaudio, slow
 
 
 # We can't use this mixin because it assumes TF support.
 # from .test_pipelines_common import CustomInputPipelineCommonMixin
 
 
+@is_pipeline_test
 class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
     @require_torch
     @slow

--- a/tests/test_pipelines_automatic_speech_recognition.py
+++ b/tests/test_pipelines_automatic_speech_recognition.py
@@ -34,14 +34,14 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
     def test_torch_small(self):
         import numpy as np
 
-        nlp = pipeline(
+        speech_recognizer = pipeline(
             task="automatic-speech-recognition",
             model="facebook/s2t-small-mustc-en-fr-st",
             tokenizer="facebook/s2t-small-mustc-en-fr-st",
             framework="pt",
         )
         waveform = np.zeros((34000,))
-        output = nlp(waveform)
+        output = speech_recognizer(waveform)
         self.assertEqual(output, {"text": "C'est ce que j'ai fait à ce moment-là."})
 
     @require_datasets
@@ -50,21 +50,21 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
     def test_torch_large(self):
         import numpy as np
 
-        nlp = pipeline(
+        speech_recognizer = pipeline(
             task="automatic-speech-recognition",
             model="facebook/wav2vec2-base-960h",
             tokenizer="facebook/wav2vec2-base-960h",
             framework="pt",
         )
         waveform = np.zeros((34000,))
-        output = nlp(waveform)
+        output = speech_recognizer(waveform)
         self.assertEqual(output, {"text": ""})
 
         from datasets import load_dataset
 
         ds = load_dataset("patrickvonplaten/librispeech_asr_dummy", "clean", split="validation")
         filename = ds[0]["file"]
-        output = nlp(filename)
+        output = speech_recognizer(filename)
         self.assertEqual(output, {"text": "A MAN SAID TO THE UNIVERSE SIR I EXIST"})
 
     @slow


### PR DESCRIPTION
# What does this PR do?

Implements the default load logic to make `AutomaticSpeechRecognitionPipeline` work
like other pipelines with `pipeline(task="automatic-speech-recognition", ...)`.

The main issue with current implementation is `"config"` choice for AutoModel. It would be great to have the
possibility to have something like `AutoModelFor` that would implement
the same logic (Load the config, check Architectures and load the first
one)

Alternatives:

- Implement `AutoModelForCTC`, `AutoModelForConditionalGeneration`, allow the `ALLOWED_TASKS` mapping
  to accept iterables, and try to load models accordingly.
  This might enable better switch handling case here: https://github.com/huggingface/transformers/blob/master/src/transformers/pipelines/automatic_speech_recognition.py#L141 with actual `isinstance` instead of the dummy string check.
  This would change `ALLOWED_TASKS` logic but might be closer to existing code.


Other discussion could include the `Mixin` which wasn't used here. The main reason is because the mixin supposes
that TF is enabled, but the ASR models do not have a TF alternative right now. Still imported the main tests.

Better care of error raised could be added for the `feature_extractor` missing or incorrect.



<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->