### PR TITLE
GPT-Neo ONNX export

### DIFF
--- a/src/transformers/models/gpt_neo/__init__.py
+++ b/src/transformers/models/gpt_neo/__init__.py
@@ -43,7 +43,7 @@ if is_flax_available():
 
 
 if TYPE_CHECKING:
-    from .configuration_gpt_neo import GPT_NEO_PRETRAINED_CONFIG_ARCHIVE_MAP, GPTNeoConfig
+    from .configuration_gpt_neo import GPT_NEO_PRETRAINED_CONFIG_ARCHIVE_MAP, GPTNeoConfig, GPTNeoOnnxConfig
 
     if is_torch_available():
         from .modeling_gpt_neo import (

--- a/src/transformers/models/gpt_neo/__init__.py
+++ b/src/transformers/models/gpt_neo/__init__.py
@@ -21,7 +21,7 @@ from ...file_utils import _LazyModule, is_flax_available, is_torch_available
 
 
 _import_structure = {
-    "configuration_gpt_neo": ["GPT_NEO_PRETRAINED_CONFIG_ARCHIVE_MAP", "GPTNeoConfig"],
+    "configuration_gpt_neo": ["GPT_NEO_PRETRAINED_CONFIG_ARCHIVE_MAP", "GPTNeoConfig", "GPTNeoOnnxConfig"],
 }
 
 if is_torch_available():

--- a/src/transformers/models/gpt_neo/configuration_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/configuration_gpt_neo.py
@@ -183,20 +183,64 @@ class GPTNeoConfig(PretrainedConfig):
 def custom_unfold(input, dimension, size, step):
     """Custom torch.Tensor.unfold implementation to enable export to ONNX."""
     import torch
-
-    shape = input.shape
+    shape = input.size()
     rank = len(shape)
     sizedim = shape[dimension]
-    low_indices = range(0, sizedim, step)
-    hi_indices = range(size, sizedim + 1, step)
+    low_indices = torch.arange(0, sizedim, step)
+    hi_indices = torch.arange(size, sizedim + 1, step)
+    min_length = (sizedim - size) // step + 1
+    # print("low_indices", low_indices)
+    # print("hi_indices", hi_indices)
+    # print("min_length", min_length)
+    # hi_indices = hi_indices[:min_length]
+    # import pdb; pdb.set_trace()
+    # indices = torch.stack([low_indices, hi_indices], dim=1)
+    # indices = indices[:, :, None]
+    # print("low_indices", low_indices)
+    # print("hi_indices", hi_indices)
+    it = list(zip(range(0, sizedim, step), range(size, sizedim + 1, step)))
+    supposed_indices = torch.stack(
+        [torch.arange(start=lo, end=hi) for (lo, hi) in it],
+        dim=0
+    )
+    print(supposed_indices)
+    # print("supposed indices", supposed_indices)
+    indices = torch.arange(size) + low_indices[:min_length][:, None]
+    print(indices)
+
+    #indices = indices[:min_length]
+    # print(indices)
+    # print(supposed_indices)
+    print("matching", torch.all(indices == supposed_indices))
+    # stack = input[torch.arange(indices.shape[0])[:, None] , :]
+    s = [slice(None)] * rank
+    s[dimension] = indices
+    sliced = input[s]
+    print("input shape", input.shape)
+    print("indices shape", indices.shape)
+    print("sliced shape", sliced.shape)
+    # print(stack, stack.shape)
     stack = []
-    for low, hi in zip(low_indices, hi_indices):
+    for t in it:
         s = [slice(None)] * rank
-        s[dimension] = slice(low, hi)
+        s[dimension] = slice(t[0], t[1])
         stack.append(input[s])
+        # stack.append(torch.narrow(input, dim=dimension, start=t[0], length=t[1]-t[0]))
+    print("stack shape", len(stack), stack[0].shape)
     perm = list(range(0, rank))
+    sliced_perm = list(range(0, rank + 1))
     perm.append(perm.pop(dimension))
+    sliced_perm.append(sliced_perm.pop(dimension + 1))
+    print("perm", perm)
+    print("sliced perm", perm)
+    # stack = stack.permute(perm)
     unsqueeze = [t.permute(perm).unsqueeze(dimension) for t in stack]
+    ready_sliced = sliced.permute(sliced_perm)
+    print("unsqueeze shape", unsqueeze[0].shape)
+    print("ready_sliced shape", ready_sliced.shape)
+    res = torch.cat(unsqueeze, dim=dimension)
+    print("res shape", res.shape)
+    return ready_sliced
     return torch.cat(unsqueeze, dim=dimension)
 
 

--- a/src/transformers/models/gpt_neo/modeling_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/modeling_gpt_neo.py
@@ -1121,7 +1121,7 @@ class GPTNeoForSequenceClassification(GPTNeoPreTrainedModel):
                     f"unexpected if using padding tokens in conjunction with `inputs_embeds.`"
                 )
 
