### PR TITLE
[trainer + examples] set log level from CLI

### DIFF
--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -165,14 +165,17 @@ warnings you could run it as:
 
 .. code-block:: bash
 
-    my_app.py ... --log_level warn --log_level_replica error
+    my_app.py ... --log_level warning --log_level_replica error
 
 In the multi-node environment if you also don't want the logs to repeat for each node's main process, you will want to
 change the above to:
 
 .. code-block:: bash
 
-    my_app.py ... --log_level warn --log_level_replica error --log_on_each_node 0
+    my_app.py ... --log_level warning --log_level_replica error --log_on_each_node 0
+
+and then only the main process of the first node will log at the "warning" level, and all other processes on the main
+node and all processes on other nodes will log at the "error" level.
 
 If you need your application to be as quiet as possible you could do:
 
@@ -180,6 +183,7 @@ If you need your application to be as quiet as possible you could do:
 
     my_app.py ... --log_level error --log_level_replica error --log_on_each_node 0
 
+(add ``--log_on_each_node 0`` if on multi-node environment)
 
 
 

--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -122,17 +122,17 @@ TFTrainingArguments
 Logging
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default :class:`~transformers.Trainer` will use ``logging.INFO`` for the main node and ``logging.WARNING`` for the
-replica nodes if any.
+By default :class:`~transformers.Trainer` will use ``logging.INFO`` for the main process and ``logging.WARNING`` for the
+replicas if any.
 
 These defaults can be overridden to use any of the 5 ``logging`` levels with :class:`~transformers.TrainingArguments`'s
 arguments:
 
-- ``log_level`` - for the main node
-- ``log_level_replica`` - for the replica nodes
+- ``log_level`` - for the main process
+- ``log_level_replica`` - for the replicas
 
 Further, if :class:`~transformers.TrainingArguments`'s ``log_on_each_node`` is set to ``True`` all nodes will use the
-log level settings for the main node.
+log level settings for the main process.
 
 Note that :class:`~transformers.Trainer` is going to set ``transformers``'s log level separately for each node in its
 :meth:`~transformers.Trainer.__init__`. So you may want to set this sooner (see the next example) if you tap into other

--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -119,6 +119,60 @@ TFTrainingArguments
     :members:
 
 
+Logging
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default :class:`~transformers.Trainer` will use ``logging.INFO`` for the main node and ``logging.WARNING`` for the
+replica nodes if any.
+
+These defaults can be overridden to use any of the 5 ``logging`` levels with :class:`~transformers.TrainingArguments`'s
+arguments:
+
+- ``log_level`` - for the main node
+- ``log_level_replica`` - for the replica nodes
+
+Further, if :class:`~transformers.TrainingArguments`'s ``log_on_each_node`` is set to ``True`` all nodes will use the
+log level settings for the main node.
+
+Note that :class:`~transformers.Trainer` is going to set ``transformers``'s log level separately for each node in its
+:meth:`~transformers.Trainer.__init__`. So you may want to set this sooner (see the next example) if you tap into other
+``transformers`` functionality before creating the :class:`~transformers.Trainer` object.
+
+Here is an example of how this can be used in an application:
+
+.. code-block:: python
+
+    [...]
+    logger = logging.getLogger(__name__)
+
+    # Setup logging
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s",
+        datefmt="%m/%d/%Y %H:%M:%S",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+
+    # set the main code and the modules it uses to the same log-level according to the node
+    log_level = training_args.get_node_log_level()
+    logger.setLevel(log_level)
+    datasets.utils.logging.set_verbosity(log_level)
+    transformers.utils.logging.set_verbosity(log_level)
+
+And then if you only want to see warnings on the main node and all other nodes to not print any most likely duplicated
+warnings you could run it as:
+
+.. code-block:: bash
+
+    my_app.py ... --log_level warn --log_level_replica error
+
+or if you need your application to be as quiet as possible you could do:
+
+.. code-block:: bash
+
+    my_app.py ... --log_level error --log_level_replica error
+
+
+
 Randomness
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -122,8 +122,8 @@ TFTrainingArguments
 Logging
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default :class:`~transformers.Trainer` will use ``logging.INFO`` for the main process and ``logging.WARNING`` for the
-replicas if any.
+By default :class:`~transformers.Trainer` will use ``logging.INFO`` for the main process and ``logging.WARNING`` for
+the replicas if any.
 
 These defaults can be overridden to use any of the 5 ``logging`` levels with :class:`~transformers.TrainingArguments`'s
 arguments:
@@ -131,8 +131,8 @@ arguments:
 - ``log_level`` - for the main process
 - ``log_level_replica`` - for the replicas
 
