### PR TITLE
Provide mask_time_indices to `_mask_hidden_states` to avoid double masking

### DIFF
--- a/src/transformers/models/hubert/modeling_hubert.py
+++ b/src/transformers/models/hubert/modeling_hubert.py
@@ -911,11 +911,7 @@ class HubertModel(HubertPreTrainedModel):
             attention_mask = attention_mask.flip([-1]).cumsum(-1).flip([-1]).bool()
 
         hidden_states = self.feature_projection(extract_features)
-
-        if mask_time_indices is not None:  # apply SpecAugment along time axis with given indices
-            hidden_states[mask_time_indices] = self.masked_spec_embed.to(hidden_states.dtype)
-
-        hidden_states = self._mask_hidden_states(hidden_states)
+        hidden_states = self._mask_hidden_states(hidden_states, mask_time_indices=mask_time_indices)
 
         encoder_outputs = self.encoder(
             hidden_states,

--- a/src/transformers/models/hubert/modeling_tf_hubert.py
+++ b/src/transformers/models/hubert/modeling_tf_hubert.py
@@ -1227,13 +1227,6 @@ class TFHubertMainLayer(tf.keras.layers.Layer):
         hidden_states = self.feature_projection(hidden_states, training=inputs["training"])
 
         mask_time_indices = kwargs.get("mask_time_indices", None)
-        if mask_time_indices is not None:  # apply SpecAugment along time axis with given indices
-            hidden_states = tf.where(
-                tf.cast(mask_time_indices[:, :, tf.newaxis], tf.bool),
-                self.masked_spec_embed[tf.newaxis, tf.newaxis, :],
-                hidden_states,
-            )
-
         if inputs["training"]:
             hidden_states = self._mask_hidden_states(hidden_states, mask_time_indices=mask_time_indices)
 

--- a/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py
@@ -1218,13 +1218,6 @@ class TFWav2Vec2MainLayer(tf.keras.layers.Layer):
         hidden_states = self.feature_projection(hidden_states, training=inputs["training"])
 
         mask_time_indices = kwargs.get("mask_time_indices", None)
-        if mask_time_indices is not None:  # apply SpecAugment along time axis with given indices
-            hidden_states = tf.where(
-                tf.cast(mask_time_indices[:, :, tf.newaxis], tf.bool),
-                self.masked_spec_embed[tf.newaxis, tf.newaxis, :],
-                hidden_states,
-            )
-
         if inputs["training"]:
             hidden_states = self._mask_hidden_states(hidden_states, mask_time_indices=mask_time_indices)
 

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -1049,7 +1049,7 @@ class Wav2Vec2Model(Wav2Vec2PreTrainedModel):
             attention_mask = attention_mask.flip([-1]).cumsum(-1).flip([-1]).bool()
 
         hidden_states, extract_features = self.feature_projection(extract_features)
-        hidden_states = self._mask_hidden_states(hidden_states, mask_time_indices)
+        hidden_states = self._mask_hidden_states(hidden_states, mask_time_indices=mask_time_indices)
 
         encoder_outputs = self.encoder(
             hidden_states,

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -1049,11 +1049,7 @@ class Wav2Vec2Model(Wav2Vec2PreTrainedModel):
             attention_mask = attention_mask.flip([-1]).cumsum(-1).flip([-1]).bool()
 
         hidden_states, extract_features = self.feature_projection(extract_features)
-
-        if mask_time_indices is not None:  # apply SpecAugment along time axis with given indices
-            hidden_states[mask_time_indices] = self.masked_spec_embed.to(hidden_states.dtype)
-
-        hidden_states = self._mask_hidden_states(hidden_states)
+        hidden_states = self._mask_hidden_states(hidden_states, mask_time_indices)
 
         encoder_outputs = self.encoder(
             hidden_states,


### PR DESCRIPTION
The current behavior for training Hubert masks randomly some "spans" of time according to a `mask_time_indices`  which can be provided or not to the `forward(..., mask_time_indices=Optional[torch.Tensor])` .

When providing this value (_interesting to mask the loss over non masked spans_), the mask was applied outside of the `_mask_hidden_states(...)` function. 

Then, a new mask `_mask_hidden_states(...)` inside was generated potentially masking again some others tokens independently from what was provided through `mask_time_indices`.

This PR provides a fix by ensuring we only mask spans inside `_mask_hidden_states(...)` and correctly apply the masking operating one time.