### PR TITLE
[docs/gpt-j] add a note about tokenizer

### DIFF
--- a/docs/source/model_doc/gptj.rst
+++ b/docs/source/model_doc/gptj.rst
@@ -34,6 +34,11 @@ Tips:
 
     >>> model =  GPTJForCausalLM.from_pretrained("EleutherAI/gpt-j-6B", torch_dtype=torch.float16)
 
+- Although the embedding matrix has a size of 50400, only 50257 entries are used by the GPT-2 tokenizer. These extra
+  tokens are added for the sake of efficiency on TPUs. To avoid the mis-match between embedding matrix size and vocab
+  size, the tokenizer for [GPT-J](https://huggingface.co/EleutherAI/gpt-j-6B) contains 143 extra tokens
+  ``<|extratoken_1|>... <|extratoken_143|>``, so the ``vocab_size`` of tokenizer also becomes 50400.
+
 Generation
 _______________________________________________________________________________________________________________________
 


### PR DESCRIPTION
# What does this PR do?

This PR adds a note about why the `gpt-j` tokenizer has `vocab_size` of 50400 instead of 50257 as the original tokenizer.