### PR TITLE
[Proposal] Adding infinite generation as an option to generate

### DIFF
--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -118,7 +118,6 @@ class TFGenerationMixin:
                 The id of the `end-of-sequence` token.
             length_penalty (:obj:`float`, `optional`, defaults to 1.0):
                 Exponential penalty to the length. 1.0 means no penalty.
-
                 Set to values < 1.0 in order to encourage the model to generate shorter sequences, to a value > 1.0 in
                 order to encourage the model to produce longer sequences.
             no_repeat_ngram_size (:obj:`int`, `optional`, defaults to 0):
@@ -131,9 +130,7 @@ class TFGenerationMixin:
             attention_mask (:obj:`tf.Tensor` of :obj:`dtype=tf.int32` and shape :obj:`(batch_size, sequence_length)`, `optional`):
                 Mask to avoid performing attention on padding token indices. Mask values are in ``[0, 1]``, 1 for
                 tokens that are not masked, and 0 for masked tokens.
-
                 If not provided, will default to a tensor the same shape as :obj:`input_ids` that masks the pad token.
-
                 `What are attention masks? <../glossary.html#attention-mask>`__
             decoder_start_token_id (:obj:`int`, `optional`):
                 If an encoder-decoder model starts decoding with a different token than `bos`, the id of that token.
@@ -146,7 +143,7 @@ class TFGenerationMixin:
                 needs to be the target language token.
             forced_eos_token_id (:obj:`int`, `optional`):
                 The id of the token to force as the last generated token when :obj:`max_length` is reached.
-            infinite (:obj:`bool`, `optional`, default: :obj:`False`):
+            infinite (:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Will generate tokens infinitely by left truncating extra tokens when necessary. (Not available for all
                 models).
             model_specific_kwargs:

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -117,9 +117,9 @@ class TFGenerationMixin:
             eos_token_id (:obj:`int`, `optional`):
                 The id of the `end-of-sequence` token.
             length_penalty (:obj:`float`, `optional`, defaults to 1.0):
-                Exponential penalty to the length. 1.0 means no penalty.
-                Set to values < 1.0 in order to encourage the model to generate shorter sequences, to a value > 1.0 in
-                order to encourage the model to produce longer sequences.
+                Exponential penalty to the length. 1.0 means no penalty. Set to values < 1.0 in order to encourage the
+                model to generate shorter sequences, to a value > 1.0 in order to encourage the model to produce longer
+                sequences.
             no_repeat_ngram_size (:obj:`int`, `optional`, defaults to 0):
                 If set to int > 0, all ngrams of that size can only occur once.
             bad_words_ids(:obj:`List[int]`, `optional`):
@@ -129,9 +129,9 @@ class TFGenerationMixin:
                 The number of independently computed returned sequences for each element in the batch.
             attention_mask (:obj:`tf.Tensor` of :obj:`dtype=tf.int32` and shape :obj:`(batch_size, sequence_length)`, `optional`):
                 Mask to avoid performing attention on padding token indices. Mask values are in ``[0, 1]``, 1 for
-                tokens that are not masked, and 0 for masked tokens.
-                If not provided, will default to a tensor the same shape as :obj:`input_ids` that masks the pad token.
-                `What are attention masks? <../glossary.html#attention-mask>`__
+                tokens that are not masked, and 0 for masked tokens. If not provided, will default to a tensor the same
+                shape as :obj:`input_ids` that masks the pad token. `What are attention masks?
+                <../glossary.html#attention-mask>`__
             decoder_start_token_id (:obj:`int`, `optional`):
                 If an encoder-decoder model starts decoding with a different token than `bos`, the id of that token.
             use_cache: (:obj:`bool`, `optional`, defaults to :obj:`True`):

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -69,6 +69,7 @@ class TFGenerationMixin:
         use_cache=None,
         forced_bos_token_id=None,
         forced_eos_token_id=None,
+        infinite_generation=False,
     ):
         r"""
         Generates sequences for models with a language modeling head. The method currently supports greedy decoding,
@@ -145,6 +146,9 @@ class TFGenerationMixin:
                 needs to be the target language token.
             forced_eos_token_id (:obj:`int`, `optional`):
                 The id of the token to force as the last generated token when :obj:`max_length` is reached.
+            infinite (:obj:`bool`, `optional`, default: :obj:`False`):
+                Will generate tokens infinitely by left truncating extra tokens when necessary.
+                (Not available for all models).
             model_specific_kwargs:
                 Additional model specific kwargs will be forwarded to the :obj:`forward` function of the model.
 

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -117,9 +117,10 @@ class TFGenerationMixin:
             eos_token_id (:obj:`int`, `optional`):
                 The id of the `end-of-sequence` token.
             length_penalty (:obj:`float`, `optional`, defaults to 1.0):
-                Exponential penalty to the length. 1.0 means no penalty. Set to values < 1.0 in order to encourage the
-                model to generate shorter sequences, to a value > 1.0 in order to encourage the model to produce longer
-                sequences.
+                Exponential penalty to the length. 1.0 means no penalty.
+
+                Set to values < 1.0 in order to encourage the model to generate shorter sequences, to a value > 1.0 in
+                order to encourage the model to produce longer sequences.
             no_repeat_ngram_size (:obj:`int`, `optional`, defaults to 0):
                 If set to int > 0, all ngrams of that size can only occur once.
             bad_words_ids(:obj:`List[int]`, `optional`):
@@ -129,9 +130,11 @@ class TFGenerationMixin:
                 The number of independently computed returned sequences for each element in the batch.
             attention_mask (:obj:`tf.Tensor` of :obj:`dtype=tf.int32` and shape :obj:`(batch_size, sequence_length)`, `optional`):
                 Mask to avoid performing attention on padding token indices. Mask values are in ``[0, 1]``, 1 for
-                tokens that are not masked, and 0 for masked tokens. If not provided, will default to a tensor the same
-                shape as :obj:`input_ids` that masks the pad token. `What are attention masks?
-                <../glossary.html#attention-mask>`__
+                tokens that are not masked, and 0 for masked tokens.
+
+                If not provided, will default to a tensor the same shape as :obj:`input_ids` that masks the pad token.
+
+                `What are attention masks? <../glossary.html#attention-mask>`__
             decoder_start_token_id (:obj:`int`, `optional`):
                 If an encoder-decoder model starts decoding with a different token than `bos`, the id of that token.
             use_cache: (:obj:`bool`, `optional`, defaults to :obj:`True`):

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -69,7 +69,7 @@ class TFGenerationMixin:
         use_cache=None,
         forced_bos_token_id=None,
         forced_eos_token_id=None,
-        infinite_generation=False,
+        infinite=False,
     ):
         r"""
         Generates sequences for models with a language modeling head. The method currently supports greedy decoding,
