### PR TITLE
Add Wav2Vec2 & Hubert ForSequenceClassification

### DIFF
--- a/docs/source/model_doc/hubert.rst
+++ b/docs/source/model_doc/hubert.rst
@@ -64,6 +64,14 @@ HubertForCTC
 .. autoclass:: transformers.HubertForCTC
     :members: forward
 
+
+HubertForSequenceClassification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: transformers.HubertForSequenceClassification
+    :members: forward
+
+
 TFHubertModel
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/model_doc/wav2vec2.rst
+++ b/docs/source/model_doc/wav2vec2.rst
@@ -96,6 +96,14 @@ Wav2Vec2ForCTC
 .. autoclass:: transformers.Wav2Vec2ForCTC
     :members: forward
 
+
+Wav2Vec2ForSequenceClassification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: transformers.Wav2Vec2ForSequenceClassification
+    :members: forward
+
+
 Wav2Vec2ForPreTraining
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -818,6 +818,7 @@ if is_torch_available():
         [
             "HUBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
             "HubertForCTC",
+            "HubertForSequenceClassification",
             "HubertModel",
             "HubertPreTrainedModel",
         ]
@@ -2423,6 +2424,7 @@ if TYPE_CHECKING:
         from .models.hubert import (
             HUBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
             HubertForCTC,
+            HubertForSequenceClassification,
             HubertModel,
             HubertPreTrainedModel,
         )

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -1129,6 +1129,7 @@ if is_torch_available():
             "Wav2Vec2ForCTC",
             "Wav2Vec2ForMaskedLM",
             "Wav2Vec2ForPreTraining",
+            "Wav2Vec2ForSequenceClassification",
             "Wav2Vec2Model",
             "Wav2Vec2PreTrainedModel",
         ]
@@ -2683,6 +2684,7 @@ if TYPE_CHECKING:
             Wav2Vec2ForCTC,
             Wav2Vec2ForMaskedLM,
             Wav2Vec2ForPreTraining,
+            Wav2Vec2ForSequenceClassification,
             Wav2Vec2Model,
             Wav2Vec2PreTrainedModel,
         )

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -818,6 +818,7 @@ if is_torch_available():
         [
             "HUBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
             "HubertForCTC",
+            "HubertForSequenceClassification",
             "HubertModel",
             "HubertPreTrainedModel",
         ]
@@ -2424,6 +2425,7 @@ if TYPE_CHECKING:
         from .models.hubert import (
             HUBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
             HubertForCTC,
+            HubertForSequenceClassification,
             HubertModel,
             HubertPreTrainedModel,
         )

--- a/src/transformers/models/hubert/__init__.py
+++ b/src/transformers/models/hubert/__init__.py
@@ -28,6 +28,7 @@ if is_torch_available():
     _import_structure["modeling_hubert"] = [
         "HUBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
         "HubertForCTC",
+        "HubertForSequenceClassification",
         "HubertModel",
         "HubertPreTrainedModel",
     ]
@@ -48,6 +49,7 @@ if TYPE_CHECKING:
         from .modeling_hubert import (
             HUBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
             HubertForCTC,
+            HubertForSequenceClassification,
             HubertModel,
             HubertPreTrainedModel,
         )

