### PR TITLE
Pass `model_kwargs` when loading a model in `pipeline()`

### DIFF
--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -406,7 +406,13 @@ def pipeline(
     # Will load the correct model if possible
     model_classes = {"tf": targeted_task["tf"], "pt": targeted_task["pt"]}
     framework, model = infer_framework_load_model(
-        model, model_classes=model_classes, config=config, framework=framework, revision=revision, task=task
+        model,
+        model_classes=model_classes,
+        config=config,
+        framework=framework,
+        revision=revision,
+        task=task,
+        **model_kwargs,
     )
 
     model_config = model.config

--- a/tests/test_pipelines_token_classification.py
+++ b/tests/test_pipelines_token_classification.py
@@ -66,14 +66,10 @@ class TokenClassificationPipelineTests(CustomInputPipelineCommonMixin, unittest.
 
     @require_torch
     def test_model_kwargs_passed_to_model_load(self):
-        # Tests the model_kwargs parameter is passed properly when loading a model with pipeline()
-        # Currently uses the cache_dir parameter of from_pretrained()
-        # There might be a better parameter, but this one is fairly easy to test.
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            self.assertFalse(os.listdir(tmpdirname))
-            _ = pipeline(task="ner", model=self.small_models[0], model_kwargs={"cache_dir": tmpdirname})
-            file_url = hf_bucket_url(self.small_models[0], filename=WEIGHTS_NAME)
-            self.assertTrue(get_from_cache(file_url, cache_dir=tmpdirname, local_files_only=True))
+        ner_pipeline = pipeline(task="ner", model=self.small_models[0])
+        self.assertFalse(ner_pipeline.model.config.output_attentions)
+        ner_pipeline = pipeline(task="ner", model=self.small_models[0], model_kwargs={"output_attentions": True})
+        self.assertTrue(ner_pipeline.model.config.output_attentions)
 
     @require_torch
     @slow

--- a/tests/test_pipelines_token_classification.py
+++ b/tests/test_pipelines_token_classification.py
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import tempfile
 import unittest
 
 import numpy as np
 
 from transformers import AutoModelForTokenClassification, AutoTokenizer, pipeline
-from transformers.file_utils import WEIGHTS_NAME, get_from_cache, hf_bucket_url
 from transformers.pipelines import AggregationStrategy, Pipeline, TokenClassificationArgumentHandler
 from transformers.testing_utils import nested_simplify, require_tf, require_torch, slow
 


### PR DESCRIPTION
# What does this PR do?

Fixes #12448

When working on this, I considered adding a test, but none of the pipeline tests even use the `model_kwargs` parameter. I could add a test to one of the `test_pipelines_*.py` files to ensure that a local cache is used as a way of testing, but I'm not sure if that is the best option.

The parameter is indirectly used in `test_onnx.py`, but there is no verification that the parameter actually works properly. (Given that those tests pass without it working, maybe those tests might not need to use it, anyway.)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

pipelines: @LysandreJik