### PR TITLE
Conversational pipeline: pop instead of get to avoir duplicate kwargs

### DIFF
--- a/src/transformers/pipelines/conversational.py
+++ b/src/transformers/pipelines/conversational.py
@@ -264,7 +264,7 @@ class ConversationalPipeline(Pipeline):
         return {"input_ids": input_ids, "conversation": conversation}
 
     def _forward(self, model_inputs, minimum_tokens=10, **generate_kwargs):
-        max_length = generate_kwargs.get("max_length", self.model.config.max_length)
+        max_length = generate_kwargs.pop("max_length", self.model.config.max_length)
 
         n = model_inputs["input_ids"].shape[1]
         if max_length - minimum_tokens < n:


### PR DESCRIPTION
The following two tests fail:
```
FAILED tests/test_pipelines_conversational.py::ConversationalPipelineTests::test_integration_torch_conversation
FAILED tests/test_pipelines_conversational.py::ConversationalPipelineTests::test_integration_torch_conversation_encoder_decoder
```

For the following reason:

```
    def _forward(self, model_inputs, minimum_tokens=10, **generate_kwargs):
        max_length = generate_kwargs.get("max_length", self.model.config.max_length)
    
        n = model_inputs["input_ids"].shape[1]
        if max_length - minimum_tokens < n:
            logger.warning(f"Conversation input is to long ({n}), trimming it to ({max_length} - {minimum_tokens})")
            trim = max_length - minimum_tokens
            model_inputs["input_ids"] = model_inputs["input_ids"][:, -trim:]
            if "attention_mask" in model_inputs:
                model_inputs["attention_mask"] = model_inputs["attention_mask"][:, -trim:]
        conversation = model_inputs.pop("conversation")
        model_inputs["max_length"] = max_length
>       output_ids = self.model.generate(**model_inputs, **generate_kwargs)
E       TypeError: generate() got multiple values for keyword argument 'max_length'
```

This PR fixes that.