### PR TITLE
Ignore `past_key_values` during GPT-Neo inference

### DIFF
--- a/src/transformers/models/gpt_neo/configuration_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/configuration_gpt_neo.py
@@ -96,6 +96,7 @@ class GPTNeoConfig(PretrainedConfig):
             >>> configuration = model.config
     """
     model_type = "gpt_neo"
+    keys_to_ignore_at_inference = ["past_key_values"]
     attribute_map = {"num_attention_heads": "num_heads", "num_hidden_layers": "num_layers"}
 
     def __init__(


### PR DESCRIPTION
# What does this PR do?

Applies #8633 to GPT-Neo.

I was getting errors like `RuntimeError: Sizes of tensors must match except in dimension 2. Got 20 and 19 (The offending index is 0)` during the evaluation step of `Trainer.train()` with GPT-Neo.

This was fixed in an internal implementation of `GPTNeoForSequenceClassification` by @manuelciosici before an official version of the class was released for `transformers`. I converted our code to use the `transformers` version of the class and realized the solution should be upstreamed. I'm just mentioning this here because I don't get all the credit for this patch.

This might be needed for other models as well, but I don't know of a good way to figure that out without testing them all.

## Who can review?

trainer: @sgugger