### PR TITLE
fix typo in modeling_t5.py docstring

### DIFF
--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -1711,7 +1711,7 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
 
 
 @add_start_docstrings(
-    "The bare T5 Model transformer outputting encoder's raw hidden-states" "without any specific head on top.",
+    "The bare T5 Model transformer outputting encoder's raw hidden-states without any specific head on top.",
     T5_START_DOCSTRING,
 )
 class T5EncoderModel(T5PreTrainedModel):


### PR DESCRIPTION
fixes a small typo