### PR TITLE
Double check for attribute num_examples

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2245,7 +2245,9 @@ class Trainer:
         # Number of samples
         if not isinstance(eval_dataset, IterableDataset):
             num_samples = len(eval_dataset)
-        elif isinstance(eval_dataset, IterableDatasetShard):
+        # The instance check is weird and does not actually check for the type, but whether the dataset has the right
+        # methods. Therefore we need to make sure it also has the attribute.
+        elif isinstance(eval_dataset, IterableDatasetShard) and hasattr(train_dataloader.dataset, "num_examples"):
             num_samples = eval_dataset.num_examples
         else:
             num_samples = observed_num_examples

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2247,7 +2247,7 @@ class Trainer:
             num_samples = len(eval_dataset)
         # The instance check is weird and does not actually check for the type, but whether the dataset has the right
         # methods. Therefore we need to make sure it also has the attribute.
-        elif isinstance(eval_dataset, IterableDatasetShard) and hasattr(train_dataloader.dataset, "num_examples"):
+        elif isinstance(eval_dataset, IterableDatasetShard) and hasattr(eval_dataset, "num_examples"):
             num_samples = eval_dataset.num_examples
         else:
             num_samples = observed_num_examples


### PR DESCRIPTION
# What does this PR do?

As pointed out by #12479, the `isinstance` check for `IterableDataset` and its subclasses does not look at the type, but whether the class implements some methods, but not all attributes. This PR adds a double check when necessary to avoid an `AttributeError`.

Fixes #12479