### PR TITLE
Add truncation_side option to tokenizers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ _deps = [
     "tensorflow>=2.3",
     "timeout-decorator",
     "timm",
-    "tokenizers>=0.10.1,<0.11",
+    "tokenizers>=0.10.1,<0.12",
     "torch>=1.0",
     "torchaudio",
     "pyctcdecode>=0.2.0",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -59,7 +59,7 @@ deps = {
     "tensorflow": "tensorflow>=2.3",
     "timeout-decorator": "timeout-decorator",
     "timm": "timm",
-    "tokenizers": "tokenizers>=0.10.1,<0.11",
+    "tokenizers": "tokenizers>=0.10.1,<0.12",
     "torch": "torch>=1.0",
     "torchaudio": "torchaudio",
     "pyctcdecode": "pyctcdecode>=0.2.0",

--- a/src/transformers/feature_extraction_sequence_utils.py
+++ b/src/transformers/feature_extraction_sequence_utils.py
@@ -307,15 +307,15 @@ class SequenceFeatureExtractor(FeatureExtractionMixin):
         """
         Truncate inputs (on left/right and up to predefined length or max length in the batch)
 
-        Truncation side (left/right) values are defined at the feature extractor level (with ``self.truncation_side``)
+        Truncation side (left/right) values are defined at the feature extractor level (with `self.truncation_side`)
 
         Args:
-            processed_features: Dictionary of input values (`np.ndarray[float]`) / input vectors (`List[np.ndarray[float]]`) or batch of inputs values (`List[np.ndarray[int]]`) / input vectors (`List[np.ndarray[int]]`)
+            processed_features: Dictionary of input values (*np.ndarray[float]*) / input vectors (*List[np.ndarray[float]]*) or batch of inputs values (*List[np.ndarray[int]]*) / input vectors (*List[np.ndarray[int]]*)
             max_length: maximum length of the returned list and optionally padding length (see below)
             pad_to_multiple_of: (optional) Integer if set will pad the sequence to a multiple of the provided value.
                 This is especially useful to enable the use of Tensor Core on NVIDIA hardware with compute capability
                 >= 7.5 (Volta), or on TPUs which benefit from having sequence lengths be a multiple of 128.
-            truncation: (optional) Activates truncation to cut input sequences longer than `max_length` to `max_length`.
+            truncation: (optional) Activates truncation to cut input sequences longer than *max_length* to *max_length*.
         """
         if not truncation:
             return processed_features

--- a/src/transformers/feature_extraction_sequence_utils.py
+++ b/src/transformers/feature_extraction_sequence_utils.py
@@ -344,7 +344,7 @@ class SequenceFeatureExtractor(FeatureExtractionMixin):
                 if "attention_mask" in processed_features:
                     processed_features["attention_mask"] = processed_features["attention_mask"][max_length:]
             else:
-                raise ValueError("invalid truncation strategy:" + str(self.truncation_side))
+                raise ValueError(f"invalid truncation strategy: {self.truncation_side}")
 
         return processed_features
 

--- a/src/transformers/feature_extraction_sequence_utils.py
+++ b/src/transformers/feature_extraction_sequence_utils.py
@@ -339,7 +339,7 @@ class SequenceFeatureExtractor(FeatureExtractionMixin):
                     processed_features["attention_mask"] = processed_features["attention_mask"][:max_length]
             elif self.truncation_side == "left":
                 processed_features[self.model_input_names[0]] = processed_features[self.model_input_names[0]][
-                    max_length:
+                    -max_length:
                 ]
                 if "attention_mask" in processed_features:
                     processed_features["attention_mask"] = processed_features["attention_mask"][max_length:]

--- a/src/transformers/feature_extraction_sequence_utils.py
+++ b/src/transformers/feature_extraction_sequence_utils.py
@@ -342,7 +342,7 @@ class SequenceFeatureExtractor(FeatureExtractionMixin):
                     -max_length:
                 ]
                 if "attention_mask" in processed_features:
-                    processed_features["attention_mask"] = processed_features["attention_mask"][max_length:]
+                    processed_features["attention_mask"] = processed_features["attention_mask"][-max_length:]
             else:
                 raise ValueError(f"invalid truncation strategy: {self.truncation_side}")
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1469,16 +1469,16 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
 
         # Padding side is right by default and overridden in subclasses. If specified in the kwargs, it is changed.
         self.padding_side = kwargs.pop("padding_side", self.padding_side)
-        assert self.padding_side in [
-            "right",
-            "left",
-        ], f"Padding side should be selected between 'right' and 'left', current value: {self.padding_side}"
+        if self.padding_side not in ["right", "left"]:
+            raise ValueError(
+                f"Padding side should be selected between 'right' and 'left', current value: {self.padding_side}"
+            )
         # Truncation side is right by default and overridden in subclasses. If specified in the kwargs, it is changed.
         self.truncation_side = kwargs.pop("truncation_side", self.truncation_side)
-        assert self.truncation_side in [
-            "right",
-            "left",
-        ], f"Truncation side should be selected between 'right' and 'left', current value: {self.truncation_side}"
+        if self.truncation_side not in ["right", "left"]:
+            raise ValueError(
+                f"Truncation side should be selected between 'right' and 'left', current value: {self.truncation_side}"
+            )
         self.model_input_names = kwargs.pop("model_input_names", self.model_input_names)
 
         self.deprecation_warnings = (
@@ -3046,7 +3046,6 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
 
                     - 'left': truncates sequences from the left
                     - 'right': truncates sequences from the right
-
 
             stride (:obj:`int`, `optional`, defaults to 0):
 >>>>>>> First pass

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1371,39 +1371,35 @@ ENCODE_PLUS_ADDITIONAL_KWARGS_DOCSTRING = r"""
 
 INIT_TOKENIZER_DOCSTRING = r"""
     Class attributes (overridden by derived classes)
-
-        - **vocab_files_names** (*Dict[str, str]*) -- A dictionary with, as keys, the *__init__* keyword name of
+        - **vocab_files_names** (`Dict[str, str]`) -- A dictionary with, as keys, the `__init__` keyword name of
           each vocabulary file required by the model, and as associated values, the filename for saving the associated
           file (string).
-        - **pretrained_vocab_files_map** (*Dict[str, Dict[str, str]]*) -- A dictionary of dictionaries, with the
-          high-level keys being the *__init__* keyword name of each vocabulary file required by the model, the
-          low-level being the *short-cut-names* of the pretrained models with, as associated values, the
-          *url* to the associated pretrained vocabulary file.
-        - **max_model_input_sizes** (*Dict[str, Optional[int]]*) -- A dictionary with, as keys, the
-          *short-cut-names* of the pretrained models, and as associated values, the maximum length of the sequence
-          inputs of this model, or *None* if the model has no maximum input size.
-        - **pretrained_init_configuration** (*Dict[str, Dict[str, Any]]*) -- A dictionary with, as keys, the
-          *short-cut-names* of the pretrained models, and as associated values, a dictionary of specific arguments
-          to pass to the *__init__* method of the tokenizer class for this pretrained model when loading the
-          tokenizer with the [*~tokenization_utils_base.PreTrainedTokenizerBase.from_pretrained*]
+        - **pretrained_vocab_files_map** (`Dict[str, Dict[str, str]]`) -- A dictionary of dictionaries, with the
+          high-level keys being the `__init__` keyword name of each vocabulary file required by the model, the
+          low-level being the `short-cut-names` of the pretrained models with, as associated values, the
+          `url` to the associated pretrained vocabulary file.
+        - **max_model_input_sizes** (`Dict[str, Optional[int]]`) -- A dictionary with, as keys, the
+          `short-cut-names` of the pretrained models, and as associated values, the maximum length of the sequence
+          inputs of this model, or `None` if the model has no maximum input size.
+        - **pretrained_init_configuration** (`Dict[str, Dict[str, Any]]`) -- A dictionary with, as keys, the
+          `short-cut-names` of the pretrained models, and as associated values, a dictionary of specific arguments
+          to pass to the `__init__` method of the tokenizer class for this pretrained model when loading the
+          tokenizer with the [`~tokenization_utils_base.PreTrainedTokenizerBase.from_pretrained`]
           method.
         - **model_input_names** (`List[str]`) -- A list of inputs expected in the forward pass of the model.
         - **padding_side** (`str`) -- The default value for the side on which the model should have padding
           applied. Should be `'right'` or `'left'`.
-        - **truncation_side** (`str`) -- The default value for the side on which the model should truncate
-          sequences. Should be `'right'` or `'left'`.
-
     Args:
-        model_max_length (*int*, *optional*):
+        model_max_length (`int`, *optional*):
             The maximum length (in number of tokens) for the inputs to the transformer model. When the tokenizer is
-            loaded with [*~tokenization_utils_base.PreTrainedTokenizerBase.from_pretrained*], this
-            will be set to the value stored for the associated model in *max_model_input_sizes* (see above). If no
-            value is provided, will default to VERY_LARGE_INTEGER (*int(1e30)*).
-        padding_side: (*str*, *optional*):
+            loaded with [`~tokenization_utils_base.PreTrainedTokenizerBase.from_pretrained`], this
+            will be set to the value stored for the associated model in `max_model_input_sizes` (see above). If no
+            value is provided, will default to VERY_LARGE_INTEGER (`int(1e30)`).
+        padding_side: (`str`, *optional*):
             The side on which the model should have padding applied. Should be selected between ['right', 'left'].
             Default value is picked from the class attribute of the same name.
         truncation_side: (`str`, *optional*):
-            The side on which the model should truncate sequences. Should be selected between ['right', 'left'].
+            The side on which the model should have truncation applied. Should be selected between ['right', 'left'].
             Default value is picked from the class attribute of the same name.
         model_input_names (`List[string]`, *optional*):
             The list of inputs accepted by the forward pass of the model (like `"token_type_ids"` or
@@ -1419,21 +1415,21 @@ INIT_TOKENIZER_DOCSTRING = r"""
             `self.unk_token_id`.
         sep_token (`str` or `tokenizers.AddedToken`, *optional*):
             A special token separating two different sentences in the same input (used by BERT for instance). Will be
-            associated to *self.sep_token* and *self.sep_token_id*.
-        pad_token (*str* or *tokenizers.AddedToken*, *optional*):
+            associated to `self.sep_token` and `self.sep_token_id`.
+        pad_token (`str` or `tokenizers.AddedToken`, *optional*):
             A special token used to make arrays of tokens the same size for batching purpose. Will then be ignored by
-            attention mechanisms or loss computation. Will be associated to *self.pad_token* and
-            *self.pad_token_id*.
-        cls_token (*str* or *tokenizers.AddedToken*, *optional*):
+            attention mechanisms or loss computation. Will be associated to `self.pad_token` and
+            `self.pad_token_id`.
+        cls_token (`str` or `tokenizers.AddedToken`, *optional*):
             A special token representing the class of the input (used by BERT for instance). Will be associated to
-            *self.cls_token* and *self.cls_token_id*.
-        mask_token (*str* or *tokenizers.AddedToken*, *optional*):
+            `self.cls_token` and `self.cls_token_id`.
+        mask_token (`str` or `tokenizers.AddedToken`, *optional*):
             A special token representing a masked token (used by masked-language modeling pretraining objectives, like
-            BERT). Will be associated to *self.mask_token* and *self.mask_token_id*.
-        additional_special_tokens (tuple or list of *str* or *tokenizers.AddedToken*, *optional*):
+            BERT). Will be associated to `self.mask_token` and `self.mask_token_id`.
+        additional_special_tokens (tuple or list of `str` or `tokenizers.AddedToken`, *optional*):
             A tuple or a list of additional special tokens. Add them here to ensure they won't be split by the
-            tokenization process. Will be associated to *self.additional_special_tokens* and
-            *self.additional_special_tokens_ids*.
+            tokenization process. Will be associated to `self.additional_special_tokens` and
+            `self.additional_special_tokens_ids`.
 """
 
 
@@ -3012,50 +3008,37 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         stride: int = 0,
     ) -> Tuple[List[int], List[int], List[int]]:
         """
-                Truncates a sequence pair in-place following the strategy.
-
-                Args:
-                    ids (*List[int]*):
-                        Tokenized input ids of the first sequence. Can be obtained from a string by chaining the *tokenize*
-                        and *convert_tokens_to_ids* methods.
-                    pair_ids (*List[int]*, *optional*):
-                        Tokenized input ids of the second sequence. Can be obtained from a string by chaining the *tokenize*
-                        and *convert_tokens_to_ids* methods.
-                    num_tokens_to_remove (*int*, *optional*, defaults to 0):
-                        Number of tokens to remove using the truncation strategy.
-                    truncation_strategy (*str* or [*~tokenization_utils_base.TruncationStrategy*], *optional*, defaults to *False*):
-                        The strategy to follow for truncation. Can be:
-
-                        - *'longest_first'*: Truncate to a maximum length specified with the argument *max_length* or
-                          to the maximum acceptable input length for the model if that argument is not provided. This will
-                          truncate token by token, removing a token from the longest sequence in the pair if a pair of
-                          sequences (or a batch of pairs) is provided.
-                        - *'only_first'*: Truncate to a maximum length specified with the argument *max_length* or to
-                          the maximum acceptable input length for the model if that argument is not provided. This will only
-                          truncate the first sequence of a pair if a pair of sequences (or a batch of pairs) is provided.
-                        - *'only_second'*: Truncate to a maximum length specified with the argument *max_length* or
-                          to the maximum acceptable input length for the model if that argument is not provided. This will only
-                          truncate the second sequence of a pair if a pair of sequences (or a batch of pairs) is provided.
-                        - *'do_not_truncate'* (default): No truncation (i.e., can output batch with sequence lengths
-                          greater than the model maximum admissible input size).
-                <<<<<<< HEAD
-                            stride (*int*, *optional*, defaults to 0):
-                =======
-
-                                The tokenizer truncation sides are defined in self.truncation_side:
-
-                                    - 'left': truncates sequences from the left
-                                    - 'right': truncates sequences from the right
-
-                            stride (`int`, *optional*, defaults to 0):
-                >>>>>>> First pass
-                                If set to a positive number, the overflowing tokens returned will contain some tokens from the main
-                                sequence returned. The value of this argument defines the number of additional tokens.
-
-                        Returns:
-                            *Tuple[List[int], List[int], List[int]]*: The truncated *ids*, the truncated *pair_ids* and the
-                            list of overflowing tokens. Note: The *longest_first* strategy returns empty list of overflowing tokens if
-                            a pair of sequences (or a batch of pairs) is provided.
+        Truncates a sequence pair in-place following the strategy.
+        Args:
+            ids (`List[int]`):
+                Tokenized input ids of the first sequence. Can be obtained from a string by chaining the `tokenize`
+                and `convert_tokens_to_ids` methods.
+            pair_ids (`List[int]`, *optional*):
+                Tokenized input ids of the second sequence. Can be obtained from a string by chaining the `tokenize`
+                and `convert_tokens_to_ids` methods.
+            num_tokens_to_remove (`int`, *optional*, defaults to 0):
+                Number of tokens to remove using the truncation strategy.
+            truncation_strategy (`str` or [`~tokenization_utils_base.TruncationStrategy`], *optional*, defaults to `False`):
+                The strategy to follow for truncation. Can be:
+                - `'longest_first'`: Truncate to a maximum length specified with the argument `max_length` or
+                  to the maximum acceptable input length for the model if that argument is not provided. This will
+                  truncate token by token, removing a token from the longest sequence in the pair if a pair of
+                  sequences (or a batch of pairs) is provided.
+                - `'only_first'`: Truncate to a maximum length specified with the argument `max_length` or to
+                  the maximum acceptable input length for the model if that argument is not provided. This will only
+                  truncate the first sequence of a pair if a pair of sequences (or a batch of pairs) is provided.
+                - `'only_second'`: Truncate to a maximum length specified with the argument `max_length` or
+                  to the maximum acceptable input length for the model if that argument is not provided. This will only
+                  truncate the second sequence of a pair if a pair of sequences (or a batch of pairs) is provided.
+                - `'do_not_truncate'` (default): No truncation (i.e., can output batch with sequence lengths
+                  greater than the model maximum admissible input size).
+            stride (`int`, *optional*, defaults to 0):
+                If set to a positive number, the overflowing tokens returned will contain some tokens from the main
+                sequence returned. The value of this argument defines the number of additional tokens.
+        Returns:
+            `Tuple[List[int], List[int], List[int]]`: The truncated `ids`, the truncated `pair_ids` and the
+            list of overflowing tokens. Note: The *longest_first* strategy returns empty list of overflowing tokens if
+            a pair of sequences (or a batch of pairs) is provided.
         """
         if num_tokens_to_remove <= 0:
             return ids, pair_ids, []
@@ -3064,36 +3047,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             truncation_strategy = TruncationStrategy(truncation_strategy)
 
         overflowing_tokens = []
-        if truncation_strategy == TruncationStrategy.LONGEST_FIRST:
-            for _ in range(num_tokens_to_remove):
-                if pair_ids is None or len(ids) > len(pair_ids):
-                    if not overflowing_tokens:
-                        window_len = min(len(ids), stride + 1)
-                    else:
-                        window_len = 1
-                    if self.truncation_side == "right":
-                        overflowing_tokens.extend(ids[-window_len:])
-                        ids = ids[:-1]
-                    elif self.truncation_side == "left":
-                        overflowing_tokens.extend(ids[:window_len])
-                        ids = ids[1:]
-                    else:
-                        raise ValueError("invalid truncation strategy:" + str(self.truncation_side))
-                else:
-                    if not overflowing_tokens:
-                        window_len = min(len(pair_ids), stride + 1)
-                    else:
-                        window_len = 1
-                    if self.truncation_side == "right":
-                        overflowing_tokens.extend(pair_ids[-window_len:])
-                        pair_ids = pair_ids[:-1]
-                    elif self.truncation_side == "left":
-                        overflowing_tokens.extend(pair_ids[:window_len])
-                        pair_ids = pair_ids[1:]
-                    else:
-                        raise ValueError("invalid truncation strategy:" + str(self.truncation_side))
-
-        elif truncation_strategy == TruncationStrategy.ONLY_FIRST:
+        if truncation_strategy == TruncationStrategy.ONLY_FIRST or (
+            truncation_strategy == TruncationStrategy.LONGEST_FIRST and pair_ids is None
+        ):
             if len(ids) > num_tokens_to_remove:
                 window_len = min(len(ids), stride + num_tokens_to_remove)
                 if self.truncation_side == "right":
@@ -3124,9 +3080,19 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             )
             for _ in range(num_tokens_to_remove):
                 if pair_ids is None or len(ids) > len(pair_ids):
-                    ids = ids[:-1]
+                    if self.truncation_side == "right":
+                        ids = ids[:-1]
+                    elif self.truncation_side == "left":
+                        ids = ids[1:]
+                    else:
+                        raise ValueError("invalid truncation strategy:" + str(self.truncation_side))
                 else:
-                    pair_ids = pair_ids[:-1]
+                    if self.truncation_side == "right":
+                        pair_ids = pair_ids[:-1]
+                    elif self.truncation_side == "left":
+                        pair_ids = pair_ids[1:]
+                    else:
+                        raise ValueError("invalid truncation strategy:" + str(self.truncation_side))
         elif truncation_strategy == TruncationStrategy.ONLY_SECOND and pair_ids is not None:
             if len(pair_ids) > num_tokens_to_remove:
                 window_len = min(len(pair_ids), stride + num_tokens_to_remove)

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1372,68 +1372,68 @@ ENCODE_PLUS_ADDITIONAL_KWARGS_DOCSTRING = r"""
 INIT_TOKENIZER_DOCSTRING = r"""
     Class attributes (overridden by derived classes)
 
-        - **vocab_files_names** (`Dict[str, str]`) -- A dictionary with, as keys, the `__init__` keyword name of
+        - **vocab_files_names** (*Dict[str, str]*) -- A dictionary with, as keys, the *__init__* keyword name of
           each vocabulary file required by the model, and as associated values, the filename for saving the associated
           file (string).
-        - **pretrained_vocab_files_map** (`Dict[str, Dict[str, str]]`) -- A dictionary of dictionaries, with the
-          high-level keys being the `__init__` keyword name of each vocabulary file required by the model, the
-          low-level being the `short-cut-names` of the pretrained models with, as associated values, the
-          `url` to the associated pretrained vocabulary file.
-        - **max_model_input_sizes** (`Dict[str, Optional[int]]`) -- A dictionary with, as keys, the
-          `short-cut-names` of the pretrained models, and as associated values, the maximum length of the sequence
-          inputs of this model, or `None` if the model has no maximum input size.
-        - **pretrained_init_configuration** (`Dict[str, Dict[str, Any]]`) -- A dictionary with, as keys, the
-          `short-cut-names` of the pretrained models, and as associated values, a dictionary of specific arguments
-          to pass to the `__init__` method of the tokenizer class for this pretrained model when loading the
-          tokenizer with the [`~tokenization_utils_base.PreTrainedTokenizerBase.from_pretrained`]
+        - **pretrained_vocab_files_map** (*Dict[str, Dict[str, str]]*) -- A dictionary of dictionaries, with the
+          high-level keys being the *__init__* keyword name of each vocabulary file required by the model, the
+          low-level being the *short-cut-names* of the pretrained models with, as associated values, the
+          *url* to the associated pretrained vocabulary file.
+        - **max_model_input_sizes** (*Dict[str, Optional[int]]*) -- A dictionary with, as keys, the
+          *short-cut-names* of the pretrained models, and as associated values, the maximum length of the sequence
+          inputs of this model, or *None* if the model has no maximum input size.
+        - **pretrained_init_configuration** (*Dict[str, Dict[str, Any]]*) -- A dictionary with, as keys, the
+          *short-cut-names* of the pretrained models, and as associated values, a dictionary of specific arguments
+          to pass to the *__init__* method of the tokenizer class for this pretrained model when loading the
+          tokenizer with the [*~tokenization_utils_base.PreTrainedTokenizerBase.from_pretrained*]
           method.
-        - **model_input_names** (:obj:`List[str]`) -- A list of inputs expected in the forward pass of the model.
-        - **padding_side** (:obj:`str`) -- The default value for the side on which the model should have padding
-          applied. Should be :obj:`'right'` or :obj:`'left'`.
-        - **truncation_side** (:obj:`str`) -- The default value for the side on which the model should truncate
-          sequences. Should be :obj:`'right'` or :obj:`'left'`.
+        - **model_input_names** (`List[str]`) -- A list of inputs expected in the forward pass of the model.
+        - **padding_side** (`str`) -- The default value for the side on which the model should have padding
+          applied. Should be `'right'` or `'left'`.
+        - **truncation_side** (`str`) -- The default value for the side on which the model should truncate
+          sequences. Should be `'right'` or `'left'`.
 
     Args:
-        model_max_length (`int`, *optional*):
+        model_max_length (*int*, *optional*):
             The maximum length (in number of tokens) for the inputs to the transformer model. When the tokenizer is
-            loaded with [`~tokenization_utils_base.PreTrainedTokenizerBase.from_pretrained`], this
-            will be set to the value stored for the associated model in `max_model_input_sizes` (see above). If no
-            value is provided, will default to VERY_LARGE_INTEGER (`int(1e30)`).
-        padding_side: (`str`, *optional*):
+            loaded with [*~tokenization_utils_base.PreTrainedTokenizerBase.from_pretrained*], this
+            will be set to the value stored for the associated model in *max_model_input_sizes* (see above). If no
+            value is provided, will default to VERY_LARGE_INTEGER (*int(1e30)*).
+        padding_side: (*str*, *optional*):
             The side on which the model should have padding applied. Should be selected between ['right', 'left'].
             Default value is picked from the class attribute of the same name.
-        truncation_side: (:obj:`str`, `optional`):
+        truncation_side: (`str`, *optional*):
             The side on which the model should truncate sequences. Should be selected between ['right', 'left'].
             Default value is picked from the class attribute of the same name.
-        model_input_names (:obj:`List[string]`, `optional`):
-            The list of inputs accepted by the forward pass of the model (like :obj:`"token_type_ids"` or
-            :obj:`"attention_mask"`). Default value is picked from the class attribute of the same name.
-        bos_token (:obj:`str` or :obj:`tokenizers.AddedToken`, `optional`):
-            A special token representing the beginning of a sentence. Will be associated to ``self.bos_token`` and
-            ``self.bos_token_id``.
-        eos_token (:obj:`str` or :obj:`tokenizers.AddedToken`, `optional`):
-            A special token representing the end of a sentence. Will be associated to ``self.eos_token`` and
-            ``self.eos_token_id``.
-        unk_token (:obj:`str` or :obj:`tokenizers.AddedToken`, `optional`):
-            A special token representing an out-of-vocabulary token. Will be associated to ``self.unk_token`` and
-            ``self.unk_token_id``.
-        sep_token (:obj:`str` or :obj:`tokenizers.AddedToken`, `optional`):
+        model_input_names (`List[string]`, *optional*):
+            The list of inputs accepted by the forward pass of the model (like `"token_type_ids"` or
+            `"attention_mask"`). Default value is picked from the class attribute of the same name.
+        bos_token (`str` or `tokenizers.AddedToken`, *optional*):
+            A special token representing the beginning of a sentence. Will be associated to `self.bos_token` and
+            `self.bos_token_id`.
+        eos_token (`str` or `tokenizers.AddedToken`, *optional*):
+            A special token representing the end of a sentence. Will be associated to `self.eos_token` and
+            `self.eos_token_id`.
+        unk_token (`str` or `tokenizers.AddedToken`, *optional*):
+            A special token representing an out-of-vocabulary token. Will be associated to `self.unk_token` and
+            `self.unk_token_id`.
+        sep_token (`str` or `tokenizers.AddedToken`, *optional*):
             A special token separating two different sentences in the same input (used by BERT for instance). Will be
-            associated to `self.sep_token` and `self.sep_token_id`.
-        pad_token (`str` or `tokenizers.AddedToken`, *optional*):
+            associated to *self.sep_token* and *self.sep_token_id*.
+        pad_token (*str* or *tokenizers.AddedToken*, *optional*):
             A special token used to make arrays of tokens the same size for batching purpose. Will then be ignored by
-            attention mechanisms or loss computation. Will be associated to `self.pad_token` and
-            `self.pad_token_id`.
-        cls_token (`str` or `tokenizers.AddedToken`, *optional*):
+            attention mechanisms or loss computation. Will be associated to *self.pad_token* and
+            *self.pad_token_id*.
+        cls_token (*str* or *tokenizers.AddedToken*, *optional*):
             A special token representing the class of the input (used by BERT for instance). Will be associated to
-            `self.cls_token` and `self.cls_token_id`.
-        mask_token (`str` or `tokenizers.AddedToken`, *optional*):
+            *self.cls_token* and *self.cls_token_id*.
+        mask_token (*str* or *tokenizers.AddedToken*, *optional*):
             A special token representing a masked token (used by masked-language modeling pretraining objectives, like
-            BERT). Will be associated to `self.mask_token` and `self.mask_token_id`.
-        additional_special_tokens (tuple or list of `str` or `tokenizers.AddedToken`, *optional*):
+            BERT). Will be associated to *self.mask_token* and *self.mask_token_id*.
+        additional_special_tokens (tuple or list of *str* or *tokenizers.AddedToken*, *optional*):
             A tuple or a list of additional special tokens. Add them here to ensure they won't be split by the
