### PR TITLE
[Flax] Fix hybrid clip

### DIFF
--- a/examples/research_projects/jax-projects/hybrid_clip/README.md
+++ b/examples/research_projects/jax-projects/hybrid_clip/README.md
@@ -68,6 +68,34 @@ export MODEL_DIR="./clip-roberta-base
 ln -s ~/transformers/examples/flax/summarization/run_hybrid_clip.py run_hybrid_clip.py
 ```
 
+## How to use the `FlaxHybridCLIP` model:
+
+The `FlaxHybridCLIP` class let's you load any text and vision encoder model to create a dual encoder. 
+Here is an example of how to load the model using pre-trained text and vision models.
+
+```python
+from modeling_hybrid_clip import FlaxHybridCLIP
+
+model = FlaxHybridCLIP.from_text_vision_pretrained("bert-base-uncased", "openai/clip-vit-base-patch32")
+
+# save the model
+model.save_pretrained("bert-clip")
+
+# load the saved model
+model = FlaxHybridCLIP.from_pretrained("bert-clip")
+```
+
+If the checkpoints are in PyTorch then one could pass `text_from_pt=True` and `vision_from_pt=True`. This will load the model
+PyTorch checkpoints convert them to flax and load the model.
+
+```python
+model = FlaxHybridCLIP.from_text_vision_pretrained("bert-base-uncased", "openai/clip-vit-base-patch32", text_from_pt=True, vision_from_pt=True)
+```
+
+This loads both the text and vision encoders using pre-trained weights, the projection layers are randomly
+initialized except for CLIP's vision model. If you use CLIP to initialize the vision model then the vision projection weights are also
+loaded using the pre-trained weights.
+
 ## Prepare the dataset
 
 We will use the MS-COCO dataset to train our dual encoder model. MS-COCO contains over 82,000 images, each of which has at least 5 different caption annotations. The dataset is usually used for image captioning tasks, but we can repurpose the image-caption pairs to train our dual encoder model for image search.
@@ -124,7 +152,7 @@ with open("coco_dataset/valid_dataset.json", "w") as f:
 Next we can run the example script to train the model:
 
 ```bash
-python run_clip.py \
+python run_hybrid_clip.py \
     --output_dir ${MODEL_DIR} \
     --text_model_name_or_path="roberta-base" \
     --vision_model_name_or_path="openai/clip-vit-base-patch32" \

--- a/examples/research_projects/jax-projects/hybrid_clip/run_hybrid_clip.py
+++ b/examples/research_projects/jax-projects/hybrid_clip/run_hybrid_clip.py
@@ -87,6 +87,10 @@ class ModelArguments:
             "Don't set if you want to train a model from scratch."
         },
     )
+    from_pt: bool = field(
+        default=True,
+        metadata={"help": "whether to load the text and vision model using PyTorch checkpoints."},
+    )
     config_name: Optional[str] = field(
         default=None, metadata={"help": "Pretrained config name or path if not the same as model_name"}
     )
@@ -332,6 +336,8 @@ def main():
         model_args.vision_model_name_or_path,
         seed=training_args.seed,
         dtype=getattr(jnp, model_args.dtype),
+        text_from_pt=model_args.from_pt,
+        vision_from_pt=model_args.from_pt,
     )
     config = model.config
     # set seed for torch dataloaders


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue with saving and loading `HybridCLIPConfig` which was causing issues when loading the model.

The config was expecting the `text_config_dict` and `vision_config_dict` arguments, but in the `to_dict` it was saved as `text_config` and `vision_config`. So the next time when `config` was loaded using `from_pretrained` the `model_type` key was missing from `text_config_dict` and `vision_config_dict` as we pop that in the init.

This PR renames `text_config_dict` and `vision_config_dict` to `text_config` and `vision_config` respectively. This is slightly breaking as we won't be able to load previously saved configs. A simple workaround for that is to re-initialize the config using
`from_text_vision_configs` method and resave them.

This PR also adds some usage examples for `FlaxHybridCLIP`.

Fixes #12513

(I should really add tests for this)