### PR TITLE
[Examples] create model with custom config on the fly

### DIFF
--- a/examples/pytorch/language-modeling/README.md
+++ b/examples/pytorch/language-modeling/README.md
@@ -161,3 +161,20 @@ concatenates all texts and then splits them in blocks of the same length).
 
 **Note:** On TPU, you should use the flag `--pad_to_max_length` in conjunction with the `--line_by_line` flag to make
 sure all your batches have the same length.
+
+
+## Creating a model on the fly
+
+A model can be created on the fly with the help of `--config_overrides`
+
+```bash
+python run_clm.py --model_type gpt2 --tokenizer_name gpt2 \ --config_overrides="n_embd=1024,n_head=16,n_layer=48,n_positions=102" \
+[...]
+```
+
+At the moment this is only available in `run_clm.py` but eventually should be copied to all other LM examples.
+
+This feature can also be used to activate gradient checkpointing by passing:
+```
+--config_overrides "gradient_checkpointing=true,use_cache=False"
+```

--- a/examples/pytorch/language-modeling/README.md
+++ b/examples/pytorch/language-modeling/README.md
@@ -165,7 +165,8 @@ sure all your batches have the same length.
 
 ## Creating a model on the fly
 
-A model can be created on the fly with the help of `--config_overrides`
+When training a model from scratch, configuration values may be overridden with the help of `--config_overrides`:
+
 
 ```bash
 python run_clm.py --model_type gpt2 --tokenizer_name gpt2 \ --config_overrides="n_embd=1024,n_head=16,n_layer=48,n_positions=102" \

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -322,7 +322,7 @@ def main():
     else:
         model = AutoModelForCausalLM.from_config(config)
         n_params = sum(dict((p.data_ptr(), p.numel()) for p in model.parameters()).values())
-        logger.info(f"Training new model from scratch - number of params={n_params>>20}M")
+        logger.info(f"Training new model from scratch - Total size={n_params/2**20:.2f}M params")
 
     model.resize_token_embeddings(len(tokenizer))
 

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -105,13 +105,6 @@ class ModelArguments:
         },
     )
 
-    def __post_init__(self):
-        # convert "key1=val1,key2=val2" into a kwargs dict
-        if self.config_overrides is not None:
-            d = dict(x.split("=") for x in self.config_overrides.split(","))
-            # XXX: need more intelligent code to handle various types of numbers - currently just int
-            self.config_overrides = {k: int(v) for k, v in d.items()}
-
 
 @dataclass
 class DataTrainingArguments:
@@ -292,7 +285,7 @@ def main():
         logger.warning("You are instantiating a new config instance from scratch.")
         if model_args.config_overrides is not None:
             print("Overriding config:", model_args.config_overrides)
-            config.update(model_args.config_overrides)
+            config.update_from_string(model_args.config_overrides)
 
     tokenizer_kwargs = {
         "cache_dir": model_args.cache_dir,

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -287,7 +287,7 @@ def main():
         config = CONFIG_MAPPING[model_args.model_type]()
         logger.warning("You are instantiating a new config instance from scratch.")
         if model_args.config_overrides is not None:
-            logger.info("Overriding config:", model_args.config_overrides)
+            logger.info(f"Overriding config: {model_args.config_overrides}")
             config.update_from_string(model_args.config_overrides)
 
     tokenizer_kwargs = {

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -77,7 +77,10 @@ class ModelArguments:
     )
     config_overrides: Optional[str] = field(
         default=None,
-        metadata={"help": "override the default configs if any, format: key1=val1,key2=val2"},
+        metadata={
+            "help": "Override some existing default config settings. Example: "
+            "n_embd=10,resid_pdrop=0.2,scale_attn_weights=false,summary_type=cls_index"
+        },
     )
     config_name: Optional[str] = field(
         default=None, metadata={"help": "Pretrained config name or path if not the same as model_name"}

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -287,7 +287,7 @@ def main():
         config = CONFIG_MAPPING[model_args.model_type]()
         logger.warning("You are instantiating a new config instance from scratch.")
         if model_args.config_overrides is not None:
-            print("Overriding config:", model_args.config_overrides)
+            logger.info("Overriding config:", model_args.config_overrides)
             config.update_from_string(model_args.config_overrides)
 
     tokenizer_kwargs = {

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -78,7 +78,7 @@ class ModelArguments:
     config_overrides: Optional[str] = field(
         default=None,
         metadata={
-            "help": "Override some existing default config settings. Example: "
+            "help": "Override some existing default config settings when a model is trained from scratch. Example: "
             "n_embd=10,resid_pdrop=0.2,scale_attn_weights=false,summary_type=cls_index"
         },
     )
@@ -107,6 +107,12 @@ class ModelArguments:
             "with private models)."
         },
     )
+
+    def __post_init__(self):
+        if self.config_overrides is not None and (self.config_name is not None or self.model_name_or_path is not None):
+            raise ValueError(
+                "--config_overrides can't be used in combination with --config_name or --model_name_or_path"
+            )
 
 
 @dataclass

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -693,9 +693,9 @@ class PretrainedConfig(PushToHubMixin):
 
             old_v = getattr(self, k)
             if isinstance(old_v, bool):
-                if v.lower() == "true":
+                if v.lower() in ['true', '1', 'y', 'yes']:
                     v = True
-                elif v.lower() == "false":
+                elif v.lower() in ['false', '0', 'n', 'no']:
                     v = False
                 else:
                     raise ValueError(f"can't derive true or false from {v} (key {k})")

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -704,6 +704,6 @@ class PretrainedConfig(PushToHubMixin):
             elif isinstance(old_v, float):
                 v = float(v)
             elif not isinstance(old_v, str):
-                raise ValueError(f"{v} (key {k}) is not int/float/bool/str")
+                raise ValueError(f"You can only update int, float, bool or string values in the config, got {v} for key {k}")
 
             setattr(self, k, v)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -676,10 +676,10 @@ class PretrainedConfig(PushToHubMixin):
         """
         Updates attributes of this class with attributes from ``update_str``.
 
-        The expected format is in the form of this example ``key1=10,key2=0.2,key3=true,key4=string`` - i.e. just write
-        ints and floats and strings as is, and for booleans use ``true`` or ``false``.
+        The expected format is ints, floats and strings as is, and for booleans use ``true`` or ``false``. For example:
+        "n_embd=10,resid_pdrop=0.2,scale_attn_weights=false,summary_type=cls_index"
 
-        The key has to already exist in the config object.
+        The keys to change have to already exist in the config object.
 
         Args:
             update_str (:obj:`str`): String with attributes that should be updated for this class.

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -667,7 +667,43 @@ class PretrainedConfig(PushToHubMixin):
         Updates attributes of this class with attributes from ``config_dict``.
 
         Args:
-            config_dict (:obj:`Dict[str, Any]`): Dictionary of attributes that shall be updated for this class.
+            config_dict (:obj:`Dict[str, Any]`): Dictionary of attributes that should be updated for this class.
         """
         for key, value in config_dict.items():
             setattr(self, key, value)
+
+    def update_from_string(self, update_str: str):
+        """
+        Updates attributes of this class with attributes from ``update_str``.
+
+        The expected format is in the form of this example ``key1=10,key2=0.2,key3=true,key4=string`` - i.e. just write
+        ints and floats and strings as is, and for booleans use ``true`` or ``false``.
+
+        The key has to already exist in the config object.
+
+        Args:
+            update_str (:obj:`str`): String with attributes that should be updated for this class.
+
+        """
+
+        d = dict(x.split("=") for x in update_str.split(","))
+        for k, v in d.items():
+            if not hasattr(self, k):
+                raise ValueError(f"key {k} isn't in the original config dict")
+
+            old_v = getattr(self, k)
+            if isinstance(old_v, bool):
+                if v.lower() == "true":
+                    v = True
+                elif v.lower() == "false":
+                    v = False
+                else:
+                    raise ValueError(f"can't derive true or false from {v} (key {k})")
+            elif isinstance(old_v, int):
+                v = int(v)
+            elif isinstance(old_v, float):
+                v = float(v)
+            elif not isinstance(old_v, str):
+                raise ValueError(f"{v} (key {k}) is not int/float/bool/str")
+
+            setattr(self, k, v)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -693,9 +693,9 @@ class PretrainedConfig(PushToHubMixin):
 
             old_v = getattr(self, k)
             if isinstance(old_v, bool):
-                if v.lower() in ['true', '1', 'y', 'yes']:
+                if v.lower() in ["true", "1", "y", "yes"]:
                     v = True
-                elif v.lower() in ['false', '0', 'n', 'no']:
+                elif v.lower() in ["false", "0", "n", "no"]:
                     v = False
                 else:
                     raise ValueError(f"can't derive true or false from {v} (key {k})")
@@ -704,6 +704,8 @@ class PretrainedConfig(PushToHubMixin):
             elif isinstance(old_v, float):
                 v = float(v)
             elif not isinstance(old_v, str):
-                raise ValueError(f"You can only update int, float, bool or string values in the config, got {v} for key {k}")
+                raise ValueError(
+                    f"You can only update int, float, bool or string values in the config, got {v} for key {k}"
+                )
 
             setattr(self, k, v)

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -21,7 +21,7 @@ import unittest
 
 from huggingface_hub import HfApi
 from requests.exceptions import HTTPError
-from transformers import BertConfig
+from transformers import BertConfig, GPT2Config
 from transformers.testing_utils import ENDPOINT_STAGING, PASS, USER, is_staging_test
 
 
@@ -138,3 +138,21 @@ class ConfigPushToHubTester(unittest.TestCase):
             for k, v in config.__dict__.items():
                 if k != "transformers_version":
                     self.assertEqual(v, getattr(new_config, k))
+
+
+class ConfigTestUtils(unittest.TestCase):
+    def test_config_from_string(self):
+        c = GPT2Config()
+
+        # attempt to modify each of int/float/bool/str config records and verify they were updated
+        n_embd = c.n_embd + 1  # int
+        resid_pdrop = c.resid_pdrop + 1.0  # float
+        scale_attn_weights = not c.scale_attn_weights  # bool
+        summary_type = c.summary_type + "foo"  # str
+        c.update_from_string(
+            f"n_embd={n_embd},resid_pdrop={resid_pdrop},scale_attn_weights={scale_attn_weights},summary_type={summary_type}"
+        )
+        self.assertEqual(n_embd, c.n_embd, "mismatch for key: n_embd")
+        self.assertEqual(resid_pdrop, c.resid_pdrop, "mismatch for key: resid_pdrop")
+        self.assertEqual(scale_attn_weights, c.scale_attn_weights, "mismatch for key: scale_attn_weights")
+        self.assertEqual(summary_type, c.summary_type, "mismatch for key: summary_type")


### PR DESCRIPTION
This PR is addressing a need to:
1. be able to quickly whip up a model of any desired size for the big-science experiments.
2. be able to activate gradient checkpointing (later addition)

We already have the functionality to create a model instead of using a pretrained one, but there was no way to control its config - it would choose the defaults of the Config object, which is very doubtful is of any practical use.

This PR:

1. adds a new `PretrainedConfig` method: `update_from_string` so one can update from a string.
```
config.update_from_string("n_embd=10,n_head=5,scale_attn_weights=false,summary_type=super_cls_index")
```

   plus test.

2. adds a new `ModelArguments` arg: `--config_overrides="n_embd=1024,n_head=16,n_layer=48,n_positions=102"` which overrides the default config

3. auto-logs the resulting model size e.g.:
```
Training new model from scratch - Total size=626.69M params
```

Usage:
```
PYTHONPATH=src python examples/pytorch/language-modeling/run_clm.py --dataset_name \
"stas/openwebtext-10k" --output_dir output_dir --overwrite_output_dir --do_train --do_eval \
--max_train_samples 10000 --max_eval_samples 1000 --per_device_train_batch_size 4 \
--per_device_eval_batch_size 4 --num_train_epochs 1 --warmup_steps 8 --block_size 64 --fp16 \
--report_to none --model_type gpt2 --tokenizer_name gpt2 \
--config_overrides "n_embd=1024,n_head=16,n_layer=48,n_positions=1024"
```

Only `run_clm.py` for this experiment.

@sgugger, @LysandreJik 
