### PR TITLE
Fix caching issue #12536

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1679,9 +1679,15 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                         use_auth_token=use_auth_token,
                         user_agent=user_agent,
                     )
-
+                
                 except FileNotFoundError as error:
                     if local_files_only:
+                        unresolved_files.append(file_id)
+                    else:
+                        raise error
+                
+                except ValueError as error:
+                    if not local_files_only:
                         unresolved_files.append(file_id)
                     else:
                         raise error

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1679,7 +1679,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                         use_auth_token=use_auth_token,
                         user_agent=user_agent,
                     )
-                
+
                 except FileNotFoundError as error:
                     if local_files_only:
                         unresolved_files.append(file_id)


### PR DESCRIPTION
# What does this PR do?

This PR is a proposed fix to issue #12536 . It does so by simply logging the unfound file instead of raising an error causing program execution, in the special case of non-existent optional vocab files which are handled in the case `local_files_only=True` (`FileNotFoundError`) and the case where  `local_files_only=False` and user is online, but not the case where `local_files_only=False` and user is offlline.

This needs to be reviewed to ensure this is the direction to go to fix this issue, and that this will not be a problem in other cases.

Fixes #12536


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@LysandreJik 