### PR TITLE
Fix and improve documentation for LEDForConditionalGeneration

### DIFF
--- a/src/transformers/models/led/modeling_led.py
+++ b/src/transformers/models/led/modeling_led.py
@@ -1462,7 +1462,7 @@ LED_GENERATION_EXAMPLE = r"""
             address such interactions. On the other hand, our proposed Longformer is able to
             build contextual representations of the entire context using multiple layers of
             attention, reducing the need for task-specific architectures.\"\"\"
-        >>> inputs = tokenizer.encode(TXT, return_tensors='pt')
+        >>> inputs = tokenizer.encode(ARTICLE_TO_SUMMARIZE, return_tensors='pt')
         
         >>> # Global attention on the first token (cf. Beltagy et al. 2020)
         >>> global_attention_mask = torch.zeros_like(inputs)

--- a/src/transformers/models/led/modeling_led.py
+++ b/src/transformers/models/led/modeling_led.py
@@ -1436,17 +1436,42 @@ LED_START_DOCSTRING = r"""
 LED_GENERATION_EXAMPLE = r"""
     Summarization example::
 
-        >>> from transformers import LEDTokenizer, LEDForConditionalGeneration, LEDConfig
+        >>> from transformers import LEDTokenizer, LEDForConditionalGeneration
 
-        >>> model = LEDForConditionalGeneration.from_pretrained('allenai/led-base-16384')
-        >>> tokenizer = LEDTokenizer.from_pretrained('allenai/led-base-16384')
+        >>> model = LEDForConditionalGeneration.from_pretrained('allenai/led-large-16384-arxiv')
+        >>> tokenizer = LEDTokenizer.from_pretrained('allenai/led-large-16384-arxiv')
 
-        >>> ARTICLE_TO_SUMMARIZE = "My friends are cool but they eat too many carbs."
-        >>> inputs = tokenizer([ARTICLE_TO_SUMMARIZE], max_length=1024, return_tensors='pt')
+        >>> ARTICLE_TO_SUMMARIZE = \"\"\"Transformers (Vaswani et al., 2017) have achieved state-of-the-art
+            results in a wide range of natural language tasks including generative
+            language modeling (Dai et al., 2019; Radford et al., 2019) and discriminative
+            language understanding (Devlin et al., 2019). This success is partly due to
+            the self-attention component which enables the network to capture contextual
+            information from the entire sequence. While powerful, the memory and computational
+            requirements of self-attention grow quadratically with sequence length, making
+            it infeasible (or very expensive) to process long sequences.
+            
+            To address this limitation, we present Longformer, a modified Transformer
+            architecture with a self-attention operation that scales linearly with the
+            sequence length, making it versatile for processing long documents (Fig 1). This
+            is an advantage for natural language tasks such as long document classification,
+            question answering (QA), and coreference resolution, where existing approaches
+            partition or shorten the long context into smaller sequences that fall within the
+            typical 512 token limit of BERT-style pretrained models. Such partitioning could
+            potentially result in loss of important cross-partition information, and to
+            mitigate this problem, existing methods often rely on complex architectures to
+            address such interactions. On the other hand, our proposed Longformer is able to
+            build contextual representations of the entire context using multiple layers of
+            attention, reducing the need for task-specific architectures.\"\"\"
+        >>> inputs = tokenizer.encode(TXT, return_tensors='pt')
+        
+        >>> # Global attention on the first token (cf. Beltagy et al. 2020)
+        >>> global_attention_mask = torch.zeros_like(inputs)
+        >>> global_attention_mask[:, 0] = 1
 
         >>> # Generate Summary
-        >>> summary_ids = model.generate(inputs['input_ids'], num_beams=4, max_length=5, early_stopping=True)
-        >>> print([tokenizer.decode(g, skip_special_tokens=True, clean_up_tokenization_spaces=False) for g in summary_ids])
+        >>> summary_ids = model.generate(inputs, global_attention_mask=global_attention_mask,
+                                         num_beams=3, max_length=32, early_stopping=True)
+        >>> print(tokenizer.decode(summary_ids[0], skip_special_tokens=True, clean_up_tokenization_spaces=True))
 """
 
 LED_INPUTS_DOCSTRING = r"""

--- a/src/transformers/models/led/modeling_led.py
+++ b/src/transformers/models/led/modeling_led.py
@@ -1436,41 +1436,42 @@ LED_START_DOCSTRING = r"""
 LED_GENERATION_EXAMPLE = r"""
     Summarization example::
 
+        >>> import torch
         >>> from transformers import LEDTokenizer, LEDForConditionalGeneration
 
         >>> model = LEDForConditionalGeneration.from_pretrained('allenai/led-large-16384-arxiv')
         >>> tokenizer = LEDTokenizer.from_pretrained('allenai/led-large-16384-arxiv')
 
-        >>> ARTICLE_TO_SUMMARIZE = \"\"\"Transformers (Vaswani et al., 2017) have achieved state-of-the-art
-            results in a wide range of natural language tasks including generative
-            language modeling (Dai et al., 2019; Radford et al., 2019) and discriminative
-            language understanding (Devlin et al., 2019). This success is partly due to
-            the self-attention component which enables the network to capture contextual
-            information from the entire sequence. While powerful, the memory and computational
-            requirements of self-attention grow quadratically with sequence length, making
-            it infeasible (or very expensive) to process long sequences.
-            
-            To address this limitation, we present Longformer, a modified Transformer
-            architecture with a self-attention operation that scales linearly with the
-            sequence length, making it versatile for processing long documents (Fig 1). This
-            is an advantage for natural language tasks such as long document classification,
-            question answering (QA), and coreference resolution, where existing approaches
-            partition or shorten the long context into smaller sequences that fall within the
-            typical 512 token limit of BERT-style pretrained models. Such partitioning could
-            potentially result in loss of important cross-partition information, and to
-            mitigate this problem, existing methods often rely on complex architectures to
-            address such interactions. On the other hand, our proposed Longformer is able to
-            build contextual representations of the entire context using multiple layers of
-            attention, reducing the need for task-specific architectures.\"\"\"
+        >>> ARTICLE_TO_SUMMARIZE = '''Transformers (Vaswani et al., 2017) have achieved state-of-the-art
+        ... results in a wide range of natural language tasks including generative
+        ... language modeling (Dai et al., 2019; Radford et al., 2019) and discriminative
+        ... language understanding (Devlin et al., 2019). This success is partly due to
+        ... the self-attention component which enables the network to capture contextual
+        ... information from the entire sequence. While powerful, the memory and computational
+        ... requirements of self-attention grow quadratically with sequence length, making
+        ... it infeasible (or very expensive) to process long sequences.
+        ...
+        ... To address this limitation, we present Longformer, a modified Transformer
+        ... architecture with a self-attention operation that scales linearly with the
+        ... sequence length, making it versatile for processing long documents (Fig 1). This
+        ... is an advantage for natural language tasks such as long document classification,
+        ... question answering (QA), and coreference resolution, where existing approaches
+        ... partition or shorten the long context into smaller sequences that fall within the
+        ... typical 512 token limit of BERT-style pretrained models. Such partitioning could
+        ... potentially result in loss of important cross-partition information, and to
+        ... mitigate this problem, existing methods often rely on complex architectures to
+        ... address such interactions. On the other hand, our proposed Longformer is able to
+        ... build contextual representations of the entire context using multiple layers of
+        ... attention, reducing the need for task-specific architectures.'''
         >>> inputs = tokenizer.encode(ARTICLE_TO_SUMMARIZE, return_tensors='pt')
-        
+
         >>> # Global attention on the first token (cf. Beltagy et al. 2020)
         >>> global_attention_mask = torch.zeros_like(inputs)
         >>> global_attention_mask[:, 0] = 1
 
         >>> # Generate Summary
         >>> summary_ids = model.generate(inputs, global_attention_mask=global_attention_mask,
-                                         num_beams=3, max_length=32, early_stopping=True)
+        ...                              num_beams=3, max_length=32, early_stopping=True)
         >>> print(tokenizer.decode(summary_ids[0], skip_special_tokens=True, clean_up_tokenization_spaces=True))
 """
 

