### PR TITLE
Fix TAPAS test uncovered by #12446

### DIFF
--- a/tests/test_modeling_tapas.py
+++ b/tests/test_modeling_tapas.py
@@ -106,7 +106,7 @@ class TapasModelTester:
         average_logits_per_cell=True,
         select_one_column=True,
         allow_empty_column_selection=False,
-        init_cell_selection_weights_to_zero=False,
+        init_cell_selection_weights_to_zero=True,
         reset_position_index_per_cell=True,
         disable_per_token_loss=False,
         scope=None,


### PR DESCRIPTION
#12446 cleaned up a typo in a test name that uncovered a failure in the TAPAS test.

The failure in the TAPAS test is the following: `test_save_load_fast_init_from_base`. It adds a mock initialization. However, TAPAS has `nn.Parameter` attributes which are not impacted by that initialization, and end up having random values when loaded from the base model.

Updating this configuration parameter ensures that these values get initialized to 0.
