### PR TITLE
Changed modeling_fx_utils.py to utils/fx.py for clarity

### DIFF
--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -11,7 +11,7 @@ from torch.fx.node import Argument
 
 from transformers.file_utils import TORCH_FX_REQUIRED_VERSION, importlib_metadata, is_torch_fx_available
 
-from . import (
+from .. import (
     MODEL_FOR_CAUSAL_LM_MAPPING,
     MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING,
     MODEL_FOR_MASKED_LM_MAPPING,
@@ -26,7 +26,7 @@ from . import (
     PreTrainedModel,
     logging,
 )
-from .models.auto import get_values
+from ..models.auto import get_values
 
 
 logger = logging.get_logger(__name__)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -67,7 +67,7 @@ if is_torch_available():
     )
 
 if is_torch_fx_available():
-    from transformers.modeling_fx_utils import symbolic_trace
+    from transformers.utils.fx import symbolic_trace
 
 
 def _config_zero_init(config):


### PR DESCRIPTION
Moved **modeling_fx_utils.py** to **utils/fx.py** to make it clear that it is not "modeling_flax_utils.py".

Since there are a modeling_utils.py for PyTorch, and a modeling_tf_utils.py for TensorFlow, modeling_fx_utils.py could be believed to be the Flax counterpart, but it is actually related to the torch.fx feature, hence the pull request.