### PR TITLE
Use powers of 2 in download size calculations

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -1518,6 +1518,7 @@ def http_get(url: str, temp_file: BinaryIO, proxies=None, resume_size=0, headers
     progress = tqdm(
         unit="B",
         unit_scale=True,
+        unit_divisor=1024,
         total=total,
         initial=resume_size,
         desc="Downloading",


### PR DESCRIPTION
This fix makes `1GB = 1024MB` instead of the default `1000MB` in the `from_pretrained()` progress bars, which makes the download sizes consistent with the HF Hub file sizes.

Thanks to @stas00 for catching this!