### PR TITLE
Implement len in IterableDatasetShard

### DIFF
--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -772,6 +772,13 @@ class IterableDatasetShard(IterableDataset):
             for i in process_slice:
                 yield current_batch[i]
 
+    def __len__(self):
+        # Will raise an error if the underlying dataset is not sized.
+        if self.drop_last:
+            return len(self.dataset) // self.num_processes
+        else:
+            return math.ceil(len(self.dataset) / self.num_processes)
+
 
 # In order to keep `trainer.py` compact and easy to understand, place any secondary PT Trainer
 # helper methods here


### PR DESCRIPTION
# What does this PR do?

Currently code using a size iterable dataset in distributed mode will fail because:
- the Trainer will detect the dataset is sized and try to get the length of the DataLoader
- the DataLoader will call the length of its dataset which is an IterableDatasetShard
- the IterableDatasetShard has no length

This PR adds the `__len__` method to `IterableDatasetShard` to solve that issue. The one thing that is midly annoying is that it will make all instance of `IterableDatasetShard` be recognized as `collections.abc.Sized` instances since they do implement the len method, even if that method will return an error. But that check is only used on the dataset passed along to the `Trainer`, not that wrapper, so I think we should be fine.