### PR TITLE
Fix VisualBert Embeddings

### DIFF
--- a/src/transformers/models/visual_bert/modeling_visual_bert.py
+++ b/src/transformers/models/visual_bert/modeling_visual_bert.py
@@ -123,7 +123,7 @@ class VisualBertEmbeddings(nn.Module):
             inputs_embeds = self.word_embeddings(input_ids)
 
         if token_type_ids is None:
-            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=self.input_embeds.device)
+            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=self.position_ids.device)
 
         token_type_embeddings = self.token_type_embeddings(token_type_ids)
 


### PR DESCRIPTION
# What does this PR do?
This PR addresses the issue mentioned in #13001. The `self.input_embeds` has been replaced with `self.position_ids` as suggested by @NielsRogge.