### PR TITLE
[parallelism doc] document Deepspeed-Inference and parallelformers

### DIFF
--- a/docs/source/parallelism.md
+++ b/docs/source/parallelism.md
@@ -224,7 +224,11 @@ Implementations:
 - DeepSpeed calls it [tensor slicing](https://www.deepspeed.ai/features/#model-parallelism)
 - [Megatron-LM](https://github.com/NVIDIA/Megatron-LM) has an internal implementation.
 
-🤗 Transformers status: not yet implemented
+🤗 Transformers status:
+- core: not yet implemented in the core
+- but if you want inference https://github.com/tunib-ai/parallelformers provides this support for most of our models. So until this is implemented in the core you can use theirs. And hopefully training-mode will be supported too.
+- Deepspeed-Inference also supports our BERT, GPT-2, and GPT-Neo models in their super-fast CUDA-kernel-based inference mode: https://www.deepspeed.ai/tutorials/inference-tutorial/
+
 
 
 ## DP+PP

--- a/docs/source/parallelism.md
+++ b/docs/source/parallelism.md
@@ -226,8 +226,8 @@ Implementations:
 
 🤗 Transformers status:
 - core: not yet implemented in the core
-- but if you want inference https://github.com/tunib-ai/parallelformers provides this support for most of our models. So until this is implemented in the core you can use theirs. And hopefully training-mode will be supported too.
-- Deepspeed-Inference also supports our BERT, GPT-2, and GPT-Neo models in their super-fast CUDA-kernel-based inference mode: https://www.deepspeed.ai/tutorials/inference-tutorial/
+- but if you want inference [parallelformers](https://github.com/tunib-ai/parallelformers) provides this support for most of our models. So until this is implemented in the core you can use theirs. And hopefully training mode will be supported too.
+- Deepspeed-Inference also supports our BERT, GPT-2, and GPT-Neo models in their super-fast CUDA-kernel-based inference mode, see more [here](https://www.deepspeed.ai/tutorials/inference-tutorial/)
 
 
 


### PR DESCRIPTION
This PR adds references to Tensor parallel implementations of Deepspeed-Inference and parallelformers (for transformers).

As discussed at https://github.com/huggingface/transformers/issues/12772

@sgugger 