### PR TITLE
Fix metric computation in `run_glue_no_trainer`

### DIFF
--- a/examples/pytorch/text-classification/run_glue_no_trainer.py
+++ b/examples/pytorch/text-classification/run_glue_no_trainer.py
@@ -404,7 +404,7 @@ def main():
         model.eval()
         for step, batch in enumerate(eval_dataloader):
             outputs = model(**batch)
-            predictions = outputs.logits.argmax(dim=-1)
+            predictions = outputs.logits.argmax(dim=-1) if not is_regression else outputs.logits.squeeze()
             metric.add_batch(
                 predictions=accelerator.gather(predictions),
                 references=accelerator.gather(batch["labels"]),


### PR DESCRIPTION
# What does this PR do?

There is a problem in the metric computation in `run_glue_no_trainer`, which always takes the argmax regardless of the task: when the problem is a regression problem it should not be the case.
Fixes #11555