### PR TITLE
1x model size CPU memory usage for `from_pretrained` 

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1479,10 +1479,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 missing_keys, add_prefix=add_prefix, remove_prefix=remove_prefix
             )
             for module in uninitialized_modules:
-                # # XXX: untested
-                # # put the params that aren't going to be replaced by state_dict to CPU before running init
-                # for p in module.parameters(recursive=False):
-                #     p = p.to(device='cpu')
                 model._init_weights(module)
 
         # copy state_dict so _load_from_state_dict can modify it
@@ -1598,11 +1594,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # putting those on the meta device
         for k in loaded_state_dict_keys:
             split_name = k.split(".")
-            # print(k)
             m = model
-            matched = True
+            matched = False
             while len(split_name) > 1:
                 if hasattr(m, split_name[0]):
+                    matched = True
                     m = getattr(m, split_name[0])
                     del split_name[0]
                 else:
@@ -1632,9 +1628,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         for k in loaded_state_dict_keys:
             split_name = k.split(".")
             m = model
-            matched = True
+            matched = False
             while len(split_name) > 1:
                 if hasattr(m, split_name[0]):
+                    matched = True
                     m = getattr(m, split_name[0])
                     del split_name[0]
                 else:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1318,8 +1318,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             if low_cpu_mem_usage:
                 # only float state_dict keys (that can be fed to nn.Parameter)
                 # XXX: this currently skips registered buffers
-                low_cpu_mem_state_dict_keys = [k for k,v in state_dict.items()]# if v.is_floating_point() or v.is_complex()]
-                del state_dict # save memory - will reload again later
+                low_cpu_mem_state_dict_keys = [
+                    k for k, v in state_dict.items()
+                ]  # if v.is_floating_point() or v.is_complex()]
+                del state_dict  # save memory - will reload again later
 
         config.name_or_path = pretrained_model_name_or_path
 
@@ -1384,7 +1386,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 # putting those on the meta device
                 for k in low_cpu_mem_state_dict_keys:
                     split_name = k.split(".")
-                    #print(k)
+                    # print(k)
                     m = model
                     matched = True
                     while len(split_name) > 1:
@@ -1395,7 +1397,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                             matched = False
                             break
                     if matched:
-                        #print(k)
+                        # print(k)
                         m.to("meta")
                         # p = getattr(m, split_name[0])
                         # print(p.device)
@@ -1421,10 +1423,12 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                             matched = False
                             break
                     if matched:
-                        #print(k)
-                        persistent_buffers = {k: v for k, v in m._buffers.items() if k not in m._non_persistent_buffers_set}
-                        #print("KEYS", persistent_buffers.keys())
-                        #m.to("cpu")
+                        # print(k)
+                        persistent_buffers = {
+                            k: v for k, v in m._buffers.items() if k not in m._non_persistent_buffers_set
+                        }
+                        # print("KEYS", persistent_buffers.keys())
+                        # m.to("cpu")
                         if split_name[0] in persistent_buffers:
                             m._buffers[split_name[0]] = state_dict[k]
                         else:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1173,7 +1173,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         _fast_init = kwargs.pop("_fast_init", True)
         torch_dtype = kwargs.pop("torch_dtype", None)
         low_cpu_mem_usage = kwargs.pop("low_cpu_mem_usage", False)
-
+        # XXX: low_cpu_mem_usage requires pt-1.9.0 or higher and no deepspeed
         from_pt = not (from_tf | from_flax)
 
         user_agent = {"file_type": "model", "framework": "pytorch", "from_auto_class": from_auto_class}


### PR DESCRIPTION
The problem is that currently to load a model using `from_pretrained` requires 2x model size on CPU memory and for those odd cases where a user has large GPU memory, but very little CPU memory it's a problem.

This PR is trying to solve the puzzle of loading "EleutherAI/gpt-j-6B", with revision="float16" and torch_dtype=torch.float16 for the model in full FP16. it shouldn't use more than 12.1GB of cpu RAM to work on colab.

So this should use 12.1GB of CPU memory including peak memory:
```
m = GPTJForCausalLM.from_pretrained("EleutherAI/gpt-j-6B", revision="float16", torch_dtype=torch.float16, low_cpu_mem_usage=True)
```

This of course won't be enough to be used on the free google colab since it has a total of 12GB of CPU RAM for everything, so by the time we come to `from_pretrained` a few GBs will be already consumed by python/torch/transformers, leaving less than 10GB of CPU RAM.

Here is what this PR does:

1. load state_dict and register which keys we have
2. drop state_dict
3. switch to the meta device all params/buffers that are going to be replaced from the loaded state_dict
4. load state_dict 2nd time
5. replace the params/buffers from the state_dict

See the snapshot showing the memory use of just 1x model size and a bit more for temps (this includes peak memory usage).

(The automatic cpu/gpu memory usage reporting in the snapshot is courtesy of https://github.com/stas00/ipyexperiments)
![snapshot_27](https://user-images.githubusercontent.com/10676103/132447001-61652e49-1e79-4d7c-adad-4de0d685194b.png)

TODO:

- if this gets a green light - need to write a test that measure 1x memory size

@LysandreJik, @sgugger 