### PR TITLE
Add checks to build cleaner model cards

### DIFF
--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -315,6 +315,8 @@ def _insert_values_as_list(metadata, name, values):
         return metadata
     if isinstance(values, str):
         values = [values]
+    if None in values:
+        values.remove(None)
     if len(values) == 0:
         return metadata
     metadata[name] = values
@@ -438,7 +440,9 @@ class TrainingSummary:
                         }
                     )
 
-            model_index["results"].append(result)
+            # Remove partial results to avoid the model card being rejected.
+            if "task" in result and "dataset" in result and "metrics" in result:
+                model_index["results"].append(result)
 
         return [model_index]
 

--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -315,8 +315,7 @@ def _insert_values_as_list(metadata, name, values):
         return metadata
     if isinstance(values, str):
         values = [values]
-    if None in values:
-        values.remove(None)
+    values = [v for v in values if v is not None]
     if len(values) == 0:
         return metadata
     metadata[name] = values
@@ -443,6 +442,8 @@ class TrainingSummary:
             # Remove partial results to avoid the model card being rejected.
             if "task" in result and "dataset" in result and "metrics" in result:
                 model_index["results"].append(result)
+            else:
+                logger.info(f"Dropping the following result as it does not have all the necessary field:\n{result}")
 
         return [model_index]
 


### PR DESCRIPTION
# What does this PR do?

To avoid model cards being rejected by the metadata validation on the Hub, this PR cleans up a few things:
- removing None values from lists so that a [None] passed for a field is ignored (this fixes #13528 )
- ignoring results that don't have the three keys task, datasat and metrics since those three are mandatory.