-        pooled_logits = logits[range(batch_size), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size), sequence_lengths]
 
         loss = None
         if labels is not None:

--- a/src/transformers/onnx/__init__.py
+++ b/src/transformers/onnx/__init__.py
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .config import EXTERNAL_DATA_FORMAT_SIZE_LIMIT, OnnxConfig, OnnxConfigWithPast
+from .config import EXTERNAL_DATA_FORMAT_SIZE_LIMIT, OnnxConfig, OnnxConfigWithPast, PatchingSpec
 from .convert import export, validate_model_outputs
 from .utils import ParameterFormat, compute_serialized_parameters_size

--- a/src/transformers/onnx/__main__.py
+++ b/src/transformers/onnx/__main__.py
@@ -14,91 +14,12 @@
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Callable, Tuple
 
-from transformers.models.albert import AlbertOnnxConfig
 from transformers.models.auto import AutoTokenizer
-from transformers.models.bart import BartOnnxConfig
-from transformers.models.bert import BertOnnxConfig
-from transformers.models.distilbert import DistilBertOnnxConfig
-from transformers.models.gpt2 import GPT2OnnxConfig
-from transformers.models.longformer import LongformerOnnxConfig
-from transformers.models.roberta import RobertaOnnxConfig
-from transformers.models.t5 import T5OnnxConfig
-from transformers.models.xlm_roberta import XLMRobertaOnnxConfig
 
-from .. import is_torch_available
 from ..utils import logging
 from .convert import export, validate_model_outputs
-
-
-if is_torch_available():
-    from transformers import AutoModel, PreTrainedModel
-
-    FEATURES_TO_AUTOMODELS = {
-        "default": AutoModel,
-    }
-
-
-# Set of model topologies we support associated to the features supported by each topology and the factory
-SUPPORTED_MODEL_KIND = {
-    "albert": {"default": AlbertOnnxConfig.default},
-    "bart": {"default": BartOnnxConfig.default},
-    "bert": {"default": BertOnnxConfig.default},
-    "distilbert": {"default": DistilBertOnnxConfig.default},
-    "gpt2": {"default": GPT2OnnxConfig.default},
-    "longformer": {"default": LongformerOnnxConfig.default},
-    "roberta": {"default": RobertaOnnxConfig},
-    "t5": {"default": T5OnnxConfig.default},
-    "xlm-roberta": {"default": XLMRobertaOnnxConfig.default},
-}
-
-
-def get_model_from_features(features: str, model: str):
-    """
-    Attempt to retrieve a model from a model's name and the features to be enabled.
-
-    Args:
-        features: The features required
-        model: The name of the model to export
-
-    Returns:
-
-    """
-    if features not in FEATURES_TO_AUTOMODELS:
-        raise KeyError(f"Unknown feature: {features}." f"Possible values are {list(FEATURES_TO_AUTOMODELS.values())}")
-
-    return FEATURES_TO_AUTOMODELS[features].from_pretrained(model)
-
-
-def check_supported_model_or_raise(model: PreTrainedModel, features: str = "default") -> Tuple[str, Callable]:
-    """
-    Check whether or not the model has the requested features
-
-    Args:
-        model: The model to export
-        features: The name of the features to check if they are avaiable
-
-    Returns:
-        (str) The type of the model (OnnxConfig) The OnnxConfig instance holding the model export properties
-
-    """
-    if model.config.model_type not in SUPPORTED_MODEL_KIND:
-        raise KeyError(
-            f"{model.config.model_type} ({model.name}) is not supported yet. "
-            f"Only {SUPPORTED_MODEL_KIND} are supported. "
-            f"If you want to support ({model.config.model_type}) please propose a PR or open up an issue."
-        )
-
-    # Look for the features
-    model_features = SUPPORTED_MODEL_KIND[model.config.model_type]
-    if features not in model_features:
-        raise ValueError(
-            f"{model.config.model_type} doesn't support features {features}. "
-            f"Supported values are: {list(model_features.keys())}"
-        )
-
-    return model.config.model_type, SUPPORTED_MODEL_KIND[model.config.model_type][features]
+from .features import FeaturesManager
 
 
 def main():
