### PR TITLE
Add text_column_name and label_column_name to run_ner and run_ner_no_trainer args

### DIFF
--- a/examples/pytorch/token-classification/run_ner.py
+++ b/examples/pytorch/token-classification/run_ner.py
@@ -106,6 +106,12 @@ class DataTrainingArguments:
         default=None,
         metadata={"help": "An optional input test data file to predict on (a csv or JSON file)."},
     )
+    text_column_name: Optional[str] = field(
+        default=None, metadata={"help": "The column name of text to input in the file (a csv or JSON file)."}
+    )
+    label_column_name: Optional[str] = field(
+        default=None, metadata={"help": "The column name of label to input in the file (a csv or JSON file)."}
+    )
     overwrite_cache: bool = field(
         default=False, metadata={"help": "Overwrite the cached training and evaluation sets"}
     )
@@ -249,10 +255,16 @@ def main():
     else:
         column_names = datasets["validation"].column_names
         features = datasets["validation"].features
+
     text_column_name = "tokens" if "tokens" in column_names else column_names[0]
+    if data_args.text_column_name is not None:
+        text_column_name = data_args.text_column_name
+
     label_column_name = (
         f"{data_args.task_name}_tags" if f"{data_args.task_name}_tags" in column_names else column_names[1]
     )
+    if data_args.label_column_name is not None:
+        label_column_name = data_args.label_column_name
 
     # In the event the labels are not a `Sequence[ClassLabel]`, we will need to go through the dataset to get the
     # unique labels.

--- a/examples/pytorch/token-classification/run_ner.py
+++ b/examples/pytorch/token-classification/run_ner.py
@@ -256,15 +256,19 @@ def main():
         column_names = datasets["validation"].column_names
         features = datasets["validation"].features
 
-    text_column_name = "tokens" if "tokens" in column_names else column_names[0]
     if data_args.text_column_name is not None:
         text_column_name = data_args.text_column_name
+    elif "tokens" in column_names:
+        text_column_name = "tokens"
+    else:
+        text_column_name = column_names[0]
 
-    label_column_name = (
-        f"{data_args.task_name}_tags" if f"{data_args.task_name}_tags" in column_names else column_names[1]
-    )
     if data_args.label_column_name is not None:
         label_column_name = data_args.label_column_name
+    elif f"{data_args.task_name}_tags" in column_names:
+        label_column_name = f"{data_args.task_name}_tags"
+    else:
+        label_column_name = column_names[1]
 
     # In the event the labels are not a `Sequence[ClassLabel]`, we will need to go through the dataset to get the
     # unique labels.

--- a/examples/pytorch/token-classification/run_ner_no_trainer.py
+++ b/examples/pytorch/token-classification/run_ner_no_trainer.py
@@ -265,12 +265,20 @@ def main():
     else:
         column_names = raw_datasets["validation"].column_names
         features = raw_datasets["validation"].features
-    text_column_name = "tokens" if "tokens" in column_names else column_names[0]
-    if args.text_column_name is not None:
-        text_column_name = args.text_column_name
-    label_column_name = f"{args.task_name}_tags" if f"{args.task_name}_tags" in column_names else column_names[1]
-    if args.label_column_name is not None:
-        label_column_name = args.label_column_name
+
+    if data_args.text_column_name is not None:
+        text_column_name = data_args.text_column_name
+    elif "tokens" in column_names:
+        text_column_name = "tokens"
+    else:
+        text_column_name = column_names[0]
+
+    if data_args.label_column_name is not None:
+        label_column_name = data_args.label_column_name
+    elif f"{data_args.task_name}_tags" in column_names:
+        label_column_name = f"{data_args.task_name}_tags"
+    else:
+        label_column_name = column_names[1]
 
     # In the event the labels are not a `Sequence[ClassLabel]`, we will need to go through the dataset to get the
     # unique labels.

--- a/examples/pytorch/token-classification/run_ner_no_trainer.py
+++ b/examples/pytorch/token-classification/run_ner_no_trainer.py
@@ -76,6 +76,12 @@ def parse_args():
         "--validation_file", type=str, default=None, help="A csv or a json file containing the validation data."
     )
     parser.add_argument(
+        "--text_column_name", type=str, default=None, help="The column name of text to input in the file (a csv or JSON file)."
+    )
+    parser.add_argument(
+        "--label_column_name", type=str, default=None, help="The column name of label to input in the file (a csv or JSON file)."
+    )
+    parser.add_argument(
         "--max_length",
         type=int,
         default=128,
@@ -260,7 +266,11 @@ def main():
         column_names = raw_datasets["validation"].column_names
         features = raw_datasets["validation"].features
     text_column_name = "tokens" if "tokens" in column_names else column_names[0]
+    if args.text_column_name is not None:
+        text_column_name = args.text_column_name
     label_column_name = f"{args.task_name}_tags" if f"{args.task_name}_tags" in column_names else column_names[1]
+    if args.label_column_name is not None:
+        label_column_name = args.label_column_name
 
     # In the event the labels are not a `Sequence[ClassLabel]`, we will need to go through the dataset to get the
     # unique labels.


### PR DESCRIPTION
# What does this PR do?

it's nice to enable to specify which columns are for `text` and `label` for run_ner with its arguments.
especially it's useful when we train it on not csv (i.e. json) dataset because `text` and `label` columns are determined by column order if default columns are missing.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

```
% python -m pytest -n auto --dist=loadfile -s -v ./examples/
...
Results (1653.79s):
      18 passed
       3 skipped
```

## Who can review?

- maintained examples (not research project or legacy): @sgugger, @patil-suraj

