### PR TITLE
Fix AutoTokenizer when no fast tokenizer is available

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -229,12 +229,12 @@ def tokenizer_class_from_name(class_name: str):
 
     for module_name, tokenizers in TOKENIZER_MAPPING_NAMES.items():
         if class_name in tokenizers:
-            break
+            module_name = model_type_to_module_name(module_name)
 
-    module_name = model_type_to_module_name(module_name)
+            module = importlib.import_module(f".{module_name}", "transformers.models")
+            return getattr(module, class_name)
 
-    module = importlib.import_module(f".{module_name}", "transformers.models")
-    return getattr(module, class_name)
+    return None
 
 
 def get_tokenizer_config(

--- a/tests/test_tokenization_auto.py
+++ b/tests/test_tokenization_auto.py
@@ -22,6 +22,7 @@ from transformers import (
     AutoTokenizer,
     BertTokenizer,
     BertTokenizerFast,
+    CTRLTokenizer,
     GPT2Tokenizer,
     GPT2TokenizerFast,
     PreTrainedTokenizerFast,
@@ -161,6 +162,11 @@ class AutoTokenizerTest(unittest.TestCase):
 
         self.assertIsInstance(tokenizer2, tokenizer.__class__)
         self.assertEqual(tokenizer2.vocab_size, 12)
+
+    def test_auto_tokenizer_fast_no_slow(self):
+        tokenizer = AutoTokenizer.from_pretrained("ctrl")
+        # There is no fast CTRL so this always gives us a slow tokenizer.
+        self.assertIsInstance(tokenizer, CTRLTokenizer)
 
     def test_get_tokenizer_config(self):
         # Check we can load the tokenizer config of an online model.


### PR DESCRIPTION
# What does this PR do?

Currently, the `AutoTokenzier` API will not work when a user tries to instantiate a model that does not have a fast tokenizer, due to some wrong logic in the function `tokenizer_class_from_name`. This PR fixes that.

Fixes #13161