-Further, if :class:`~transformers.TrainingArguments`'s ``log_on_each_node`` is set to ``True`` all nodes will use the
-log level settings for the main process.
+Further, if :class:`~transformers.TrainingArguments`'s ``log_on_each_node`` is set to ``False`` only the main node will
+use the log level settings for its main process, all other nodes will use the log level settings for replicas.
 
 Note that :class:`~transformers.Trainer` is going to set ``transformers``'s log level separately for each node in its
 :meth:`~transformers.Trainer.__init__`. So you may want to set this sooner (see the next example) if you tap into other
@@ -158,6 +158,8 @@ Here is an example of how this can be used in an application:
     datasets.utils.logging.set_verbosity(log_level)
     transformers.utils.logging.set_verbosity(log_level)
 
+    trainer = Trainer(...)
+
 And then if you only want to see warnings on the main node and all other nodes to not print any most likely duplicated
 warnings you could run it as:
 
@@ -165,11 +167,19 @@ warnings you could run it as:
 
     my_app.py ... --log_level warn --log_level_replica error
 
-or if you need your application to be as quiet as possible you could do:
+In the multi-node environment if you also don't want the logs to repeat for each node's main process, you will want to
+change the above to:
 
 .. code-block:: bash
 
-    my_app.py ... --log_level error --log_level_replica error
+    my_app.py ... --log_level warn --log_level_replica error --log_on_each_node 0
+
+If you need your application to be as quiet as possible you could do:
+
+.. code-block:: bash
+
+    my_app.py ... --log_level error --log_level_replica error --log_on_each_node 0
+
 
 
 

--- a/examples/pytorch/translation/run_translation.py
+++ b/examples/pytorch/translation/run_translation.py
@@ -245,20 +245,16 @@ def main():
         handlers=[logging.StreamHandler(sys.stdout)],
     )
 
-    if training_args.log_level == -1:
-        logger.setLevel(logging.INFO if training_args.should_log else logging.WARN)
-    else:
-        logger.setLevel(training_args.log_level)
-        datasets_module.utils.logging.set_verbosity(training_args.log_level)
+    log_level = training_args.get_node_log_level()
+    logger.setLevel(log_level)
+    datasets_module.utils.logging.set_verbosity(log_level)
+    transformers.utils.logging.set_verbosity(log_level)
 
     # Log on each process the small summary:
     logger.warning(
         f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
         + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
     )
-    # Set the verbosity to info of the Transformers logger (on main process only):
-    if training_args.should_log and training_args.log_level == -1:
-        transformers.utils.logging.set_verbosity_info()
     logger.info(f"Training/evaluation parameters {training_args}")
 
     if data_args.source_prefix is None and model_args.model_name_or_path in [

--- a/examples/pytorch/translation/run_translation.py
+++ b/examples/pytorch/translation/run_translation.py
@@ -24,6 +24,7 @@ import sys
 from dataclasses import dataclass, field
 from typing import Optional
 
+import datasets as datasets_module
 import numpy as np
 from datasets import load_dataset, load_metric
 
@@ -243,7 +244,12 @@ def main():
         datefmt="%m/%d/%Y %H:%M:%S",
         handlers=[logging.StreamHandler(sys.stdout)],
     )
-    logger.setLevel(logging.INFO if training_args.should_log else logging.WARN)
+
+    if training_args.log_level == -1:
+        logger.setLevel(logging.INFO if training_args.should_log else logging.WARN)
+    else:
+        logger.setLevel(training_args.log_level)
+        datasets_module.utils.logging.set_verbosity(training_args.log_level)
 
     # Log on each process the small summary:
     logger.warning(
@@ -251,7 +257,7 @@ def main():
         + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
     )
     # Set the verbosity to info of the Transformers logger (on main process only):
-    if training_args.should_log:
+    if training_args.should_log and training_args.log_level == -1:
         transformers.utils.logging.set_verbosity_info()
     logger.info(f"Training/evaluation parameters {training_args}")
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -290,6 +290,9 @@ class Trainer:
         self._memory_tracker = TrainerMemoryTracker(self.args.skip_memory_metrics)
         self._memory_tracker.start()
 
+        if args.log_level != -1:
+            logging.set_verbosity(args.log_level)
+
         # force device and distributed setup init explicitly
         args._setup_devices
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -290,8 +290,9 @@ class Trainer:
         self._memory_tracker = TrainerMemoryTracker(self.args.skip_memory_metrics)
         self._memory_tracker.start()
 
-        if args.log_level != -1:
-            logging.set_verbosity(args.log_level)
+        # set the correct log level depending on the node
+        log_level = args.get_node_log_level()
+        logging.set_verbosity(log_level)
 
         # force device and distributed setup init explicitly
         args._setup_devices

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -905,12 +905,12 @@ def log_metrics(self, split, metrics):
     if not self.is_world_process_zero():
         return
 
