### PR TITLE
[models] respect dtype of the model when instantiating it

### DIFF
--- a/docs/source/main_classes/deepspeed.rst
+++ b/docs/source/main_classes/deepspeed.rst
@@ -1530,6 +1530,8 @@ Note: If the fp16 weights of the model can't fit onto the memory of a single GPU
 For full details on this method and other related features please refer to `Constructing Massive Models
 <https://deepspeed.readthedocs.io/en/latest/zero3.html#constructing-massive-models>`__.
 
+Also when loading fp16-pretrained models, you will want to tell ``from_pretrained`` to use
+``torch_dtype=torch.float16``. For details, please, see :ref:`from_pretrained-torch-dtype`.
 
 
 Gathering Parameters

--- a/docs/source/main_classes/model.rst
+++ b/docs/source/main_classes/model.rst
@@ -56,7 +56,7 @@ and then ``dtype`` will be automatically derived from the model's weights:
 
 .. code-block:: python
 
-    model = AutoModel.from_config(config, torch_dtype="auto")
+    model = T5ForConditionalGeneration.from_pretrained("t5", torch_dtype="auto")
 
 Models instantiated from scratch can also be told which ``dtype`` to use with:
 

--- a/docs/source/main_classes/model.rst
+++ b/docs/source/main_classes/model.rst
@@ -52,7 +52,7 @@ either explicitly pass the desired ``dtype`` using ``torch_dtype`` argument:
     model = T5ForConditionalGeneration.from_pretrained("t5", torch_dtype=torch.float16)
 
 or, if you want the model to always load in the most optimal memory pattern, you can use the special value ``"auto"``,
-and then ``dtype`` will be automatically derived from the model weights:
+and then ``dtype`` will be automatically derived from the model's weights:
 
 .. code-block:: python
 

--- a/docs/source/main_classes/model.rst
+++ b/docs/source/main_classes/model.rst
@@ -1,4 +1,4 @@
-.. 
+..
     Copyright 2020 The HuggingFace Team. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
@@ -36,6 +36,37 @@ PreTrainedModel
 
 .. autoclass:: transformers.PreTrainedModel
     :members:
+
+
+.. _from_pretrained-torch-dtype:
+
+Model Instantiation dtype
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Under Pytorch a model normally gets instantiated with ``torch.float32`` format. This can be an issue if one tries to
+load a model whose weights are in fp16, since it'd require twice as much memory. To overcome this limitation, you can
+either explicitly pass the desired ``dtype`` using ``torch_dtype`` argument:
+
+.. code-block:: python
+
+    model = T5ForConditionalGeneration.from_pretrained("t5", torch_dtype=torch.float16)
+
+or, if you want the model to always load in the most optimal memory pattern, you can use the special value ``"auto"``,
+and then ``dtype`` will be automatically derived from the model weights:
+
+.. code-block:: python
+
+    model = AutoModel.from_config(config, torch_dtype="auto")
+
+Models instantiated from scratch can also be told which ``dtype`` to use with:
+
+.. code-block:: python
+
+    config = T5Config.from_pretrained("t5")
+    model = AutoModel.from_config(config)
+
+Due to Pytorch design, this functionality is only available for floating dtypes.
+
 
 
 ModuleUtilsMixin

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -196,7 +196,7 @@ class PretrainedConfig(PushToHubMixin):
           initialize the model to a non-default ``dtype`` (which is normally ``float32``) and thus allow for optimal
           storage allocation. For example, if the saved model is ``float16``, ideally we want to load it back using the
           minimal amount of memory needed to load ``float16`` weights. Since the config object is stored in plain text,
-          this attribute contains just the floating type string without the ``torch\.`` prefix. For example, for
+          this attribute contains just the floating type string without the ``torch.`` prefix. For example, for
           ``torch.float16`` ``torch_dtype`` is the ``"float16"`` string.
 
     TensorFlow specific parameters

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -192,12 +192,12 @@ class PretrainedConfig(PushToHubMixin):
         - **tie_word_embeddings** (:obj:`bool`, `optional`, defaults to :obj:`True`) -- Whether the model's input and
           output word embeddings should be tied. Note that this is only relevant if the model has a output word
           embedding layer.
