### PR TITLE
Add torch to requirements.txt in language-modeling

### DIFF
--- a/examples/pytorch/language-modeling/requirements.txt
+++ b/examples/pytorch/language-modeling/requirements.txt
@@ -1,4 +1,4 @@
-torch
+torch >= 1.3
 datasets >= 1.1.3
 sentencepiece != 0.1.92
 protobuf

--- a/examples/pytorch/language-modeling/requirements.txt
+++ b/examples/pytorch/language-modeling/requirements.txt
@@ -1,3 +1,4 @@
+torch
 datasets >= 1.1.3
 sentencepiece != 0.1.92
 protobuf


### PR DESCRIPTION
it seems the requirements.txt was missing `torch`, which is seemingly required. Just adding it. 

@sgugger 