### PR TITLE
[Wav2Vec2FeatureExtractor] Fix `extractor.pad()` dtype backwards compatibility

### DIFF
--- a/src/transformers/feature_extraction_sequence_utils.py
+++ b/src/transformers/feature_extraction_sequence_utils.py
@@ -240,6 +240,8 @@ class SequenceFeatureExtractor(FeatureExtractionMixin):
             for key, value in outputs.items():
                 if key not in batch_outputs:
                     batch_outputs[key] = []
+                if value.dtype is np.dtype(np.float64):
+                    value = value.astype(np.float32)
                 batch_outputs[key].append(value)
 
         return BatchFeature(batch_outputs, tensor_type=return_tensors)

--- a/src/transformers/feature_extraction_sequence_utils.py
+++ b/src/transformers/feature_extraction_sequence_utils.py
@@ -187,23 +187,6 @@ class SequenceFeatureExtractor(FeatureExtractionMixin):
         padding_strategy = self._get_padding_strategies(padding=padding, max_length=max_length)
 
         required_input = processed_features[self.model_input_names[0]]
-        if required_input and not isinstance(required_input[0], np.ndarray):
-            # truncation
-            processed_features = self._truncate(
-                processed_features,
-                max_length=max_length,
-                pad_to_multiple_of=pad_to_multiple_of,
-                truncation=truncation,
-            )
-            # padding
-            processed_features = self._pad(
-                processed_features,
-                max_length=max_length,
-                padding_strategy=padding_strategy,
-                pad_to_multiple_of=pad_to_multiple_of,
-                return_attention_mask=return_attention_mask,
-            )
-            return BatchFeature(processed_features, tensor_type=return_tensors)
 
         batch_size = len(required_input)
         if not all(len(v) == batch_size for v in processed_features.values()):

--- a/tests/test_feature_extraction_speech_to_text.py
+++ b/tests/test_feature_extraction_speech_to_text.py
@@ -19,7 +19,6 @@ import random
 import unittest
 
 import numpy as np
-import torch
 
 from transformers import is_speech_available
 from transformers.testing_utils import require_torch, require_torchaudio
@@ -238,6 +237,8 @@ class Speech2TextFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unitt
         self.assertEqual(input_features.shape, (3, 6, 24))
 
     def test_double_precision_pad(self):
+        import torch
+
         feature_extractor = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
         np_speech_inputs = np.random.rand(100, 32).astype(np.float64)
         py_speech_inputs = np_speech_inputs.tolist()

--- a/tests/test_feature_extraction_speech_to_text.py
+++ b/tests/test_feature_extraction_speech_to_text.py
@@ -19,6 +19,7 @@ import random
 import unittest
 
 import numpy as np
+import torch
 
 from transformers import is_speech_available
 from transformers.testing_utils import require_torch, require_torchaudio
@@ -235,3 +236,14 @@ class Speech2TextFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unitt
 
         # make sure that if max_length < longest -> then pad to max_length
         self.assertEqual(input_features.shape, (3, 6, 24))
+
+    def test_double_precision_pad(self):
+        feature_extractor = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
+        np_speech_inputs = np.random.rand(100, 32).astype(np.float64)
+        py_speech_inputs = np_speech_inputs.tolist()
+
+        for inputs in [py_speech_inputs, np_speech_inputs]:
+            np_processed = feature_extractor.pad([{"input_features": inputs}], return_tensors="np")
+            self.assertTrue(np_processed.input_features.dtype == np.float32)
+            pt_processed = feature_extractor.pad([{"input_features": inputs}], return_tensors="pt")
+            self.assertTrue(pt_processed.input_features.dtype == torch.float32)

--- a/tests/test_feature_extraction_wav2vec2.py
+++ b/tests/test_feature_extraction_wav2vec2.py
@@ -19,7 +19,6 @@ import random
 import unittest
 
 import numpy as np
-import torch
 
 from transformers import WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST, Wav2Vec2Config, Wav2Vec2FeatureExtractor
 from transformers.testing_utils import require_torch, slow
@@ -199,6 +198,8 @@ class Wav2Vec2FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
 
     @require_torch
     def test_double_precision_pad(self):
+        import torch
+
         feature_extractor = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
         np_speech_inputs = np.random.rand(100).astype(np.float64)
         py_speech_inputs = np_speech_inputs.tolist()

--- a/tests/test_feature_extraction_wav2vec2.py
+++ b/tests/test_feature_extraction_wav2vec2.py
@@ -19,6 +19,7 @@ import random
 import unittest
 
 import numpy as np
+import torch
 
 from transformers import WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST, Wav2Vec2Config, Wav2Vec2FeatureExtractor
 from transformers.testing_utils import require_torch, slow
@@ -195,6 +196,18 @@ class Wav2Vec2FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
 
         # make sure that if max_length > longest -> then pad to longest
         self.assertTrue(input_values.shape == (3, 1200))
+
+    @require_torch
+    def test_double_precision_pad(self):
+        feature_extractor = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
+        np_speech_inputs = np.random.rand(100).astype(np.float64)
+        py_speech_inputs = np_speech_inputs.tolist()
+
+        for inputs in [py_speech_inputs, np_speech_inputs]:
+            np_processed = feature_extractor.pad([{"input_values": inputs}], return_tensors="np")
+            self.assertTrue(np_processed.input_values.dtype == np.float32)
+            pt_processed = feature_extractor.pad([{"input_values": inputs}], return_tensors="pt")
+            self.assertTrue(pt_processed.input_values.dtype == torch.float32)
 
     @slow
     @require_torch


### PR DESCRIPTION
Resolves #13689

This fixes an issue introduced by #13650 with speech feature extractors' tensors being returned as torch.float64 when `.pad()` is called directly:

```python
from transformers import Wav2Vec2FeatureExtractor
import numpy as np

extractor = Wav2Vec2FeatureExtractor.from_pretrained("facebook/wav2vec2-base-960h")

rand_input = np.ones((100,), dtype=np.float64)
out = extractor.pad([{"input_values": rand_input}], return_tensors="pt")

print(out.dtype) # <- this should be `torch.float32`
```

This is due to how pytorch converts float numpy arrays (new padding logic) vs python lists (old padding logic):

* uses torch.float32 for python lists by default: `torch.tensor([1.2, 2.3]).dtype  #  torch.float32`
* `np.array([1.2, 2.3]).dtype  # np.float64` 
* uses source dtype for numpy arrays: `torch.tensor(np.array([1.2, 2.3])).dtype  #  torch.float64`