### PR TITLE
Make username optional in hub_model_id

### DIFF
--- a/src/transformers/keras_callbacks.py
+++ b/src/transformers/keras_callbacks.py
@@ -39,10 +39,12 @@ class PushToHubCallback(Callback):
         tokenizer (:obj:`PreTrainedTokenizerBase`, `optional`):
             The tokenizer used by the model. If supplied, will be uploaded to the repo alongside the weights.
         hub_model_id (:obj:`str`, `optional`):
-            The name of the repository to keep in sync with the local `output_dir`. Should be the whole repository
-            name, for instance :obj:`"user_name/model"`, which allows you to push to an organization you are a member
-            of with :obj:`"organization_name/model"`. Will default to :obj:`user_name/output_dir_name` with
-            `output_dir_name` being the name of :obj:`output_dir`.
+            The name of the repository to keep in sync with the local `output_dir`. It can be a simple model ID in
+            which case the model will be pushed in your namespace. Otherwise it should be the whole repository name,
+            for instance :obj:`"user_name/model"`, which allows you to push to an organization you are a member of with
+            :obj:`"organization_name/model"`.
+
+            Will default to to the name of :obj:`output_dir`.
         hub_token (:obj:`str`, `optional`):
             The token to use to push the model to the Hub. Will default to the token in the cache folder obtained with
             :obj:`huggingface-cli login`.
@@ -56,11 +58,11 @@ class PushToHubCallback(Callback):
         self.save_steps = save_steps
         output_dir = Path(output_dir)
         if hub_model_id is None:
-            repo_name = get_full_repo_name(output_dir.absolute().name, token=hub_token)
-        else:
-            repo_name = hub_model_id
+            hub_model_id = output_dir.absolute().name
+        if "/" not in hub_model_id:
+            hub_model_id = get_full_repo_name(hub_model_id, token=hub_token)
         self.output_dir = output_dir
-        self.repo = Repository(str(output_dir), clone_from=repo_name)
+        self.repo = Repository(str(output_dir), clone_from=hub_model_id)
         self.tokenizer = tokenizer
         self.last_job = None
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2542,9 +2542,11 @@ class Trainer:
             return
         use_auth_token = True if self.args.hub_token is None else self.args.hub_token
         if self.args.hub_model_id is None:
-            repo_name = get_full_repo_name(Path(self.args.output_dir).name, token=self.args.hub_token)
+            repo_name = Path(self.args.output_dir).absolute().name
         else:
             repo_name = self.args.hub_model_id
+        if "/" not in repo_name:
+            repo_name = get_full_repo_name(repo_name, token=self.args.hub_token)
 
         try:
             self.repo = Repository(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -349,12 +349,13 @@ class TrainingArguments:
             the `example scripts <https://github.com/huggingface/transformers/tree/master/examples>`__ for more
             details.
         hub_model_id (:obj:`str`, `optional`):
-            The name of the repository to keep in sync with the local `output_dir`. Should be the whole repository
-            name, for instance :obj:`"user_name/model"`, which allows you to push to an organization you are a member
-            of with :obj:`"organization_name/model"`.
+            The name of the repository to keep in sync with the local `output_dir`. It can be a simple model ID in
+            which case the model will be pushed in your namespace. Otherwise it should be the whole repository name,
+            for instance :obj:`"user_name/model"`, which allows you to push to an organization you are a member of with
+            :obj:`"organization_name/model"`. Will default to :obj:`user_name/output_dir_name` with `output_dir_name`
+            being the name of :obj:`output_dir`.
 
-            Will default to :obj:`user_name/output_dir_name` with `output_dir_name` being the name of
-            :obj:`output_dir`.
+            Will default to to the name of :obj:`output_dir`.
         hub_strategy (:obj:`str` or :class:`~transformers.trainer_utils.HubStrategy`, `optional`, defaults to :obj:`"every_save"`):
             Defines the scope of what is pushed to the Hub and when. Possible values are:
 


### PR DESCRIPTION
# What does this PR do?

This PR makes the username in the `hub_model_id` optional, by checking whether there is a "/" in it and adding the username if needed. Since no one is allowed to push to base repo IDs (like `"bert-base-cased"`) anymore, this shouldn't lock any usecase while making the API delightfully easier.