### PR TITLE
Raise warning in HP search when hp is not in args

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -851,9 +851,10 @@ class Trainer:
 
         for key, value in params.items():
             if not hasattr(self.args, key):
-                raise AttributeError(
+                logger.warn(
                     f"Trying to set {key} in the hyperparameter search but there is no corresponding field in `TrainingArguments`."
                 )
+                continue
             old_attr = getattr(self.args, key, None)
             # Casting value to the proper type
             if old_attr is not None:


### PR DESCRIPTION
# What does this PR do?

As seen on the [forums](https://discuss.huggingface.co/t/using-hyperparameter-search-in-trainer/785), an HP search using the `Trainer` will error if someone tries to include model parameters like dropout in the search. This PR addresses that by changing an error to a warning in that case.