### PR TITLE
id2label is list but we need dict to load models properly from tf.saved_model

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -287,7 +287,7 @@ class PretrainedConfig(PushToHubMixin):
         self.label2id = kwargs.pop("label2id", None)
         if self.id2label is not None:
             kwargs.pop("num_labels", None)
-            self.id2label = dict((int(key), value) for key, value in self.id2label.items())
+            self.id2label = dict(key, value) for key, value in enumerate(self.id2label))
             # Keys are always strings in JSON so convert ids to int here.
         else:
             self.num_labels = kwargs.pop("num_labels", 2)


### PR DESCRIPTION
id2label is list and is consistent throughout pytorch and transformers the config.json file created through TFmodel.save_pretrained keeps it as list as well, the code above expected the id2label to be a dict obj but was list instead causing errors in loading saved models in tensorflow.

# What does this PR do?

<!--
prevented properly loading models from tensorflow
-->

<!-- Remove if not applicable -->

Fixes # (issue)

# id2label AttributeError : 'list' object has no attribute 'items' when loading saved model in TF
<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 @LysandreJik

 -->
