### PR TITLE
[template runner CI] copies need to be fixed too

### DIFF
--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -49,6 +49,7 @@ jobs:
           make style
           python utils/check_table.py --fix_and_overwrite
           python utils/check_dummies.py --fix_and_overwrite
+          python utils/check_copies.py --fix_and_overwrite
 
       - name: Run all non-slow tests
         run: |


### PR DESCRIPTION
This PR https://github.com/huggingface/transformers/pull/11475 gets model-templates job fail because it doesn't fix the copy and then `make fixup` fails, see: https://github.com/huggingface/transformers/pull/11475/checks?check_run_id=2502230586

Also it's unclear what purpose serves: `git fetch origin master:master` here:

https://github.com/huggingface/transformers/blob/2ce0fb84cc500a26b0c45bec1f8a42e33d13e05d/.github/workflows/model-templates.yml#L59

@LysandreJik, @sgugger 