### PR TITLE
Fix filtering in test fetcher utils

### DIFF
--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -442,8 +442,10 @@ def infer_tests_to_run(output_file, diff_with_last_commit=False, filters=None):
         # Make sure we did not end up with a test file that was removed
         test_files_to_run = [f for f in test_files_to_run if os.path.isfile(f) or os.path.isdir(f)]
         if filters is not None:
+            filtered_files = []
             for filter in filters:
-                test_files_to_run = [f for f in test_files_to_run if f.startswith(filter)]
+                filtered_files.extend([f for f in test_files_to_run if f.startswith(filter)])
+            test_files_to_run = filtered_files
 
     print(f"\n### TEST TO RUN ###\n{_print_list(test_files_to_run)}")
     if len(test_files_to_run) > 0:


### PR DESCRIPTION
# What does this PR do?

The examples tests are never run because there is a bug in the way filtering is applied to the tests to fetch. This PR addresses that.