### PR TITLE
Run model templates on master

### DIFF
--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -1,6 +1,9 @@
 name: Model templates runner
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     paths:
       - "src/**"


### PR DESCRIPTION
It currently runs on branches, but not on `master`.