### PR TITLE
Make quality scripts work when one backend is missing.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,6 +391,8 @@ jobs:
         docker:
             - image: circleci/python:3.6
         resource_class: medium
+        environment:
+            TRANSFORMERS_IS_CI: yes
         parallelism: 1
         steps:
             - checkout

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -295,7 +295,7 @@ def check_models_are_auto_configured(module, all_auto_models):
 
 def check_all_models_are_auto_configured():
     """Check all models are each in an auto class."""
-    if os.getenv("TRANSFORMERS_IS_CI").upper() in ENV_VARS_TRUE_VALUES:
+    if os.getenv("TRANSFORMERS_IS_CI", "").upper() in ENV_VARS_TRUE_VALUES:
         raise Exception("Variable is properly set.")
     missing_backends = []
     if not is_torch_available():
@@ -306,7 +306,7 @@ def check_all_models_are_auto_configured():
         missing_backends.append("Flax")
     if len(missing_backends) > 0:
         missing = ", ".join(missing_backends)
-        if os.getenv("TRANSFORMERS_IS_CI").upper() in ENV_VARS_TRUE_VALUES:
+        if os.getenv("TRANSFORMERS_IS_CI", "").upper() in ENV_VARS_TRUE_VALUES:
             raise Exception(
                 "Full quality checks require all backends to be installed (with `pip install -e .[dev]` in the "
                 f"Transformers repo, the following are missing: {missing}."

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -295,10 +295,6 @@ def check_models_are_auto_configured(module, all_auto_models):
 
 def check_all_models_are_auto_configured():
     """Check all models are each in an auto class."""
-    print(f'TRANFORMERS_IS_CI: {os.getenv("TRANSFORMERS_IS_CI", "").upper()}')
-    print(os.getenv("TRANSFORMERS_IS_CI", "").upper() in ENV_VARS_TRUE_VALUES)
-    if os.getenv("TRANSFORMERS_IS_CI", "").upper() in ENV_VARS_TRUE_VALUES:
-        raise Exception("Variable is properly set.")
     missing_backends = []
     if not is_torch_available():
         missing_backends.append("PyTorch")

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -17,8 +17,10 @@ import importlib
 import inspect
 import os
 import re
+import warnings
 from pathlib import Path
 
+from transformers import is_flax_available, is_tf_available, is_torch_available
 from transformers.models.auto import get_values
 
 
@@ -250,15 +252,18 @@ def check_all_models_are_tested():
 def get_all_auto_configured_models():
     """Return the list of all models in at least one auto class."""
     result = set()  # To avoid duplicates we concatenate all model classes in a set.
-    for attr_name in dir(transformers.models.auto.modeling_auto):
-        if attr_name.startswith("MODEL_") and attr_name.endswith("MAPPING"):
-            result = result | set(get_values(getattr(transformers.models.auto.modeling_auto, attr_name)))
-    for attr_name in dir(transformers.models.auto.modeling_tf_auto):
-        if attr_name.startswith("TF_MODEL_") and attr_name.endswith("MAPPING"):
-            result = result | set(get_values(getattr(transformers.models.auto.modeling_tf_auto, attr_name)))
-    for attr_name in dir(transformers.models.auto.modeling_flax_auto):
-        if attr_name.startswith("FLAX_MODEL_") and attr_name.endswith("MAPPING"):
-            result = result | set(get_values(getattr(transformers.models.auto.modeling_flax_auto, attr_name)))
+    if is_torch_available():
+        for attr_name in dir(transformers.models.auto.modeling_auto):
+            if attr_name.startswith("MODEL_") and attr_name.endswith("MAPPING"):
+                result = result | set(get_values(getattr(transformers.models.auto.modeling_auto, attr_name)))
+    if is_tf_available():
+        for attr_name in dir(transformers.models.auto.modeling_tf_auto):
+            if attr_name.startswith("TF_MODEL_") and attr_name.endswith("MAPPING"):
+                result = result | set(get_values(getattr(transformers.models.auto.modeling_tf_auto, attr_name)))
+    if is_flax_available():
+        for attr_name in dir(transformers.models.auto.modeling_flax_auto):
+            if attr_name.startswith("FLAX_MODEL_") and attr_name.endswith("MAPPING"):
+                result = result | set(get_values(getattr(transformers.models.auto.modeling_flax_auto, attr_name)))
     return [cls.__name__ for cls in result]
 
 
@@ -289,6 +294,21 @@ def check_models_are_auto_configured(module, all_auto_models):
 
 def check_all_models_are_auto_configured():
     """Check all models are each in an auto class."""
+    missing_backends = []
+    if not is_torch_available():
+        missing_backends.append("PyTorch")
+    if not is_tf_available():
+        missing_backends.append("TensorFlow")
+    if not is_flax_available():
+        missing_backends.append("Flax")
+    if len(missing_backends) > 0:
+        missing = ", ".join(missing_backends)
+        warnings.warn(
+            "Full quality checks require all backends to be installed (with `pip install -e .[dev]` in the "
+            f"Transformers repo, the following are missing: {missing}. While it's probably fine as long as you didn't "
+            "make any change in one of those backends modeling files, you should probably execute the command above "
+            "to be on the safe side."
+        )
     modules = get_model_modules()
     all_auto_models = get_all_auto_configured_models()
     failures = []

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -295,7 +295,7 @@ def check_models_are_auto_configured(module, all_auto_models):
 
 def check_all_models_are_auto_configured():
     """Check all models are each in an auto class."""
-    print(f"TRANFORMERS_IS_CI: {os.getenv("TRANSFORMERS_IS_CI", "").upper()}")
+    print(f'TRANFORMERS_IS_CI: {os.getenv("TRANSFORMERS_IS_CI", "").upper()}')
     print(os.getenv("TRANSFORMERS_IS_CI", "").upper() in ENV_VARS_TRUE_VALUES)
     if os.getenv("TRANSFORMERS_IS_CI", "").upper() in ENV_VARS_TRUE_VALUES:
         raise Exception("Variable is properly set.")

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -295,6 +295,8 @@ def check_models_are_auto_configured(module, all_auto_models):
 
 def check_all_models_are_auto_configured():
     """Check all models are each in an auto class."""
+    print(f"TRANFORMERS_IS_CI: {os.getenv("TRANSFORMERS_IS_CI", "").upper()}")
+    print(os.getenv("TRANSFORMERS_IS_CI", "").upper() in ENV_VARS_TRUE_VALUES)
     if os.getenv("TRANSFORMERS_IS_CI", "").upper() in ENV_VARS_TRUE_VALUES:
         raise Exception("Variable is properly set.")
     missing_backends = []


### PR DESCRIPTION
# What does this PR do?

This PR makes the quality scripts issue a warning instead of erroring when one backend is missing (which shouldn't be the case since the contributing guide says to run `pip install -e .[dev]` but we never know). It's also fine since a user is unlikely to make changes to a specific backend of the library if it's not even installed.

Fixes #11570