### PR TITLE
🐛: skip_special_tokens in tokenization_utils.py

### DIFF
--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -748,7 +748,7 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
         sub_texts = []
         current_sub_text = []
         for token in filtered_tokens:
-            if skip_special_tokens and token in self.all_special_ids:
+            if skip_special_tokens and token in self.all_special_tokens:
                 continue
             if token in self.added_tokens_encoder:
                 if current_sub_text:


### PR DESCRIPTION
# What does this PR do?
🐛: skip_special_tokens in tokenization_utils.py

The skip_special_tokens in tokenization_utils.py does not work, because token never in self.all_special_ids, which shoule be fixed to self.all_special_tokens.

Many thakns! @n1t0 @LysandreJik .