### PR TITLE
Fix failing test on Windows Platform

### DIFF
--- a/examples/pytorch/translation/run_translation.py
+++ b/examples/pytorch/translation/run_translation.py
@@ -571,7 +571,7 @@ def main():
                 )
                 predictions = [pred.strip() for pred in predictions]
                 output_prediction_file = os.path.join(training_args.output_dir, "generated_predictions.txt")
-                with open(output_prediction_file, "w") as writer:
+                with open(output_prediction_file, "w", encoding="utf-8") as writer:
                     writer.write("\n".join(predictions))
 
     if training_args.push_to_hub:

--- a/tests/test_tokenization_wav2vec2.py
+++ b/tests/test_tokenization_wav2vec2.py
@@ -229,9 +229,10 @@ class Wav2Vec2TokenizerTest(unittest.TestCase):
         tmpdirname2 = tempfile.mkdtemp()
 
         tokenizer_files = tokenizer.save_pretrained(tmpdirname2)
+        separator = "\\" if os.name == "nt" else "/"
         self.assertSequenceEqual(
             sorted(tuple(VOCAB_FILES_NAMES.values()) + ("special_tokens_map.json", "added_tokens.json")),
-            sorted(tuple(x.split("/")[-1] for x in tokenizer_files)),
+            sorted(tuple(x.split(separator)[-1] for x in tokenizer_files)),
         )
 
         # Checks everything loads correctly in the same way

--- a/tests/test_tokenization_wav2vec2.py
+++ b/tests/test_tokenization_wav2vec2.py
@@ -229,10 +229,9 @@ class Wav2Vec2TokenizerTest(unittest.TestCase):
         tmpdirname2 = tempfile.mkdtemp()
 
         tokenizer_files = tokenizer.save_pretrained(tmpdirname2)
-        separator = "\\" if os.name == "nt" else "/"
         self.assertSequenceEqual(
             sorted(tuple(VOCAB_FILES_NAMES.values()) + ("special_tokens_map.json", "added_tokens.json")),
-            sorted(tuple(x.split(separator)[-1] for x in tokenizer_files)),
+            sorted(tuple(x.split(os.path.sep)[-1] for x in tokenizer_files)),
         )
 
         # Checks everything loads correctly in the same way

--- a/tests/test_utils_check_copies.py
+++ b/tests/test_utils_check_copies.py
@@ -70,7 +70,7 @@ class CopyCheckTester(unittest.TestCase):
             expected = comment + f"\nclass {class_name}(nn.Module):\n" + overwrite_result
         code = black.format_str(code, mode=black.FileMode([black.TargetVersion.PY35], line_length=119))
         fname = os.path.join(self.transformer_dir, "new_code.py")
-        with open(fname, "w") as f:
+        with open(fname, "w", newline="\n") as f:
             f.write(code)
         if overwrite_result is None:
             self.assertTrue(len(check_copies.is_copy_consistent(fname)) == 0)

--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -197,7 +197,7 @@ def get_model_list():
     # If the introduction or the conclusion of the list change, the prompts may need to be updated.
     _start_prompt = "🤗 Transformers currently provides the following architectures"
     _end_prompt = "1. Want to contribute a new model?"
-    with open(os.path.join(REPO_PATH, "README.md"), "r", encoding="utf-8", newline="\n") as f:
+    with open(os.path.join(REPO_PATH, "README.md"), "r", encoding="utf-8", newline=None) as f:
         lines = f.readlines()
     # Find the start of the list.
     start_index = 0

--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -197,7 +197,7 @@ def get_model_list():
     # If the introduction or the conclusion of the list change, the prompts may need to be updated.
     _start_prompt = "🤗 Transformers currently provides the following architectures"
     _end_prompt = "1. Want to contribute a new model?"
-    with open(os.path.join(REPO_PATH, "README.md"), "r", encoding="utf-8", newline=None) as f:
+    with open(os.path.join(REPO_PATH, "README.md"), "r", encoding="utf-8", newline="\n") as f:
         lines = f.readlines()
     # Find the start of the list.
     start_index = 0


### PR DESCRIPTION
- test_tokenization_wav2vec2.py failure on Windows - fixed by changing directory separator when running on Windows. 
- tests/test_utils_check_copies.py failure on Windows due to splitting text with "\n" on Windows, instead of "\r\n" - fixed by using universal newlines. 
- tests/extended/test_trainer_ext.py failure on Windows due to "\r" characters encoding issue - fixed by specifying utf-8 encoding. 

Fix for tests in Windows #11586 