@@ -398,6 +398,7 @@ class TFGenerationMixin:
                 use_cache=use_cache,
                 forced_bos_token_id=forced_bos_token_id,
                 forced_eos_token_id=forced_eos_token_id,
+                infinite=infinite,
             )
         else:
             output = self._generate_no_beam_search(
@@ -419,6 +420,7 @@ class TFGenerationMixin:
                 encoder_outputs=encoder_outputs,
                 attention_mask=attention_mask,
                 use_cache=use_cache,
+                infinite=infinite,
             )
 
         return output

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -147,8 +147,8 @@ class TFGenerationMixin:
             forced_eos_token_id (:obj:`int`, `optional`):
                 The id of the token to force as the last generated token when :obj:`max_length` is reached.
             infinite (:obj:`bool`, `optional`, default: :obj:`False`):
-                Will generate tokens infinitely by left truncating extra tokens when necessary.
-                (Not available for all models).
+                Will generate tokens infinitely by left truncating extra tokens when necessary. (Not available for all
+                models).
             model_specific_kwargs:
                 Additional model specific kwargs will be forwarded to the :obj:`forward` function of the model.
 

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -785,7 +785,6 @@ class GenerationMixin:
             infinite (:obj:`bool`, `optional`, defaults to :obj:`False`):
                 If enabled, model will attempt to generate infinitely many tokens, by left clipping tokens as
                 necessary. (Not enabled on all architectures)
-
             model_kwargs:
                 Additional model specific kwargs will be forwarded to the :obj:`forward` function of the model. If the
                 model is an encoder-decoder model, encoder specific kwargs should not be prefixed and decoder specific

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -674,6 +674,7 @@ class GenerationMixin:
         forced_eos_token_id: Optional[int] = None,
         remove_invalid_values: Optional[bool] = None,
         synced_gpus: Optional[bool] = None,
