### PR TITLE
minimal fixes to run DataCollatorForWholeWordMask with return_tensors="np" and return_tensors="tf"

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -1060,11 +1060,8 @@ class DataCollatorForWholeWordMask(DataCollatorForLanguageModeling):
         indices_random = (
             np.random.binomial(1, 0.5, size=labels.shape).astype(np.bool) & masked_indices & ~indices_replaced
         )
-        random_words = np.random.randint(
-            low=0, high=len(self.tokenizer), size=np.count_nonzero(indices_random), dtype=np.int64
-        )
-        if any(random_words):
-            inputs[indices_random] = random_words[indices_random]
+        random_words = np.random.randint(low=0, high=len(self.tokenizer), size=labels.shape, dtype=np.int64)
+        inputs[indices_random] = random_words[indices_random]
 
         # The rest of the time (10% of the time) we keep the masked input tokens unchanged
         return inputs, labels

--- a/tests/test_data_collator.py
+++ b/tests/test_data_collator.py
@@ -24,6 +24,7 @@ from transformers import (
     DataCollatorForLanguageModeling,
     DataCollatorForPermutationLanguageModeling,
     DataCollatorForTokenClassification,
+    DataCollatorForWholeWordMask,
     DataCollatorWithPadding,
     default_data_collator,
     is_tf_available,
@@ -223,6 +224,16 @@ class DataCollatorIntegrationTest(unittest.TestCase):
         no_pad_features = [list(range(10)), list(range(10))]
         pad_features = [list(range(5)), list(range(10))]
         self._test_no_pad_and_pad(no_pad_features, pad_features)
+
+    def test_data_collator_for_whole_word_mask(self):
+        features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
+
+        tokenizer = BertTokenizer(self.vocab_file)
+        data_collator = DataCollatorForWholeWordMask(tokenizer, return_tensors="pt")
+        batch = data_collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 10)))
+        self.assertEqual(batch["labels"].shape, torch.Size((2, 10)))
 
     def test_plm(self):
         tokenizer = BertTokenizer(self.vocab_file)
@@ -488,6 +499,16 @@ class TFDataCollatorIntegrationTest(unittest.TestCase):
         pad_features = [list(range(5)), list(range(10))]
         self._test_no_pad_and_pad(no_pad_features, pad_features)
 
+    def test_data_collator_for_whole_word_mask(self):
+        features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
+
+        tokenizer = BertTokenizer(self.vocab_file)
+        data_collator = DataCollatorForWholeWordMask(tokenizer, return_tensors="tf")
+        batch = data_collator(features)
+
+        self.assertEqual(batch["input_ids"].shape.as_list(), [2, 10])
+        self.assertEqual(batch["labels"].shape.as_list(), [2, 10])
+
     def test_plm(self):
         tokenizer = BertTokenizer(self.vocab_file)
         no_pad_features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
@@ -749,6 +770,16 @@ class NumpyDataCollatorIntegrationTest(unittest.TestCase):
         no_pad_features = [list(range(10)), list(range(10))]
         pad_features = [list(range(5)), list(range(10))]
         self._test_no_pad_and_pad(no_pad_features, pad_features)
+
+    def test_data_collator_for_whole_word_mask(self):
+        features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
+
+        tokenizer = BertTokenizer(self.vocab_file)
+        data_collator = DataCollatorForWholeWordMask(tokenizer, return_tensors="np")
+        batch = data_collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, (2, 10))
+        self.assertEqual(batch["labels"].shape, (2, 10))
 
     def test_plm(self):
         tokenizer = BertTokenizer(self.vocab_file)


### PR DESCRIPTION
# What does this PR do?

This PR addresses https://github.com/huggingface/transformers/issues/13890 with the minimal fixes to run `DataCollatorForWholeWordMask` with `return_tensors="np"` and `return_tensors="tf"`

Specific problems addressed:
* Renamed `np_call` -> `numpy_call`
* Call `_numpy_collate_batch` instead of` _tf_collate_batch` when returning numpy tensors
* Fix size of `random_words` in `numpy_mask_tokens`
* Clone tensorflow tensors with `tf.identity(tensor)`
* Use tensorflow tensors’ built-in iteration instead of attempting to convert to list
* Change calls to `tf.convert_to_tensor` with `dtype=tf.bool` to `tf.cast` with `dtype=tf.bool`

I've only added a simple test to check for regressions vs all of the padded/unpadded cases as is done for `DataCollatorForLanguageModeling`

Fixes https://github.com/huggingface/transformers/issues/13890


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

CC @Rocketknight1 (looks like you did the initial Numpy/TF implementation of these data collators)