### PR TITLE
T5 with past ONNX export

### DIFF
--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -429,8 +429,6 @@ class T5Attention(nn.Module):
         # past_key_value[0] is (batch_size, n_heads, q_len - 1, dim_per_head)
         batch_size, seq_length = hidden_states.shape[:2]
 
-        int_seq_length = int(seq_length)
-
         real_seq_length = seq_length
 
         if past_key_value is not None:
@@ -499,7 +497,7 @@ class T5Attention(nn.Module):
             # if key and values are already calculated
             # we want only the last query position bias
             if past_key_value is not None:
-                position_bias = position_bias[:, :, -int_seq_length:, :]
+                position_bias = position_bias[:, :, -hidden_states.size(1) :, :]
 
             if mask is not None:
                 position_bias = position_bias + mask  # (batch_size, n_heads, seq_length, key_length)
@@ -629,7 +627,7 @@ class T5Block(nn.Module):
             if len(past_key_value) != expected_num_past_key_values:
                 raise ValueError(
                     f"There should be {expected_num_past_key_values} past states. "
-                    f"{'2 (past / key) for cross attention' if expected_num_past_key_values == 4 else ''}."
+                    f"{'2 (past / key) for cross attention. ' if expected_num_past_key_values == 4 else ''}"
                     f"Got {len(past_key_value)} past key / value states"
                 )
 

--- a/src/transformers/onnx/config.py
+++ b/src/transformers/onnx/config.py
@@ -14,7 +14,7 @@
 import dataclasses
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from typing import Any, Callable, List, Mapping, Optional
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional
 
 from transformers import PretrainedConfig, PreTrainedTokenizer, TensorType
 