+        infinite: bool = False,
         **model_kwargs,
     ) -> Union[GreedySearchOutput, SampleOutput, BeamSearchOutput, BeamSampleOutput, torch.LongTensor]:
         r"""
@@ -781,6 +782,9 @@ class GenerationMixin:
                 crash. Note that using ``remove_invalid_values`` can slow down generation.
             synced_gpus (:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether to continue running the while loop until max_length (needed for ZeRO stage 3)
+            infinite (:obj:`bool`, `optional`, defaults to :obj:`False`):
+                If enabled, model will attempt to generate infinitely many tokens, by left clipping tokens as
+                necessary. (Not enabled on all architectures)
 
             model_kwargs:
                 Additional model specific kwargs will be forwarded to the :obj:`forward` function of the model. If the
@@ -940,6 +944,7 @@ class GenerationMixin:
 
         # set model_kwargs
         model_kwargs["use_cache"] = use_cache
+        model_kwargs["infinite"] = infinite
 
         # get distribution pre_processing samplers
         logits_processor = self._get_logits_processor(

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -881,15 +881,24 @@ class GPT2LMHeadModel(GPT2PreTrainedModel):
         self.lm_head = new_embeddings
 
     def prepare_inputs_for_generation(self, input_ids, past=None, **kwargs):
+        n_positions = self.config.n_positions
         token_type_ids = kwargs.get("token_type_ids", None)
         # only last token for inputs_ids if past is defined in kwargs
         if past:
             input_ids = input_ids[:, -1].unsqueeze(-1)
             if token_type_ids is not None:
                 token_type_ids = token_type_ids[:, -1].unsqueeze(-1)
+            past = tuple([tuple([key[:, :, -n_positions + 1 :] for key in p]) for p in past])
+
+        if input_ids.shape[-1] > n_positions:
+            logger.warning("Context is too long, clipping leftmost values")
+        input_ids = input_ids[:, -n_positions:]
 
         attention_mask = kwargs.get("attention_mask", None)
         position_ids = kwargs.get("position_ids", None)
+
+        if attention_mask is not None:
+            attention_mask = attention_mask[:, -n_positions:]
 
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation
@@ -1052,16 +1061,33 @@ class GPT2DoubleHeadsModel(GPT2PreTrainedModel):
     def set_output_embeddings(self, new_embeddings):
         self.lm_head = new_embeddings
 
-    def prepare_inputs_for_generation(self, input_ids, past=None, **kwargs):
+    def prepare_inputs_for_generation(self, input_ids, past=None, infinite=False, **kwargs):
+        n_positions = self.config.n_positions
+
         token_type_ids = kwargs.get("token_type_ids", None)
         # only last token for inputs_ids if past is defined in kwargs
         if past:
             input_ids = input_ids[:, -1].unsqueeze(-1)
             if token_type_ids is not None:
                 token_type_ids = token_type_ids[:, -1].unsqueeze(-1)
+            if infinite:
+                past = tuple([tuple([key[:, :, -n_positions + 1 :] for key in p]) for p in past])
+
+        if input_ids is not None and infinite and input_ids.shape[-1] > n_positions:
+            logger.warning("Context is too long, clipping leftmost values")
+            input_ids = input_ids[:, -n_positions + 1 :]
 
         attention_mask = kwargs.get("attention_mask", None)
         position_ids = kwargs.get("position_ids", None)
+
+        if attention_mask is not None and infinite and attention_mask.shape[1] > n_positions:
+            attention_mask = attention_mask[:, -n_positions + 1 :]
+
+        if position_ids is not None and infinite and position_ids.shape[1] > n_positions:
+            position_ids = position_ids[:, -n_positions + 1 :]
+
+        if token_type_ids is not None and infinite and token_type_ids.shape[1] > n_positions:
+            token_type_ids = token_type_ids[:, -n_positions + 1 :]
 
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -145,7 +145,9 @@ class TextGenerationPipeline(Pipeline):
                     input_ids is None or input_ids.shape[0] == 1
                 ), "Batch generation is currently not supported. See https://github.com/huggingface/transformers/issues/3021 for more information."
 
-                output_sequences = self.model.generate(input_ids=input_ids, **generate_kwargs)  # BS x SL
+                output_sequences = self.model.generate(
+                    input_ids=input_ids, infinite=True, **generate_kwargs
+                )  # BS x SL
 
             result = []
             for generated_sequence in output_sequences:

--- a/tests/test_pipelines_text_generation.py
+++ b/tests/test_pipelines_text_generation.py
@@ -15,7 +15,7 @@
 import unittest
 
 from transformers import pipeline
-from transformers.testing_utils import require_torch
+from transformers.testing_utils import require_torch, slow
 
 from .test_pipelines_common import MonoInputPipelineCommonMixin
 
@@ -60,3 +60,10 @@ class TextGenerationPipelineTests(MonoInputPipelineCommonMixin, unittest.TestCas
 
         outputs = text_generator("This is a test", return_full_text=True)
         self.assertIn("This is a test", outputs[0]["generated_text"])
+
+    @slow
+    @require_torch
+    def test_infinite_generation_gpt2(self):
+        text_generator = pipeline(task="text-generation", model="gpt2")
+        outputs = text_generator("This is a test" * 1000, max_new_tokens=10)
+        self.assertIn("This is a test" * 1000, outputs[0]["generated_text"])


### PR DESCRIPTION
# What does this PR do?

`generate` is limited in a lot of models, where we can't generate
more tokens than the limit of a said model (`seq_length`,
`max_position_embeddings`).

It corresponds to a reality of how models where trained, but advanced
usage like inference might rely on using the models to generate longer
output than this. It is also quite inconvenient to hit that barrier when
using pipelines (where inputs are text and not tokens).

So the main goal is to make this behavior non-default but opted
in by users as they should understand what is happening and the
limits linked to this behavior.

The following proposal is to enable (model per model) infinite
generation. It *might* be doable generally, however `past` seems
to be model dependant so it could be harder to do in general.

The implementation here simply clips any left values if somehow
the `input_ids` (or `past`) is larger than what the model can cope with.
We also propose to enable that by default for `text-generation`
models (`text2text-generation` might also make use of it).

Happy to hear your thoughts on this:

1- Should we enable that kind of feature ?
2- Is optional, with enabled by default for pipelines correct ?
3- Can we enable for every models instead of on a model-per-model basis ?


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@patrickvonplaten @LysandreJik @patil-suraj

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->