### PR TITLE
Update Loss calculation in prediction_step

### DIFF
--- a/examples/legacy/seq2seq/seq2seq_trainer.py
+++ b/examples/legacy/seq2seq/seq2seq_trainer.py
@@ -226,10 +226,11 @@ class Seq2SeqTrainer(Trainer):
             if generated_tokens.shape[-1] < gen_kwargs["max_length"]:
                 generated_tokens = self._pad_tensors_to_max_len(generated_tokens, gen_kwargs["max_length"])
 
-        labels = inputs.pop("labels")
-        with torch.no_grad():
-            # compute loss on predict data
-            loss, logits = self._compute_loss(model, inputs, labels)
+#         labels = inputs.pop("labels")
+#         with torch.no_grad():
+#             # compute loss on predict data
+#             loss, logits = self._compute_loss(model, inputs, labels)
+        loss, logits = self.compute_loss(model, inputs)
 
         loss = loss.mean().detach()
         if self.args.prediction_loss_only:


### PR DESCRIPTION
In `predition_step` function, loss is calculated using `_compute_loss` function. If the `compute_loss` function is overridden by a customized loss function, the evaluation will still calculate the original loss. I think it is more interesting to use `compute_loss` function rather than `_compute_loss` function in `prediction_step`.

# What does this PR do?


## Before submitting
- [ x ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Did you make sure to update the documentation with your changes? I think that no need to update documentation.


## Who can review?

Library:

- text generation: @patrickvonplaten
- trainer: @sgugger
- pipelines: @LysandreJik