### PR TITLE
Use `config_dict_or_path` for deepspeed.zero.Init

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1340,7 +1340,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             logger.info("Detected DeepSpeed ZeRO-3: activating zero.init() for this model")
             # this immediately partitions the model across all gpus, to avoid the overhead in time
             # and memory copying it on CPU or each GPU first
-            with deepspeed.zero.Init(config=deepspeed_config()):
+            with deepspeed.zero.Init(config_dict_or_path=deepspeed_config()):
                 with no_init_weights(_enable=_fast_init):
                     model = cls(config, *model_args, **model_kwargs)
         else:


### PR DESCRIPTION
# What does this PR do?

While #13587 fixes one DeepSpeed warning, it missed a similar one. This applies the same change of `config` -> `config_dict_or_path` in another location.

## Who can review?

@sgugger (same reviewer as #13587)