### PR TITLE
Fix default bool in argparser

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -112,8 +112,8 @@ class HfArgumentParser(ArgumentParser):
                 # Hack because type=bool in argparse does not behave as we want.
                 kwargs["type"] = string_to_bool
                 if field.type is bool or (field.default is not None and field.default is not dataclasses.MISSING):
-                    # Default value is True if we have no default when of type bool.
-                    default = True if field.default is dataclasses.MISSING else field.default
+                    # Default value is False if we have no default when of type bool.
+                    default = False if field.default is dataclasses.MISSING else field.default
                     # This is the value that will get picked if we don't include --field_name in any way
                     kwargs["default"] = default
                     # This tells argparse we accept 0 or 1 value after --field_name

--- a/tests/test_hf_argparser.py
+++ b/tests/test_hf_argparser.py
@@ -109,6 +109,10 @@ class HfArgumentParserTest(unittest.TestCase):
         expected.add_argument("--flag", type=string_to_bool, default=False, const=True, nargs="?")
         self.argparsersEqual(parser, expected)
 
+        args = ["--foo", "1", "--baz", "quux", "--bar", "0.5"]
+        (example,) = parser.parse_args_into_dataclasses(args, look_for_args_file=False)
+        self.assertFalse(example.flag)
+
     def test_with_default(self):
         parser = HfArgumentParser(WithDefaultExample)
 

--- a/tests/test_hf_argparser.py
+++ b/tests/test_hf_argparser.py
@@ -106,7 +106,7 @@ class HfArgumentParserTest(unittest.TestCase):
         expected.add_argument("--foo", type=int, required=True)
         expected.add_argument("--bar", type=float, required=True)
         expected.add_argument("--baz", type=str, required=True)
-        expected.add_argument("--flag", type=string_to_bool, default=True, const=True, nargs="?")
+        expected.add_argument("--flag", type=string_to_bool, default=False, const=True, nargs="?")
         self.argparsersEqual(parser, expected)
 
     def test_with_default(self):


### PR DESCRIPTION
# What does this PR do?

As outlined in #12423, in a dataclass with no default for a bool parameter, the bool ended up defaulting to `True` when not passed, which is the opposite of the wanted behavior.
Fixes #12423