### PR TITLE
Skip test while the model is not available

### DIFF
--- a/tests/test_modeling_megatron_bert.py
+++ b/tests/test_modeling_megatron_bert.py
@@ -356,6 +356,7 @@ TOLERANCE = 1e-4
 @require_tokenizers
 class MegatronBertModelIntegrationTests(unittest.TestCase):
     @slow
+    @unittest.skip("Model is not available.")
     def test_inference_no_head(self):
         directory = "nvidia/megatron-bert-uncased-345m"
         if "MYDIR" in os.environ:


### PR DESCRIPTION
Skip the test while the model cannot be accessed through the hub.