### PR TITLE
Proper import for unittest.mock.patch

### DIFF
--- a/tests/test_trainer_callback.py
+++ b/tests/test_trainer_callback.py
@@ -15,6 +15,7 @@
 import shutil
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from transformers import (
     DefaultFlowCallback,
@@ -234,7 +235,7 @@ class TrainerCallbackTest(unittest.TestCase):
         self.assertEqual(events, self.get_expected_events(trainer))
 
         # warning should be emitted for duplicated callbacks
-        with unittest.mock.patch("transformers.trainer_callback.logger.warning") as warn_mock:
+        with patch("transformers.trainer_callback.logger.warning") as warn_mock:
             trainer = self.get_trainer(
                 callbacks=[MyTestTrainerCallback, MyTestTrainerCallback],
             )


### PR DESCRIPTION
# What does this PR do?

Import from `unittest.mock` to avoid errors.