### PR TITLE
Correct validation_split_percentage argument from int (ex:5) to float (0.05)

### DIFF
--- a/examples/flax/language-modeling/README.md
+++ b/examples/flax/language-modeling/README.md
@@ -211,7 +211,7 @@ from transformers import GPT2Config
 
 model_dir = "./norwegian-gpt2"  # ${MODEL_DIR}
 
-config = GPT2Config.from_pretrained("gpt2", resid_pdrop=0.0, embd_pdrop=0.0, attn_pdrop=0.0, vocab_size=tokenizer.vocab_size)
+config = GPT2Config.from_pretrained("gpt2", resid_pdrop=0.0, embd_pdrop=0.0, attn_pdrop=0.0, vocab_size=tokenizer.get_vocab_size())
 config.save_pretrained(model_dir)
 ```
 

--- a/examples/flax/language-modeling/run_clm_flax.py
+++ b/examples/flax/language-modeling/run_clm_flax.py
@@ -308,14 +308,14 @@ def main():
             extension = "text"
         dataset = load_dataset(extension, data_files=data_files, cache_dir=model_args.cache_dir)
 
-        if "validation" not in datasets.keys():
-            datasets["validation"] = load_dataset(
+        if "validation" not in dataset.keys():
+            dataset["validation"] = load_dataset(
                 extension,
                 data_files=data_files,
                 split=f"train[:{data_args.validation_split_percentage}%]",
                 cache_dir=model_args.cache_dir,
             )
-            datasets["train"] = load_dataset(
+            dataset["train"] = load_dataset(
                 extension,
                 data_files=data_files,
                 split=f"train[{data_args.validation_split_percentage}%:]",

--- a/examples/tensorflow/language-modeling/run_clm.py
+++ b/examples/tensorflow/language-modeling/run_clm.py
@@ -438,7 +438,7 @@ def main():
             f"Validation file not found: using {data_args.validation_split_percentage}% of the dataset as validation as provided in data_args"
         )
         train_indices, val_indices = train_test_split(
-            list(range(len(train_dataset))), test_size=data_args.validation_split_percentage
+            list(range(len(train_dataset))), test_size=data_args.validation_split_percentage/100
         )
 
         eval_dataset = train_dataset.select(val_indices)

--- a/examples/tensorflow/language-modeling/run_mlm.py
+++ b/examples/tensorflow/language-modeling/run_mlm.py
@@ -499,7 +499,7 @@ def main():
             f"Validation file not found: using {data_args.validation_split_percentage}% of the dataset as validation as provided in data_args"
         )
         train_indices, val_indices = train_test_split(
-            list(range(len(train_dataset))), test_size=data_args.validation_split_percentage
+            list(range(len(train_dataset))), test_size=data_args.validation_split_percentage/100
         )
 
         eval_dataset = train_dataset.select(val_indices)

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -70,8 +70,10 @@ class Seq2SeqTrainer(Trainer):
             A dictionary containing the evaluation loss and the potential metrics computed from the predictions. The
             dictionary also contains the epoch number which comes from the training state.
         """
-        self._max_length = max_length
-        self._num_beams = num_beams
+        if max_length is not None or not hasattr(self, "_max_length"):
+            self._max_length = max_length
+        if num_beams is not None or not hasattr(self, "_num_beams"):
+            self._num_beams = num_beams
         return super().evaluate(eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
 
     def predict(
@@ -117,8 +119,10 @@ class Seq2SeqTrainer(Trainer):
             - metrics (:obj:`Dict[str, float]`, `optional`): The potential dictionary of metrics (if the dataset
               contained labels).
         """
-        self._max_length = max_length
-        self._num_beams = num_beams
+        if max_length is not None or not hasattr(self, "_max_length"):
+            self._max_length = max_length
+        if num_beams is not None or not hasattr(self, "_num_beams"):
+            self._num_beams = num_beams
         return super().predict(test_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
 
     def prediction_step(

--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -357,7 +357,7 @@ def symbolic_trace(
 
     Example::
 
-        from transformers.modeling_fx_utils import symbolic_trace
+        from transformers.utils.fx import symbolic_trace
         traced_model = symbolic_trace(
             model,
             input_names=["input_ids", "attention_mask", "token_type_ids"],


### PR DESCRIPTION

# What does this PR do?
This PR is for fixing a bug in the run_clm.py and run_mlm.py examples in the tensorflow section. I have merely divided the value by 100 on the train_test_split test_size argument. This will make it work as intended now.




## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
https://github.com/huggingface/transformers/pull/11690

- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).

- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Related People: @sgugger and @patil-suraj 
