### PR TITLE
Easily train a new fast tokenizer from a given one

### DIFF
--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -42,7 +42,7 @@ deps = {
     "pytest-sugar": "pytest-sugar",
     "pytest-xdist": "pytest-xdist",
     "python": "python>=3.6.0",
-    "ray": "ray",
+    "ray[tune]": "ray[tune]",
     "recommonmark": "recommonmark",
     "regex": "regex!=2019.12.17",
     "requests": "requests",

--- a/src/transformers/models/albert/tokenization_albert_fast.py
+++ b/src/transformers/models/albert/tokenization_albert_fast.py
@@ -121,7 +121,7 @@ class AlbertTokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
+        vocab_file=None,
         tokenizer_file=None,
         do_lower_case=True,
         remove_space=True,

--- a/src/transformers/models/barthez/tokenization_barthez_fast.py
+++ b/src/transformers/models/barthez/tokenization_barthez_fast.py
@@ -109,7 +109,7 @@ class BarthezTokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
+        vocab_file=None,
         tokenizer_file=None,
         bos_token="<s>",
         eos_token="</s>",

--- a/src/transformers/models/bert/tokenization_bert_fast.py
+++ b/src/transformers/models/bert/tokenization_bert_fast.py
@@ -162,7 +162,7 @@ class BertTokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
+        vocab_file=None,
         tokenizer_file=None,
         do_lower_case=True,
         unk_token="[UNK]",

--- a/src/transformers/models/big_bird/tokenization_big_bird_fast.py
+++ b/src/transformers/models/big_bird/tokenization_big_bird_fast.py
@@ -103,7 +103,7 @@ class BigBirdTokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
+        vocab_file=None,
         tokenizer_file=None,
         unk_token="<unk>",
         bos_token="<s>",

--- a/src/transformers/models/blenderbot_small/tokenization_blenderbot_small_fast.py
+++ b/src/transformers/models/blenderbot_small/tokenization_blenderbot_small_fast.py
@@ -63,8 +63,8 @@ class BlenderbotSmallTokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
-        merges_file,
+        vocab_file=None,
+        merges_file=None,
         unk_token="<|endoftext|>",
         bos_token="<|endoftext|>",
         eos_token="<|endoftext|>",

--- a/src/transformers/models/camembert/tokenization_camembert_fast.py
+++ b/src/transformers/models/camembert/tokenization_camembert_fast.py
@@ -105,7 +105,7 @@ class CamembertTokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
+        vocab_file=None,
         tokenizer_file=None,
         bos_token="<s>",
         eos_token="</s>",

--- a/src/transformers/models/clip/tokenization_clip_fast.py
+++ b/src/transformers/models/clip/tokenization_clip_fast.py
@@ -105,8 +105,8 @@ class CLIPTokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
-        merges_file,
+        vocab_file=None,
+        merges_file=None,
         tokenizer_file=None,
         unk_token="<|endoftext|>",
         bos_token="<|startoftext|>",

--- a/src/transformers/models/deberta/tokenization_deberta_fast.py
+++ b/src/transformers/models/deberta/tokenization_deberta_fast.py
@@ -95,8 +95,8 @@ class DebertaTokenizerFast(GPT2TokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
-        merges_file,
+        vocab_file=None,
+        merges_file=None,
         tokenizer_file=None,
         errors="replace",
         bos_token="[CLS]",

--- a/src/transformers/models/funnel/tokenization_funnel_fast.py
+++ b/src/transformers/models/funnel/tokenization_funnel_fast.py
@@ -88,7 +88,7 @@ class FunnelTokenizerFast(BertTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
+        vocab_file=None,
         tokenizer_file=None,
         do_lower_case=True,
         unk_token="<unk>",

--- a/src/transformers/models/gpt2/tokenization_gpt2_fast.py
+++ b/src/transformers/models/gpt2/tokenization_gpt2_fast.py
@@ -125,8 +125,8 @@ class GPT2TokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
-        merges_file,
+        vocab_file=None,
+        merges_file=None,
         tokenizer_file=None,
         unk_token="<|endoftext|>",
         bos_token="<|endoftext|>",

--- a/src/transformers/models/herbert/tokenization_herbert_fast.py
+++ b/src/transformers/models/herbert/tokenization_herbert_fast.py
@@ -67,8 +67,8 @@ class HerbertTokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
-        merges_file,
+        vocab_file=None,
+        merges_file=None,
         tokenizer_file=None,
         cls_token="<s>",
         unk_token="<unk>",

--- a/src/transformers/models/mbart/tokenization_mbart.py
+++ b/src/transformers/models/mbart/tokenization_mbart.py
@@ -121,7 +121,10 @@ class MBartTokenizer(XLMRobertaTokenizer):
         self._additional_special_tokens = list(self.lang_code_to_id.keys())
 
         if additional_special_tokens is not None:
-            self._additional_special_tokens.extend(additional_special_tokens)
+            # Only add those special tokens if they are not already there.
+            self._additional_special_tokens.extend(
+                [t for t in additional_special_tokens if t not in self._additional_special_tokens]
+            )
 
         self._src_lang = src_lang if src_lang is not None else "en_XX"
         self.cur_lang_code_id = self.lang_code_to_id[self._src_lang]

--- a/src/transformers/models/mbart/tokenization_mbart50_fast.py
+++ b/src/transformers/models/mbart/tokenization_mbart50_fast.py
@@ -110,7 +110,7 @@ class MBart50TokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
+        vocab_file=None,
         src_lang=None,
         tgt_lang=None,
         tokenizer_file=None,

--- a/src/transformers/models/mbart/tokenization_mbart_fast.py
+++ b/src/transformers/models/mbart/tokenization_mbart_fast.py
@@ -113,10 +113,16 @@ class MBartTokenizerFast(XLMRobertaTokenizerFast):
     suffix_tokens: List[int] = []
 
     def __init__(
-        self, *args, tokenizer_file=None, src_lang=None, tgt_lang=None, additional_special_tokens=None, **kwargs
+        self,
+        vocab_file=None,
+        tokenizer_file=None,
+        src_lang=None,
+        tgt_lang=None,
+        additional_special_tokens=None,
+        **kwargs
     ):
         super().__init__(
-            *args,
+            vocab_file=vocab_file,
             tokenizer_file=tokenizer_file,
             src_lang=src_lang,
             tgt_lang=tgt_lang,

--- a/src/transformers/models/mbart/tokenization_mbart_fast.py
+++ b/src/transformers/models/mbart/tokenization_mbart_fast.py
@@ -133,7 +133,10 @@ class MBartTokenizerFast(XLMRobertaTokenizerFast):
         _additional_special_tokens = FAIRSEQ_LANGUAGE_CODES.copy()
 
         if additional_special_tokens is not None:
-            _additional_special_tokens.extend(additional_special_tokens)
+            # Only add those special tokens if they are not already there.
+            _additional_special_tokens.extend(
+                [t for t in additional_special_tokens if t not in _additional_special_tokens]
+            )
 
         self.add_special_tokens({"additional_special_tokens": _additional_special_tokens})
 

--- a/src/transformers/models/mpnet/tokenization_mpnet_fast.py
+++ b/src/transformers/models/mpnet/tokenization_mpnet_fast.py
@@ -106,7 +106,7 @@ class MPNetTokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
+        vocab_file=None,
         tokenizer_file=None,
         do_lower_case=True,
         bos_token="<s>",

--- a/src/transformers/models/openai/tokenization_openai_fast.py
+++ b/src/transformers/models/openai/tokenization_openai_fast.py
@@ -64,7 +64,7 @@ class OpenAIGPTTokenizerFast(PreTrainedTokenizerFast):
     model_input_names = ["input_ids", "attention_mask"]
     slow_tokenizer_class = OpenAIGPTTokenizer
 
-    def __init__(self, vocab_file, merges_file, tokenizer_file=None, unk_token="<unk>", **kwargs):
+    def __init__(self, vocab_file=None, merges_file=None, tokenizer_file=None, unk_token="<unk>", **kwargs):
         super().__init__(vocab_file, merges_file, tokenizer_file=tokenizer_file, unk_token=unk_token, **kwargs)
 
     @property

--- a/src/transformers/models/pegasus/tokenization_pegasus_fast.py
+++ b/src/transformers/models/pegasus/tokenization_pegasus_fast.py
@@ -98,7 +98,7 @@ class PegasusTokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
+        vocab_file=None,
         tokenizer_file=None,
         pad_token="<pad>",
         eos_token="</s>",

--- a/src/transformers/models/reformer/tokenization_reformer_fast.py
+++ b/src/transformers/models/reformer/tokenization_reformer_fast.py
@@ -87,7 +87,7 @@ class ReformerTokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
+        vocab_file=None,
         tokenizer_file=None,
         eos_token="</s>",
         unk_token="<unk>",

--- a/src/transformers/models/roberta/tokenization_roberta_fast.py
+++ b/src/transformers/models/roberta/tokenization_roberta_fast.py
@@ -143,8 +143,8 @@ class RobertaTokenizerFast(GPT2TokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
-        merges_file,
+        vocab_file=None,
+        merges_file=None,
         tokenizer_file=None,
         errors="replace",
         bos_token="<s>",

--- a/src/transformers/models/roformer/tokenization_roformer_fast.py
+++ b/src/transformers/models/roformer/tokenization_roformer_fast.py
@@ -73,7 +73,7 @@ class RoFormerTokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
+        vocab_file=None,
         tokenizer_file=None,
         do_lower_case=True,
         unk_token="[UNK]",

--- a/src/transformers/models/t5/tokenization_t5_fast.py
+++ b/src/transformers/models/t5/tokenization_t5_fast.py
@@ -104,7 +104,7 @@ class T5TokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
+        vocab_file=None,
         tokenizer_file=None,
         eos_token="</s>",
         unk_token="<unk>",

--- a/src/transformers/models/xlm_roberta/tokenization_xlm_roberta_fast.py
+++ b/src/transformers/models/xlm_roberta/tokenization_xlm_roberta_fast.py
@@ -117,7 +117,7 @@ class XLMRobertaTokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
+        vocab_file=None,
         tokenizer_file=None,
         bos_token="<s>",
         eos_token="</s>",

--- a/src/transformers/models/xlnet/tokenization_xlnet_fast.py
+++ b/src/transformers/models/xlnet/tokenization_xlnet_fast.py
@@ -124,7 +124,7 @@ class XLNetTokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
+        vocab_file=None,
         tokenizer_file=None,
         do_lower_case=False,
         remove_space=True,

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -610,11 +610,11 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
                     unk_token = special_tokens_map[unk_token]
                 tokenizer_json["model"]["unk_id"] = 0
                 tokenizer_json["model"]["vocab"] = [[unk_token, 0.0]]
-        elif tokenizer_json["model"]["type"] == ["WordLevel", "WordPiece"]:
+        elif tokenizer_json["model"]["type"] in ["WordLevel", "WordPiece"]:
             tokenizer_json["model"]["vocab"] = {}
         else:
             raise ValueError(
-                f"This method does not support this type of tokenizer (found {tokenizer_json['model']['vocab']}) "
+                f"This method does not support this type of tokenizer (found {tokenizer_json['model']['type']}) "
                 "only BPE, Unigram, WordLevel and WordPiece."
             )
 

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -609,7 +609,11 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
                     unk_token = special_tokens_map[unk_token]
                 tokenizer_json["model"]["unk_id"] = 0
                 tokenizer_json["model"]["vocab"] = [[unk_token, 0.0]]
-        elif tokenizer_json["model"]["type"] in ["WordLevel", "WordPiece"]:
+        elif tokenizer_json["model"]["type"] == "WordPiece":
+            tokenizer_json["model"]["vocab"] = {}
+            if special_tokens_map is not None and tokenizer_json["model"]["unk_token"] in special_tokens_map:
+                tokenizer_json["model"]["unk_token"] = special_tokens_map[tokenizer_json["model"]["unk_token"]]
+        elif tokenizer_json["model"]["type"] == "WordLevel":
             tokenizer_json["model"]["vocab"] = {}
         else:
             raise ValueError(

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -610,17 +610,20 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
                     unk_token = special_tokens_map[unk_token]
                 tokenizer_json["model"]["unk_id"] = 0
                 tokenizer_json["model"]["vocab"] = [[unk_token, 0.0]]
-        elif tokenizer_json["model"]["type"] == "WordPiece":
-            tokenizer_json["model"]["vocab"] = {}
-            if special_tokens_map is not None and tokenizer_json["model"]["unk_token"] in special_tokens_map:
-                tokenizer_json["model"]["unk_token"] = special_tokens_map[tokenizer_json["model"]["unk_token"]]
-        elif tokenizer_json["model"]["type"] == "WordLevel":
+        elif tokenizer_json["model"]["type"] == ["WordLevel", "WordPiece"]:
             tokenizer_json["model"]["vocab"] = {}
         else:
             raise ValueError(
                 f"This method does not support this type of tokenizer (found {tokenizer_json['model']['vocab']}) "
                 "only BPE, Unigram, WordLevel and WordPiece."
             )
+
+        if (
+            special_tokens_map is not None
+            and "unk_token" in tokenizer_json["model"]
+            and tokenizer_json["model"]["unk_token"] in special_tokens_map
+        ):
+            tokenizer_json["model"]["unk_token"] = special_tokens_map[tokenizer_json["model"]["unk_token"]]
 
         tokenizer = TokenizerFast.from_str(json.dumps(tokenizer_json))
 
@@ -667,29 +670,40 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
                 trained_tokenizer_json["model"]["unk_id"] = unk_id
                 tokenizer = TokenizerFast.from_str(json.dumps(trained_tokenizer_json))
 
-        if post_processor is not None and "special_tokens" in post_processor:
-            # Almost done, we just have to adjust the token IDs in the post processor
+        if post_processor is not None:
             trained_tokenizer_json = json.loads(tokenizer.to_str())
-            for key in post_processor["special_tokens"]:
-                tokens = post_processor["special_tokens"][key]["tokens"]
-                if special_tokens_map is not None:
-                    tokens = [special_tokens_map.get(token, token) for token in tokens]
-                post_processor["special_tokens"][key]["tokens"] = tokens
-                post_processor["special_tokens"][key]["ids"] = [tokenizer.token_to_id(token) for token in tokens]
+            # Almost done, we just have to adjust the token IDs in the post processor
+            if "special_tokens" in post_processor:
+                for key in post_processor["special_tokens"]:
+                    tokens = post_processor["special_tokens"][key]["tokens"]
+                    if special_tokens_map is not None:
+                        tokens = [special_tokens_map.get(token, token) for token in tokens]
+                    post_processor["special_tokens"][key]["tokens"] = tokens
+                    post_processor["special_tokens"][key]["ids"] = [tokenizer.token_to_id(token) for token in tokens]
+
+            for special_token in ["cls", "sep"]:
+                if special_token in post_processor:
+                    token, _ = post_processor[special_token]
+                    if special_tokens_map is not None and token in special_tokens_map:
+                        token = special_tokens_map[token]
+                    token_id = tokenizer.token_to_id(token)
+                    post_processor[special_token] = [token, token_id]
+
             trained_tokenizer_json["post_processor"] = post_processor
             tokenizer = TokenizerFast.from_str(json.dumps(trained_tokenizer_json))
 
         kwargs = self.init_kwargs.copy()
         # Map pad/cls/mask token at the Transformers level
-        if special_tokens_map is not None:
-            special_tokens_list = SpecialTokensMixin.SPECIAL_TOKENS_ATTRIBUTES.copy()
-            special_tokens_list.remove("additional_special_tokens")
-            for token in special_tokens_list:
-                # Get the private one to avoid unnecessary warnings.
-                if getattr(self, f"_{token}") is not None:
-                    special_token = getattr(self, token)
-                    if special_token in special_tokens_map:
-                        kwargs[token] = special_tokens_map[special_token]
+        special_tokens_list = SpecialTokensMixin.SPECIAL_TOKENS_ATTRIBUTES.copy()
+        special_tokens_list.remove("additional_special_tokens")
+        for token in special_tokens_list:
+            # Get the private one to avoid unnecessary warnings.
+            if getattr(self, f"_{token}") is not None:
+                special_token = getattr(self, token)
+                if special_tokens_map is not None and special_token in special_tokens_map:
+                    kwargs[token] = special_tokens_map[special_token]
+                elif kwargs.get(token, None) != special_token:
+                    kwargs[token] = special_token
 
         additional_special_tokens = self.additional_special_tokens
         if new_special_tokens is not None:

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from tokenizers import Encoding as EncodingFast
 from tokenizers import Tokenizer as TokenizerFast
 from tokenizers.decoders import Decoder as DecoderFast
-from tokenizers.trainers import BpeTrainer, UnigramTrainer, WordPieceTrainer
+from tokenizers.trainers import BpeTrainer, UnigramTrainer, WordLevelTrainer, WordPieceTrainer
 
 from .convert_slow_tokenizer import convert_slow_tokenizer
 from .file_utils import PaddingStrategy, add_end_docstrings
@@ -65,6 +65,7 @@ INIT_TOKENIZER_DOCSTRING += """
 MODEL_TO_TRAINER_MAPPING = {
     "BPE": BpeTrainer,
     "Unigram": UnigramTrainer,
+    "WordLevel": WordLevelTrainer,
     "WordPiece": WordPieceTrainer,
 }
 

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -16,7 +16,6 @@
  Tokenization classes for fast tokenizers (provided by HuggingFace's tokenizers library). For slow (python) tokenizers
  see tokenization_utils.py
 """
-
 import json
 import os
 from collections import defaultdict
@@ -701,8 +700,19 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
             if getattr(self, f"_{token}") is not None:
                 special_token = getattr(self, token)
                 if special_tokens_map is not None and special_token in special_tokens_map:
-                    kwargs[token] = special_tokens_map[special_token]
-                elif kwargs.get(token, None) != special_token:
+                    special_token = special_tokens_map[special_token]
+
+                special_token_full = getattr(self, f"_{token}")
+                if isinstance(special_token_full, AddedToken):
+                    # Create an added token with the same paramters except the content
+                    kwargs[token] = AddedToken(
+                        special_token,
+                        single_word=special_token_full.single_word,
+                        lstrip=special_token_full.lstrip,
+                        rstrip=special_token_full.rstrip,
+                        normalized=special_token_full.normalized,
+                    )
+                else:
                     kwargs[token] = special_token
 
         additional_special_tokens = self.additional_special_tokens

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -633,6 +633,20 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         if new_special_tokens is not None:
             special_tokens.extend(new_special_tokens)
 
+        # Trainer needs to know the end of word / continuing subword thingies in BPE
+        if (
+            tokenizer_json["model"]["type"] == "BPE"
+            and "continuing_subword_prefix" not in kwargs
+            and tokenizer_json["model"]["continuing_subword_prefix"] is not None
+        ):
+            kwargs["continuing_subword_prefix"] = tokenizer_json["model"]["continuing_subword_prefix"]
+        if (
+            tokenizer_json["model"]["type"] == "BPE"
+            and "end_of_work_suffix" not in kwargs
+            and tokenizer_json["model"]["end_of_word_suffix"] is not None
+        ):
+            kwargs["end_of_word_suffix"] = tokenizer_json["model"]["end_of_word_suffix"]
+
         trainer_class = MODEL_TO_TRAINER_MAPPING[tokenizer_json["model"]["type"]]
         trainer = trainer_class(vocab_size=vocab_size, special_tokens=special_tokens, **kwargs)
         tokenizer.train_from_iterator(text_iterator, trainer=trainer)

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -674,6 +674,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
             trained_tokenizer_json["post_processor"] = post_processor
             tokenizer = TokenizerFast.from_str(json.dumps(trained_tokenizer_json))
 
+        kwargs = self.init_kwargs.copy()
         # Map pad/cls/mask token at the Transformers level
         if special_tokens_map is not None:
             special_tokens_list = SpecialTokensMixin.SPECIAL_TOKENS_ATTRIBUTES.copy()

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -665,7 +665,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         if special_tokens_map is not None:
             init_signature = inspect.signature(self.__class__)
             for name, param in init_signature.parameters.items():
-                if param.default in special_tokens_map:
+                if isinstance(param.default, str) and param.default in special_tokens_map:
                     kwargs[name] = special_tokens_map[param.default]
         if new_special_tokens is not None:
             kwargs["additional_special_tokens"] = new_special_tokens

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -17,7 +17,6 @@
  see tokenization_utils.py
 """
 
-import inspect
 import json
 import os
 from collections import defaultdict
@@ -38,6 +37,7 @@ from .tokenization_utils_base import (
     PreTokenizedInput,
     PreTokenizedInputPair,
     PreTrainedTokenizerBase,
+    SpecialTokensMixin,
     TextInput,
     TextInputPair,
     TruncationStrategy,
@@ -675,13 +675,20 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
             tokenizer = TokenizerFast.from_str(json.dumps(trained_tokenizer_json))
 
         # Map pad/cls/mask token at the Transformers level
-        kwargs = {}
         if special_tokens_map is not None:
-            init_signature = inspect.signature(self.__class__)
-            for name, param in init_signature.parameters.items():
-                if isinstance(param.default, str) and param.default in special_tokens_map:
-                    kwargs[name] = special_tokens_map[param.default]
+            special_tokens_list = SpecialTokensMixin.SPECIAL_TOKENS_ATTRIBUTES.copy()
+            special_tokens_list.remove("additional_special_tokens")
+            for token in special_tokens_list:
+                # Get the private one to avoid unnecessary warnings.
+                if getattr(self, f"_{token}") is not None:
+                    special_token = getattr(self, token)
+                    if special_token in special_tokens_map:
+                        kwargs[token] = special_tokens_map[special_token]
+
+        additional_special_tokens = self.additional_special_tokens
         if new_special_tokens is not None:
-            kwargs["additional_special_tokens"] = new_special_tokens
+            additional_special_tokens.extend(new_special_tokens)
+        if len(additional_special_tokens) > 0:
+            kwargs["additional_special_tokens"] = additional_special_tokens
 
         return self.__class__(tokenizer_object=tokenizer, **kwargs)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -3162,11 +3162,14 @@ class TokenizerTesterMixin:
         new_tokenizer = tokenizer.train_new_from_iterator(SMALL_TRAINING_CORPUS, 100)
 
         # Test we can use the new tokenizer with something not seen during training
-        inputs = new_tokenizer(["This is the first sentence.", "This sentence is different 🤗."])
+        inputs = new_tokenizer(["This is the first sentence", "This sentence is different 🤗."])
         self.assertEqual(len(inputs["input_ids"]), 2)
+        decoded_input = new_tokenizer.decode(inputs["input_ids"][0], skip_special_tokens=True)
+        self.assertEqual("this is the first sentence", decoded_input.lower())
 
         # Test with a special tokens map
-        if tokenizer._cls_token is not None:
+        class_signature = inspect.signature(tokenizer.__class__)
+        if "cls_token" in class_signature.parameters:
             new_tokenizer = tokenizer.train_new_from_iterator(
                 SMALL_TRAINING_CORPUS, 100, special_tokens_map={tokenizer.cls_token: "<cls>"}
             )

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -59,7 +59,7 @@ NON_ENGLISH_TAGS = ["chinese", "dutch", "french", "finnish", "german", "multilin
 
 SMALL_TRAINING_CORPUS = [
     ["This is the first sentence.", "This is the second one."],
-    ["This sentence (contains #) over symbols and numbers 12 3 🤗 .", "But not this one."],
+    ["This sentence (contains #) over symbols and numbers 12 3.", "But not this one."],
 ]
 
 
@@ -3161,8 +3161,8 @@ class TokenizerTesterMixin:
         tokenizer = self.get_rust_tokenizer()
         new_tokenizer = tokenizer.train_new_from_iterator(SMALL_TRAINING_CORPUS, 100)
 
-        # Test we can use the new tokenizer
-        inputs = new_tokenizer(SMALL_TRAINING_CORPUS[1])
+        # Test we can use the new tokenizer with something not seen during training
+        inputs = new_tokenizer(["This is the first sentence.", "This sentence is different 🤗."])
         self.assertEqual(len(inputs["input_ids"]), 2)
 
 

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -3166,9 +3166,11 @@ class TokenizerTesterMixin:
         inputs = new_tokenizer(["This is the first sentence", "This sentence is different 🤗."])
         self.assertEqual(len(inputs["input_ids"]), 2)
         decoded_input = new_tokenizer.decode(inputs["input_ids"][0], skip_special_tokens=True)
-        if new_tokenizer.init_kwargs["do_lower_case"]:
+        expected_result = "This is the first sentence"
+        if new_tokenizer.init_kwargs.get("do_lower_case", False):
             decoded_input = decoded_input.lower()
-        self.assertEqual("this is the first sentence", decoded_input)
+            expected_result = expected_result.lower()
+        self.assertEqual(expected_result, decoded_input)
 
         # We check that the parameters of the tokenizer remained the same
         # Check we have the same number of added_tokens for both pair and non-pair inputs.
@@ -3233,9 +3235,11 @@ class TokenizerTesterMixin:
         inputs = new_tokenizer(["This is the first sentence", "This sentence is different 🤗."])
         self.assertEqual(len(inputs["input_ids"]), 2)
         decoded_input = new_tokenizer.decode(inputs["input_ids"][0], skip_special_tokens=True)
-        if new_tokenizer.init_kwargs["do_lower_case"]:
+        expected_result = "This is the first sentence"
+        if new_tokenizer.init_kwargs.get("do_lower_case", False):
             decoded_input = decoded_input.lower()
-        self.assertEqual("this is the first sentence", decoded_input)
+            expected_result = expected_result.lower()
+        self.assertEqual(expected_result, decoded_input)
 
 
 @is_staging_test

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -390,7 +390,11 @@ class TokenizerTesterMixin:
         tokenizer = self.get_rust_tokenizer()
 
         for parameter_name, parameter in signature.parameters.items():
-            if parameter.default != inspect.Parameter.empty and parameter_name != "tokenizer_file":
+            if parameter.default != inspect.Parameter.empty and parameter_name not in [
+                "vocab_file",
+                "merges_file",
+                "tokenizer_file",
+            ]:
                 self.assertIn(parameter_name, tokenizer.init_kwargs)
 
     def test_rust_and_python_full_tokenizers(self):

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -57,6 +57,11 @@ if TYPE_CHECKING:
 
 NON_ENGLISH_TAGS = ["chinese", "dutch", "french", "finnish", "german", "multilingual"]
 
+SMALL_TRAINING_CORPUS = [
+    ["This is the first sentence.", "This is the second one."],
+    ["This sentence (contains #) over symbols and numbers 12 3.", "But not this one."],
+]
+
 
 def filter_non_english(_, pretrained_name: str):
     """Filter all the model for non-english language"""
@@ -3147,6 +3152,18 @@ class TokenizerTesterMixin:
                     self.assertEqual(cr_output, r_output)
                     self.assertTrue(special_token_id in p_output)
                     self.assertTrue(special_token_id in cr_output)
+
+    def test_training_new_tokenizer(self):
+        # This feature only exists for fast tokenizers
+        if not self.test_rust_tokenizer:
+            return
+
+        tokenizer = self.get_rust_tokenizer()
+        new_tokenizer = tokenizer.train_new_from_iterator(SMALL_TRAINING_CORPUS, 100)
+
+        # Test we can use the new tokenizer
+        inputs = new_tokenizer(SMALL_TRAINING_CORPUS[1])
+        self.assertEqual(len(inputs["input_ids"]), 2)
 
 
 @is_staging_test

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -3166,7 +3166,9 @@ class TokenizerTesterMixin:
         inputs = new_tokenizer(["This is the first sentence", "This sentence is different 🤗."])
         self.assertEqual(len(inputs["input_ids"]), 2)
         decoded_input = new_tokenizer.decode(inputs["input_ids"][0], skip_special_tokens=True)
-        self.assertEqual("this is the first sentence", decoded_input.lower())
+        if new_tokenizer.init_kwargs["do_lower_case"]:
+            decoded_input = decoded_input.lower()
+        self.assertEqual("this is the first sentence", decoded_input)
 
         # We check that the parameters of the tokenizer remained the same
         # Check we have the same number of added_tokens for both pair and non-pair inputs.
@@ -3226,12 +3228,14 @@ class TokenizerTesterMixin:
 
                 new_id = new_tokenizer.get_vocab()[new_special_token]
                 self.assertEqual(getattr(new_tokenizer, f"{token}_id"), new_id)
-        
+
         # Test we can use the new tokenizer with something not seen during training
         inputs = new_tokenizer(["This is the first sentence", "This sentence is different 🤗."])
         self.assertEqual(len(inputs["input_ids"]), 2)
         decoded_input = new_tokenizer.decode(inputs["input_ids"][0], skip_special_tokens=True)
-        self.assertEqual("this is the first sentence", decoded_input.lower())
+        if new_tokenizer.init_kwargs["do_lower_case"]:
+            decoded_input = decoded_input.lower()
+        self.assertEqual("this is the first sentence", decoded_input)
 
 
 @is_staging_test

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -3167,8 +3167,11 @@ class TokenizerTesterMixin:
         self.assertEqual(len(inputs["input_ids"]), 2)
         decoded_input = new_tokenizer.decode(inputs["input_ids"][0], skip_special_tokens=True)
         expected_result = "This is the first sentence"
-        if new_tokenizer.init_kwargs.get("do_lower_case", False):
-            decoded_input = decoded_input.lower()
+
+        # OpenAIGPT always lowercases and has no arg.
+        if new_tokenizer.init_kwargs.get("do_lower_case", False) or tokenizer.__class__.__name__.startswith(
+            "OpenAIGPT"
+        ):
             expected_result = expected_result.lower()
         self.assertEqual(expected_result, decoded_input)
 
@@ -3182,10 +3185,10 @@ class TokenizerTesterMixin:
         self.assertEqual(tokenizer.max_len_sentences_pair, new_tokenizer.max_len_sentences_pair)
 
         # Assert the set of special tokens match as we didn't ask to change them
-        self.assertSequenceEqual(
-            tokenizer.special_tokens_map.items(),
-            new_tokenizer.special_tokens_map.items(),
-        )
+        # The assertDictEqual fails for T5 even if the dicts are the same so we check manually
+        self.assertListEqual(list(tokenizer.special_tokens_map.keys()), list(new_tokenizer.special_tokens_map.keys()))
+        for key in tokenizer.special_tokens_map.keys():
+            self.assertEqual(tokenizer.special_tokens_map[key], new_tokenizer.special_tokens_map[key])
 
     def test_training_new_tokenizer_with_special_tokens_change(self):
         # This feature only exists for fast tokenizers
@@ -3236,8 +3239,11 @@ class TokenizerTesterMixin:
         self.assertEqual(len(inputs["input_ids"]), 2)
         decoded_input = new_tokenizer.decode(inputs["input_ids"][0], skip_special_tokens=True)
         expected_result = "This is the first sentence"
-        if new_tokenizer.init_kwargs.get("do_lower_case", False):
-            decoded_input = decoded_input.lower()
+
+        # OpenAIGPT always lowercases and has no arg.
+        if new_tokenizer.init_kwargs.get("do_lower_case", False) or tokenizer.__class__.__name__.startswith(
+            "OpenAIGPT"
+        ):
             expected_result = expected_result.lower()
         self.assertEqual(expected_result, decoded_input)
 

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -59,7 +59,7 @@ NON_ENGLISH_TAGS = ["chinese", "dutch", "french", "finnish", "german", "multilin
 
 SMALL_TRAINING_CORPUS = [
     ["This is the first sentence.", "This is the second one."],
-    ["This sentence (contains #) over symbols and numbers 12 3.", "But not this one."],
+    ["This sentence (contains #) over symbols and numbers 12 3 🤗 .", "But not this one."],
 ]
 
 

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -3185,10 +3185,7 @@ class TokenizerTesterMixin:
         self.assertEqual(tokenizer.max_len_sentences_pair, new_tokenizer.max_len_sentences_pair)
 
         # Assert the set of special tokens match as we didn't ask to change them
-        # The assertDictEqual fails for T5 even if the dicts are the same so we check manually
-        self.assertListEqual(list(tokenizer.special_tokens_map.keys()), list(new_tokenizer.special_tokens_map.keys()))
-        for key in tokenizer.special_tokens_map.keys():
-            self.assertEqual(tokenizer.special_tokens_map[key], new_tokenizer.special_tokens_map[key])
+        self.assertDictEqual(tokenizer.special_tokens_map, new_tokenizer.special_tokens_map)
 
     def test_training_new_tokenizer_with_special_tokens_change(self):
         # This feature only exists for fast tokenizers

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -3165,6 +3165,15 @@ class TokenizerTesterMixin:
         inputs = new_tokenizer(["This is the first sentence.", "This sentence is different 🤗."])
         self.assertEqual(len(inputs["input_ids"]), 2)
 
+        # Test with a special tokens map
+        if tokenizer._cls_token is not None:
+            new_tokenizer = tokenizer.train_new_from_iterator(
+                SMALL_TRAINING_CORPUS, 100, special_tokens_map={tokenizer.cls_token: "<cls>"}
+            )
+            cls_id = new_tokenizer.get_vocab()["<cls>"]
+            self.assertEqual(new_tokenizer.cls_token, "<cls>")
+            self.assertEqual(new_tokenizer.cls_token_id, cls_id)
+
 
 @is_staging_test
 class TokenizerPushToHubTester(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

This PR does two different things at the same time:
- it allows to instantiate a subclass of a `PreTrainedTokenizerFast` with just the tokenizer object by making arguments like vocab or merges optional (only done for three models here but can complete if the design is accepted)
- adds a method to train a new fast tokenizer from an existing one, using the same normalizer, pre-tokenizers and post-processors.

With this done, one can do:
```
from transformers import AutoTokenizer

checkpoint = "bert-base-cased" # or any checkpoint that has a fast tokenizer.
tokenizer = AutoTokenizer.from_pretrained(checkpoint)
assert tokenizer.is_fast, "This only works for fast tokenizers."

# Should be a generator of list of texts.
training_corpus = [
    ["This is the first sentence.", "This is the second one."],
    ["This sentence (contains #) over symbols and numbers 12 3.", "But not this one."],
]
new_tokenizer = tokenizer.train_new_from_iterator(training_corpus, vocab_size=25000)
```
The new tokenizer can then be used, saved, pushed to the hub. It has the same type as `tokenizer`.