### PR TITLE
[wav2vec2 / Deepspeed] sync LayerDrop for Wav2Vec2Encoder + tests

### DIFF
--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -548,15 +548,18 @@ class Wav2Vec2Encoder(nn.Module):
         hidden_states = self.layer_norm(hidden_states)
         hidden_states = self.dropout(hidden_states)
 
+        deepspeed_zero3_is_enabled = is_deepspeed_zero3_enabled()
+
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states = all_hidden_states + (hidden_states,)
 
             # add LayerDrop (see https://arxiv.org/abs/1909.11556 for description)
             dropout_probability = np.random.uniform(0, 1)
-            if self.training and (dropout_probability < self.config.layerdrop):  # skip the layer
-                layer_outputs = (None, None)
-            else:
+
+            skip_the_layer = True if self.training and (dropout_probability < self.config.layerdrop) else False
+            if not skip_the_layer or deepspeed_zero3_is_enabled:
+                # under deepspeed zero3 all gpus must run in sync
                 if getattr(self.config, "gradient_checkpointing", False) and self.training:
                     # create gradient checkpointing function
                     def create_custom_forward(module):
@@ -575,6 +578,9 @@ class Wav2Vec2Encoder(nn.Module):
                         hidden_states, attention_mask=attention_mask, output_attentions=output_attentions
                     )
                 hidden_states = layer_outputs[0]
+
+            if skip_the_layer:
+                layer_outputs = (None, None)
 
             if output_attentions:
                 all_self_attentions = all_self_attentions + (layer_outputs[1],)


### PR DESCRIPTION
This PR continues https://github.com/huggingface/transformers/pull/11638 and:
- adds the same gpu syncing for `Wav2Vec2Encoder` LayerDrop as there is for ` Wav2Vec2EncoderStableLayerNorm`
- double the tests to test `"patrickvonplaten/wav2vec2_tiny_random"` to exercise `Wav2Vec2Encoder` too

@patrickvonplaten 
