### PR TITLE
Fix special tokens not correctly tokenized

### DIFF
--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -453,7 +453,9 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
         # TODO: should this be in the base class?
         if hasattr(self, "do_lower_case") and self.do_lower_case:
             # convert non-special tokens to lowercase
-            escaped_special_toks = [re.escape(s_tok) for s_tok in self.all_special_tokens]
+            escaped_special_toks = [
+                re.escape(s_tok) for s_tok in (self.unique_no_split_tokens + self.all_special_tokens)
+            ]
             pattern = r"(" + r"|".join(escaped_special_toks) + r")|" + r"(.+?)"
             text = re.sub(pattern, lambda m: m.groups()[0] or m.groups()[1].lower(), text)
 

--- a/tests/test_tokenization_canine.py
+++ b/tests/test_tokenization_canine.py
@@ -160,6 +160,31 @@ class CanineTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 decoded = tokenizer.decode(encoded, skip_special_tokens=True)
                 self.assertTrue(special_token not in decoded)
 
+    def test_tokenize_special_tokens(self):
+        tokenizers = self.get_tokenizers(do_lower_case=True)
+        for tokenizer in tokenizers:
+            with self.subTest(f"{tokenizer.__class__.__name__}"):
+                SPECIAL_TOKEN_1 = chr(0xE005)
+                SPECIAL_TOKEN_2 = chr(0xE006)
+
+                text_1 = SPECIAL_TOKEN_1
+                text_2 = SPECIAL_TOKEN_2
+
+                # The list in which `_add_tokens` method stores special tokens. (in tokenization_utils.py)
+                tokenizer.unique_no_split_tokens = [SPECIAL_TOKEN_1]
+                # The property storing additional special tokens which occur in `all_special_tokens`. (in tokenization_utils_base.py)
+                tokenizer.additional_special_tokens = [SPECIAL_TOKEN_2]
+                # Add all special tokens into `unique_no_split_tokens`.
+                tokenizer.sanitize_special_tokens()
+
+                token_1 = tokenizer.tokenize(text_1)
+                token_2 = tokenizer.tokenize(text_2)
+
+                self.assertEqual(len(token_1), 1)
+                self.assertEqual(len(token_2), 1)
+                self.assertEqual(token_1[0], SPECIAL_TOKEN_1)
+                self.assertEqual(token_2[0], SPECIAL_TOKEN_2)
+
     @require_tokenizers
     def test_added_token_serializable(self):
         tokenizers = self.get_tokenizers(do_lower_case=False)

--- a/tests/test_tokenization_canine.py
+++ b/tests/test_tokenization_canine.py
@@ -167,18 +167,14 @@ class CanineTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 SPECIAL_TOKEN_1 = chr(0xE005)
                 SPECIAL_TOKEN_2 = chr(0xE006)
 
-                text_1 = SPECIAL_TOKEN_1
-                text_2 = SPECIAL_TOKEN_2
+                # `add_tokens` method stores special tokens only in `tokenizer.unique_no_split_tokens`. (in tokenization_utils.py)
+                tokenizer.add_tokens([SPECIAL_TOKEN_1], special_tokens=True)
+                # `add_special_tokens` method stores special tokens in `tokenizer.additional_special_tokens`,
+                # which also occur in `tokenizer.all_special_tokens`. (in tokenization_utils_base.py)
+                tokenizer.add_special_tokens({"additional_special_tokens": [SPECIAL_TOKEN_2]})
 
-                # The list in which `_add_tokens` method stores special tokens. (in tokenization_utils.py)
-                tokenizer.unique_no_split_tokens = [SPECIAL_TOKEN_1]
-                # The property storing additional special tokens which occur in `all_special_tokens`. (in tokenization_utils_base.py)
-                tokenizer.additional_special_tokens = [SPECIAL_TOKEN_2]
-                # Add all special tokens into `unique_no_split_tokens`.
-                tokenizer.sanitize_special_tokens()
-
-                token_1 = tokenizer.tokenize(text_1)
-                token_2 = tokenizer.tokenize(text_2)
+                token_1 = tokenizer.tokenize(SPECIAL_TOKEN_1)
+                token_2 = tokenizer.tokenize(SPECIAL_TOKEN_2)
 
                 self.assertEqual(len(token_1), 1)
                 self.assertEqual(len(token_2), 1)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -315,7 +315,8 @@ class TokenizerTesterMixin:
         """Test `tokenize` with special tokens."""
         tokenizer = self.get_tokenizer()
 
