### PR TITLE
Fixed horizon_length for PPLM

### DIFF
--- a/examples/research_projects/pplm/run_pplm.py
+++ b/examples/research_projects/pplm/run_pplm.py
@@ -181,7 +181,11 @@ def perturb_past(
             for _ in range(horizon_length):
                 inputs_embeds = torch.matmul(curr_probs, wte.weight.data)
                 lm_output = model(past_key_values=curr_unpert_past, inputs_embeds=inputs_embeds)
-                curr_all_logits, curr_unpert_past, curr_all_hidden = lm_output['logits'], lm_output["past_key_values"], lm_output["hidden_states"]
+                curr_all_logits, curr_unpert_past, curr_all_hidden = (
+                    lm_output["logits"],
+                    lm_output["past_key_values"],
+                    lm_output["hidden_states"],
+                )
                 curr_logits = curr_all_logits[:, -1, :]
                 curr_probs = nn.functional.softmax(curr_logits, dim=-1)
                 curr_probs = torch.unsqueeze(curr_probs, dim=1)

--- a/examples/research_projects/pplm/run_pplm.py
+++ b/examples/research_projects/pplm/run_pplm.py
@@ -181,7 +181,11 @@ def perturb_past(
             for _ in range(horizon_length):
                 inputs_embeds = torch.matmul(curr_probs, wte.weight.data)
                 lm_output = model(past_key_values=curr_unpert_past, inputs_embeds=inputs_embeds)
-                curr_unpert_past, curr_all_hidden = lm_output["past_key_values"], lm_output["hidden_states"]
+                curr_all_logits, curr_unpert_past, curr_all_hidden = lm_output['logits'], lm_output["past_key_values"], lm_output["hidden_states"]
+                curr_hidden = curr_all_hidden[-1]
+                curr_logits = curr_all_logits[:, -1, :]
+                curr_probs = nn.functional.softmax(curr_logits, dim=-1)
+                curr_probs = torch.unsqueeze(curr_probs, dim=1)
                 curr_hidden = curr_all_hidden[-1]
                 new_accumulated_hidden = new_accumulated_hidden + torch.sum(curr_hidden, dim=1)
 

--- a/examples/research_projects/pplm/run_pplm.py
+++ b/examples/research_projects/pplm/run_pplm.py
@@ -182,7 +182,6 @@ def perturb_past(
                 inputs_embeds = torch.matmul(curr_probs, wte.weight.data)
                 lm_output = model(past_key_values=curr_unpert_past, inputs_embeds=inputs_embeds)
                 curr_all_logits, curr_unpert_past, curr_all_hidden = lm_output['logits'], lm_output["past_key_values"], lm_output["hidden_states"]
-                curr_hidden = curr_all_hidden[-1]
                 curr_logits = curr_all_logits[:, -1, :]
                 curr_probs = nn.functional.softmax(curr_logits, dim=-1)
                 curr_probs = torch.unsqueeze(curr_probs, dim=1)


### PR DESCRIPTION
# What does this PR do?
The current code can only run at horizon_length=1.
However, It's not applicable if we want to run at horizon_length > 1 since the curr_probs is not updated in the for_loop.
This PR is to update the curr_probs in the horizon_length in the for_loop.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
