### PR TITLE
add torchvision in example test requirements

### DIFF
--- a/examples/pytorch/_tests_requirements.txt
+++ b/examples/pytorch/_tests_requirements.txt
@@ -18,3 +18,4 @@ pytest
 conllu
 sentencepiece != 0.1.92
 protobuf
+torchvision


### PR DESCRIPTION
# What does this PR do?

The pytorch example tests are failing for `image-classification` example as `torchvision` is not installed on the CI. This PR adds `torchvision` in `_test_requirements.py`.