--- a/src/transformers/models/led/modeling_led.py
+++ b/src/transformers/models/led/modeling_led.py
@@ -2305,13 +2305,9 @@ class LEDForConditionalGeneration(LEDPreTrainedModel):
 
             >>> model = LEDForConditionalGeneration.from_pretrained('allenai/led-base-16384')
             >>> input_ids = tokenizer([TXT], return_tensors='pt')['input_ids']
-            >>> logits = model(input_ids).logits
 
-            >>> masked_index = (input_ids[0] == tokenizer.mask_token_id).nonzero().item()
-            >>> probs = logits[0, masked_index].softmax(dim=0)
-            >>> values, predictions = probs.topk(5)
-
-            >>> tokenizer.decode(predictions).split()
+            >>> prediction = model.generate(input_ids)[0]
+            >>> print(tokenizer.decode(prediction, skip_special_tokens=True))
         """
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 


### PR DESCRIPTION
# What does this PR do?

As reported in #12268, the example for text generation with LED does not work because it relies on an implementation detail of the BART model for which it was originally conceived. Further, the summarization example uses a checkpoint that was not finetuned on a summarization task, leading to the model just repeating the entire input.

This PR replaces both examples with versions that are fully functional and illustrate the respective task.

<!-- Remove if not applicable -->

Fixes #12268

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger @patrickvonplaten 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
