### PR TITLE
Fix loss reporting with deepspeed

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1752,7 +1752,8 @@ class Trainer:
         elif self.deepspeed:
             self.deepspeed.backward(loss)
             # to report the proper loss, we do the scaling here, after the `backward` pass
-            loss = loss / self.args.gradient_accumulation_steps
+            if self.args.gradient_accumulation_steps > 1:
+                loss = loss / self.args.gradient_accumulation_steps
         else:
             loss.backward()
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1750,8 +1750,9 @@ class Trainer:
             with amp.scale_loss(loss, self.optimizer) as scaled_loss:
                 scaled_loss.backward()
         elif self.deepspeed:
-            # loss gets scaled under gradient_accumulation_steps in deepspeed
-            loss = self.deepspeed.backward(loss)
+            self.deepspeed.backward(loss)
+            # to report the proper loss, we do the scaling here, after the `backward` pass
+            loss = loss / self.args.gradient_accumulation_steps
         else:
             loss.backward()
 


### PR DESCRIPTION
# What does this PR do?

In the deepspeed integration inside `Trainer`, the loss currently reported is the scaled loss, as in scaled by the loss scaling factor used during mixed precision training. This has nothing to do with the actual loss (the scaling factor is the highest possible value that does not make the gradients overflow basically), this PR fixes that.

Fixes #11919