### PR TITLE
**encode_plus() shouldn't run for  W2V2CTC

### DIFF
--- a/tests/test_tokenization_wav2vec2.py
+++ b/tests/test_tokenization_wav2vec2.py
@@ -554,3 +554,11 @@ class Wav2Vec2CTCTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
                 self.assertGreater(tokens[-3], tokens[-4])
                 self.assertEqual(tokens[0], tokenizer.eos_token_id)
                 self.assertEqual(tokens[-3], tokenizer.pad_token_id)
+
+    @unittest.skip("The tokenizer shouldn't be used to encode input IDs (except for labels), only to decode.")
+    def test_tf_encode_plus_sent_to_model(self):
+        pass
+
+    @unittest.skip("The tokenizer shouldn't be used to encode input IDs (except for labels), only to decode.")
+    def test_pt_encode_plus_sent_to_model(self):
+        pass

--- a/tests/test_tokenization_wav2vec2.py
+++ b/tests/test_tokenization_wav2vec2.py
@@ -560,5 +560,5 @@ class Wav2Vec2CTCTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         pass
 
     @unittest.skip("The tokenizer shouldn't be used to encode input IDs (except for labels), only to decode.")
-    def test_pt_encode_plus_sent_to_model(self):
+    def test_torch_encode_plus_sent_to_model(self):
         pass


### PR DESCRIPTION
The W2V2CTC shouldn't be used to create the input values for W2V2, so the output of `encode_plus` shouldn't be used as raw input for the model.