### PR TITLE
Rework LongFormer to make it compatible with ONNX

### DIFF
--- a/src/transformers/models/longformer/modeling_longformer.py
+++ b/src/transformers/models/longformer/modeling_longformer.py
@@ -816,7 +816,7 @@ class LongformerSelfAttention(nn.Module):
         # bcxd: batch_size * num_heads x chunks x 2window_overlap x head_dim
         # bcyd: batch_size * num_heads x chunks x 2window_overlap x head_dim
         # bcxy: batch_size * num_heads x chunks x 2window_overlap x 2window_overlap
-        diagonal_chunked_attention_scores = torch.einsum("bcxd,bcyd->bcxy", (query, key))  # multiply
+        diagonal_chunked_attention_scores = torch.matmul(query, key.transpose(3, 2))  # multiply
 
         # convert diagonals into columns
         diagonal_chunked_attention_scores = self._pad_and_transpose_last_two_dims(

--- a/src/transformers/models/longformer/modeling_longformer.py
+++ b/src/transformers/models/longformer/modeling_longformer.py
@@ -1561,7 +1561,7 @@ class LongformerModel(LongformerPreTrainedModel):
                 inputs_embeds = torch.cat([inputs_embeds, inputs_embeds_padding], dim=-2)
 
             attention_mask = nn.functional.pad(
-                attention_mask, (0, padding_len), value=False
+                attention_mask, (0, padding_len), value=0  # 0 = False
             )  # no attention on the padding tokens
             token_type_ids = nn.functional.pad(token_type_ids, (0, padding_len), value=0)  # pad with token_type_id = 0
 


### PR DESCRIPTION
- [x] Remove implicit `bool` -> `int` conversion while padding attention_mask with `False` value.
- [x] Remove call to `einsum` where `matmul` + `transpose` can be used (makes optimizations easier for ONNX)
- [ ] Diagonal matrix computation try to avoid ScatterND with negative steps / index
- [ ] Use `torch.div(a, b, rounding_mode='trunc')` instead of `floor_divide` 
- [ ] Check [function](https://github.com/huggingface/transformers/blob/master/src/transformers/models/longformer/modeling_longformer.py#L783) reporting `torch.Tensor` return type which doesn't return anything