### PR TITLE
Fix T5 beam search when using parallelize

### DIFF
--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -1682,7 +1682,7 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
             for layer_past_state in layer_past_states:
                 # need to set correct `past` for each of the four key / value states
                 reordered_layer_past_states = reordered_layer_past_states + (
-                    layer_past_state.index_select(0, beam_idx),
+                    layer_past_state.index_select(0, beam_idx.to(layer_past_state.device)),
                 )
 
             assert reordered_layer_past_states[0].shape == layer_past_states[0].shape


### PR DESCRIPTION
# What does this PR do?

As requested by @patrickvonplaten in conversation on issue https://github.com/huggingface/transformers/issues/9200, this fixes a crash when trying to use beam search on T5 models split across multiple GPUs using `model.parallelize()`. It uses the fix from https://github.com/huggingface/transformers/pull/9219, applied to the T5-specific code (also related is https://github.com/huggingface/transformers/pull/9596 which refactored the `_reorder_cache` functions).

I tested the fix on a t5-small model. Before:

```
from transformers import AutoTokenizer, AutoModelForSeq2SeqLM  
tokenizer = AutoTokenizer.from_pretrained("allenai/unifiedqa-t5-small")
model = AutoModelForSeq2SeqLM.from_pretrained("allenai/unifiedqa-t5-small")
device_map = {0: range(0,3), 1: range(3, 6)}
input_string = "What was the color of the sky?\\nIt was a dark stormy night."
input_ids = tokenizer.encode(input_string,return_tensors="pt").to("cuda:0")
output = model.generate(input_ids, num_beams=2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/oyvindt/miniconda3/envs/transformers4/lib/python3.9/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/home/oyvindt/miniconda3/envs/transformers4/lib/python3.9/site-packages/transformers/generation_utils.py", line 1044, in generate
    return self.beam_search(
  File "/home/oyvindt/miniconda3/envs/transformers4/lib/python3.9/site-packages/transformers/generation_utils.py", line 1788, in beam_search
    model_kwargs["past"] = self._reorder_cache(model_kwargs["past"], beam_idx)
  File "/home/oyvindt/miniconda3/envs/transformers4/lib/python3.9/site-packages/transformers/models/t5/modeling_t5.py", line 1635, in _reorder_cache
    layer_past_state.index_select(0, beam_idx),
RuntimeError: Input, output and indices must be on the current device
```
After:
```
...
output = model.generate(input_ids, num_beams=2)
tokenizer.batch_decode(output, skip_special_tokens=True)
 --> ['dark stormy']
```

As far as I know this small fix shouldn't have any adverse effects. As to why the tests added in  https://github.com/huggingface/transformers/pull/9219 didn't catch this, possibly that's because they're not generally run in multi-GPU setups? 
