### PR TITLE
[versions] rm require_version_examples

### DIFF
--- a/examples/legacy/pytorch-lightning/lightning_base.py
+++ b/examples/legacy/pytorch-lightning/lightning_base.py
@@ -28,12 +28,12 @@ from transformers.optimization import (
     get_linear_schedule_with_warmup,
     get_polynomial_decay_schedule_with_warmup,
 )
-from transformers.utils.versions import require_version_examples
+from transformers.utils.versions import require_version
 
 
 logger = logging.getLogger(__name__)
 
-require_version_examples("pytorch_lightning>=1.0.4")
+require_version("pytorch_lightning>=1.0.4")
 
 MODEL_MODES = {
     "base": AutoModel,

--- a/examples/research_projects/rag-end2end-retriever/lightning_base.py
+++ b/examples/research_projects/rag-end2end-retriever/lightning_base.py
@@ -29,12 +29,12 @@ from transformers.optimization import (
     get_linear_schedule_with_warmup,
     get_polynomial_decay_schedule_with_warmup,
 )
-from transformers.utils.versions import require_version_examples
+from transformers.utils.versions import require_version
 
 
 logger = logging.getLogger(__name__)
 
-require_version_examples("pytorch_lightning>=1.0.4")
+require_version("pytorch_lightning>=1.0.4")
 
 MODEL_MODES = {
     "base": AutoModel,

--- a/examples/research_projects/rag/lightning_base.py
+++ b/examples/research_projects/rag/lightning_base.py
@@ -28,12 +28,12 @@ from transformers.optimization import (
     get_linear_schedule_with_warmup,
     get_polynomial_decay_schedule_with_warmup,
 )
-from transformers.utils.versions import require_version_examples
+from transformers.utils.versions import require_version
 
 
 logger = logging.getLogger(__name__)
 
-require_version_examples("pytorch_lightning>=1.0.4")
+require_version("pytorch_lightning>=1.0.4")
 
 MODEL_MODES = {
     "base": AutoModel,

--- a/examples/research_projects/seq2seq-distillation/lightning_base.py
+++ b/examples/research_projects/seq2seq-distillation/lightning_base.py
@@ -28,12 +28,12 @@ from transformers.optimization import (
     get_linear_schedule_with_warmup,
     get_polynomial_decay_schedule_with_warmup,
 )
-from transformers.utils.versions import require_version_examples
+from transformers.utils.versions import require_version
 
 
 logger = logging.getLogger(__name__)
 
-require_version_examples("pytorch_lightning>=1.0.4")
+require_version("pytorch_lightning>=1.0.4")
 
 MODEL_MODES = {
     "base": AutoModel,

--- a/src/transformers/utils/versions.py
+++ b/src/transformers/utils/versions.py
@@ -118,9 +118,3 @@ def require_version_core(requirement):
     """require_version wrapper which emits a core-specific hint on failure"""
     hint = "Try: pip install transformers -U or pip install -e '.[dev]' if you're working with git master"
     return require_version(requirement, hint)
-
-
-def require_version_examples(requirement):
-    """require_version wrapper which emits examples-specific hint on failure"""
-    hint = "Try: pip install -r examples/requirements.txt"
-    return require_version(requirement, hint)

--- a/tests/test_versions_utils.py
+++ b/tests/test_versions_utils.py
@@ -15,12 +15,7 @@
 import sys
 
 from transformers.testing_utils import TestCasePlus
-from transformers.utils.versions import (
-    importlib_metadata,
-    require_version,
-    require_version_core,
-    require_version_examples,
-)
+from transformers.utils.versions import importlib_metadata, require_version, require_version_core
 
 
 numpy_ver = importlib_metadata.version("numpy")
@@ -87,14 +82,6 @@ class DependencyVersionCheckTest(TestCasePlus):
                 require_version_core(req)
             except ValueError as e:
                 self.assertIn("need one of ", str(e))
-
-    def test_examples(self):
-        # the main functionality is tested in `test_core`, this is just the hint check
-        try:
-            require_version_examples("numpy>1000.4.5")
-        except ImportError as e:
-            self.assertIn("is required", str(e))
-            self.assertIn("pip install -r examples/requirements.txt", str(e))
 
     def test_python(self):
 


### PR DESCRIPTION
As explained in https://github.com/huggingface/transformers/issues/12086 `require_version_examples` wrapper is no longer useful since examples' requirements are now scattered across multiple files, so removing it as it can't be used because of that.

Fixes: https://github.com/huggingface/transformers/issues/12086

@sgugger  