### PR TITLE
Add MacOS TF version

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -89,6 +89,7 @@ if USE_TF in ENV_VARS_TRUE_AND_AUTO_VALUES and USE_TORCH not in ENV_VARS_TRUE_VA
             "tf-nightly-gpu",
             "intel-tensorflow",
             "tensorflow-rocm",
+            "tensorflow-macos",
         )
         _tf_version = None
         # For the metadata, we have to look for both tensorflow and tensorflow-cpu


### PR DESCRIPTION
# What does this PR do?

This PR adds the MacOS TensorFlow version mostly for the M1 Apple laptop that is the recommended version to use.