### PR TITLE
Fix torchscript tests

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -575,13 +575,16 @@ class ModelTesterMixin:
 
             self.assertEqual(set(model_state_dict.keys()), set(loaded_model_state_dict.keys()))
 
+            model_buffers = list(model.buffers())
             for non_persistent_buffer in non_persistent_buffers.values():
                 found_buffer = False
-                for model_buffer in model.buffers():
+                for i, model_buffer in enumerate(model_buffers):
                     if torch.equal(non_persistent_buffer, model_buffer):
                         found_buffer = True
+                        break
 
                 self.assertTrue(found_buffer)
+                model_buffers.pop(i)
 
             models_equal = True
             for layer_name, p1 in model_state_dict.items():

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1587,7 +1587,6 @@ class ModelUtilsTest(unittest.TestCase):
             self.assertIsNotNone(model)
             self.assertIsInstance(model, PreTrainedModel)
             for value in loading_info.values():
-                print(loading_info)
                 self.assertEqual(len(value), 0)
 
             config = BertConfig.from_pretrained(model_name, output_attentions=True, output_hidden_states=True)


### PR DESCRIPTION
With the new non persistent buffers, the TorchScript tests fail. This PR updates the TorchScript tests to allow for non-persistent buffers.