### PR TITLE
Fixing bug with param count without embeddings

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -354,7 +354,7 @@ class ModuleUtilsMixin:
 
         if exclude_embeddings:
             embedding_param_names = [
-                name + ".weight" for name, module_type in self.named_modules() if isinstance(module_type, nn.Embedding)
+                f"{name}.weight" for name, module_type in self.named_modules() if isinstance(module_type, nn.Embedding)
             ]
             non_embedding_parameters = [
                 parameter for name, parameter in self.named_parameters() if name not in embedding_param_names

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -352,11 +352,17 @@ class ModuleUtilsMixin:
             :obj:`int`: The number of parameters.
         """
 
-        def parameter_filter(x):
-            return (x.requires_grad or not only_trainable) and not (isinstance(x, nn.Embedding) and exclude_embeddings)
+        if exclude_embeddings:
+            embedding_param_names = [
+                name + ".weight" for name, module_type in self.named_modules() if isinstance(module_type, nn.Embedding)
+            ]
+            non_embedding_parameters = [
+                parameter for name, parameter in self.named_parameters() if name not in embedding_param_names
+            ]
+            return sum(p.numel() for p in non_embedding_parameters if p.requires_grad or not only_trainable)
+        else:
+            return sum(p.numel() for p in self.parameters() if p.requires_grad or not only_trainable)
 
-        params = filter(parameter_filter, self.parameters()) if only_trainable else self.parameters()
-        return sum(p.numel() for p in params)
 
     def estimate_tokens(self, input_dict: Dict[str, Union[torch.Tensor, Any]]) -> int:
         """

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -363,7 +363,6 @@ class ModuleUtilsMixin:
         else:
             return sum(p.numel() for p in self.parameters() if p.requires_grad or not only_trainable)
 
-
     def estimate_tokens(self, input_dict: Dict[str, Union[torch.Tensor, Any]]) -> int:
         """
         Helper function to estimate the total number of tokens from the model inputs.


### PR DESCRIPTION
The model param number count utility (`model.num_parameters`) had an `exclude_embeddings` flag that did not actually exclude embedding counts. This PR fixes this bug so that the flag behaves properly.