### PR TITLE
Fix ModelOutput instantiation form dictionaries

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -1850,11 +1850,15 @@ class ModelOutput(OrderedDict):
         other_fields_are_none = all(getattr(self, field.name) is None for field in class_fields[1:])
 
         if other_fields_are_none and not is_tensor(first_field):
-            try:
-                iterator = iter(first_field)
+            if isinstance(first_field, dict):
+                iterator = first_field.items()
                 first_field_iterator = True
-            except TypeError:
-                first_field_iterator = False
+            else:
+                try:
+                    iterator = iter(first_field)
+                    first_field_iterator = True
+                except TypeError:
+                    first_field_iterator = False
 
             # if we provided an iterator as first field and the iterator is a (key, value) iterator
             # set the associated fields

--- a/tests/test_model_output.py
+++ b/tests/test_model_output.py
@@ -101,7 +101,7 @@ class ModelOutputTester(unittest.TestCase):
         x["a"] = 10
         self.assertEqual(x.a, 10)
         self.assertEqual(x["a"], 10)
-    
+
     def test_instantiate_from_dict(self):
         x = ModelOutputTest({"a": 30, "b": 10})
         self.assertEqual(list(x.keys()), ["a", "b"])

--- a/tests/test_model_output.py
+++ b/tests/test_model_output.py
@@ -101,3 +101,9 @@ class ModelOutputTester(unittest.TestCase):
         x["a"] = 10
         self.assertEqual(x.a, 10)
         self.assertEqual(x["a"], 10)
+    
+    def test_instantiate_from_dict(self):
+        x = ModelOutputTest({"a": 30, "b": 10})
+        self.assertEqual(list(x.keys()), ["a", "b"])
+        self.assertEqual(x.a, 30)
+        self.assertEqual(x.b, 10)


### PR DESCRIPTION
# What does this PR do?

Currently, instantiating a `ModelOutput` from a dictionary does not yield proper results. It nests the dictionary in the first field instead of populating the fields with the content of the dictionary.

This PR fixes that and adds a regression test to make sure this behavior is not accidentally removed.