-            tokenization process. Will be associated to `self.additional_special_tokens` and
-            `self.additional_special_tokens_ids`.
+            tokenization process. Will be associated to *self.additional_special_tokens* and
+            *self.additional_special_tokens_ids*.
 """
 
 
@@ -3012,50 +3012,50 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         stride: int = 0,
     ) -> Tuple[List[int], List[int], List[int]]:
         """
-        Truncates a sequence pair in-place following the strategy.
+                Truncates a sequence pair in-place following the strategy.
 
-        Args:
-            ids (`List[int]`):
-                Tokenized input ids of the first sequence. Can be obtained from a string by chaining the `tokenize`
-                and `convert_tokens_to_ids` methods.
-            pair_ids (`List[int]`, *optional*):
-                Tokenized input ids of the second sequence. Can be obtained from a string by chaining the `tokenize`
-                and `convert_tokens_to_ids` methods.
-            num_tokens_to_remove (`int`, *optional*, defaults to 0):
-                Number of tokens to remove using the truncation strategy.
-            truncation_strategy (`str` or [`~tokenization_utils_base.TruncationStrategy`], *optional*, defaults to `False`):
-                The strategy to follow for truncation. Can be:
+                Args:
+                    ids (*List[int]*):
+                        Tokenized input ids of the first sequence. Can be obtained from a string by chaining the *tokenize*
+                        and *convert_tokens_to_ids* methods.
+                    pair_ids (*List[int]*, *optional*):
+                        Tokenized input ids of the second sequence. Can be obtained from a string by chaining the *tokenize*
+                        and *convert_tokens_to_ids* methods.
+                    num_tokens_to_remove (*int*, *optional*, defaults to 0):
+                        Number of tokens to remove using the truncation strategy.
+                    truncation_strategy (*str* or [*~tokenization_utils_base.TruncationStrategy*], *optional*, defaults to *False*):
+                        The strategy to follow for truncation. Can be:
 
