### PR TITLE
T5ForConditionalGeneration: enabling using past_key_values and labels in training

### DIFF
--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -1593,15 +1593,6 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
             # get decoder inputs from shifting lm labels to the right
             decoder_input_ids = self._shift_right(labels)
 
-        # If decoding with past key value states, only the last tokens
-        # should be given as an input
-        # if past_key_values is not None and use_cache:
-        #      assert labels is None, "Decoder should not use cached key value states when training."
-        #     if decoder_input_ids is not None:
-        #         decoder_input_ids = decoder_input_ids[:, -1:]
-        #     if decoder_inputs_embeds is not None:
-        #         decoder_inputs_embeds = decoder_inputs_embeds[:, -1:]
-
         # Set device for model parallelism
         if self.model_parallel:
             torch.cuda.set_device(self.decoder.first_device)

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -621,7 +621,7 @@ class T5Block(nn.Module):
     ):
 
         if past_key_value is not None:
-            # assert self.is_decoder, "Only decoder can use `past_key_values`"
+            #assert self.is_decoder, "Only decoder can use `past_key_values`"
             expected_num_past_key_values = 2 if encoder_hidden_states is None else 4
 
             if len(past_key_value) != expected_num_past_key_values:

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -621,7 +621,7 @@ class T5Block(nn.Module):
     ):
 
         if past_key_value is not None:
-            #assert self.is_decoder, "Only decoder can use `past_key_values`"
+            assert self.is_decoder, "Only decoder can use `past_key_values`"
             expected_num_past_key_values = 2 if encoder_hidden_states is None else 4
 
             if len(past_key_value) != expected_num_past_key_values:
@@ -632,7 +632,7 @@ class T5Block(nn.Module):
                 )
 
             self_attn_past_key_value = past_key_value[:2]
-            cross_attn_past_key_value = past_key_value[-2:]
+            cross_attn_past_key_value = past_key_value[2:]
         else:
             self_attn_past_key_value, cross_attn_past_key_value = None, None
 
@@ -1595,12 +1595,12 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
 
         # If decoding with past key value states, only the last tokens
         # should be given as an input
-        if past_key_values is not None and use_cache:
-            # assert labels is None, "Decoder should not use cached key value states when training."
-            if decoder_input_ids is not None:
-                decoder_input_ids = decoder_input_ids[:, -1:]
-            if decoder_inputs_embeds is not None:
-                decoder_inputs_embeds = decoder_inputs_embeds[:, -1:]
+        # if past_key_values is not None and use_cache:
+        #      assert labels is None, "Decoder should not use cached key value states when training."
+        #     if decoder_input_ids is not None:
+        #         decoder_input_ids = decoder_input_ids[:, -1:]
+        #     if decoder_inputs_embeds is not None:
+        #         decoder_inputs_embeds = decoder_inputs_embeds[:, -1:]
 
         # Set device for model parallelism
         if self.model_parallel:

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -621,7 +621,7 @@ class T5Block(nn.Module):
     ):
 
         if past_key_value is not None:
-            assert self.is_decoder, "Only decoder can use `past_key_values`"
+            # assert self.is_decoder, "Only decoder can use `past_key_values`"
             expected_num_past_key_values = 2 if encoder_hidden_states is None else 4
 
             if len(past_key_value) != expected_num_past_key_values:
@@ -632,7 +632,7 @@ class T5Block(nn.Module):
                 )
 
             self_attn_past_key_value = past_key_value[:2]
-            cross_attn_past_key_value = past_key_value[2:]
+            cross_attn_past_key_value = past_key_value[-2:]
         else:
             self_attn_past_key_value, cross_attn_past_key_value = None, None
 
@@ -1595,8 +1595,8 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
 
         # If decoding with past key value states, only the last tokens
         # should be given as an input
-        if past_key_values is not None:
-            assert labels is None, "Decoder should not use cached key value states when training."
+        if past_key_values is not None and use_cache:
+            # assert labels is None, "Decoder should not use cached key value states when training."
             if decoder_input_ids is not None:
                 decoder_input_ids = decoder_input_ids[:, -1:]
             if decoder_inputs_embeds is not None:


### PR DESCRIPTION
In T5ForConditionalGeneration, when training, we're not able to use the parameter _past_key_values_ together with _labels_. 
And even if we use decoder_input_ids rather than labels, only the last target token is used, if the _past_key_values_ parameter is provided.  
These limitations do not exist in other models like BART and BERT. 
Fixes:
- Delete the whole if statement to enabling using past_key_values in the T5Decoder when training.


These changes will not affect the `forward()` and `generate()` under normal conditions. And they make it possible to modify _past_key_values_ in the training of T5 the same way I've done in BARTForConditionalGeneration.



# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes https://github.com/huggingface/transformers/issues/13711





## Who can review?

@patrickvonplaten, @patil-suraj

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
