### PR TITLE
Fix hp search for non sigopt backends

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1238,7 +1238,11 @@ class Trainer:
         self.callback_handler.lr_scheduler = self.lr_scheduler
         self.callback_handler.train_dataloader = train_dataloader
         self.state.trial_name = self.hp_name(trial) if self.hp_name is not None else None
-        self.state.trial_params = hp_params(trial.assignments) if trial is not None else None
+        if trial is not None:
+            assignments = trial.assignments if self.hp_search_backend == HPSearchBackend.SIGOPT else trial
+            self.state.trial_params = hp_params(assignments)
+        else:
+            self.state.trial_params = None
         # This should be the same if the state has been saved but in case the training arguments changed, it's safer
         # to set this after the load.
         self.state.max_steps = max_steps


### PR DESCRIPTION
# What does this PR do?

This PR fixes the bug introduced in #13572 for the hyperparameter search using Ray Tune or Optuna. More speficially the bug introduced is on [this line](https://github.com/huggingface/transformers/blob/36fc401621297d2f917a0b4df4a0718067966c12/src/transformers/trainer.py#L1241)
```py
self.state.trial_params = hp_params(trial.assignments) if trial is not None else None
```

which used to be
```py
self.state.trial_params = hp_params(trial) if trial is not None else None
```

For the HP backends different from SigOpt, the `trial` object has no `assignmnents`, hence the failure.

Fixes #13875 