### PR TITLE
Clean push to hub API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ _deps = [
     "flake8>=3.8.3",
     "flax>=0.3.4",
     "fugashi>=1.0",
-    "huggingface-hub==0.0.8",
+    "huggingface-hub==0.0.11",
     "importlib_metadata",
     "ipadic>=1.0.0,<2.0",
     "isort>=5.5.4",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -16,7 +16,7 @@ deps = {
     "flake8": "flake8>=3.8.3",
     "flax": "flax>=0.3.4",
     "fugashi": "fugashi>=1.0",
-    "huggingface-hub": "huggingface-hub==0.0.8",
+    "huggingface-hub": "huggingface-hub==0.0.11",
     "importlib_metadata": "importlib_metadata",
     "ipadic": "ipadic>=1.0.0,<2.0",
     "isort": "isort>=5.5.4",

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -2099,7 +2099,7 @@ class PushToHubMixin:
         if commit_message is None:
             if "Tokenizer" in cls.__name__:
                 commit_message = "add tokenizer"
-            if "Config" in cls.__name__:
+            elif "Config" in cls.__name__:
                 commit_message = "add config"
             else:
                 commit_message = "add model"

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -1982,6 +1982,8 @@ class PushToHubMixin:
         if temp_dir:
             # Make sure we use the right `repo_name` for the `repo_url` before replacing it.
             if repo_url is None:
+                if use_auth_token is None:
+                    use_auth_token = True
                 repo_name = Path(repo_path_or_name).name
                 repo_url = self._get_repo_url_from_name(
                     repo_name, organization=organization, private=private, use_auth_token=use_auth_token
@@ -2007,8 +2009,8 @@ class PushToHubMixin:
 
         return url
 
+    @staticmethod
     def _get_repo_url_from_name(
-        self,
         repo_name: str,
         organization: Optional[str] = None,
         private: bool = None,
@@ -2037,8 +2039,9 @@ class PushToHubMixin:
             exist_ok=True,
         )
 
+    @classmethod
     def _create_or_get_repo(
-        self,
+        cls,
         repo_path_or_name: Optional[str] = None,
         repo_url: Optional[str] = None,
         organization: Optional[str] = None,
@@ -2057,7 +2060,7 @@ class PushToHubMixin:
         if repo_url is None:
             repo_name = Path(repo_path_or_name).name
             # Special provision for the test endpoint (CI)
-            repo_url = self._get_repo_url_from_name(
+            repo_url = cls._get_repo_url_from_name(
                 repo_name, organization=organization, private=private, use_auth_token=use_auth_token
             )
 

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -1947,7 +1947,7 @@ class PushToHubMixin:
         use_auth_token: Optional[Union[bool, str]] = None,
     ) -> str:
         """
-        Upload model checkpoint or tokenizer files to the 🤗 Model Hub while synchronize a local clone of the repo in
+        Upload model checkpoint or tokenizer files to the 🤗 Model Hub while synchronizing a local clone of the repo in
         :obj:`repo_path_or_name`.
 
         Parameters:

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -2038,7 +2038,7 @@ class PushToHubMixin:
         organization: Optional[str] = None,
         private: bool = None,
         use_auth_token: Optional[Union[bool, str]] = None,
-    ):
+    ) -> str:
         if isinstance(use_auth_token, str):
             token = use_auth_token
         elif use_auth_token:
@@ -2070,7 +2070,7 @@ class PushToHubMixin:
         organization: Optional[str] = None,
         private: bool = None,
         use_auth_token: Optional[Union[bool, str]] = None,
-    ):
+    ) -> Repository:
         if repo_path_or_name is None and repo_url is None:
             raise ValueError("You need to specify a `repo_path_or_name` or a `repo_url`.")
 

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -1992,6 +1992,10 @@ class PushToHubMixin:
         if use_auth_token is None and repo_url is None:
             use_auth_token = True
 
+        # Create workind_directory if it does not exist.
+        if working_directory is not None and not os.path.isdir(working_directory):
+            os.makedirs(working_directory)
+
         if isinstance(use_auth_token, str):
             token = use_auth_token
         elif use_auth_token:

--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -565,6 +565,14 @@ class TrainingSummary:
         if model_name is None:
             model_name = Path(trainer.args.output_dir).name
 
+        # Add `generated_from_trainer` to the tags
+        if tags is None:
+            tags = ["generated_from_trainer"]
+        elif isinstance(tags, str) and tags != "generated_from_trainer":
+            tags = [tags, "generated_from_trainer"]
+        elif "generated_from_trainer" not in tags:
+            tags.append("generated_from_trainer")
+
         _, eval_lines, eval_results = parse_log_history(trainer.state.log_history)
         hyperparameters = extract_hyperparameters_from_trainer(trainer)
 

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -28,7 +28,6 @@ from jax.random import PRNGKey
 
 from .configuration_utils import PretrainedConfig
 from .file_utils import (
-    CONFIG_NAME,
     FLAX_WEIGHTS_NAME,
     WEIGHTS_NAME,
     PushToHubMixin,
@@ -409,6 +408,14 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
                 Directory to which to save. Will be created if it doesn't exist.
             push_to_hub (:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to push your model to the Hugging Face model hub after saving it.
+
+                .. warning::
+
+                    Using :obj:`push_to_hub=True` will synchronize the repository you are pushing to with
+                    :obj:`save_directory`, which requires :obj:`save_directory` to be a local clone of the repo you are
+                    pushing to if it's an existing folder. Pass along :obj:`temp_dir=True` to use a temporary directory
+                    instead.
+
             kwargs:
                 Additional key word arguments passed along to the
                 :meth:`~transformers.file_utils.PushToHubMixin.push_to_hub` method.
@@ -416,6 +423,11 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
         if os.path.isfile(save_directory):
             logger.error(f"Provided path ({save_directory}) should be a directory, not a file")
             return
+
+        if push_to_hub:
+            commit_message = kwargs.pop("commit_message", None)
+            repo = self._create_or_get_repo(save_directory, **kwargs)
+
         os.makedirs(save_directory, exist_ok=True)
 
         # get abs dir
@@ -434,8 +446,7 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
         logger.info(f"Model weights saved in {output_model_file}")
 
         if push_to_hub:
-            saved_files = [os.path.join(save_directory, CONFIG_NAME), output_model_file]
-            url = self._push_to_hub(save_files=saved_files, **kwargs)
+            url = self._push_to_hub(repo, commit_message=commit_message)
             logger.info(f"Model pushed to the hub in this commit: {url}")
 
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -30,7 +30,6 @@ from tensorflow.python.keras.saving import hdf5_format
 
 from .configuration_utils import PretrainedConfig
 from .file_utils import (
-    CONFIG_NAME,
     DUMMY_INPUTS,
     TF2_WEIGHTS_NAME,
     WEIGHTS_NAME,
@@ -1029,6 +1028,14 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                 https://www.tensorflow.org/tfx/serving/serving_basic
             push_to_hub (:obj:`bool`, `optional`, defaults to :obj:`False`):
                 Whether or not to push your model to the Hugging Face model hub after saving it.
+
+                .. warning::
+
+                    Using :obj:`push_to_hub=True` will synchronize the repository you are pushing to with
+                    :obj:`save_directory`, which requires :obj:`save_directory` to be a local clone of the repo you are
+                    pushing to if it's an existing folder. Pass along :obj:`temp_dir=True` to use a temporary directory
+                    instead.
+
             kwargs:
                 Additional key word arguments passed along to the
                 :meth:`~transformers.file_utils.PushToHubMixin.push_to_hub` method.
@@ -1036,6 +1043,11 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         if os.path.isfile(save_directory):
             logger.error(f"Provided path ({save_directory}) should be a directory, not a file")
             return
+
+        if push_to_hub:
+            commit_message = kwargs.pop("commit_message", None)
+            repo = self._create_or_get_repo(save_directory, **kwargs)
+
         os.makedirs(save_directory, exist_ok=True)
 
         if saved_model:
@@ -1053,8 +1065,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         logger.info(f"Model weights saved in {output_model_file}")
 
         if push_to_hub:
-            saved_files = [os.path.join(save_directory, CONFIG_NAME), output_model_file]
-            url = self._push_to_hub(save_files=saved_files, **kwargs)
+            url = self._push_to_hub(repo, commit_message=commit_message)
             logger.info(f"Model pushed to the hub in this commit: {url}")
 
     @classmethod

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -855,7 +855,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 .. warning::
 
                     Using :obj:`push_to_hub=True` will synchronize the repository you are pushing to with
-                    :obj:`save_directory`, which may add files in it.
+                    :obj:`save_directory`, which requires :obj:`save_directory` to be a local clone of the repo you are
+                    pushing to if it's an existing folder. Pass along :obj:`temp_dir=True` to use a temporary directory
+                    instead.
 
             kwargs:
                 Additional key word arguments passed along to the
@@ -864,11 +866,12 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if os.path.isfile(save_directory):
             logger.error(f"Provided path ({save_directory}) should be a directory, not a file")
             return
-        os.makedirs(save_directory, exist_ok=True)
 
         if push_to_hub:
             commit_message = kwargs.pop("commit_message", None)
             repo = self._create_or_get_repo(save_directory, **kwargs)
+
+        os.makedirs(save_directory, exist_ok=True)
 
         # Only save the model itself if we are using distributed training
         model_to_save = unwrap_model(self)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -854,9 +854,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
                 .. warning::
 
-                    Using :obj:`push_to_hub=True` might be unsafe if the folder you are passing along is not in sync
-                    with the repository you want to push to (it will pull the repo before saving to be able to push
-                    after the model is saved, so it might erase some uncommitted changes in that folder)
+                    Using :obj:`push_to_hub=True` will synchronize the repository you are pushing to with
+                    :obj:`save_directory`, which may add files in it.
 
             kwargs:
                 Additional key word arguments passed along to the

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -24,7 +24,6 @@ import random
 import re
 import shutil
 import sys
-import tempfile
 import time
 import warnings
 from logging import StreamHandler
@@ -387,9 +386,12 @@ class Trainer:
         # Will be set to True by `self._setup_loggers()` on first call to `self.log()`.
         self._loggers_initialized = False
 
-        # Create output directory if needed
+        # Create clone of distant repo and output directory if needed
+        if self.args.push_to_hub:
+            self.init_git_repo()
         if self.is_world_process_zero():
             os.makedirs(self.args.output_dir, exist_ok=True)
+
         if not callable(self.data_collator) and callable(getattr(self.data_collator, "collate_batch", None)):
             raise ValueError("The `data_collator` should be a simple callable (function, class with `__call__`).")
 
@@ -2426,6 +2428,25 @@ class Trainer:
         else:
             return 0
 
+    def init_git_repo(self):
+        """
+        Initializes a git repo in :obj:`self.args.push_to_hub_model_id`.
+        """
+        if not self.is_world_process_zero():
+            return
+        use_auth_token = True if self.args.push_to_hub_token is None else self.args.push_to_hub_token
+        repo_url = PushToHubMixin._get_repo_url_from_name(
+            self.args.push_to_hub_model_id,
+            organization=self.args.push_to_hub_organization,
+            use_auth_token=use_auth_token,
+        )
+        self.repo = PushToHubMixin._create_or_get_repo(self.args.output_dir, repo_url=repo_url)
+
+        # By default, ignore the checkpoint folders
+        if not os.path.exists(os.path.join(self.args.output_dir, ".gitignore")):
+            with open(os.path.join(self.args.output_dir, ".gitignore"), "w", encoding="utf-8") as writer:
+                writer.writelines(["checkpoint-*/"])
+
     def create_model_card(
         self,
         language: Optional[str] = None,
@@ -2454,38 +2475,13 @@ class Trainer:
         with open(os.path.join(self.args.output_dir, "README.md"), "w") as f:
             f.write(model_card)
 
-    def push_to_hub(
-        self,
-        repo_name: Optional[str] = None,
-        repo_url: Optional[str] = None,
-        commit_message: Optional[str] = "add model",
-        organization: Optional[str] = None,
-        private: bool = None,
-        use_auth_token: Optional[Union[bool, str]] = None,
-        **kwargs,
-    ):
+    def push_to_hub(self, commit_message: Optional[str] = "add model", **kwargs):
         """
-        Upload `self.model` to the 🤗 model hub.
+        Upload `self.model` and `self.tokenizer` to the 🤗 model hub on the repo `self.args.push_to_hub_model_id`.
 
         Parameters:
-            repo_name (:obj:`str`, `optional`):
-                Repository name for your model or tokenizer in the hub. If not specified and :obj:`repo_url` is not
-                specified either, will default to the stem of :obj:`self.args.output_dir`.
-            repo_url (:obj:`str`, `optional`):
-                Specify this in case you want to push to an existing repository in the hub. If unspecified, a new
-                repository will be created in your namespace (unless you specify an :obj:`organization`) with
-                :obj:`repo_name`.
             commit_message (:obj:`str`, `optional`, defaults to :obj:`"add model"`):
                 Message to commit while pushing.
-            organization (:obj:`str`, `optional`):
-                Organization in which you want to push your model or tokenizer (you must be a member of this
-                organization).
-            private (:obj:`bool`, `optional`):
-                Whether or not the repository created should be private (requires a paying subscription).
-            use_auth_token (:obj:`bool` or :obj:`str`, `optional`):
-                The token to use as HTTP bearer authorization for remote files. If :obj:`True`, will use the token
-                generated when running :obj:`transformers-cli login` (stored in :obj:`~/.huggingface`). Will default to
-                :obj:`True` if :obj:`repo_url` is not specified.
             kwargs:
                 Additional keyword arguments passed along to :meth:`~transformers.Trainer.create_model_card`.
 
@@ -2495,37 +2491,9 @@ class Trainer:
         if not self.is_world_process_zero():
             return
 
-        if not isinstance(unwrap_model(self.model), PushToHubMixin):
-            raise ValueError(
-                "The `upload_model_to_hub` method only works for models that inherit from `PushToHubMixin` models."
-            )
-
-        if repo_url is None and repo_name is None:
-            repo_name = Path(self.args.output_dir).name
-
-        if repo_name is not None:
-            model_name = repo_name
-        elif repo_url is not None:
-            model_name = repo_url.split("/")[-1]
-        else:
-            model_name = None
-        self.create_model_card(model_name=model_name, **kwargs)
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            shutil.copy(os.path.join(self.args.output_dir, "README.md"), os.path.join(tmp_dir, "README.md"))
-            unwrap_model(self.model).save_pretrained(tmp_dir)
-            if self.tokenizer is not None:
-                self.tokenizer.save_pretrained(tmp_dir)
-
-            return unwrap_model(self.model)._push_to_hub(
-                save_directory=tmp_dir,
-                repo_name=repo_name,
-                repo_url=repo_url,
-                commit_message=commit_message,
-                organization=organization,
-                private=private,
-                use_auth_token=use_auth_token,
-            )
+        self.create_model_card(model_name=self.args.push_to_hub_model_id, **kwargs)
+        self.save_model()
+        return PushToHubMixin._push_to_hub(repo=self.repo, commit_message=commit_message)
 
     #
     # Deprecated code

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2497,7 +2497,7 @@ class Trainer:
 
         self.create_model_card(model_name=self.args.push_to_hub_model_id, **kwargs)
         self.save_model()
-        return PushToHubMixin._push_to_hub(repo=self.repo, commit_message=commit_message)
+        return self.repo.push_to_hub(commit_message=commit_message)
 
     #
     # Deprecated code

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2479,7 +2479,7 @@ class Trainer:
         with open(os.path.join(self.args.output_dir, "README.md"), "w") as f:
             f.write(model_card)
 
-    def push_to_hub(self, commit_message: Optional[str] = "add model", **kwargs):
+    def push_to_hub(self, commit_message: Optional[str] = "add model", **kwargs) -> str:
         """
         Upload `self.model` and `self.tokenizer` to the 🤗 model hub on the repo `self.args.push_to_hub_model_id`.
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2444,7 +2444,9 @@ class Trainer:
             organization=self.args.push_to_hub_organization,
             use_auth_token=use_auth_token,
         )
-        self.repo = PushToHubMixin._create_or_get_repo(self.args.output_dir, repo_url=repo_url)
+        self.repo = PushToHubMixin._create_or_get_repo(
+            self.args.output_dir, repo_url=repo_url, use_auth_token=use_auth_token
+        )
 
         # By default, ignore the checkpoint folders
         if not os.path.exists(os.path.join(self.args.output_dir, ".gitignore")):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -17,6 +17,7 @@ import os
 import warnings
 from dataclasses import asdict, dataclass, field
 from enum import Enum
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .debug_utils import DebugOption
@@ -146,7 +147,7 @@ class TrainingArguments:
             :obj:`warmup_ratio`.
         logging_dir (:obj:`str`, `optional`):
             `TensorBoard <https://www.tensorflow.org/tensorboard>`__ log directory. Will default to
-            `runs/**CURRENT_DATETIME_HOSTNAME**`.
+            `output_dir/runs/**CURRENT_DATETIME_HOSTNAME**`.
         logging_strategy (:obj:`str` or :class:`~transformers.trainer_utils.IntervalStrategy`, `optional`, defaults to :obj:`"steps"`):
             The logging strategy to adopt during training. Possible values are:
 
@@ -307,10 +308,9 @@ class TrainingArguments:
             Whether to skip adding of memory profiler reports to metrics. This is skipped by default because it slows
             down the training and evaluation speed.
         push_to_hub (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            Whether or not to upload the trained model to the hub after training. This argument is not directly used by
-            :class:`~transformers.Trainer`, it's intended to be used by your training/evaluation scripts instead. See
-            the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`__ for more
-            details.
+            Whether or not to upload the trained model to the hub after training. If this is activated, and
+            :obj:`output_dir` exists, it needs to be a local clone of the repository to which the
+            :class:`~transformers.Trainer` will be pushed.
         resume_from_checkpoint (:obj:`str`, `optional`):
             The path to a folder with a valid checkpoint for your model. This argument is not directly used by
             :class:`~transformers.Trainer`, it's intended to be used by your training/evaluation scripts instead. See
@@ -318,6 +318,14 @@ class TrainingArguments:
             details.
         log_on_each_node (:obj:`bool`, `optional`, defaults to :obj:`True`):
             In multinode distributed training, whether to log once per node, or only on the main node.
+        push_to_hub_model_id (:obj:`str`, `optional`):
+            The name of the repository to which push the :class:`~transformers.Trainer` when :obj:`push_to_hub=True`.
+            Will default to the name of :obj:`output_dir`.
+        push_to_hub_organization (:obj:`str`, `optional`):
+            The name of the organization in with to which push the :class:`~transformers.Trainer`.
+        push_to_hub_token (:obj:`str`, `optional`):
+            The token to use to push the model to the Hub. Will default to the token in the cache folder obtained with
+            :obj:`huggingface-cli login`.
     """
 
     output_dir: str = field(
@@ -397,7 +405,7 @@ class TrainingArguments:
     )
     warmup_steps: int = field(default=0, metadata={"help": "Linear warmup over warmup_steps."})
 
-    logging_dir: Optional[str] = field(default_factory=default_logdir, metadata={"help": "Tensorboard log dir."})
+    logging_dir: Optional[str] = field(default=None, metadata={"help": "Tensorboard log dir."})
     logging_strategy: IntervalStrategy = field(
         default="steps",
         metadata={"help": "The logging strategy to use."},
@@ -567,6 +575,13 @@ class TrainingArguments:
             "help": "When doing a multinode distributed training, whether to log once per node or just once on the main node."
         },
     )
+    push_to_hub_model_id: str = field(
+        default=None, metadata={"help": "The name of the repository to which push the `Trainer`."}
+    )
+    push_to_hub_organization: str = field(
+        default=None, metadata={"help": "The name of the organization in with to which push the `Trainer`."}
+    )
+    push_to_hub_token: str = field(default=None, metadata={"help": "The token to use to push to the Model Hub."})
     _n_gpu: int = field(init=False, repr=False, default=-1)
     mp_parameters: str = field(
         default="",
@@ -585,6 +600,8 @@ class TrainingArguments:
         #  see https://github.com/huggingface/transformers/issues/10628
         if self.output_dir is not None:
             self.output_dir = os.path.expanduser(self.output_dir)
+        if self.logging_dir is None and self.output_dir is not None:
+            self.logging_dir = os.path.join(self.output_dir, default_logdir())
         if self.logging_dir is not None:
             self.logging_dir = os.path.expanduser(self.logging_dir)
 
@@ -677,6 +694,9 @@ class TrainingArguments:
             # note: leave self.deepspeed unmodified in case a user relies on it not to be modified)
             self.hf_deepspeed_config = HfTrainerDeepSpeedConfig(self.deepspeed)
             self.hf_deepspeed_config.trainer_config_process(self)
+
+        if self.push_to_hub_model_id is None:
+            self.push_to_hub_model_id = Path(self.output_dir).name
 
     def __str__(self):
         self_as_dict = asdict(self)

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -113,7 +113,7 @@ class ConfigPushToHubTester(unittest.TestCase):
             vocab_size=99, hidden_size=32, num_hidden_layers=5, num_attention_heads=4, intermediate_size=37
         )
         with tempfile.TemporaryDirectory() as tmp_dir:
-            config.save_pretrained(tmp_dir, push_to_hub=True, repo_name="test-config", use_auth_token=self._token)
+            config.save_pretrained(os.path.join(tmp_dir, "test-config"), push_to_hub=True, use_auth_token=self._token)
 
             new_config = BertConfig.from_pretrained(f"{USER}/test-config")
             for k, v in config.__dict__.items():
@@ -127,9 +127,8 @@ class ConfigPushToHubTester(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             config.save_pretrained(
-                tmp_dir,
+                os.path.join(tmp_dir, "test-config-org"),
                 push_to_hub=True,
-                repo_name="test-config-org",
                 use_auth_token=self._token,
                 organization="valid_org",
             )

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1613,7 +1613,7 @@ class ModelPushToHubTester(unittest.TestCase):
         )
         model = BertModel(config)
         with tempfile.TemporaryDirectory() as tmp_dir:
-            model.save_pretrained(tmp_dir, push_to_hub=True, repo_name="test-model", use_auth_token=self._token)
+            model.save_pretrained(os.path.join(tmp_dir, "test-model"), push_to_hub=True, use_auth_token=self._token)
 
             new_model = BertModel.from_pretrained(f"{USER}/test-model")
             for p1, p2 in zip(model.parameters(), new_model.parameters()):
@@ -1626,9 +1626,8 @@ class ModelPushToHubTester(unittest.TestCase):
         model = BertModel(config)
         with tempfile.TemporaryDirectory() as tmp_dir:
             model.save_pretrained(
-                tmp_dir,
+                os.path.join(tmp_dir, "test-model-org"),
                 push_to_hub=True,
-                repo_name="test-model-org",
                 use_auth_token=self._token,
                 organization="valid_org",
             )

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -16,14 +16,25 @@ import copy
 import inspect
 import random
 import tempfile
+import unittest
 from typing import List, Tuple
 
 import numpy as np
 
 import transformers
-from transformers import is_flax_available, is_torch_available
+from huggingface_hub import HfApi
+from requests.exceptions import HTTPError
+from transformers import BertConfig, FlaxBertModel, is_flax_available, is_torch_available
 from transformers.models.auto import get_values
-from transformers.testing_utils import is_pt_flax_cross_test, require_flax, slow
+from transformers.testing_utils import (
+    ENDPOINT_STAGING,
+    PASS,
+    USER,
+    is_pt_flax_cross_test,
+    is_staging_test,
+    require_flax,
+    slow,
+)
 
 
 if is_flax_available():
@@ -504,3 +515,65 @@ class FlaxModelTesterMixin:
                 list(self_attentions[0].shape[-3:]),
                 [self.model_tester.num_attention_heads, encoder_seq_length, encoder_key_length],
             )
+
+
+@require_flax
+@is_staging_test
+class FlaxModelPushToHubTester(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._api = HfApi(endpoint=ENDPOINT_STAGING)
+        cls._token = cls._api.login(username=USER, password=PASS)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls._api.delete_repo(token=cls._token, name="test-model-flax")
+        except HTTPError:
+            pass
+
+        try:
+            cls._api.delete_repo(token=cls._token, name="test-model-flax-org", organization="valid_org")
+        except HTTPError:
+            pass
+
+    def test_push_to_hub(self):
+        config = BertConfig(
+            vocab_size=99, hidden_size=32, num_hidden_layers=5, num_attention_heads=4, intermediate_size=37
+        )
+        model = FlaxBertModel(config)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model.save_pretrained(
+                os.path.join(tmp_dir, "test-model-flax"), push_to_hub=True, use_auth_token=self._token
+            )
+
+            new_model = FlaxBertModel.from_pretrained(f"{USER}/test-model-flax")
+
+            base_params = flatten_dict(unfreeze(model.params))
+            new_params = flatten_dict(unfreeze(new_model.params))
+
+            for key in base_params.keys():
+                max_diff = (base_params[key] - new_params[key]).sum().item()
+                self.assertLessEqual(max_diff, 1e-3, msg=f"{key} not identical")
+
+    def test_push_to_hub_in_organization(self):
+        config = BertConfig(
+            vocab_size=99, hidden_size=32, num_hidden_layers=5, num_attention_heads=4, intermediate_size=37
+        )
+        model = FlaxBertModel(config)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model.save_pretrained(
+                os.path.join(tmp_dir, "test-model-flax-org"),
+                push_to_hub=True,
+                use_auth_token=self._token,
+                organization="valid_org",
+            )
+
+            new_model = FlaxBertModel.from_pretrained("valid_org/test-model-flax-org")
+
+            base_params = flatten_dict(unfreeze(model.params))
+            new_params = flatten_dict(unfreeze(new_model.params))
+
+            for key in base_params.keys():
+                max_diff = (base_params[key] - new_params[key]).sum().item()
+                self.assertLessEqual(max_diff, 1e-3, msg=f"{key} not identical")

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1413,7 +1413,7 @@ class TFModelPushToHubTester(unittest.TestCase):
         # Make sure model is properly initialized
         _ = model(model.dummy_inputs)
         with tempfile.TemporaryDirectory() as tmp_dir:
-            model.save_pretrained(tmp_dir, push_to_hub=True, repo_name="test-model-tf", use_auth_token=self._token)
+            model.save_pretrained(os.path.join(tmp_dir, "test-model-tf"), push_to_hub=True, use_auth_token=self._token)
 
             new_model = TFBertModel.from_pretrained(f"{USER}/test-model-tf")
             models_equal = True
@@ -1429,9 +1429,8 @@ class TFModelPushToHubTester(unittest.TestCase):
         model = TFBertModel(config)
         with tempfile.TemporaryDirectory() as tmp_dir:
             model.save_pretrained(
-                tmp_dir,
+                os.path.join(tmp_dir, "test-model-tf-org"),
                 push_to_hub=True,
-                repo_name="test-model-tf-org",
                 use_auth_token=self._token,
                 organization="valid_org",
             )

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -3173,7 +3173,7 @@ class TokenizerPushToHubTester(unittest.TestCase):
                 vocab_writer.write("".join([x + "\n" for x in self.vocab_tokens]))
             tokenizer = BertTokenizer(vocab_file)
             tokenizer.save_pretrained(
-                tmp_dir, push_to_hub=True, repo_name="test-tokenizer", use_auth_token=self._token
+                os.path.join(tmp_dir, "test-tokenizer"), push_to_hub=True, use_auth_token=self._token
             )
 
             new_tokenizer = BertTokenizer.from_pretrained(f"{USER}/test-tokenizer")
@@ -3186,9 +3186,8 @@ class TokenizerPushToHubTester(unittest.TestCase):
                 vocab_writer.write("".join([x + "\n" for x in self.vocab_tokens]))
             tokenizer = BertTokenizer(vocab_file)
             tokenizer.save_pretrained(
-                tmp_dir,
+                os.path.join(tmp_dir, "test-tokenizer-org"),
                 push_to_hub=True,
-                repo_name="test-tokenizer-org",
                 use_auth_token=self._token,
                 organization="valid_org",
             )

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1221,8 +1221,12 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
 
     def test_push_to_hub(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            trainer = get_regression_trainer(output_dir=tmp_dir)
-            url = trainer.push_to_hub(repo_name="test-trainer", use_auth_token=self._token)
+            trainer = get_regression_trainer(
+                output_dir=os.path.join(tmp_dir, "test-trainer"),
+                push_to_hub=True,
+                push_to_hub_token=self._token,
+            )
+            url = trainer.push_to_hub()
 
             # Extract repo_name from the url
             re_search = re.search(ENDPOINT_STAGING + r"/([^/]+/[^/]+)/", url)
@@ -1239,9 +1243,13 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             trainer = get_regression_trainer(output_dir=tmp_dir)
             trainer.save_model()
-            url = trainer.push_to_hub(
-                repo_name="test-trainer-org", organization="valid_org", use_auth_token=self._token
+            trainer = get_regression_trainer(
+                output_dir=os.path.join(tmp_dir, "test-trainer-org"),
+                push_to_hub=True,
+                push_to_hub_organization="valid_org",
+                push_to_hub_token=self._token,
             )
+            url = trainer.push_to_hub()
 
             # Extract repo_name from the url
             re_search = re.search(ENDPOINT_STAGING + r"/([^/]+/[^/]+)/", url)


### PR DESCRIPTION
# What does this PR do?

This PR reworks the way the push to hub API works by avoiding cloning in a temporary directory, copying the files saved then pushing, by creating and cloning the repo first, then saving the object and lastly pushing it to the hub. The general commands does not bring any major breaking change although the behavior of `object.push_to_hub(repo_name)` and `object.save_pretrained(push_to_hub=True)` changes slightly (see below). That last API is not used much however, since it's new and completely undocumented, so I think it's okay.

`push_to_hub` takes a `repo_name_or_path` and will create a local clone of the repo if it does not exist. That local clone is synced with the distant repo. This is a bit different from before where a temp dir was used for the clone and push, this behavior is still accessible by passing along `temp_dir=True`.

## `push_to_hub` API for models, tokenizers and configs

Works like before with a slight change of behavior::
```
model.push_to_hub(repo_name_or_path="my-awesome-model")
```
will push to the hub the model by creating the repo, cloning it if it exists, saving the model inside and pushing. The change with before is that a local folder named "my_awesome_model" will be created if it does not exist, and if it exists it will either:
- be put in sync with the distant repo if the distant repo exists
- error if it is not a local clone of the distant repo
 
In the same vein
```
model.save_pretrained(my_folder, push_to_hub=True)
```
will use `my_folder` as a working directory and create it if it exists, error if it exists and is not a local clone of the distant repo and do a `git pull` if it exists and is a local clone of the distant repo.

In both cases, the previous behavior can be activated by passing along `temp_dir=True`.

Side note: this PR adds tests for the `FlaxPretrainedModel.push_to_hub` method.

## `push_to_hub` API for the Trainer

Here there are also slightly breaking changes in the sense that the control over the repo to which we push moves from arguments in the `push_to_hub` method to the fields in `TrainingArguments`. This is because the repo is now initialized at init, so we need to know the repo name, organization and potential token there.

The `Trainer` adds an automatic `.gitignore` to ignore all checkpoints folder, which can be changed by the user (we can add a CLI argument to control that in the future) and the `push_to_hub` method now just triggers a save, writes the model card then push the whole output dir to the distant repo.

Another slightly breaking change is that the default for the `logging_dir` (for TensorBoard) changes, so that the logs are inside the output_dir and also pushed to the hub.