### PR TITLE
Remove extra self from _save_checkpoint call

### DIFF
--- a/src/transformers/sagemaker/trainer_sm.py
+++ b/src/transformers/sagemaker/trainer_sm.py
@@ -242,7 +242,7 @@ class SageMakerTrainer(Trainer):
             if self.is_world_process_zero():
                 self._rotate_checkpoints(use_mtime=True, output_dir=run_dir)
         else:
-            super()._save_checkpoint(self, model, trial, metrics=metrics)
+            super()._save_checkpoint(model, trial, metrics=metrics)
 
     def _load_optimizer_and_scheduler(self, checkpoint):
         """If optimizer and scheduler states exist, load them."""


### PR DESCRIPTION
Currently this code is completely broken with non-distributed training. I'm not clear on how it has ever worked:

```
  File "run.py", line 152, in <module>
    trainer.train() #resume_from_checkpoint=get_last_checkpoint("/opt/ml/checkpoints"))
  File "/opt/conda/lib/python3.6/site-packages/transformers/trainer.py", line 1105, in train
    self._maybe_log_save_evaluate(tr_loss, model, trial, epoch)
  File "/opt/conda/lib/python3.6/site-packages/transformers/trainer.py", line 1202, in _maybe_log_save_evaluate
    self._save_checkpoint(model, trial, metrics=metrics)
  File "/opt/conda/lib/python3.6/site-packages/transformers/sagemaker/trainer_sm.py", line 245, in _save_checkpoint
    super()._save_checkpoint(self, model, trial, metrics=metrics)
TypeError: _save_checkpoint() got multiple values for argument 'metrics'
```

This is because the `self` argument shouldn't be passed, so `trial` ends up as `metrics` via it's position.