-                - `'longest_first'`: Truncate to a maximum length specified with the argument `max_length` or
-                  to the maximum acceptable input length for the model if that argument is not provided. This will
-                  truncate token by token, removing a token from the longest sequence in the pair if a pair of
-                  sequences (or a batch of pairs) is provided.
-                - `'only_first'`: Truncate to a maximum length specified with the argument `max_length` or to
-                  the maximum acceptable input length for the model if that argument is not provided. This will only
-                  truncate the first sequence of a pair if a pair of sequences (or a batch of pairs) is provided.
-                - `'only_second'`: Truncate to a maximum length specified with the argument `max_length` or
-                  to the maximum acceptable input length for the model if that argument is not provided. This will only
-                  truncate the second sequence of a pair if a pair of sequences (or a batch of pairs) is provided.
-                - `'do_not_truncate'` (default): No truncation (i.e., can output batch with sequence lengths
-                  greater than the model maximum admissible input size).
-<<<<<<< HEAD
-            stride (`int`, *optional*, defaults to 0):
-=======
+                        - *'longest_first'*: Truncate to a maximum length specified with the argument *max_length* or
+                          to the maximum acceptable input length for the model if that argument is not provided. This will
+                          truncate token by token, removing a token from the longest sequence in the pair if a pair of
+                          sequences (or a batch of pairs) is provided.
+                        - *'only_first'*: Truncate to a maximum length specified with the argument *max_length* or to
+                          the maximum acceptable input length for the model if that argument is not provided. This will only
+                          truncate the first sequence of a pair if a pair of sequences (or a batch of pairs) is provided.
+                        - *'only_second'*: Truncate to a maximum length specified with the argument *max_length* or
+                          to the maximum acceptable input length for the model if that argument is not provided. This will only
+                          truncate the second sequence of a pair if a pair of sequences (or a batch of pairs) is provided.
+                        - *'do_not_truncate'* (default): No truncation (i.e., can output batch with sequence lengths
+                          greater than the model maximum admissible input size).
+                <<<<<<< HEAD
+                            stride (*int*, *optional*, defaults to 0):
+                =======
 
