### PR TITLE
Have dummy processors have a `from_pretrained` method

### DIFF
--- a/src/transformers/utils/dummy_flax_objects.py
+++ b/src/transformers/utils/dummy_flax_objects.py
@@ -6,10 +6,18 @@ class FlaxLogitsProcessor:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["flax"])
 
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxLogitsProcessorList:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["flax"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
 
 
 class FlaxLogitsWarper:

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -127,30 +127,54 @@ class ForcedBOSTokenLogitsProcessor:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])
 
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class ForcedEOSTokenLogitsProcessor:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
 
 
 class HammingDiversityLogitsProcessor:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])
 
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class InfNanRemoveLogitsProcessor:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
 
 
 class LogitsProcessor:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])
 
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LogitsProcessorList:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
 
 
 class LogitsWarper:
@@ -162,25 +186,45 @@ class MinLengthLogitsProcessor:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])
 
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class NoBadWordsLogitsProcessor:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
 
 
 class NoRepeatNGramLogitsProcessor:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])
 
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class PrefixConstrainedLogitsProcessor:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])
 
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class RepetitionPenaltyLogitsProcessor:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
 
 
 class TemperatureLogitsWarper:

--- a/src/transformers/utils/dummy_sentencepiece_and_speech_objects.py
+++ b/src/transformers/utils/dummy_sentencepiece_and_speech_objects.py
@@ -5,3 +5,7 @@ from ..file_utils import requires_backends
 class Speech2TextProcessor:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["sentencepiece", "speech"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["sentencepiece", "speech"])

--- a/src/transformers/utils/dummy_vision_objects.py
+++ b/src/transformers/utils/dummy_vision_objects.py
@@ -16,6 +16,10 @@ class CLIPProcessor:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["vision"])
 
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["vision"])
+
 
 class DeiTFeatureExtractor:
     def __init__(self, *args, **kwargs):

--- a/utils/check_dummies.py
+++ b/utils/check_dummies.py
@@ -115,6 +115,7 @@ def create_dummy_object(name, backend_name):
         "ForTokenClassification",
         "Model",
         "Tokenizer",
+        "Processor",
     ]
     if name.isupper():
         return DUMMY_CONSTANT.format(name)


### PR DESCRIPTION
Fix https://github.com/huggingface/transformers/issues/12100

Before:

```py
>>> from transformers import Speech2TextProcessor
>>> processor =Speech2TextProcessor.from_pretrained("facebook/s2t-small-librispeech-asr")
```
```out
Traceback (most recent call last):
  File "<input>", line 1, in <module>
AttributeError: type object 'Speech2TextProcessor' has no attribute 'from_pretrained'
```

After:

```py
>>> from transformers import Speech2TextProcessor
>>> processor =Speech2TextProcessor.from_pretrained("facebook/s2t-small-librispeech-asr")
```
```out
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/home/lysandre/Workspaces/Python/transformers/src/transformers/utils/dummy_sentencepiece_and_speech_objects.py", line 11, in from_pretrained
    requires_backends(cls, ["sentencepiece", "speech"])
  File "/home/lysandre/Workspaces/Python/transformers/src/transformers/file_utils.py", line 606, in requires_backends
    raise ImportError("".join([BACKENDS_MAPPING[backend][1].format(name) for backend in backends]))
ImportError: 
Speech2TextProcessor requires the SentencePiece library but it was not found in your environment. Checkout the instructions on the
installation page of its repo: https://github.com/google/sentencepiece#installation and follow the ones
that match your environment.

Speech2TextProcessor requires the torchaudio library but it was not found in your environment. You can install it with pip:
`pip install torchaudio`


```