### PR TITLE
Add support for XLM-R XL and XXL models 

### DIFF
--- a/src/transformers/models/roberta/configuration_roberta.py
+++ b/src/transformers/models/roberta/configuration_roberta.py
@@ -62,9 +62,11 @@ class RobertaConfig(BertConfig):
     """
     model_type = "roberta"
 
-    def __init__(self, pad_token_id=1, bos_token_id=0, eos_token_id=2, **kwargs):
+    def __init__(self, pad_token_id=1, bos_token_id=0, eos_token_id=2, normalize_embeddings=True, **kwargs):
         """Constructs RobertaConfig."""
         super().__init__(pad_token_id=pad_token_id, bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
+
+        self.normalize_embeddings = normalize_embeddings
 
 
 class RobertaOnnxConfig(OnnxConfig):


### PR DESCRIPTION
This PR adds support for the newly released XL and XXL models for XLM-R. These models are described in the "Larger-Scale Transformers for Multilingual Masked Language Modeling" paper.

I compared fairseq and transformers side by side, 
and managed output same. 

torch.Size([1, 10, 250880]) torch.Size([1, 10, 250880])
max_absolute_diff = 0.00022125244140614
Do both models outut the same tensors?  🔥

Since fairseq roberta to transformers conversion was made a long time ago, 
transformers architecture differs far from fairseq which originally started from, 
and it makes quite confusion to write right code.
I synced transformers code to allow fairseq model structure.

And the original PR https://github.com/huggingface/transformers/pull/12082#issue-665786049 was closed by its author @stefan-it and the PR(https://github.com/stefan-it/transformers/pull/1) I pushed for his repo about 40 days ago but got no response,
so I opened the new PR.