### PR TITLE
Ci last fix

### DIFF
--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -296,7 +296,7 @@ jobs:
           fi
 
       - name: Failure short reports
-        if: ${{ always() }}
+        if: ${{ failures() }}
         run: cat reports/tests_torch_cuda_extensions_gpu_failures_short.txt
 
       - name: Test suite reports artifacts
@@ -351,7 +351,7 @@ jobs:
           fi
 
       - name: Failure short reports
-        if: ${{ always() }}
+        if: ${{ failures() }}
         run: cat reports/tests_torch_cuda_extensions_multi_gpu_failures_short.txt
 
       - name: Test suite reports artifacts

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
       - name: Failure short reports
-        if: ${{ always() }}
+        if: ${{ failure() }}
         run: cat reports/tests_torch_gpu_failures_short.txt
 
       - name: Test suite reports artifacts
@@ -125,7 +125,7 @@ jobs:
 #          fi
 #
 #      - name: Failure short reports
-#        if: ${{ always() }}
+#        if: ${{ failure() }}
 #        run: cat reports/tests_tf_gpu_failures_short.txt
 #
 #      - name: Test suite reports artifacts
@@ -184,7 +184,7 @@ jobs:
           fi
 
       - name: Failure short reports
-        if: ${{ always() }}
+        if: ${{ failure() }}
         run: cat reports/tests_torch_multi_gpu_failures_short.txt
 
       - name: Test suite reports artifacts
@@ -241,7 +241,7 @@ jobs:
 #          fi
 #
 #      - name: Failure short reports
-#        if: ${{ always() }}
+#        if: ${{ failure() }}
 #        run: cat reports/tests_tf_multi_gpu_failures_short.txt
 #
 #      - name: Test suite reports artifacts

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -296,7 +296,7 @@ jobs:
           fi
 
       - name: Failure short reports
-        if: ${{ failures() }}
+        if: ${{ failure() }}
         run: cat reports/tests_torch_cuda_extensions_gpu_failures_short.txt
 
       - name: Test suite reports artifacts
@@ -351,7 +351,7 @@ jobs:
           fi
 
       - name: Failure short reports
-        if: ${{ failures() }}
+        if: ${{ failure() }}
         run: cat reports/tests_torch_cuda_extensions_multi_gpu_failures_short.txt
 
       - name: Test suite reports artifacts


### PR DESCRIPTION
# What does this PR do?

The GPU/multi-GPU tests for the cuda extensions failed on the last commit on master because there is nothing to report if no tests were run. Changing the condition from always to failure (we don't want to report anything if there is no failure anyway) fixes that.