### PR TITLE
Updating CITATION.cff to fix GitHub citation prompt BibTeX output.

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,7 +37,7 @@ authors:
   - family-names: Rush
     given-names: "Alexander M."
 preferred-citation:
-  type: inproceedings
+  type: conference-paper
   authors:
   - family-names: Wolf
     given-names: Thomas


### PR DESCRIPTION
# What does this PR do?

This is a small tweak to the `CITATION.cff` file to fix the output from the GitHub 'cite this repository' prompt, as [this is now supported](https://github.com/citation-file-format/ruby-cff/commit/5407f8e207c1f362568bb21e22865a512be9841f) in the Gem GitHub uses, and that gem is now live on GitHub.

Old BibTeX output: 

```

@misc{Wolf_Transformers_StateoftheArt_Natural_2020,
    author = {Wolf, Thomas and Debut, Lysandre and Sanh, Victor and Chaumond, Julien and Delangue, Clement and Moi, Anthony and Cistac, Perric and Ma, Clara and Jernite, Yacine and Plu, Julien and Xu, Canwen and Le Scao, Teven and Gugger, Sylvain and Drame, Mariama and Lhoest, Quentin and Rush, Alexander M.},
    month = {10},
    pages = {38--45},
    title = {{Transformers: State-of-the-Art Natural Language Processing}},
    url = {https://www.aclweb.org/anthology/2020.emnlp-demos.6},
    year = {2020}
}
```

New BibTeX output:

```
@inproceedings{Wolf_Transformers_StateoftheArt_Natural_2020,
    author = {Wolf, Thomas and Debut, Lysandre and Sanh, Victor and Chaumond, Julien and Delangue, Clement and Moi, Anthony and Cistac, Perric and Ma, Clara and Jernite, Yacine and Plu, Julien and Xu, Canwen and Le Scao, Teven and Gugger, Sylvain and Drame, Mariama and Lhoest, Quentin and Rush, Alexander M.},
    month = {10},
    pages = {38--45},
    publisher = {Association for Computational Linguistics},
    title = {{Transformers: State-of-the-Art Natural Language Processing}},
    url = {https://www.aclweb.org/anthology/2020.emnlp-demos.6},
    year = {2020}
}
```

Tagging @sgugger who merged the original PR that added a `CITATION.cff` file in https://github.com/huggingface/transformers/pull/13214.
