### PR TITLE
Fix order of state and input in Flax Quickstart README

### DIFF
--- a/examples/research_projects/jax-projects/README.md
+++ b/examples/research_projects/jax-projects/README.md
@@ -621,7 +621,7 @@ state = model_flax.init(rng, dummy_input_ids)
 and then we can do the forward pass.
 
 ```python
-sequences = model_flax.apply(input_ids, state)
+sequences = model_flax.apply(state, input_ids)
 ```
 
 Visually, the forward pass would now be represented as passing all tensors required for the computation to the model's object:


### PR DESCRIPTION
# What does this PR do?
Correct the order of state and input for `flax.linen.apply()` in Flax Quickstart README

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?
@patrickvonplaten @patil-suraj 