### PR TITLE
[Trainer] Fix nan-loss condition

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1311,10 +1311,13 @@ class Trainer:
                 else:
                     tr_loss_step = self.training_step(model, inputs)
 
-                if args.logging_nan_inf_filter and not is_torch_tpu_available():
-                    if torch.isnan(tr_loss_step) or torch.isinf(tr_loss_step):
-                        # if loss is nan or inf simply add the average of previous logged losses
-                        tr_loss += tr_loss / (1 + self.state.global_step - self._globalstep_last_logged)
+                if (
+                    args.logging_nan_inf_filter
+                    and not is_torch_tpu_available()
+                    and (torch.isnan(tr_loss_step) or torch.isinf(tr_loss_step))
+                ):
+                    # if loss is nan or inf simply add the average of previous logged losses
+                    tr_loss += tr_loss / (1 + self.state.global_step - self._globalstep_last_logged)
                 else:
                     tr_loss += tr_loss_step
 


### PR DESCRIPTION
Fixes a change in the nan loss handling logic introduced by #13896

With `is_torch_tpu_available()==False` and `(torch.isnan(tr_loss_step) or torch.isinf(tr_loss_step))==False` 
the `else:` condition was never reached, so the training loss was always `0.0`.