### PR TITLE
Add early stopping args to TrainingArguments

### DIFF
--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -510,7 +510,7 @@ class EarlyStoppingCallback(TrainerCallback):
        early_stopping_patience (:obj:`int`):
             Use with :obj:`metric_for_best_model` to stop training when the specified metric worsens for
             :obj:`early_stopping_patience` evaluation calls.
-       early_stopping_threshold(:obj:`float`, `optional`):
+       early_stopping_threshold (:obj:`float`, `optional`):
             Use with TrainingArguments :obj:`metric_for_best_model` and :obj:`early_stopping_patience` to denote how
             much the specified metric must improve to satisfy early stopping conditions.
 

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -512,7 +512,7 @@ class EarlyStoppingCallback(TrainerCallback):
             :obj:`early_stopping_patience` evaluation calls.
        early_stopping_threshold(:obj:`float`, `optional`):
             Use with TrainingArguments :obj:`metric_for_best_model` and :obj:`early_stopping_patience` to denote how
-            much the specified metric must improve to satisfy early stopping conditions. `
+            much the specified metric must improve to satisfy early stopping conditions.
 
     This callback depends on :class:`~transformers.TrainingArguments` argument `load_best_model_at_end` functionality
     to set best_metric in :class:`~transformers.TrainerState`.

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -578,15 +578,11 @@ class TrainingArguments:
     )
     early_stopping_patience: int = field(
         default=1,
-        metadata={
-            "help": "The number of evaluation calls to wait before stopping training while metric worsens."
-        },
+        metadata={"help": "The number of evaluation calls to wait before stopping training while metric worsens."},
     )
     early_stopping_threshold: float = field(
         default=0.0,
-        metadata={
-            "help": "How much the metric must improve to satisfy early stopping conditions."
-        },
+        metadata={"help": "How much the metric must improve to satisfy early stopping conditions."},
     )
 
     def __post_init__(self):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -320,7 +320,7 @@ class TrainingArguments:
             In multinode distributed training, whether to log once per node, or only on the main node.
         early_stopping_patience (:obj:`int`, `optional`, defaults to 1):
             The number of evaluation calls to wait before stopping training while metric worsens.
-        early_stopping_threshold(:obj:`float`, `optional`, defaults  to 0.0):
+        early_stopping_threshold (:obj:`float`, `optional`, defaults  to 0.0):
             How much the metric must improve to satisfy early stopping conditions.
     """
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -318,6 +318,10 @@ class TrainingArguments:
             details.
         log_on_each_node (:obj:`bool`, `optional`, defaults to :obj:`True`):
             In multinode distributed training, whether to log once per node, or only on the main node.
+        early_stopping_patience (:obj:`int`, `optional`, defaults to 1):
+            The number of evaluation calls to wait before stopping training while metric worsens.
+        early_stopping_threshold(:obj:`float`, `optional`, defaults  to 0.0):
+            How much the metric must improve to satisfy early stopping conditions.
     """
 
     output_dir: str = field(
@@ -571,6 +575,18 @@ class TrainingArguments:
     mp_parameters: str = field(
         default="",
         metadata={"help": "Used by the SageMaker launcher to send mp-specific args. Ignored in Trainer"},
+    )
+    early_stopping_patience: int = field(
+        default=1,
+        metadata={
+            "help": "The number of evaluation calls to wait before stopping training while metric worsens."
+        },
+    )
+    early_stopping_threshold: float = field(
+        default=0.0,
+        metadata={
+            "help": "How much the metric must improve to satisfy early stopping conditions."
+        },
     )
 
     def __post_init__(self):


### PR DESCRIPTION
# What does this PR do?

While working in the collaborative training project, I added early stopping args to `TrainingArguments`.

Feel free to close this PR if you consider it is not pertinent.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger 