### PR TITLE
[deepspeed] nvme test hanging experiment: take4

### DIFF
--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -205,6 +205,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # clean up binary CUDA extensions from previous builds
+          rm -rf ~/.cache/torch_extensions/
           apt -y update && apt install -y libaio-dev
           pip install --upgrade pip
           pip install .[testing,deepspeed]
@@ -246,6 +248,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # clean up binary CUDA extensions from previous builds
+          rm -rf ~/.cache/torch_extensions/
           apt -y update && apt install -y libaio-dev
           pip install --upgrade pip
           pip install .[testing,deepspeed,fairscale]

--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -262,6 +262,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # clean up binary CUDA extensions from previous builds
+          rm -rf ~/.cache/torch_extensions/
           apt -y update && apt install -y libaio-dev
           pip install --upgrade pip
           pip install .[testing,deepspeed]
@@ -303,6 +305,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # clean up binary CUDA extensions from previous builds
+          rm -rf ~/.cache/torch_extensions/
           apt -y update && apt install -y libaio-dev
           pip install --upgrade pip
           pip install .[testing,deepspeed,fairscale]


### PR DESCRIPTION
As reported in https://github.com/huggingface/transformers/issues/12715 nvme CUDA extension of deepspeed fails to build and leads to a hanging test. As suggested by @tjruwase we should be clearing out the CUDA binary extensions dir, since a new release might be incompatible with the old binary and things break. 
```
rm -rf ~/.cache/torch_extensions/
```

And all appears to be resolved. Replicated to the scheduled job too.

Fixes: https://github.com/huggingface/transformers/issues/12715

@sgugger, @LysandreJik 