### PR TITLE
Context managers

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -37,7 +37,7 @@ from functools import partial, wraps
 from hashlib import sha256
 from pathlib import Path
 from types import ModuleType
-from typing import Any, BinaryIO, Dict, List, Optional, Tuple, Union, ContextManager
+from typing import Any, BinaryIO, ContextManager, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 from uuid import uuid4
 from zipfile import ZipFile, is_zipfile

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -30,14 +30,14 @@ import tarfile
 import tempfile
 import types
 from collections import OrderedDict, UserDict
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import fields
 from enum import Enum
 from functools import partial, wraps
 from hashlib import sha256
 from pathlib import Path
 from types import ModuleType
-from typing import Any, BinaryIO, Dict, List, Optional, Tuple, Union
+from typing import Any, BinaryIO, Dict, List, Optional, Tuple, Union, ContextManager
 from urllib.parse import urlparse
 from uuid import uuid4
 from zipfile import ZipFile, is_zipfile
@@ -2270,3 +2270,21 @@ def get_full_repo_name(model_id: str, organization: Optional[str] = None, token:
         return f"{username}/{model_id}"
     else:
         return f"{organization}/{model_id}"
+
+
+class ContextManagers:
+    """
+    Wrapper for `contextlib.ExitStack` which enters a collection of context managers. Adaptation of `ContextManagers`
+    in the `fastcore` library.
+    """
+
+    def __init__(self, context_managers: List[ContextManager]):
+        self.context_managers = context_managers
+        self.stack = ExitStack()
+
+    def __enter__(self):
+        for context_manager in self.context_managers:
+            self.stack.enter_context(context_manager)
+
+    def __exit__(self, *args, **kwargs):
+        self.stack.__exit__(*args, **kwargs)


### PR DESCRIPTION
# What does this PR do?
This PR adds a `ContextManagers` class that wraps one, multiple or no context managers and acts as a single context manager as discussed with @sgugger and @stas00. This should reduce code duplications where the context is conditional e.g. can only be applied if a framework is used or flag is set. 

## Example
The following example should illustrate how the `ContextManagers` class works:
```Python
import contextlib

@contextlib.contextmanager
def context_en():
    print('Welcome!')
    yield
    print('Bye!')
    
@contextlib.contextmanager
def context_fr():
    print('Bonjour!')
    yield
    print('Au revoir!')
```
We can then either specify no, one, or more contexts:
```Python
with ContextManagers([]):
    print('Transformers are awesome!')
print()

with ContextManagers([context_en()]):
    print('Transformers are awesome!')
print()
    
with ContextManagers([context_en(), context_fr()]):
    print('Transformers are awesome!')
```
The context managers will be nested in the `ContextManagers`
```Python
>>>Transformers are awesome!
>>>
>>>Welcome!
>>>Transformers are awesome!
>>>Bye!
>>>
>>>Welcome!
>>>Bonjour!
>>>Transformers are awesome!
>>>Au revoir!
>>>Bye!
```

## Use cases
With this class the following code snippets can be rewritten: https://github.com/huggingface/transformers/blob/aea7c5b0c8b8d0e03dea2046599f09e16357070f/src/transformers/modeling_utils.py#L767-L773

```Python
contexts = []
if is_deepspeed_zero3_enabled():
    import deepspeed

    contexts.append(deepspeed.zero.GatheredParameters(old_embeddings.weight, modifier_rank=None))

with ContextManagers(contexts):
    old_num_tokens, old_embedding_dim = old_embeddings.weight.size()
```

Contexts with additional conditional statements are probably best dealt with like that:
https://github.com/huggingface/transformers/blob/aea7c5b0c8b8d0e03dea2046599f09e16357070f/src/transformers/modeling_utils.py#L796-L805

```Python
contexts = []
if is_deepspeed_zero3_enabled():
    import deepspeed
    
    contexts.append(deepspeed.zero.GatheredParameters(old_embeddings.weight, modifier_rank=0))

with ContextManagers(contexts):
    if not is_deepspeed_zero3_enabled() or torch.distributed.get_rank() == 0:
        new_embeddings.weight.data[:n, :] = old_embeddings.weight.data[:n, :]
```

Another place where code duplication is even more severe is in upcasting added in #13573:
https://github.com/huggingface/transformers/blob/aea7c5b0c8b8d0e03dea2046599f09e16357070f/src/transformers/models/gpt2/modeling_gpt2.py#L243-L251

What do you think about this implementation?