### PR TITLE
[self-push CI] sync with self-scheduled

### DIFF
--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -204,6 +204,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          apt -y update && apt install -y libaio-dev
           pip install --upgrade pip
           pip install .[testing,deepspeed]
 
@@ -244,6 +245,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          apt -y update && apt install -y libaio-dev
           pip install --upgrade pip
           pip install .[testing,deepspeed,fairscale]
 


### PR DESCRIPTION
I forgot to add the missing `libaio-dev` to this workflow. This PR is fixing that.

Thank you!

@sgugger  or @LysandreJik 
