### PR TITLE
[trainer] memory metrics: add memory at the start report

### DIFF
--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -477,12 +477,13 @@ class TrainerMemoryTracker:
         # memory usage, in particular for GPU, let's report memory usage at the point init was called
         if stages[0] == "init":
             metrics["before_init_mem_cpu"] = self.cpu["init"]["begin"]
-            metrics["before_init_mem_gpu"] = self.gpu["init"]["begin"]
+            if self.torch is not None:
+                metrics["before_init_mem_gpu"] = self.gpu["init"]["begin"]
             # if we also wanted to report any additional memory allocations in between init and
             # whatever the next stage was we could also report this:
             # if self.cpu["init"]["end"] != self.cpu[stage]["begin"]:
             #     metrics[f"after_init_mem_cpu_delta"] = self.cpu[stage]["begin"] - self.cpu["init"]["end"]
-            # if self.gpu["init"]["end"] != self.gpu[stage]["begin"]:
+            # if self.torch is not None and self.gpu["init"]["end"] != self.gpu[stage]["begin"]:
             #     metrics[f"after_init_mem_gpu_delta"] = self.gpu[stage]["begin"] - self.gpu["init"]["end"]
 
     def stop_and_update_metrics(self, metrics=None):

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -427,6 +427,8 @@ class TrainerMemoryTracker:
             self.gpu_mem_used_now = self.torch.cuda.memory_allocated()
             self.gpu_mem_used_peak = self.torch.cuda.max_memory_allocated()
             self.gpu[self.cur_stage] = dict(
+                begin=self.gpu_mem_used_at_start,
+                end=self.gpu_mem_used_now,
                 alloc=(self.gpu_mem_used_now - self.gpu_mem_used_at_start),
                 peaked=max(0, self.gpu_mem_used_peak - self.gpu_mem_used_now),
             )
@@ -434,6 +436,8 @@ class TrainerMemoryTracker:
         # cpu
         self.cpu_mem_used_now = self.cpu_mem_used()
         self.cpu[self.cur_stage] = dict(
+            begin=self.cpu_mem_used_at_start,
+            end=self.cpu_mem_used_now,
             alloc=(self.cpu_mem_used_now - self.cpu_mem_used_at_start),
             peaked=max(0, self.cpu_mem_used_peak - self.cpu_mem_used_now),
         )
@@ -462,6 +466,24 @@ class TrainerMemoryTracker:
                     metrics[f"{stage}_mem_cpu_{t}_delta"] = self.cpu[stage][t]
                 if self.torch is not None and stage in self.gpu and t in self.gpu[stage]:
                     metrics[f"{stage}_mem_gpu_{t}_delta"] = self.gpu[stage][t]
+            # if we need additional debug info, enable the following
+            # for t in ["begin", "end"]:
+            #     if stage in self.cpu and t in self.cpu[stage]:
+            #         metrics[f"{stage}_mem_cpu_{t}"] = self.cpu[stage][t]
+            #     if self.torch is not None and stage in self.gpu and t in self.gpu[stage]:
+            #         metrics[f"{stage}_mem_gpu_{t}"] = self.gpu[stage][t]
+
+        # since memory can be allocated before init, and it might be difficult to track overall
+        # memory usage, in particular for GPU, let's report memory usage at the point init was called
+        if stages[0] == "init":
+            metrics["before_init_mem_cpu"] = self.cpu["init"]["begin"]
+            metrics["before_init_mem_gpu"] = self.gpu["init"]["begin"]
+            # if we also wanted to report any additional memory allocations in between init and
+            # whatever the next stage was we could also report this:
+            # if self.cpu["init"]["end"] != self.cpu[stage]["begin"]:
+            #     metrics[f"after_init_mem_cpu_delta"] = self.cpu[stage]["begin"] - self.cpu["init"]["end"]
+            # if self.gpu["init"]["end"] != self.gpu[stage]["begin"]:
+            #     metrics[f"after_init_mem_gpu_delta"] = self.gpu[stage]["begin"] - self.gpu["init"]["end"]
 
     def stop_and_update_metrics(self, metrics=None):
         """combine stop and metrics update in one call for simpler code"""


### PR DESCRIPTION
While debugging a user report https://github.com/huggingface/transformers/issues/13616, I have noticed when we use deepspeed w/ zero3 it allocates some memory on GPU before Trainer's init, so this memory doesn't get reported and then I got a mysterious negative delta:
```
  train_mem_gpu_alloc_delta  =     -153MB
  train_mem_gpu_peaked_delta =     2012MB
```
so it was very confusing. This PR adds another 2 metrics which report memory usage at the very start of the Trainer (init), so now the report becomes:
```
  before_init_mem_gpu        =      312MB
  train_mem_gpu_alloc_delta  =     -153MB
  train_mem_gpu_peaked_delta =     2012MB
```
and it becomes obvious that some memory was allocated before the Trainer started and now the minus can be added to a non-zero initial value.

For symmetry added the cpu memory usage as well.

Examples of the new report (deleted all, but memory metrics):
```
$ CUDA_VISIBLE_DEVICES=0 PYTHONPATH=src python examples/pytorch/language-modeling/run_clm.py \
--model_name_or_path gpt2 --do_train --train_file tests/fixtures/sample_text.txt --fp16 true \
--output_dir output --overwrite_output_dir 1 --per_device_train_batch_size 1 --report_to none \
--skip_memory_metrics 0

***** train metrics *****
  before_init_mem_cpu        =     1945MB
  before_init_mem_gpu        =        0MB
  init_mem_cpu_alloc_delta   =     3249MB
  init_mem_cpu_peaked_delta  =      443MB
  init_mem_gpu_alloc_delta   =      487MB
  init_mem_gpu_peaked_delta  =        0MB
  train_mem_cpu_alloc_delta  =      151MB
  train_mem_cpu_peaked_delta =        0MB
  train_mem_gpu_alloc_delta  =     1431MB
  train_mem_gpu_peaked_delta =      562MB

$ PYTHONPATH=src deepspeed --num_gpus 1 examples/pytorch/language-modeling/run_clm.py \
--deepspeed tests/deepspeed/ds_config_zero3.json --model_name_or_path gpt2 --do_train \
--train_file tests/fixtures/sample_text.txt --fp16 true --output_dir output \
--overwrite_output_dir 1 --per_device_train_batch_size 1 --report_to none \
--skip_memory_metrics 0

***** train metrics *****
  before_init_mem_cpu        =     5262MB
  before_init_mem_gpu        =      312MB
  init_mem_cpu_alloc_delta   =        0MB
  init_mem_cpu_peaked_delta  =        0MB
  init_mem_gpu_alloc_delta   =        0MB
  init_mem_gpu_peaked_delta  =        0MB
  train_mem_cpu_alloc_delta  =     3288MB
  train_mem_cpu_peaked_delta =      465MB
  train_mem_gpu_alloc_delta  =     -153MB
  train_mem_gpu_peaked_delta =     2012MB
```
For the non-DS case, the gpu memory usage is usually 0 and it's reflected in the report, and non-0 with DS.

Additionally I prepared several other possible reports if someone puzzles over the math or has a complex situation. Left those in the comments if someone needs them.

@sgugger 