### PR TITLE
Ci continue through smi failure

### DIFF
--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -23,7 +23,6 @@ env:
 
 jobs:
   run_tests_torch_gpu:
-    continue-on-error: true
     runs-on: [self-hosted, docker-gpu, single-gpu]
     container:
       image: pytorch/pytorch:1.9.0-cuda11.1-cudnn8-runtime
@@ -139,7 +138,6 @@ jobs:
 
   run_tests_torch_multi_gpu:
     runs-on: [self-hosted, docker-gpu, multi-gpu]
-    continue-on-error: true
     container:
       image: pytorch/pytorch:1.9.0-cuda11.1-cudnn8-runtime
       options: --gpus all --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
@@ -321,6 +319,7 @@ jobs:
           fetch-depth: 2
 
       - name: NVIDIA-SMI
+        continue-on-error: true
         run: |
           nvidia-smi
 

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -157,6 +157,7 @@ jobs:
           fetch-depth: 2
 
       - name: NVIDIA-SMI
+        continue-on-error: true
         run: |
           nvidia-smi
 

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   run_tests_torch_gpu:
+    continue-on-error: true
     runs-on: [self-hosted, docker-gpu, single-gpu]
     container:
       image: pytorch/pytorch:1.9.0-cuda11.1-cudnn8-runtime
@@ -138,6 +139,7 @@ jobs:
 
   run_tests_torch_multi_gpu:
     runs-on: [self-hosted, docker-gpu, multi-gpu]
+    continue-on-error: true
     container:
       image: pytorch/pytorch:1.9.0-cuda11.1-cudnn8-runtime
       options: --gpus all --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/

--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -150,6 +150,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: NVIDIA-SMI
+        continue-on-error: true
         run: |
           nvidia-smi
 
@@ -204,6 +205,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: NVIDIA-SMI
+        continue-on-error: true
         run: |
           nvidia-smi
 
@@ -300,6 +302,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: NVIDIA-SMI
+        continue-on-error: true
         run: |
           nvidia-smi
 


### PR DESCRIPTION
Temporary fix in order to get coverage while we replace the machine: apply the `continue-on-error` option to NVIDIA-SMI runs that run on the multi-gpu machine