### PR TITLE
Some `model_type`s cannot be in the mapping

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1799,7 +1799,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                             break
 
                 if model_type is not None:
-                    config_tokenizer_class, config_tokenizer_class_fast = TOKENIZER_MAPPING_NAMES.get(model_type, (None, None))
+                    config_tokenizer_class, config_tokenizer_class_fast = TOKENIZER_MAPPING_NAMES.get(
+                        model_type, (None, None)
+                    )
                     if config_tokenizer_class is None:
                         config_tokenizer_class = config_tokenizer_class_fast
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1799,7 +1799,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                             break
 
                 if model_type is not None:
-                    config_tokenizer_class, config_tokenizer_class_fast = TOKENIZER_MAPPING_NAMES[model_type]
+                    config_tokenizer_class, config_tokenizer_class_fast = TOKENIZER_MAPPING_NAMES.get(model_type, (None, None))
                     if config_tokenizer_class is None:
                         config_tokenizer_class = config_tokenizer_class_fast
 


### PR DESCRIPTION
Some `model_type`s cannot be in the mapping. This PR offers a fallback for these cases.

The following had stopped working (tested by `test_bert2bert_summarization`):

```
tokenizer = BertTokenizer.from_pretrained("patrickvonplaten/bert2bert-cnn_dailymail-fp16"
``` 