### PR TITLE
[tokenizer.prepare_seq2seq_batch] change deprecation to be easily actionable

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3277,8 +3277,10 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         # docstyle-ignore
         formatted_warning = """
 `prepare_seq2seq_batch` is deprecated and will be removed in version 5 of HuggingFace Transformers. Use the regular
-`__call__` method to prepare your inputs and the tokenizer under the `as_target_tokenizer context manager to prepare
-your targets. Here is a short example:
+`__call__` method to prepare your inputs and the tokenizer under the `as_target_tokenizer` context manager to prepare
+your targets.
+
+Here is a short example:
 
 model_inputs = tokenizer(src_texts, ...)
 with tokenizer.as_target_tokenizer():

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3282,7 +3282,7 @@ it copy-n-paste the internals of this function. The gist of which is:
 model_inputs = tokenizer(src_texts, ...) with tokenizer.as_target_tokenizer(): labels = tokenizer(tgt_texts, ...)
 model_inputs["labels"] = labels["input_ids"]
 
-See the documentation of your specific tokenizer for more details on the specific arguments to the tokenizer of choice
+See the documentation of your specific tokenizer for more details on the specific arguments to the tokenizer of choice.
 """,
             FutureWarning,
         )

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3275,10 +3275,15 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             Otherwise, input_ids, attention_mask will be the only keys.
         """
         warnings.warn(
-            "`prepare_seq2seq_batch` is deprecated and will be removed in version 5 of 🤗 Transformers. Use the "
-            "regular `__call__` method to prepare your inputs and the tokenizer under the `as_target_tokenizer` "
-            "context manager to prepare your targets. See the documentation of your specific tokenizer for more "
-            "details",
+            """
+`prepare_seq2seq_batch` is deprecated and will be removed in version 5 of HuggingFace Transformers. To continue using
+it copy-n-paste the internals of this function. The gist of which is:
+
+model_inputs = tokenizer(src_texts, ...) with tokenizer.as_target_tokenizer(): labels = tokenizer(tgt_texts, ...)
+model_inputs["labels"] = labels["input_ids"]
+
+See the documentation of your specific tokenizer for more details on the specific arguments to the tokenizer of choice
+""",
             FutureWarning,
         )
         # mBART-specific kwargs that should be ignored by other models.

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3274,15 +3274,22 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             The full set of keys ``[input_ids, attention_mask, labels]``, will only be returned if tgt_texts is passed.
             Otherwise, input_ids, attention_mask will be the only keys.
         """
-        warnings.warn(
-            """
-`prepare_seq2seq_batch` is deprecated and will be removed in version 5 of HuggingFace Transformers. To continue using
-it copy-n-paste the internals of this function. The gist of which is:
+        # docstyle-ignore
+        example = """
 
-model_inputs = tokenizer(src_texts, ...) with tokenizer.as_target_tokenizer(): labels = tokenizer(tgt_texts, ...)
+model_inputs = tokenizer(src_texts, ...)
+with tokenizer.as_target_tokenizer():
+    labels = tokenizer(tgt_texts, ...)
 model_inputs["labels"] = labels["input_ids"]
+"""
+        warnings.warn(
+            f"""
+`prepare_seq2seq_batch` is deprecated and will be removed in version 5 of HuggingFace Transformers. Use the regular
+`__call__` method to prepare your inputs and the tokenizer under the `as_target_tokenizer context manager to prepare
+your targets. Here is a short example:{example}
 
 See the documentation of your specific tokenizer for more details on the specific arguments to the tokenizer of choice.
+For a more complete example, see the implementation of `prepare_seq2seq_batch`.
 """,
             FutureWarning,
         )

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3275,24 +3275,20 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             Otherwise, input_ids, attention_mask will be the only keys.
         """
         # docstyle-ignore
-        example = """
+        formatted_warning = """
+`prepare_seq2seq_batch` is deprecated and will be removed in version 5 of HuggingFace Transformers. Use the regular
+`__call__` method to prepare your inputs and the tokenizer under the `as_target_tokenizer context manager to prepare
+your targets. Here is a short example:
 
 model_inputs = tokenizer(src_texts, ...)
 with tokenizer.as_target_tokenizer():
     labels = tokenizer(tgt_texts, ...)
 model_inputs["labels"] = labels["input_ids"]
-"""
-        warnings.warn(
-            f"""
-`prepare_seq2seq_batch` is deprecated and will be removed in version 5 of HuggingFace Transformers. Use the regular
-`__call__` method to prepare your inputs and the tokenizer under the `as_target_tokenizer context manager to prepare
-your targets. Here is a short example:{example}
 
 See the documentation of your specific tokenizer for more details on the specific arguments to the tokenizer of choice.
 For a more complete example, see the implementation of `prepare_seq2seq_batch`.
-""",
-            FutureWarning,
-        )
+"""
+        warnings.warn(formatted_warning, FutureWarning)
         # mBART-specific kwargs that should be ignored by other models.
         kwargs.pop("src_lang", None)
         kwargs.pop("tgt_lang", None)


### PR DESCRIPTION
Attempt to make an easier to understand and act upon deprecation by giving explicit instructions on what needs to be done:

Fixes: https://github.com/huggingface/transformers/issues/12622

@sgugger 