### PR TITLE
[ci] nightly: add deepspeed master

### DIFF
--- a/.github/workflows/self-nightly-scheduled.yml
+++ b/.github/workflows/self-nightly-scheduled.yml
@@ -159,9 +159,9 @@ jobs:
               run: |
                   apt -y update && apt install -y libaio-dev
                   pip install --upgrade pip
-                  pip install .[testing,deepspeed]
                   pip install --pre torch torchvision torchaudio -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html -U
-
+                  pip install .[testing,deepspeed]
+                  pip install git+https://github.com/microsoft/DeepSpeed
 
             - name: Are GPUs recognized by our DL frameworks
               run: |
@@ -203,7 +203,9 @@ jobs:
               run: |
                   apt -y update && apt install -y libaio-dev
                   pip install --upgrade pip
+                  pip install --pre torch torchvision torchaudio -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html -U
                   pip install .[testing,deepspeed,fairscale]
+                  pip install git+https://github.com/microsoft/DeepSpeed
 
             - name: Are GPUs recognized by our DL frameworks
               run: |
@@ -215,8 +217,7 @@ jobs:
             - name: Run all tests on GPU
               run: |
                   python -m pytest -n 1 -v --dist=loadfile --make-reports=tests_torch_cuda_extensions_multi_gpu tests/deepspeed tests/extended
-                  pip install --pre torch torchvision torchaudio -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html -U
-
+ 
             - name: Failure short reports
               if: ${{ always() }}
               run: cat reports/tests_torch_cuda_extensions_multi_gpu_failures_short.txt


### PR DESCRIPTION
We recently saw bugs introduced in Deepspeed master that were caught only on their new release. Which creates a gap in time where deepspeed integration doesn't work. To avoid that let's also test deepspeed master with the pytorch-nightly as there both pushing the bleeding edge.

Additionally this PR fixes the nightly pip install line that was misplaced originally. and pushes it first, before any other installs. Otherwise we end up first installing the current pytorch via dependencies of sub-packages, and then again the nightly.

@LysandreJik 