### PR TITLE
Change a parameter name in FlaxBartForConditionalGeneration.decode()

### DIFF
--- a/src/transformers/models/bart/modeling_flax_bart.py
+++ b/src/transformers/models/bart/modeling_flax_bart.py
@@ -1335,7 +1335,7 @@ class FlaxBartForConditionalGeneration(FlaxBartPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        deterministic: bool = True,
+        train: bool = False,
         params: dict = None,
         dropout_rng: PRNGKey = None,
     ):
@@ -1427,7 +1427,7 @@ class FlaxBartForConditionalGeneration(FlaxBartPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            deterministic=deterministic,
+            deterministic=not train,
             rngs=rngs,
             mutable=mutable,
             method=_decoder_forward,

--- a/src/transformers/models/marian/modeling_flax_marian.py
+++ b/src/transformers/models/marian/modeling_flax_marian.py
@@ -1293,7 +1293,7 @@ class FlaxMarianMTModel(FlaxMarianPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        deterministic: bool = True,
+        train: bool = False,
         params: dict = None,
         dropout_rng: PRNGKey = None,
     ):
@@ -1385,7 +1385,7 @@ class FlaxMarianMTModel(FlaxMarianPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            deterministic=deterministic,
+            deterministic=not train,
             rngs=rngs,
             mutable=mutable,
             method=_decoder_forward,

--- a/src/transformers/models/mbart/modeling_flax_mbart.py
+++ b/src/transformers/models/mbart/modeling_flax_mbart.py
@@ -1359,7 +1359,7 @@ class FlaxMBartForConditionalGeneration(FlaxMBartPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        deterministic: bool = True,
+        train: bool = False,
         params: dict = None,
         dropout_rng: PRNGKey = None,
     ):
@@ -1451,7 +1451,7 @@ class FlaxMBartForConditionalGeneration(FlaxMBartPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            deterministic=deterministic,
+            deterministic=not train,
             rngs=rngs,
             mutable=mutable,
             method=_decoder_forward,


### PR DESCRIPTION
# What does this PR do?

In short: Change a parameter name in `FlaxBartForConditionalGeneration.decode()`: `deterministic` -> `train`.

In the current version of `FlaxBartForConditionalGeneration.decode()` method, it takes an argument `deterministic`, while 
`FlaxBartPreTrainedModel.decode()`, `FlaxT5PreTrainedModel.decode()`, `FlaxT5ForConditionalGeneration.decode()`, and similar places in `FlaxGPT2`, they all use `train` as the argument.

It seems to me that there is a (implicit?) convention that, in Flax models, we use `deterministic` parameter for `nn.Module` and parameter `train` for models inheriting from `FlaxPreTrainedModel`.

This PR fix this small inconsistency in `FlaxBartForConditionalGeneration.decode()`. I hope this PR makes sense, despite the change is really small.

## Before submitting

- [ x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests)

## Who can review?

@patrickvonplaten 
@patil-suraj 


