### PR TITLE
[trainer] release tmp memory in checkpoint load

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1076,6 +1076,9 @@ class Trainer:
                 # If the model is on the GPU, it still works!
                 self._load_state_dict_in_model(state_dict)
 
+            # release memory
+            del state_dict
+
         # If model was re-initialized, put it on the right device and update self.model_wrapped
         if model_reloaded:
             if self.place_model_on_device:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1076,8 +1076,8 @@ class Trainer:
                 # If the model is on the GPU, it still works!
                 self._load_state_dict_in_model(state_dict)
 
-            # release memory
-            del state_dict
+                # release memory
+                del state_dict
 
         # If model was re-initialized, put it on the right device and update self.model_wrapped
         if model_reloaded:


### PR DESCRIPTION
As discovered in https://github.com/huggingface/transformers/issues/12680#issuecomment-880194562 we had a model-size memory leak on loading checkpoint. @sgugger  found a fix which is what this this PR is.

@sgugger 