### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 119
-target-version = ['py35']
+target-version = ['py36']


### PR DESCRIPTION
You don't support Python 3.5, so I've bumped the black `target-version` to `'py36'`.