### PR TITLE
Fix RNG saves in distributed mode.

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1527,8 +1527,8 @@ class Trainer:
         if is_torch_tpu_available():
             rng_states["xla"] = xm.get_rng_state()
 
-        # A process can arrive here before the process 0 has a chance to save the model, in which output_dir may not
-        # exist yet.
+        # A process can arrive here before the process 0 has a chance to save the model, in which case output_dir may
+        # not yet exist.
         os.makedirs(output_dir, exist_ok=True)
         local_rank = xm.get_local_ordinal() if is_torch_tpu_available() else self.args.local_rank
         if local_rank == -1:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1527,6 +1527,9 @@ class Trainer:
         if is_torch_tpu_available():
             rng_states["xla"] = xm.get_rng_state()
 
+        # A process can arrive here before the process 0 has a chance to save the model, in which output_dir may not
+        # exist yet.
+        os.makedirs(output_dir, exist_ok=True)
         local_rank = xm.get_local_ordinal() if is_torch_tpu_available() else self.args.local_rank
         if local_rank == -1:
             torch.save(rng_states, os.path.join(output_dir, "rng_state.pth"))


### PR DESCRIPTION
# What does this PR do?

The newly introduced RNG saves in the Trainer checkpoints can yield to an error when one of the process of local_rank != 0 arrives to the end of the function faster then the process local_rank=0 arrived at the beginning: in this case the subfolder "checkpoint-xxx" is not created yet, so trying to save inside fails.

This PR fixes that.

Fixes #11618