### PR TITLE
fill-mask pipeline: fix handling topk() indices

### DIFF
--- a/src/transformers/pipelines/fill_mask.py
+++ b/src/transformers/pipelines/fill_mask.py
@@ -196,6 +196,8 @@ class FillMaskPipeline(Pipeline):
                     probs = probs[..., target_ids]
 
                 values, predictions = probs.topk(top_k)
+                if targets is not None:
+                    predictions = target_ids[predictions]
 
             for v, p in zip(values.tolist(), predictions.tolist()):
                 tokens = input_ids.numpy()

--- a/src/transformers/pipelines/fill_mask.py
+++ b/src/transformers/pipelines/fill_mask.py
@@ -195,7 +195,8 @@ class FillMaskPipeline(Pipeline):
                 if targets is not None:
                     probs = probs[..., target_ids]
 
-                values, predictions = probs.topk(top_k)
+                values, indices = probs.topk(top_k)
+                predictions = target_ids[indices]
 
             for v, p in zip(values.tolist(), predictions.tolist()):
                 tokens = input_ids.numpy()


### PR DESCRIPTION
# What does this PR do?

Fixes #12113, where indices in the targets array were used instead of their corresponding token ids. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@Narsil @LysandreJik