### PR TITLE
Trainer: adjust wandb installation example

### DIFF
--- a/src/transformers/trainer_tf.py
+++ b/src/transformers/trainer_tf.py
@@ -115,7 +115,7 @@ class TFTrainer:
         elif os.getenv("WANDB_DISABLED", "").upper() not in ENV_VARS_TRUE_VALUES:
             logger.info(
                 "You are instantiating a Trainer but W&B is not installed. To use wandb logging, "
-                "run `pip install wandb; wandb login` see https://docs.wandb.com/huggingface."
+                "run `pip install wandb && wandb login` see https://docs.wandb.com/huggingface."
             )
 
         if is_comet_available():


### PR DESCRIPTION
Hi,

this is a very pedantic fix for the `wandb` installation example.

In the original version, `wandb login` will be executed, even when the previous command - `pip install wandb` - failed.

This can be solved by using the "and" operator.

@sgugger 