### PR TITLE
examples: minor fixes in flax example readme

### DIFF
--- a/examples/flax/language-modeling/README.md
+++ b/examples/flax/language-modeling/README.md
@@ -92,7 +92,7 @@ tokenizer.train_from_iterator(batch_iterator(), vocab_size=50265, min_frequency=
 ])
 
 # Save files to disk
-tokenizer.save("./")
+tokenizer.save("./tokenizer.json")
 ```
 
 ### Create configuration
@@ -241,7 +241,7 @@ Finally, we can run the example script to pretrain the model:
 
 ```bash
 ./run_clm_flax.py \
-    --output_dir="./l" \
+    --output_dir="./" \
     --model_type="gpt2" \
     --config_name="./" \
     --tokenizer_name="./" \


### PR DESCRIPTION
Hi,

this PR introduces some minor fixes in the FLAX LM doc.

It mainly prevents an:

```
In [6]: tokenizer.save("./")
---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
<ipython-input-6-7d2c76b50951> in <module>
----> 1 tokenizer.save("./")

~/dev/lib/python3.8/site-packages/tokenizers/implementations/base_tokenizer.py in save(self, path, pretty)
    334                 A path to the destination Tokenizer file
    335         """
--> 336         return self._tokenizer.save(path, pretty)
    337 
    338     def to_str(self, pretty: bool = False):

Exception: Is a directory (os error 21)
```

error, because `.save()` function of the `ByteLevelBPETokenizer` instance expects a file name.