### PR TITLE
Update generate method - Fix floor_divide warning

### DIFF
--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -1835,7 +1835,7 @@ class GenerationMixin:
                 next_token_scores, 2 * num_beams, dim=1, largest=True, sorted=True
             )
 
-            next_indices = next_tokens // vocab_size
+            next_indices = (next_tokens / vocab_size).long()
             next_tokens = next_tokens % vocab_size
 
             # stateless


### PR DESCRIPTION
# What does this PR do?

Starting with PyTorch 1.9, a HF translation model (or any generation model) gives the following warning message:
```
/home/reimers/miniconda3/envs/easynmt/lib/python3.8/site-packages/torch/_tensor.py:575: UserWarning: floor_divide is deprecated, and will be removed in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values.
To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor'). (Triggered internally at  /opt/conda/conda-bld/pytorch_1623448234945/work/aten/src/ATen/native/BinaryOps.cpp:467.)
  return torch.floor_divide(self, other)
```

Here the code to produce this warning:
```
import warnings
warnings.filterwarnings("error")   #Turn warning into an exception for traceback

from transformers import MarianTokenizer, MarianMTModel

model_name = 'Helsinki-NLP/opus-mt-de-en'
tokenizer = MarianTokenizer.from_pretrained(model_name)
model = MarianMTModel.from_pretrained(model_name)
model.eval()

inputs = tokenizer(["Hallo Welt"], return_tensors="pt")
translated = model.generate(**inputs, num_beams=3)
print(translated)
```

Here the responsible line:
https://github.com/huggingface/transformers/blob/a6d62aaba01ce4ff1b2ee8705bf113904672c345/src/transformers/generation_utils.py#L1838

The // operator is translated to floor_divide, which is deprecated starting PyTorch 1.9:
https://pytorch.org/docs/stable/generated/torch.floor_divide.html


We replace this line with:
```
next_indices = (next_tokens/vocab_size).long()  
```

which is is compatible with any PyTorch version and yields identical results to `next_tokens // vocab_size`.


Here a test to show this:
```
import random
import torch
for _ in range(100):
    a = torch.tensor([random.randint(1, 1000)])
    b = torch.tensor([random.randint(1, 100)])
    c = a // b
    d = (a/b).long()
    assert torch.equal(c,d)
```` 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@sgugger