-    logger.info(f"***** {split} metrics *****")
+    print(f"***** {split} metrics *****")
     metrics_formatted = self.metrics_format(metrics)
     k_width = max(len(str(x)) for x in metrics_formatted.keys())
     v_width = max(len(str(x)) for x in metrics_formatted.values())
     for key in sorted(metrics_formatted.keys()):
-        logger.info(f"  {key: <{k_width}} = {metrics_formatted[key]:>{v_width}}")
+        print(f"  {key: <{k_width}} = {metrics_formatted[key]:>{v_width}}")
 
 
 def save_metrics(self, split, metrics, combined=True):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -149,7 +149,7 @@ class TrainingArguments:
         log_level (:obj:`str`, `optional`, defaults to ``passive``):
             Logger log level to use on the main node. Possible choices are the log levels as strings: 'debug', 'info',
             'warning', 'error' and 'critical', plus a 'passive' level which doesn't set anything and lets the
-            application set the level. Defaults to 'passive'.
+            application set the level.
         log_level_replica (:obj:`str`, `optional`, defaults to ``passive``):
             Logger log level to use on replica nodes. Same choices as ``log_level``"
         log_on_each_node (:obj:`bool`, `optional`, defaults to :obj:`True`):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -147,13 +147,14 @@ class TrainingArguments:
             Number of steps used for a linear warmup from 0 to :obj:`learning_rate`. Overrides any effect of
             :obj:`warmup_ratio`.
         log_level (:obj:`str`, `optional`, defaults to ``passive``):
-            Logger log level to use on the main process. Possible choices are the log levels as strings: 'debug', 'info',
-            'warning', 'error' and 'critical', plus a 'passive' level which doesn't set anything and lets the
+            Logger log level to use on the main process. Possible choices are the log levels as strings: 'debug',
+            'info', 'warning', 'error' and 'critical', plus a 'passive' level which doesn't set anything and lets the
             application set the level.
         log_level_replica (:obj:`str`, `optional`, defaults to ``passive``):
             Logger log level to use on replicas. Same choices as ``log_level``"
         log_on_each_node (:obj:`bool`, `optional`, defaults to :obj:`True`):
-            In multinode distributed training, whether to log using :obj:`log_level` once per node, or only on the main node.
+            In multinode distributed training, whether to log using :obj:`log_level` once per node, or only on the main
+            node.
         logging_dir (:obj:`str`, `optional`):
             `TensorBoard <https://www.tensorflow.org/tensorboard>`__ log directory. Will default to
             `runs/**CURRENT_DATETIME_HOSTNAME**`.

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -147,13 +147,13 @@ class TrainingArguments:
             Number of steps used for a linear warmup from 0 to :obj:`learning_rate`. Overrides any effect of
             :obj:`warmup_ratio`.
         log_level (:obj:`str`, `optional`, defaults to ``passive``):
-            Logger log level to use on the main node. Possible choices are the log levels as strings: 'debug', 'info',
+            Logger log level to use on the main process. Possible choices are the log levels as strings: 'debug', 'info',
             'warning', 'error' and 'critical', plus a 'passive' level which doesn't set anything and lets the
             application set the level.
         log_level_replica (:obj:`str`, `optional`, defaults to ``passive``):
-            Logger log level to use on replica nodes. Same choices as ``log_level``"
+            Logger log level to use on replicas. Same choices as ``log_level``"
         log_on_each_node (:obj:`bool`, `optional`, defaults to :obj:`True`):
-            In multinode distributed training, whether to log once per node, or only on the main node.
+            In multinode distributed training, whether to log using :obj:`log_level` once per node, or only on the main node.
         logging_dir (:obj:`str`, `optional`):
             `TensorBoard <https://www.tensorflow.org/tensorboard>`__ log directory. Will default to
             `runs/**CURRENT_DATETIME_HOSTNAME**`.

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -102,6 +102,10 @@ def _reset_library_root_logger() -> None:
         _default_handler = None
 
 
