### PR TITLE
Fix tapas issue

### DIFF
--- a/src/transformers/models/tapas/modeling_tapas.py
+++ b/src/transformers/models/tapas/modeling_tapas.py
@@ -1697,9 +1697,9 @@ def _segment_reduce(values, index, segment_reduce_fn, name):
 
     segment_means = scatter(
         src=flat_values,
-        index=flat_index.indices.type(torch.long),
+        index=flat_index.indices.long(),
         dim=0,
-        dim_size=flat_index.num_segments,
+        dim_size=int(flat_index.num_segments),
         reduce=segment_reduce_fn,
     )
 

--- a/tests/test_modeling_tapas.py
+++ b/tests/test_modeling_tapas.py
@@ -1044,7 +1044,6 @@ class TapasUtilitiesTest(unittest.TestCase):
         # We use np.testing.assert_array_equal rather than Tensorflow's assertAllEqual
         np.testing.assert_array_equal(maximum.numpy(), [2, 3])
 
-    @unittest.skip("Fix me I'm failing on CI")
     def test_reduce_sum_vectorized(self):
         values = torch.as_tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [3.0, 4.0, 5.0]])
         index = IndexMap(indices=torch.as_tensor([0, 0, 1]), num_segments=2, batch_dims=0)


### PR DESCRIPTION
# What does this PR do?

Fixes #12060

However, the (slow) integration tests of TAPAS that use relative position embeddings are failing for me locally, most likely due to the new version of the [torch-scatter](https://github.com/rusty1s/pytorch_scatter) dependency. I'll look into that.

Update: just tested the models in Google Colab (which has `torch 1.8.1+cu101`). Everything seems to work fine there. However, when running locally on `torch 1.8.1+cu111`, I'm getting entirely different logits/hidden states. Both are using `torch-scatter 2.7.0`.