### PR TITLE
Refer warmup_ratio when setting warmup_num_steps.

### DIFF
--- a/src/transformers/deepspeed.py
+++ b/src/transformers/deepspeed.py
@@ -244,10 +244,7 @@ class HfTrainerDeepSpeedConfig(HfDeepSpeedConfig):
 
         # scheduler
         self.fill_match("scheduler.params.total_num_steps", num_training_steps, "num_training_steps (calculated)")
-        if args.warmup_ratio > 0:
-            self.fill_match("scheduler.params.warmup_num_steps", int(args.warmup_ratio * num_training_steps), "warmup_steps")
-        else:
-            self.fill_match("scheduler.params.warmup_num_steps", args.warmup_steps, "warmup_steps")
+        self.fill_match("scheduler.params.warmup_num_steps", args.get_warmup_steps(num_training_steps), "warmup_steps")
 
         if len(self.mismatches) > 0:
             mismatches = "\n".join(self.mismatches)

--- a/src/transformers/deepspeed.py
+++ b/src/transformers/deepspeed.py
@@ -204,7 +204,6 @@ class HfTrainerDeepSpeedConfig(HfDeepSpeedConfig):
 
         self.fill_only("scheduler.params.warmup_min_lr", 0)  # not a trainer arg
         self.fill_match("scheduler.params.warmup_max_lr", args.learning_rate, "learning_rate")
-        self.fill_match("scheduler.params.warmup_num_steps", args.warmup_steps, "warmup_steps")
         # total_num_steps - will get set in trainer_config_finalize
 
         # fp16
@@ -245,6 +244,10 @@ class HfTrainerDeepSpeedConfig(HfDeepSpeedConfig):
 
         # scheduler
         self.fill_match("scheduler.params.total_num_steps", num_training_steps, "num_training_steps (calculated)")
+        if args.warmup_ratio > 0:
+            self.fill_match("scheduler.params.warmup_num_steps", int(args.warmup_ratio * num_training_steps), "warmup_steps")
+        else:
+            self.fill_match("scheduler.params.warmup_num_steps", args.warmup_steps, "warmup_steps")
 
         if len(self.mismatches) > 0:
             mismatches = "\n".join(self.mismatches)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -822,16 +822,10 @@ class Trainer:
             num_training_steps (int): The number of training steps to do.
         """
         if self.lr_scheduler is None:
-            warmup_steps = (
-                self.args.warmup_steps
-                if self.args.warmup_steps > 0
-                else math.ceil(num_training_steps * self.args.warmup_ratio)
-            )
-
             self.lr_scheduler = get_scheduler(
                 self.args.lr_scheduler_type,
                 self.optimizer,
-                num_warmup_steps=warmup_steps,
+                num_warmup_steps=self.args.get_warmup_steps(num_training_steps),
                 num_training_steps=num_training_steps,
             )
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -14,6 +14,7 @@
 
 import contextlib
 import json
+import math
 import os
 import warnings
 from dataclasses import asdict, dataclass, field
@@ -1064,6 +1065,17 @@ class TrainingArguments:
                         torch.distributed.barrier()
         else:
             yield
+
+    def get_warmup_steps(self, num_training_steps):
+        """
+        Get number of steps used for a linear warmup.
+        """
+        warmup_steps = (
+            self.warmup_steps
+            if self.warmup_steps > 0
+            else math.ceil(num_training_steps * self.args.warmup_ratio)
+        )
+        return warmup_steps
 
     def to_dict(self):
         """

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1073,7 +1073,7 @@ class TrainingArguments:
         warmup_steps = (
             self.warmup_steps
             if self.warmup_steps > 0
-            else math.ceil(num_training_steps * self.args.warmup_ratio)
+            else math.ceil(num_training_steps * self.warmup_ratio)
         )
         return warmup_steps
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1066,7 +1066,7 @@ class TrainingArguments:
         else:
             yield
 
-    def get_warmup_steps(self, num_training_steps):
+    def get_warmup_steps(self, num_training_steps: int):
         """
         Get number of steps used for a linear warmup.
         """


### PR DESCRIPTION
# What does this PR do?

This PR fixes the bug that DeepSpeed schduler does not refer warmup_ratio argument, although DeepSpeed schduler refers warmup_steps argument.   This contradicts to the warning message "Both warmup_ratio and warmup_steps given, warmup_steps will override any effect of warmup_ratio during training" defined in training_args.py L.700.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

Because this PR relates to DeepSpeed integration, I hope @stas00 may review this.