### PR TITLE
Depreciate pythonic Mish and support PyTorch 1.9 version of Mish

### DIFF
--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -73,8 +73,17 @@ else:
     silu = nn.functional.silu
 
 
-def mish(x):
+def _mish_python(x):
+    """
+    See Mish: A Self-Regularized Non-Monotonic Activation Function (Misra., https://arxiv.org/abs/1908.08681).
+    Also visit the official repository for the paper: https://github.com/digantamisra98/Mish
+    """
     return x * torch.tanh(nn.functional.softplus(x))
+
+if version.parse(torch.__version__) < version.parse("1.9"):
+    mish = _mish_python
+else:
+    mish = nn.functional.mish
 
 
 def linear_act(x):

--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -75,10 +75,11 @@ else:
 
 def _mish_python(x):
     """
-    See Mish: A Self-Regularized Non-Monotonic Activation Function (Misra., https://arxiv.org/abs/1908.08681).
-    Also visit the official repository for the paper: https://github.com/digantamisra98/Mish
+    See Mish: A Self-Regularized Non-Monotonic Activation Function (Misra., https://arxiv.org/abs/1908.08681). Also
+    visit the official repository for the paper: https://github.com/digantamisra98/Mish
     """
     return x * torch.tanh(nn.functional.softplus(x))
+
 
 if version.parse(torch.__version__) < version.parse("1.9"):
     mish = _mish_python

--- a/src/transformers/models/mobilebert/modeling_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_mobilebert.py
@@ -140,10 +140,6 @@ def load_tf_weights_in_mobilebert(model, config, tf_checkpoint_path):
     return model
 
 
-def mish(x):
-    return x * torch.tanh(nn.functional.softplus(x))
-
-
 class NoNorm(nn.Module):
     def __init__(self, feat_size, eps=None):
         super().__init__()

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_{{cookiecutter.lowercase_modelname}}.py
@@ -138,10 +138,6 @@ def load_tf_weights_in_{{cookiecutter.lowercase_modelname}}(model, config, tf_ch
     return model
 
 
-def mish(x):
-    return x * torch.tanh(nn.functional.softplus(x))
-
-
 # Copied from transformers.models.bert.modeling_bert.BertEmbeddings with Bert->{{cookiecutter.camelcase_modelname}}
 class {{cookiecutter.camelcase_modelname}}Embeddings(nn.Module):
     """Construct the embeddings from word, position and token_type embeddings."""


### PR DESCRIPTION
This PR removes the old pure pythonic version of [Mish](https://arxiv.org/abs/1908.08681) and now enables support for the [PyTorch 1.9 Mish version](https://pytorch.org/docs/stable/generated/torch.nn.Mish.html#torch.nn.Mish). It also removes isolated references of the function where it is not used. 
