### PR TITLE
[WIP] Patch BigBird tokenization test

### DIFF
--- a/tests/test_tokenization_big_bird.py
+++ b/tests/test_tokenization_big_bird.py
@@ -220,7 +220,7 @@ class BigBirdTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokenizer = BigBirdTokenizer.from_pretrained("google/bigbird-roberta-base")
         decoded_text = tokenizer.decode(tokenizer("Paris is the [MASK].").input_ids)
 
-        self.assertTrue(decoded_text == "[CLS] Paris is the [MASK].[SEP]")
+        self.assertTrue(decoded_text == "[CLS] Paris is the[MASK].[SEP]")
 
     @slow
     def test_tokenizer_integration(self):


### PR DESCRIPTION
This patches the BigBird integration test.

The core of the issue is that the `[MASK]` token is an `AddedToken` with `lstrip=True`. It, therefore, gobbles up the spaces on the left without getting a sentence piece underline.

Therefore, when decoding, the internal sentence piece tokenizer is unaware that it should add a space in front of the `[MASK]` token.

However, the original tokenizer does correctly decode with the space, so I believe there's an issue with our implementation.

@vasudevgupta7 do you know of the difference between the two implementations? Also cc @n1t0 and @SaulLu 

Do not merge this as this isn't the correct fix :)