### PR TITLE
Correct GPT-J voab_size

### DIFF
--- a/src/transformers/models/gptj/configuration_gptj.py
+++ b/src/transformers/models/gptj/configuration_gptj.py
@@ -36,7 +36,7 @@ class GPTJConfig(PretrainedConfig):
     :class:`~transformers.PretrainedConfig` for more information.
 
     Args:
-        vocab_size (:obj:`int`, `optional`, defaults to 50400):
+        vocab_size (:obj:`int`, `optional`, defaults to 50257):
             Vocabulary size of the GPT-J model. Defines the number of different tokens that can be represented by the
             :obj:`inputs_ids` passed when calling :class:`~transformers.GPTJModel`.
         n_positions (:obj:`int`, `optional`, defaults to 2048):
@@ -96,7 +96,7 @@ class GPTJConfig(PretrainedConfig):
 
     def __init__(
         self,
-        vocab_size=50400,
+        vocab_size=50257,
         n_positions=2048,
         n_ctx=2048,
         n_embd=4096,


### PR DESCRIPTION
# What does this PR do?

Corrects GPT-J `vocab_size`. GPT-J has 50400 `vocab_size` but the tokenizer’s vocab size is 50257. And the `run_clm.py` script always resizes the token embeddings using `len(tokenizer)`, so when the model is fine-tuned with that script, it changes the embedding size, which results in shape mismatch as described in #13499.
These extra tokens are for the sake of efficiency on TPU and are not used by the model.

This however would break all existing downloaded models, since those checkpoints will have 50400 `vocab_size`. The solution would be to manually change the `vocab_size` in the `config.json` file to 50257.


Fixes  #13499, Fixes #13581