### PR TITLE
[Trainer] add train loss and flops metrics reports

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1362,20 +1362,23 @@ class Trainer:
                     self.state.best_model_checkpoint, load_optimizer_states=False, load_lr_scheduler_states=False
                 )
 
-        metrics = speed_metrics("train", start_time, num_samples=num_train_samples, num_steps=self.state.max_steps)
-        self.store_flos()
-        metrics["total_flos"] = self.state.total_flos
-        self.log(metrics)
-
         self.control = self.callback_handler.on_train_end(args, self.state, self.control)
         # add remaining tr_loss
         self._total_loss_scalar += tr_loss.item()
+        training_loss = self._total_loss_scalar / self.state.global_step
+
+        metrics = speed_metrics("train", start_time, num_samples=num_train_samples, num_steps=self.state.max_steps)
+        self.store_flos()
+        metrics["total_flos"] = self.state.total_flos
+        metrics["train_loss"] = training_loss
 
         self.is_in_train = False
 
         self._memory_tracker.stop_and_update_metrics(metrics)
 
-        return TrainOutput(self.state.global_step, self._total_loss_scalar / self.state.global_step, metrics)
+        self.log(metrics)
+
+        return TrainOutput(self.state.global_step, training_loss, metrics)
 
     def _load_state_dict_in_model(self, state_dict):
         load_result = self.model.load_state_dict(state_dict, strict=False)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1362,7 +1362,6 @@ class Trainer:
                     self.state.best_model_checkpoint, load_optimizer_states=False, load_lr_scheduler_states=False
                 )
 
-        self.control = self.callback_handler.on_train_end(args, self.state, self.control)
         # add remaining tr_loss
         self._total_loss_scalar += tr_loss.item()
         train_loss = self._total_loss_scalar / self.state.global_step
@@ -1377,6 +1376,8 @@ class Trainer:
         self._memory_tracker.stop_and_update_metrics(metrics)
 
         self.log(metrics)
+
+        self.control = self.callback_handler.on_train_end(args, self.state, self.control)
 
         return TrainOutput(self.state.global_step, train_loss, metrics)
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1365,12 +1365,12 @@ class Trainer:
         self.control = self.callback_handler.on_train_end(args, self.state, self.control)
         # add remaining tr_loss
         self._total_loss_scalar += tr_loss.item()
-        training_loss = self._total_loss_scalar / self.state.global_step
+        train_loss = self._total_loss_scalar / self.state.global_step
 
         metrics = speed_metrics("train", start_time, num_samples=num_train_samples, num_steps=self.state.max_steps)
         self.store_flos()
         metrics["total_flos"] = self.state.total_flos
-        metrics["train_loss"] = training_loss
+        metrics["train_loss"] = train_loss
 
         self.is_in_train = False
 
@@ -1378,7 +1378,7 @@ class Trainer:
 
         self.log(metrics)
 
-        return TrainOutput(self.state.global_step, training_loss, metrics)
+        return TrainOutput(self.state.global_step, train_loss, metrics)
 
     def _load_state_dict_in_model(self, state_dict):
         load_result = self.model.load_state_dict(state_dict, strict=False)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -311,13 +311,11 @@ class TrainerIntegrationCommon:
         log_history = state.pop("log_history", None)
         log_history1 = state1.pop("log_history", None)
         self.assertEqual(state, state1)
+        skip_log_keys = ["train_runtime", "train_samples_per_second", "train_steps_per_second", "train_loss"]
         for log, log1 in zip(log_history, log_history1):
-            _ = log.pop("train_runtime", None)
-            _ = log1.pop("train_runtime", None)
-            _ = log.pop("train_samples_per_second", None)
-            _ = log1.pop("train_samples_per_second", None)
-            _ = log.pop("train_steps_per_second", None)
-            _ = log1.pop("train_steps_per_second", None)
+            for key in skip_log_keys:
+                _ = log.pop(key, None)
+                _ = log1.pop(key, None)
             self.assertEqual(log, log1)
 
 


### PR DESCRIPTION
The train wasn't reporting loss metrics (and flops it seems), this PR fixes that. Now we get:

```
***** train metrics *****
  epoch                    =        1.0
  total_flos               =      405GF
  train_loss               =     2.9435
  train_runtime            = 0:00:01.75
  train_samples            =         20
  train_samples_per_second =     11.401
  train_steps_per_second   =       1.14
```

Also moves metrics logging to when all metrics have been updated.

@sgugger 