### PR TITLE
Fix bug in Masked Language Modeling example scripts (#11840))

### DIFF
--- a/examples/flax/language-modeling/run_mlm_flax.py
+++ b/examples/flax/language-modeling/run_mlm_flax.py
@@ -442,7 +442,7 @@ if __name__ == "__main__":
         # We use `return_special_tokens_mask=True` because DataCollatorForLanguageModeling (see below) is more
         # efficient when it receives the `special_tokens_mask`.
         def tokenize_function(examples):
-            return tokenizer(examples[text_column_name], return_special_tokens_mask=True)
+            return tokenizer(examples[text_column_name], add_special_tokens=False, return_special_tokens_mask=True)
 
         tokenized_datasets = datasets.map(
             tokenize_function,
@@ -455,15 +455,30 @@ if __name__ == "__main__":
         # Main data processing function that will concatenate all texts from our dataset and generate chunks of
         # max_seq_length.
         def group_texts(examples):
+            max_seq_length_without_special_tokens = max_seq_length - 2
+            head = {
+                "input_ids": tokenizer.cls_token_id, 
+                "token_type_ids": 0, 
+                "attention_mask": 1, 
+                "special_tokens_mask": 1,
+            }
+            tail = {
+                "input_ids": tokenizer.sep_token_id, 
+                "token_type_ids": 0, 
+                "attention_mask": 1, 
+                "special_tokens_mask": 1,
+            }
             # Concatenate all texts.
             concatenated_examples = {k: sum(examples[k], []) for k in examples.keys()}
             total_length = len(concatenated_examples[list(examples.keys())[0]])
             # We drop the small remainder, we could add padding if the model supported it instead of this drop, you can
             # customize this part to your needs.
-            total_length = (total_length // max_seq_length) * max_seq_length
+            total_length = (total_length // max_seq_length_without_special_tokens) \
+                * max_seq_length_without_special_tokens
             # Split by chunks of max_len.
             result = {
-                k: [t[i : i + max_seq_length] for i in range(0, total_length, max_seq_length)]
+                k: [[head[k]] + t[i:i + max_seq_length_without_special_tokens] + [tail[k]] \
+                for i in range(0, total_length, max_seq_length_without_special_tokens)] \
                 for k, t in concatenated_examples.items()
             }
             return result

--- a/examples/pytorch/language-modeling/run_mlm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_mlm_no_trainer.py
@@ -350,7 +350,7 @@ def main():
         # We use `return_special_tokens_mask=True` because DataCollatorForLanguageModeling (see below) is more
         # efficient when it receives the `special_tokens_mask`.
         def tokenize_function(examples):
-            return tokenizer(examples[text_column_name], return_special_tokens_mask=True)
+            return tokenizer(examples[text_column_name], add_special_tokens=False, return_special_tokens_mask=True)
 
         tokenized_datasets = raw_datasets.map(
             tokenize_function,
@@ -363,15 +363,30 @@ def main():
         # Main data processing function that will concatenate all texts from our dataset and generate chunks of
         # max_seq_length.
         def group_texts(examples):
+            max_seq_length_without_special_tokens = max_seq_length - 2
+            head = {
+                "input_ids": tokenizer.cls_token_id, 
+                "token_type_ids": 0, 
+                "attention_mask": 1, 
+                "special_tokens_mask": 1,
+            }
+            tail = {
+                "input_ids": tokenizer.sep_token_id, 
+                "token_type_ids": 0, 
+                "attention_mask": 1, 
+                "special_tokens_mask": 1,
+            }
             # Concatenate all texts.
             concatenated_examples = {k: sum(examples[k], []) for k in examples.keys()}
             total_length = len(concatenated_examples[list(examples.keys())[0]])
             # We drop the small remainder, we could add padding if the model supported it instead of this drop, you can
             # customize this part to your needs.
-            total_length = (total_length // max_seq_length) * max_seq_length
+            total_length = (total_length // max_seq_length_without_special_tokens) \
+                * max_seq_length_without_special_tokens
             # Split by chunks of max_len.
             result = {
-                k: [t[i : i + max_seq_length] for i in range(0, total_length, max_seq_length)]
+                k: [[head[k]] + t[i:i + max_seq_length_without_special_tokens] + [tail[k]] \
+                for i in range(0, total_length, max_seq_length_without_special_tokens)] \
                 for k, t in concatenated_examples.items()
             }
             return result


### PR DESCRIPTION
# What does this PR do?
when `data_args.line_by_line == False`, the script firstly converts given examples into input_ids, token_type_ids, attention_mask and special_tokens_mask including cls_token, sep_token. Then it concatenates all tokenized outputs and generate chunks of max_seq_length. However, it will generate unintended training examples such as [871, 512, 2492, 1111, 947, 533] not [2 (cls_token), 512, 2492, 1111, 947, 3 (sep_token)]. I fix this problem.

Fixes #11840 
@sgugger, @patil-suraj