### PR TITLE
Fall back to `observed_batch_size` when the `dataloader` does not know the `batch_size`.

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2208,6 +2208,9 @@ class Trainer:
             observed_batch_size = find_batch_size(inputs)
             if observed_batch_size is not None:
                 observed_num_examples += observed_batch_size
+                # For batch samplers, batch_size is not known by the dataloader in advance.
+                if batch_size is None:
+                    batch_size = observed_batch_size
 
             # Prediction step
             loss, logits, labels = self.prediction_step(model, inputs, prediction_loss_only, ignore_keys=ignore_keys)


### PR DESCRIPTION
# What does this PR do?

Motivated by #12995, this adds support for users to provide a `batch_sampler` to the DataLoader instead of a (single index) `sampler`. (The [pytorch docs](https://pytorch.org/docs/stable/data.html) has more info on these two sampler types.)

When we provide a `batch_sampler`, a DataLoader doesn't know the batch size, so it's set to `None`. Currently, the Trainer retrieves the batch size from the data loader:

https://github.com/huggingface/transformers/blob/1fec32adc6a4840123d5ec5ff5cf419c02342b5a/src/transformers/trainer.py#L2172

... leading to a crash a few lines later when it tries to use it:

https://github.com/huggingface/transformers/blob/1fec32adc6a4840123d5ec5ff5cf419c02342b5a/src/transformers/trainer.py#L2217

```txt
TypeError: repeat(): argument 'repeats' (position 1) must be tuple of ints, not NoneType
```

Fortunately, the observed batch size is calculated between those two spots, so this change simply uses it instead if the batch size wasn't found on the data loader.

I added the `None` check just to ensure this does not change existing behavior, though I would imagine it would not even without the check.

_Re: testing: I was not sure how much code you want surrounding this fix / added support, as I don't think Transformers includes any batch samplers itself yet, so I didn't include a test. Let me know otherwise and I can take a stab at it!_

## Who can review?

I suggest @sgugger due to issue context and Trainer :-)
