### PR TITLE
[Flax] Add logging steps, eval steps, and save steps for hybrid CLIP example

### DIFF
--- a/examples/research_projects/jax-projects/hybrid_clip/run_hybrid_clip.py
+++ b/examples/research_projects/jax-projects/hybrid_clip/run_hybrid_clip.py
@@ -550,7 +550,6 @@ def main():
 
                 # normalize eval metrics
                 eval_metrics = get_metrics(eval_metrics)
-
                 eval_metrics = jax.tree_map(jnp.mean, eval_metrics)
 
                 # Print metrics and update progress bar


### PR DESCRIPTION
# What does this PR do?

This PR enables users to set `logging_steps`, `eval_steps`, and `save_steps` when training a model using the Hybrid CLIP example. `logging_steps` helps to keep the train_metrics small so that we can avoid fragmentation errors. `eval_steps` and `save_steps` enables users to save evaluation results and model checkpoints based on steps instead of epochs which may run for days especially when using large datasets.

Discussed in #13095

## Notes
I'd like to have input on the following:
- I've tested the script using the same dataset as the one described in the readme. The run can be found on [tensorboard.dev](https://tensorboard.dev/experiment/WH8xEX25RVavnizS4VaU8Q/#scalars). I'm not sure if I should update the tensorboard in the readme or not.
- I'm also not sure if we should save the final model once the training is done, or only save the model based on the steps only. Right now the script also saves the final model after the whole training is done.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. Yes, discussed in #13095
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@patil-suraj
