### PR TITLE
Fix barrier for SM distributed

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1052,6 +1052,8 @@ class TrainingArguments:
                     logger.debug(f"{self.process_index}: waiting for the {main_process_desc} to perform {desc}")
                     if is_torch_tpu_available():
                         xm.rendezvous(desc)
+                    elif is_sagemaker_dp_enabled():
+                        sm_dist.Barrier()
                     else:
                         torch.distributed.barrier()
                 yield
@@ -1061,6 +1063,8 @@ class TrainingArguments:
                     logger.debug(f"{self.process_index}: {main_process_desc} completed {desc}, releasing all replicas")
                     if is_torch_tpu_available():
                         xm.rendezvous(desc)
+                    elif is_sagemaker_dp_enabled():
+                        sm_dist.Barrier()
                     else:
                         torch.distributed.barrier()
         else:


### PR DESCRIPTION
# What does this PR do?

#12351 introduced a new context manager for having the main process execute an instruction while other process have to wait. That context manager was missing special treatment for TPUs (added in #12464) and SageMaker distributed. This PR adds the latter.

Fixes #12847