### PR TITLE
Longer timeout for slow tests

### DIFF
--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -14,7 +14,7 @@ env:
   RUN_SLOW: yes
   OMP_NUM_THREADS: 16
   MKL_NUM_THREADS: 16
-  PYTEST_TIMEOUT: 300
+  PYTEST_TIMEOUT: 600
 
 jobs:
   run_all_tests_torch_gpu:


### PR DESCRIPTION
About 50 slow tests go over to 5 minutes mark and currently get killed by the timeout. I don't have time to fix them right now so putting the timeout to 10 minutes so that we still have coverage on those tests. Will get back to it when I have a free cycle.