### PR TITLE
Prevent `Trainer.evaluate()` crash when using only tensorboardX

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -401,6 +401,7 @@ class TensorBoardCallback(TrainerCallback):
     def on_train_end(self, args, state, control, **kwargs):
         if self.tb_writer:
             self.tb_writer.close()
+            self.tb_writer = None
 
 
 class WandbCallback(TrainerCallback):


### PR DESCRIPTION
# What does this PR do?

Fixes #12962

I did not write any tests because it seems like the logging integration callbacks have absolutely no testing at all, and I'm not creating a whole set of tests for a one-line fix.

## Who can review?

trainer: @sgugger
