### PR TITLE
Don't duplicate the elements in dir

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -2034,7 +2034,13 @@ class _LazyModule(ModuleType):
 
     # Needed for autocompletion in an IDE
     def __dir__(self):
-        return super().__dir__() + self.__all__
+        result = super().__dir__()
+        # The elements of self.__all__ that are submodules may or may not be in the dir already, depending on whether
+        # they have been accessed or not. So we only add the elements of self.__all__ that are not already in the dir.
+        for attr in self.__all__:
+            if attr not in result:
+                result.append(attr)
+        return result
 
     def __getattr__(self, name: str) -> Any:
         if name in self._objects:


### PR DESCRIPTION
# What does this PR do?

There is a tiny bug in the way the `__dir__` method of our lazy modules is implemented. To see it run:

```
import transformers
dir(transformers.models.bert)
```

which will give a list ending with
```
[...,
 'configuration_bert',
 'configuration_bert',
 'load_tf_weights_in_bert',
 'modeling_bert',
 'modeling_flax_bert',
 'modeling_tf_bert',
 'tokenization_bert',
 'tokenization_bert',
 'tokenization_bert_fast'
]
```
You can already see some elements are duplicated, and accessing some other submodules (like the modeling ones) will grow the list of duplicates.

This comes because we always add all the submodules to the `__dir__` even if they are already there (the fact they are there or not depends on whether some element of the submodule was accessed to, because of the lazy init).

This PR fixes that.

Thanks to @NielsRogge for reporting the bug!