### PR TITLE
Silence warning in gradient checkpointing when it's False

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -332,7 +332,7 @@ class PretrainedConfig(PushToHubMixin):
         self.transformers_version = kwargs.pop("transformers_version", None)
 
         # Deal with gradient checkpointing
-        if "gradient_checkpointing" in kwargs:
+        if kwargs.get("gradient_checkpointing", True):
             warnings.warn(
                 "Passing `gradient_checkpointing` to a config initialization is deprecated and will be removed in v5 "
                 "Transformers. Using `model.gradient_checkpointing_enable()` instead, or if you are using the "


### PR DESCRIPTION
# What does this PR do?

Currently, when loading a `bert-base-cased` model, one gets the warning 
```
UserWarning: Passing `gradient_checkpointing` to a config initialization is deprecated and will be removed in v5 Transformers. Using `model.gradient_checkpointing_enable()` instead, or if you are using the `Trainer` API, pass `gradient_checkpointing=True` in your `TrainingArguments`.
```
because it's config has the line `"gradient_checkpointing": false`.

This PR only issues the warning only when the value passed for `gradient_checkpointing` is `True`.