### PR TITLE
Refactor internals for Trainer push_to_hub

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -2238,3 +2238,13 @@ class PushToHubMixin:
                 commit_message = "add model"
 
         return repo.push_to_hub(commit_message=commit_message)
+
+
+def get_full_repo_name(model_id: str, organization: Optional[str] = None, token: Optional[str] = None):
+    if token is None:
+        token = HfFolder.get_token()
+    if organization is None:
+        username = HfApi().whoami(token)["name"]
+        return f"{username}/{model_id}"
+    else:
+        return f"{organization}/{model_id}"

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1299,7 +1299,7 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
             trainer = get_regression_trainer(
                 output_dir=os.path.join(tmp_dir, "test-trainer"),
                 push_to_hub=True,
-                push_to_hub_token=self._token,
+                hub_token=self._token,
             )
             url = trainer.push_to_hub()
 
@@ -1321,8 +1321,8 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
             trainer = get_regression_trainer(
                 output_dir=os.path.join(tmp_dir, "test-trainer-org"),
                 push_to_hub=True,
-                push_to_hub_organization="valid_org",
-                push_to_hub_token=self._token,
+                hub_model_id="valid_org/test-trainer-org",
+                hub_token=self._token,
             )
             url = trainer.push_to_hub()
 


### PR DESCRIPTION
# What does this PR do?

This PR refactors the internals of the `Trainer` integration with the hub to use a `Repository` object instead of relying on the `PushToHubMixin` (which will get simplified drastically soon, see https://github.com/huggingface/huggingface_hub/pull/321).

In passing, to get closer to the way `Repository` works, the `push_to_hub_model_id` and `push_to_hub_organization` are both deprecated in favor of `hub_model_id`, which should contain the full ID of the model (either username/model_name or organization/model_name). `push_to_hub_token` is deprecated in favor of `hub_token`, which is easier.

Tests are adapted to use those new arg names, but otherwise there is no breaking change.