### PR TITLE
Use existing functionality for #13251

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -37,6 +37,7 @@ from .configuration_auto import (
     CONFIG_MAPPING_NAMES,
     AutoConfig,
     config_class_to_model_type,
+    model_type_to_module_name,
     replace_list_option_in_docstrings,
 )
 
@@ -230,10 +231,9 @@ def tokenizer_class_from_name(class_name: str):
         if class_name in tokenizers:
             break
 
-    if module_name == "openai-gpt":
-        module_name = "openai"
+    module_name = model_type_to_module_name(module_name)
 
-    module = importlib.import_module(f".{module_name.replace('-', '_')}", "transformers.models")
+    module = importlib.import_module(f".{module_name}", "transformers.models")
     return getattr(module, class_name)
 
 


### PR DESCRIPTION
# What does this PR do?

#13251 fixes some issue while re-implementing existing functionality. This PR refactors the fix to re-use the `model_type_to_module_name` implemented.