### PR TITLE
Fix tests without any real effect in EncoderDecoderMixin

### DIFF
--- a/tests/test_modeling_encoder_decoder.py
+++ b/tests/test_modeling_encoder_decoder.py
@@ -200,7 +200,7 @@ class EncoderDecoderMixin:
 
             with tempfile.TemporaryDirectory() as tmpdirname:
                 enc_dec_model.save_pretrained(tmpdirname)
-                EncoderDecoderModel.from_pretrained(tmpdirname)
+                enc_dec_model = EncoderDecoderModel.from_pretrained(tmpdirname)
 
                 after_outputs = enc_dec_model(
                     input_ids=input_ids,
@@ -241,7 +241,7 @@ class EncoderDecoderMixin:
             with tempfile.TemporaryDirectory() as encoder_tmp_dirname, tempfile.TemporaryDirectory() as decoder_tmp_dirname:
                 enc_dec_model.encoder.save_pretrained(encoder_tmp_dirname)
                 enc_dec_model.decoder.save_pretrained(decoder_tmp_dirname)
-                EncoderDecoderModel.from_encoder_decoder_pretrained(
+                enc_dec_model = EncoderDecoderModel.from_encoder_decoder_pretrained(
                     encoder_pretrained_model_name_or_path=encoder_tmp_dirname,
                     decoder_pretrained_model_name_or_path=decoder_tmp_dirname,
                 )


### PR DESCRIPTION
# What does this PR do?

In `test_modeling_encoder_decoder.py`, there are 2 places like

```
enc_dec_model.save_pretrained(tmpdirname)
EncoderDecoderModel.from_pretrained(tmpdirname)

after_outputs = enc_dec_model(...)
```
Therefore `after_outputs` will be exactly the same `outputs`, since `enc_dec_model` doesn't get the new value.
For the testing purpose, we need to do
```
enc_dec_model = EncoderDecoderModel.from_pretrained(tmpdirname)
```
(Hope I get it right)

## Who can review?

@patrickvonplaten @sgugger 
