### PR TITLE
Align attention_mask dtype to the attention_scores for BERT to speedup mixed precision inference and training

### DIFF
--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -322,6 +322,8 @@ class BertSelfAttention(nn.Module):
 
         attention_scores = attention_scores / math.sqrt(self.attention_head_size)
         if attention_mask is not None:
+            if attention_mask.dtype != attention_scores.dtype:
+                attention_mask = attention_mask.to(attention_scores.dtype)
             # Apply the attention mask is (precomputed for all layers in BertModel forward() function)
             attention_scores = attention_scores + attention_mask
 


### PR DESCRIPTION
# Why we need to align the attention_mask dtype to the attention_scores
For the encoder layer in BERT model, the attention_scores need to add the attention_mask info before the add and softmax layer to process the masked batch inputs.
The  attention_mask is always FP32 in this repository, It works well for fully FP32 data type, but when we use mixed precision, the attention_scores is low precision, such as bf16,  and the output of add operation will be FP32 in PyTorch. so the following softmax and dropout will also run with FP32 and introduce addition "to" operation. So, it will obviously reduce the performance for mixed precision performance with FP32 attention_mask. 
# Optimization 
Convert the attention_mask to the same type of  attention_scores  in the first encoder layer. With this optimization, we only need to convert the data type once and the following softmax and dropout will also use low precision data type to reduce memory footprint to improve the performance. 