-        - **torch_dtype** (:obj:`str`, `optional`, defaults to :obj:`None`) -- The :obj:`dtype` of the weights. This
-          attribute is used to initialize the model to a non-default ``dtype`` (which is normally ``float32``) and thus
-          allow for optimal storage allocation. For example, if the saved model is ``float16``, we want to load it back
-          using the minimal amount of memory needed to load ``float16`` weights. XXX: The saved config As this is a
-          config object we store just the name of the ``torch`` attribute, i.e. for ``torch.float32`` ``dtype`` is
-          ``"float32"`` string.
+        - **torch_dtype** (:obj:`str`, `optional`) -- The :obj:`dtype` of the weights. This attribute is used to
+          initialize the model to a non-default ``dtype`` (which is normally ``float32``) and thus allow for optimal
+          storage allocation. For example, if the saved model is ``float16``, we want to load it back using the minimal
+          amount of memory needed to load ``float16`` weights. Since the config object is stored in plain text, this
+          attribute contains just the floating type string without the ``torch\.`` prefix. For example, for
+          ``torch.float16`` ``torch_dtype`` is the ``"float16"`` string.
 
     TensorFlow specific parameters
 

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -192,6 +192,12 @@ class PretrainedConfig(PushToHubMixin):
         - **tie_word_embeddings** (:obj:`bool`, `optional`, defaults to :obj:`True`) -- Whether the model's input and
           output word embeddings should be tied. Note that this is only relevant if the model has a output word
           embedding layer.
+        - **torch_dtype** (:obj:`str`, `optional`, defaults to :obj:`None`) -- The :obj:`dtype` of the weights. This
+          attribute is used to initialize the model to a non-default ``dtype`` (which is normally ``float32``) and thus
+          allow for optimal storage allocation. For example, if the saved model is ``float16``, we want to load it back
+          using the minimal amount of memory needed to load ``float16`` weights. XXX: The saved config As this is a
+          config object we store just the name of the ``torch`` attribute, i.e. for ``torch.float32`` ``dtype`` is
+          ``"float32"`` string.
 
     TensorFlow specific parameters
 
@@ -207,6 +213,7 @@ class PretrainedConfig(PushToHubMixin):
         self.output_hidden_states = kwargs.pop("output_hidden_states", False)
         self.output_attentions = kwargs.pop("output_attentions", False)
         self.torchscript = kwargs.pop("torchscript", False)  # Only used by PyTorch models
