### PR TITLE
`Seq2SeqTrainer` set max_length and num_beams only when non None 

### DIFF
--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -70,9 +70,9 @@ class Seq2SeqTrainer(Trainer):
             A dictionary containing the evaluation loss and the potential metrics computed from the predictions. The
             dictionary also contains the epoch number which comes from the training state.
         """
-        if max_length is not None or not hasattr(self, '_max_length'):
+        if max_length is not None or not hasattr(self, "_max_length"):
             self._max_length = max_length
-        if num_beams is not None or not hasattr(self, '_num_beams'):
+        if num_beams is not None or not hasattr(self, "_num_beams"):
             self._num_beams = num_beams
         return super().evaluate(eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
 
@@ -119,9 +119,9 @@ class Seq2SeqTrainer(Trainer):
             - metrics (:obj:`Dict[str, float]`, `optional`): The potential dictionary of metrics (if the dataset
               contained labels).
         """
-        if max_length is not None or not hasattr(self, '_max_length'):
+        if max_length is not None or not hasattr(self, "_max_length"):
             self._max_length = max_length
-        if num_beams is not None or not hasattr(self, '_num_beams'):
+        if num_beams is not None or not hasattr(self, "_num_beams"):
             self._num_beams = num_beams
         return super().predict(test_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
 

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -70,8 +70,10 @@ class Seq2SeqTrainer(Trainer):
             A dictionary containing the evaluation loss and the potential metrics computed from the predictions. The
             dictionary also contains the epoch number which comes from the training state.
         """
-        self._max_length = max_length
-        self._num_beams = num_beams
+        if max_length:
+            self._max_length = max_length
+        if num_beams:
+            self._num_beams = num_beams
         return super().evaluate(eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
 
     def predict(
@@ -117,8 +119,10 @@ class Seq2SeqTrainer(Trainer):
             - metrics (:obj:`Dict[str, float]`, `optional`): The potential dictionary of metrics (if the dataset
               contained labels).
         """
-        self._max_length = max_length
-        self._num_beams = num_beams
+        if max_length:
+            self._max_length = max_length
+        if num_beams:
+            self._num_beams = num_beams
         return super().predict(test_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
 
     def prediction_step(

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -70,9 +70,9 @@ class Seq2SeqTrainer(Trainer):
             A dictionary containing the evaluation loss and the potential metrics computed from the predictions. The
             dictionary also contains the epoch number which comes from the training state.
         """
-        if max_length:
+        if max_length is not None or not hasattr(self, '_max_length'):
             self._max_length = max_length
-        if num_beams:
+        if num_beams is not None or not hasattr(self, '_num_beams'):
             self._num_beams = num_beams
         return super().evaluate(eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
 
@@ -119,9 +119,9 @@ class Seq2SeqTrainer(Trainer):
             - metrics (:obj:`Dict[str, float]`, `optional`): The potential dictionary of metrics (if the dataset
               contained labels).
         """
-        if max_length:
+        if max_length is not None or not hasattr(self, '_max_length'):
             self._max_length = max_length
-        if num_beams:
+        if num_beams is not None or not hasattr(self, '_num_beams'):
             self._num_beams = num_beams
         return super().predict(test_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
 


### PR DESCRIPTION
# What does this PR do?

This PR slightly modifies the logic of setting `self._max_length` and `self._num_beams` in `Seq2SeqTrainer`'s `evaluate()` and `predict()` methods, i.e., the two variables will be set only when they are provided non `None` values.

This is to address a potentially inconsistent evaluation configuration inside the Seq2Seq training loop. For example, if you create a `Seq2SeqTrainer` object and invoke its `train()` method with a by epoch evaluation strategy, this line will do the evaluation after each training epoch: https://github.com/huggingface/transformers/blob/ba15fe7995a02357ecea6e7024918f6915564c36/src/transformers/trainer.py#L1437

`Seq2SeqTrainer ` subclasses `Trainer`, so the actual `evaluate()` method is https://github.com/huggingface/transformers/blob/ba15fe7995a02357ecea6e7024918f6915564c36/src/transformers/trainer_seq2seq.py#L36-L43

Now the problem is that `max_length` and `num_beams` can only be the default value `None` inside the training loop, since the training method is not aware of parameters introduced from the subclass.  To avoid this issue, this PR basically says that we will set the two variables only when non `None` values are provided. This allows users to set them using `seq2seq_trainer._max_length = 100` and `seq2seq_trainer._num_beams = 4` before entering the training loop (and won't be reset to `None` during training).



## Who can review?
@patrickvonplaten @sgugger 