@@ -59,6 +59,7 @@ class OnnxConfig(ABC):
     _TASKS_TO_COMMON_OUTPUTS = {
         "default": OrderedDict({"last_hidden_state": {0: "batch", 1: "sequence"}}),
         "causal-lm": OrderedDict({"logits": {0: "batch", 1: "sequence"}}),
+        "seq2seq-lm": OrderedDict({"logits": {0: "batch", 1: "decoder_sequence"}}),
         "sequence-classification": OrderedDict({"logits": {0: "batch"}}),
         "token-classification": OrderedDict({"logits": {0: "batch", 1: "sequence"}}),
         "multiple-choice": OrderedDict({"logits": {0: "batch"}}),
@@ -227,6 +228,24 @@ class OnnxConfig(ABC):
         for spec in self._patching_specs:
             orig_op = spec.orig_op if spec.op_wrapper is None else spec.op_wrapper(spec.orig_op)
             setattr(spec.o, spec.name, orig_op)
+
+    @staticmethod
+    def flatten_output_collection_property(name: str, field: Iterable[Any]) -> Dict[str, Any]:
+        """
+        Flatten any potential nested structure expanding the name of the field with the index of the element within the
+        structure.
+
+        Args:
+            name: The name of the nested structure
+            field: The structure to, potentially, be flattened
+
+        Returns:
+            (Dict[str, Any]): Outputs with flattened structure and key mapping this new structure.
+
+        """
+        from itertools import chain
+
+        return {f"{name}.{idx}": item for idx, item in enumerate(chain.from_iterable(field))}
 
 
 class OnnxConfigWithPast(OnnxConfig, ABC):

--- a/src/transformers/onnx/config.py
+++ b/src/transformers/onnx/config.py
@@ -304,3 +304,15 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
         # Generate dummy inputs according to compute batch and sequence
         dummy_input = [" ".join([tokenizer.unk_token]) * seq_length] * batch_size
         return OrderedDict(dict(tokenizer(dummy_input, return_tensors=framework)))
+
+    @staticmethod
+    def flatten_output_collection_property(name: str, field: Iterable[Any]) -> Dict[str, Any]:
+        if name in ["present", "past_key_values"]:
+            flatten_output = {}
+            for idx, t in enumerate(field):
+                flatten_output[f"{name}.{idx}.key"] = t[0]
+                flatten_output[f"{name}.{idx}.value"] = t[1]
+
+            return flatten_output
+
+        return super().flatten_output_collection_property(name, field)

--- a/src/transformers/onnx/convert.py
+++ b/src/transformers/onnx/convert.py
@@ -24,7 +24,6 @@ from .. import PreTrainedModel, PreTrainedTokenizer, TensorType, TFPreTrainedMod
 from ..file_utils import is_torch_onnx_dict_inputs_support_available
 from ..utils import logging
 from .config import OnnxConfig
-from .utils import flatten_output_collection_property
 
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -163,7 +162,7 @@ def validate_model_outputs(
         if name == "past_key_values":
             name = "present"
         if isinstance(value, (list, tuple)):
-            value = flatten_output_collection_property(name, value)
+            value = config.flatten_output_collection_property(name, value)
             ref_outputs_dict.update(value)
         else:
             ref_outputs_dict[name] = value
@@ -172,7 +171,7 @@ def validate_model_outputs(
     onnx_inputs = {}
     for name, value in reference_model_inputs.items():
         if isinstance(value, (list, tuple)):
-            value = flatten_output_collection_property(name, value)
+            value = config.flatten_output_collection_property(name, value)
             onnx_inputs.update({tensor_name: pt_tensor.numpy() for tensor_name, pt_tensor in value.items()})
         else:
             onnx_inputs[name] = value.numpy()

--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -21,6 +21,7 @@ if is_torch_available():
         AutoModelForCausalLM,
         AutoModelForMultipleChoice,
         AutoModelForQuestionAnswering,
+        AutoModelForSeq2SeqLM,
         AutoModelForSequenceClassification,
         AutoModelForTokenClassification,
     )
@@ -46,6 +47,7 @@ class FeaturesManager:
     _TASKS_TO_AUTOMODELS = {
         "default": AutoModel,
         "causal-lm": AutoModelForCausalLM,
+        "seq2seq-lm": AutoModelForSeq2SeqLM,
         "sequence-classification": AutoModelForSequenceClassification,
         "token-classification": AutoModelForTokenClassification,
         "multiple-choice": AutoModelForMultipleChoice,
@@ -61,7 +63,9 @@ class FeaturesManager:
         "gpt2": supported_features_mapping("default", onnx_config_cls=GPT2OnnxConfig),
         "longformer": supported_features_mapping("default", onnx_config_cls=LongformerOnnxConfig),
         "roberta": supported_features_mapping("default", onnx_config_cls=RobertaOnnxConfig),
-        "t5": supported_features_mapping("default", onnx_config_cls=T5OnnxConfig),
+        "t5": supported_features_mapping(
+            "default", "default-with-past", "seq2seq-lm", "seq2seq-lm-with-past", onnx_config_cls=T5OnnxConfig
+        ),
         "xlm-roberta": supported_features_mapping("default", onnx_config_cls=XLMRobertaOnnxConfig),
         "gpt-neo": supported_features_mapping(
             "default",

--- a/src/transformers/onnx/utils.py
+++ b/src/transformers/onnx/utils.py
@@ -14,7 +14,6 @@
 
 from ctypes import c_float, sizeof
 from enum import Enum
-from typing import Any, Dict, Iterable
 
 
 class ParameterFormat(Enum):
@@ -62,21 +61,3 @@ def compute_serialized_parameters_size(num_parameters: int, dtype: ParameterForm
         Size (in byte) taken to save all the parameters
     """
     return num_parameters * dtype.size
-
-
-def flatten_output_collection_property(name: str, field: Iterable[Any]) -> Dict[str, Any]:
-    """
-    Flatten any potential nested structure expanding the name of the field with the index of the element within the
-    structure.
-
-    Args:
-        name: The name of the nested structure
-        field: The structure to, potentially, be flattened
-
-    Returns:
-        (Dict[str, Any]): Outputs with flattened structure and key mapping this new structure.
-
-    """
-    from itertools import chain
-
-    return {f"{name}.{idx}": item for idx, item in enumerate(chain.from_iterable(field))}

--- a/tests/test_onnx_v2.py
+++ b/tests/test_onnx_v2.py
@@ -34,11 +34,7 @@ from transformers.onnx import (
     validate_model_outputs,
 )
 from transformers.onnx.config import DEFAULT_ONNX_OPSET, OnnxConfigWithPast
-from transformers.onnx.utils import (
-    compute_effective_axis_dimension,
-    compute_serialized_parameters_size,
-    flatten_output_collection_property,
-)
+from transformers.onnx.utils import compute_effective_axis_dimension, compute_serialized_parameters_size
 from transformers.testing_utils import require_onnx, require_torch, slow
 
 
@@ -95,7 +91,7 @@ class OnnxUtilsTestCaseV2(TestCase):
         ONNX exporter will export nested collections as ${collection_name}.${level_idx_0}.${level_idx_1}...${idx_n}
         """
         self.assertEqual(
-            flatten_output_collection_property("past_key", [[0], [1], [2]]),
+            OnnxConfig.flatten_output_collection_property("past_key", [[0], [1], [2]]),
             {
                 "past_key.0": 0,
                 "past_key.1": 1,


### PR DESCRIPTION
This PR enables the export of T5 with past keys and values to ONNX.

It also enhances the ONNX export when using past keys and values by making the inputs and outputs names for past_key_values more explicit and easy to understand.