### PR TITLE
Accept tensorflow-rocm package when checking TF availability

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -88,6 +88,7 @@ if USE_TF in ENV_VARS_TRUE_AND_AUTO_VALUES and USE_TORCH not in ENV_VARS_TRUE_VA
             "tf-nightly-cpu",
             "tf-nightly-gpu",
             "intel-tensorflow",
+            "tensorflow-rocm",
         )
         _tf_version = None
         # For the metadata, we have to look for both tensorflow and tensorflow-cpu


### PR DESCRIPTION
When working [on AMD GPU:s the TensorFlow package is called `tensorflow-rocm`](https://rocmdocs.amd.com/en/latest/Deep_learning/Deep-learning.html#tensorflow). This trivial PR just adds that to the list of accepted package names when checking for TensorFlow availability in `src/transformers/file_utils.py`.

At least the basic benchmark `run_benchmark_tf.py` seems to work fine on AMD MI50 and MI100 GPUs