### PR TITLE
Update deepspeed config to reflect hyperparameter search parameters

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -864,6 +864,7 @@ class Trainer:
         if self.args.deepspeed:
             # Rebuild the deepspeed config to reflect the updated training parameters
             from transformers.integrations import DeepSpeedConfigHF
+
             self.args.deepspeed_config_hf = DeepSpeedConfigHF(self.args)
 
     def _report_to_hp_search(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -861,6 +861,10 @@ class Trainer:
             setattr(self.args, key, value)
         if self.hp_search_backend == HPSearchBackend.OPTUNA:
             logger.info("Trial:", trial.params)
+        if self.args.deepspeed:
+            # Rebuild the deepspeed config to reflect the updated training parameters
+            from transformers.integrations import DeepSpeedConfigHF
+            self.args.deepspeed_config_hf = DeepSpeedConfigHF(self.args)
 
     def _report_to_hp_search(
         self, trial: Union["optuna.Trial", Dict[str, Any]], epoch: int, metrics: Dict[str, float]


### PR DESCRIPTION
# What does this PR do?

This PR adds a few lines of code to the Trainer so that it rebuilds the Deepspeed config when running hyperparameter_search. As is, if you run hyperparameter_search while using Deepspeed the TrainingArguments are updated but the Deepspeed config is not, the two become out of sync, and Deepspeed effectively ignores the parameters of any hyperparameter search trials which are set by the Deepspeed config. 
This fixes #11894


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. --> https://github.com/huggingface/transformers/issues/11894
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

I ran the Deepspeed tests and Trainer tests locally; everything passed except for `test_stage3_nvme_offload` but I think that was a hardware compatibility issue on my local machine. 

## Who can review?

@stas00 (and maybe whoever implemented hyperparameter_search() in the Trainer)
