### PR TITLE
Report test durations in scheduled CI tests

### DIFF
--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run all tests on GPU
         run: |
-          python -m pytest -n 1 -v --dist=loadfile --make-reports=tests_torch_gpu tests
+          python -m pytest -n 1 -v --dist=loadfile --make-reports=tests_torch_gpu --durations=0 --durations-min=10.0 tests
 
       - name: Failure short reports
         if: ${{ always() }}
@@ -72,7 +72,7 @@ jobs:
         env:
           RUN_PIPELINE_TESTS: yes
         run: |
-          python -m pytest -n 1 -v --dist=loadfile -m is_pipeline_test --make-reports=tests_torch_pipeline_gpu tests
+          python -m pytest -n 1 -v --dist=loadfile -m is_pipeline_test --make-reports=tests_torch_pipeline_gpu --durations=0 --durations-min=10.0 tests
 
       - name: Failure short reports
         if: ${{ always() }}
@@ -112,7 +112,7 @@ jobs:
 
       - name: Run all tests on GPU
         run: |
-          python -m pytest -n 1 -v --dist=loadfile --make-reports=tests_flax_gpu tests
+          python -m pytest -n 1 -v --dist=loadfile --make-reports=tests_flax_gpu --durations=0 --durations-min=10.0 tests
 
       - name: Failure short reports
         if: ${{ always() }}
@@ -154,7 +154,7 @@ jobs:
           TF_NUM_INTEROP_THREADS: 1
           TF_NUM_INTRAOP_THREADS: 16
         run: |
-          python -m pytest -n 1 -v --dist=loadfile --make-reports=tests_tf_gpu tests
+          python -m pytest -n 1 -v --dist=loadfile --make-reports=tests_tf_gpu --durations=0 --durations-min=10.0 tests
 
       - name: Failure short reports
         if: ${{ always() }}
@@ -167,7 +167,7 @@ jobs:
           TF_NUM_INTEROP_THREADS: 1
           TF_NUM_INTRAOP_THREADS: 16
         run: |
-          python -m pytest -n 1 -v --dist=loadfile -m is_pipeline_test --make-reports=tests_tf_pipeline_gpu tests
+          python -m pytest -n 1 -v --dist=loadfile -m is_pipeline_test --make-reports=tests_tf_pipeline_gpu --durations=0 --durations-min=10.0 tests
 
       - name: Failure short reports
         if: ${{ always() }}
@@ -211,7 +211,7 @@ jobs:
         env:
           MKL_SERVICE_FORCE_INTEL: 1
         run: |
-          python -m pytest -n 1 -v --dist=loadfile --make-reports=tests_torch_multi_gpu tests
+          python -m pytest -n 1 -v --dist=loadfile --make-reports=tests_torch_multi_gpu --durations=0 --durations-min=10.0 tests
 
       - name: Failure short reports
         if: ${{ always() }}
@@ -222,7 +222,7 @@ jobs:
         env:
           RUN_PIPELINE_TESTS: yes
         run: |
-          python -m pytest -n 1 -v --dist=loadfile -m is_pipeline_test --make-reports=tests_torch_pipeline_multi_gpu tests
+          python -m pytest -n 1 -v --dist=loadfile -m is_pipeline_test --make-reports=tests_torch_pipeline_multi_gpu --durations=0 --durations-min=10.0 tests
 
       - name: Failure short reports
         if: ${{ always() }}
@@ -265,7 +265,7 @@ jobs:
           TF_NUM_INTEROP_THREADS: 1
           TF_NUM_INTRAOP_THREADS: 16
         run: |
-          python -m pytest -n 1 -v --dist=loadfile --make-reports=tests_tf_multi_gpu tests
+          python -m pytest -n 1 -v --dist=loadfile --make-reports=tests_tf_multi_gpu --durations=0 --durations-min=10.0 tests
 
       - name: Failure short reports
         if: ${{ always() }}
@@ -278,7 +278,7 @@ jobs:
           TF_NUM_INTEROP_THREADS: 1
           TF_NUM_INTRAOP_THREADS: 16
         run: |
-          python -m pytest -n 1 -v --dist=loadfile -m is_pipeline_test --make-reports=tests_tf_pipeline_multi_gpu tests
+          python -m pytest -n 1 -v --dist=loadfile -m is_pipeline_test --make-reports=tests_tf_pipeline_multi_gpu --durations=0 --durations-min=10.0 tests
 
       - name: Failure short reports
         if: ${{ always() }}


### PR DESCRIPTION
The scheduled pytorch tests start to hit the 6-hour timeout for self-hosted CI runners (see [**Job execution time**](https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration#usage-limits)). At the moment, `GPT-J` is the main source of 10-minute `pytest` timeouts (50 minutes in total), but there are some other tests that could probably be improved time-wise or pruned altogether. 

To investigate the slowdowns in the CI, I propose enabling the test duration tracking (at least for a while), that generates logs like these at the end of pytest runs:
```
=================== slowest durations ===================================
600.02s call     tests/test_modeling_gptj.py::GPTJModelTest::test_model_from_pretrained
600.01s call     tests/test_modeling_gptj.py::GPTJModelTest::test_batch_generation
600.00s call     tests/test_modeling_gptj.py::GPTJModelLanguageGenerationTest::test_gptj_sample
284.58s call     tests/test_modeling_gpt_neo.py::GPTNeoModelLanguageGenerationTest::test_batch_generation
80.10s call     tests/test_modeling_fsmt.py::FSMTModelIntegrationTests::test_inference_no_head
78.26s call     tests/test_modeling_fsmt.py::FSMTModelIntegrationTests::test_translation_direct_1_ru_en
72.04s call     tests/test_modeling_fsmt.py::FSMTModelIntegrationTests::test_translation_direct_2_en_de
70.72s call     tests/test_modeling_fsmt.py::FSMTModelIntegrationTests::test_translation_direct_3_de_en
37.69s call     tests/test_modeling_funnel.py::FunnelModelIntegrationTest::test_inference_model
30.18s call     tests/test_modeling_flaubert.py::FlaubertModelIntegrationTest::test_inference_no_head_absolute_embedding
25.47s call     tests/test_modeling_encoder_decoder.py::BertGenerationEncoderDecoderModelTest::test_real_model_save_load_from_pretrained
21.86s call     tests/test_modeling_blenderbot.py::Blenderbot3BIntegrationTests::test_generation_from_short_input_same_as_parlai_3B
19.56s call     tests/test_modeling_encoder_decoder.py::GPT2EncoderDecoderModelTest::test_bert2gpt2_summarization
19.56s call     tests/test_modeling_encoder_decoder.py::BertGenerationEncoderDecoderModelTest::test_roberta2roberta_summarization

...

11.36s call     tests/test_modeling_bart.py::BartModelIntegrationTests::test_cnn_summarization_same_as_fairseq
11.12s call     tests/test_modeling_bart.py::BartModelIntegrationTests::test_base_mask_filling
10.40s call     tests/test_modeling_gpt_neo.py::GPTNeoModelLanguageGenerationTest::test_lm_generate_gpt_neo
10.01s call     tests/test_modeling_albert.py::AlbertModelTest::test_model_outputs_equivalence

(7320 durations < 10s hidden.  Use -vv to show these durations.)
```

- "Short report" generation should not get affected by this (@LysandreJik correct me if I'm wrong?)
- Tests with runtimes shorter than 10s will not get reported, to keep the logs manageable.