### PR TITLE
[examples/hybrid_clip] fix loading clip vision model

### DIFF
--- a/examples/research_projects/jax-projects/hybrid_clip/configuration_hybrid_clip.py
+++ b/examples/research_projects/jax-projects/hybrid_clip/configuration_hybrid_clip.py
@@ -75,6 +75,10 @@ class HybridCLIPConfig(PretrainedConfig):
 
         if vision_model_type == "clip":
             self.vision_config = AutoConfig.for_model(vision_model_type, **vision_config).vision_config
+        elif vision_model_type == "clip_vision_model":
+            from transformers import CLIPVisionConfig
+
+            self.vision_config = CLIPVisionConfig(**vision_config)
         else:
             self.vision_config = AutoConfig.for_model(vision_model_type, **vision_config)
 


### PR DESCRIPTION
# What does this PR do?

Fix loading config when the model is of type `clip_vision_model`.