### PR TITLE
Fix RemBERT tokenizer initialization

### DIFF
--- a/src/transformers/models/rembert/modeling_rembert.py
+++ b/src/transformers/models/rembert/modeling_rembert.py
@@ -54,6 +54,7 @@ logger = logging.get_logger(__name__)
 
 _CONFIG_FOR_DOC = "RemBertConfig"
 _TOKENIZER_FOR_DOC = "RemBertTokenizer"
+_CHECKPOINT_FOR_DOC = "google/rembert"
 
 REMBERT_PRETRAINED_MODEL_ARCHIVE_LIST = [
     "google/rembert",

--- a/src/transformers/models/rembert/tokenization_rembert_fast.py
+++ b/src/transformers/models/rembert/tokenization_rembert_fast.py
@@ -100,7 +100,7 @@ class RemBertTokenizerFast(PreTrainedTokenizerFast):
 
     def __init__(
         self,
-        vocab_file,
+        vocab_file=None,
         tokenizer_file=None,
         do_lower_case=True,
         remove_space=True,


### PR DESCRIPTION
Fixes an issue with the tokenizer initializer for RemBERT which has a requirement on `vocab_file`, hence making initialization through `tokenizer_file` impossible.

Also adds a missing `_CHECKPOINT_FOR_DOC` for the same model.