### PR TITLE
Fix DataCollatorForSeq2Seq when labels are supplied as Numpy array instead of list

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -517,6 +517,8 @@ class DataCollatorForSeq2Seq:
     return_tensors: str = "pt"
 
     def __call__(self, features, return_tensors=None):
+        import numpy as np
+
         if return_tensors is None:
             return_tensors = self.return_tensors
         labels = [feature["labels"] for feature in features] if "labels" in features[0].keys() else None
@@ -527,9 +529,14 @@ class DataCollatorForSeq2Seq:
             padding_side = self.tokenizer.padding_side
             for feature in features:
                 remainder = [self.label_pad_token_id] * (max_label_length - len(feature["labels"]))
-                feature["labels"] = (
-                    feature["labels"] + remainder if padding_side == "right" else remainder + feature["labels"]
-                )
+                if isinstance(feature["labels"], list):
+                    feature["labels"] = (
+                        feature["labels"] + remainder if padding_side == "right" else remainder + feature["labels"]
+                    )
+                elif padding_side == "right":
+                    feature["labels"] = np.concatenate([feature["labels"], remainder])
+                else:
+                    feature["labels"] = np.concatenate([remainder, feature["labels"]])
 
         features = self.tokenizer.pad(
             features,

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -534,9 +534,9 @@ class DataCollatorForSeq2Seq:
                         feature["labels"] + remainder if padding_side == "right" else remainder + feature["labels"]
                     )
                 elif padding_side == "right":
-                    feature["labels"] = np.concatenate([feature["labels"], remainder])
+                    feature["labels"] = np.concatenate([feature["labels"], remainder]).astype(np.int64)
                 else:
-                    feature["labels"] = np.concatenate([remainder, feature["labels"]])
+                    feature["labels"] = np.concatenate([remainder, feature["labels"]]).astype(np.int64)
 
         features = self.tokenizer.pad(
             features,


### PR DESCRIPTION
Found a bug in my data collator code - the Seq2Seq collator doesn't work unless labels are supplied as a list, and it fails if they're passed as an array.