### PR TITLE
Add tokenizer_file parameter to PreTrainedTokenizerFast docstring

### DIFF
--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -59,6 +59,9 @@ INIT_TOKENIZER_DOCSTRING += """
         tokenizer_object (:class:`tokenizers.Tokenizer`):
             A :class:`tokenizers.Tokenizer` object from 🤗 tokenizers to instantiate from. See :doc:`Using tokenizers
             from 🤗 tokenizers <../fast_tokenizers>` for more information.
+        tokenizer_file (:class:`str`):
+            A path to a local JSON file representing a previously serialized :class:`tokenizers.Tokenizer` object from
+            🤗 tokenizers.
 """
 
 MODEL_TO_TRAINER_MAPPING = {


### PR DESCRIPTION
## What does this PR do?

- Add tokenizer_file parameter to PreTrainedTokenizerFast docstring
- References [this](https://github.com/huggingface/transformers/issues/12583#issuecomment-876613898) comment from @sgugger


