### PR TITLE
Test checkpointing

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1058,7 +1058,18 @@ class Trainer:
                 # We load the model state dict on the CPU to avoid an OOM error.
                 state_dict = torch.load(os.path.join(resume_from_checkpoint, WEIGHTS_NAME), map_location="cpu")
                 # If the model is on the GPU, it still works!
-                self.model.load_state_dict(state_dict)
+                load_result = self.model.load_state_dict(state_dict, strict=False)
+                if len(load_result.missing_keys) != 0:
+                    if load_result.missing_keys == self.model._keys_to_ignore_on_save:
+                        self.model.tie_weights()
+                    else:
+                        logger.warn(
+                            f"There were missing keys in the checkpoint model loaded: {load_result.missing_keys}."
+                        )
+                if len(load_result.unexpected_keys) != 0:
+                    logger.warn(
+                        f"There were unexpected keys in the checkpoint model loaded: {load_result.unexpected_keys}."
+                    )
 
         # If model was re-initialized, put it on the right device and update self.model_wrapped
         if model_reloaded:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -176,9 +176,13 @@ class ModelTesterMixin:
                 state_dict_saved = torch.load(output_model_file)
                 for k in _keys_to_ignore_on_save:
                     self.assertNotIn(k, state_dict_saved)
-                
+
                 # Test we can load the state dict in the model, necessary for the checkpointing API in Trainer.
-                model.load_state_dict(state_dict_saved)
+                load_result = model.load_state_dict(state_dict_saved, strict=False)
+                self.assertTrue(
+                    len(load_result.missing_keys) == 0 or load_result.missing_keys == model._keys_to_ignore_on_save
+                )
+                self.assertTrue(len(load_result.unexpected_keys) == 0)
 
     def _mock_init_weights(self, module):
         if hasattr(module, "weight") and module.weight is not None:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -176,6 +176,9 @@ class ModelTesterMixin:
                 state_dict_saved = torch.load(output_model_file)
                 for k in _keys_to_ignore_on_save:
                     self.assertNotIn(k, state_dict_saved)
+                
+                # Test we can load the state dict in the model, necessary for the checkpointing API in Trainer.
+                model.load_state_dict(state_dict_saved)
 
     def _mock_init_weights(self, module):
         if hasattr(module, "weight") and module.weight is not None:


### PR DESCRIPTION
# What does this PR do?

This fixes how weights are loading when resuming training from a checkpoint, in the instances some weights are tied with other (and thus not saved). It also adds a test in the common tests to make sure the mechanism used is not broken by mistake.

Fixes #11666