### PR TITLE
[Deepspeed] fix resize_token_embeddings

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -682,7 +682,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             )
 
         # Build new embeddings
-        new_embeddings = nn.Embedding(new_num_tokens, old_embedding_dim).to(self.device)
+        new_embeddings = nn.Embedding(new_num_tokens, old_embedding_dim).to(
+            self.device, dtype=old_embeddings.weight.dtype
+        )
 
         # initialize all new embeddings (in particular added tokens)
         self._init_weights(new_embeddings)


### PR DESCRIPTION
the introduction of `model.resize_token_embeddings(len(tokenizer))` in https://github.com/huggingface/transformers/commit/57c8e822f7faa1c19f9926338f21f3aab2269997#diff-09777f56cee1060a535a72ce99a6c96cdb7f330c8cc3f9dcca442b3f7768237a
uncovered a bug in Deepspeed integration. 

We have to create the new resized embedding with the same dtype as the original.
If not deepspeed will fail to initialize with: `"Model must initialized in fp16 mode for ZeRO Stage 3.` error.

This PR fixes this bug.

@sgugger 
 