### PR TITLE
Use a released version of optax rather than installing from Git.

### DIFF
--- a/examples/flax/language-modeling/requirements.txt
+++ b/examples/flax/language-modeling/requirements.txt
@@ -2,3 +2,4 @@ datasets >= 1.1.3
 jax>=0.2.8
 jaxlib>=0.1.59
 flax>=0.3.4
+optax>=0.0.8

--- a/examples/flax/text-classification/requirements.txt
+++ b/examples/flax/text-classification/requirements.txt
@@ -2,4 +2,4 @@ datasets >= 1.1.3
 jax>=0.2.8
 jaxlib>=0.1.59
 flax>=0.3.4
-git+https://github.com/deepmind/optax.git
+optax>=0.0.8


### PR DESCRIPTION
(We were using a new API that hadn't been released until a few weeks
ago)

# What does this PR do?

Update the version of Optax we depend on in Flax examples' requirement.py to the latest released version.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests? <-- I installed dependencies via requirements.txt and then ran run_flax_glue.py.


