### PR TITLE
Fix flos single node

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1909,7 +1909,7 @@ class Trainer:
             self.state.total_flos += distributed_broadcast_scalars([self.current_flos]).sum().item()
             self.current_flos = 0
         else:
-            self.state.total_flos = self.current_flos
+            self.state.total_flos += self.current_flos
             self.current_flos = 0
 
     def _sorted_checkpoints(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1397,6 +1397,7 @@ class Trainer:
 
             self._total_loss_scalar += tr_loss_scalar
             self._globalstep_last_logged = self.state.global_step
+            self.store_flos()
 
             self.log(logs)
 


### PR DESCRIPTION
This PR fixes a bug typo where in single-node settings, flos in the Trainer would stay constant, and also updates the flo count in the trainer state at every log occasion (instead of every model-saving occasion) so that users that wish to use a flo-logging callback can access it more frequently. I feel like the first bug should have been caught by a test (at the moment few other people use trainer flos, since it's mostly for large-scale training and researchers that need or want to report flos, and neither group uses the Trainer a lot, so it's mostly the HF bigscience efforts), and I should make one.

@sgugger 