### PR TITLE
Fix type of max_seq_length arg in run_swag.py

### DIFF
--- a/examples/pytorch/multiple-choice/run_swag.py
+++ b/examples/pytorch/multiple-choice/run_swag.py
@@ -106,7 +106,7 @@ class DataTrainingArguments:
         default=None,
         metadata={"help": "The number of processes to use for the preprocessing."},
     )
-    max_seq_length: int = field(
+    max_seq_length: Optional[int] = field(
         default=None,
         metadata={
             "help": "The maximum total input sequence length after tokenization. If passed, sequences longer "


### PR DESCRIPTION
# What does this PR do?

The `max_seq_length` argument in the `run_swag.py` example should be an `Optional[int]`, because its default value is `None`. This fixes the error, found by `mypy`.
