### PR TITLE
[trainer] fix label smoothing for default compute_loss

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1780,7 +1780,7 @@ class Trainer:
         Subclass and override for custom behavior.
         """
         if self.label_smoother is not None and "labels" in inputs:
-            labels = inputs.pop("labels")
+            labels = inputs["labels"]
         else:
             labels = None
         outputs = model(**inputs)


### PR DESCRIPTION
# What does this PR do?

Keeps 'labels' in the inputs which are passed to model.

Without this change, the model I'm using (PegasusForConditionalGeneration) can't calculate loss and generate outputs. Change assumes that all other models also need 'labels' in inputs.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->



## Who can review?

trainer: @sgugger
