### PR TITLE
[run_clm.py] restore caching

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -230,7 +230,9 @@ def main():
     # download the dataset.
     if data_args.dataset_name is not None:
         # Downloading and loading a dataset from the hub.
-        datasets = load_dataset(data_args.dataset_name, data_args.dataset_config_name, cache_dir=model_args.cache_dir, keep_in_memory=False)
+        datasets = load_dataset(
+            data_args.dataset_name, data_args.dataset_config_name, cache_dir=model_args.cache_dir, keep_in_memory=False
+        )
         if "validation" not in datasets.keys():
             datasets["validation"] = load_dataset(
                 data_args.dataset_name,

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -230,7 +230,7 @@ def main():
     # download the dataset.
     if data_args.dataset_name is not None:
         # Downloading and loading a dataset from the hub.
-        datasets = load_dataset(data_args.dataset_name, data_args.dataset_config_name, cache_dir=model_args.cache_dir)
+        datasets = load_dataset(data_args.dataset_name, data_args.dataset_config_name, cache_dir=model_args.cache_dir, keep_in_memory=False)
         if "validation" not in datasets.keys():
             datasets["validation"] = load_dataset(
                 data_args.dataset_name,


### PR DESCRIPTION
`datasets==0.1.6` introduced in-memory datasets, which unfortunately has no caching which makes it very slow to develop with as the dataset gets reprocessed on every run. Supposedly this should make things faster overall, but at this huge cost to us developers.

It's also inconsistent where some datasets behave in one way, others in another way. This is too magical, IMHO.

This PR adds `keep_in_memory=False`, to disable in-memory cache, but restores normal caching.

Perhaps adding a note in the example that the user can change it to `True` if they don't care for the slow startup?

Alternatively, if you believe that the new behavior is good, let's create an env var at `datasets` that will control that, so that we can turn off this painful behavior w/o needing to manually modify the code.

Fixes: https://github.com/huggingface/transformers/issues/11801

p.s. working on this one script on many fronts - and then will sync other scripts at once.

@sgugger, @VictorSanh, @lhoestq 