### PR TITLE
[Wav2Vec2] Fix normalization for non-padded tensors

### DIFF
--- a/src/transformers/feature_extraction_sequence_utils.py
+++ b/src/transformers/feature_extraction_sequence_utils.py
@@ -341,7 +341,7 @@ class SequenceFeatureExtractor(FeatureExtractionMixin):
 
         return processed_features
 
-    def _get_padding_strategies(self, padding=False, max_length=None, pad_to_multiple_of=None, **kwargs):
+    def _get_padding_strategies(self, padding=False, max_length=None):
         """
         Find the correct padding strategy
         """

--- a/src/transformers/models/speech_to_text/feature_extraction_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/feature_extraction_speech_to_text.py
@@ -233,12 +233,6 @@ class Speech2TextFeatureExtractor(SequenceFeatureExtractor):
             **kwargs,
         )
 
-        #        if "attention_mask" in padded_inputs:
-        #            input_lengths = padded_inputs["attention_mask"].sum(-1)
-        #        else:
-        #            padded_input_values = padded_inputs["input_features"]
-        #            input_lengths = [padded_input_values.shape[-1] for _ in range(padded_input_values.shape[0])]
-
         # make sure list is in array format
         input_features = padded_inputs.get("input_features")
         if isinstance(input_features[0], list):

--- a/src/transformers/models/speech_to_text/feature_extraction_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/feature_extraction_speech_to_text.py
@@ -93,10 +93,13 @@ class Speech2TextFeatureExtractor(SequenceFeatureExtractor):
 
     @staticmethod
     def utterance_cmvn(
-        x: np.ndarray, input_length: int, normalize_means: Optional[bool] = True, normalize_vars: Optional[bool] = True
+        x: np.ndarray,
+        input_length: int,
+        normalize_means: Optional[bool] = True,
+        normalize_vars: Optional[bool] = True,
+        padding_value: float = 0.0,
     ) -> np.ndarray:
         # make sure we normalie float32 arrays
-
         mean = x[:input_length].mean(axis=0)
         square_sums = (x[:input_length] ** 2).sum(axis=0)
 
@@ -107,15 +110,21 @@ class Speech2TextFeatureExtractor(SequenceFeatureExtractor):
             std = np.sqrt(np.maximum(var, 1e-10))
             x = np.divide(x, std)
 
+        if x.shape[0] > input_length:
+            x[input_length:] = padding_value
+
         # make sure array is in float32
         x = x.astype(np.float32)
 
         return x
 
-    def normalize(self, input_values: List[np.ndarray], input_lengths: List[int]) -> List[np.ndarray]:
+    def normalize(
+        self, input_features: List[np.ndarray], attention_mask: Optional[np.ndarray] = None
+    ) -> List[np.ndarray]:
+        lengths = attention_mask.sum(-1) if attention_mask is not None else [x.shape[0] for x in input_features]
         return [
-            self.utterance_cmvn(x, n, self.normalize_means, self.normalize_vars)
-            for x, n in zip(input_values, input_lengths)
+            self.utterance_cmvn(x, n, self.normalize_means, self.normalize_vars, self.padding_value)
+            for x, n in zip(input_features, lengths)
         ]
 
     def __call__(
@@ -197,7 +206,6 @@ class Speech2TextFeatureExtractor(SequenceFeatureExtractor):
             and (isinstance(raw_speech[0], np.ndarray) or isinstance(raw_speech[0], (tuple, list)))
         )
 
-        # make sure input is in list format
         if is_batched and not isinstance(raw_speech[0], np.ndarray):
             raw_speech = [np.asarray(speech) for speech in raw_speech]
         elif not is_batched and not isinstance(raw_speech, np.ndarray):
@@ -225,21 +233,31 @@ class Speech2TextFeatureExtractor(SequenceFeatureExtractor):
             **kwargs,
         )
 