+def get_log_levels_dict():
+    return log_levels
+
+
 def get_logger(name: Optional[str] = None) -> logging.Logger:
     """
     Return a logger with the specified name.

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -27,12 +27,20 @@ import numpy as np
 
 from huggingface_hub import HfApi
 from requests.exceptions import HTTPError
-from transformers import AutoTokenizer, IntervalStrategy, PretrainedConfig, TrainingArguments, is_torch_available
+from transformers import (
+    AutoTokenizer,
+    IntervalStrategy,
+    PretrainedConfig,
+    TrainingArguments,
+    is_torch_available,
+    logging,
+)
 from transformers.file_utils import WEIGHTS_NAME
 from transformers.testing_utils import (
     ENDPOINT_STAGING,
     PASS,
     USER,
+    CaptureLogger,
     TestCasePlus,
     get_gpu_count,
     get_tests_dir,
@@ -608,6 +616,29 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
         self.assertFalse(torch.allclose(trainer.model.a, a))
         self.assertFalse(torch.allclose(trainer.model.b, b))
         self.assertGreater(trainer.optimizer.state_dict()["param_groups"][0]["lr"], 0)
+
+    def test_log_level(self):
+        # testing only --log_level (--log_level_replica requires multiple nodes)
+        logger = logging.get_logger()
+        log_info_string = "Running training"
+
+        # test with the default log level - should be info and thus log
+        with CaptureLogger(logger) as cl:
+            trainer = get_regression_trainer()
+            trainer.train()
+        self.assertIn(log_info_string, cl.out)
+
+        # test with low log level - lower than info
+        with CaptureLogger(logger) as cl:
+            trainer = get_regression_trainer(log_level="debug")
+            trainer.train()
+        self.assertIn(log_info_string, cl.out)
+
+        # test with high log level - should be quiet
+        with CaptureLogger(logger) as cl:
+            trainer = get_regression_trainer(log_level="error")
+            trainer.train()
+        self.assertNotIn(log_info_string, cl.out)
 
     def test_model_init(self):
         train_dataset = RegressionDataset()


### PR DESCRIPTION
As examples keep adding more more debug dumps as info (3 new dumps in `run_translation.py`) and repetitive logger warnings keep on growing - w/o being able to control the level of noise, this PR gives the noise control back to the user. 

One of the main pros of this change is that now we can actually use `logger.debug` and put the less important info there, and only activate it when reporting issues or debugging something. Much better than having only `info` or `warning` toggle to logging.

This PR:

1. Introduces `--log_level` which has the normal 5 levels, plus "passive" which doesn't do anything special and let's the driver application do whatever it wants. if it's not `passive` it sets the log level to that arg's value asap.
2. Change Traner's `log_metrics` to be a non-logger print, since this is the whole point of the training/eval and thus IMHO should be always printed as its result. I can see where someone would say, but what if I don't want even this printed. This is fair, in which case I propose to add an explicit new arg `--print_results`.
3. As a single template to work on changes `run_translation.py` to also use this new CLI arg to do the log settings in its own and all sub-modules it uses, e.g. `datasets` here. e.g. previously `datasets` verbosity was on its own.

Questions/Notes to reviewers:
1. If this is accepted I propose to deprecate `training_args.should_log`  since now it's no longer just `info` or `warn`, but provides a more refined control over log levels. And if it's passed to auto-set `--log_level=info`. I left the original logic there for now. The examples can still default to `warn` as they are now.
2. It's however possible that there should be `--train_log_level` and `--log_level` with the latter overriding the former if set, but most likely these should be in sync with everything.
3. Obviously if this is accepted once this example is polished - we will replicate the same for other examples in another PR.
4. I couldn't find how get rid of logger warnings at import time, but it's alright, as now there are only a few left.
5. Specific to Deepspeed integration I need to find a way to do the same there as it's *very* noisy. (in a follow up PR most likely if  find a way).
 
I am very open to other ways of implementing it, naming it, etc.  Not really attached to how, but when I develop/debug code I want to see only the messages that I need to focus on and not hundreds of lines of noise that it's always the same and makes it difficult to see the important things.

With this PR I get:

```
export BS=16; rm -r output_dir; PYTHONPATH=src USE_TF=0 CUDA_VISIBLE_DEVICES=0 python examples/pytorch/translation/run_translation.py --model_name_or_path t5-small --output_dir output_dir --adam_eps 1e-06  --do_train --label_smoothing 0.1 --learning_rate 3e-5 --logging_first_step --logging_steps 500 --max_source_length 128 --max_target_length 128 --num_train_epochs 1 --overwrite_output_dir --per_device_train_batch_size $BS --predict_with_generate --sortish_sampler --source_lang en --target_lang ro --dataset_name wmt16 --dataset_config "ro-en" --source_prefix "translate English to Romanian: " --val_max_target_length 128 --warmup_steps 50 --max_train_samples 50 --max_eval_samples 50 \
--log_level=critical
2021-06-20 19:17:40.705704: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcudart.so.11.0
{'loss': 3.0621, 'learning_rate': 6.000000000000001e-07, 'epoch': 0.25}                                                                                          
{'train_runtime': 1.3178, 'train_samples_per_second': 37.943, 'train_steps_per_second': 3.035, 'train_loss': 2.9988757967948914, 'epoch': 1.0}                   
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00,  7.43it/s]
***** train metrics *****
  epoch                    =        1.0
  train_loss               =     2.9989
  train_runtime            = 0:00:01.31
  train_samples            =         50
  train_samples_per_second =     37.943
  train_steps_per_second   =      3.035
```

Thank you.

@sgugger, @LysandreJik, @patrickvonplaten 
