### PR TITLE
Update Kwargs for EncoderDecoderModel

### DIFF
--- a/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
@@ -468,7 +468,9 @@ class EncoderDecoderModel(PreTrainedModel):
     def prepare_inputs_for_generation(
         self, input_ids, past=None, attention_mask=None, use_cache=None, encoder_outputs=None, **kwargs
     ):
-        decoder_inputs = self.decoder.prepare_inputs_for_generation(input_ids, past=past)
+        DEFAULT_KEYS = ["attention_mask", "decoder_attention_mask", "decoder_input_ids", "encoder_outputs", "past_key_values", "use_cache"]
+        
+        decoder_inputs = self.decoder.prepare_inputs_for_generation(input_ids, past=past, **kwargs)
         decoder_attention_mask = decoder_inputs["attention_mask"] if "attention_mask" in decoder_inputs else None
         input_dict = {
             "attention_mask": attention_mask,
@@ -478,6 +480,10 @@ class EncoderDecoderModel(PreTrainedModel):
             "past_key_values": decoder_inputs["past_key_values"],
             "use_cache": use_cache,
         }
+        
+        for key, value in decoder_inputs.items():
+            if not key in DEFAULT_KEYS:
+                input_dict.update({key: value})
         return input_dict
 
     def resize_token_embeddings(self, *args, **kwargs):

--- a/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
@@ -466,7 +466,7 @@ class EncoderDecoderModel(PreTrainedModel):
         )
 
     def prepare_inputs_for_generation(
-        self, input_ids, past=None, attention_mask=None, use_cache=None, encoder_outputs=None, **kwargs
+        self, input_ids, past=None, attention_mask=None, use_cache=None, encoder_outputs=None, use_default_keys=True, **kwargs
     ):
         DEFAULT_KEYS = ["attention_mask", "decoder_attention_mask", "decoder_input_ids", "encoder_outputs", "past_key_values", "use_cache"]
         
@@ -481,10 +481,10 @@ class EncoderDecoderModel(PreTrainedModel):
             "use_cache": use_cache,
         }
         
-        print(decoder_inputs)
-        for key, value in decoder_inputs.items():
-            if not key in DEFAULT_KEYS:
-                input_dict.update({key: value})
+        if not use_default_keys:
+            for key, value in decoder_inputs.items():
+                if not key in DEFAULT_KEYS:
+                    input_dict.update({key: value})
         return input_dict
 
     def resize_token_embeddings(self, *args, **kwargs):

--- a/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
@@ -481,6 +481,7 @@ class EncoderDecoderModel(PreTrainedModel):
             "use_cache": use_cache,
         }
         
+        print(decoder_inputs)
         for key, value in decoder_inputs.items():
             if not key in DEFAULT_KEYS:
                 input_dict.update({key: value})


### PR DESCRIPTION
# What does this PR do?
EncoderDecoderModel can't get additional parameters for customized models.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)
https://github.com/huggingface/transformers/issues/13887
Below, that function gets Kwargs for dynamic parameters,
```
def prepare_inputs_for_generation(
        self, input_ids, past=None, attention_mask=None, use_cache=None, encoder_outputs=None, **kwargs
    ):
```
but it doesn't reflect actually. I modified this function to
```
decoder_inputs = self.decoder.prepare_inputs_for_generation(input_ids, past=past)
        decoder_attention_mask = decoder_inputs["attention_mask"] if "attention_mask" in decoder_inputs else None
        input_dict = {
            "attention_mask": attention_mask,
            "decoder_attention_mask": decoder_attention_mask,
            "decoder_input_ids": decoder_inputs["input_ids"],
            "encoder_outputs": encoder_outputs,
            "past_key_values": decoder_inputs["past_key_values"],
            "use_cache": use_cache,
        }
        return input_dict
```

## Before submitting
- [] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@LysandreJik, @patrickvonplaten, @sgugger
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