-        text = "The first [SPECIAL_TOKEN_1] and the second [SPECIAL_TOKEN_2] to test the tokenizer."
+        text_1 = "[SPECIAL_TOKEN_1]"
+        text_2 = "[SPECIAL_TOKEN_2]"
 
         # TODO: Can we replace `unique_no_split_tokens` and `all_special_tokens` with one variable(property) for a better maintainability?
         # The list in which `_add_tokens` method stores special tokens. (in tokenization_utils.py)
@@ -325,11 +326,13 @@ class TokenizerTesterMixin:
         # Add all special tokens into `unique_no_split_tokens`.
         tokenizer.sanitize_special_tokens()
 
-        tokens = tokenizer.tokenize(text)
+        token_1 = tokenizer.tokenize(text_1)
+        token_2 = tokenizer.tokenize(text_2)
 
-        self.assertEqual(len(tokens), 12)
-        self.assertEqual(tokens[2], "[SPECIAL_TOKEN_1]")
-        self.assertEqual(tokens[6], "[SPECIAL_TOKEN_2]")
+        self.assertEqual(len(token_1), 1)
+        self.assertEqual(len(token_2), 1)
+        self.assertEqual(token_1[0], "[SPECIAL_TOKEN_1]")
+        self.assertEqual(token_2[0], "[SPECIAL_TOKEN_2]")
 
     # TODO: this test could be extended to all tokenizers - not just the sentencepiece
     def test_sentencepiece_tokenize_and_convert_tokens_to_string(self):

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -319,13 +319,15 @@ class TokenizerTesterMixin:
                 SPECIAL_TOKEN_1 = "[SPECIAL_TOKEN_1]"
                 SPECIAL_TOKEN_2 = "[SPECIAL_TOKEN_2]"
 
-                # TODO: Can we replace `unique_no_split_tokens` and `all_special_tokens` with one variable(property) for a better maintainability?
-                # The list in which `_add_tokens` method stores special tokens. (in tokenization_utils.py)
-                tokenizer.unique_no_split_tokens = [SPECIAL_TOKEN_1]
-                # The property storing additional special tokens which occur in `all_special_tokens`. (in tokenization_utils_base.py)
-                tokenizer.additional_special_tokens = [SPECIAL_TOKEN_2]
-                # Add all special tokens into `unique_no_split_tokens`.
-                tokenizer.sanitize_special_tokens()
+                # TODO:
+                # Can we combine `unique_no_split_tokens` and `all_special_tokens`(and properties related to it)
+                # with one variable(property) for a better maintainability?
+
+                # `add_tokens` method stores special tokens only in `tokenizer.unique_no_split_tokens`. (in tokenization_utils.py)
+                tokenizer.add_tokens([SPECIAL_TOKEN_1], special_tokens=True)
+                # `add_special_tokens` method stores special tokens in `tokenizer.additional_special_tokens`,
+                # which also occur in `tokenizer.all_special_tokens`. (in tokenization_utils_base.py)
+                tokenizer.add_special_tokens({"additional_special_tokens": [SPECIAL_TOKEN_2]})
 
                 token_1 = tokenizer.tokenize(SPECIAL_TOKEN_1)
                 token_2 = tokenizer.tokenize(SPECIAL_TOKEN_2)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -310,6 +310,27 @@ class TokenizerTesterMixin:
             for i in range(len(batch_encode_plus_sequences["input_ids"]))
         ]
 
+    # TODO: this test can be combined with `test_sentencepiece_tokenize_and_convert_tokens_to_string` after the latter is extended to all tokenizers.
+    def test_tokenize_special_tokens(self):
+        """Test `tokenize` with special tokens."""
+        tokenizer = self.get_tokenizer()
+
+        text = "The first [SPECIAL_TOKEN_1] and the second [SPECIAL_TOKEN_2] to test the tokenizer."
+
+        # TODO: Can we replace `unique_no_split_tokens` and `all_special_tokens` with one variable(property) for a better maintainability?
+        # The list in which `_add_tokens` method stores special tokens. (in tokenization_utils.py)
+        tokenizer.unique_no_split_tokens = ["[SPECIAL_TOKEN_1]"]
+        # The property storing additional special tokens which occur in `all_special_tokens`. (in tokenization_utils_base.py)
+        tokenizer.additional_special_tokens = ["[SPECIAL_TOKEN_2]"]
+        # Add all special tokens into `unique_no_split_tokens`.
+        tokenizer.sanitize_special_tokens()
+
+        tokens = tokenizer.tokenize(text)
+
+        self.assertEqual(len(tokens), 12)
+        self.assertEqual(tokens[2], "[SPECIAL_TOKEN_1]")
+        self.assertEqual(tokens[6], "[SPECIAL_TOKEN_2]")
+
     # TODO: this test could be extended to all tokenizers - not just the sentencepiece
     def test_sentencepiece_tokenize_and_convert_tokens_to_string(self):
         """Test ``_tokenize`` and ``convert_tokens_to_string``."""

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -313,7 +313,7 @@ class TokenizerTesterMixin:
     # TODO: this test can be combined with `test_sentencepiece_tokenize_and_convert_tokens_to_string` after the latter is extended to all tokenizers.
     def test_tokenize_special_tokens(self):
         """Test `tokenize` with special tokens."""
