### PR TITLE
[Deepspeed] non-native optimizers are mostly ok with zero-offload

### DIFF
--- a/docs/source/main_classes/deepspeed.rst
+++ b/docs/source/main_classes/deepspeed.rst
@@ -1061,7 +1061,8 @@ optimizers, with the exception of using the combination of HuggingFace scheduler
 | DS Optimizer | No           | Yes          |
 +--------------+--------------+--------------+
 
-If ``offload_optimizer`` is enabled you must use both DeepSpeed scheduler and DeepSpeed optimizer.
+It is possible to use a non-DeepSpeed optimizer when ``offload_optimizer`` is enabled, as long as it has both CPU and
+GPU implementation (except LAMB).
 
 
 


### PR DESCRIPTION
As noticed in https://github.com/huggingface/transformers/issues/11044#issuecomment-870742459 most non-DS optimizers should work with zero-offload as long as they have cpu+gpu implementation (except LAMB).

So this PR relaxes the earlier incorrectly imposed restriction.

@sgugger 

