### PR TITLE
Fix megatron_gpt2 attention block's causal mask

### DIFF
--- a/src/transformers/models/megatron_gpt2/convert_megatron_gpt2_checkpoint.py
+++ b/src/transformers/models/megatron_gpt2/convert_megatron_gpt2_checkpoint.py
@@ -125,8 +125,10 @@ def convert_megatron_checkpoint(args, input_state_dict):
         elif op_name == "attention.query_key_value" and weight_or_bias == "weight":
 
             # Insert a tensor of 1x1xDxD bias.
-            zeros = torch.ones(1, 1, hidden_size, hidden_size)
-            output_state_dict[layer_name + ".attn.bias"] = zeros
+            causal_mask = torch.tril(torch.ones((hidden_size, hidden_size), dtype=torch.uint8)).view(
+                1, 1, hidden_size, hidden_size
+            )
+            output_state_dict[layer_name + ".attn.bias"] = causal_mask
 
             # Insert a "dummy" tensor for masked_bias.
             masked_bias = torch.tensor(-1e4)

--- a/tests/test_modeling_megatron_gpt2.py
+++ b/tests/test_modeling_megatron_gpt2.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from transformers import is_torch_available
+from transformers.testing_utils import require_sentencepiece, require_tokenizers, require_torch, slow, torch_device
+
+if is_torch_available():
+    import torch
+    from transformers import GPT2LMHeadModel
+
+@require_torch
+@require_sentencepiece
+@require_tokenizers
+class MegatronGPT2IntegrationTest(unittest.TestCase):
+    def test_inference_no_head(self):
+        directory = "nvidia/megatron-gpt2-345m/"
+        if "MYDIR" in os.environ:
+            directory = os.path.join(os.environ["MYDIR"], directory)
+        model = GPT2LMHeadModel.from_pretrained(directory)
+        model.to(torch_device)
+        model.half()
+
+        input_ids = torch.tensor(
+            [[101, 7110, 1005, 1056, 2023, 11333, 17413, 1029, 102]],
+            device=torch_device,
+            dtype=torch.long,
+        )
+
+        with torch.no_grad():
+            output = model(input_ids).logits
+
+        expected_shape = torch.Size((1, 9, 50257))
+        self.assertEqual(output.shape, expected_shape)
+
+        expected_diag = torch.tensor(
+            [ 4.9414, -0.2920, -1.2148, -4.0273, -0.5161,
+             -5.2109, -1.2412, -1.8301, -1.7734, -4.7148,
+             -0.2317, -1.0811, -2.1777,  0.4141, -3.7969,
+             -4.0586, -2.5332, -3.3809,  4.3867],
+            device=torch_device,
+            dtype=torch.half,
+        )
+
+        for i in range(19):
+            r, c = 8 * i // 17, 2792 * i # along the diagonal
+            computed, expected = output[0,r,c], expected_diag[i]
+            msg = f"row={r} col={c} computed={computed} expected={expected}"
+            self.assertAlmostEqual(computed, expected, delta=1e-4, msg=msg)
+

--- a/tests/test_modeling_megatron_gpt2.py
+++ b/tests/test_modeling_megatron_gpt2.py
@@ -19,14 +19,18 @@ import unittest
 from transformers import is_torch_available
 from transformers.testing_utils import require_sentencepiece, require_tokenizers, require_torch, slow, torch_device
 
+
 if is_torch_available():
     import torch
+
     from transformers import GPT2LMHeadModel
+
 
 @require_torch
 @require_sentencepiece
 @require_tokenizers
 class MegatronGPT2IntegrationTest(unittest.TestCase):
+    @slow
     def test_inference_no_head(self):
         directory = "nvidia/megatron-gpt2-345m/"
         if "MYDIR" in os.environ:
@@ -48,17 +52,33 @@ class MegatronGPT2IntegrationTest(unittest.TestCase):
         self.assertEqual(output.shape, expected_shape)
 
         expected_diag = torch.tensor(
-            [ 4.9414, -0.2920, -1.2148, -4.0273, -0.5161,
-             -5.2109, -1.2412, -1.8301, -1.7734, -4.7148,
-             -0.2317, -1.0811, -2.1777,  0.4141, -3.7969,
-             -4.0586, -2.5332, -3.3809,  4.3867],
+            [
+                4.9414,
+                -0.2920,
+                -1.2148,
+                -4.0273,
+                -0.5161,
+                -5.2109,
+                -1.2412,
+                -1.8301,
+                -1.7734,
+                -4.7148,
+                -0.2317,
+                -1.0811,
+                -2.1777,
+                0.4141,
+                -3.7969,
+                -4.0586,
+                -2.5332,
+                -3.3809,
+                4.3867,
+            ],
             device=torch_device,
             dtype=torch.half,
         )
 
         for i in range(19):
-            r, c = 8 * i // 17, 2792 * i # along the diagonal
-            computed, expected = output[0,r,c], expected_diag[i]
+            r, c = 8 * i // 17, 2792 * i  # along the diagonal
+            computed, expected = output[0, r, c], expected_diag[i]
             msg = f"row={r} col={c} computed={computed} expected={expected}"
             self.assertAlmostEqual(computed, expected, delta=1e-4, msg=msg)
-


### PR DESCRIPTION
# What does this PR do?
Fixes the conversion between Megatron-LM's GPT2 parameters and transformer's GPT2.
In Megatron-LM the attention mask is implemented differently and is not part of the provided checkpoint.
This PR initializes the mask as in [GPT2](https://github.com/huggingface/transformers/blob/master/src/transformers/models/gpt2/modeling_gpt2.py#L131).

Fixes [#11916](https://github.com/huggingface/transformers/issues/11916) and [#12004](https://github.com/huggingface/transformers/issues/12004).

Regarding [#11916](https://github.com/huggingface/transformers/issues/11916), this PR lowers the perplexity to 20 (cf. 30 for gpt2) without fine-tuning.

Regarding [#12004](https://github.com/huggingface/transformers/issues/12004), the prompt in the issue now is continued coherently.
> How are you doing these days?
> I'm just trying to get through the day. I've been working on a lot of things, but it's hard when your kids come home and they're not here with me anymore because we don't have that connection like before." She said she has had some good times since her son was born in January 2012: "It feels great being able for him [to] be around his dad again," he added as if remembering how much fun their relationship used too! The couple also share two daughters together – Ella Rose (born April 2013) who is now 10 years old; Aviana Grace Marie-Gracee DeSantis Jr., 5th grade daughter from an earlier marriage whom Lohan recently

 ## Who can review?
The PR for the megatron models was reviewed by @LysandreJik
@jdemouth 