### PR TITLE
TF multiple choice loss fix

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -220,8 +220,11 @@ class TFSequenceClassificationLoss:
         return loss_fn(labels, logits)
 
 
-class TFMultipleChoiceLoss(TFSequenceClassificationLoss):
+class TFMultipleChoiceLoss:
     """Loss function suitable for multiple choice tasks."""
+    def compute_loss(self, labels, logits):
+        loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True, reduction=tf.keras.losses.Reduction.NONE)
+        return loss_fn(labels, logits)
 
 
 class TFMaskedLanguageModelingLoss(TFCausalLanguageModelingLoss):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -222,8 +222,11 @@ class TFSequenceClassificationLoss:
 
 class TFMultipleChoiceLoss:
     """Loss function suitable for multiple choice tasks."""
+
     def compute_loss(self, labels, logits):
-        loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True, reduction=tf.keras.losses.Reduction.NONE)
+        loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(
+            from_logits=True, reduction=tf.keras.losses.Reduction.NONE
+        )
         return loss_fn(labels, logits)
 
 

--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -882,12 +882,13 @@ class TFT5PreTrainedModel(TFPreTrainedModel):
         shifted_input_ids = tf.where(
             shifted_input_ids == -100,
             tf.cast(tf.fill(shape_list(shifted_input_ids), pad_token_id), shifted_input_ids.dtype),
-            shifted_input_ids
+            shifted_input_ids,
         )
 
         # "Verify that `labels` has only positive values and -100"
-        assert_gte0 = tf.debugging.assert_greater_equal(shifted_input_ids,
-                                                        tf.constant(0, dtype=shifted_input_ids.dtype))
+        assert_gte0 = tf.debugging.assert_greater_equal(
+            shifted_input_ids, tf.constant(0, dtype=shifted_input_ids.dtype)
+        )
 
         # Make sure the assertion op is called by wrapping the result in an identity no-op
         with tf.control_dependencies([assert_gte0]):

--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -882,13 +882,12 @@ class TFT5PreTrainedModel(TFPreTrainedModel):
         shifted_input_ids = tf.where(
             shifted_input_ids == -100,
             tf.cast(tf.fill(shape_list(shifted_input_ids), pad_token_id), shifted_input_ids.dtype),
-            shifted_input_ids,
+            shifted_input_ids
         )
 
         # "Verify that `labels` has only positive values and -100"
-        assert_gte0 = tf.debugging.assert_greater_equal(
-            shifted_input_ids, tf.constant(0, dtype=shifted_input_ids.dtype)
-        )
+        assert_gte0 = tf.debugging.assert_greater_equal(shifted_input_ids,
+                                                        tf.constant(0, dtype=shifted_input_ids.dtype))
 
         # Make sure the assertion op is called by wrapping the result in an identity no-op
         with tf.control_dependencies([assert_gte0]):


### PR DESCRIPTION
The `TFMultipleChoiceLoss` inherits from `TFSequenceClassificationLoss` and can get confused when some of the input dimensions (specifically, the number of multiple choices) are not known at compile time. This can cause a compilation failure or other misbehaviour. Ensuring that the `TFMultipleChoiceLoss` never attempts to do regression fixes the problem.