### PR TITLE
Patch recursive import

### DIFF
--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -25,7 +25,6 @@ from tokenizers import Regex, Tokenizer, decoders, normalizers, pre_tokenizers, 
 from tokenizers.models import BPE, Unigram, WordPiece
 
 from .file_utils import requires_backends
-from .models.roformer.tokenization_utils import JiebaPreTokenizer
 
 
 class SentencePieceExtractor:
@@ -299,6 +298,8 @@ class RobertaConverter(Converter):
 
 class RoFormerConverter(Converter):
     def converted(self) -> Tokenizer:
+        from .models.roformer.tokenization_utils import JiebaPreTokenizer
+
         vocab = self.original_tokenizer.vocab
         tokenizer = Tokenizer(WordPiece(vocab, unk_token=str(self.original_tokenizer.unk_token)))
 

--- a/tests/test_tokenization_utils.py
+++ b/tests/test_tokenization_utils.py
@@ -12,6 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+isort:skip_file
+"""
 import os
 import pickle
 import tempfile
@@ -20,12 +23,14 @@ from typing import Callable, Optional
 
 import numpy as np
 
+# Ensure there are no circular imports when importing the parent class
+from transformers import PreTrainedTokenizerFast
+
 from transformers import (
     BatchEncoding,
     BertTokenizer,
     BertTokenizerFast,
     PreTrainedTokenizer,
-    PreTrainedTokenizerFast,
     TensorType,
     TokenSpan,
     is_tokenizers_available,


### PR DESCRIPTION
The RoFormer converter requires the `JiebaPreTokenizer` which was imported at the root of the file.

This resulted in a cyclic dependency and a partially initialized module.

This PR fixes the issue by importing it only when necessary and additionally tests that the `PreTrainedTokenizerFast` can be loaded as a standalone.