### PR TITLE
Log Azure ML metrics only for rank 0

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -571,7 +571,7 @@ class AzureMLCallback(TrainerCallback):
             self.azureml_run = Run.get_context()
 
     def on_log(self, args, state, control, logs=None, **kwargs):
-        if self.azureml_run:
+        if self.azureml_run and state.is_world_process_zero :
             for k, v in logs.items():
                 if isinstance(v, (int, float)):
                     self.azureml_run.log(k, v, description=k)

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -571,7 +571,7 @@ class AzureMLCallback(TrainerCallback):
             self.azureml_run = Run.get_context()
 
     def on_log(self, args, state, control, logs=None, **kwargs):
-        if self.azureml_run and state.is_world_process_zero :
+        if self.azureml_run and state.is_world_process_zero:
             for k, v in logs.items():
                 if isinstance(v, (int, float)):
                     self.azureml_run.log(k, v, description=k)


### PR DESCRIPTION
Collect only the loss values reported in the log file on 0th process from a multi GPU experiment into the Metrics table/chart.

Fixes # (issue)
The loss values displayed in the metrics from from all devices which does not reflect the correct total loss for distributed runs.
