### PR TITLE
Fix to keep up with the changes made in fairseq's RobertaModel

### DIFF
--- a/src/transformers/models/roberta/convert_roberta_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/roberta/convert_roberta_original_pytorch_checkpoint_to_pytorch.py
@@ -56,11 +56,11 @@ def convert_roberta_checkpoint_to_pytorch(
     roberta_sent_encoder = roberta.model.encoder.sentence_encoder
     config = RobertaConfig(
         vocab_size=roberta_sent_encoder.embed_tokens.num_embeddings,
-        hidden_size=roberta.args.encoder_embed_dim,
-        num_hidden_layers=roberta.args.encoder_layers,
-        num_attention_heads=roberta.args.encoder_attention_heads,
-        intermediate_size=roberta.args.encoder_ffn_embed_dim,
-        max_position_embeddings=514,
+        hidden_size=roberta.model.args.encoder_embed_dim,
+        num_hidden_layers=roberta.model.args.encoder_layers,
+        num_attention_heads=roberta.model.args.encoder_attention_heads,
+        intermediate_size=roberta.model.args.encoder_ffn_embed_dim,
+        max_position_embeddings=roberta_sent_encoder.embed_positions.num_embeddings,
         type_vocab_size=1,
         layer_norm_eps=1e-5,  # PyTorch default used in fairseq
     )
@@ -78,8 +78,8 @@ def convert_roberta_checkpoint_to_pytorch(
     model.roberta.embeddings.token_type_embeddings.weight.data = torch.zeros_like(
         model.roberta.embeddings.token_type_embeddings.weight
     )  # just zero them out b/c RoBERTa doesn't use them.
-    model.roberta.embeddings.LayerNorm.weight = roberta_sent_encoder.emb_layer_norm.weight
-    model.roberta.embeddings.LayerNorm.bias = roberta_sent_encoder.emb_layer_norm.bias
+    model.roberta.embeddings.LayerNorm.weight = roberta_sent_encoder.layernorm_embedding.weight
+    model.roberta.embeddings.LayerNorm.bias = roberta_sent_encoder.layernorm_embedding.bias
 
     for i in range(config.num_hidden_layers):
         # Encoder: start of layer


### PR DESCRIPTION
# What does this PR do?

- This PR fixes broken model conversion script.
  - Current script seems to be outdated with the latest release and main branch fairseq.
    - `RobertaModel.from_pretrained` now returns RobertaHubInterface, which seems to be different from the assumption of the current implementation.
    - cf. https://github.com/pytorch/fairseq/blob/v0.10.2/fairseq/models/roberta/model.py#L256

- This PR also make this script to use the positional encoding size from the model, not the hardcoded value.

Current implementation causes errors like: 
```
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.7/dist-packages/transformers/models/roberta/convert_roberta_original_pytorch_checkpoint_to_pytorch.py", line 177, in <module>
    args.roberta_checkpoint_path, args.pytorch_dump_folder_path, args.classification_head
  File "/usr/local/lib/python3.7/dist-packages/transformers/models/roberta/convert_roberta_original_pytorch_checkpoint_to_pytorch.py", line 59, in convert_roberta_checkpoint_to_pytorch
    hidden_size=roberta.args.encoder_embed_dim,
  File "/usr/local/lib/python3.7/dist-packages/torch/nn/modules/module.py", line 1131, in __getattr__
    type(self).__name__, name))
AttributeError: 'RobertaHubInterface' object has no attribute 'args'
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
  - There is no mention of this script in the documentation.
- [ ] Did you write any new necessary tests?
  - There is no test of this script in the repository.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Ping to the contributors of this script:
- @LysandreJik
- @sgugger

