### PR TITLE
Fix LayoutLM ONNX test error

### DIFF
--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -42,6 +42,7 @@ Ready-made configurations include the following models:
 - BERT
 - DistilBERT
 - GPT-2
+- LayoutLM
 - RoBERTa
 - T5
 - XLM-RoBERTa

--- a/src/transformers/models/layoutlm/configuration_layoutlm.py
+++ b/src/transformers/models/layoutlm/configuration_layoutlm.py
@@ -19,7 +19,7 @@ from typing import Any, List, Mapping, Optional
 from transformers import PretrainedConfig, PreTrainedTokenizer, TensorType
 
 from ... import is_torch_available
-from ...onnx import OnnxConfig, PatchingSpec, compute_effective_axis_dimension
+from ...onnx import OnnxConfig, PatchingSpec
 from ...utils import logging
 from ..bert.configuration_bert import BertConfig
 
@@ -183,22 +183,6 @@ class LayoutLMOnnxConfig(OnnxConfig):
             raise ValueError("Cannot generate dummy inputs without PyTorch installed.")
         import torch
 
-        # If dynamic axis (-1) we forward with a fixed dimension of 2 samples to avoid optimizations made by ONNX
-        batch_size = compute_effective_axis_dimension(
-            batch_size, fixed_dimension=OnnxConfig.DEFAULT_FIXED_BATCH, num_token_to_add=0
-        )
-
-        # If dynamic axis (-1) we forward with a fixed dimension of 8 tokens to avoid optimizations made by ONNX
-        token_to_add = tokenizer.num_special_tokens_to_add(is_pair)
-        seq_length = compute_effective_axis_dimension(
-            seq_length, fixed_dimension=OnnxConfig.DEFAULT_FIXED_SEQUENCE, num_token_to_add=token_to_add
-        )
-
-        input_dict["bbox"] = torch.tensor(
-            [
-                [0] * 4,
-                *[box] * seq_length,
-                [self.max_2d_positions] * 4,
-            ]
-        ).tile(batch_size, 1, 1)
+        batch_size, seq_length = input_dict["input_ids"].shape
+        input_dict["bbox"] = torch.tensor([*[box] * seq_length]).tile(batch_size, 1, 1)
         return input_dict

--- a/src/transformers/onnx/__init__.py
+++ b/src/transformers/onnx/__init__.py
@@ -15,4 +15,4 @@
 
 from .config import EXTERNAL_DATA_FORMAT_SIZE_LIMIT, OnnxConfig, OnnxConfigWithPast, PatchingSpec
 from .convert import export, validate_model_outputs
-from .utils import ParameterFormat, compute_serialized_parameters_size
+from .utils import ParameterFormat, compute_effective_axis_dimension, compute_serialized_parameters_size

--- a/src/transformers/onnx/__init__.py
+++ b/src/transformers/onnx/__init__.py
@@ -15,4 +15,4 @@
 
 from .config import EXTERNAL_DATA_FORMAT_SIZE_LIMIT, OnnxConfig, OnnxConfigWithPast, PatchingSpec
 from .convert import export, validate_model_outputs
-from .utils import ParameterFormat, compute_effective_axis_dimension, compute_serialized_parameters_size
+from .utils import ParameterFormat, compute_serialized_parameters_size


### PR DESCRIPTION
# What does this PR do?

Fixes the batch_size and seq_len computation during ONNX export in configuration_layoutlm.py.

PRs: #13702, #13562
Issue: #13300

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@michaelbenayoun @LysandreJik @NielsRogge @mfuntowicz 