### PR TITLE
Fix release utilpattern in conf.py

### DIFF
--- a/utils/release.py
+++ b/utils/release.py
@@ -26,7 +26,7 @@ REPLACE_PATTERNS = {
     "examples": (re.compile(r'^check_min_version\("[^"]+"\)\s*$', re.MULTILINE), 'check_min_version("VERSION")\n'),
     "init": (re.compile(r'^__version__\s+=\s+"([^"]+)"\s*$', re.MULTILINE), '__version__ = "VERSION"\n'),
     "setup": (re.compile(r'^(\s*)version\s*=\s*"[^"]+",', re.MULTILINE), r'\1version="VERSION",'),
-    "doc": (re.compile(r"^(\s*)release\s*=\s*u'[^']+'$", re.MULTILINE), "release = u'VERSION'\n"),
+    "doc": (re.compile(r'^(\s*)release\s*=\s*"[^"]+"$', re.MULTILINE), "release = u'VERSION'\n"),
 }
 REPLACE_FILES = {
     "init": "src/transformers/__init__.py",


### PR DESCRIPTION
# What does this PR do?

When we applied black to the conf.py style, the line with the version changed but the pattern in our release util script was not updated. This PR fixes that.