### PR TITLE
[examples `run_glue.py`] missing requirements `scipy`, `sklearn`

### DIFF
--- a/examples/pytorch/text-classification/requirements.txt
+++ b/examples/pytorch/text-classification/requirements.txt
@@ -1,6 +1,7 @@
 accelerate
 datasets >= 1.8.0
 sentencepiece != 0.1.92
+scipy
 scikit-learn
 protobuf
 torch >= 1.3

--- a/examples/pytorch/text-classification/requirements.txt
+++ b/examples/pytorch/text-classification/requirements.txt
@@ -1,5 +1,6 @@
 accelerate
 datasets >= 1.8.0
 sentencepiece != 0.1.92
+scikit-learn
 protobuf
 torch >= 1.3


### PR DESCRIPTION
`run_glue.py` requires `sklearn` (which installs `scipy`)

When running:
```
RUN_SLOW=1 pytest tests/deepspeed/test_model_zoo.py::TestDeepSpeedModelZoo::test_zero_to_fp32_zero2_clas_xlnet -sv
```
which internally calls `examples/pytorch/text-classification/run_glue.py`

After 
```
pip install .[testing]
pip install deepspeed
pip install -r  examples/pytorch/text-classification/requirements.txt
```
it fails:
```
metric = load_metric("glue", data_args.task_name)
[...]

ImportError:File "/tmp/actions-runner/gh-runner/lib/python3.6/site-packages/datasets/load.py", line 819, in load_metric
781
E               metric = load_metric("glue", data_args.task_name)
[...]
 To be able to use this metric, you need to install the following dependencies['scipy', 'sklearn'] using 'pip install scipy sklearn' for instance'
```

it looks like it's enough to require `sklearn` - `scipy` gets installed along.
```
pip install sklearn
Collecting sklearn
  Downloading sklearn-0.0.tar.gz (1.1 kB)
Collecting scikit-learn
  Downloading scikit_learn-1.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (25.8 MB)
     |████████████████████████████████| 25.8 MB 814 kB/s 
Requirement already satisfied: joblib>=0.11 in /mnt/nvme1/anaconda3/envs/ds-test/lib/python3.8/site-packages (from scikit-learn->sklearn) (1.0.1)
Collecting scipy>=1.1.0
  Using cached scipy-1.7.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl (28.4 MB)
Collecting threadpoolctl>=2.0.0
  Using cached threadpoolctl-2.2.0-py3-none-any.whl (12 kB)
Requirement already satisfied: numpy>=1.14.6 in /mnt/nvme1/anaconda3/envs/ds-test/lib/python3.8/site-packages (from scikit-learn->sklearn) (1.21.2)
Building wheels for collected packages: sklearn
  Building wheel for sklearn (setup.py) ... done
  Created wheel for sklearn: filename=sklearn-0.0-py2.py3-none-any.whl size=1309 sha256=e55ca522573bec0880cf084944cb1e3235d38bf66ea96f54b94fc1088a6e9dde
  Stored in directory: /home/stas/.cache/pip/wheels/22/0b/40/fd3f795caaa1fb4c6cb738bc1f56100be1e57da95849bfc897
Successfully built sklearn
Installing collected packages: threadpoolctl, scipy, scikit-learn, sklearn
Successfully installed scikit-learn-1.0 scipy-1.7.1 sklearn-0.0 threadpoolctl-2.2.0
```
but may be it's best to list both explicitly.

Alternatively we should move `sklearn` from `[dev]` to `[testing]` in `setup.py`

context: Deepspeed integrating our deepspeed tests into their test suite:
https://github.com/microsoft/DeepSpeed/blob/e2de528632e122d7f359d9f5dedf4c0150cae072/.github/workflows/main.yml#L70-L98
I think it'd be too much to ask them to install `.[dev]` as it's too much unnecessary overhead.

The reason I'm considering changing this in `setup.py`'s `testing` is because any other example wanting to do metric `glue` will want those deps.

@sgugger, @LysandreJik 
