### PR TITLE
Add some tests to the slow suite 

### DIFF
--- a/tests/test_modeling_bigbird_pegasus.py
+++ b/tests/test_modeling_bigbird_pegasus.py
@@ -361,9 +361,11 @@ class BigBirdPegasusModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.
         model.generate(**input_dict)
         model.generate(**input_dict, do_sample=True, early_stopping=False, num_return_sequences=3)
 
+    @slow
     def test_batched_forward_original_full(self):
         self._check_batched_forward(attn_type="original_full")
 
+    @slow
     def test_batched_forward_block_sparse(self):
         self._check_batched_forward(attn_type="block_sparse", tolerance=1e-1)
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -496,15 +496,18 @@ class ModelTesterMixin:
                     [self.model_tester.num_attention_heads, encoder_seq_length, encoder_key_length],
                 )
 
+    @slow
     def test_torchscript(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         self._create_and_check_torchscript(config, inputs_dict)
 
+    @slow
     def test_torchscript_output_attentions(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.output_attentions = True
         self._create_and_check_torchscript(config, inputs_dict)
 
+    @slow
     def test_torchscript_output_hidden_state(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.output_hidden_states = True


### PR DESCRIPTION
This PR adds the torchscript tests to the slow suite. The current CI isn't passing because it crashes and exceeds the 10-minute timeout, this PR is a first step into fixing that.

Will look into re-enabling the torchscript tests on each commit (they'll be tested every day for now) once we refactor the test suite to be less hungry.