### PR TITLE
Improve documentation of pooler_output in ModelOutput

### DIFF
--- a/src/transformers/modeling_outputs.py
+++ b/src/transformers/modeling_outputs.py
@@ -55,9 +55,10 @@ class BaseModelOutputWithPooling(ModelOutput):
         last_hidden_state (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, hidden_size)`):
             Sequence of hidden-states at the output of the last layer of the model.
         pooler_output (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, hidden_size)`):
-            Last layer hidden-state of the first token of the sequence (classification token) further processed by a
-            Linear layer and a Tanh activation function. The Linear layer weights are trained from the next sentence
-            prediction (classification) objective during pretraining.
+            Last layer hidden-state of the first token of the sequence (classification token) after further processing through the 
+            layers used for the auxiliary pre-training task. E.g. For BERT-family of models, this returns the classification token 
+            after processing through a Linear layer and a Tanh activation function. The Linear layer weights are trained from the 
+            next sentence prediction (classification) objective during pretraining.
         hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
             Tuple of :obj:`torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer)
             of shape :obj:`(batch_size, sequence_length, hidden_size)`.
@@ -158,9 +159,10 @@ class BaseModelOutputWithPoolingAndCrossAttentions(ModelOutput):
         last_hidden_state (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, hidden_size)`):
             Sequence of hidden-states at the output of the last layer of the model.
         pooler_output (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, hidden_size)`):
-            Last layer hidden-state of the first token of the sequence (classification token) further processed by a
-            Linear layer and a Tanh activation function. The Linear layer weights are trained from the next sentence
-            prediction (classification) objective during pretraining.
+            Last layer hidden-state of the first token of the sequence (classification token) after further processing through the 
+            layers used for the auxiliary pre-training task. E.g. For BERT-family of models, this returns the classification token 
+            after processing through a Linear layer and a Tanh activation function. The Linear layer weights are trained from the 
+            next sentence prediction (classification) objective during pretraining.
         hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
             Tuple of :obj:`torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer)
             of shape :obj:`(batch_size, sequence_length, hidden_size)`.

--- a/src/transformers/modeling_outputs.py
+++ b/src/transformers/modeling_outputs.py
@@ -160,8 +160,8 @@ class BaseModelOutputWithPoolingAndCrossAttentions(ModelOutput):
             Sequence of hidden-states at the output of the last layer of the model.
         pooler_output (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, hidden_size)`):
             Last layer hidden-state of the first token of the sequence (classification token) after further processing through the 
-            layers used for the auxiliary pre-training task. E.g. For BERT-family of models, this returns the classification token 
-            after processing through a Linear layer and a Tanh activation function. The Linear layer weights are trained from the 
+            layers used for the auxiliary pretraining task. E.g. for BERT-family of models, this returns the classification token 
+            after processing through a linear layer and a tanh activation function. The linear layer weights are trained from the 
             next sentence prediction (classification) objective during pretraining.
         hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
             Tuple of :obj:`torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer)

--- a/src/transformers/modeling_outputs.py
+++ b/src/transformers/modeling_outputs.py
@@ -56,8 +56,8 @@ class BaseModelOutputWithPooling(ModelOutput):
             Sequence of hidden-states at the output of the last layer of the model.
         pooler_output (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, hidden_size)`):
             Last layer hidden-state of the first token of the sequence (classification token) after further processing through the 
-            layers used for the auxiliary pre-training task. E.g. For BERT-family of models, this returns the classification token 
-            after processing through a Linear layer and a Tanh activation function. The Linear layer weights are trained from the 
+            layers used for the auxiliary pretraining task. E.g. for BERT-family of models, this returns the classification token 
+            after processing through a linear layer and a tanh activation function. The linear layer weights are trained from the 
             next sentence prediction (classification) objective during pretraining.
         hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
             Tuple of :obj:`torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer)


### PR DESCRIPTION
# What does this PR do?
Improves the doc string for pooler_output in modeling_outputs.py – making it more clear, and opening its availability to a more generic use-case than just BERT-family of models.

**Motivation**:
I was writing a `cls_pooler` for a sentence embeddings usage, and initially thought this is the CLS token output from the last layer – which is not the case, that would just be `last_hidden_state[0]`

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?
@sgugger 