### PR TITLE
reinitialize wandb config for each hyperparameter search run

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -713,6 +713,7 @@ class WandbCallback(TrainerCallback):
         hp_search = state.is_hyper_param_search
         if hp_search:
             self._wandb.finish()
+            self._initialized = False
         if not self._initialized:
             self.setup(args, state, model, **kwargs)
 


### PR DESCRIPTION
# What does this PR do?

Fixes #11944 

This is the quick/easy fix I'm using to work around the issue locally by just rerunning the WandbCallback integration `setup()` method for each run. This works fine for me, but if for some reason it's not safe/desirable to rerun the `WandbCallback.setup()` please feel free to just close this PR. 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Unsure; probably whoever did the wandb integration is best. Otherwise maybe @sgugger because it's Trainer related? 
