### PR TITLE
Slow tests - run rag token in half precision

### DIFF
--- a/tests/test_modeling_rag.py
+++ b/tests/test_modeling_rag.py
@@ -988,6 +988,9 @@ class RagModelIntegrationTests(unittest.TestCase):
             torch_device
         )
 
+        if torch_device == "cuda":
+            rag_token.half()
+
         input_dict = tokenizer(
             self.test_data_questions,
             return_tensors="pt",


### PR DESCRIPTION
Currently `tests/test_modeling_rag.py::RagModelIntegrationTests::test_rag_token_generate_batch` errors out with OOM in the slow tests -> let's run it in half  precision on GPU. Output has been verified to stay the same