### PR TITLE
Cast logits from bf16 to fp32 at the end of TF_T5

### DIFF
--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -1407,6 +1407,8 @@ class TFT5ForConditionalGeneration(TFT5PreTrainedModel, TFCausalLanguageModeling
         else:
             logits = self.lm_head(sequence_output)
 
+        logits = tf.cast(logits, tf.float32)
+
         loss = None if inputs["labels"] is None else self.compute_loss(inputs["labels"], logits)
 
         if not inputs["return_dict"]:


### PR DESCRIPTION
# What does this PR do?

This change enables tf.keras.mixed_precision with bf16

I found that T5 model does not follow the [official TF guidelines regarding mixed precision](https://www.tensorflow.org/guide/mixed_precision). Therefore it's impossible to use 
`tf.keras.mixed_precision.set_global_policy('mixed_bfloat16')` which is the recommended way of training on bfloat16.

I took a notebook [snapthat/TF-T5-text-to-text](https://github.com/snapthat/TF-T5-text-to-text/blob/master/snapthatT5/notebooks/TF-T5-%20Training.ipynb) and added `tf.keras.mixed_precision.set_global_policy('mixed_bfloat16')`.

Experiments were done on tensorflow-cpu == 2.4.1, datasets == 1.8.0, transformers == 4.6.1.

The first issue is with the loss curve:
![loss_t5](https://user-images.githubusercontent.com/37601244/123172656-b81f6d80-d47d-11eb-886a-f3974321f9d8.PNG)

And the second is with inference (also included in the notebook):
```
  File "bf16_experiment.py", line 136, in <module>
    max_length=decoder_max_len, top_p=0.95, top_k=50, repetition_penalty=2)
  File "/home/mszutenberg/venv24/lib/python3.6/site-packages/transformers/generation_tf_utils.py", line 417, in generate
    use_cache=use_cache,
  File "/home/mszutenberg/venv24/lib/python3.6/site-packages/transformers/generation_tf_utils.py", line 472, in _generate_no_beam_search
    next_token_logits = tf.math.multiply(next_token_logits, next_token_logits_penalties)
  File "/home/mszutenberg/venv24/lib/python3.6/site-packages/tensorflow/python/util/dispatch.py", line 201, in wrapper
    return target(*args, **kwargs)
  File "/home/mszutenberg/venv24/lib/python3.6/site-packages/tensorflow/python/ops/math_ops.py", line 518, in multiply
    return gen_math_ops.mul(x, y, name)
  File "/home/mszutenberg/venv24/lib/python3.6/site-packages/tensorflow/python/ops/gen_math_ops.py", line 6068, in mul
    _ops.raise_from_not_ok_status(e, name)
  File "/home/mszutenberg/venv24/lib/python3.6/site-packages/tensorflow/python/framework/ops.py", line 6862, in raise_from_not_ok_status
    six.raise_from(core._status_to_exception(e.code, message), None)
  File "<string>", line 3, in raise_from
tensorflow.python.framework.errors_impl.InvalidArgumentError: cannot compute Mul as input #1(zero-based) was expected to be a bfloat16 tensor but is a float tensor [Op:Mul]
```

This fix solves both issues. I see that the problem may also occur in other models. I can check and prepare fixes if this PR is approved.

## Who can review?

@LysandreJik @patrickvonplaten