### PR TITLE
Easily train a new fast tokenizer from a given one - tackle the special tokens format (str or AddedToken)

### DIFF
--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -706,7 +706,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
                 if isinstance(special_token_full, AddedToken):
                     # Create an added token with the same paramters except the content
                     kwargs[token] = AddedToken(
-                        special_tokens_map[special_token],
+                        special_token,
                         single_word=special_token_full.single_word,
                         lstrip=special_token_full.lstrip,
                         rstrip=special_token_full.rstrip,

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -16,7 +16,6 @@
  Tokenization classes for fast tokenizers (provided by HuggingFace's tokenizers library). For slow (python) tokenizers
  see tokenization_utils.py
 """
-import inspect
 import json
 import os
 from collections import defaultdict
@@ -691,14 +690,13 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
                         special_token_full = getattr(self, f"_{token}")
                         if isinstance(special_token_full, AddedToken):
                             # Create an added token with the same paramters except the content
-                            signature = dict(inspect.signature(AddedToken).parameters)
-                            signature.pop("self", None)
-                            kwargs_added_token = {}
-                            for arg in signature.keys():
-                                kwargs_added_token[arg] = getattr(special_token_full, arg)
-                            kwargs_added_token["content"] = special_tokens_map[special_token]
-                            new_added_token = AddedToken(**kwargs_added_token)
-                            kwargs[token] = new_added_token
+                            kwargs[token] = AddedToken(
+                                special_tokens_map[special_token],
+                                single_word=special_token_full.single_word,
+                                lstrip=special_token_full.lstrip,
+                                rstrip=special_token_full.rstrip,
+                                normalized=special_token_full.normalized,
+                            )
                         else:
                             kwargs[token] = special_tokens_map[special_token]
 

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -3245,7 +3245,7 @@ class TokenizerTesterMixin:
                     f"'{special_token}' should be in {new_tokenizer.all_special_tokens_extended}",
                 )
             elif isinstance(special_token, AddedToken):
-                # The special token must appear in the list of the new tokenizer as an object of type AddedToken with 
+                # The special token must appear in the list of the new tokenizer as an object of type AddedToken with
                 # the same parameters as the old AddedToken except the content that the user has requested to change.
                 special_token_str = special_token.content
                 new_special_token_str = special_tokens_map[special_token_str]

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -3184,6 +3184,11 @@ class TokenizerTesterMixin:
 
         # Assert the set of special tokens match as we didn't ask to change them
         self.assertSequenceEqual(
+            tokenizer.all_special_tokens_extended,
+            new_tokenizer.all_special_tokens_extended,
+        )
+
+        self.assertSequenceEqual(
             tokenizer.special_tokens_map.items(),
             new_tokenizer.special_tokens_map.items(),
         )
@@ -3231,6 +3236,51 @@ class TokenizerTesterMixin:
 
                 new_id = new_tokenizer.get_vocab()[new_special_token]
                 self.assertEqual(getattr(new_tokenizer, f"{token}_id"), new_id)
+
+        # Check if the AddedToken / string format has been kept
+        for special_token in tokenizer.all_special_tokens_extended:
+            if isinstance(special_token, AddedToken) and special_token.content not in special_tokens_map:
+                # The special token must appear identically in the list of the new tokenizer.
+                self.assertTrue(
+                    special_token in new_tokenizer.all_special_tokens_extended,
+                    f"'{special_token}' should be in {new_tokenizer.all_special_tokens_extended}",
+                )
+            elif isinstance(special_token, AddedToken):
+                # The special token must appear in the list of the new tokenizer as an object of type AddedToken with 
+                # the same parameters as the old AddedToken except the content that the user has requested to change.
+                special_token_str = special_token.content
+                new_special_token_str = special_tokens_map[special_token_str]
+
+                find = False
+                for candidate in new_tokenizer.all_special_tokens_extended:
+                    if (
+                        isinstance(candidate, AddedToken)
+                        and candidate.content == new_special_token_str
+                        and candidate.lstrip == special_token.lstrip
+                        and candidate.rstrip == special_token.rstrip
+                        and candidate.normalized == special_token.normalized
+                        and candidate.single_word == special_token.single_word
+                    ):
+                        find = True
+                        break
+                self.assertTrue(
+                    find,
+                    (
+                        f"'{new_special_token_str}' doesn't appear in the list "
+                        f"'{new_tokenizer.all_special_tokens_extended}' as an AddedToken with the same parameters as "
+                        f"'{special_token}' in the list {tokenizer.all_special_tokens_extended}"
+                    ),
+                )
+            elif special_token not in special_tokens_map:
+                # The special token must appear identically in the list of the new tokenizer.
+                self.assertTrue(
+                    special_token in new_tokenizer.all_special_tokens_extended,
+                    f"'{special_token}' should be in {new_tokenizer.all_special_tokens_extended}",
+                )
+
+            else:
+                # The special token must appear in the list of the new tokenizer as an object of type string.
+                self.assertTrue(special_tokens_map[special_token] in new_tokenizer.all_special_tokens_extended)
 
         # Test we can use the new tokenizer with something not seen during training
         text_input = ["This is the first sentence", "This sentence is different 🤗."]

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -3163,15 +3163,14 @@ class TokenizerTesterMixin:
         new_tokenizer = tokenizer.train_new_from_iterator(SMALL_TRAINING_CORPUS, 100)
 
         # Test we can use the new tokenizer with something not seen during training
-        text_input = ["This is the first sentence", "This sentence is different 🤗."]
-        inputs = new_tokenizer(text_input)
+        inputs = new_tokenizer(["This is the first sentence", "This sentence is different 🤗."])
         self.assertEqual(len(inputs["input_ids"]), 2)
         decoded_input = new_tokenizer.decode(inputs["input_ids"][0], skip_special_tokens=True)
-        if not hasattr(new_tokenizer, "do_lower_case") or (
-            "do_lower_case" in new_tokenizer.init_kwargs and not new_tokenizer.init_kwargs["do_lower_case"]
-        ):
+        expected_result = "This is the first sentence"
+        if new_tokenizer.init_kwargs.get("do_lower_case", False):
             decoded_input = decoded_input.lower()
-        self.assertEqual(text_input[0].lower(), decoded_input)
+            expected_result = expected_result.lower()
+        self.assertEqual(expected_result, decoded_input)
 
         # We check that the parameters of the tokenizer remained the same
         # Check we have the same number of added_tokens for both pair and non-pair inputs.
@@ -3283,15 +3282,14 @@ class TokenizerTesterMixin:
                 self.assertTrue(special_tokens_map[special_token] in new_tokenizer.all_special_tokens_extended)
 
         # Test we can use the new tokenizer with something not seen during training
-        text_input = ["This is the first sentence", "This sentence is different 🤗."]
-        inputs = new_tokenizer(text_input)
+        inputs = new_tokenizer(["This is the first sentence", "This sentence is different 🤗."])
         self.assertEqual(len(inputs["input_ids"]), 2)
         decoded_input = new_tokenizer.decode(inputs["input_ids"][0], skip_special_tokens=True)
-        if not hasattr(new_tokenizer, "do_lower_case") or (
-            "do_lower_case" in new_tokenizer.init_kwargs and not new_tokenizer.init_kwargs["do_lower_case"]
-        ):
+        expected_result = "This is the first sentence"
+        if new_tokenizer.init_kwargs.get("do_lower_case", False):
             decoded_input = decoded_input.lower()
-        self.assertEqual(text_input[0].lower(), decoded_input)
+            expected_result = expected_result.lower()
+        self.assertEqual(expected_result, decoded_input)
 
 
 @is_staging_test

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -3163,12 +3163,15 @@ class TokenizerTesterMixin:
         new_tokenizer = tokenizer.train_new_from_iterator(SMALL_TRAINING_CORPUS, 100)
 
         # Test we can use the new tokenizer with something not seen during training
-        inputs = new_tokenizer(["This is the first sentence", "This sentence is different 🤗."])
+        text_input = ["This is the first sentence", "This sentence is different 🤗."]
+        inputs = new_tokenizer(text_input)
         self.assertEqual(len(inputs["input_ids"]), 2)
         decoded_input = new_tokenizer.decode(inputs["input_ids"][0], skip_special_tokens=True)
-        if new_tokenizer.init_kwargs["do_lower_case"]:
+        if not hasattr(new_tokenizer, "do_lower_case") or (
+            "do_lower_case" in new_tokenizer.init_kwargs and not new_tokenizer.init_kwargs["do_lower_case"]
+        ):
             decoded_input = decoded_input.lower()
-        self.assertEqual("this is the first sentence", decoded_input)
+        self.assertEqual(text_input[0].lower(), decoded_input)
 
         # We check that the parameters of the tokenizer remained the same
         # Check we have the same number of added_tokens for both pair and non-pair inputs.
@@ -3230,12 +3233,15 @@ class TokenizerTesterMixin:
                 self.assertEqual(getattr(new_tokenizer, f"{token}_id"), new_id)
 
         # Test we can use the new tokenizer with something not seen during training
-        inputs = new_tokenizer(["This is the first sentence", "This sentence is different 🤗."])
+        text_input = ["This is the first sentence", "This sentence is different 🤗."]
+        inputs = new_tokenizer(text_input)
         self.assertEqual(len(inputs["input_ids"]), 2)
         decoded_input = new_tokenizer.decode(inputs["input_ids"][0], skip_special_tokens=True)
-        if new_tokenizer.init_kwargs["do_lower_case"]:
+        if not hasattr(new_tokenizer, "do_lower_case") or (
+            "do_lower_case" in new_tokenizer.init_kwargs and not new_tokenizer.init_kwargs["do_lower_case"]
+        ):
             decoded_input = decoded_input.lower()
-        self.assertEqual("this is the first sentence", decoded_input)
+        self.assertEqual(text_input[0].lower(), decoded_input)
 
 
 @is_staging_test


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

This PR is a sub-PR of the feature developed in PR #12361.

In the `train_new_from_iterator` method, the user can indicate that he wants to change the wording of a special token with the `special_tokens_map` argument. 

In terms of behavior, we expect the resulting tokenizer to have special tokens that behave like the special tokens that were in the initial tokenizer. In other words, if in the initial token the special token linked to the `mask_token` was an `AddedToken` with `lstrip=True` then this parameter must be kept in the new trained tokenizer even if the user in the `special_tokens_map` argument indicates that the wording changes. For example from `[MASK]` to `<mask>`.

This PR proposes this behavior and tests it
