### PR TITLE
Fix save when laod_best_model_at_end=True

### DIFF
--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -418,8 +418,6 @@ class DefaultFlowCallback(TrainerCallback):
         # Evaluate
         if args.evaluation_strategy == IntervalStrategy.STEPS and state.global_step % args.eval_steps == 0:
             control.should_evaluate = True
-            if args.load_best_model_at_end:
-                control.should_save = True
 
         # Save
         if (


### PR DESCRIPTION
# What does this PR do?

As pointed out on the [forums](https://discuss.huggingface.co/t/why-save-steps-should-be-a-round-multiple-of-eval-steps-when-load-best-model-at-end-true/10841/3), the `Trainer` keeps saving every `eval_steps` when `load_best_model_at_end=True` even though we now enforce that `save_steps` can be independent as long as it's a round multiple of `eval_steps`.

This PR fixes that.