### PR TITLE
fix `tokenizer_class_from_name` for models with `-` in the name

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -222,6 +222,9 @@ def tokenizer_class_from_name(class_name: str):
         if class_name in tokenizers:
             break
 
+    if module_name == "openai-gpt":
+        module_name = "openai"
+
     module = importlib.import_module(f".{module_name.replace('-', '_')}", "transformers.models")
     return getattr(module, class_name)
 

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -222,7 +222,7 @@ def tokenizer_class_from_name(class_name: str):
         if class_name in tokenizers:
             break
 
-    module = importlib.import_module(f".{module_name}", "transformers.models")
+    module = importlib.import_module(f".{module_name.replace('-', '_')}", "transformers.models")
     return getattr(module, class_name)
 
 

--- a/tests/test_tokenization_auto.py
+++ b/tests/test_tokenization_auto.py
@@ -29,7 +29,11 @@ from transformers import (
     RobertaTokenizerFast,
 )
 from transformers.models.auto.configuration_auto import AutoConfig
-from transformers.models.auto.tokenization_auto import TOKENIZER_MAPPING, get_tokenizer_config
+from transformers.models.auto.tokenization_auto import (
+    TOKENIZER_MAPPING,
+    get_tokenizer_config,
+    tokenizer_class_from_name,
+)
 from transformers.models.roberta.configuration_roberta import RobertaConfig
 from transformers.testing_utils import (
     DUMMY_DIFF_TOKENIZER_IDENTIFIER,
@@ -104,6 +108,24 @@ class AutoTokenizerTest(unittest.TestCase):
                 for parent_config, _ in mapping[: index + 1]:
                     with self.subTest(msg=f"Testing if {child_config.__name__} is child of {parent_config.__name__}"):
                         self.assertFalse(issubclass(child_config, parent_config))
+
+    def test_model_name_edge_cases_in_mappings(self):
+        # tests: https://github.com/huggingface/transformers/pull/13251
+        # 1. models with `-`, e.g. xlm-roberta -> xlm_roberta
+        # 2. models that don't remap 1-1 from model-name to model file, e.g., openai-gpt -> openai
+        tokenizers = TOKENIZER_MAPPING.values()
+        tokenizer_names = []
+
+        for slow_tok, fast_tok in tokenizers:
+            if slow_tok is not None:
+                tokenizer_names.append(slow_tok.__name__)
+
+            if fast_tok is not None:
+                tokenizer_names.append(fast_tok.__name__)
+
+        for tokenizer_name in tokenizer_names:
+            # must find the right class
+            tokenizer_class_from_name(tokenizer_name)
 
     @require_tokenizers
     def test_from_pretrained_use_fast_toggle(self):


### PR DESCRIPTION
https://github.com/huggingface/transformers/pull/13023 breaks for some models with `-` in its name. e.g. `xlm-roberta`,

For example:

```

Traceback (most recent call last):
  File "/mnt/nvme1/code/huggingface/transformers-master/examples/pytorch/language-modeling/run_mlm.py", line 550, in <module>
    main()
  File "/mnt/nvme1/code/huggingface/transformers-master/examples/pytorch/language-modeling/run_mlm.py", line 337, in main
    tokenizer = AutoTokenizer.from_pretrained(model_args.model_name_or_path, **tokenizer_kwargs)
  File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/models/auto/tokenization_auto.py", line 432, in from_pretrained
    tokenizer_class = tokenizer_class_from_name(tokenizer_class_candidate)
  File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/models/auto/tokenization_auto.py", line 226, in tokenizer_class_from_name
    module = importlib.import_module(f".{module_name}", "transformers.models")
  File "/home/stas/anaconda3/envs/py38-pt19/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'transformers.models.xlm-roberta'
```

as you can see it tries to import "`transformers.models.xlm-roberta`", to reproduce:

```
RUN_SLOW=1 pytest tests/deepspeed -k clm_xlm_roberta
```

```
# module_name, tokenizers debug print:
xlm-roberta ('XLMRobertaTokenizer', 'XLMRobertaTokenizerFast')
```

This PR fixes it:
```
 module = importlib.import_module(f".{module_name.replace('-', '_')}", "transformers.models")
```

Oddly enough I don't get this problem if I run `xlm-roberta-base`, so this is an edge case. As the core models seems to not trigger the problem. Not sure why.

In the deepspeed test suite the 2 failing tests were:

```
RUN_SLOW=1 pytest tests/deepspeed -k clm_xlm_roberta
```

Now it has a core test - thanks @LysandreJik 

@LysandreJik also pushed a fix for model names that mismatch model files which is the case with `openai-gpt`

@LysandreJik, @sgugger 