### PR TITLE
[Documentation] Warn that DataCollatorForWholeWordMask is limited to BertTokenizer-like tokenizers

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -23,6 +23,7 @@ from torch.nn.utils.rnn import pad_sequence
 from ..file_utils import PaddingStrategy
 from ..modeling_utils import PreTrainedModel
 from ..tokenization_utils_base import BatchEncoding, PreTrainedTokenizerBase
+from ..models.bert import BertTokenizer, BertTokenizerFast
 
 
 InputDataClass = NewType("InputDataClass", Any)
@@ -395,10 +396,18 @@ class DataCollatorForLanguageModeling:
 @dataclass
 class DataCollatorForWholeWordMask(DataCollatorForLanguageModeling):
     """
-    Data collator used for language modeling.
+    Data collator used for language modeling that masks entire words.
 
     - collates batches of tensors, honoring their tokenizer's pad_token
     - preprocesses batches for masked language modeling
+
+    .. note::
+
+        This collator relies on details of the implementation of subword tokenization
+        by :class:`~transformers.BertTokenizer`, specifically that subword tokens are
+        prefixed with `##`. For tokenizers that do not adhere to this scheme, this
+        collator will produce an output that is roughly equivalent to
+        :class:`.DataCollatorForLanguageModeling`.
     """
 
     def __call__(
@@ -435,6 +444,9 @@ class DataCollatorForWholeWordMask(DataCollatorForLanguageModeling):
         """
         Get 0/1 labels for masked tokens with whole word mask proxy
         """
+        if not isinstance(self.tokenizer, (BertTokenizer, BertTokenizerFast)):
+            warnings.warn("DataCollatorForWholeWordMask is only suitable for BertTokenizer-like tokenizers."
+                          "Please refer to the documentation for more information.")
 
         cand_indexes = []
         for (i, token) in enumerate(input_tokens):

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -22,8 +22,8 @@ from torch.nn.utils.rnn import pad_sequence
 
 from ..file_utils import PaddingStrategy
 from ..modeling_utils import PreTrainedModel
-from ..tokenization_utils_base import BatchEncoding, PreTrainedTokenizerBase
 from ..models.bert import BertTokenizer, BertTokenizerFast
+from ..tokenization_utils_base import BatchEncoding, PreTrainedTokenizerBase
 
 
 InputDataClass = NewType("InputDataClass", Any)
@@ -403,10 +403,9 @@ class DataCollatorForWholeWordMask(DataCollatorForLanguageModeling):
 
     .. note::
 
-        This collator relies on details of the implementation of subword tokenization
-        by :class:`~transformers.BertTokenizer`, specifically that subword tokens are
-        prefixed with `##`. For tokenizers that do not adhere to this scheme, this
-        collator will produce an output that is roughly equivalent to
+        This collator relies on details of the implementation of subword tokenization by
+        :class:`~transformers.BertTokenizer`, specifically that subword tokens are prefixed with `##`. For tokenizers
+        that do not adhere to this scheme, this collator will produce an output that is roughly equivalent to
         :class:`.DataCollatorForLanguageModeling`.
     """
 
@@ -445,8 +444,10 @@ class DataCollatorForWholeWordMask(DataCollatorForLanguageModeling):
         Get 0/1 labels for masked tokens with whole word mask proxy
         """
         if not isinstance(self.tokenizer, (BertTokenizer, BertTokenizerFast)):
-            warnings.warn("DataCollatorForWholeWordMask is only suitable for BertTokenizer-like tokenizers."
-                          "Please refer to the documentation for more information.")
+            warnings.warn(
+                "DataCollatorForWholeWordMask is only suitable for BertTokenizer-like tokenizers."
+                "Please refer to the documentation for more information."
+            )
 
         cand_indexes = []
         for (i, token) in enumerate(input_tokens):


### PR DESCRIPTION
# What does this PR do?

Currently, the `DataCollatorForWholeWordMasking` added with #7925 only works for one specific family of tokenizers, but the documentation does not mention this nor is the user warned when using this data collator with an incompatible tokenizer. Since the data collator will run with all tokenizers, just not produce the desired output, this is very misleading for users. 

This PR adds a note to the documentation and a warning that is issued when a user attempts to create the whole word mask with a (presumably) incompatible tokenizer.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #11768


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
