### PR TITLE
Don't stop at num_epochs when using IterableDataset

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1110,7 +1110,8 @@ class Trainer:
         else:
             # see __init__. max_steps is set when the dataset has no __len__
             max_steps = args.max_steps
-            num_train_epochs = int(args.num_train_epochs)
+            # Setting a very large number of epochs so we go as many times as necessary over the iterator.
+            num_train_epochs = sys.maxsize
             num_update_steps_per_epoch = max_steps
             num_train_samples = args.max_steps * total_train_batch_size
 


### PR DESCRIPTION
# What does this PR do?

Currently, when someone uses an `IterableDataset` inside the `Trainer`, the training loop stops after 3 iterations over the iterable dataset, this PR fixes that to just rely on `max_steps` (has to be set or there is an error at init).

Fixes #12499