### PR TITLE
Fix fallback of test_fetcher

### DIFF
--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -454,4 +454,7 @@ if __name__ == "__main__":
         except Exception as e:
             print(f"\nError when trying to grab the relevant tests: {e}\n\nRunning all tests.")
             with open(args.output_file, "w", encoding="utf-8") as f:
-                f.write("./tests/")
+                if args.filters is None:
+                    f.write("./tests/")
+                else:
+                    f.write(" ".join(args.filters))


### PR DESCRIPTION
# What does this PR do?

When the `test_fetcher` util fails, it falls back to all tests, which is fine when we have not set any filters, but not fine if we did.