### PR TITLE
[trainer] sanity checks for `save_steps=0|None` and `logging_steps=0`

### DIFF
--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -403,19 +403,11 @@ class DefaultFlowCallback(TrainerCallback):
         # Log
         if state.global_step == 1 and args.logging_first_step:
             control.should_log = True
-        if (
-            args.logging_strategy == IntervalStrategy.STEPS
-            and args.logging_steps > 0
-            and state.global_step % args.logging_steps == 0
-        ):
+        if args.logging_strategy == IntervalStrategy.STEPS and state.global_step % args.logging_steps == 0:
             control.should_log = True
 
         # Evaluate
-        if (
-            args.evaluation_strategy == IntervalStrategy.STEPS
-            and args.eval_steps > 0
-            and state.global_step % args.eval_steps == 0
-        ):
+        if args.evaluation_strategy == IntervalStrategy.STEPS and state.global_step % args.eval_steps == 0:
             control.should_evaluate = True
             if args.load_best_model_at_end:
                 control.should_save = True

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -411,7 +411,11 @@ class DefaultFlowCallback(TrainerCallback):
             control.should_log = True
 
         # Evaluate
-        if args.evaluation_strategy == IntervalStrategy.STEPS and state.global_step % args.eval_steps == 0:
+        if (
+            args.evaluation_strategy == IntervalStrategy.STEPS
+            and args.eval_steps > 0
+            and state.global_step % args.eval_steps == 0
+        ):
             control.should_evaluate = True
             if args.load_best_model_at_end:
                 control.should_save = True

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -665,8 +665,9 @@ class TrainingArguments:
             self.do_eval = True
 
         # eval_steps has to be defined and non-zero, fallbacks to logging_steps if the latter is non-zero
-        if self.do_eval and (self.eval_steps is None or self.eval_steps == 0):
+        if self.evaluation_strategy == IntervalStrategy.STEPS and (self.eval_steps is None or self.eval_steps == 0):
             if self.logging_steps > 0:
+                logger.info(f"using `logging_steps` to initialize `eval_steps` to {self.logging_steps}")
                 self.eval_steps = self.logging_steps
             else:
                 raise ValueError(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -674,7 +674,7 @@ class TrainingArguments:
                 )
 
         # logging_steps must be non-zero for logging_strategy that is other than 'no'
-        if self.logging_strategy != IntervalStrategy.NO and self.logging_steps == 0:
+        if self.logging_strategy == IntervalStrategy.STEPS and self.logging_steps == 0:
             raise ValueError(f"logging strategy {self.logging_strategy} requires non-zero --logging_steps")
 
         # Sanity checks for load_best_model_at_end: we require save and eval strategies to be compatible.

--- a/tests/extended/test_trainer_ext.py
+++ b/tests/extended/test_trainer_ext.py
@@ -248,6 +248,7 @@ class TestTrainerExt(TestCasePlus):
             --learning_rate {learning_rate}
             --warmup_steps 8
             --logging_steps 0
+            --logging_strategy no
             --save_steps {str(eval_steps)}
             --group_by_length
             --label_smoothing_factor 0.1


### PR DESCRIPTION
This PR deals with combinations of training args that lead to:


```
# --do_eval --evaluation_strategy=steps --logging_steps 0 (no --eval_args)
Traceback (most recent call last):
  File "examples/pytorch/translation/run_translation.py", line 617, in <module>
    main()
  File "examples/pytorch/translation/run_translation.py", line 537, in main
    train_result = trainer.train(resume_from_checkpoint=checkpoint)
  File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/trainer.py", line 1340, in train
    self.control = self.callback_handler.on_step_end(args, self.state, self.control)
  File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/trainer_callback.py", line 359, in on_step_end
    return self.call_event("on_step_end", args, state, control)
  File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/trainer_callback.py", line 378, in call_event
    result = getattr(callback, event)(
  File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/trainer_callback.py", line 414, in on_step_end
    if args.evaluation_strategy == IntervalStrategy.STEPS and state.global_step % args.eval_steps == 0:
ZeroDivisionError: integer division or modulo by zero
```

and:

```
# --do_eval --evaluation_strategy=steps --logging_steps 0 --eval_args 5
Traceback (most recent call last):
  File "examples/pytorch/translation/run_translation.py", line 617, in <module>
    main()
  File "examples/pytorch/translation/run_translation.py", line 537, in main
    train_result = trainer.train(resume_from_checkpoint=checkpoint)
  File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/trainer.py", line 1343, in train
    self.control = self.callback_handler.on_step_end(args, self.state, self.control)
  File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/trainer_callback.py", line 359, in on_step_end
    return self.call_event("on_step_end", args, state, control)
  File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/trainer_callback.py", line 378, in call_event
    result = getattr(callback, event)(
  File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/trainer_callback.py", line 406, in on_step_end
    if args.logging_strategy == IntervalStrategy.STEPS and state.global_step % args.logging_steps == 0:
ZeroDivisionError: integer division or modulo by zero
```
(this last one doesn't happen with master, but I reworked things to do the same enforcement in init as for `eval_steps`)

@sgugger 
