### PR TITLE
Add accelerate to examples requirements

### DIFF
--- a/examples/pytorch/language-modeling/requirements.txt
+++ b/examples/pytorch/language-modeling/requirements.txt
@@ -1,3 +1,4 @@
+accelerate
 torch >= 1.3
 datasets >= 1.8.0
 sentencepiece != 0.1.92

--- a/examples/pytorch/multiple-choice/requirements.txt
+++ b/examples/pytorch/multiple-choice/requirements.txt
@@ -1,3 +1,4 @@
+accelerate
 sentencepiece != 0.1.92
 protobuf
 torch >= 1.3

--- a/examples/pytorch/question-answering/requirements.txt
+++ b/examples/pytorch/question-answering/requirements.txt
@@ -1,2 +1,3 @@
+accelerate
 datasets >= 1.8.0
 torch >= 1.3.0

--- a/examples/pytorch/summarization/requirements.txt
+++ b/examples/pytorch/summarization/requirements.txt
@@ -1,3 +1,4 @@
+accelerate
 datasets >= 1.8.0
 sentencepiece != 0.1.92
 protobuf

--- a/examples/pytorch/token-classification/requirements.txt
+++ b/examples/pytorch/token-classification/requirements.txt
@@ -1,3 +1,4 @@
+accelerate
 seqeval
 datasets >= 1.8.0
 torch >= 1.3

--- a/examples/pytorch/translation/requirements.txt
+++ b/examples/pytorch/translation/requirements.txt
@@ -1,3 +1,4 @@
+accelerate
 datasets >= 1.8.0
 sentencepiece != 0.1.92
 protobuf


### PR DESCRIPTION
# What does this PR do?

As mentioned in #12849, the `requirements.txt` for most PyTorch examples does not contain `accelerate`, so the `run_xxx_no_trainer.py` example cannot be executed. This PR fixes that.

Fixes #12489