### PR TITLE
Fix missing id2label and label2id in run_ner.py

### DIFF
--- a/examples/pytorch/token-classification/run_ner.py
+++ b/examples/pytorch/token-classification/run_ner.py
@@ -281,6 +281,8 @@ def main():
     config = AutoConfig.from_pretrained(
         model_args.config_name if model_args.config_name else model_args.model_name_or_path,
         num_labels=num_labels,
+        label2id=label_to_id,
+        id2label={label: i for i, label in enumerate(label_to_id)},
         finetuning_task=data_args.task_name,
         cache_dir=model_args.cache_dir,
         revision=model_args.model_revision,


### PR DESCRIPTION
This is to retain the NER labels when training, so it can be used to map the labels during later prediction.

This functionality is present in the old version [https://github.com/huggingface/transformers/blob/master/examples/legacy/token-classification/run_ner.py#L170](https://github.com/huggingface/transformers/blob/master/examples/legacy/token-classification/run_ner.py#L170), but missing in the current one.

@sgugger 