-        tokenizers = [self.get_tokenizer(do_lower_case=True)] if self.test_slow_tokenizer else []
+        tokenizers = self.get_tokenizers(fast=True)
         for tokenizer in tokenizers:
             with self.subTest(f"{tokenizer.__class__.__name__}"):
                 SPECIAL_TOKEN_1 = "[SPECIAL_TOKEN_1]"

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -313,26 +313,27 @@ class TokenizerTesterMixin:
     # TODO: this test can be combined with `test_sentencepiece_tokenize_and_convert_tokens_to_string` after the latter is extended to all tokenizers.
     def test_tokenize_special_tokens(self):
         """Test `tokenize` with special tokens."""
-        tokenizer = self.get_tokenizer()
+        tokenizers = [self.get_tokenizer(do_lower_case=True)] if self.test_slow_tokenizer else []
+        for tokenizer in tokenizers:
+            with self.subTest(f"{tokenizer.__class__.__name__}"):
+                SPECIAL_TOKEN_1 = "[SPECIAL_TOKEN_1]"
+                SPECIAL_TOKEN_2 = "[SPECIAL_TOKEN_2]"
 
-        text_1 = "[SPECIAL_TOKEN_1]"
-        text_2 = "[SPECIAL_TOKEN_2]"
+                # TODO: Can we replace `unique_no_split_tokens` and `all_special_tokens` with one variable(property) for a better maintainability?
+                # The list in which `_add_tokens` method stores special tokens. (in tokenization_utils.py)
+                tokenizer.unique_no_split_tokens = [SPECIAL_TOKEN_1]
+                # The property storing additional special tokens which occur in `all_special_tokens`. (in tokenization_utils_base.py)
+                tokenizer.additional_special_tokens = [SPECIAL_TOKEN_2]
+                # Add all special tokens into `unique_no_split_tokens`.
+                tokenizer.sanitize_special_tokens()
 
-        # TODO: Can we replace `unique_no_split_tokens` and `all_special_tokens` with one variable(property) for a better maintainability?
-        # The list in which `_add_tokens` method stores special tokens. (in tokenization_utils.py)
-        tokenizer.unique_no_split_tokens = ["[SPECIAL_TOKEN_1]"]
-        # The property storing additional special tokens which occur in `all_special_tokens`. (in tokenization_utils_base.py)
-        tokenizer.additional_special_tokens = ["[SPECIAL_TOKEN_2]"]
-        # Add all special tokens into `unique_no_split_tokens`.
-        tokenizer.sanitize_special_tokens()
+                token_1 = tokenizer.tokenize(SPECIAL_TOKEN_1)
+                token_2 = tokenizer.tokenize(SPECIAL_TOKEN_2)
 
-        token_1 = tokenizer.tokenize(text_1)
-        token_2 = tokenizer.tokenize(text_2)
-
-        self.assertEqual(len(token_1), 1)
-        self.assertEqual(len(token_2), 1)
-        self.assertEqual(token_1[0], "[SPECIAL_TOKEN_1]")
-        self.assertEqual(token_2[0], "[SPECIAL_TOKEN_2]")
+                self.assertEqual(len(token_1), 1)
+                self.assertEqual(len(token_2), 1)
+                self.assertEqual(token_1[0], SPECIAL_TOKEN_1)
+                self.assertEqual(token_2[0], SPECIAL_TOKEN_2)
 
     # TODO: this test could be extended to all tokenizers - not just the sentencepiece
     def test_sentencepiece_tokenize_and_convert_tokens_to_string(self):


### PR DESCRIPTION
# What does this PR do?

Fixes #13483.

I think this is a quite complex issue. The purpose of `unique_no_split_tokens` in `tokenization_utils.py` and `all_special_tokens` in `tokenization_utils_base.py` seems ambiguous as they all store special tokens that don't want to be splitted or lower_cased. This two separated variables may result in a hard maintainable code. I'm guessing this is probably due to the workaround for FastTokenizers' functionality.

Additionally, should we resolve this TODO?

https://github.com/huggingface/transformers/blob/c37573806ab3526dd805c49cbe2489ad4d68a9d7/src/transformers/tokenization_utils.py#L275-L282


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger @LysandreJik 