+        self.torch_dtype = kwargs.pop("torch_dtype", None)  # Only used by PyTorch models
         self.use_bfloat16 = kwargs.pop("use_bfloat16", False)
         self.pruned_heads = kwargs.pop("pruned_heads", {})
         self.tie_word_embeddings = kwargs.pop(

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -192,11 +192,11 @@ class PretrainedConfig(PushToHubMixin):
         - **tie_word_embeddings** (:obj:`bool`, `optional`, defaults to :obj:`True`) -- Whether the model's input and
           output word embeddings should be tied. Note that this is only relevant if the model has a output word
           embedding layer.
-        - **torch_dtype** (:obj:`str`, `optional`) -- The :obj:`dtype` of the weights. This attribute is used to
+        - **torch_dtype** (:obj:`str`, `optional`) -- The :obj:`dtype` of the weights. This attribute can be used to
           initialize the model to a non-default ``dtype`` (which is normally ``float32``) and thus allow for optimal
-          storage allocation. For example, if the saved model is ``float16``, we want to load it back using the minimal
-          amount of memory needed to load ``float16`` weights. Since the config object is stored in plain text, this
-          attribute contains just the floating type string without the ``torch\.`` prefix. For example, for
+          storage allocation. For example, if the saved model is ``float16``, ideally we want to load it back using the
+          minimal amount of memory needed to load ``float16`` weights. Since the config object is stored in plain text,
+          this attribute contains just the floating type string without the ``torch\.`` prefix. For example, for
           ``torch.float16`` ``torch_dtype`` is the ``"float16"`` string.
 
     TensorFlow specific parameters

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -115,7 +115,7 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
     @classmethod
     def _from_config(cls, config, **kwargs):
         """
-        All context managers that the model should be init'ed under go here
+        All context managers that the model should be initialized under go here.
         """
         return cls(config, **kwargs)
 

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -112,6 +112,13 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
     def init_weights(self, rng: jax.random.PRNGKey, input_shape: Tuple) -> Dict:
         raise NotImplementedError(f"init method has to be implemented for {self}")
 
+    @classmethod
+    def _from_config(cls, config, **kwargs):
+        """
+        All context managers that the model should be init'ed under go here
+        """
+        return cls(config, **kwargs)
+
     @property
     def config(self) -> PretrainedConfig:
         return self._config

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -647,7 +647,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
     @classmethod
     def _from_config(cls, config, **kwargs):
         """
-        All context managers that the model should be init'ed under go here
+        All context managers that the model should be initialized under go here.
         """
         return cls(config, **kwargs)
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -644,6 +644,13 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         self.config = config
         self.name_or_path = config.name_or_path
 
+    @classmethod
+    def _from_config(cls, config, **kwargs):
+        """
+        All context managers that the model should be init'ed under go here
+        """
+        return cls(config, **kwargs)
+
     @tf.function(
         input_signature=[
             {

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -500,7 +500,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
     @classmethod
     def _set_default_torch_dtype(cls, dtype: torch.dtype) -> torch.dtype:
         """
-        Change the default dtype and return the previous one. This is needed when wanting to instantiate the model under specific dtype.
+        Change the default dtype and return the previous one. This is needed when wanting to instantiate the model
+        under specific dtype.
 
         Args:
             dtype (:obj:`torch.dtype`):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -517,11 +517,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             raise ValueError(f"dtype is expected to be the string attribute name of ``torch``, got {config_dtype_str}")
 
         if "float" not in dtype_str:
-            print(f"instantiating {cls.__name__} model under default dtype, since {dtype_str} is not a float dtype")
+            logger.info(f"instantiating {cls.__name__} model under default dtype, since {dtype_str} is not a float dtype")
             return None
 
         dtype = getattr(torch, dtype_str)
-        print(f"instantiating {cls.__name__} model under default dtype {dtype}")
+        logger.info(f"instantiating {cls.__name__} model under default dtype {dtype}")
         dtype_orig = torch.get_default_dtype()
         torch.set_default_dtype(dtype)
         return dtype_orig

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -521,13 +521,13 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if not isinstance(dtype_str, str):
             raise ValueError(f"dtype is expected to be the string attribute name of ``torch``, got {config_dtype_str}")
 
-        if "float" not in dtype_str:
+        dtype = getattr(torch, dtype_str)
+        if not dtype.is_floating_point:
             logger.warning(
-                f"instantiating {cls.__name__} model under default torch.dtype, since {dtype_str} is not a float dtype"
+                f"instantiating {cls.__name__} model under ``torch.get_default_dtype()``, since {dtype} is not a floating point dtype"
             )
             return None
 
-        dtype = getattr(torch, dtype_str)
         logger.info(f"instantiating {cls.__name__} model under default dtype {dtype}")
         dtype_orig = torch.get_default_dtype()
         torch.set_default_dtype(dtype)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1215,9 +1215,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                         "If you tried to load a PyTorch model from a TF 2.0 checkpoint, please set from_tf=True. "
                     )
 
-            # set dtype to instantiate the model according to the weights' dtype
+            # set dtype to instantiate the model under:
             # 1. If config.torch_dtype is not None, we use that dtype
-            # 2. Otherwise, we try to detect it from the loaded state_dict, by checking the first
+            # 2. Otherwise, we try to auto-detect it from the loaded state_dict, by checking the first
             #    entry - we assume all weights are of the same dtype
             dtype_orig = None
             dtype = _dtype_from_str(config.torch_dtype)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1050,7 +1050,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 Whether or not to disable fast initialization.
             torch_dtype (:obj:`str` or :obj:`torch.dtype`, `optional`):
                 Override the default ``torch.dtype`` and load the model under this dtype. If ``"auto"`` is passed the
-                dtype will be automatically derived from the model weights.
+                dtype will be automatically derived from the model's weights.
 
                 .. warning::
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -498,27 +498,32 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         used to change the global dtype. Which is needed when wanting to instantiate the model under specific dtype.
 
         Args:
-            config_dtype_str - ``config.torch_dtype``
-            weight_dtype - optional ``dtype`` of one of the weights
+            config_dtype_str (:obj:`str`):
+                value of ``config.torch_dtype``
+            weight_dtype (:obj:`torch.dtype`, `optional`, defaults to :obj:`None`):
+                ``dtype`` of one of the pretrained weights
 
-        Returns:`` the original ``dtype`` that can be used to restore torch.set_default_dtype(dtype) if it was
-        modified. It it wasn't returns :obj:`None`
+        Returns:
+            :obj:`torch.dtype`: the original ``dtype`` that can be used to restore ``torch.set_default_dtype(dtype)``
+            if it was modified. If it wasn't, returns :obj:`None`.
 
-        Note ``set_default_dtype`` currently only works with floating-point types and assert if for
-        example``torch.int64`` is passed. So if non-float ``dtype`` is passed we don't do anything.
-
+        Note ``set_default_dtype`` currently only works with floating-point types and asserts if for example,
+        ``torch.int64`` is passed. So if a non-float ``dtype`` is passed we don't do anything other than logging a
+        warning that the non-float dtype was ignored.
         """
         dtype_str = config_dtype_str
         if dtype_str is None and weight_dtype is not None:
             dtype_str = str(weight_dtype).split(".")[1]
+
         if dtype_str is None:
             return None
+
         if not isinstance(dtype_str, str):
             raise ValueError(f"dtype is expected to be the string attribute name of ``torch``, got {config_dtype_str}")
 
         if "float" not in dtype_str:
-            logger.info(
-                f"instantiating {cls.__name__} model under default dtype, since {dtype_str} is not a float dtype"
+            logger.warning(
+                f"instantiating {cls.__name__} model under default torch.dtype, since {dtype_str} is not a float dtype"
             )
             return None
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1238,9 +1238,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
             # set dtype to instantiate the model under:
             # 1. If torch_dtype is not None, we use that dtype
-            # 2. If torch_dtype_auto_detect is True, we auto-detect it from the loaded state_dict, by checking the first
-            #    entry - we assume all weights are of the same dtype
-            # we also may have config.torch_dtype but we won't rely on it till v5
+            # 2. If torch_dtype is "auto", we auto-detect dtype from the loaded state_dict, by checking its first
+            #    weights entry - we assume all weights are of the same dtype
+            # we also may have config.torch_dtype available, but we won't rely on it till v5
             dtype_orig = None
             if torch_dtype is not None:
                 if isinstance(torch_dtype, str):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -468,7 +468,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
     @classmethod
     def _from_config(cls, config, **kwargs):
         """
-        All context managers that the model should be init'ed under go here
+        All context managers that the model should be initialized under go here.
         """
 
         # override default dtype if needed
@@ -500,7 +500,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         Args:
             config_dtype_str (:obj:`str`):
                 value of ``config.torch_dtype``
-            weight_dtype (:obj:`torch.dtype`, `optional`, defaults to :obj:`None`):
+            weight_dtype (:obj:`torch.dtype`, `optional`):
                 ``dtype`` of one of the pretrained weights
 
         Returns:
@@ -524,11 +524,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         dtype = getattr(torch, dtype_str)
         if not dtype.is_floating_point:
             logger.warning(
-                f"instantiating {cls.__name__} model under ``torch.get_default_dtype()``, since {dtype} is not a floating point dtype"
+                f"instantiating {cls.__name__} model under {torch.get_default_dtype()}, since {dtype} is not a floating point dtype"
             )
             return None
 
-        logger.info(f"instantiating {cls.__name__} model under default dtype {dtype}")
+        logger.info(f"Instantiating {cls.__name__} model under default dtype {dtype}.")
         dtype_orig = torch.get_default_dtype()
         torch.set_default_dtype(dtype)
         return dtype_orig

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -471,7 +471,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         All context managers that the model should be initialized under go here.
 
         Args:
-            `torch_dtype` - see ``from_pretrained`` for details
+            torch_dtype (:obj:`torch.dtype`, `optional`):
+                Override the default ``torch.dtype`` and load the model under this dtype.
         """
         torch_dtype = kwargs.pop("torch_dtype", None)
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -517,7 +517,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             raise ValueError(f"dtype is expected to be the string attribute name of ``torch``, got {config_dtype_str}")
 
         if "float" not in dtype_str:
-            logger.info(f"instantiating {cls.__name__} model under default dtype, since {dtype_str} is not a float dtype")
+            logger.info(
+                f"instantiating {cls.__name__} model under default dtype, since {dtype_str} is not a float dtype"
+            )
             return None
 
         dtype = getattr(torch, dtype_str)

--- a/tests/extended/test_trainer_ext.py
+++ b/tests/extended/test_trainer_ext.py
@@ -45,6 +45,9 @@ with ExtendSysPath(f"{bindir}/../../examples/pytorch/translation"):
 set_seed(42)
 MARIAN_MODEL = "sshleifer/student_marian_en_ro_6_1"
 MBART_TINY = "sshleifer/tiny-mbart"
+T5_TINY = "patrickvonplaten/t5-tiny-random"
+# using T5_TINY as it's fp32 model, MBART_TINY which is fp16 fails under 0 gpus with various
+# Half-related issues, e.g. RuntimeError: "LayerNormKernelImpl" not implemented for 'Half'
 
 
 # a candidate for testing_utils
@@ -82,7 +85,7 @@ class TestTrainerExt(TestCasePlus):
         output_dir = self.run_trainer(
             eval_steps=1,
             max_len=12,
-            model_name=MBART_TINY,
+            model_name=T5_TINY,
             num_train_epochs=1,
             distributed=distributed,
             extra_args_str=extra_args_str,

--- a/tests/extended/test_trainer_ext.py
+++ b/tests/extended/test_trainer_ext.py
@@ -45,9 +45,6 @@ with ExtendSysPath(f"{bindir}/../../examples/pytorch/translation"):
 set_seed(42)
 MARIAN_MODEL = "sshleifer/student_marian_en_ro_6_1"
 MBART_TINY = "sshleifer/tiny-mbart"
-T5_TINY = "patrickvonplaten/t5-tiny-random"
-# using T5_TINY as it's fp32 model, MBART_TINY which is fp16 fails under 0 gpus with various
-# Half-related issues, e.g. RuntimeError: "LayerNormKernelImpl" not implemented for 'Half'
 
 
 # a candidate for testing_utils
@@ -85,7 +82,7 @@ class TestTrainerExt(TestCasePlus):
         output_dir = self.run_trainer(
             eval_steps=1,
             max_len=12,
-            model_name=T5_TINY,
+            model_name=MBART_TINY,
             num_train_epochs=1,
             distributed=distributed,
             extra_args_str=extra_args_str,

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1624,7 +1624,7 @@ class ModelUtilsTest(TestCasePlus):
         model = T5ForConditionalGeneration.from_pretrained(model_path)
         self.assertEqual(model.dtype, torch.float32)
         # test with auto-detection
-        model = T5ForConditionalGeneration.from_pretrained(model_path, torch_dtype_auto_detect=True)
+        model = T5ForConditionalGeneration.from_pretrained(model_path, torch_dtype="auto")
         self.assertEqual(model.dtype, torch.float32)
 
         # test forced loading in fp16 (even though the weights are in fp32)
@@ -1634,8 +1634,8 @@ class ModelUtilsTest(TestCasePlus):
         # test fp16 save_pretrained, loaded with auto-detection
         model = model.half()
         model.save_pretrained(model_path)
-        model = T5ForConditionalGeneration.from_pretrained(model_path, torch_dtype_auto_detect=True)
-        self.assertEqual(model.config.torch_dtype, "float16")  # also test `config.torch_dtype` saving
+        model = T5ForConditionalGeneration.from_pretrained(model_path, torch_dtype="auto")
+        self.assertEqual(model.config.torch_dtype, "float16")  # tests `config.torch_dtype` saving
         self.assertEqual(model.dtype, torch.float16)
 
         # test fp16 save_pretrained, loaded with the explicit fp16


### PR DESCRIPTION
update for future readers - the initially proposed API has changed through the process of review, so below is slightly autodated, e.g. there is no `torch_dtype_auto_detect`, but `torch_dtype=auto`.

----------------

This PR resolves the issue discussed in https://github.com/huggingface/transformers/issues/12062.

The main feature is: 
1. model will now be instantiated with the `dtype`  passed via `from_pretrained` and `from_config` `torch_dtype` arg
2. alternatively `from_pretrained` now has `torch_dtype_auto_detect` which can do the same automatically

Examples:
```
model = AutoModel.from_config(config, torch_dtype=torch.float16)
model = T5ForConditionalGeneration.from_pretrained(model_path, torch_dtype=torch.float16)
model = T5ForConditionalGeneration.from_pretrained(model_path, torch_dtype_auto_detect=True)
```

**Important: only float dtypes are supported by `torch.set_default_dtype(dtype)`, so if it's not float, say int8, an exception will be generated**

Changes:
- `PreTrainedModel` now has a new `_from_config` method where all the context managers for the model instantiation are done
- `auto_factory`'s `from_config` is back to being a thin wrapper - all the deepspeed stuff has now moved to PT's version of  `_from_config` 
- The PT's version of  `_from_config` now also sports the context manager-like functionality for dtype
- TF and Flax now have a thin `_from_config` method 
- `from_pretrained`: had to move `torch.load` before model instantiation to enabled auto-discovery
- `from_pretrained`: like `from_config` has a similar context manager for dtype
- extensive tests added

Possible changes:
- I wasn't sure whether to call `config.torch_dtype` or `config.dtype` - I went with the former as it'd be easy to rename after reviews. I don't know whether we want it generic or torch specific - I don't know if tf/flax use similar names, but I guess we could automatically remap those if needed.
- When saving the dtype I saved only "float32" part of "torch.float32" - I could save "torch.float32" instead - either way I have to reconstruct the dtype object from string. same uncertainty as in the item above. 
- the dtype context managers are poor man's versions since at the moment they are unique in each place, due to 3 frameworks using the same `from_pretrained` method - if we ever split it then we can use an actual context manager in `from_pretrained`.

Questions:
- should `T5ForConditionalGeneration.from_config(config)` be supported? Currently it's not and `T5ForConditionalGeneration(config)` ignores model instantiation context managers - just saves the config object
- probably should document this feature somewhere in the docs? Any suggestion where? It will work out-of-the-box but the documenting part would be handy for someone who wants to create a model from scratch in a non-default dtype.


Also note the new `log.info` entry:
```
Instantiating T5ForConditionalGeneration model under default dtype torch.float16
```
So one can tell what's happening.


The original version of this PR which tried to do the right thing automatically was dropped due to:

Possible issues:
- fp16 saved models now will be loaded as such and not fp32 as before - so some usages under CPU may fail, e.g. with:
```
RuntimeError: "LayerNormKernelImpl" not implemented for 'Half'
```
e.g. many of our tiny models are fp16.

Another one on CUDA:
```
RuntimeError: Found param model.shared.weight with type torch.cuda.HalfTensor, expected torch.cuda.FloatTensor.
```


Fixes: https://github.com/huggingface/transformers/issues/12062

@sgugger, @LysandreJik, @patrickvonplaten 