### PR TITLE
Fix reference to XLNet

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -202,7 +202,7 @@ class TrainingArguments:
             Number of subprocesses to use for data loading (PyTorch only). 0 means that the data will be loaded in the
             main process.
         past_index (:obj:`int`, `optional`, defaults to -1):
-            Some models like :doc:`TransformerXL <../model_doc/transformerxl>` or :doc`XLNet <../model_doc/xlnet>` can
+            Some models like :doc:`TransformerXL <../model_doc/transformerxl>` or :doc:`XLNet <../model_doc/xlnet>` can
             make use of the past hidden states for their predictions. If this argument is set to a positive int, the
             ``Trainer`` will use the corresponding output (usually index 2) as the past state and feed it to the model
             at the next training step under the keyword argument ``mems``.


### PR DESCRIPTION
# What does this PR do?

Fixes a reference to the XLNet page in the documentation of TrainingArguments.
Fixes #11831