-                The tokenizer truncation sides are defined in self.truncation_side:
+                                The tokenizer truncation sides are defined in self.truncation_side:
 
-                    - 'left': truncates sequences from the left
-                    - 'right': truncates sequences from the right
+                                    - 'left': truncates sequences from the left
+                                    - 'right': truncates sequences from the right
 
-            stride (:obj:`int`, `optional`, defaults to 0):
->>>>>>> First pass
-                If set to a positive number, the overflowing tokens returned will contain some tokens from the main
-                sequence returned. The value of this argument defines the number of additional tokens.
+                            stride (`int`, *optional*, defaults to 0):
+                >>>>>>> First pass
+                                If set to a positive number, the overflowing tokens returned will contain some tokens from the main
+                                sequence returned. The value of this argument defines the number of additional tokens.
 
-        Returns:
-            `Tuple[List[int], List[int], List[int]]`: The truncated `ids`, the truncated `pair_ids` and the
-            list of overflowing tokens. Note: The *longest_first* strategy returns empty list of overflowing tokens if
-            a pair of sequences (or a batch of pairs) is provided.
+                        Returns:
+                            *Tuple[List[int], List[int], List[int]]*: The truncated *ids*, the truncated *pair_ids* and the
+                            list of overflowing tokens. Note: The *longest_first* strategy returns empty list of overflowing tokens if
+                            a pair of sequences (or a batch of pairs) is provided.
         """
         if num_tokens_to_remove <= 0:
             return ids, pair_ids, []

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1371,6 +1371,7 @@ ENCODE_PLUS_ADDITIONAL_KWARGS_DOCSTRING = r"""
 
 INIT_TOKENIZER_DOCSTRING = r"""
     Class attributes (overridden by derived classes)
+
         - **vocab_files_names** (`Dict[str, str]`) -- A dictionary with, as keys, the `__init__` keyword name of
           each vocabulary file required by the model, and as associated values, the filename for saving the associated
           file (string).
@@ -1389,6 +1390,7 @@ INIT_TOKENIZER_DOCSTRING = r"""
         - **model_input_names** (`List[str]`) -- A list of inputs expected in the forward pass of the model.
         - **padding_side** (`str`) -- The default value for the side on which the model should have padding
           applied. Should be `'right'` or `'left'`.
