### PR TITLE
Remove side effects of disabling gradient computaiton

### DIFF
--- a/src/transformers/onnx/convert.py
+++ b/src/transformers/onnx/convert.py
@@ -127,6 +127,7 @@ def export(
     )
 
     config.restore_ops()
+    torch.set_grad_enabled(False)
 
     return matched_inputs, onnx_outputs
 


### PR DESCRIPTION
Disabling gradient computation here will affect all next operations using torch, and will remove the gradient computation. This made a few `Trainer` test fail in slow tests.