-        if "attention_mask" in padded_inputs:
-            input_lengths = padded_inputs["attention_mask"].sum(-1)
-        else:
-            padded_input_values = padded_inputs["input_features"]
-            input_lengths = [padded_input_values.shape[-1] for _ in range(padded_input_values.shape[0])]
+        #        if "attention_mask" in padded_inputs:
+        #            input_lengths = padded_inputs["attention_mask"].sum(-1)
+        #        else:
+        #            padded_input_values = padded_inputs["input_features"]
+        #            input_lengths = [padded_input_values.shape[-1] for _ in range(padded_input_values.shape[0])]
+
+        # make sure list is in array format
+        input_features = padded_inputs.get("input_features")
+        if isinstance(input_features[0], list):
+            padded_inputs["input_features"] = [np.asarray(feature, dtype=np.float32) for feature in input_features]
+
+        attention_mask = padded_inputs.get("attention_mask")
+        if attention_mask is not None:
+            padded_inputs["attention_mask"] = [np.asarray(array, dtype=np.bool) for array in attention_mask]
 
         # Utterance-level cepstral mean and variance normalization
         if self.do_ceptral_normalize:
-            input_features = padded_inputs["input_features"]
-
-            # make sure list is in array format
-            if isinstance(input_features[0], list):
-                input_features = [np.asarray(feature, dtype=np.float32) for feature in input_features]
-
-            padded_inputs["input_features"] = self.normalize(input_features, input_lengths=input_lengths)
+            attention_mask = (
+                np.array(attention_mask, dtype=np.bool)
+                if self._get_padding_strategies(padding, max_length=max_length) is not PaddingStrategy.DO_NOT_PAD
+                else None
+            )
+            padded_inputs["input_features"] = self.normalize(
+                padded_inputs["input_features"], attention_mask=attention_mask
+            )
 
         if return_tensors is not None:
             padded_inputs = padded_inputs.convert_to_tensors(return_tensors)

--- a/src/transformers/models/wav2vec2/feature_extraction_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/feature_extraction_wav2vec2.py
@@ -79,13 +79,27 @@ class Wav2Vec2FeatureExtractor(SequenceFeatureExtractor):
         self.do_normalize = do_normalize
 
     @staticmethod
-    def zero_mean_unit_var_norm(input_values: List[np.ndarray], input_lengths: List[int]) -> List[np.ndarray]:
+    def zero_mean_unit_var_norm(
+        input_values: List[np.ndarray], attention_mask: List[np.ndarray], padding_value=0.0
+    ) -> List[np.ndarray]:
         """
         Every array in the list is normalized to have zero mean and unit variance
         """
-        normed_input_values = [
-            (x - np.mean(x[:i])) / np.sqrt(np.var(x[:i]) + 1e-5) for x, i in zip(input_values, input_lengths)
-        ]
+
+        if attention_mask is not None and any(0 in mask for mask in attention_mask):
+            normed_input_values = np.asarray(
+                [
+                    (x - np.mean(x[:i])) / np.sqrt(np.var(x[:i]) + 1e-7)
+                    for x, i in zip(input_values, attention_mask.sum(-1))
+                ]
+            )
+            normed_input_values[(1 - attention_mask).astype(np.bool)] = padding_value
+        else:
+            normed_input_values = np.asarray([(x - np.mean(x)) / np.sqrt(np.var(x) + 1e-7) for x in input_values])
+
+        if isinstance(input_values[0], np.ndarray):
+            input_values = [x.astype(np.float32) for x in input_values]
+
         return normed_input_values
 
     def __call__(
@@ -196,19 +210,12 @@ class Wav2Vec2FeatureExtractor(SequenceFeatureExtractor):
             return_attention_mask=return_attention_mask,
         )
 
-        if "attention_mask" in padded_inputs:
-            input_lengths = padded_inputs["attention_mask"].sum(-1)
-        else:
-            padded_input_values = padded_inputs["input_values"]
-            input_lengths = [padded_input_values.shape[-1] for _ in range(padded_input_values.shape[0])]
-
-        if isinstance(padded_inputs["input_values"][0], np.ndarray):
-            padded_inputs["input_values"] = [x.astype(np.float32) for x in padded_inputs["input_values"]]
+        attention_mask = padded_inputs.get("attention_mask")
 
         # zero-mean and unit-variance normalization
         if self.do_normalize:
             padded_inputs["input_values"] = self.zero_mean_unit_var_norm(
-                padded_inputs["input_values"], input_lengths=input_lengths
+                padded_inputs["input_values"], attention_mask=attention_mask, padding_value=self.padding_value
             )
 
         if return_tensors is not None:

--- a/src/transformers/models/wav2vec2/feature_extraction_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/feature_extraction_wav2vec2.py
@@ -86,7 +86,7 @@ class Wav2Vec2FeatureExtractor(SequenceFeatureExtractor):
         Every array in the list is normalized to have zero mean and unit variance
         """
 
-        if attention_mask is not None and any(0 in mask for mask in attention_mask):
+        if attention_mask is not None:
             normed_input_values = np.asarray(
                 [
                     (x - np.mean(x[:i])) / np.sqrt(np.var(x[:i]) + 1e-7)
@@ -97,8 +97,6 @@ class Wav2Vec2FeatureExtractor(SequenceFeatureExtractor):
         else:
             normed_input_values = np.asarray([(x - np.mean(x)) / np.sqrt(np.var(x) + 1e-7) for x in input_values])
 
-        if isinstance(input_values[0], np.ndarray):
-            input_values = [x.astype(np.float32) for x in input_values]
 
         return normed_input_values
 

--- a/src/transformers/models/wav2vec2/feature_extraction_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/feature_extraction_wav2vec2.py
@@ -79,9 +79,7 @@ class Wav2Vec2FeatureExtractor(SequenceFeatureExtractor):
         self.do_normalize = do_normalize
 
     @staticmethod
-    def zero_mean_unit_var_norm(
-        input_values: List[np.ndarray], attention_mask: List[np.ndarray], padding_value=0.0
-    ) -> List[np.ndarray]:
+    def zero_mean_unit_var_norm(input_values: List[np.ndarray], attention_mask: List[np.ndarray]) -> List[np.ndarray]:
         """
         Every array in the list is normalized to have zero mean and unit variance
         """

--- a/tests/test_feature_extraction_wav2vec2.py
+++ b/tests/test_feature_extraction_wav2vec2.py
@@ -123,31 +123,40 @@ class Wav2Vec2FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
     def test_zero_mean_unit_variance_normalization_np(self):
         feat_extract = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
         speech_inputs = [floats_list((1, x))[0] for x in range(800, 1400, 200)]
-        processed = feat_extract(speech_inputs, padding="longest", return_tensors="np")
-        input_values = processed.input_values
 
-        def _check_zero_mean_unit_variance(input_vector):
-            self.assertTrue(np.abs(np.mean(input_vector)) < 1e-3)
-            self.assertTrue(np.abs(np.var(input_vector) - 1) < 1e-3)
+        paddings = ["longest", "do_not_pad", "max_length"]
+        max_lengths = [None, None, 1600]
+        for max_length, padding in zip(max_lengths, paddings):
+            processed = feat_extract(speech_inputs, padding=padding, max_length=max_length, return_tensors="np")
+            input_values = processed.input_values
 
-        _check_zero_mean_unit_variance(input_values[0, :800])
-        _check_zero_mean_unit_variance(input_values[1, :1000])
-        _check_zero_mean_unit_variance(input_values[2])
+            def _check_zero_mean_unit_variance(input_vector):
+                self.assertTrue(np.abs(np.mean(input_vector)) < 1e-3)
+                self.assertTrue(np.abs(np.var(input_vector) - 1) < 1e-3)
+
+            _check_zero_mean_unit_variance(input_values[0][:800])
+            _check_zero_mean_unit_variance(input_values[1][:1000])
+            _check_zero_mean_unit_variance(input_values[2][:1200])
 
     def test_zero_mean_unit_variance_normalization(self):
         feat_extract = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
         lengths = range(800, 1400, 200)
         speech_inputs = [floats_list((1, x))[0] for x in lengths]
-        processed = feat_extract(speech_inputs)
-        input_values = processed.input_values
 
-        def _check_zero_mean_unit_variance(input_vector):
-            self.assertTrue(np.abs(np.mean(input_vector)) < 1e-3)
-            self.assertTrue(np.abs(np.var(input_vector) - 1) < 1e-3)
+        paddings = ["longest", "do_not_pad", "max_length"]
+        max_lengths = [None, None, 1600]
 
-        for normalized_array, length in zip(input_values, lengths):
-            self.assertEqual(len(normalized_array), length)
-            _check_zero_mean_unit_variance(normalized_array)
+        for max_length, padding in zip(max_lengths, paddings):
+            processed = feat_extract(speech_inputs, max_length=max_length, padding=padding)
+            input_values = processed.input_values
+
+            def _check_zero_mean_unit_variance(input_vector):
+                self.assertTrue(np.abs(np.mean(input_vector)) < 1e-3)
+                self.assertTrue(np.abs(np.var(input_vector) - 1) < 1e-3)
+
+            _check_zero_mean_unit_variance(input_values[0][:800])
+            _check_zero_mean_unit_variance(input_values[1][:1000])
+            _check_zero_mean_unit_variance(input_values[2][:1200])
 
     def test_zero_mean_unit_variance_normalization_trunc_np(self):
         feat_extract = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())

--- a/tests/test_feature_extraction_wav2vec2.py
+++ b/tests/test_feature_extraction_wav2vec2.py
@@ -120,7 +120,7 @@ class Wav2Vec2FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         for enc_seq_1, enc_seq_2 in zip(encoded_sequences_1, encoded_sequences_2):
             self.assertTrue(np.allclose(enc_seq_1, enc_seq_2, atol=1e-3))
 
-    def test_zero_mean_unit_variance_normalization(self):
+    def test_zero_mean_unit_variance_normalization_np(self):
         feat_extract = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
         speech_inputs = [floats_list((1, x))[0] for x in range(800, 1400, 200)]
         processed = feat_extract(speech_inputs, padding="longest", return_tensors="np")
@@ -134,7 +134,22 @@ class Wav2Vec2FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         _check_zero_mean_unit_variance(input_values[1, :1000])
         _check_zero_mean_unit_variance(input_values[2])
 
-    def test_zero_mean_unit_variance_normalization_trunc(self):
+    def test_zero_mean_unit_variance_normalization(self):
+        feat_extract = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
+        lengths = range(800, 1400, 200)
+        speech_inputs = [floats_list((1, x))[0] for x in lengths]
+        processed = feat_extract(speech_inputs)
+        input_values = processed.input_values
+
+        def _check_zero_mean_unit_variance(input_vector):
+            self.assertTrue(np.abs(np.mean(input_vector)) < 1e-3)
+            self.assertTrue(np.abs(np.var(input_vector) - 1) < 1e-3)
+
+        for normalized_array, length in zip(input_values, lengths):
+            self.assertEqual(len(normalized_array), length)
+            _check_zero_mean_unit_variance(normalized_array)
+
+    def test_zero_mean_unit_variance_normalization_trunc_np(self):
         feat_extract = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
         speech_inputs = [floats_list((1, x))[0] for x in range(800, 1400, 200)]
         processed = feat_extract(

--- a/tests/test_feature_extraction_wav2vec2.py
+++ b/tests/test_feature_extraction_wav2vec2.py
@@ -124,8 +124,8 @@ class Wav2Vec2FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         feat_extract = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
         speech_inputs = [floats_list((1, x))[0] for x in range(800, 1400, 200)]
 
-        paddings = ["longest", "do_not_pad", "max_length"]
-        max_lengths = [None, None, 1600]
+        paddings = ["longest", "max_length", "do_not_pad"]
+        max_lengths = [None, 1600, None]
         for max_length, padding in zip(max_lengths, paddings):
             processed = feat_extract(speech_inputs, padding=padding, max_length=max_length, return_tensors="np")
             input_values = processed.input_values
@@ -143,8 +143,8 @@ class Wav2Vec2FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         lengths = range(800, 1400, 200)
         speech_inputs = [floats_list((1, x))[0] for x in lengths]
 
-        paddings = ["longest", "do_not_pad", "max_length"]
-        max_lengths = [None, None, 1600]
+        paddings = ["longest", "max_length", "do_not_pad"]
+        max_lengths = [None, 1600, None]
 
         for max_length, padding in zip(max_lengths, paddings):
             processed = feat_extract(speech_inputs, max_length=max_length, padding=padding)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR fixes a problem with normalization when the input is a list of different length that is not numpified - see: https://github.com/huggingface/transformers/issues/13504

Just noticed that this bug is pretty severe actually as it affects all large-Wav2Vec2 fine-tuning  :-/.
It was introduced by me in this PR: https://github.com/huggingface/transformers/pull/12804/files - I should have written more and better tests for this. 

=> This means that from transformers 4.9.0 to until this PR is merged the normalization for all large Wav2Vec2 models was way off when fine-tuning the model.
 
@LysandreJik - do you think it might be possible to do a patched release for this? 
