### PR TITLE
Use `self.assertEqual` instead of `assert` in deberta v2 test.

### DIFF
--- a/tests/test_tokenization_deberta_v2.py
+++ b/tests/test_tokenization_deberta_v2.py
@@ -102,10 +102,11 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         encoded_sentence = tokenizer.build_inputs_with_special_tokens(text)
         encoded_pair = tokenizer.build_inputs_with_special_tokens(text, text_2)
 
-        assert encoded_sentence == [tokenizer.cls_token_id] + text + [tokenizer.sep_token_id]
-        assert encoded_pair == [tokenizer.cls_token_id] + text + [tokenizer.sep_token_id] + text_2 + [
-            tokenizer.sep_token_id
-        ]
+        self.assertEqual([tokenizer.cls_token_id] + text + [tokenizer.sep_token_id], encoded_sentence)
+        self.assertEqual(
+            [tokenizer.cls_token_id] + text + [tokenizer.sep_token_id] + text_2 + [tokenizer.sep_token_id],
+            encoded_pair,
+        )
 
     def test_tokenizer_integration(self):
         tokenizer_classes = [self.tokenizer_class]


### PR DESCRIPTION
PR to fix #11929