### PR TITLE
Fixed the MultilabelTrainer document, which would cause a potential bug when executing the code originally documented.

### DIFF
--- a/docs/source/main_classes/trainer.rst
+++ b/docs/source/main_classes/trainer.rst
@@ -64,9 +64,9 @@ classification:
 
     class MultilabelTrainer(Trainer):
         def compute_loss(self, model, inputs, return_outputs=False):
-            labels = inputs.pop("labels")
+            labels = inputs.get("labels")
             outputs = model(**inputs)
-            logits = outputs.logits
+            logits = outputs.get('logits')
             loss_fct = nn.BCEWithLogitsLoss()
             loss = loss_fct(logits.view(-1, self.model.config.num_labels),
                             labels.float().view(-1, self.model.config.num_labels))


### PR DESCRIPTION
if train with the MultilabelTrainer documented in the original document 

```
from torch import nn
from transformers import Trainer

class MultilabelTrainer(Trainer):
    def compute_loss(self, model, inputs, return_outputs=False):
        labels = inputs.pop("labels")
        outputs = model(**inputs)
        logits = outputs.logits
        loss_fct = nn.BCEWithLogitsLoss()
        loss = loss_fct(logits.view(-1, self.model.config.num_labels),
                        labels.float().view(-1, self.model.config.num_labels))
        return (loss, outputs) if return_outputs else loss
```

a bug that looks like this would appear:
`
  File "~/anaconda3/lib/python3.8/site-packages/transformers/trainer.py", in train
    self._maybe_log_save_evaluate(tr_loss, model, trial, epoch)
  File "~/anaconda3/lib/python3.8/site-packages/transformers/trainer.py", in _maybe_log_save_evaluate
    metrics = self.evaluate()
  File "~/anaconda3/lib/python3.8/site-packages/transformers/trainer.py", in evaluate
    output = self.prediction_loop(
  File "~/anaconda3/lib/python3.8/site-packages/transformers/trainer.py", in prediction_loop
    loss, logits, labels = self.prediction_step(model, inputs, prediction_loss_only, ignore_keys=ignore_keys)
  File "~/anaconda3/lib/python3.8/site-packages/transformers/trainer.py", in prediction_step
    labels = nested_detach(tuple(inputs.get(name) for name in self.label_names))
  File "~/anaconda3/lib/python3.8/site-packages/transformers/trainer_pt_utils.py", in nested_detach
    return type(tensors)(nested_detach(t) for t in tensors)
  File "~/anaconda3/lib/python3.8/site-packages/transformers/trainer_pt_utils.py", in <genexpr>
    return type(tensors)(nested_detach(t) for t in tensors)
  File "~/anaconda3/lib/python3.8/site-packages/transformers/trainer_pt_utils.py", in nested_detach
    return tensors.detach()
AttributeError: 'NoneType' object has no attribute 'detach'
`

change the original code to below would effectively avoid this bug.
```
from torch import nn
from transformers import Trainer

class MultilabelTrainer(Trainer):
    def compute_loss(self, model, inputs, return_outputs=False):
        labels = inputs.get("labels")
        outputs = model(**inputs)
        logits = outputs.get('logits')
        loss_fct = nn.BCEWithLogitsLoss()
        loss = loss_fct(logits.view(-1, self.model.config.num_labels),
                        labels.float().view(-1, self.model.config.num_labels))
        return (loss, outputs) if return_outputs else loss
```
