### PR TITLE
[testing] auto-replay captured streams

### DIFF
--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -1080,6 +1080,8 @@ If you need to capture both streams at once, use the parent :obj:`CaptureStd` cl
         function_that_writes_to_stdout_and_stderr()
     print(cs.err, cs.out)
 
+Also, to aid debugging test issues, by default these context managers automatically replay the captured streams on exit
+from the context.
 
 
 Capturing logger stream


### PR DESCRIPTION
This is a sync with the BigScience project https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/120

tldr; `CaptureStd*` interferes with `pytest` flags like `-sv` that should normally prints the std streams to the output. This PR fixes that.

Detailed: We noticed that when `CaptureStd` was used on the whole sub-process run it'd make it very difficult to debug problematic tests, since well it eats the output. So this PR changes the default behavior to replay the captured streams and adds a config arg to disable that.

This is a testing feature so backward compatibility shouldn't be an issue, and it will make things easier for us developers, rather than more difficult. And by default `pytest` captures/hides the std streams anyway.

@sgugger, @LysandreJik 