### PR TITLE
skip image classification example test

### DIFF
--- a/examples/pytorch/test_examples.py
+++ b/examples/pytorch/test_examples.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import sys
+from unittest.case import skip
 from unittest.mock import patch
 
 import torch
@@ -343,6 +344,7 @@ class ExamplesTests(TestCasePlus):
             result = get_results(tmp_dir)
             self.assertGreaterEqual(result["eval_bleu"], 30)
 
+    @skip("The test is failing as accuracy is 0, re-enable when fixed.")
     def test_run_image_classification(self):
         stream_handler = logging.StreamHandler(sys.stdout)
         logger.addHandler(stream_handler)


### PR DESCRIPTION
# What does this PR do?

The image classification example test is still faling, https://app.circleci.com/pipelines/github/huggingface/transformers/27636/workflows/fad6d0a8-e8fa-413b-a519-a4794673749a/jobs/268590

Skip the test for now, until fixed (cc @nateraw)
