### PR TITLE
Authorize args when instantiating an AutoModel

### DIFF
--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -357,7 +357,7 @@ class _BaseAutoModelClass:
     # Base class for auto models.
     _model_mapping = None
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         raise EnvironmentError(
             f"{self.__class__.__name__} is designed to be instantiated "
             f"using the `{self.__class__.__name__}.from_pretrained(pretrained_model_name_or_path)` or "


### PR DESCRIPTION
The current `_BaseAutoModelClass` class initialization does not accept any argument, and therefore fails with an arcane error when instantiating it incorrectly, as shown in https://github.com/huggingface/transformers/issues/11953 by @g-karthik:

```py
from transformers import AutoConfig, AutoModelForCausalLM

config = AutoConfig.from_pretrained("gpt2", return_dict=True, gradient_checkpointing=False)
model = AutoModelForCausalLM(config)
```
```out
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __init__() takes 1 positional argument but 2 were given
```

This PR adds possible arguments and keyword arguments so that the error is always correctly raised:

```out
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/home/xxx/transformers/src/transformers/models/auto/auto_factory.py", line 361, in __init__
    raise EnvironmentError(
OSError: AutoModel is designed to be instantiated using the `AutoModel.from_pretrained(pretrained_model_name_or_path)` or `AutoModel.from_config(config)` methods.
```

Taking this opportunity to re-open the question asked by @g-karthik of whether the `AutoModel`s should have the ability to be instantiated using configuration objects via the `__init__`, similarly to other `PreTrainedModel`s.

@patrickvonplaten @sgugger 