### PR TITLE
changing find_batch_size to work with tokenizer outputs

### DIFF
--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -112,7 +112,7 @@ def find_batch_size(tensors):
             result = find_batch_size(t)
             if result is not None:
                 return result
-    elif isinstance(tensors, dict):
+    elif isinstance(tensors, (dict, BatchEncoding)):
         for key, value in tensors.items():
             result = find_batch_size(value)
             if result is not None:


### PR DESCRIPTION
trainer_pt_utils.find_batch_size currently does not recognize the batch size of BatchEncoding objects. This can cause an error when a trainer relies on find_batch_size to report the number of observed examples in the evaluation loop, which is the case when the eval dataset is Iterable.

# What does this PR do?

Very simple change that lets find_batch_size find the batch size of BatchEncoding objects.

Fixes # (11882)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x ] Was this discussed via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
        https://github.com/huggingface/transformers/issues/11882

- [x ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [x ] Did you write any new necessary tests?


@LysandreJik @sgugger


