### PR TITLE
Add conversion from TF to PT for Tapas retrieval models

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -981,6 +981,7 @@ if is_torch_available():
             "TapasForQuestionAnswering",
             "TapasForSequenceClassification",
             "TapasModel",
+            "load_tf_weights_in_tapas",
         ]
     )
     _import_structure["models.transfo_xl"].extend(
@@ -2316,6 +2317,7 @@ if TYPE_CHECKING:
             TapasForQuestionAnswering,
             TapasForSequenceClassification,
             TapasModel,
+            load_tf_weights_in_tapas,
         )
         from .models.transfo_xl import (
             TRANSFO_XL_PRETRAINED_MODEL_ARCHIVE_LIST,

--- a/src/transformers/models/tapas/__init__.py
+++ b/src/transformers/models/tapas/__init__.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 from ...file_utils import _BaseLazyModule, is_torch_available
 
+
 _import_structure = {
     "configuration_tapas": ["TAPAS_PRETRAINED_CONFIG_ARCHIVE_MAP", "TapasConfig"],
     "tokenization_tapas": ["TapasTokenizer"],

--- a/src/transformers/models/tapas/__init__.py
+++ b/src/transformers/models/tapas/__init__.py
@@ -20,7 +20,6 @@ from typing import TYPE_CHECKING
 
 from ...file_utils import _BaseLazyModule, is_torch_available
 
-
 _import_structure = {
     "configuration_tapas": ["TAPAS_PRETRAINED_CONFIG_ARCHIVE_MAP", "TapasConfig"],
     "tokenization_tapas": ["TapasTokenizer"],
@@ -33,6 +32,7 @@ if is_torch_available():
         "TapasForQuestionAnswering",
         "TapasForSequenceClassification",
         "TapasModel",
+        "load_tf_weights_in_tapas",
     ]
 
 
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
             TapasForQuestionAnswering,
             TapasForSequenceClassification,
             TapasModel,
+            load_tf_weights_in_tapas,
         )
 
 else:

--- a/src/transformers/models/tapas/convert_tapas_original_tf_checkpoint_to_pytorch.py
+++ b/src/transformers/models/tapas/convert_tapas_original_tf_checkpoint_to_pytorch.py
@@ -33,7 +33,7 @@ logging.set_verbosity_info()
 
 
 def convert_tf_checkpoint_to_pytorch(
-    task, reset_position_index_per_cell, tf_checkpoint_path, tapas_config_file, pytorch_dump_path
+    task, reset_position_index_per_cell, tf_checkpoint_path, tapas_config_file, vocab_file, pytorch_dump_path
 ):
     # Initialise PyTorch model.
     # If you want to convert a checkpoint that uses absolute position embeddings, make sure to set reset_position_index_per_cell of
@@ -81,24 +81,46 @@ def convert_tf_checkpoint_to_pytorch(
         model = TapasForMaskedLM(config=config)
     elif task == "INTERMEDIATE_PRETRAINING":
         model = TapasModel(config=config)
+    elif task == "RETRIEVAL":
+        question_model = TapasModel(config=config)
+        table_model = TapasModel(config=config)
 
     print(f"Building PyTorch model from configuration: {config}")
 
-    # Load weights from tf checkpoint
-    load_tf_weights_in_tapas(model, config, tf_checkpoint_path)
+    if task == "RETRIEVAL":
+        # Load weights from tf checkpoint
+        load_tf_weights_in_tapas(question_model, config, tf_checkpoint_path, "bert_1")
+        load_tf_weights_in_tapas(table_model, config, tf_checkpoint_path, "bert")
 
-    # Save pytorch-model (weights and configuration)
-    print(f"Save PyTorch model to {pytorch_dump_path}")
-    model.save_pretrained(pytorch_dump_path[:-17])
+        # Save pytorch-model (weights and configuration)
+        print(f"Save PyTorch question encoder model to {pytorch_dump_path}/question_encoder")
+        question_model.save_pretrained(f"{pytorch_dump_path}/question_encoder")
 
-    # Save tokenizer files
-    dir_name = r"C:\Users\niels.rogge\Documents\Python projecten\tensorflow\Tensorflow models\SQA\Base\tapas_sqa_inter_masklm_base_reset"
-    tokenizer = TapasTokenizer(vocab_file=dir_name + r"\vocab.txt", model_max_length=512)
+        print(f"Save PyTorch table encoder model to {pytorch_dump_path}/table_encoder")
+        table_model.save_pretrained(f"{pytorch_dump_path}/table_encoder")
 
-    print(f"Save tokenizer files to {pytorch_dump_path}")
-    tokenizer.save_pretrained(pytorch_dump_path[:-17])
+        # Save tokenizer files
+        tokenizer = TapasTokenizer(vocab_file=vocab_file, model_max_length=512)
+        print(f"Save tokenizer files to {pytorch_dump_path}/question_encoder")
+        tokenizer.save_pretrained(f"{pytorch_dump_path}/question_encoder")
 
-    print("Used relative position embeddings:", model.config.reset_position_index_per_cell)
+        print(f"Save tokenizer files to {pytorch_dump_path}/table_encoder")
+        tokenizer.save_pretrained(f"{pytorch_dump_path}/question_encoder")
+    else:
+        # Load weights from tf checkpoint
+        load_tf_weights_in_tapas(model, config, tf_checkpoint_path)
+
+        # Save pytorch-model (weights and configuration)
+        print(f"Save PyTorch model to {pytorch_dump_path}")
+        model.save_pretrained(pytorch_dump_path)
+
+        # Save tokenizer files
+        tokenizer = TapasTokenizer(vocab_file=vocab_file, model_max_length=512)
+
+        print(f"Save tokenizer files to {pytorch_dump_path}")
+        tokenizer.save_pretrained(pytorch_dump_path)
+
+    print("Used relative position embeddings:", config.reset_position_index_per_cell)
 
 
 if __name__ == "__main__":

--- a/src/transformers/models/tapas/convert_tapas_original_tf_checkpoint_to_pytorch.py
+++ b/src/transformers/models/tapas/convert_tapas_original_tf_checkpoint_to_pytorch.py
@@ -105,7 +105,7 @@ def convert_tf_checkpoint_to_pytorch(
         tokenizer.save_pretrained(f"{pytorch_dump_path}/question_encoder")
 
         print(f"Save tokenizer files to {pytorch_dump_path}/table_encoder")
-        tokenizer.save_pretrained(f"{pytorch_dump_path}/question_encoder")
+        tokenizer.save_pretrained(f"{pytorch_dump_path}/table_encoder")
     else:
         # Load weights from tf checkpoint
         load_tf_weights_in_tapas(model, config, tf_checkpoint_path)

--- a/src/transformers/models/tapas/modeling_tapas.py
+++ b/src/transformers/models/tapas/modeling_tapas.py
@@ -123,7 +123,7 @@ class TableQuestionAnsweringOutput(ModelOutput):
     attentions: Optional[Tuple[torch.FloatTensor]] = None
 
 
-def load_tf_weights_in_tapas(model, config, tf_checkpoint_path):
+def load_tf_weights_in_tapas(model, config, tf_checkpoint_path, model_prefix=None):
     """
     Load tf checkpoints in a PyTorch model. This is an adaptation from load_tf_weights_in_bert
 
@@ -145,6 +145,8 @@ def load_tf_weights_in_tapas(model, config, tf_checkpoint_path):
     logger.info(f"Converting TensorFlow checkpoint from {tf_path}")
     # Load weights from TF model
     init_vars = tf.train.list_variables(tf_path)
+    if model_prefix:
+        init_vars = [var for var in init_vars if var[0].split("/")[0] == model_prefix]
     names = []
     arrays = []
     for name, shape in init_vars:
@@ -184,7 +186,7 @@ def load_tf_weights_in_tapas(model, config, tf_checkpoint_path):
                 logger.info(f"Skipping {'/'.join(name)}")
                 continue
         # if first scope name starts with "bert", change it to "tapas"
-        if name[0] == "bert":
+        if name[0] == "bert" or name[0] == "bert_1":
             name[0] = "tapas"
         pointer = model
         for m_name in name:

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -2807,6 +2807,10 @@ class TapasModel:
         requires_backends(self, ["torch"])
 
 
+def load_tf_weights_in_tapas(*args, **kwargs):
+    requires_backends(load_tf_weights_in_tapas, ["torch"])
+
+
 TRANSFO_XL_PRETRAINED_MODEL_ARCHIVE_LIST = None
 
 


### PR DESCRIPTION
# What does this PR do?

Table Retrieval models based on Tapas as described [here](https://arxiv.org/pdf/2103.12011.pdf) just got published in the [Tapas repository](https://github.com/google-research/tapas). The existing conversion function does not work with the retrieval models, so I added support to convert them to Pytorch.
Unfortunately, this only converts the language model without the down projection layer. However, I think this might still be useful to some people who, for instance, want to fine-tune the pre-trained models. 
Unfortunately, I do not have the time at the moment to add the down projection layer myself.


## Who can review?

@NielsRogge 
