### PR TITLE
[AutomaticSpeechRecognitionPipeline] Ensure input tensors are on device

### DIFF
--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -136,6 +136,7 @@ class AutomaticSpeechRecognitionPipeline(Pipeline):
         processed = self.feature_extractor(
             inputs, sampling_rate=self.feature_extractor.sampling_rate, return_tensors="pt"
         )
+        processed = self.ensure_tensor_on_device(**processed)
 
         name = self.model.__class__.__name__
         if name.endswith("ForConditionalGeneration"):


### PR DESCRIPTION
# What does this PR do?

Enables using AutomaticSpeechRecognitionPipeline on GPU. 
The feature extractor does not create tensors on the appropriate device, so we call `ensure_tensor_on_device` before feeding the processed inputs to the model.

Fixes #11829 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
 @LysandreJik are there tests running on GPU? The other pipelines do not seem to test GPU inference, either.

## Who can review?
@LysandreJik, @Narsil 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.