### PR TITLE
Add RemBert to AutoTokenizer

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -199,6 +199,13 @@ else:
                     "MBart50TokenizerFast" if is_tokenizers_available() else None,
                 ),
             ),
+            (
+                "rembert",
+                (
+                    "RemBertTokenizer" if is_sentencepiece_available() else None,
+                    "RemBertTokenizerFast" if is_tokenizers_available() else None,
+                ),
+            ),
         ]
     )
 


### PR DESCRIPTION
The RemBert tokenizer was not added to the `AutoTokenizer` factory. This fixes it.