### PR TITLE
Reduce to 1 worker and set timeout for GPU TF tests

### DIFF
--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -63,6 +63,7 @@ jobs:
 
   run_tests_tf_gpu:
     runs-on: [self-hosted, docker-gpu, single-gpu]
+    timeout-minutes: 120
     container:
       image: tensorflow/tensorflow:2.4.1-gpu
       options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
@@ -89,7 +90,7 @@ jobs:
           TF_NUM_INTRAOP_THREADS: 8
           TF_NUM_INTEROP_THREADS: 1
         run: |
-          python -m pytest -n 2 --dist=loadfile --make-reports=tests_tf_gpu tests
+          python -m pytest -n 1 --dist=loadfile --make-reports=tests_tf_gpu tests
 
       - name: Failure short reports
         if: ${{ always() }}
@@ -148,6 +149,7 @@ jobs:
 
   run_tests_tf_multi_gpu:
     runs-on: [self-hosted, docker-gpu, multi-gpu]
+    timeout-minutes: 120
     container:
       image: tensorflow/tensorflow:2.4.1-gpu
       options: --gpus all --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
@@ -174,7 +176,7 @@ jobs:
           TF_NUM_INTRAOP_THREADS: 8
           TF_NUM_INTEROP_THREADS: 1
         run: |
-          python -m pytest -n 2 --dist=loadfile --make-reports=tests_tf_multi_gpu tests
+          python -m pytest -n 1 --dist=loadfile --make-reports=tests_tf_multi_gpu tests
 
       - name: Failure short reports
         if: ${{ always() }}


### PR DESCRIPTION
This PR reduces the amount of workers for the TensorFlow tests and adds a timeout to 120 minutes to prevent crashed pytest workers from hanging indefinitely.