### PR TITLE
Add attention-mask support for ViTModel

### DIFF
--- a/tests/test_modeling_beit.py
+++ b/tests/test_modeling_beit.py
@@ -199,6 +199,7 @@ class BeitModelTest(ModelTesterMixin, unittest.TestCase):
 
             expected_arg_names = ["pixel_values"]
             self.assertListEqual(arg_names[:1], expected_arg_names)
+            self.assertTrue("attention_mask" in arg_names)
 
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/test_modeling_flax_beit.py
+++ b/tests/test_modeling_flax_beit.py
@@ -208,6 +208,7 @@ class FlaxBeitModelTest(FlaxModelTesterMixin, unittest.TestCase):
 
             expected_arg_names = ["pixel_values"]
             self.assertListEqual(arg_names[:1], expected_arg_names)
+            self.assertTrue("attention_mask" in arg_names)
 
     # We neeed to override this test because Beit expects pixel_values instead of input_ids
     def test_jit_compilation(self):

--- a/tests/test_modeling_flax_vit.py
+++ b/tests/test_modeling_flax_vit.py
@@ -177,6 +177,7 @@ class FlaxViTModelTest(FlaxModelTesterMixin, unittest.TestCase):
 
             expected_arg_names = ["pixel_values"]
             self.assertListEqual(arg_names[:1], expected_arg_names)
+            self.assertTrue("attention_mask" in arg_names)
 
     # We neeed to override this test because ViT expects pixel_values instead of input_ids
     def test_jit_compilation(self):

--- a/tests/test_modeling_vit.py
+++ b/tests/test_modeling_vit.py
@@ -189,6 +189,7 @@ class ViTModelTest(ModelTesterMixin, unittest.TestCase):
 
             expected_arg_names = ["pixel_values"]
             self.assertListEqual(arg_names[:1], expected_arg_names)
+            self.assertTrue("attention_mask" in arg_names)
 
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()


### PR DESCRIPTION
# What does this PR do?

Transformers currently only support head-masks, however recent works
in vision language modeling have used the ViTModel with attention-masks.
Adding attention-masks to ViTSelfAttention and ViTModel allow
transformers modeling_vit to be used in implementing these models.

This commit adds attention-mask implementations from BertSelfAttention
as the forward param attention_mask. This change preserves the existing
behavior by default.

A specific example of how this change will be useful is being able to
implement ViLT https://arxiv.org/abs/2102.03334, using ViTModel as the main trunk.

Unit-tests seemed to pass, though there wasn't a unit-test for head_masks,
so I just added a check for attention_mask in the signature.
Thanks!


src/transformers/models/vit/modeling_vit.py @LysandreJik, @sgugger 
