### PR TITLE
Add missing git dependency for RAG example

### DIFF
--- a/examples/research_projects/rag/requirements.txt
+++ b/examples/research_projects/rag/requirements.txt
@@ -4,3 +4,4 @@ psutil >= 5.7.0
 torch >= 1.4.0
 transformers
 pytorch-lightning==1.0.4
+GitPython


### PR DESCRIPTION
As noticed in https://github.com/huggingface/transformers/issues/11609, one must install the `git` dependency.
I added it to the requirements.txt of the rag example