### PR TITLE
Update version of `packaging` package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ _deps = [
     "onnxruntime>=1.4.0",
     "optuna",
     "optax>=0.0.8",
-    "packaging",
+    "packaging>=20.0",
     "parameterized",
     "protobuf",
     "psutil",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -33,7 +33,7 @@ deps = {
     "onnxruntime": "onnxruntime>=1.4.0",
     "optuna": "optuna",
     "optax": "optax>=0.0.8",
-    "packaging": "packaging",
+    "packaging": "packaging>=20.0",
     "parameterized": "parameterized",
     "protobuf": "protobuf",
     "psutil": "psutil",


### PR DESCRIPTION
This fixes an error when using packaging<20.0 with transformers.

With `packaging==19.0`:

```python
ipython3
Python 3.6.14 (default, Jun 29 2021, 00:00:00) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.6.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import transformers                                                                                                                                             
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-1-279c49635b32> in <module>
----> 1 import transformers

~/.local/lib/python3.6/site-packages/transformers/__init__.py in <module>
     41 
     42 # Check the dependencies satisfy the minimal versions required.
---> 43 from . import dependency_versions_check
     44 from .file_utils import (
     45     _LazyModule,

~/.local/lib/python3.6/site-packages/transformers/dependency_versions_check.py in <module>
     34         if pkg == "tokenizers":
     35             # must be loaded here, or else tqdm check may fail
---> 36             from .file_utils import is_tokenizers_available
     37 
     38             if not is_tokenizers_available():

~/.local/lib/python3.6/site-packages/transformers/file_utils.py in <module>
    310 if _torch_available:
    311     torch_version = version.parse(importlib_metadata.version("torch"))
--> 312     _torch_fx_available = (torch_version.major, torch_version.minor) == (
    313         TORCH_FX_REQUIRED_VERSION.major,
    314         TORCH_FX_REQUIRED_VERSION.minor,

AttributeError: 'Version' object has no attribute 'major'
```
This is fixed with `packaging>=20.0`


The `major` attribute was added in v20.0 of `packaging`. [Relevant changelog](https://packaging.pypa.io/en/latest/changelog.html#id11) excerpt:

> 20.0 - 2020-01-06¶
> Add major, minor, and micro aliases to packaging.version.Version (#226)

Therefore, have constrained version of packaging to '>=20.0'.

Please let me know if there are any setup.py-related tests to be updated.

CC @stas00 @sgugger 