### PR TITLE
add flax mbart in auto seq2seq lm

### DIFF
--- a/src/transformers/models/auto/modeling_flax_auto.py
+++ b/src/transformers/models/auto/modeling_flax_auto.py
@@ -81,6 +81,7 @@ FLAX_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING_NAMES = OrderedDict(
     [
         # Model for Seq2Seq Causal LM mapping
         ("bart", "FlaxBartForConditionalGeneration"),
+        ("mbart", "FlaxMBartForConditionalGeneration"),
         ("t5", "FlaxT5ForConditionalGeneration"),
         ("mt5", "FlaxMT5ForConditionalGeneration"),
         ("marian", "FlaxMarianMTModel"),


### PR DESCRIPTION
# What does this PR do?

Adds `FlaxMBartForConditionalGeneration` in `FLAX_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING_NAMES`