### PR TITLE
[TrainerArguments] format and sort __repr__, add __str__

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -680,8 +680,9 @@ class TrainingArguments:
 
     def __repr__(self):
         self_as_dict = asdict(self)
+
         # We remove deprecated arguments from the repr. That code should be removed once
-        # those deprecated arguments are removed form TrainingArguments. (TODO: v5)
+        # those deprecated arguments are removed from TrainingArguments. (TODO: v5)
         del self_as_dict["per_gpu_train_batch_size"]
         del self_as_dict["per_gpu_eval_batch_size"]
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -679,13 +679,16 @@ class TrainingArguments:
             self.hf_deepspeed_config.trainer_config_process(self)
 
     def __repr__(self):
-        # We override the default repr to remove deprecated arguments from the repr. This method should be removed once
-        # those deprecated arguments are removed form TrainingArguments. (TODO: v5)
         self_as_dict = asdict(self)
+        # We remove deprecated arguments from the repr. That code should be removed once
+        # those deprecated arguments are removed form TrainingArguments. (TODO: v5)
         del self_as_dict["per_gpu_train_batch_size"]
         del self_as_dict["per_gpu_eval_batch_size"]
-        attrs_as_str = [f"{k}={v}" for k, v in self_as_dict.items()]
-        return f"{self.__class__.__name__}({', '.join(attrs_as_str)})"
+
+        attrs_as_str = [f"{k}={v},\n" for k, v in sorted(self_as_dict.items())]
+        return f"{self.__class__.__name__}(\n{''.join(attrs_as_str)})"
+
+    __str__ = __repr__
 
     @property
     def train_batch_size(self) -> int:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -678,18 +678,16 @@ class TrainingArguments:
             self.hf_deepspeed_config = HfTrainerDeepSpeedConfig(self.deepspeed)
             self.hf_deepspeed_config.trainer_config_process(self)
 
-    def __repr__(self):
+    def __str__(self):
         self_as_dict = asdict(self)
 
-        # We remove deprecated arguments from the repr. That code should be removed once
+        # Remove deprecated arguments. That code should be removed once
         # those deprecated arguments are removed from TrainingArguments. (TODO: v5)
         del self_as_dict["per_gpu_train_batch_size"]
         del self_as_dict["per_gpu_eval_batch_size"]
 
         attrs_as_str = [f"{k}={v},\n" for k, v in sorted(self_as_dict.items())]
         return f"{self.__class__.__name__}(\n{''.join(attrs_as_str)})"
-
-    __str__ = __repr__
 
     @property
     def train_batch_size(self) -> int:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -689,6 +689,8 @@ class TrainingArguments:
         attrs_as_str = [f"{k}={v},\n" for k, v in sorted(self_as_dict.items())]
         return f"{self.__class__.__name__}(\n{''.join(attrs_as_str)})"
 
+    __repr__ = __str__
+
     @property
     def train_batch_size(self) -> int:
         """


### PR DESCRIPTION
This PR:
- makes the `TrainerArguments` log dump more readable - by sorting and formatting the output
- `__repr__` wasn't actually used in examples, but `__str__` was needed - so fixing that buglet

New dump looks like:

```
06/03/2021 17:05:12 - INFO - __main__ -   Training/evaluation parameters Seq2SeqTrainingArguments(
_n_gpu=1,
adafactor=False,
adam_beta1=0.9,
adam_beta2=0.999,
adam_epsilon=1e-06,
dataloader_drop_last=False,
dataloader_num_workers=0,
dataloader_pin_memory=True,
ddp_find_unused_parameters=None,
debug=[],
deepspeed=None,
disable_tqdm=False,
do_eval=True,
do_predict=False,
do_train=False,
eval_accumulation_steps=None,
eval_steps=2500,
evaluation_strategy=IntervalStrategy.STEPS,
fp16=False,
fp16_backend=auto,
fp16_full_eval=True,
fp16_opt_level=O1,
gradient_accumulation_steps=1,
greater_is_better=None,
group_by_length=False,
ignore_data_skip=False,
label_names=None,
label_smoothing_factor=0.1,
learning_rate=3e-05,
length_column_name=length,
load_best_model_at_end=False,
local_rank=-1,
log_on_each_node=True,
logging_dir=runs/Jun03_17-05-12_hope,
logging_first_step=True,
logging_steps=500,
logging_strategy=IntervalStrategy.STEPS,
lr_scheduler_type=SchedulerType.LINEAR,
max_grad_norm=1.0,
max_steps=-1,
metric_for_best_model=None,
mp_parameters=,
no_cuda=False,
num_train_epochs=1.0,
output_dir=output_dir,
overwrite_output_dir=True,
past_index=-1,
per_device_eval_batch_size=16,
per_device_train_batch_size=8,
predict_with_generate=True,
prediction_loss_only=False,
push_to_hub=False,
remove_unused_columns=True,
report_to=['tensorboard'],
resume_from_checkpoint=None,
run_name=output_dir,
save_steps=500,
save_strategy=IntervalStrategy.STEPS,
save_total_limit=None,
seed=42,
sharded_ddp=[],
skip_memory_metrics=True,
sortish_sampler=True,
tpu_metrics_debug=False,
tpu_num_cores=None,
use_legacy_prediction_loop=False,
warmup_ratio=0.0,
warmup_steps=50,
weight_decay=0.0,
)
```

@sgugger 