### PR TITLE
pad_to_multiple_of added to DataCollatorForWholeWordMask

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -418,7 +418,7 @@ class DataCollatorForWholeWordMask(DataCollatorForLanguageModeling):
             input_ids = examples
             examples = [{"input_ids": e} for e in examples]
 
-        batch_input = _collate_batch(input_ids, self.tokenizer)
+        batch_input = _collate_batch(input_ids, self.tokenizer, pad_to_multiple_of=self.pad_to_multiple_of)
 
         mask_labels = []
         for e in examples:

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -435,7 +435,7 @@ class DataCollatorForWholeWordMask(DataCollatorForLanguageModeling):
                     if i in ref_pos:
                         ref_tokens[i] = "##" + ref_tokens[i]
             mask_labels.append(self._whole_word_mask(ref_tokens))
-        batch_mask = _collate_batch(mask_labels, self.tokenizer)
+        batch_mask = _collate_batch(mask_labels, self.tokenizer, pad_to_multiple_of=self.pad_to_multiple_of)
         inputs, labels = self.mask_tokens(batch_input, batch_mask)
         return {"input_ids": inputs, "labels": labels}
 


### PR DESCRIPTION
There is a small bug in `DataCollatorForWholeWordMask`: it has an argument `pad_to_multiple_of`, however, when doing `_collate_batch` inside `__call__` method, this argument is not provided. This commit adds the usage of the argument.