### PR TITLE
Fix scheduled TF Speech tests

### DIFF
--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt -y update && apt install -y git
+          apt -y update && apt install -y libsndfile1-dev git
           pip install --upgrade pip
           pip install .[sklearn,testing,onnx,sentencepiece,tf-speech]
 
@@ -251,7 +251,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt -y update && apt install -y git
+          apt -y update && apt install -y libsndfile1-dev git
           pip install --upgrade pip
           pip install .[sklearn,testing,onnx,sentencepiece,tf-speech]
 


### PR DESCRIPTION
CI logs: https://github.com/huggingface/transformers/runs/3501334018?check_suite_focus=true

**Context**
Doing `import soundfile as sf` was causing `OSError: sndfile library not found` on all integration tests for `TFWav2Vec2` and `TFHubert`

**Solution**
This PR adds `libsndfile` as a dependency for the TF jobs, like it was done for the Pytorch counterparts.

CC @patrickvonplaten 