### PR TITLE
Reproducible checkpoint

### DIFF
--- a/examples/pytorch/test_examples.py
+++ b/examples/pytorch/test_examples.py
@@ -204,7 +204,6 @@ class ExamplesTests(TestCasePlus):
             run_ner.main()
             result = get_results(tmp_dir)
             self.assertGreaterEqual(result["eval_accuracy"], 0.75)
-            self.assertGreaterEqual(result["eval_precision"], 0.75)
             self.assertLess(result["eval_loss"], 0.5)
 
     def test_run_squad(self):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1272,7 +1272,7 @@ class Trainer:
                                 else:
                                     torch.cuda.random.set_rng_state(checkpoint_rng_state[f"cuda_{args.local_rank}"])
                             else:
-                                if f"cuda" not in checkpoint_rng_state:
+                                if "cuda" not in checkpoint_rng_state:
                                     logger.warn(
                                         "You are resuming a training that was launched in a non-distributed fashion "
                                         "with GPUs on either in a distributed fashion or not on GPUs. Reproducibility "

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1409,10 +1409,10 @@ class Trainer:
                 )
                 return
         else:
-            rng_file = os.path.join(checkpoint, f"rng_state.pth")
+            rng_file = os.path.join(checkpoint, "rng_state.pth")
             if not os.path.isfile(os.path.join(checkpoint, rng_file)):
                 logger.info(
-                    f"Didn't find an RNG file, if you are resuming a training that was launched in a distributed "
+                    "Didn't find an RNG file, if you are resuming a training that was launched in a distributed "
                     "fashion, reproducibility is not guaranteed."
                 )
                 return
@@ -1518,10 +1518,10 @@ class Trainer:
                 # In non distributed, we save the global CUDA RNG state (will take care of DataParallel)
                 rng_states["cuda"] = torch.cuda.random.get_rng_state_all()
             else:
-                rng_states[f"cuda"] = torch.cuda.random.get_rng_state()
+                rng_states["cuda"] = torch.cuda.random.get_rng_state()
 
         if is_torch_tpu_available():
