### PR TITLE
Fix CpmTokenizer for training/finetuning CPM model

### DIFF
--- a/src/transformers/models/cpm/tokenization_cpm.py
+++ b/src/transformers/models/cpm/tokenization_cpm.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Tokenization classes."""
 from ...utils import logging
-from ..xlnet.tokenization_xlnet import XLNetTokenizer
+from ..xlnet.tokenization_xlnet_fast import XLNetTokenizerFast
 
 
 logger = logging.get_logger(__name__)
@@ -28,7 +28,7 @@ PRETRAINED_VOCAB_FILES_MAP = {
 }
 
 
-class CpmTokenizer(XLNetTokenizer):
+class CpmTokenizer(XLNetTokenizerFast):
     """Runs pre-tokenization with Jieba segmentation tool. It is used in CPM models."""
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
When CpmTokenizer extends XLNetTokenizer, it works for inference/generation, but model in training/finetuning will failed after some steps, its error is random like:

    RuntimeError: CUDA error: device-side assert triggered
    terminate called after throwing an instance of 'std::runtime_error'
    what():  NCCL error in: /pytorch/torch/lib/c10d/../c10d/NCCLUtils.hpp:136, unhandled cuda error, NCCL version 2.7.8,

failed when in different tensor operation every time, very strange.
after extend XLNetTokenizerFast, inference/training/finetuning all working.
