### PR TITLE
Fix type annotations for `distributed_concat()`

### DIFF
--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -25,7 +25,7 @@ import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
 from logging import StreamHandler
-from typing import Dict, Iterator, List, Optional, Union
+from typing import Any, Dict, Iterator, List, Optional, Union
 
 import numpy as np
 import torch
@@ -157,7 +157,9 @@ def nested_xla_mesh_reduce(tensors, name):
         raise ImportError("Torch xla must be installed to use `nested_xla_mesh_reduce`")
 
 
-def distributed_concat(tensor: "torch.Tensor", num_total_examples: Optional[int] = None) -> torch.Tensor:
+def distributed_concat(
+    tensor: Union[torch.Tensor, Any], num_total_examples: Optional[int] = None
+) -> Union[torch.Tensor, Any]:
     try:
         if isinstance(tensor, (tuple, list)):
             return type(tensor)(distributed_concat(t, num_total_examples) for t in tensor)

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -157,9 +157,7 @@ def nested_xla_mesh_reduce(tensors, name):
         raise ImportError("Torch xla must be installed to use `nested_xla_mesh_reduce`")
 
 
-def distributed_concat(
-    tensor: Union[torch.Tensor, Any], num_total_examples: Optional[int] = None
-) -> Union[torch.Tensor, Any]:
+def distributed_concat(tensor: Any, num_total_examples: Optional[int] = None) -> Any:
     try:
         if isinstance(tensor, (tuple, list)):
             return type(tensor)(distributed_concat(t, num_total_examples) for t in tensor)


### PR DESCRIPTION
# What does this PR do?

Fix the type annotations for [`trainer_pt_utils.distributed_concat()`](https://github.com/huggingface/transformers/blob/91df45516c9c21283df21d564bc352067d8c5f62/src/transformers/trainer_pt_utils.py#L160).

The input of this function could be a `torch.Tensor` or `list` / `tuple`, so I guess the type annotations:

https://github.com/huggingface/transformers/blob/91df45516c9c21283df21d564bc352067d8c5f62/src/transformers/trainer_pt_utils.py#L160

should be:

```python
def distributed_concat(
    tensor: Union[torch.Tensor, Any], num_total_examples: Optional[int] = None
) -> Union[torch.Tensor, Any]:
```


## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?


## Who can review?

@sgugger