+
     Args:
         model_max_length (`int`, *optional*):
             The maximum length (in number of tokens) for the inputs to the transformer model. When the tokenizer is
@@ -3009,6 +3011,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
     ) -> Tuple[List[int], List[int], List[int]]:
         """
         Truncates a sequence pair in-place following the strategy.
+
         Args:
             ids (`List[int]`):
                 Tokenized input ids of the first sequence. Can be obtained from a string by chaining the `tokenize`
@@ -3020,6 +3023,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 Number of tokens to remove using the truncation strategy.
             truncation_strategy (`str` or [`~tokenization_utils_base.TruncationStrategy`], *optional*, defaults to `False`):
                 The strategy to follow for truncation. Can be:
+
                 - `'longest_first'`: Truncate to a maximum length specified with the argument `max_length` or
                   to the maximum acceptable input length for the model if that argument is not provided. This will
                   truncate token by token, removing a token from the longest sequence in the pair if a pair of
@@ -3035,6 +3039,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             stride (`int`, *optional*, defaults to 0):
                 If set to a positive number, the overflowing tokens returned will contain some tokens from the main
                 sequence returned. The value of this argument defines the number of additional tokens.
+
         Returns:
             `Tuple[List[int], List[int], List[int]]`: The truncated `ids`, the truncated `pair_ids` and the
             list of overflowing tokens. Note: The *longest_first* strategy returns empty list of overflowing tokens if

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -352,7 +352,12 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
             if _truncation is not None:
                 self._tokenizer.no_truncation()
         else:
-            target = {"max_length": max_length, "stride": stride, "strategy": truncation_strategy.value}
+            target = {
+                "max_length": max_length,
+                "stride": stride,
+                "strategy": truncation_strategy.value,
+                "direction": self.truncation_side,
+            }
             if _truncation != target:
                 self._tokenizer.enable_truncation(**target)
 

--- a/tests/test_tokenization_auto.py
+++ b/tests/test_tokenization_auto.py
@@ -209,6 +209,7 @@ class AutoTokenizerTest(unittest.TestCase):
         self.assertEqual(tokenizer.vocab_size, 30000)
         self.assertEqual(tokenizer.unk_token, "[UNK]")
         self.assertEqual(tokenizer.padding_side, "right")
+        self.assertEqual(tokenizer.truncation_side, "right")
 
     def test_auto_tokenizer_from_local_folder(self):
         tokenizer = AutoTokenizer.from_pretrained(SMALL_MODEL_IDENTIFIER)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1585,6 +1585,29 @@ class TokenizerTesterMixin:
                     assert attention_mask + [0] * padding_size == right_padded_attention_mask
                     assert [0] * padding_size + attention_mask == left_padded_attention_mask
 
+    def test_right_and_left_truncation(self):
+        tokenizers = self.get_tokenizers(do_lower_case=False)
+        for tokenizer in tokenizers:
+            with self.subTest(f"{tokenizer.__class__.__name__}"):
+                sequence = "I wanted to go running"
+                max_length = 5
+
+                # LEFT TRUNCATION
+                tokenizer.truncation_side = "left"
+                truncated_sequence_left = tokenizer.encode(
+                    sequence,
+                    max_length=max_length,
+                    truncation=True,
+                )
+                truncated_sequence_left_length = len(truncated_sequence_left)
+                assert max_length == truncated_sequence_left_length
+
+                # RIGHT TRUNCATION
+                tokenizer.truncation_side = "right"
+                truncated_sequence_right = tokenizer.encode(sequence, max_length=max_length, truncation=True)
+                truncated_sequence_right_length = len(truncated_sequence_right)
+                assert max_length == truncated_sequence_right_length
+
     def test_separate_tokenizers(self):
         # This tests that tokenizers don't impact others. Unfortunately the case where it fails is when
         # we're loading an S3 configuration from a pre-trained identifier, and we have no way of testing those today.

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1600,13 +1600,13 @@ class TokenizerTesterMixin:
                     truncation=True,
                 )
                 truncated_sequence_left_length = len(truncated_sequence_left)
-                assert max_length == truncated_sequence_left_length
+                self.assertEqual(max_length, truncated_sequence_left_length)
 
                 # RIGHT TRUNCATION
                 tokenizer.truncation_side = "right"
                 truncated_sequence_right = tokenizer.encode(sequence, max_length=max_length, truncation=True)
                 truncated_sequence_right_length = len(truncated_sequence_right)
-                assert max_length == truncated_sequence_right_length
+                self.assertEqual(max_length, truncated_sequence_right_length)
 
     def test_separate_tokenizers(self):
         # This tests that tokenizers don't impact others. Unfortunately the case where it fails is when

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1589,24 +1589,44 @@ class TokenizerTesterMixin:
         tokenizers = self.get_tokenizers(do_lower_case=False)
         for tokenizer in tokenizers:
             with self.subTest(f"{tokenizer.__class__.__name__}"):
-                sequence = "I wanted to go running"
+                sequence = "I wanted to go running, swimming and singing."
                 max_length = 5
+
+                tokenize_sequence = tokenizer(sequence, add_special_tokens=False)
 
                 # LEFT TRUNCATION
                 tokenizer.truncation_side = "left"
-                truncated_sequence_left = tokenizer.encode(
+                truncated_sequence_left_without_special_tokens = tokenizer(
+                    sequence, max_length=max_length, truncation=True, add_special_tokens=False
+                )
+                truncated_sequence_left_with_special_tokens = tokenizer(
                     sequence,
                     max_length=max_length,
                     truncation=True,
                 )
-                truncated_sequence_left_length = len(truncated_sequence_left)
-                self.assertEqual(max_length, truncated_sequence_left_length)
+
+                for key in tokenize_sequence.keys():
+                    self.assertEqual(max_length, len(truncated_sequence_left_with_special_tokens[key]))
+                    self.assertListEqual(
+                        tokenize_sequence[key][-max_length:], truncated_sequence_left_without_special_tokens[key]
+                    )
 
                 # RIGHT TRUNCATION
                 tokenizer.truncation_side = "right"
-                truncated_sequence_right = tokenizer.encode(sequence, max_length=max_length, truncation=True)
-                truncated_sequence_right_length = len(truncated_sequence_right)
-                self.assertEqual(max_length, truncated_sequence_right_length)
+                truncated_sequence_right_without_special_tokens = tokenizer(
+                    sequence, max_length=max_length, truncation=True, add_special_tokens=False
+                )
+                truncated_sequence_right_with_special_tokens = tokenizer(
+                    sequence,
+                    max_length=max_length,
+                    truncation=True,
+                )
+
+                for key in tokenize_sequence.keys():
+                    self.assertEqual(max_length, len(truncated_sequence_right_with_special_tokens[key]))
+                    self.assertListEqual(
+                        tokenize_sequence[key][:max_length], truncated_sequence_right_without_special_tokens[key]
+                    )
 
     def test_separate_tokenizers(self):
         # This tests that tokenizers don't impact others. Unfortunately the case where it fails is when

--- a/tests/test_tokenization_tapas.py
+++ b/tests/test_tokenization_tapas.py
@@ -820,6 +820,12 @@ class TapasTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                     for key, value in normal_tokens.items():
                         self.assertEqual(len(value) % 8, 0, f"BatchEncoding.{key} is not multiple of 8")
 
+    @unittest.skip(
+        "TAPAS tokenizer only supports 2 truncation strategies, namely 'drop_rows_to_fit' and 'do_not_truncate'."
+    )
+    def test_right_and_left_truncation(self):
+        pass
+
     @unittest.skip("TAPAS cannot handle `prepare_for_model` without passing by `encode_plus` or `batch_encode_plus`")
     def test_prepare_for_model(self):
         pass


### PR DESCRIPTION
# What does this PR do?

As requested by #12909, it would be handy if one could also decide on whether to truncate sequences from the left instead of from the right. 

As we already have a `padding_side` (which can be either left/right), it makes sense to also add a `truncation_side` (which by default is set to `"right"`, but users can initialize a tokenizer with `truncation_side` set to `"left"`).

The test could possibly be improved (for which I'd like to get some help).

Also requesting review from @patrickvonplaten since I've also added the option in `feature_extraction_sequence_utils.py`. 

Regarding the fast tokenizers, I see `padding_side` is used [here](https://github.com/huggingface/transformers/blob/12e02e339f6d19218b36a30883188ea0254bc7e7/src/transformers/tokenization_utils_fast.py#L362). Should I define something similar for `truncation_side`?

Fixes #12909 