@@ -127,8 +48,8 @@ def main():
 
     # Allocate the model
     tokenizer = AutoTokenizer.from_pretrained(args.model)
-    model = get_model_from_features(args.features, args.model)
-    model_kind, model_onnx_config = check_supported_model_or_raise(model, features=args.features)
+    model = FeaturesManager.get_model_from_features(args.features, args.model)
+    model_kind, model_onnx_config = FeaturesManager.check_supported_model_or_raise(model, features=args.features)
     onnx_config = model_onnx_config(model.config)
 
     # Ensure the requested opset is sufficient

--- a/src/transformers/onnx/__main__.py
+++ b/src/transformers/onnx/__main__.py
@@ -26,10 +26,10 @@ def main():
     parser = ArgumentParser("Hugging Face ONNX Exporter tool")
     parser.add_argument("-m", "--model", type=str, required=True, help="Model's name of path on disk to load.")
     parser.add_argument(
-        "--features",
-        choices=["default"],
+        "--feature",
+        choices=list(FeaturesManager.AVAILABLE_FEATURES),
         default="default",
-        help="Export the model with some additional features.",
+        help="Export the model with some additional feature.",
     )
     parser.add_argument(
         "--opset", type=int, default=12, help="ONNX opset version to export the model with (default 12)."
@@ -48,8 +48,8 @@ def main():
 
     # Allocate the model
     tokenizer = AutoTokenizer.from_pretrained(args.model)
-    model = FeaturesManager.get_model_from_features(args.features, args.model)
-    model_kind, model_onnx_config = FeaturesManager.check_supported_model_or_raise(model, features=args.features)
+    model = FeaturesManager.get_model_from_feature(args.feature, args.model)
+    model_kind, model_onnx_config = FeaturesManager.check_supported_model_or_raise(model, feature=args.feature)
     onnx_config = model_onnx_config(model.config)
 
     # Ensure the requested opset is sufficient

--- a/src/transformers/onnx/config.py
+++ b/src/transformers/onnx/config.py
@@ -29,11 +29,23 @@ EXTERNAL_DATA_FORMAT_SIZE_LIMIT = 2 * 1024 * 1024 * 1024
 
 @dataclasses.dataclass
 class PatchingSpec:
+    """
+    Data class that holds patching specifications.
+
+    Args:
+        o: Module / object where the op to patch is located
+        name: Name of the op to monkey patch
+        custom_op: Custom op that patches the original op
+        orig_op: Original op that is being patched
+        op_wrapper: Wrapper (optional) that wraps both the original and custom ops.
+            It is useful for ops that are class or static methods for instance.
+    """
+
     o: Any
     name: str
     custom_op: Callable
     orig_op: Optional[Callable] = None
-    op_wrapper: Optional[str] = None
+    op_wrapper: Optional[Callable] = None
 
 
 class OnnxConfig(ABC):

--- a/src/transformers/onnx/convert.py
+++ b/src/transformers/onnx/convert.py
@@ -105,6 +105,10 @@ def export(
     if not inputs_match:
         raise ValueError("Model and config inputs doesn't match")
 
+    config.patch_ops()
+
+    outputs = model(**model_inputs)
+
     # export can works with named args but the dict containing named args as to be last element of the args tuple
     export(
         model,
@@ -118,6 +122,8 @@ def export(
         enable_onnx_checker=True,
         opset_version=opset,
     )
+
+    config.restore_ops()
 
     return matched_inputs, onnx_outputs
 

--- a/src/transformers/onnx/convert.py
+++ b/src/transformers/onnx/convert.py
@@ -184,7 +184,7 @@ def validate_model_outputs(
 
     # Check the shape and values match
     for name, ort_value in zip(onnx_named_outputs, onnx_outputs):
-        ref_value = ref_outputs_dict[name].numpy()
+        ref_value = ref_outputs_dict[name].detach().numpy()
         logger.info(f'\t- Validating ONNX Model output "{name}":')
 
         # Shape

--- a/src/transformers/onnx/convert.py
+++ b/src/transformers/onnx/convert.py
@@ -107,8 +107,6 @@ def export(
 
     config.patch_ops()
 
-    outputs = model(**model_inputs)
-
     # export can works with named args but the dict containing named args as to be last element of the args tuple
     export(
         model,

--- a/src/transformers/onnx/convert.py
+++ b/src/transformers/onnx/convert.py
@@ -138,6 +138,8 @@ def validate_model_outputs(
 
     logger.info("Validating ONNX model...")
 
+    # TODO: generate inputs with a different batch_size and seq_len that was used for conversion to properly test
+    # dynamic input shapes.
     reference_model_inputs = config.generate_dummy_inputs(tokenizer, framework=TensorType.PYTORCH)
 
     # Create ONNX Runtime session
@@ -150,6 +152,10 @@ def validate_model_outputs(
 
     # We flatten potential collection of outputs (i.e. past_keys) to a flat structure
     for name, value in ref_outputs.items():
+        # Overwriting the output name as "present" since it is the name used for the ONNX ouputs
+        # ("past_key_values" being taken for the ONNX inputs)
+        if name == "past_key_values":
+            name = "present"
         if isinstance(value, (list, tuple)):
             value = flatten_output_collection_property(name, value)
             ref_outputs_dict.update(value)

--- a/src/transformers/onnx/convert.py
+++ b/src/transformers/onnx/convert.py
@@ -201,7 +201,7 @@ def validate_model_outputs(
                 f"Got {ref_value.shape} (reference) and {ort_value.shape} (ONNX)"
             )
         else:
-            logger.info(f"\t\t-[✓] {ort_value.shape} matchs {ref_value.shape}")
+            logger.info(f"\t\t-[✓] {ort_value.shape} matches {ref_value.shape}")
 
         # Values
         if not np.allclose(ref_value, ort_value, atol=atol):

--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -1,0 +1,142 @@
+from collections import OrderedDict
+from functools import partial
+from typing import Callable, Tuple
+
+# from ..models.albert import AlbertOnnxConfig
+import transformers.models.albert
+from ..models.bart import BartOnnxConfig
+# from ..models.bert import BertOnnxConfig
+import transformers.models.bert.BertOnnxConfig as BertOnnxConfig
+from ..models.distilbert import DistilBertOnnxConfig
+from ..models.gpt2 import GPT2OnnxConfig
+from ..models.longformer import LongformerOnnxConfig
+from ..models.roberta import RobertaOnnxConfig
+from ..models.t5 import T5OnnxConfig
+from ..models.xlm_roberta import XLMRobertaOnnxConfig
+from ..models.gpt_neo import GPTNeoOnnxConfig
+
+from .. import is_torch_available
+
+if is_torch_available():
+    from transformers import PreTrainedModel
+    from transformers.models.auto import (
+        AutoModel,
+        AutoModelForCausalLM,
+        AutoModelForSequenceClassification,
+        AutoModelForTokenClassification,
+        AutoModelForMultipleChoice,
+        AutoModelForQuestionAnswering,
+    )
+
+
+def supported_features_mapping(*supported_features, onnx_config_cls=None):
+    """Generates the mapping between supported features and their corresponding OnnxConfig."""
+    if onnx_config_cls is None:
+        raise ValueError("A OnnxConfig class must be provided")
+
+    mapping = {}
+    for feature in supported_features:
+        if "-with-past" in feature:
+            task = feature.replace("-with-past", "")
+            mapping[task] = partial(onnx_config_cls.with_past, task=task)
+        else:
+            mapping[feature] = partial(onnx_config_cls.from_model_config, task=feature)
+
+    return mapping
+
+
+class FeaturesManager:
+    _TASKS_TO_COMMON_OUTPUTS = {
+        "default": OrderedDict({"last_hidden_state": {0: "batch", 1: "sequence"}}),
+        "causal-lm": OrderedDict({"logits": {0: "batch", 1: "sequence"}}),
+        "sequence-classification": OrderedDict({"logits": {0: "batch"}}),
+        "token-classification": OrderedDict({"logits": {0: "batch", 1: "sequence"}}),
+        "multiple-choice": OrderedDict({"logits": {0: "batch"}}),
+        "question-answering": OrderedDict({
+            "start_logits": {0: "batch", 1: "sequence"},
+            "end_logits": {0: "batch", 1: "sequence"},
+        }),
+    }
+
+    _TASKS_TO_AUTOMODELS = {
+        "default": AutoModel,
+        "causal-lm": AutoModelForCausalLM,
+        "sequence-classification": AutoModelForSequenceClassification,
+        "token-classification": AutoModelForTokenClassification,
+        "multiple-choice": AutoModelForMultipleChoice,
+        "question-answering": AutoModelForQuestionAnswering,
+    }
+
+    # Set of model topologies we support associated to the features supported by each topology and the factory
+    _SUPPORTED_MODEL_KIND = {
+        "albert": supported_features_mapping("default", onnx_config_cls=AlbertOnnxConfig),
+        "bart": supported_features_mapping("default", onnx_config_cls=BartOnnxConfig),
+        "bert": supported_features_mapping("default", onnx_config_cls=BertOnnxConfig),
+        "distilbert": supported_features_mapping("default", onnx_config_cls=DistilBertOnnxConfig),
+        "gpt2": supported_features_mapping("default", onnx_config_cls=GPT2OnnxConfig),
+        "longformer": supported_features_mapping("default", onnx_config_cls=LongformerOnnxConfig),
+        "roberta": supported_features_mapping("default", onnx_config_cls=RobertaOnnxConfig),
+        "t5": supported_features_mapping("default", onnx_config_cls=T5OnnxConfig),
+        "xlm-roberta": supported_features_mapping("default", onnx_config_cls=XLMRobertaOnnxConfig),
+        "gpt-neo": supported_features_mapping(
+            "default",
+            "causal-lm",
+            "sequence-classification",
+            "default-with-past",
+            "causal-lm-with-past",
+            "sequence-classification-with-past",
+            onnx_config_cls=GPTNeoOnnxConfig
+        ),
+    }
+
+    @staticmethod
+    def feature_to_task(feature: str) -> str:
+        return feature.replace("-with-past", "")
+
+    @staticmethod
+    def get_model_from_feature(feature: str, model: str):
+        """
+        Attempt to retrieve a model from a model's name and the feature to be enabled.
+
+        Args:
+            feature: The feature required
+            model: The name of the model to export
+
+        Returns:
+
+        """
+        task = FeaturesManager.feature_to_task(feature)
+        if task not in FeaturesManager._TASKS_TO_AUTOMODELS:
+            raise KeyError(f"Unknown task: {feature}." f"Possible values are {list(FeaturesManager._TASKS_TO_AUTOMODELS.values())}")
+
+        return FeaturesManager._TASKS_TO_AUTOMODELS[feature].from_pretrained(model)
+
+    @staticmethod
+    def check_supported_model_or_raise(model: PreTrainedModel, feature: str = "default") -> Tuple[str, Callable]:
+        """
+        Check whether or not the model has the requested features
+
+        Args:
+            model: The model to export
+            feature: The name of the feature to check if it is avaiable
+
+        Returns:
+            (str) The type of the model (OnnxConfig) The OnnxConfig instance holding the model export properties
+
+        """
+        if model.config.model_type not in FeaturesManager._SUPPORTED_MODEL_KIND:
+            raise KeyError(
+                f"{model.config.model_type} ({model.name}) is not supported yet. "
+                f"Only {FeaturesManager._SUPPORTED_MODEL_KIND} are supported. "
+                f"If you want to support ({model.config.model_type}) please propose a PR or open up an issue."
+            )
+
+        # Look for the features
+        model_features = FeaturesManager._SUPPORTED_MODEL_KIND[model.config.model_type]
+        if feature not in model_features:
+            raise ValueError(
+                f"{model.config.model_type} doesn't support feature {feature}. "
+                f"Supported values are: {list(model_features.keys())}"
+            )
+
+        return model.config.model_type, FeaturesManager._SUPPORTED_MODEL_KIND[model.config.model_type][feature]

--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -1,31 +1,28 @@
-from collections import OrderedDict
-from functools import partial
+from functools import partial, reduce
 from typing import Callable, Tuple
 
-# from ..models.albert import AlbertOnnxConfig
-import transformers.models.albert
+from .. import is_torch_available
+from ..models.albert import AlbertOnnxConfig
 from ..models.bart import BartOnnxConfig
-# from ..models.bert import BertOnnxConfig
-import transformers.models.bert.BertOnnxConfig as BertOnnxConfig
+from ..models.bert import BertOnnxConfig
 from ..models.distilbert import DistilBertOnnxConfig
 from ..models.gpt2 import GPT2OnnxConfig
+from ..models.gpt_neo import GPTNeoOnnxConfig
 from ..models.longformer import LongformerOnnxConfig
 from ..models.roberta import RobertaOnnxConfig
 from ..models.t5 import T5OnnxConfig
 from ..models.xlm_roberta import XLMRobertaOnnxConfig
-from ..models.gpt_neo import GPTNeoOnnxConfig
 
-from .. import is_torch_available
 
 if is_torch_available():
     from transformers import PreTrainedModel
     from transformers.models.auto import (
         AutoModel,
         AutoModelForCausalLM,
-        AutoModelForSequenceClassification,
-        AutoModelForTokenClassification,
         AutoModelForMultipleChoice,
         AutoModelForQuestionAnswering,
+        AutoModelForSequenceClassification,
+        AutoModelForTokenClassification,
     )
 
 
@@ -38,7 +35,7 @@ def supported_features_mapping(*supported_features, onnx_config_cls=None):
     for feature in supported_features:
         if "-with-past" in feature:
             task = feature.replace("-with-past", "")
-            mapping[task] = partial(onnx_config_cls.with_past, task=task)
+            mapping[feature] = partial(onnx_config_cls.with_past, task=task)
         else:
             mapping[feature] = partial(onnx_config_cls.from_model_config, task=feature)
 
@@ -46,18 +43,6 @@ def supported_features_mapping(*supported_features, onnx_config_cls=None):
 
 
 class FeaturesManager:
-    _TASKS_TO_COMMON_OUTPUTS = {
-        "default": OrderedDict({"last_hidden_state": {0: "batch", 1: "sequence"}}),
-        "causal-lm": OrderedDict({"logits": {0: "batch", 1: "sequence"}}),
-        "sequence-classification": OrderedDict({"logits": {0: "batch"}}),
-        "token-classification": OrderedDict({"logits": {0: "batch", 1: "sequence"}}),
-        "multiple-choice": OrderedDict({"logits": {0: "batch"}}),
-        "question-answering": OrderedDict({
-            "start_logits": {0: "batch", 1: "sequence"},
-            "end_logits": {0: "batch", 1: "sequence"},
-        }),
-    }
-
     _TASKS_TO_AUTOMODELS = {
         "default": AutoModel,
         "causal-lm": AutoModelForCausalLM,
@@ -85,9 +70,11 @@ class FeaturesManager:
             "default-with-past",
             "causal-lm-with-past",
             "sequence-classification-with-past",
-            onnx_config_cls=GPTNeoOnnxConfig
+            onnx_config_cls=GPTNeoOnnxConfig,
         ),
     }
+
+    AVAILABLE_FEATURES = sorted(reduce(lambda s1, s2: s1 | s2, (v.keys() for v in _SUPPORTED_MODEL_KIND.values())))
 
     @staticmethod
     def feature_to_task(feature: str) -> str:
@@ -107,9 +94,12 @@ class FeaturesManager:
         """
         task = FeaturesManager.feature_to_task(feature)
         if task not in FeaturesManager._TASKS_TO_AUTOMODELS:
-            raise KeyError(f"Unknown task: {feature}." f"Possible values are {list(FeaturesManager._TASKS_TO_AUTOMODELS.values())}")
+            raise KeyError(
+                f"Unknown task: {feature}."
+                f"Possible values are {list(FeaturesManager._TASKS_TO_AUTOMODELS.values())}"
+            )
 
-        return FeaturesManager._TASKS_TO_AUTOMODELS[feature].from_pretrained(model)
+        return FeaturesManager._TASKS_TO_AUTOMODELS[task].from_pretrained(model)
 
     @staticmethod
     def check_supported_model_or_raise(model: PreTrainedModel, feature: str = "default") -> Tuple[str, Callable]:
@@ -124,19 +114,22 @@ class FeaturesManager:
             (str) The type of the model (OnnxConfig) The OnnxConfig instance holding the model export properties
 
         """
-        if model.config.model_type not in FeaturesManager._SUPPORTED_MODEL_KIND:
+        model_type = model.config.model_type.replace("_", "-")
+        model_name = getattr(model, "name", "")
+        model_name = f"({model_name})" if model_name else ""
+        if model_type not in FeaturesManager._SUPPORTED_MODEL_KIND:
             raise KeyError(
-                f"{model.config.model_type} ({model.name}) is not supported yet. "
+                f"{model.config.model_type} ({model_name}) is not supported yet. "
                 f"Only {FeaturesManager._SUPPORTED_MODEL_KIND} are supported. "
                 f"If you want to support ({model.config.model_type}) please propose a PR or open up an issue."
             )
 
         # Look for the features
-        model_features = FeaturesManager._SUPPORTED_MODEL_KIND[model.config.model_type]
+        model_features = FeaturesManager._SUPPORTED_MODEL_KIND[model_type]
         if feature not in model_features:
             raise ValueError(
                 f"{model.config.model_type} doesn't support feature {feature}. "
                 f"Supported values are: {list(model_features.keys())}"
             )
 
-        return model.config.model_type, FeaturesManager._SUPPORTED_MODEL_KIND[model.config.model_type][feature]
+        return model.config.model_type, FeaturesManager._SUPPORTED_MODEL_KIND[model_type][feature]

--- a/tests/test_onnx_v2.py
+++ b/tests/test_onnx_v2.py
@@ -9,6 +9,7 @@ from transformers import (  # LongformerConfig,; T5Config,
     BartConfig,
     DistilBertConfig,
     GPT2Config,
+    GPTNeoConfig,
     RobertaConfig,
     XLMRobertaConfig,
     is_torch_available,
@@ -20,6 +21,7 @@ from transformers.models.distilbert import DistilBertOnnxConfig
 
 # from transformers.models.longformer import LongformerOnnxConfig
 from transformers.models.gpt2 import GPT2OnnxConfig
+from transformers.models.gpt_neo import GPTNeoOnnxConfig
 from transformers.models.roberta import RobertaOnnxConfig
 
 # from transformers.models.t5 import T5OnnxConfig
@@ -175,6 +177,7 @@ if is_torch_available():
         BertModel,
         DistilBertModel,
         GPT2Model,
+        GPTNeoModel,
         RobertaModel,
         XLMRobertaModel,
     )
@@ -185,6 +188,7 @@ if is_torch_available():
         ("BERT", "bert-base-cased", BertModel, BertConfig, BertOnnxConfig),
         ("DistilBERT", "distilbert-base-cased", DistilBertModel, DistilBertConfig, DistilBertOnnxConfig),
         ("GPT2", "gpt2", GPT2Model, GPT2Config, GPT2OnnxConfig),
+        ("GPT-Neo", "EleutherAI/gpt-neo-125M", GPTNeoModel, GPTNeoConfig, GPTNeoOnnxConfig),
         # ("LongFormer", "longformer-base-4096", LongformerModel, LongformerConfig, LongformerOnnxConfig),
         ("Roberta", "roberta-base", RobertaModel, RobertaConfig, RobertaOnnxConfig),
         ("XLM-Roberta", "roberta-base", XLMRobertaModel, XLMRobertaConfig, XLMRobertaOnnxConfig),

--- a/tests/test_onnx_v2.py
+++ b/tests/test_onnx_v2.py
@@ -138,7 +138,8 @@ class OnnxConfigWithPastTestCaseV2(TestCase):
         for name, config in OnnxConfigWithPastTestCaseV2.SUPPORTED_WITH_PAST_CONFIGS:
             with self.subTest(name):
                 self.assertFalse(
-                    OnnxConfigWithPast.default(config()).use_past, "OnnxConfigWithPast.default() should not use_past"
+                    OnnxConfigWithPast.from_model_config(config()).use_past,
+                    "OnnxConfigWithPast.from_model_config() should not use_past",
                 )
 
                 self.assertTrue(
@@ -154,7 +155,7 @@ class OnnxConfigWithPastTestCaseV2(TestCase):
             with self.subTest(name):
 
                 # without past
-                onnx_config_default = OnnxConfigWithPast.default(config())
+                onnx_config_default = OnnxConfigWithPast.from_model_config(config())
                 self.assertIsNotNone(onnx_config_default.values_override, "values_override should not be None")
                 self.assertIn("use_cache", onnx_config_default.values_override, "use_cache should be present")
                 self.assertFalse(


### PR DESCRIPTION
# What does this PR do?

This PR enables the export of GPT-Neo to ONNX by extending the new module transformers.onnx.

It also provides a possible way of implementing the export for specific tasks: the task can be specified when instantiating an OnnxConfig. It is a nice approach because it makes factoring most of the code for the inputs / outputs very easy, but it is less aligned with transformers DNA than having subclasses (such as OnnxConfigForSequenceClassification, etc)  taking care of that.

The issue with having many subclasses is that it would have to be done everytime one wants to add the support for a model. 
What do you think?