### PR TITLE
Import check_inits handling of duplicate definitions.

### DIFF
--- a/utils/check_inits.py
+++ b/utils/check_inits.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 import os
 import re
 
@@ -154,12 +155,22 @@ def analyze_results(import_dict_objects, type_hint_objects):
     """
     Analyze the differences between _import_structure objects and TYPE_CHECKING objects found in an init.
     """
+    def find_duplicates(seq):
+        return [k for k, v in collections.Counter(seq).items() if v > 1]
+
     if list(import_dict_objects.keys()) != list(type_hint_objects.keys()):
         return ["Both sides of the init do not have the same backends!"]
 
     errors = []
     for key in import_dict_objects.keys():
-        if sorted(import_dict_objects[key]) != sorted(type_hint_objects[key]):
+        duplicate_imports = find_duplicates(import_dict_objects[key])
+        if duplicate_imports:
+            errors.append(f"Duplicate _import_structure definitions for: {duplicate_imports}")
+        duplicate_type_hints = find_duplicates(type_hint_objects[key])
+        if duplicate_type_hints:
+            errors.append(f"Duplicate TYPE_CHECKING objects for: {duplicate_type_hints}")
+
+        if sorted(set(import_dict_objects[key])) != sorted(set(type_hint_objects[key])):
             name = "base imports" if key == "none" else f"{key} backend"
             errors.append(f"Differences for {name}:")
             for a in type_hint_objects[key]:

--- a/utils/check_inits.py
+++ b/utils/check_inits.py
@@ -155,6 +155,7 @@ def analyze_results(import_dict_objects, type_hint_objects):
     """
     Analyze the differences between _import_structure objects and TYPE_CHECKING objects found in an init.
     """
+
     def find_duplicates(seq):
         return [k for k, v in collections.Counter(seq).items() if v > 1]
 


### PR DESCRIPTION
# Improves the handling of duplicate definitions for `utils/check_inits.py`

Currently if there are duplicate definitions of import structure or type hints, the model may or not may fail depending on if the import_structure and TYPE_HINTS are duplicated in the same way. If it fails, it will show the wrong error message.

This ensures this test always fails and displays the appropriate error message.

This is particularly useful if things go wrong while merging master into a model PR after a long time.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Did you write any new necessary tests? -> N/A.


## Who can review?
 @sgugger since he first wrote the tool