### PR TITLE
[tokenizer] use use_auth_token for config

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1741,12 +1741,23 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 logger.info(f"loading file {file_path} from cache at {resolved_vocab_files[file_id]}")
 
         return cls._from_pretrained(
-            resolved_vocab_files, pretrained_model_name_or_path, init_configuration, *init_inputs, **kwargs
+            resolved_vocab_files,
+            pretrained_model_name_or_path,
+            use_auth_token,
+            init_configuration,
+            *init_inputs,
+            **kwargs,
         )
 
     @classmethod
     def _from_pretrained(
-        cls, resolved_vocab_files, pretrained_model_name_or_path, init_configuration, *init_inputs, **kwargs
+        cls,
+        resolved_vocab_files,
+        pretrained_model_name_or_path,
+        use_auth_token,
+        init_configuration,
+        *init_inputs,
+        **kwargs
     ):
         # We instantiate fast tokenizers based on a slow tokenizer if we don't have access to the tokenizer.json
         # file or if `from_slow` is set to True.
@@ -1784,7 +1795,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
 
             # Second attempt. If we have not yet found tokenizer_class, let's try to use the config.
             try:
-                config = AutoConfig.from_pretrained(pretrained_model_name_or_path)
+                config = AutoConfig.from_pretrained(pretrained_model_name_or_path, use_auth_token=use_auth_token)
                 config_tokenizer_class = config.tokenizer_class
             except (OSError, ValueError, KeyError):
                 # skip if an error occurred.

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1743,9 +1743,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         return cls._from_pretrained(
             resolved_vocab_files,
             pretrained_model_name_or_path,
-            use_auth_token,
             init_configuration,
             *init_inputs,
+            use_auth_token=use_auth_token,
             **kwargs,
         )
 
@@ -1754,9 +1754,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         cls,
         resolved_vocab_files,
         pretrained_model_name_or_path,
-        use_auth_token,
         init_configuration,
         *init_inputs,
+        use_auth_token=None,
         **kwargs
     ):
         # We instantiate fast tokenizers based on a slow tokenizer if we don't have access to the tokenizer.json


### PR DESCRIPTION
This PR forwards `use_auth_token` to `AutoConfig.from_pretrained()` when `AutoTokenizer.from_pretrained(mname, use_auth_token=True)` is used. Otherwise `AutoConfig` fails to retrieve `config.json` with 404.

Model's `from_pretrained` does the right thing.

@sgugger, @LysandreJik 