### PR TITLE
neptune.ai logger: utilize `rewrite_logs` in `NeptuneCallback` as in `WandbCallback`

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -744,6 +744,7 @@ class NeptuneCallback(TrainerCallback):
         if not self._initialized:
             self.setup(args, state, model)
         if state.is_world_process_zero:
+            logs = rewrite_logs(logs)
             for k, v in logs.items():
                 self._neptune_run[k].log(v, step=state.global_step)
 


### PR DESCRIPTION
single line ischanged,

utilized a missing conversion in neptune logger as implemented in wandb logger

trainer: @sgugger