### PR TITLE
[lm examples] fix overflow in perplexity calc

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -443,7 +443,7 @@ def main():
         try:
             perplexity = math.exp(metrics["eval_loss"])
         except OverflowError:
-            perplexity = float("nan")
+            perplexity = float("inf")
         metrics["perplexity"] = perplexity
 
         trainer.log_metrics("eval", metrics)

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -440,7 +440,10 @@ def main():
 
         max_eval_samples = data_args.max_eval_samples if data_args.max_eval_samples is not None else len(eval_dataset)
         metrics["eval_samples"] = min(max_eval_samples, len(eval_dataset))
-        perplexity = math.exp(metrics["eval_loss"])
+        try:
+            perplexity = math.exp(metrics["eval_loss"])
+        except OverflowError:
+            perplexity = float("nan")
         metrics["perplexity"] = perplexity
 
         trainer.log_metrics("eval", metrics)

--- a/examples/pytorch/language-modeling/run_clm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_clm_no_trainer.py
@@ -442,7 +442,10 @@ def main():
 
         losses = torch.cat(losses)
         losses = losses[: len(eval_dataset)]
-        perplexity = math.exp(torch.mean(losses))
+        try:
+            perplexity = math.exp(torch.mean(losses))
+        except OverflowError:
+            perplexity = float("nan")
 
         logger.info(f"epoch {epoch}: perplexity: {perplexity}")
 

--- a/examples/pytorch/language-modeling/run_clm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_clm_no_trainer.py
@@ -445,7 +445,7 @@ def main():
         try:
             perplexity = math.exp(torch.mean(losses))
         except OverflowError:
-            perplexity = float("nan")
+            perplexity = float("inf")
 
         logger.info(f"epoch {epoch}: perplexity: {perplexity}")
 

--- a/examples/pytorch/language-modeling/run_mlm.py
+++ b/examples/pytorch/language-modeling/run_mlm.py
@@ -469,7 +469,10 @@ def main():
 
         max_eval_samples = data_args.max_eval_samples if data_args.max_eval_samples is not None else len(eval_dataset)
         metrics["eval_samples"] = min(max_eval_samples, len(eval_dataset))
-        perplexity = math.exp(metrics["eval_loss"])
+        try:
+            perplexity = math.exp(metrics["eval_loss"])
+        except OverflowError:
+            perplexity = float("nan")
         metrics["perplexity"] = perplexity
 
         trainer.log_metrics("eval", metrics)

--- a/examples/pytorch/language-modeling/run_mlm.py
+++ b/examples/pytorch/language-modeling/run_mlm.py
@@ -472,7 +472,7 @@ def main():
         try:
             perplexity = math.exp(metrics["eval_loss"])
         except OverflowError:
-            perplexity = float("nan")
+            perplexity = float("inf")
         metrics["perplexity"] = perplexity
 
         trainer.log_metrics("eval", metrics)

--- a/examples/pytorch/language-modeling/run_mlm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_mlm_no_trainer.py
@@ -486,7 +486,10 @@ def main():
 
         losses = torch.cat(losses)
         losses = losses[: len(eval_dataset)]
-        perplexity = math.exp(torch.mean(losses))
+        try:
+            perplexity = math.exp(metrics["eval_loss"])
+        except OverflowError:
+            perplexity = float("nan")
 
         logger.info(f"epoch {epoch}: perplexity: {perplexity}")
 

--- a/examples/pytorch/language-modeling/run_mlm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_mlm_no_trainer.py
@@ -487,7 +487,7 @@ def main():
         losses = torch.cat(losses)
         losses = losses[: len(eval_dataset)]
         try:
-            perplexity = math.exp(metrics["eval_loss"])
+            perplexity = math.exp(torch.mean(losses))
         except OverflowError:
             perplexity = float("inf")
 

--- a/examples/pytorch/language-modeling/run_mlm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_mlm_no_trainer.py
@@ -489,7 +489,7 @@ def main():
         try:
             perplexity = math.exp(metrics["eval_loss"])
         except OverflowError:
-            perplexity = float("nan")
+            perplexity = float("inf")
 
         logger.info(f"epoch {epoch}: perplexity: {perplexity}")
 

--- a/examples/pytorch/language-modeling/run_plm.py
+++ b/examples/pytorch/language-modeling/run_plm.py
@@ -445,7 +445,10 @@ def main():
 
         max_eval_samples = data_args.max_eval_samples if data_args.max_eval_samples is not None else len(eval_dataset)
         metrics["eval_samples"] = min(max_eval_samples, len(eval_dataset))
-        perplexity = math.exp(metrics["eval_loss"])
+        try:
+            perplexity = math.exp(metrics["eval_loss"])
+        except OverflowError:
+            perplexity = float("nan")
         metrics["perplexity"] = perplexity
 
         trainer.log_metrics("eval", metrics)

--- a/examples/pytorch/language-modeling/run_plm.py
+++ b/examples/pytorch/language-modeling/run_plm.py
@@ -448,7 +448,7 @@ def main():
         try:
             perplexity = math.exp(metrics["eval_loss"])
         except OverflowError:
-            perplexity = float("nan")
+            perplexity = float("inf")
         metrics["perplexity"] = perplexity
 
         trainer.log_metrics("eval", metrics)


### PR DESCRIPTION
This PR fixes overflow exception in perplexity calculation. Triggered when doing eval on untrained model and the loss is huge.

@sgugger 