### PR TITLE
fix: keep separate hypothesis for different beam group

### DIFF
--- a/src/transformers/generation_beam_search.py
+++ b/src/transformers/generation_beam_search.py
@@ -179,12 +179,14 @@ class BeamSearchScorer(BeamScorer):
                     num_beams=self.group_size,
                     length_penalty=self.length_penalty,
                     early_stopping=self.do_early_stopping,
-                ) for _ in range(num_beam_groups)
+                )
+                for _ in range(num_beam_groups)
             ]
             for _ in range(batch_size)
-        ] # individual beam hypothesis for each group and each input
-        self._done = torch.tensor([[False for _ in range(num_beam_groups)] for _ in range(batch_size)],
-                                  dtype=torch.bool, device=self.device)
+        ]  # individual beam hypothesis for each group and each input
+        self._done = torch.tensor(
+            [[False for _ in range(num_beam_groups)] for _ in range(batch_size)], dtype=torch.bool, device=self.device
+        )
 
         if not isinstance(num_beams, int) or num_beams <= 1:
             raise ValueError(
@@ -328,7 +330,11 @@ class BeamSearchScorer(BeamScorer):
                     best_score = best_hyp_tuple[0]
                     best_hyp = best_hyp_tuple[1]
 
-                    batch_beam_idx = self.num_beam_hyps_to_keep * batch_idx + self.num_beam_hyps_to_keep_per_group * beam_group_idx + j
+                    batch_beam_idx = (
+                        self.num_beam_hyps_to_keep * batch_idx
+                        + self.num_beam_hyps_to_keep_per_group * beam_group_idx
+                        + j
+                    )
                     sent_lengths[batch_beam_idx] = len(best_hyp)
 
                     # append to lists

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -2464,6 +2464,7 @@ class GenerationMixin:
                     next_indices,
                     pad_token_id=pad_token_id,
                     eos_token_id=eos_token_id,
+                    beam_group_idx=beam_group_idx
                 )
                 beam_scores[batch_group_indices] = beam_outputs["next_beam_scores"]
                 beam_next_tokens = beam_outputs["next_beam_tokens"]
@@ -2526,7 +2527,7 @@ class GenerationMixin:
 
         if return_dict_in_generate:
             if not output_scores:
-                sequence_outputs["sequence_scores"] = None
+                return sequence_outputs["sequence_scores"] = None
             if self.config.is_encoder_decoder:
                 return BeamSearchEncoderDecoderOutput(
                     sequences=sequence_outputs["sequences"],

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -2527,7 +2527,7 @@ class GenerationMixin:
 
         if return_dict_in_generate:
             if not output_scores:
-                return sequence_outputs["sequence_scores"] = None
+                sequence_outputs["sequence_scores"] = None
             if self.config.is_encoder_decoder:
                 return BeamSearchEncoderDecoderOutput(
                     sequences=sequence_outputs["sequences"],

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -2464,7 +2464,7 @@ class GenerationMixin:
                     next_indices,
                     pad_token_id=pad_token_id,
                     eos_token_id=eos_token_id,
-                    beam_group_idx=beam_group_idx
+                    beam_group_idx=beam_group_idx,
                 )
                 beam_scores[batch_group_indices] = beam_outputs["next_beam_scores"]
                 beam_next_tokens = beam_outputs["next_beam_tokens"]


### PR DESCRIPTION
# What does this PR do?
It fixes the issue in diverse beam search implementation. <be>

# What was the issue?
By definition, diverse beam search is a variant of beam search which tries to group beams and introduce variance between the groups.

After successful decoding, we select beams from each group thus giving diverse solutions.

For example with beam size 3 and group size 3, we will have 1 beam in each group. And finally, if we want the top 3 suggestions, we should select the top suggestion from each group.

This condition was violated in the current implementation thus giving similar generated sequences in some cases.

Paper for reference [Diverse Beam Search](https://arxiv.org/pdf/1610.02424.pdf)


## Who can review?
@patrickvonplaten Please review changes