### PR TITLE
[Speech2Text2] Skip newly added tokenizer test

### DIFF
--- a/tests/test_tokenization_speech_to_text_2.py
+++ b/tests/test_tokenization_speech_to_text_2.py
@@ -150,6 +150,10 @@ class SpeechToTextTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         pass
 
     # currently tokenizer cannot do encoding, but just decoding
+    def test_added_token_are_matched_longest_first(self):
+        pass
+
+    # currently tokenizer cannot do encoding, but just decoding
     @is_pt_tf_cross_test
     def test_batch_encode_plus_tensors(self):
         pass


### PR DESCRIPTION
The PR: https://github.com/huggingface/transformers/commit/3dd538c4d37248961d4cf99f4c07e8a5fe54984c added a new tokenizer test that should have been skipped for Speech2Text2 tokenizer. The Speech2Text2 tokenizers are yet to be added as explained in https://github.com/huggingface/transformers/pull/13186