-            rng_states[f"xla"] = xm.get_rng_state().item()
+            rng_states["xla"] = xm.get_rng_state()
 
         if self.args.local_rank == -1:
             torch.save(rng_states, os.path.join(output_dir, "rng_state.pth"))

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -184,16 +184,6 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-def recursive_print(state_dict, prefix=""):
-    for key, value in state_dict.items():
-        if isinstance(value, dict):
-            recursive_print(value, prefix=key)
-        elif isinstance(value, torch.Tensor):
-            print(f"{prefix}/{key}: {value.shape}, {value.view(-1,).tolist()[:10]}")
-        else:
-            print(f"{prefix}/{key}: {value}")
-
-
 class Trainer:
     """
     Trainer is a simple but feature-complete training and eval loop for PyTorch, optimized for 🤗 Transformers.

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -565,7 +565,9 @@ class Trainer:
 
         else:
             if self.args.world_size <= 1:
-                return RandomSampler(self.train_dataset, generator=generator)
+                if _is_torch_generator_available:
+                    return RandomSampler(self.train_dataset, generator=generator)
+                return RandomSampler(self.train_dataset)
             elif (
                 self.args.parallel_mode in [ParallelMode.TPU, ParallelMode.SAGEMAKER_MODEL_PARALLEL]
                 and not self.args.dataloader_drop_last

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1406,20 +1406,20 @@ class Trainer:
 
     def _load_rng_state(self, checkpoint):
         # Load RNG states from `checkpoint`
-        if resume_from_checkpoint is None or not os.path.isfile(os.path.join(checkpoint, "rng_state.pth")):
+        if checkpoint is None or not os.path.isfile(os.path.join(checkpoint, "rng_state.pth")):
             return
 
         checkpoint_rng_state = torch.load(os.path.join(checkpoint, "rng_state.pth"))
         torch.random.set_rng_state(checkpoint_rng_state["cpu"])
         if torch.cuda.is_available():
-            if args.local_rank != -1:
-                if f"cuda_{args.local_rank}" not in checkpoint_rng_state:
+            if self.args.local_rank != -1:
+                if f"cuda_{self.args.local_rank}" not in checkpoint_rng_state:
                     logger.warn(
                         "You are resuming a training that was launched in a distributed fashion in a "
                         "non-distributed way. Reproducibility cannot be guaranteed."
                     )
                 else:
-                    torch.cuda.random.set_rng_state(checkpoint_rng_state[f"cuda_{args.local_rank}"])
+                    torch.cuda.random.set_rng_state(checkpoint_rng_state[f"cuda_{self.args.local_rank}"])
             else:
                 if "cuda" not in checkpoint_rng_state:
                     logger.warn(

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -510,6 +510,7 @@ class LengthGroupedSampler(Sampler):
         batch_size: int,
         lengths: Optional[List[int]] = None,
         model_input_name: Optional[str] = None,
+        generator=None,
     ):
         self.dataset = dataset
         self.batch_size = batch_size
@@ -525,12 +526,13 @@ class LengthGroupedSampler(Sampler):
                 )
             lengths = [len(feature[self.model_input_name]) for feature in dataset]
         self.lengths = lengths
+        self.generator = generator
 
     def __len__(self):
         return len(self.lengths)
 
     def __iter__(self):
-        indices = get_length_grouped_indices(self.lengths, self.batch_size)
+        indices = get_length_grouped_indices(self.lengths, self.batch_size, generator=self.generator)
         return iter(indices)
 
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -15,7 +15,9 @@
 
 import dataclasses
 import gc
+import math
 import os
+import random
 import re
 import tempfile
 import unittest
@@ -194,6 +196,26 @@ if is_torch_available():
                 return (y, y) if self.double_output else (y,)
             loss = torch.nn.functional.mse_loss(y, labels)
             return (loss, y, y) if self.double_output else (loss, y)
+
+    class RegressionRandomPreTrainedModel(PreTrainedModel):
+        config_class = RegressionModelConfig
+        base_model_prefix = "regression"
+
+        def __init__(self, config):
+            super().__init__(config)
+            self.a = torch.nn.Parameter(torch.tensor(config.a).float())
+            self.b = torch.nn.Parameter(torch.tensor(config.b).float())
+
+        def forward(self, input_x, labels=None, **kwargs):
+            y = input_x * self.a + self.b
+            if self.training:
+                # Add random noise from torch, numpy and random
+                y += 0.05 * torch.randn(1).squeeze() + 0.05 * torch.tensor(np.random.rand() + random.random())
+
+            if labels is None:
+                return (y,)
+            loss = torch.nn.functional.mse_loss(y, labels)
+            return (loss, y)
 
     class TstLayer(torch.nn.Module):
         def __init__(self, hidden_size):
@@ -698,6 +720,27 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
         with self.assertRaises(Exception) as context:
             trainer.train(resume_from_checkpoint=True)
         self.assertTrue("No valid checkpoint found in output directory" in str(context.exception))
+
+    def test_resume_training_with_randomness(self):
+        train_dataset = RegressionDataset(length=128)
+        eval_dataset = RegressionDataset()
+
+        config = RegressionModelConfig(a=0, b=2)
+        model = RegressionRandomPreTrainedModel(config)
+
+        tmp_dir = self.get_auto_remove_tmp_dir()
+        args = RegressionTrainingArguments(tmp_dir, save_steps=5, learning_rate=0.1)
+        trainer = Trainer(model, args, train_dataset=train_dataset, eval_dataset=eval_dataset)
+
+        trainer.train()
+        (a, b) = trainer.model.a.item(), trainer.model.b.item()
+
+        model = RegressionRandomPreTrainedModel(config)
+        trainer = Trainer(model, args, train_dataset=train_dataset, eval_dataset=eval_dataset)
+        trainer.train(resume_from_checkpoint=os.path.join(tmp_dir, "checkpoint-15"))
+        (a1, b1) = trainer.model.a.item(), trainer.model.b.item()
+        self.assertTrue(math.isclose(a, a1, rel_tol=1e-4))
+        self.assertTrue(math.isclose(b, b1, rel_tol=1e-4))
 
     def test_resume_training_with_gradient_accumulation(self):
         if torch.cuda.device_count() > 2:

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -45,7 +45,6 @@ from transformers.testing_utils import (
     require_torch_multi_gpu,
     slow,
 )
-from transformers.trainer_utils import set_seed
 from transformers.utils.hp_naming import TrialShortNamer
 
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -45,6 +45,7 @@ from transformers.testing_utils import (
     require_torch_multi_gpu,
     slow,
 )
+from transformers.trainer_utils import set_seed
 from transformers.utils.hp_naming import TrialShortNamer
 
 
@@ -208,9 +209,7 @@ if is_torch_available():
 
         def forward(self, input_x, labels=None, **kwargs):
             y = input_x * self.a + self.b
-            if self.training:
-                # Add random noise from torch, numpy and random
-                y += 0.05 * torch.randn(1).squeeze() + 0.05 * torch.tensor(np.random.rand() + random.random())
+            y += 0.05 * torch.randn(1).squeeze() + 0.05 * torch.tensor(np.random.rand() + random.random())
 
             if labels is None:
                 return (y,)
@@ -722,6 +721,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
         self.assertTrue("No valid checkpoint found in output directory" in str(context.exception))
 
     def test_resume_training_with_randomness(self):
+        set_seed(63)
         train_dataset = RegressionDataset(length=128)
         eval_dataset = RegressionDataset()
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes reproducibility when resuming training from a checkpoint for PyTorch >= 1.6 and non-TPU trainings. The current implementation in the Trainer had two flaws:

First when going over the data at the beginning (skipping epochs and batches), the first shuffling was the same in the original training or resuming from the checkpoint, but not the subsequents shufflings. This is because those shufflings were determined by the global torch RNG which had a different state at the end of epoch 1 in a full training vs just after the shuffle of epoch 1 in the resumed training. I did not identify the exact reason but there was one or several calls to the global torch RNG during epoch 1 of the full training and when resuming we only called for the shuffle of epoch 1.

To fix this, a generator is now used to determine the shuffling, this way the generator is set with the same seed in both cases (full training or resuming from checkpoint) and then has the exact same number of calls (one shuffle per epoch) so that generator ends up in the same state in the full training or when resuming from a checkpoint.

The second thing that was different is the CUDAs RNG states, which are used in the dropout layer of the models. To fix this, all RNG states are saved when saving a checkpoint and set after all the data skip phase when resuming training.

Fixes #11504
Fixes #11323