### PR TITLE
Tests fetcher tests

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -142,6 +142,7 @@ class ModelTesterMixin:
     def test_save_load(self):
         # Fake modif, will remove before merging.
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         for model_class in self.all_model_classes:
             model = model_class(config)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -140,6 +140,7 @@ class ModelTesterMixin:
         return inputs_dict
 
     def test_save_load(self):
+        # Fake modif, will remove before merging.
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         for model_class in self.all_model_classes:

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -407,7 +407,6 @@ def infer_tests_to_run(output_file, diff_with_last_commit=False, filters=None):
 
     # Create the map that will give us all impacted modules.
     impacted_modules_map = create_reverse_dependency_map()
-    print(impacted_modules_map["tests/test_modeling_common.py"])
     impacted_files = modified_files.copy()
     for f in modified_files:
         if f in impacted_modules_map:

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -231,7 +231,7 @@ def create_reverse_dependency_map():
 
     # Finally we can build the reverse map.
     reverse_map = collections.defaultdict(list)
-    for m in modules:
+    for m in all_files:
         if m.endswith("__init__.py"):
             reverse_map[m].extend(direct_deps[m])
         for d in direct_deps[m]:

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -405,6 +405,7 @@ def infer_tests_to_run(output_file, diff_with_last_commit=False, filters=None):
 
     # Create the map that will give us all impacted modules.
     impacted_modules_map = create_reverse_dependency_map()
+    print(impacted_modules_map["tests/test_modeling_common.py"])
     impacted_files = modified_files.copy()
     for f in modified_files:
         if f in impacted_modules_map:

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -216,11 +216,13 @@ def create_reverse_dependency_map():
     tests = [str(f.relative_to(PATH_TO_TRANFORMERS)) for f in (Path(PATH_TO_TRANFORMERS) / "tests").glob("**/*.py")]
     direct_deps.update({t: get_test_dependencies(t) for t in tests})
 
+    all_files = modules + tests
+
     # This recurses the dependencies
     something_changed = True
     while something_changed:
         something_changed = False
-        for m in modules:
+        for m in all_files:
             for d in direct_deps[m]:
                 for dep in direct_deps[d]:
                     if dep not in direct_deps[m]:


### PR DESCRIPTION
# What does this PR do?

If you received a notification for this PR and are not a reviewer, I apologize: I clicked the button create PR to early :grimacing: 

This PR fixes the tests_fetcher utils for the test files dependencies: currently modifying `tests_modeling_common.py` won't trigger any other tests than `tests_modeling_common.py`  when we would like it to run all the modeling tests. To fix this, the same logic as in the modules is applied to the tests files: they are screened for dependencies to other tests files and this is all added before we compute the reverse dependency map.

As an example this is properly working, this PR has a diff in `tests_modeling_common.py`  and you can check the triggered tests [here](https://circle-production-customer-artifacts.s3.amazonaws.com/picard/5bdabdd888af1f000130874a/612d399a732e644e043dbe7e-0-build/artifacts/~/transformers/test_preparation.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20210830T200953Z&X-Amz-SignedHeaders=host&X-Amz-Expires=59&X-Amz-Credential=AKIAJR3Q6CR467H7Z55A%2F20210830%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=7b5b35edd60b676c46bc3bd0715fadd1089ed4d44f68c2bf987bbcd905faef3d).