### PR TITLE
Add system-wide requirements to 'transformers-cli env' documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,12 @@ or from the root of the repository the following command:
 python src/transformers/commands/transformers_cli.py env
 ```
 
+If `transformers_cli.py env` throws the error *OSError: sndfile library not
+found*, you can install librosa package with `conda install -c conda-forge
+librosa`.
+If `transformers_cli.py env` throws the error *ImportError: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found*,
+you can install it with `conda install libgcc` and set the following variable
+`export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/miniconda3/lib/`.
 
 ### Do you want to implement a new model?
 


### PR DESCRIPTION
# What does this PR do?

There are requirements that PIL and soundfile have on system-wide dependencies in order to run the command `transformer-cli env`.
This PR adds notes to the documentation about how to solve such system-wide dependencies below:

* Provide command to fix when sndfile library is not found

* Provide command to fix when the required GLIBCXX version is not found or installed

Fixes # 13270


## Before submitting
- [ X ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ X ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ X ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
It was discussed here: https://github.com/huggingface/transformers/issues/13270
- [ X ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
I changed only the documentation file needed.
- [ ] Did you write any new necessary tests?
No applicable to this PR since since it was documentation update only.


## Who can review?

@LysandreJik @sgugger