### PR TITLE
get_ordinal(local=True) replaced with get_local_ordinal() in training_args.py

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -861,7 +861,7 @@ class TrainingArguments:
         The index of the local process used.
         """
         if is_torch_tpu_available():
-            return xm.get_ordinal(local=True)
+            return xm.get_local_ordinal()
         elif is_sagemaker_mp_enabled():
             return smp.local_rank()
         elif is_sagemaker_dp_enabled():


### PR DESCRIPTION
## Fixed
Wrong method call fixed. Modified according to:
https://pytorch.org/xla/release/1.8.1/_modules/torch_xla/core/xla_model.html

TPU training as called by the following or similar scripts now works:
```ruby
python xla_spawn.py \
        --num_cores=8 \
        language-modeling/run_mlm.py \
            --train_file $TRAIN_FILE \
            --model_name_or_path bert-base-uncased \
            --output_dir $OUTPUT_DIR \
            --overwrite_output_dir True \
            --do_train True \
```

## Discussed/approved
https://github.com/huggingface/transformers/issues/11910

## Who can review?
 @sgugger
