### PR TITLE
Add substep end callback method

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1334,6 +1334,8 @@ class Trainer:
                     self.control = self.callback_handler.on_step_end(args, self.state, self.control)
 
                     self._maybe_log_save_evaluate(tr_loss, model, trial, epoch, ignore_keys_for_eval)
+                else:
+                    self.control = self.callback_handler.on_substep_end(args, self.state, self.control)
 
                 if self.control.should_epoch_stop or self.control.should_training_stop:
                     break

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -242,6 +242,12 @@ class TrainerCallback:
         """
         pass
 
+    def on_substep_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
+        """
+        Event called at the end of an substep during gradient accumulation.
+        """
+        pass
+
     def on_step_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
         """
         Event called at the end of a training step. If using gradient accumulation, one training step might take
@@ -354,6 +360,9 @@ class CallbackHandler(TrainerCallback):
         control.should_evaluate = False
         control.should_save = False
         return self.call_event("on_step_begin", args, state, control)
+
+    def on_substep_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
+        return self.call_event("on_substep_end", args, state, control)
 
     def on_step_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
         return self.call_event("on_step_end", args, state, control)


### PR DESCRIPTION
As discussed in #12920 with @sgugger, a callback method after a gradient accumulation step is needed for some training techniques such as differentially private training with Opacus (see [Opacus - Docs: virtual_step](https://opacus.ai/api/privacy_engine.html?highlight=virtual_step#opacus.privacy_engine.PrivacyEngine.virtual_step)).

This PR extends `TrainerCallback` and `CallbackHandler` with a method `on_substep_end` which ought to be called during gradient accumulation after a training step is taken (i.e. loss and gradients computed) but no model parameters are updated.


