### PR TITLE
Print defaults when using --help for scripts

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -16,7 +16,7 @@ import dataclasses
 import json
 import re
 import sys
-from argparse import ArgumentParser, ArgumentTypeError
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, ArgumentTypeError
 from enum import Enum
 from pathlib import Path
 from typing import Any, Iterable, List, NewType, Optional, Tuple, Union
@@ -59,6 +59,9 @@ class HfArgumentParser(ArgumentParser):
             kwargs:
                 (Optional) Passed to `argparse.ArgumentParser()` in the regular way.
         """
+        # To make the default appear when using --help
+        if "formatter_class" not in kwargs:
+            kwargs["formatter_class"] = ArgumentDefaultsHelpFormatter
         super().__init__(**kwargs)
         if dataclasses.is_dataclass(dataclass_types):
             dataclass_types = [dataclass_types]


### PR DESCRIPTION
# What does this PR do?

This PR uses the solution suggested in #12924 to automatically print the defaults of each argument when using `--help` for the script for instance, using `--help` on any of the examples would yield:
```
  --push_to_hub [PUSH_TO_HUB]
                        Whether or not to upload the trained model to the
                        model hub after training.
```
before, and after this PR it will yield
```
  --push_to_hub [PUSH_TO_HUB]
                        Whether or not to upload the trained model to the
                        model hub after training. (default: False)
```

Fixes #12924 