### PR TITLE
Add `Hubert` to the `AutoFeatureExtractor`

### DIFF
--- a/src/transformers/models/auto/feature_extraction_auto.py
+++ b/src/transformers/models/auto/feature_extraction_auto.py
@@ -34,6 +34,7 @@ FEATURE_EXTRACTOR_MAPPING_NAMES = OrderedDict(
     [
         ("beit", "BeitFeatureExtractor"),
         ("deit", "DeiTFeatureExtractor"),
+        ("hubert", "Wav2Vec2FeatureExtractor"),
         ("speech_to_text", "Speech2TextFeatureExtractor"),
         ("vit", "ViTFeatureExtractor"),
         ("wav2vec2", "Wav2Vec2FeatureExtractor"),

--- a/src/transformers/models/hubert/__init__.py
+++ b/src/transformers/models/hubert/__init__.py
@@ -21,6 +21,7 @@ from ...file_utils import _LazyModule, is_tf_available, is_torch_available
 
 
 _import_structure = {
+    ".wav2vec2.feature_extraction_wav2vec2": ["Wav2Vec2FeatureExtractor"],
     "configuration_hubert": ["HUBERT_PRETRAINED_CONFIG_ARCHIVE_MAP", "HubertConfig"],
 }
 
@@ -43,6 +44,7 @@ if is_tf_available():
     ]
 
 if TYPE_CHECKING:
+    from ..wav2vec2.feature_extraction_wav2vec2 import Wav2Vec2FeatureExtractor
     from .configuration_hubert import HUBERT_PRETRAINED_CONFIG_ARCHIVE_MAP, HubertConfig
 
     if is_torch_available():


### PR DESCRIPTION
Quick fix to allow `Hubert` models to auto-load `Wav2Vec2FeatureExtractor`.

Caught this while trying to load Hubert without an explicit feature extractor in `pipeline("audio-classification")` 