### PR TITLE
Fix fast tokenization problems

### DIFF
--- a/src/transformers/models/albert/tokenization_albert.py
+++ b/src/transformers/models/albert/tokenization_albert.py
@@ -142,7 +142,8 @@ class AlbertTokenizer(PreTrainedTokenizer):
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs
     ) -> None:
-        # Mask token behave like a normal word, i.e. include the space before it
+        # Mask token behave like a normal word, i.e. include the space before it and
+        # is included in the raw text, there should be a match in a non-normalized sentence.
         mask_token = (
             AddedToken(mask_token, lstrip=True, rstrip=False, normalized=False)
             if isinstance(mask_token, str)

--- a/src/transformers/models/albert/tokenization_albert.py
+++ b/src/transformers/models/albert/tokenization_albert.py
@@ -143,7 +143,7 @@ class AlbertTokenizer(PreTrainedTokenizer):
         **kwargs
     ) -> None:
         # Mask token behave like a normal word, i.e. include the space before it
-        mask_token = AddedToken(mask_token, lstrip=True, rstrip=False) if isinstance(mask_token, str) else mask_token
+        mask_token = AddedToken(mask_token, lstrip=True, rstrip=False, normalized=False) if isinstance(mask_token, str) else mask_token
 
         self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 

--- a/src/transformers/models/albert/tokenization_albert.py
+++ b/src/transformers/models/albert/tokenization_albert.py
@@ -143,7 +143,11 @@ class AlbertTokenizer(PreTrainedTokenizer):
         **kwargs
     ) -> None:
         # Mask token behave like a normal word, i.e. include the space before it
-        mask_token = AddedToken(mask_token, lstrip=True, rstrip=False, normalized=False) if isinstance(mask_token, str) else mask_token
+        mask_token = (
+            AddedToken(mask_token, lstrip=True, rstrip=False, normalized=False)
+            if isinstance(mask_token, str)
+            else mask_token
+        )
 
         self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 

--- a/src/transformers/models/albert/tokenization_albert_fast.py
+++ b/src/transformers/models/albert/tokenization_albert_fast.py
@@ -135,8 +135,6 @@ class AlbertTokenizerFast(PreTrainedTokenizerFast):
         mask_token="[MASK]",
         **kwargs
     ):
-        # Mask token behave like a normal word, i.e. include the space before it
-        mask_token = AddedToken(mask_token, lstrip=True, rstrip=False) if isinstance(mask_token, str) else mask_token
 
         super().__init__(
             vocab_file,

--- a/src/transformers/models/albert/tokenization_albert_fast.py
+++ b/src/transformers/models/albert/tokenization_albert_fast.py
@@ -20,7 +20,6 @@ from shutil import copyfile
 from typing import List, Optional, Tuple
 
 from ...file_utils import is_sentencepiece_available
-from ...tokenization_utils import AddedToken
 from ...tokenization_utils_fast import PreTrainedTokenizerFast
 from ...utils import logging
 

--- a/src/transformers/models/albert/tokenization_albert_fast.py
+++ b/src/transformers/models/albert/tokenization_albert_fast.py
@@ -20,6 +20,7 @@ from shutil import copyfile
 from typing import List, Optional, Tuple
 
 from ...file_utils import is_sentencepiece_available
+from ...tokenization_utils import AddedToken
 from ...tokenization_utils_fast import PreTrainedTokenizerFast
 from ...utils import logging
 
@@ -134,6 +135,13 @@ class AlbertTokenizerFast(PreTrainedTokenizerFast):
         mask_token="[MASK]",
         **kwargs
     ):
+        # Mask token behave like a normal word, i.e. include the space before it and
+        # is included in the raw text, there should be a match in a non-normalized sentence.
+        mask_token = (
+            AddedToken(mask_token, lstrip=True, rstrip=False, normalized=False)
+            if isinstance(mask_token, str)
+            else mask_token
+        )
 
         super().__init__(
             vocab_file,

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -131,7 +131,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
 
         # We call this after having initialized the backend tokenizer because we update it.
         super().__init__(**kwargs)
-        
+
         # Ensure special tokens directly specified from kwargs (not from tokenizer file) are sanitized.
         self.sanitize_special_tokens()
 

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -132,8 +132,9 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         # We call this after having initialized the backend tokenizer because we update it.
         super().__init__(**kwargs)
 
-        # Ensure special tokens directly specified from kwargs (not from tokenizer file) are sanitized.
-        self.sanitize_special_tokens()
+        # Ensure special tokens directly specified from kwargs (not from pretrained) are sanitized.
+        if "name_or_path" not in kwargs:
+            self.sanitize_special_tokens()
 
     @property
     def is_fast(self) -> bool:

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -131,6 +131,9 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
 
         # We call this after having initialized the backend tokenizer because we update it.
         super().__init__(**kwargs)
+        
+        # Ensure special tokens directly specified from kwargs (not from tokenizer file) are sanitized.
+        self.sanitize_special_tokens()
 
     @property
     def is_fast(self) -> bool:

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -132,10 +132,6 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         # We call this after having initialized the backend tokenizer because we update it.
         super().__init__(**kwargs)
 
-        # Ensure special tokens directly specified from kwargs (not from pretrained) are sanitized.
-        if "name_or_path" not in kwargs:
-            self.sanitize_special_tokens()
-
     @property
     def is_fast(self) -> bool:
         return True


### PR DESCRIPTION
# What does this PR do?

This PR addresses two problems of fast tokenization:

1. The special tokens specified directly from kwargs were not sanitized. (not added through `tokenizer._add_tokens` function.)
**Edited: We finally decided to not include this change in this PR.**
```python
from transformers import AlbertTokenizerFast

tokenizer = AlbertTokenizerFast("tests/fixtures/spiece.model", mask_token="[OAO]")
print(tokenizer._mask_token)
print(tokenizer.tokenize('[OAO]'))

# Outputs:
# [OAO]
# ['▁[', 'o', 'ao', ']']

# Fixed outputs:
# [OAO]
# ['[OAO]']
```
2.  The special handling of `Albert`'s `[MASK]` token incorrectly normalizes texts to be matched. (Special tokens should exactly match original text not the normalized one.)

```python
from transformers import AlbertTokenizerFast

tokenizer = AlbertTokenizerFast("tests/fixtures/spiece.model")

print(tokenizer._mask_token)
print(tokenizer.tokenize('[MASK]'))

# Outputs:
# [MASK]
# ['▁[', 'mask', ']']

# Fixed outputs:
# [MASK]
# ['[MASK]']
```



## Who can review?

@LysandreJik @sgugger @SaulLu 
