### PR TITLE
Display error message for pipeline loading failures

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -136,7 +136,8 @@ def infer_framework_load_model(
                 model = model_class.from_pretrained(model, **kwargs)
                 # Stop loading on the first successful load.
                 break
-            except (OSError, ValueError):
+            except (OSError, ValueError) as err:
+                logger.warning(f"Failed to load {model} with {model_class.__name__}: {err}")
                 continue
 
         if isinstance(model, str):


### PR DESCRIPTION
# What does this PR do?

Displays an error message when a model class fails to load a model for a pipeline.

This helped me understand what was going on when pipelines failed to load.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@Narsil @LysandreJik 