### PR TITLE
Don't modify labels inplace in `LabelSmoother`

### DIFF
--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -458,7 +458,7 @@ class LabelSmoother:
         padding_mask = labels.eq(self.ignore_index)
         # In case the ignore_index is -100, the gather will fail, so we replace labels by 0. The padding_mask
         # will ignore them in any case.
-        labels.clamp_min_(0)
+        labels = torch.clamp(labels, min=0)
         nll_loss = log_probs.gather(dim=-1, index=labels)
         # works for fp16 input tensor too, by internally upcasting it to fp32
         smoothed_loss = log_probs.sum(dim=-1, keepdim=True, dtype=torch.float32)


### PR DESCRIPTION
# What does this PR do?

Currently, the `LabelSmoother` makes an inplace modification in the labels, but those labels are re-used afterward to compute metrics (see [the forums](https://discuss.huggingface.co/t/label-smoothing-and-compute-metrics-in-trainer/9778) for instance). This PR fixes that issue