### PR TITLE
Removed console spam from misfiring warnings

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -296,7 +296,7 @@ def booleans_processing(config, **kwargs):
         if (
             kwargs["output_attentions"] not in (None, config.output_attentions)
             or kwargs["output_hidden_states"] not in (None, config.output_hidden_states)
-            or kwargs.get("use_cache", None) not in (None, config.use_cache)
+            or "use_cache" in kwargs and kwargs["use_cache"] not in (None, config.use_cache)
         ):
             tf_logger.warning(
                 "The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model."

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -294,9 +294,9 @@ def booleans_processing(config, **kwargs):
             final_booleans["use_cache"] = kwargs["use_cache"] if kwargs["use_cache"] is not None else config.use_cache
     else:
         if (
-            kwargs["output_attentions"] is not None
-            or kwargs["output_hidden_states"] is not None
-            or ("use_cache" in kwargs and kwargs["use_cache"] is not None)
+            kwargs["output_attentions"] not in (None, config.output_attentions)
+            or kwargs["output_hidden_states"] not in (None, config.output_hidden_states)
+            or kwargs.get("use_cache", None) not in (None, config.use_cache)
         ):
             tf_logger.warning(
                 "The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model."
@@ -306,7 +306,7 @@ def booleans_processing(config, **kwargs):
         final_booleans["output_attentions"] = config.output_attentions
         final_booleans["output_hidden_states"] = config.output_hidden_states
 
-        if kwargs["return_dict"] is not None:
+        if kwargs.get("return_dict", None) not in (None, True):
             tf_logger.warning(
                 "The parameter `return_dict` cannot be set in graph mode and will always be set to `True`."
             )

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -293,9 +293,23 @@ def booleans_processing(config, **kwargs):
         if "use_cache" in kwargs:
             final_booleans["use_cache"] = kwargs["use_cache"] if kwargs["use_cache"] is not None else config.use_cache
     else:
+        if (
+            kwargs["output_attentions"] is not None
+            or kwargs["output_hidden_states"] is not None
+            or ("use_cache" in kwargs and kwargs["use_cache"] is not None)
+        ):
+            tf_logger.warning(
+                "The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model."
+                "They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`)."
+            )
+
         final_booleans["output_attentions"] = config.output_attentions
         final_booleans["output_hidden_states"] = config.output_hidden_states
 
+        if kwargs["return_dict"] is not None:
+            tf_logger.warning(
+                "The parameter `return_dict` cannot be set in graph mode and will always be set to `True`."
+            )
         final_booleans["return_dict"] = True
 
         if "use_cache" in kwargs:

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -296,7 +296,8 @@ def booleans_processing(config, **kwargs):
         if (
             kwargs["output_attentions"] not in (None, config.output_attentions)
             or kwargs["output_hidden_states"] not in (None, config.output_hidden_states)
-            or "use_cache" in kwargs and kwargs["use_cache"] not in (None, config.use_cache)
+            or "use_cache" in kwargs
+            and kwargs["use_cache"] not in (None, config.use_cache)
         ):
             tf_logger.warning(
                 "The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model."

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -293,23 +293,9 @@ def booleans_processing(config, **kwargs):
         if "use_cache" in kwargs:
             final_booleans["use_cache"] = kwargs["use_cache"] if kwargs["use_cache"] is not None else config.use_cache
     else:
-        if (
-            kwargs["output_attentions"] is not None
-            or kwargs["output_hidden_states"] is not None
-            or ("use_cache" in kwargs and kwargs["use_cache"] is not None)
-        ):
-            tf_logger.warning(
-                "The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model."
-                "They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`)."
-            )
-
         final_booleans["output_attentions"] = config.output_attentions
         final_booleans["output_hidden_states"] = config.output_hidden_states
 
-        if kwargs["return_dict"] is not None:
-            tf_logger.warning(
-                "The parameter `return_dict` cannot be set in graph mode and will always be set to `True`."
-            )
         final_booleans["return_dict"] = True
 
         if "use_cache" in kwargs:


### PR DESCRIPTION
A major source of UX annoyance is that when our code is used with Keras, warnings about inappropriate arguments fire every time the model is traced/compiled, which is at least once, and sometimes several times, per training run. I don't know why the warnings were written like this in the first place, but they're definitely not working now, so I'm going to remove them for now and do a deeper dive into the reason for the misbehaviour when I have more time.