### PR TITLE
Fix loading for newer m2m models

### DIFF
--- a/src/transformers/models/m2m_100/convert_m2m100_original_checkpoint_to_pytorch.py
+++ b/src/transformers/models/m2m_100/convert_m2m100_original_checkpoint_to_pytorch.py
@@ -44,7 +44,7 @@ def make_linear_from_emb(emb):
 
 def convert_fairseq_m2m100_checkpoint_from_disk(checkpoint_path):
     m2m_100 = torch.load(checkpoint_path, map_location="cpu")
-    args = m2m_100["args"]
+    args = m2m_100["args"] or m2m_100["cfg"]["model"]
     state_dict = m2m_100["model"]
     remove_ignore_keys_(state_dict)
     vocab_size = state_dict["encoder.embed_tokens.weight"].shape[0]
@@ -78,8 +78,8 @@ def convert_fairseq_m2m100_checkpoint_from_disk(checkpoint_path):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     # Required parameters
-    parser.add_argument("fairseq_path", type=str, help="path to a model.pt on local filesystem.")
-    parser.add_argument("pytorch_dump_folder_path", default=None, type=str, help="Path to the output PyTorch model.")
+    parser.add_argument("--fairseq_path", "-i", type=str, help="path to a model.pt on local filesystem.")
+    parser.add_argument("--pytorch_dump_folder_path","-o", default=None, type=str, help="Path to the output PyTorch model.")
     args = parser.parse_args()
-    model = convert_fairseq_m2m100_checkpoint_from_disk(args.fairseq_pathß)
+    model = convert_fairseq_m2m100_checkpoint_from_disk(args.fairseq_path)
     model.save_pretrained(args.pytorch_dump_folder_path)


### PR DESCRIPTION
Newer version of m2m models have args parameter as None.

args are present in cfg['model']. Fixing input arguments to the function as well.