--- a/src/transformers/models/hubert/configuration_hubert.py
+++ b/src/transformers/models/hubert/configuration_hubert.py
@@ -116,7 +116,7 @@ class HubertConfig(PretrainedConfig):
             mainly occur when the inputs are too short to be aligned to the targets. Only relevant when training an
             instance of :class:`~transformers.HubertForCTC`.
         use_weighted_layer_sum (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            Whether to use a weighted average of layer outputs with learned weights. Only relevant when training an
+            Whether to use a weighted average of layer outputs with learned weights. Only relevant when using an
             instance of :class:`~transformers.HubertForSequenceClassification`.
         classifier_proj_size (:obj:`int`, `optional`, defaults to 256):
             Dimensionality of the projection before token mean-pooling for classification.

--- a/src/transformers/models/hubert/configuration_hubert.py
+++ b/src/transformers/models/hubert/configuration_hubert.py
@@ -115,6 +115,11 @@ class HubertConfig(PretrainedConfig):
             Whether to zero infinite losses and the associated gradients of ``torch.nn.CTCLoss``. Infinite losses
             mainly occur when the inputs are too short to be aligned to the targets. Only relevant when training an
             instance of :class:`~transformers.HubertForCTC`.
+        use_weighted_layer_sum (:obj:`bool`, `optional`, defaults to :obj:`False`):
+            Whether to use a weighted average of layer outputs with learned weights. Only relevant when training an
+            instance of :class:`~transformers.HubertForSequenceClassification`.
+        classifier_proj_size (:obj:`int`, `optional`, defaults to 256):
+            Dimensionality of the projection before token mean-pooling for classification.
         gradient_checkpointing (:obj:`bool`, `optional`, defaults to :obj:`False`):
             If True, use gradient checkpointing to save memory at the expense of slower backward pass.
 
@@ -165,6 +170,8 @@ class HubertConfig(PretrainedConfig):
         mask_feature_length=10,
         ctc_loss_reduction="sum",
         ctc_zero_infinity=False,
+        use_weighted_layer_sum=False,
+        classifier_proj_size=256,
         gradient_checkpointing=False,
         pad_token_id=0,
         bos_token_id=1,
@@ -197,6 +204,8 @@ class HubertConfig(PretrainedConfig):
         self.vocab_size = vocab_size
         self.do_stable_layer_norm = do_stable_layer_norm
         self.gradient_checkpointing = gradient_checkpointing
+        self.use_weighted_layer_sum = use_weighted_layer_sum
+        self.classifier_proj_size = classifier_proj_size
 
         if (
             (len(self.conv_stride) != self.num_feat_extract_layers)

--- a/src/transformers/models/hubert/convert_hubert_original_s3prl_checkpoint_to_pytorch.py
+++ b/src/transformers/models/hubert/convert_hubert_original_s3prl_checkpoint_to_pytorch.py
@@ -19,14 +19,7 @@ import argparse
 
 import torch
 
-from transformers import (
-    HubertConfig,
-    HubertForSequenceClassification,
-    Wav2Vec2CTCTokenizer,
-    Wav2Vec2FeatureExtractor,
-    Wav2Vec2Processor,
-    logging,
-)
+from transformers import HubertConfig, HubertForSequenceClassification, Wav2Vec2FeatureExtractor, logging
 
 
 logging.set_verbosity_info()
@@ -48,10 +41,7 @@ def convert_s3prl_checkpoint(base_model_name, config_path, checkpoint_path, mode
 
     hf_congfig = HubertConfig.from_pretrained(config_path)
     hf_model = HubertForSequenceClassification.from_pretrained(base_model_name, config=hf_congfig)
-    # TODO: remove the need for a tokenizer
-    tokenizer = Wav2Vec2CTCTokenizer.from_pretrained("facebook/wav2vec2-base-960h")
-    feature_extractor = Wav2Vec2FeatureExtractor.from_pretrained("facebook/wav2vec2-base-960h")
-    hf_processor = Wav2Vec2Processor(feature_extractor=feature_extractor, tokenizer=tokenizer)
+    hf_feature_extractor = Wav2Vec2FeatureExtractor.from_pretrained(base_model_name, do_normalize=False)
 
     if hf_congfig.use_weighted_layer_sum:
         hf_model.layer_weights.data = checkpoint["Featurizer"]["weights"]
@@ -61,7 +51,7 @@ def convert_s3prl_checkpoint(base_model_name, config_path, checkpoint_path, mode
     hf_model.classifier.weight.data = downstream_dict["model.post_net.linear.weight"]
     hf_model.classifier.bias.data = downstream_dict["model.post_net.linear.bias"]
 
-    hf_processor.save_pretrained(model_dump_path)
+    hf_feature_extractor.save_pretrained(model_dump_path)
     hf_model.save_pretrained(model_dump_path)
 
 

--- a/src/transformers/models/hubert/convert_hubert_original_s3prl_checkpoint_to_pytorch.py
+++ b/src/transformers/models/hubert/convert_hubert_original_s3prl_checkpoint_to_pytorch.py
@@ -1,0 +1,77 @@
+# coding=utf-8
+# Copyright 2021 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Convert Hubert checkpoint."""
+
+
+import argparse
+
+import torch
+
+from transformers import (
+    HubertConfig,
+    HubertForSequenceClassification,
+    Wav2Vec2CTCTokenizer,
+    Wav2Vec2FeatureExtractor,
+    Wav2Vec2Processor,
+    logging,
+)
+
+
+logging.set_verbosity_info()
+logger = logging.get_logger(__name__)
+
+SUPPORTED_MODELS = ["UtteranceLevel"]
+
+
+@torch.no_grad()
+def convert_s3prl_checkpoint(base_model_name, config_path, checkpoint_path, model_dump_path):
+    """
+    Copy/paste/tweak model's weights to transformers design.
+    """
+    checkpoint = torch.load(checkpoint_path, map_location="cpu")
+    if checkpoint["Config"]["downstream_expert"]["modelrc"]["select"] not in SUPPORTED_MODELS:
+        raise NotImplementedError(f"The supported s3prl models are {SUPPORTED_MODELS}")
+
+    downstream_dict = checkpoint["Downstream"]
+
+    hf_congfig = HubertConfig.from_pretrained(config_path)
+    hf_model = HubertForSequenceClassification.from_pretrained(base_model_name, config=hf_congfig)
+    # TODO: remove the need for a tokenizer
+    tokenizer = Wav2Vec2CTCTokenizer.from_pretrained("facebook/wav2vec2-base-960h")
+    feature_extractor = Wav2Vec2FeatureExtractor.from_pretrained("facebook/wav2vec2-base-960h")
+    hf_processor = Wav2Vec2Processor(feature_extractor=feature_extractor, tokenizer=tokenizer)
+
+    if hf_congfig.use_weighted_layer_sum:
+        hf_model.layer_weights.data = checkpoint["Featurizer"]["weights"]
+
+    hf_model.projector.weight.data = downstream_dict["projector.weight"]
+    hf_model.projector.bias.data = downstream_dict["projector.bias"]
+    hf_model.classifier.weight.data = downstream_dict["model.post_net.linear.weight"]
+    hf_model.classifier.bias.data = downstream_dict["model.post_net.linear.bias"]
+
+    hf_processor.save_pretrained(model_dump_path)
+    hf_model.save_pretrained(model_dump_path)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--base_model_name", default=None, type=str, help="Name of the huggingface pretrained base model."
+    )
+    parser.add_argument("--config_path", default=None, type=str, help="Path to the huggingface classifier config.")
+    parser.add_argument("--checkpoint_path", default=None, type=str, help="Path to the s3prl checkpoint.")
+    parser.add_argument("--model_dump_path", default=None, type=str, help="Path to the final converted model.")
+    args = parser.parse_args()
+    convert_s3prl_checkpoint(args.base_model_name, args.config_path, args.checkpoint_path, args.model_dump_path)

--- a/src/transformers/models/hubert/modeling_hubert.py
+++ b/src/transformers/models/hubert/modeling_hubert.py
@@ -1137,8 +1137,8 @@ class HubertForSequenceClassification(HubertPreTrainedModel):
             >>> from transformers import Wav2Vec2FeatureExtractor, HubertForSequenceClassification
             >>> from datasets import load_dataset
 
-            >>> processor = Wav2Vec2FeatureExtractor.from_pretrained("anton-l/hubert-base-superb-ks")
-            >>> model = HubertForSequenceClassification.from_pretrained("anton-l/hubert-base-superb-ks")
+            >>> processor = Wav2Vec2FeatureExtractor.from_pretrained("superb/hubert-base-superb-ks")
+            >>> model = HubertForSequenceClassification.from_pretrained("superb/hubert-base-superb-ks")
 
             >>> ds = load_dataset("anton-l/superb_dummy", "ks", split="test")
 

--- a/src/transformers/models/hubert/modeling_hubert.py
+++ b/src/transformers/models/hubert/modeling_hubert.py
@@ -20,12 +20,13 @@ import numpy as np
 import torch
 import torch.utils.checkpoint
 from torch import nn
+from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
 from transformers.deepspeed import is_deepspeed_zero3_enabled
 
 from ...activations import ACT2FN
 from ...file_utils import add_start_docstrings, add_start_docstrings_to_model_forward, replace_return_docstrings
-from ...modeling_outputs import BaseModelOutput, CausalLMOutput
+from ...modeling_outputs import BaseModelOutput, CausalLMOutput, SequenceClassifierOutput
 from ...modeling_utils import PreTrainedModel
 from ...utils import logging
 from .configuration_hubert import HubertConfig
@@ -1069,4 +1070,124 @@ class HubertForCTC(HubertPreTrainedModel):
 
         return CausalLMOutput(
             loss=loss, logits=logits, hidden_states=outputs.hidden_states, attentions=outputs.attentions
+        )
+
+
+@add_start_docstrings(
+    """
+    Hubert Model with a sequence classification/regression head on top (a linear layer over the pooled output) for
+    tasks like SUPERB.
+    """,
+    HUBERT_START_DOCSTRING,
+)
+class HubertForSequenceClassification(HubertPreTrainedModel):
+    def __init__(self, config):
+        super().__init__(config)
+
+        self.hubert = HubertModel(config)
+        num_layers = config.num_hidden_layers + 1  # transformer layers + input embeddings
+        if config.use_weighted_layer_sum:
+            self.layer_weights = nn.Parameter(torch.ones(num_layers) / num_layers)
+        self.projector = nn.Linear(config.hidden_size, config.classifier_proj_size)
+        self.classifier = nn.Linear(config.classifier_proj_size, config.num_labels)
+
+        self.init_weights()
+
+    def freeze_feature_extractor(self):
+        """
+        Calling this function will disable the gradient computation for the feature extractor so that its parameter
+        will not be updated during training.
+        """
+        self.hubert.feature_extractor._freeze_parameters()
+
+    def freeze_base_model(self):
+        """
+        Calling this function will disable the gradient computation for the base Hubert model so that its parameter
+        will not be updated during training. Only the classification head will be updated.
+        """
+        for param in self.hubert.parameters():
+            param.requires_grad = False
+
+    @add_start_docstrings_to_model_forward(HUBERT_INPUTS_DOCSTRING)
+    @replace_return_docstrings(output_type=SequenceClassifierOutput, config_class=_CONFIG_FOR_DOC)
+    def forward(
+        self,
+        input_values,
+        attention_mask=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+        labels=None,
+    ):
+        r"""
+        labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
+            Labels for computing the sequence classification/regression loss. Indices should be in :obj:`[0, ...,
+            config.num_labels - 1]`. If :obj:`config.num_labels == 1` a regression loss is computed (Mean-Square loss),
+            If :obj:`config.num_labels > 1` a classification loss is computed (Cross-Entropy).
+
+        Returns:
+
+        TODO: Usage example with Keyword Spotting
+        """
+
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        output_hidden_states = True if self.config.use_weighted_layer_sum else output_hidden_states
+
+        outputs = self.hubert(
+            input_values,
+            attention_mask=attention_mask,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+
+        if self.config.use_weighted_layer_sum:
+            hidden_states = outputs[1]
+            hidden_states = torch.stack(hidden_states, dim=1)
+            norm_weights = nn.functional.softmax(self.layer_weights, dim=-1)
+            hidden_states = (hidden_states * norm_weights.view(-1, 1, 1)).sum(dim=1)
+        else:
+            hidden_states = outputs[0]
+
+        hidden_states = self.projector(hidden_states)
+        if attention_mask is None:
+            pooled_output = hidden_states.mean(dim=1)
+        else:
+            output_lengths = self._get_feat_extract_output_lengths(attention_mask.sum(-1)).to(torch.long)
+            pooled_output = hidden_states.sum(dim=1) / output_lengths.view(-1, 1)
+
+        logits = self.classifier(pooled_output)
+
+        loss = None
+        if labels is not None:
+            if self.config.problem_type is None:
+                if self.config.num_labels == 1:
+                    self.config.problem_type = "regression"
+                elif self.config.num_labels > 1 and (labels.dtype == torch.long or labels.dtype == torch.int):
+                    self.config.problem_type = "single_label_classification"
+                else:
+                    self.config.problem_type = "multi_label_classification"
+
+            if self.config.problem_type == "regression":
+                loss_fct = MSELoss()
+                if self.config.num_labels == 1:
+                    loss = loss_fct(logits.squeeze(), labels.squeeze())
+                else:
+                    loss = loss_fct(logits, labels)
+            elif self.config.problem_type == "single_label_classification":
+                loss_fct = CrossEntropyLoss()
+                loss = loss_fct(logits.view(-1, self.config.num_labels), labels.view(-1))
+            elif self.config.problem_type == "multi_label_classification":
+                loss_fct = BCEWithLogitsLoss()
+                loss = loss_fct(logits, labels)
+
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return ((loss,) + output) if loss is not None else output
+
+        return SequenceClassifierOutput(
+            loss=loss,
+            logits=logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
         )

--- a/src/transformers/models/hubert/modeling_hubert.py
+++ b/src/transformers/models/hubert/modeling_hubert.py
@@ -20,7 +20,7 @@ import numpy as np
 import torch
 import torch.utils.checkpoint
 from torch import nn
-from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss
+from torch.nn import CrossEntropyLoss
 
 from transformers.deepspeed import is_deepspeed_zero3_enabled
 
@@ -1142,15 +1142,13 @@ class HubertForSequenceClassification(HubertPreTrainedModel):
             return_dict=return_dict,
         )
 
-        last_hidden_state = outputs.last_hidden_state
-
         if self.config.use_weighted_layer_sum:
-            hidden_states = outputs.hidden_states
+            hidden_states = outputs[1]
             hidden_states = torch.stack(hidden_states, dim=1)
             norm_weights = nn.functional.softmax(self.layer_weights, dim=-1)
             hidden_states = (hidden_states * norm_weights.view(-1, 1, 1)).sum(dim=1)
         else:
-            hidden_states = outputs.last_hidden_state
+            hidden_states = outputs[0]
 
         hidden_states = self.projector(hidden_states)
         if attention_mask is None:
@@ -1163,13 +1161,9 @@ class HubertForSequenceClassification(HubertPreTrainedModel):
         logits = self.classifier(pooled_output)
 
         loss = None
-        if labels is not None and self.config.problem_type is not None:
-            if self.config.problem_type == "single_label_classification":
-                loss_fct = CrossEntropyLoss()
-                loss = loss_fct(logits.view(-1, self.config.num_labels), labels.view(-1))
-            elif self.config.problem_type == "multi_label_classification":
-                loss_fct = BCEWithLogitsLoss()
-                loss = loss_fct(logits, labels)
+        if labels is not None:
+            loss_fct = CrossEntropyLoss()
+            loss = loss_fct(logits.view(-1, self.config.num_labels), labels.view(-1))
 
         if not return_dict:
             output = (logits,) + outputs[1:]

--- a/src/transformers/models/hubert/modeling_hubert.py
+++ b/src/transformers/models/hubert/modeling_hubert.py
@@ -1077,11 +1077,12 @@ class HubertForCTC(HubertPreTrainedModel):
 @add_start_docstrings(
     """
     Hubert Model with a sequence classification head on top (a linear layer over the pooled output) for tasks like
-    SUPERB.
+    SUPERB Keyword Spotting.
     """,
     HUBERT_START_DOCSTRING,
 )
 class HubertForSequenceClassification(HubertPreTrainedModel):
+    # Copied from transformers.models.wav2vec2.modeling_wav2vec2.Wav2Vec2ForSequenceClassification.__init__ with Wav2Vec2->Hubert, wav2vec2->hubert
     def __init__(self, config):
         super().__init__(config)
 
@@ -1094,17 +1095,19 @@ class HubertForSequenceClassification(HubertPreTrainedModel):
 
         self.init_weights()
 
+    # Copied from transformers.models.wav2vec2.modeling_wav2vec2.Wav2Vec2ForSequenceClassification.freeze_feature_extractor with wav2vec2->hubert
     def freeze_feature_extractor(self):
         """
-        Calling this function will disable the gradient computation for the feature extractor so that its parameter
+        Calling this function will disable the gradient computation for the feature extractor so that its parameters
         will not be updated during training.
         """
         self.hubert.feature_extractor._freeze_parameters()
 
+    # Copied from transformers.models.wav2vec2.modeling_wav2vec2.Wav2Vec2ForSequenceClassification.freeze_base_model with wav2vec2->hubert
     def freeze_base_model(self):
         """
-        Calling this function will disable the gradient computation for the base Hubert model so that its parameter
-        will not be updated during training. Only the classification head will be updated.
+        Calling this function will disable the gradient computation for the base model so that its parameters will not
+        be updated during training. Only the classification head will be updated.
         """
         for param in self.hubert.parameters():
             param.requires_grad = False
@@ -1128,7 +1131,26 @@ class HubertForSequenceClassification(HubertPreTrainedModel):
 
         Returns:
 
-        TODO: Usage example with Keyword Spotting
+        Example::
+
+            >>> import torch
+            >>> from transformers import Wav2Vec2FeatureExtractor, HubertForSequenceClassification
+            >>> from datasets import load_dataset
+
+            >>> processor = Wav2Vec2FeatureExtractor.from_pretrained("anton-l/hubert-base-superb-ks")
+            >>> model = HubertForSequenceClassification.from_pretrained("anton-l/hubert-base-superb-ks")
+
+            >>> ds = load_dataset("anton-l/superb_dummy", "ks", split="test")
+
+            >>> input_values = processor(ds["speech"][4], return_tensors="pt").input_values  # Batch size 1
+            >>> logits = model(input_values).logits
+            >>> predicted_class_ids = torch.argmax(logits, dim=-1)
+
+            >>> # compute loss
+            >>> target_label = "down"
+            >>> labels = torch.tensor([model.config.label2id[target_label]])
+
+            >>> loss = model(input_values, labels=labels).loss
         """
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict

--- a/src/transformers/models/wav2vec2/__init__.py
+++ b/src/transformers/models/wav2vec2/__init__.py
@@ -33,6 +33,7 @@ if is_torch_available():
         "Wav2Vec2ForCTC",
         "Wav2Vec2ForMaskedLM",
         "Wav2Vec2ForPreTraining",
+        "Wav2Vec2ForSequenceClassification",
         "Wav2Vec2Model",
         "Wav2Vec2PreTrainedModel",
     ]
@@ -66,6 +67,7 @@ if TYPE_CHECKING:
             Wav2Vec2ForCTC,
             Wav2Vec2ForMaskedLM,
             Wav2Vec2ForPreTraining,
+            Wav2Vec2ForSequenceClassification,
             Wav2Vec2Model,
             Wav2Vec2PreTrainedModel,
         )

--- a/src/transformers/models/wav2vec2/configuration_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/configuration_wav2vec2.py
@@ -133,6 +133,11 @@ class Wav2Vec2Config(PretrainedConfig):
             Whether to zero infinite losses and the associated gradients of ``torch.nn.CTCLoss``. Infinite losses
             mainly occur when the inputs are too short to be aligned to the targets. Only relevant when training an
             instance of :class:`~transformers.Wav2Vec2ForCTC`.
+        use_weighted_layer_sum (:obj:`bool`, `optional`, defaults to :obj:`False`):
+            Whether to use a weighted average of layer outputs with learned weights. Only relevant when using an
+            instance of :class:`~transformers.Wav2Vec2ForSequenceClassification`.
+        classifier_proj_size (:obj:`int`, `optional`, defaults to 256):
+            Dimensionality of the projection before token mean-pooling for classification.
         gradient_checkpointing (:obj:`bool`, `optional`, defaults to :obj:`False`):
             If True, use gradient checkpointing to save memory at the expense of slower backward pass.
 
@@ -191,6 +196,8 @@ class Wav2Vec2Config(PretrainedConfig):
         diversity_loss_weight=0.1,
         ctc_loss_reduction="sum",
         ctc_zero_infinity=False,
+        use_weighted_layer_sum=False,
+        classifier_proj_size=256,
         gradient_checkpointing=False,
         pad_token_id=0,
         bos_token_id=1,
@@ -223,6 +230,8 @@ class Wav2Vec2Config(PretrainedConfig):
         self.vocab_size = vocab_size
         self.do_stable_layer_norm = do_stable_layer_norm
         self.gradient_checkpointing = gradient_checkpointing
+        self.use_weighted_layer_sum = use_weighted_layer_sum
+        self.classifier_proj_size = classifier_proj_size
 
         if (
             (len(self.conv_stride) != self.num_feat_extract_layers)

--- a/src/transformers/models/wav2vec2/convert_wav2vec2_original_s3prl_checkpoint_to_pytorch.py
+++ b/src/transformers/models/wav2vec2/convert_wav2vec2_original_s3prl_checkpoint_to_pytorch.py
@@ -19,7 +19,7 @@ import argparse
 
 import torch
 
-from transformers import HubertConfig, HubertForSequenceClassification, Wav2Vec2FeatureExtractor, logging
+from transformers import Wav2Vec2Config, Wav2Vec2FeatureExtractor, Wav2Vec2ForSequenceClassification, logging
 
 
 logging.set_verbosity_info()
@@ -39,8 +39,8 @@ def convert_s3prl_checkpoint(base_model_name, config_path, checkpoint_path, mode
 
     downstream_dict = checkpoint["Downstream"]
 
-    hf_congfig = HubertConfig.from_pretrained(config_path)
-    hf_model = HubertForSequenceClassification.from_pretrained(base_model_name, config=hf_congfig)
+    hf_congfig = Wav2Vec2Config.from_pretrained(config_path)
+    hf_model = Wav2Vec2ForSequenceClassification.from_pretrained(base_model_name, config=hf_congfig)
     hf_feature_extractor = Wav2Vec2FeatureExtractor.from_pretrained(
         base_model_name, return_attention_mask=True, do_normalize=False
     )

--- a/src/transformers/models/wav2vec2/feature_extraction_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/feature_extraction_wav2vec2.py
@@ -83,9 +83,6 @@ class Wav2Vec2FeatureExtractor(SequenceFeatureExtractor):
         """
         Every array in the list is normalized to have zero mean and unit variance
         """
-        if isinstance(input_values[0], np.ndarray):
-            input_values = [x.astype(np.float32) for x in input_values]
-
         normed_input_values = [
             (x - np.mean(x[:i])) / np.sqrt(np.var(x[:i]) + 1e-5) for x, i in zip(input_values, input_lengths)
         ]
@@ -204,6 +201,9 @@ class Wav2Vec2FeatureExtractor(SequenceFeatureExtractor):
         else:
             padded_input_values = padded_inputs["input_values"]
             input_lengths = [padded_input_values.shape[-1] for _ in range(padded_input_values.shape[0])]
+
+        if isinstance(padded_inputs["input_values"][0], np.ndarray):
+            padded_inputs["input_values"] = [x.astype(np.float32) for x in padded_inputs["input_values"]]
 
         # zero-mean and unit-variance normalization
         if self.do_normalize:

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -22,6 +22,7 @@ import numpy as np
 import torch
 import torch.utils.checkpoint
 from torch import nn
+from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss
 
 from ...activations import ACT2FN
 from ...deepspeed import is_deepspeed_zero3_enabled
@@ -31,7 +32,7 @@ from ...file_utils import (
     add_start_docstrings_to_model_forward,
     replace_return_docstrings,
 )
-from ...modeling_outputs import BaseModelOutput, CausalLMOutput, MaskedLMOutput
+from ...modeling_outputs import BaseModelOutput, CausalLMOutput, MaskedLMOutput, SequenceClassifierOutput
 from ...modeling_utils import PreTrainedModel
 from ...utils import logging
 from .configuration_wav2vec2 import Wav2Vec2Config
@@ -1526,4 +1527,110 @@ class Wav2Vec2ForCTC(Wav2Vec2PreTrainedModel):
 
         return CausalLMOutput(
             loss=loss, logits=logits, hidden_states=outputs.hidden_states, attentions=outputs.attentions
+        )
+
+
+@add_start_docstrings(
+    """
+    Wav2Vec2 Model with a sequence classification head on top (a linear layer over the pooled output) for tasks like
+    SUPERB.
+    """,
+    WAV_2_VEC_2_START_DOCSTRING,
+)
+class Wav2Vec2ForSequenceClassification(Wav2Vec2PreTrainedModel):
+    def __init__(self, config):
+        super().__init__(config)
+
+        self.wav2vec2 = Wav2Vec2Model(config)
+        num_layers = config.num_hidden_layers + 1  # transformer layers + input embeddings
+        if config.use_weighted_layer_sum:
+            self.layer_weights = nn.Parameter(torch.ones(num_layers) / num_layers)
+        self.projector = nn.Linear(config.hidden_size, config.classifier_proj_size)
+        self.classifier = nn.Linear(config.classifier_proj_size, config.num_labels)
+
+        self.init_weights()
+
+    def freeze_feature_extractor(self):
+        """
+        Calling this function will disable the gradient computation for the feature extractor so that its parameter
+        will not be updated during training.
+        """
+        self.hubert.feature_extractor._freeze_parameters()
+
+    def freeze_base_model(self):
+        """
+        Calling this function will disable the gradient computation for the base Hubert model so that its parameter
+        will not be updated during training. Only the classification head will be updated.
+        """
+        for param in self.hubert.parameters():
+            param.requires_grad = False
+
+    @add_start_docstrings_to_model_forward(WAV_2_VEC_2_INPUTS_DOCSTRING)
+    @replace_return_docstrings(output_type=SequenceClassifierOutput, config_class=_CONFIG_FOR_DOC)
+    def forward(
+        self,
+        input_values,
+        attention_mask=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+        labels=None,
+    ):
+        r"""
+        labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`):
+            Labels for computing the sequence classification/regression loss. Indices should be in :obj:`[0, ...,
+            config.num_labels - 1]`. If :obj:`config.num_labels == 1` a regression loss is computed (Mean-Square loss),
+            If :obj:`config.num_labels > 1` a classification loss is computed (Cross-Entropy).
+
+        Returns:
+
+        TODO: Usage example with Keyword Spotting
+        """
+
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        output_hidden_states = True if self.config.use_weighted_layer_sum else output_hidden_states
+
+        outputs = self.wav2vec2(
+            input_values,
+            attention_mask=attention_mask,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+
+        if self.config.use_weighted_layer_sum:
+            hidden_states = outputs.hidden_states
+            hidden_states = torch.stack(hidden_states, dim=1)
+            norm_weights = nn.functional.softmax(self.layer_weights, dim=-1)
+            hidden_states = (hidden_states * norm_weights.view(-1, 1, 1)).sum(dim=1)
+        else:
+            hidden_states = outputs.last_hidden_state
+
+        hidden_states = self.projector(hidden_states)
+        if attention_mask is None:
+            pooled_output = hidden_states.mean(dim=1)
+        else:
+            output_lengths = self._get_feat_extract_output_lengths(attention_mask.sum(-1)).to(torch.long)
+            pooled_output = hidden_states.sum(dim=1) / output_lengths.view(-1, 1)
+
+        logits = self.classifier(pooled_output)
+
+        loss = None
+        if labels is not None and self.config.problem_type is not None:
+            if self.config.problem_type == "single_label_classification":
+                loss_fct = CrossEntropyLoss()
+                loss = loss_fct(logits.view(-1, self.config.num_labels), labels.view(-1))
+            elif self.config.problem_type == "multi_label_classification":
+                loss_fct = BCEWithLogitsLoss()
+                loss = loss_fct(logits, labels)
+
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return ((loss,) + output) if loss is not None else output
+
+        return SequenceClassifierOutput(
+            loss=loss,
+            logits=logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
         )

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -1590,8 +1590,8 @@ class Wav2Vec2ForSequenceClassification(Wav2Vec2PreTrainedModel):
             >>> from transformers import Wav2Vec2FeatureExtractor, Wav2Vec2ForSequenceClassification
             >>> from datasets import load_dataset
 
-            >>> processor = Wav2Vec2FeatureExtractor.from_pretrained("anton-l/wav2vec2-base-superb-ks")
-            >>> model = Wav2Vec2ForSequenceClassification.from_pretrained("anton-l/wav2vec2-base-superb-ks")
+            >>> processor = Wav2Vec2FeatureExtractor.from_pretrained("superb/wav2vec2-base-superb-ks")
+            >>> model = Wav2Vec2ForSequenceClassification.from_pretrained("superb/wav2vec2-base-superb-ks")
 
             >>> ds = load_dataset("anton-l/superb_dummy", "ks", split="test")
 

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -3482,6 +3482,15 @@ class Wav2Vec2ForPreTraining:
         requires_backends(self, ["torch"])
 
 
+class Wav2Vec2ForSequenceClassification:
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torch"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+
 class Wav2Vec2Model:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -1863,6 +1863,15 @@ class HubertForCTC:
         requires_backends(self, ["torch"])
 
 
+class HubertForSequenceClassification:
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torch"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+
 class HubertModel:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])

--- a/tests/test_modeling_hubert.py
+++ b/tests/test_modeling_hubert.py
@@ -658,8 +658,8 @@ class HubertModelIntegrationTest(unittest.TestCase):
         self.assertListEqual(predicted_trans, EXPECTED_TRANSCRIPTIONS)
 
     def test_inference_keyword_spotting(self):
-        model = HubertForSequenceClassification.from_pretrained("anton-l/hubert-base-superb-ks").to(torch_device)
-        processor = Wav2Vec2FeatureExtractor.from_pretrained("anton-l/hubert-base-superb-ks")
+        model = HubertForSequenceClassification.from_pretrained("superb/hubert-base-superb-ks").to(torch_device)
+        processor = Wav2Vec2FeatureExtractor.from_pretrained("superb/hubert-base-superb-ks")
         input_data = self._load_superb("ks", 4)
         inputs = processor(input_data["speech"], return_tensors="pt", padding=True)
 
@@ -677,8 +677,8 @@ class HubertModelIntegrationTest(unittest.TestCase):
         self.assertTrue(torch.allclose(predicted_logits, expected_logits, atol=1e-2))
 
     def test_inference_intent_classification(self):
-        model = HubertForSequenceClassification.from_pretrained("anton-l/hubert-base-superb-ic").to(torch_device)
-        processor = Wav2Vec2FeatureExtractor.from_pretrained("anton-l/hubert-base-superb-ic")
+        model = HubertForSequenceClassification.from_pretrained("superb/hubert-base-superb-ic").to(torch_device)
+        processor = Wav2Vec2FeatureExtractor.from_pretrained("superb/hubert-base-superb-ic")
         input_data = self._load_superb("ic", 4)
         inputs = processor(input_data["speech"], return_tensors="pt", padding=True)
 
@@ -708,8 +708,8 @@ class HubertModelIntegrationTest(unittest.TestCase):
         self.assertTrue(torch.allclose(predicted_logits_location, expected_logits_location, atol=3e-1))
 
     def test_inference_speaker_identification(self):
-        model = HubertForSequenceClassification.from_pretrained("anton-l/hubert-base-superb-sid").to(torch_device)
-        processor = Wav2Vec2FeatureExtractor.from_pretrained("anton-l/hubert-base-superb-sid")
+        model = HubertForSequenceClassification.from_pretrained("superb/hubert-base-superb-sid").to(torch_device)
+        processor = Wav2Vec2FeatureExtractor.from_pretrained("superb/hubert-base-superb-sid")
         input_data = self._load_superb("si", 4)
 
         output_logits = []
@@ -730,8 +730,8 @@ class HubertModelIntegrationTest(unittest.TestCase):
         self.assertTrue(torch.allclose(predicted_logits, expected_logits, atol=10))
 
     def test_inference_emotion_recognition(self):
-        model = HubertForSequenceClassification.from_pretrained("anton-l/hubert-base-superb-er").to(torch_device)
-        processor = Wav2Vec2FeatureExtractor.from_pretrained("anton-l/hubert-base-superb-er")
+        model = HubertForSequenceClassification.from_pretrained("superb/hubert-base-superb-er").to(torch_device)
+        processor = Wav2Vec2FeatureExtractor.from_pretrained("superb/hubert-base-superb-er")
         input_data = self._load_superb("er", 4)
         inputs = processor(input_data["speech"], return_tensors="pt", padding=True)
 

--- a/tests/test_modeling_hubert.py
+++ b/tests/test_modeling_hubert.py
@@ -26,6 +26,7 @@ from transformers.testing_utils import require_datasets, require_soundfile, requ
 from .test_configuration_common import ConfigTester
 from .test_modeling_common import ModelTesterMixin, _config_zero_init
 
+
 if is_torch_available():
     import torch
 
@@ -41,31 +42,31 @@ if is_torch_available():
 
 class HubertModelTester:
     def __init__(
-            self,
-            parent,
-            batch_size=13,
-            seq_length=1024,  # speech is longer
-            is_training=False,
-            hidden_size=16,
-            feat_extract_norm="group",
-            feat_extract_dropout=0.0,
-            feat_extract_activation="gelu",
-            conv_dim=(32, 32, 32),
-            conv_stride=(4, 4, 4),
-            conv_kernel=(8, 8, 8),
-            conv_bias=False,
-            num_conv_pos_embeddings=16,
-            num_conv_pos_embedding_groups=2,
-            num_hidden_layers=4,
-            num_attention_heads=2,
-            hidden_dropout_prob=0.1,  # this is most likely not correctly set yet
-            intermediate_size=20,
-            layer_norm_eps=1e-5,
-            hidden_act="gelu",
-            initializer_range=0.02,
-            vocab_size=32,
-            do_stable_layer_norm=False,
-            scope=None,
+        self,
+        parent,
+        batch_size=13,
+        seq_length=1024,  # speech is longer
+        is_training=False,
+        hidden_size=16,
+        feat_extract_norm="group",
+        feat_extract_dropout=0.0,
+        feat_extract_activation="gelu",
+        conv_dim=(32, 32, 32),
+        conv_stride=(4, 4, 4),
+        conv_kernel=(8, 8, 8),
+        conv_bias=False,
+        num_conv_pos_embeddings=16,
+        num_conv_pos_embedding_groups=2,
+        num_hidden_layers=4,
+        num_attention_heads=2,
+        hidden_dropout_prob=0.1,  # this is most likely not correctly set yet
+        intermediate_size=20,
+        layer_norm_eps=1e-5,
+        hidden_act="gelu",
+        initializer_range=0.02,
+        vocab_size=32,
+        do_stable_layer_norm=False,
+        scope=None,
     ):
         self.parent = parent
         self.batch_size = batch_size
@@ -151,16 +152,16 @@ class HubertModelTester:
 
         # pad input
         for i in range(len(input_lengths)):
-            input_values[i, input_lengths[i]:] = 0.0
-            attention_mask[i, input_lengths[i]:] = 0.0
+            input_values[i, input_lengths[i] :] = 0.0
+            attention_mask[i, input_lengths[i] :] = 0.0
 
         batch_outputs = model(input_values, attention_mask=attention_mask).last_hidden_state
 
         for i in range(input_values.shape[0]):
-            input_slice = input_values[i: i + 1, : input_lengths[i]]
+            input_slice = input_values[i : i + 1, : input_lengths[i]]
             output = model(input_slice).last_hidden_state
 
-            batch_output = batch_outputs[i: i + 1, : output.shape[1]]
+            batch_output = batch_outputs[i : i + 1, : output.shape[1]]
             if not torch.allclose(output, batch_output, atol=1e-3):
                 print(False)
             self.parent.assertTrue(torch.allclose(output, batch_output, atol=1e-3))
@@ -181,8 +182,8 @@ class HubertModelTester:
 
         # pad input
         for i in range(len(input_lengths)):
-            input_values[i, input_lengths[i]:] = 0.0
-            attention_mask[i, input_lengths[i]:] = 0
+            input_values[i, input_lengths[i] :] = 0.0
+            attention_mask[i, input_lengths[i] :] = 0
 
         model.config.ctc_loss_reduction = "sum"
         sum_loss = model(input_values, attention_mask=attention_mask, labels=labels).loss.item()
@@ -208,8 +209,8 @@ class HubertModelTester:
 
         # pad input
         for i in range(len(input_lengths)):
-            input_values[i, input_lengths[i]:] = 0.0
-            attention_mask[i, input_lengths[i]:] = 0
+            input_values[i, input_lengths[i] :] = 0.0
+            attention_mask[i, input_lengths[i] :] = 0
 
         masked_loss = model(input_values, attention_mask=attention_mask, labels=labels).loss.item()
         unmasked_loss = model(input_values, labels=labels).loss.item()
@@ -235,12 +236,12 @@ class HubertModelTester:
 
         # pad input
         for i in range(len(input_lengths)):
-            input_values[i, input_lengths[i]:] = 0.0
+            input_values[i, input_lengths[i] :] = 0.0
 
             if max_length_labels[i] < labels.shape[-1]:
                 # it's important that we make sure that target lenghts are at least
                 # one shorter than logit lenghts to prevent -inf
-                labels[i, max_length_labels[i] - 1:] = -100
+                labels[i, max_length_labels[i] - 1 :] = -100
 
         loss = model(input_values, labels=labels).loss
         self.parent.assertFalse(torch.isinf(loss).item())
@@ -263,7 +264,7 @@ class HubertModelTester:
 
         # pad input
         for i in range(len(input_lengths)):
-            input_values[i, input_lengths[i]:] = 0.0
+            input_values[i, input_lengths[i] :] = 0.0
 
         loss = model(input_values, labels=labels).loss
         self.parent.assertFalse(torch.isinf(loss).item())
@@ -631,7 +632,6 @@ class HubertModelIntegrationTest(unittest.TestCase):
         from datasets import load_dataset
 
         ds = load_dataset("anton-l/superb_dummy", task, split="test")
-        ds.to_json("batch_hubert.json")
 
         return ds[:num_samples]
 
@@ -641,7 +641,7 @@ class HubertModelIntegrationTest(unittest.TestCase):
 
         input_speech = self._load_datasamples(2)
 
-        inputs = processor(input_speech, return_tensors="pt", padding=True, truncation=True)
+        inputs = processor(input_speech, return_tensors="pt", padding=True)
 
         input_values = inputs.input_values.to(torch_device)
         attention_mask = inputs.attention_mask.to(torch_device)
@@ -679,8 +679,8 @@ class HubertModelIntegrationTest(unittest.TestCase):
         self.assertTrue(torch.allclose(predicted_logits, expected_logits, atol=1e-2))
 
     def test_inference_intent_classification(self):
-        model = HubertForSequenceClassification.from_pretrained("../hf-models/hubert-base-s3prl-superb-ic").to(torch_device)
-        processor = Wav2Vec2FeatureExtractor.from_pretrained("../hf-models/hubert-base-s3prl-superb-ic")
+        model = HubertForSequenceClassification.from_pretrained("anton-l/hubert-base-s3prl-superb-ic").to(torch_device)
+        processor = Wav2Vec2FeatureExtractor.from_pretrained("anton-l/hubert-base-s3prl-superb-ic")
         input_data = self._load_superb("ic", 4)
         inputs = processor(input_data["speech"], return_tensors="pt", padding=True)
 
@@ -697,11 +697,11 @@ class HubertModelIntegrationTest(unittest.TestCase):
         predicted_logits_location, _ = torch.max(outputs.logits[:, 20:24], dim=-1)
 
         expected_labels_action = [1, 0, 4, 3]
-        expected_logits_action = torch.tensor([5.9052, 12.5865,  4.4840, 10.0240], device=torch_device)
+        expected_logits_action = torch.tensor([5.9052, 12.5865, 4.4840, 10.0240], device=torch_device)
         expected_labels_object = [1, 10, 3, 4]
-        expected_logits_object = torch.tensor([5.5316, 11.7946,  8.1672, 23.2415], device=torch_device)
+        expected_logits_object = torch.tensor([5.5316, 11.7946, 8.1672, 23.2415], device=torch_device)
         expected_labels_location = [0, 0, 0, 1]
-        expected_logits_location = torch.tensor([5.2053,  8.9577, 10.0447,  8.1481], device=torch_device)
+        expected_logits_location = torch.tensor([5.2053, 8.9577, 10.0447, 8.1481], device=torch_device)
 
         self.assertListEqual(predicted_ids_action.tolist(), expected_labels_action)
         self.assertListEqual(predicted_ids_object.tolist(), expected_labels_object)
@@ -712,11 +712,33 @@ class HubertModelIntegrationTest(unittest.TestCase):
         self.assertTrue(torch.allclose(predicted_logits_object, expected_logits_object, atol=3e-1))
         self.assertTrue(torch.allclose(predicted_logits_location, expected_logits_location, atol=3e-1))
 
-    def test_inference_emotion_recognition(self):
-        model = HubertForSequenceClassification.from_pretrained("../hf-models/hubert-base-s3prl-superb-er").to(
+    def test_inference_speaker_identification(self):
+        model = HubertForSequenceClassification.from_pretrained("anton-l/hubert-base-s3prl-superb-sid").to(
             torch_device
         )
-        processor = Wav2Vec2FeatureExtractor.from_pretrained("../hf-models/hubert-base-s3prl-superb-er")
+        processor = Wav2Vec2FeatureExtractor.from_pretrained("anton-l/hubert-base-s3prl-superb-sid")
+        input_data = self._load_superb("si", 4)
+
+        output_logits = []
+        with torch.no_grad():
+            for example in input_data["speech"]:
+                input = processor(example, return_tensors="pt", padding=True)
+                output = model(input.input_values.to(torch_device), attention_mask=None)
+                output_logits.append(output.logits[0])
+        output_logits = torch.stack(output_logits)
+        predicted_logits, predicted_ids = torch.max(output_logits, dim=-1)
+
+        expected_labels = [5, 1, 1, 3]
+        # s3prl logits for the same batch
+        expected_logits = torch.tensor([78231.5547, 123166.6094, 122785.4141, 84851.2969], device=torch_device)
+
+        self.assertListEqual(predicted_ids.tolist(), expected_labels)
+        # higher tolerance due to different padding masking https://github.com/pytorch/fairseq/pull/3572
+        self.assertTrue(torch.allclose(predicted_logits, expected_logits, atol=10))
+
+    def test_inference_emotion_recognition(self):
+        model = HubertForSequenceClassification.from_pretrained("anton-l/hubert-base-s3prl-superb-er").to(torch_device)
+        processor = Wav2Vec2FeatureExtractor.from_pretrained("anton-l/hubert-base-s3prl-superb-er")
         input_data = self._load_superb("er", 4)
         inputs = processor(input_data["speech"], return_tensors="pt", padding=True)
 

--- a/tests/test_modeling_wav2vec2.py
+++ b/tests/test_modeling_wav2vec2.py
@@ -993,8 +993,8 @@ class Wav2Vec2ModelIntegrationTest(unittest.TestCase):
         self.assertTrue(abs(outputs.loss.item() - expected_loss) < 1e-3)
 
     def test_inference_keyword_spotting(self):
-        model = Wav2Vec2ForSequenceClassification.from_pretrained("anton-l/wav2vec2-base-superb-ks").to(torch_device)
-        processor = Wav2Vec2FeatureExtractor.from_pretrained("anton-l/wav2vec2-base-superb-ks")
+        model = Wav2Vec2ForSequenceClassification.from_pretrained("superb/wav2vec2-base-superb-ks").to(torch_device)
+        processor = Wav2Vec2FeatureExtractor.from_pretrained("superb/wav2vec2-base-superb-ks")
         input_data = self._load_superb("ks", 4)
         inputs = processor(input_data["speech"], return_tensors="pt", padding=True)
 
@@ -1012,8 +1012,8 @@ class Wav2Vec2ModelIntegrationTest(unittest.TestCase):
         self.assertTrue(torch.allclose(predicted_logits, expected_logits, atol=1e-2))
 
     def test_inference_intent_classification(self):
-        model = Wav2Vec2ForSequenceClassification.from_pretrained("anton-l/wav2vec2-base-superb-ic").to(torch_device)
-        processor = Wav2Vec2FeatureExtractor.from_pretrained("anton-l/wav2vec2-base-superb-ic")
+        model = Wav2Vec2ForSequenceClassification.from_pretrained("superb/wav2vec2-base-superb-ic").to(torch_device)
+        processor = Wav2Vec2FeatureExtractor.from_pretrained("superb/wav2vec2-base-superb-ic")
         input_data = self._load_superb("ic", 4)
         inputs = processor(input_data["speech"], return_tensors="pt", padding=True)
 
@@ -1042,8 +1042,8 @@ class Wav2Vec2ModelIntegrationTest(unittest.TestCase):
         self.assertTrue(torch.allclose(predicted_logits_location, expected_logits_location, atol=1e-2))
 
     def test_inference_speaker_identification(self):
-        model = Wav2Vec2ForSequenceClassification.from_pretrained("anton-l/wav2vec2-base-superb-sid").to(torch_device)
-        processor = Wav2Vec2FeatureExtractor.from_pretrained("anton-l/wav2vec2-base-superb-sid")
+        model = Wav2Vec2ForSequenceClassification.from_pretrained("superb/wav2vec2-base-superb-sid").to(torch_device)
+        processor = Wav2Vec2FeatureExtractor.from_pretrained("superb/wav2vec2-base-superb-sid")
         input_data = self._load_superb("si", 4)
 
         output_logits = []
@@ -1063,8 +1063,8 @@ class Wav2Vec2ModelIntegrationTest(unittest.TestCase):
         self.assertTrue(torch.allclose(predicted_logits, expected_logits, atol=1e-2))
 
     def test_inference_emotion_recognition(self):
-        model = Wav2Vec2ForSequenceClassification.from_pretrained("anton-l/wav2vec2-base-superb-er").to(torch_device)
-        processor = Wav2Vec2FeatureExtractor.from_pretrained("anton-l/wav2vec2-base-superb-er")
+        model = Wav2Vec2ForSequenceClassification.from_pretrained("superb/wav2vec2-base-superb-er").to(torch_device)
+        processor = Wav2Vec2FeatureExtractor.from_pretrained("superb/wav2vec2-base-superb-er")
         input_data = self._load_superb("er", 4)
         inputs = processor(input_data["speech"], return_tensors="pt", padding=True)
 

--- a/tests/test_modeling_wav2vec2.py
+++ b/tests/test_modeling_wav2vec2.py
@@ -26,6 +26,7 @@ from transformers.testing_utils import require_datasets, require_soundfile, requ
 from .test_configuration_common import ConfigTester
 from .test_modeling_common import ModelTesterMixin, _config_zero_init
 
+
 if is_torch_available():
     import torch
 
@@ -43,31 +44,31 @@ if is_torch_available():
 
 class Wav2Vec2ModelTester:
     def __init__(
-            self,
-            parent,
-            batch_size=13,
-            seq_length=1024,  # speech is longer
-            is_training=False,
-            hidden_size=16,
-            feat_extract_norm="group",
-            feat_extract_dropout=0.0,
-            feat_extract_activation="gelu",
-            conv_dim=(32, 32, 32),
-            conv_stride=(4, 4, 4),
-            conv_kernel=(8, 8, 8),
-            conv_bias=False,
-            num_conv_pos_embeddings=16,
-            num_conv_pos_embedding_groups=2,
-            num_hidden_layers=4,
-            num_attention_heads=2,
-            hidden_dropout_prob=0.1,  # this is most likely not correctly set yet
-            intermediate_size=20,
-            layer_norm_eps=1e-5,
-            hidden_act="gelu",
-            initializer_range=0.02,
-            vocab_size=32,
-            do_stable_layer_norm=False,
-            scope=None,
+        self,
+        parent,
+        batch_size=13,
+        seq_length=1024,  # speech is longer
+        is_training=False,
+        hidden_size=16,
+        feat_extract_norm="group",
+        feat_extract_dropout=0.0,
+        feat_extract_activation="gelu",
+        conv_dim=(32, 32, 32),
+        conv_stride=(4, 4, 4),
+        conv_kernel=(8, 8, 8),
+        conv_bias=False,
+        num_conv_pos_embeddings=16,
+        num_conv_pos_embedding_groups=2,
+        num_hidden_layers=4,
+        num_attention_heads=2,
+        hidden_dropout_prob=0.1,  # this is most likely not correctly set yet
+        intermediate_size=20,
+        layer_norm_eps=1e-5,
+        hidden_act="gelu",
+        initializer_range=0.02,
+        vocab_size=32,
+        do_stable_layer_norm=False,
+        scope=None,
     ):
         self.parent = parent
         self.batch_size = batch_size
@@ -153,16 +154,16 @@ class Wav2Vec2ModelTester:
 
         # pad input
         for i in range(len(input_lengths)):
-            input_values[i, input_lengths[i]:] = 0.0
-            attention_mask[i, input_lengths[i]:] = 0.0
+            input_values[i, input_lengths[i] :] = 0.0
+            attention_mask[i, input_lengths[i] :] = 0.0
 
         batch_outputs = model(input_values, attention_mask=attention_mask).last_hidden_state
 
         for i in range(input_values.shape[0]):
-            input_slice = input_values[i: i + 1, : input_lengths[i]]
+            input_slice = input_values[i : i + 1, : input_lengths[i]]
             output = model(input_slice).last_hidden_state
 
-            batch_output = batch_outputs[i: i + 1, : output.shape[1]]
+            batch_output = batch_outputs[i : i + 1, : output.shape[1]]
             self.parent.assertTrue(torch.allclose(output, batch_output, atol=1e-3))
 
     def check_ctc_loss(self, config, input_values, *args):
@@ -181,8 +182,8 @@ class Wav2Vec2ModelTester:
 
         # pad input
         for i in range(len(input_lengths)):
-            input_values[i, input_lengths[i]:] = 0.0
-            attention_mask[i, input_lengths[i]:] = 0
+            input_values[i, input_lengths[i] :] = 0.0
+            attention_mask[i, input_lengths[i] :] = 0
 
         model.config.ctc_loss_reduction = "sum"
         sum_loss = model(input_values, attention_mask=attention_mask, labels=labels).loss.item()
@@ -210,12 +211,12 @@ class Wav2Vec2ModelTester:
 
         # pad input
         for i in range(len(input_lengths)):
-            input_values[i, input_lengths[i]:] = 0.0
+            input_values[i, input_lengths[i] :] = 0.0
 
             if max_length_labels[i] < labels.shape[-1]:
                 # it's important that we make sure that target lenghts are at least
                 # one shorter than logit lenghts to prevent -inf
-                labels[i, max_length_labels[i] - 1:] = -100
+                labels[i, max_length_labels[i] - 1 :] = -100
 
         loss = model(input_values, labels=labels).loss
         self.parent.assertFalse(torch.isinf(loss).item())
@@ -592,7 +593,7 @@ class Wav2Vec2UtilsTest(unittest.TestCase):
         mask_length = 4
 
         attention_mask = torch.ones((batch_size, sequence_length), dtype=torch.long, device=torch_device)
-        attention_mask[:2, sequence_length // 2:] = 0
+        attention_mask[:2, sequence_length // 2 :] = 0
 
         mask = _compute_mask_indices(
             (batch_size, sequence_length), mask_prob, mask_length, device=torch_device, attention_mask=attention_mask
@@ -601,7 +602,7 @@ class Wav2Vec2UtilsTest(unittest.TestCase):
         for batch_sum in mask.sum(axis=-1):
             self.assertTrue(int(batch_sum) <= mask_prob * sequence_length)
 
-        self.assertTrue(mask[:2, sequence_length // 2:].sum() == 0)
+        self.assertTrue(mask[:2, sequence_length // 2 :].sum() == 0)
 
     def test_compute_perplexity(self):
         probs = torch.arange(100, device=torch_device).reshape(2, 5, 10) / 100
@@ -646,7 +647,7 @@ class Wav2Vec2UtilsTest(unittest.TestCase):
 
         # second half of last input tensor is padded
         attention_mask = torch.ones((batch_size, sequence_length), dtype=torch.long, device=torch_device)
-        attention_mask[-1, sequence_length // 2:] = 0
+        attention_mask[-1, sequence_length // 2 :] = 0
 
         features = (torch.arange(sequence_length * hidden_size, device=torch_device) // hidden_size).view(
             sequence_length, hidden_size

--- a/tests/test_modeling_wav2vec2.py
+++ b/tests/test_modeling_wav2vec2.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """ Testing suite for the PyTorch Wav2Vec2 model. """
 
-
 import math
 import unittest
 
@@ -26,7 +25,6 @@ from transformers.testing_utils import require_datasets, require_soundfile, requ
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_common import ModelTesterMixin, _config_zero_init
-
 
 if is_torch_available():
     import torch
@@ -45,31 +43,31 @@ if is_torch_available():
 
 class Wav2Vec2ModelTester:
     def __init__(
-        self,
-        parent,
-        batch_size=13,
-        seq_length=1024,  # speech is longer
-        is_training=False,
-        hidden_size=16,
-        feat_extract_norm="group",
-        feat_extract_dropout=0.0,
-        feat_extract_activation="gelu",
-        conv_dim=(32, 32, 32),
-        conv_stride=(4, 4, 4),
-        conv_kernel=(8, 8, 8),
-        conv_bias=False,
-        num_conv_pos_embeddings=16,
-        num_conv_pos_embedding_groups=2,
-        num_hidden_layers=4,
-        num_attention_heads=2,
-        hidden_dropout_prob=0.1,  # this is most likely not correctly set yet
-        intermediate_size=20,
-        layer_norm_eps=1e-5,
-        hidden_act="gelu",
-        initializer_range=0.02,
-        vocab_size=32,
-        do_stable_layer_norm=False,
-        scope=None,
+            self,
+            parent,
+            batch_size=13,
+            seq_length=1024,  # speech is longer
+            is_training=False,
+            hidden_size=16,
+            feat_extract_norm="group",
+            feat_extract_dropout=0.0,
+            feat_extract_activation="gelu",
+            conv_dim=(32, 32, 32),
+            conv_stride=(4, 4, 4),
+            conv_kernel=(8, 8, 8),
+            conv_bias=False,
+            num_conv_pos_embeddings=16,
+            num_conv_pos_embedding_groups=2,
+            num_hidden_layers=4,
+            num_attention_heads=2,
+            hidden_dropout_prob=0.1,  # this is most likely not correctly set yet
+            intermediate_size=20,
+            layer_norm_eps=1e-5,
+            hidden_act="gelu",
+            initializer_range=0.02,
+            vocab_size=32,
+            do_stable_layer_norm=False,
+            scope=None,
     ):
         self.parent = parent
         self.batch_size = batch_size
@@ -155,16 +153,16 @@ class Wav2Vec2ModelTester:
 
         # pad input
         for i in range(len(input_lengths)):
-            input_values[i, input_lengths[i] :] = 0.0
-            attention_mask[i, input_lengths[i] :] = 0.0
+            input_values[i, input_lengths[i]:] = 0.0
+            attention_mask[i, input_lengths[i]:] = 0.0
 
         batch_outputs = model(input_values, attention_mask=attention_mask).last_hidden_state
 
         for i in range(input_values.shape[0]):
-            input_slice = input_values[i : i + 1, : input_lengths[i]]
+            input_slice = input_values[i: i + 1, : input_lengths[i]]
             output = model(input_slice).last_hidden_state
 
-            batch_output = batch_outputs[i : i + 1, : output.shape[1]]
+            batch_output = batch_outputs[i: i + 1, : output.shape[1]]
             self.parent.assertTrue(torch.allclose(output, batch_output, atol=1e-3))
 
     def check_ctc_loss(self, config, input_values, *args):
@@ -183,8 +181,8 @@ class Wav2Vec2ModelTester:
 
         # pad input
         for i in range(len(input_lengths)):
-            input_values[i, input_lengths[i] :] = 0.0
-            attention_mask[i, input_lengths[i] :] = 0
+            input_values[i, input_lengths[i]:] = 0.0
+            attention_mask[i, input_lengths[i]:] = 0
 
         model.config.ctc_loss_reduction = "sum"
         sum_loss = model(input_values, attention_mask=attention_mask, labels=labels).loss.item()
@@ -212,12 +210,12 @@ class Wav2Vec2ModelTester:
 
         # pad input
         for i in range(len(input_lengths)):
-            input_values[i, input_lengths[i] :] = 0.0
+            input_values[i, input_lengths[i]:] = 0.0
 
             if max_length_labels[i] < labels.shape[-1]:
                 # it's important that we make sure that target lenghts are at least
                 # one shorter than logit lenghts to prevent -inf
-                labels[i, max_length_labels[i] - 1 :] = -100
+                labels[i, max_length_labels[i] - 1:] = -100
 
         loss = model(input_values, labels=labels).loss
         self.parent.assertFalse(torch.isinf(loss).item())
@@ -594,7 +592,7 @@ class Wav2Vec2UtilsTest(unittest.TestCase):
         mask_length = 4
 
         attention_mask = torch.ones((batch_size, sequence_length), dtype=torch.long, device=torch_device)
-        attention_mask[:2, sequence_length // 2 :] = 0
+        attention_mask[:2, sequence_length // 2:] = 0
 
         mask = _compute_mask_indices(
             (batch_size, sequence_length), mask_prob, mask_length, device=torch_device, attention_mask=attention_mask
@@ -603,7 +601,7 @@ class Wav2Vec2UtilsTest(unittest.TestCase):
         for batch_sum in mask.sum(axis=-1):
             self.assertTrue(int(batch_sum) <= mask_prob * sequence_length)
 
-        self.assertTrue(mask[:2, sequence_length // 2 :].sum() == 0)
+        self.assertTrue(mask[:2, sequence_length // 2:].sum() == 0)
 
     def test_compute_perplexity(self):
         probs = torch.arange(100, device=torch_device).reshape(2, 5, 10) / 100
@@ -648,7 +646,7 @@ class Wav2Vec2UtilsTest(unittest.TestCase):
 
         # second half of last input tensor is padded
         attention_mask = torch.ones((batch_size, sequence_length), dtype=torch.long, device=torch_device)
-        attention_mask[-1, sequence_length // 2 :] = 0
+        attention_mask[-1, sequence_length // 2:] = 0
 
         features = (torch.arange(sequence_length * hidden_size, device=torch_device) // hidden_size).view(
             sequence_length, hidden_size
@@ -807,7 +805,10 @@ class Wav2Vec2ModelIntegrationTest(unittest.TestCase):
 
         # fmt: off
         expected_cosine_sim_masked = torch.tensor(
-            [0.7458, 0.7188, 0.6418, 0.3729, 0.3741, 0.3694, 0.3110, 0.2257, 0.4403, 0.5415, 0.3950, 0.3701, 0.8831, 0.8613, 0.5229, 0.6696, 0.7206, 0.7877, 0.6758, 0.8746, 0.6596, 0.6282, 0.6178, 0.5839, 0.5926, 0.6651, 0.4635, 0.6332, 0.6572, 0.8776, 0.4999, 0.7001, 0.7257, 0.5098, 0.6229, 0.4566, 0.5261, 0.6363, 0.5371, 0.6997],
+            [0.7458, 0.7188, 0.6418, 0.3729, 0.3741, 0.3694, 0.3110, 0.2257, 0.4403, 0.5415, 0.3950, 0.3701, 0.8831,
+             0.8613, 0.5229, 0.6696, 0.7206, 0.7877, 0.6758, 0.8746, 0.6596, 0.6282, 0.6178, 0.5839, 0.5926, 0.6651,
+             0.4635, 0.6332, 0.6572, 0.8776, 0.4999, 0.7001, 0.7257, 0.5098, 0.6229, 0.4566, 0.5261, 0.6363, 0.5371,
+             0.6997],
             device=torch_device,
         )
         # fmt: on
@@ -939,10 +940,11 @@ class Wav2Vec2ModelIntegrationTest(unittest.TestCase):
         with torch.no_grad():
             outputs = model(input_values, attention_mask=attention_mask)
         predicted_ids = torch.argmax(outputs.logits, dim=-1)
+        predicted_logits, _ = torch.max(outputs.logits, dim=-1)
 
         expected_labels = [1, 1, 2, 2]
-        # s3prl logits for "Ses01M_impro07_F012.wav"
-        expected_logits = torch.tensor([0.3055, 1.2254, -2.1298, -1.1464], device=torch_device)
+        # s3prl logits for the same batch
+        expected_logits = torch.tensor([2.1722, 3.0779, 8.0287, 6.6797], device=torch_device)
 
         self.assertListEqual(predicted_ids.tolist(), expected_labels)
-        self.assertTrue(torch.allclose(outputs.logits[0], expected_logits, atol=1e-2))
+        self.assertTrue(torch.allclose(predicted_logits, expected_logits, atol=1e-2))

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -122,6 +122,7 @@ IGNORE_NON_AUTO_CONFIGURED = PRIVATE_MODELS.copy() + [
     "TFRagTokenForGeneration",
     "Wav2Vec2ForCTC",
     "HubertForCTC",
+    "Wav2Vec2ForSequenceClassification",
     "HubertForSequenceClassification",
     "XLMForQuestionAnswering",
     "XLNetForQuestionAnswering",

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -122,6 +122,7 @@ IGNORE_NON_AUTO_CONFIGURED = PRIVATE_MODELS.copy() + [
     "TFRagTokenForGeneration",
     "Wav2Vec2ForCTC",
     "HubertForCTC",
+    "HubertForSequenceClassification",
     "XLMForQuestionAnswering",
     "XLNetForQuestionAnswering",
     "SeparableConv1D",


### PR DESCRIPTION
# What does this PR do?

This adds a Hubert extension for sequence classification.
Ultimately this classification head should be compatible with s3prl `UtteranceLevel` [implementation](https://github.com/s3prl/s3prl/blob/master/s3prl/downstream/model.py#L35) to support classification tasks from SUPERB, such as [Keyword Spotting](https://huggingface.co/datasets/superb#ks) and transfer their pretrained models.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@patrickvonplaten @patil-suraj 
