### PR TITLE
Add tokenizer method to convert ids to tokens

### DIFF
--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -393,6 +393,24 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
             ids.append(self._convert_token_to_id_with_added_voc(token))
         return ids
 
+    def convert_ids_to_tokens(self, ids: Union[int, List[int]]) -> Union[str, List[str]]:
+        """
+        Converts an integer id (or sequence of ids) to a token string (or sequence of tokens), using the vocabulary.
+
+        Args:
+            ids (:obj: `id` or :obj:`List[int]`): One or several ids to convert to token(s).
+
+        Returns:
+            :obj:`str` or :obj:`List[str]`: The token string or list of tokens.
+        """
+        if ids is None:
+            return None
+        if not hasattr(self, 'tokens_decoder'):
+            self.tokens_decoder = dict(map(reversed, self.added_tokens_encoder.items()))
+        if isinstance(ids, str):
+            return self.tokens_decoder[ids]
+        return [self.tokens_decoder[id] for id in ids]
+
     def _convert_token_to_id_with_added_voc(self, token):
         if token is None:
             return None

--- a/tests/test_tokenization_utils.py
+++ b/tests/test_tokenization_utils.py
@@ -34,6 +34,7 @@ from transformers import (
     TensorType,
     TokenSpan,
     is_tokenizers_available,
+    T5Tokenizer,
 )
 from transformers.models.gpt2.tokenization_gpt2 import GPT2Tokenizer
 from transformers.testing_utils import CaptureStderr, require_flax, require_tf, require_tokenizers, require_torch, slow
@@ -285,3 +286,11 @@ class TokenizerUtilsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdirname:
             bert_tokenizer.save(os.path.join(tmpdirname, "tokenizer.json"))
             PreTrainedTokenizerFast(tokenizer_file=os.path.join(tmpdirname, "tokenizer.json"))
+
+    @require_tokenizers
+    def test_convert_ids_to_tokens(self):
+    tokenizer = T5Tokenizer.from_pretrained("t5-small")
+    input_ids = tokenizer('The <extra_id_0> walks in <extra_id_1> park', return_tensors='pt').input_ids
+    tokens_estimate = tokenizer.convert_ids_to_tokens(input_ids[0].numpy().tolist())
+    tokens_truth = ['▁The', '<extra_id_0>', '▁walks', '▁in', '<extra_id_1>', '▁park', '</s>']
+    self.assertEqual(tokens_estimate, tokens_truth)


### PR DESCRIPTION
Adds basic functionality to convert model output to a human-interpretable format for applications such as grammar checking with the T5 CoLA task. @thomwolf 

Fixes #12967 