### PR TITLE
Replace assert statement with if condition and raise ValueError

### DIFF
--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -201,7 +201,8 @@ def get_polynomial_decay_schedule_with_warmup(
     """
 
     lr_init = optimizer.defaults["lr"]
-    assert lr_init > lr_end, f"lr_end ({lr_end}) must be be smaller than initial lr ({lr_init})"
+    if not (lr_init > lr_end):
+        raise ValueError(f"lr_end ({lr_end}) must be be smaller than initial lr ({lr_init})")
 
     def lr_lambda(current_step: int):
         if current_step < num_warmup_steps:


### PR DESCRIPTION
# What does this PR do?

The goal of this PR is to replace assert statements with if statements and raise appropriate exceptions (see issue #12789)

Replaces 
```
assert lr_init > lr_end, f"lr_end ({lr_end}) must be be smaller than initial lr ({lr_init})"
```
with 
```
if not (lr_init > lr_end):
    raise ValueError(f"lr_end ({lr_end}) must be be smaller than initial lr ({lr_init})")
```
in optimization.py 


Contributes towards fixing issue #12789


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger 
