### PR TITLE
Fix LUKE tests

### DIFF
--- a/tests/test_tokenization_luke.py
+++ b/tests/test_tokenization_luke.py
@@ -15,6 +15,7 @@
 
 
 import unittest
+from typing import Tuple
 
 from transformers import AddedToken, LukeTokenizer
 from transformers.testing_utils import require_torch, slow
@@ -80,6 +81,11 @@ class Luke(TokenizerTesterMixin, unittest.TestCase):
 
         assert encoded_sentence == encoded_text_from_decode
         assert encoded_pair == encoded_pair_from_decode
+
+    def get_clean_sequence(self, tokenizer, max_length=20) -> Tuple[str, list]:
+        txt = "Beyonce lives in Los Angeles"
+        ids = tokenizer.encode(txt, add_special_tokens=False)
+        return txt, ids
 
     def test_space_encoding(self):
         tokenizer = self.get_tokenizer()


### PR DESCRIPTION
# What does this PR do?

3 tests defined in `test_tokenization_luke.py` were having a timeout because they were too slow:

```
FAILED tests/test_tokenization_luke.py::Luke::test_add_special_tokens
FAILED tests/test_tokenization_luke.py::Luke::test_maximum_encoding_length_pair_input
FAILED tests/test_tokenization_luke.py::Luke::test_maximum_encoding_length_single_input
```

This was caused by the `get_clean_sequence` method (used in each of those methods), which is defined in `test_tokenization_common.py` and was inherited by default. By overwriting this method with a much simpler one, the tests are significantly faster. No bottleneck anymore.