### PR TITLE
[AutoFeatureExtractor] Fix loading of local folders if config.json exists

### DIFF
--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -20,6 +20,7 @@ from collections import OrderedDict
 from typing import List, Union
 
 from ...configuration_utils import PretrainedConfig
+from ...file_utils import CONFIG_NAME
 
 
 CONFIG_MAPPING_NAMES = OrderedDict(
@@ -520,6 +521,6 @@ class AutoConfig:
 
         raise ValueError(
             f"Unrecognized model in {pretrained_model_name_or_path}. "
-            "Should have a `model_type` key in its config.json, or contain one of the following strings "
+            f"Should have a `model_type` key in its {CONFIG_NAME}, or contain one of the following strings "
             f"in its name: {', '.join(CONFIG_MAPPING.keys())}"
         )

--- a/tests/test_feature_extraction_auto.py
+++ b/tests/test_feature_extraction_auto.py
@@ -17,7 +17,7 @@ import os
 import tempfile
 import unittest
 
-from transformers import AutoConfig, AutoFeatureExtractor, Wav2Vec2Config, Wav2Vec2FeatureExtractor
+from transformers import AutoFeatureExtractor, Wav2Vec2Config, Wav2Vec2FeatureExtractor
 
 
 SAMPLE_FEATURE_EXTRACTION_CONFIG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")

--- a/tests/test_feature_extraction_auto.py
+++ b/tests/test_feature_extraction_auto.py
@@ -14,15 +14,17 @@
 # limitations under the License.
 
 import os
+import tempfile
 import unittest
 
-from transformers import AutoFeatureExtractor, Wav2Vec2FeatureExtractor
+from transformers import AutoConfig, AutoFeatureExtractor, Wav2Vec2Config, Wav2Vec2FeatureExtractor
 
 
 SAMPLE_FEATURE_EXTRACTION_CONFIG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
 SAMPLE_FEATURE_EXTRACTION_CONFIG = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "fixtures/dummy_feature_extractor_config.json"
 )
+SAMPLE_CONFIG = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures/dummy-config.json")
 
 
 class AutoFeatureExtractorTest(unittest.TestCase):
@@ -30,8 +32,25 @@ class AutoFeatureExtractorTest(unittest.TestCase):
         config = AutoFeatureExtractor.from_pretrained("facebook/wav2vec2-base-960h")
         self.assertIsInstance(config, Wav2Vec2FeatureExtractor)
 
-    def test_feature_extractor_from_local_directory(self):
+    def test_feature_extractor_from_local_directory_from_key(self):
         config = AutoFeatureExtractor.from_pretrained(SAMPLE_FEATURE_EXTRACTION_CONFIG_DIR)
+        self.assertIsInstance(config, Wav2Vec2FeatureExtractor)
+
+    def test_feature_extractor_from_local_directory_from_config(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            model_config = Wav2Vec2Config()
+
+            # remove feature_extractor_type to make sure config.json alone is enough to load feature processor locally
+            config_dict = AutoFeatureExtractor.from_pretrained(SAMPLE_FEATURE_EXTRACTION_CONFIG_DIR).to_dict()
+            config_dict.pop("feature_extractor_type")
+            config = Wav2Vec2FeatureExtractor(config_dict)
+
+            # save in new folder
+            model_config.save_pretrained(tmpdirname)
+            config.save_pretrained(tmpdirname)
+
+            config = AutoFeatureExtractor.from_pretrained(tmpdirname)
+
         self.assertIsInstance(config, Wav2Vec2FeatureExtractor)
 
     def test_feature_extractor_from_local_file(self):


### PR DESCRIPTION
# What does this PR do?

Currently there is a problem when loading the feature extractor locally via `AutoFeatureExtractor` as spotted by @philschmid:

```bash
!git lfs install
!git clone https://huggingface.co/facebook/wav2vec2-base-960h
```

and then:

```python
from transformers import AutoFeatureExtractor

extractor = AutoFeatureExtractor.from_pretrained("wav2vec2-base-960h")
```

This leads to an error. This PR fixes it and also improves the error message.