### PR TITLE
Replace NotebookProgressReporter by ProgressReporter in Ray Tune run

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -21,6 +21,7 @@ import tempfile
 from pathlib import Path
 
 from .utils import logging
+from .utils.notebook import NotebookProgressCallback
 
 
 logger = logging.get_logger(__name__)
@@ -42,7 +43,7 @@ if _has_comet:
         _has_comet = False
 
 from .file_utils import ENV_VARS_TRUE_VALUES, is_torch_tpu_available  # noqa: E402
-from .trainer_callback import TrainerCallback  # noqa: E402
+from .trainer_callback import ProgressCallback, TrainerCallback  # noqa: E402
 from .trainer_utils import PREFIX_CHECKPOINT_DIR, BestRun, IntervalStrategy  # noqa: E402
 
 
@@ -153,6 +154,9 @@ def run_hp_search_ray(trainer, n_trials: int, direction: str, **kwargs) -> BestR
     import ray
 
     def _objective(trial, local_trainer, checkpoint_dir=None):
+        if local_trainer.pop_callback(NotebookProgressCallback):
+            local_trainer.add_callback(ProgressCallback)
+
         checkpoint = None
         if checkpoint_dir:
             for subdir in os.listdir(checkpoint_dir):

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -21,7 +21,6 @@ import tempfile
 from pathlib import Path
 
 from .utils import logging
-from .utils.notebook import NotebookProgressCallback
 
 
 logger = logging.get_logger(__name__)
@@ -154,8 +153,13 @@ def run_hp_search_ray(trainer, n_trials: int, direction: str, **kwargs) -> BestR
     import ray
 
     def _objective(trial, local_trainer, checkpoint_dir=None):
-        if local_trainer.pop_callback(NotebookProgressCallback):
-            local_trainer.add_callback(ProgressCallback)
+        try:
+            from transformers.utils.notebook import NotebookProgressCallback
+
+            if local_trainer.pop_callback(NotebookProgressCallback):
+                local_trainer.add_callback(ProgressCallback)
+        except ModuleNotFoundError:
+            pass
 
         checkpoint = None
         if checkpoint_dir:


### PR DESCRIPTION
# What does this PR do?

This PR replaces the local trainer NotebookProgressReporter callback by a ProgressReporter. Generally we cannot guarantee correct display of IPython renderables in remote processes (e.g. because they get redirected into files), so it's better to replace these by text based reporters.

Otherwise, these are produced: `<IPython.core.display.HTML object>`

See also https://github.com/ray-project/ray/issues/16197

<!-- Remove if not applicable -->

Fixes https://github.com/ray-project/ray/issues/16197


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger 

