### PR TITLE
Add missing feature extractors

### DIFF
--- a/src/transformers/models/auto/feature_extraction_auto.py
+++ b/src/transformers/models/auto/feature_extraction_auto.py
@@ -37,6 +37,9 @@ FEATURE_EXTRACTOR_MAPPING_NAMES = OrderedDict(
         ("speech_to_text", "Speech2TextFeatureExtractor"),
         ("vit", "ViTFeatureExtractor"),
         ("wav2vec2", "Wav2Vec2FeatureExtractor"),
+        ("detr", "DetrFeatureExtractor"),
+        ("layoutlmv2", "LayoutLMv2FeatureExtractor"),
+        ("clip", "ClipFeatureExtractor"),
     ]
 )
 


### PR DESCRIPTION
Adds some missing feature extractors to the mapping so that they may be used with `AutoFeatureExtractor`