### PR TITLE
Fix test_configuration_tie in FlaxEncoderDecoderModelTest

### DIFF
--- a/src/transformers/models/encoder_decoder/modeling_flax_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_flax_encoder_decoder.py
@@ -371,26 +371,6 @@ class FlaxEncoderDecoderModel(FlaxPreTrainedModel):
         )
         return unfreeze(init_variables["cache"])
 
-    @property
-    def encoder(self):
-
-        encode_module = self.module.apply(
-            {"params": self.params},
-            method=lambda module: module._get_encoder_module(),
-        )
-
-        return encode_module
-
-    @property
-    def decoder(self):
-
-        decode_module = self.module.apply(
-            {"params": self.params},
-            method=lambda module: module._get_decoder_module(),
-        )
-
-        return decode_module
-
     @add_start_docstrings(ENCODER_DECODER_ENCODE_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=FlaxBaseModelOutput, config_class=_CONFIG_FOR_DOC)
     def encode(

--- a/src/transformers/models/encoder_decoder/modeling_flax_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_flax_encoder_decoder.py
@@ -371,6 +371,26 @@ class FlaxEncoderDecoderModel(FlaxPreTrainedModel):
         )
         return unfreeze(init_variables["cache"])
 
+    @property
+    def encoder(self):
+
+        encode_module = self.module.apply(
+            {"params": self.params},
+            method=lambda module: module._get_encoder_module(),
+        )
+
+        return encode_module
+
+    @property
+    def decoder(self):
+
+        decode_module = self.module.apply(
+            {"params": self.params},
+            method=lambda module: module._get_decoder_module(),
+        )
+
+        return decode_module
+
     @add_start_docstrings(ENCODER_DECODER_ENCODE_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=FlaxBaseModelOutput, config_class=_CONFIG_FOR_DOC)
     def encode(

--- a/tests/test_modeling_flax_encoder_decoder.py
+++ b/tests/test_modeling_flax_encoder_decoder.py
@@ -360,7 +360,7 @@ class FlaxEncoderDecoderModelTest(unittest.TestCase):
         assert id(model.decoder.config) == id(model.config.decoder)
         assert id(model.encoder.config) == id(model.config.encoder)
 
-    # @slow
+    @slow
     def test_configuration_tie(self):
         model = self.get_from_encoderdecoder_pretrained_model()
         self._check_configuration_tie(model)

--- a/tests/test_modeling_flax_encoder_decoder.py
+++ b/tests/test_modeling_flax_encoder_decoder.py
@@ -357,10 +357,13 @@ class FlaxEncoderDecoderModelTest(unittest.TestCase):
         return config
 
     def _check_configuration_tie(self, model):
-        assert id(model.decoder.config) == id(model.config.decoder)
-        assert id(model.encoder.config) == id(model.config.encoder)
 
-    @slow
+        module = model.module.bind(model.params)
+
+        assert id(module.decoder.config) == id(model.config.decoder)
+        assert id(module.encoder.config) == id(model.config.encoder)
+
+    # @slow
     def test_configuration_tie(self):
         model = self.get_from_encoderdecoder_pretrained_model()
         self._check_configuration_tie(model)

--- a/tests/test_modeling_flax_encoder_decoder.py
+++ b/tests/test_modeling_flax_encoder_decoder.py
@@ -363,7 +363,7 @@ class FlaxEncoderDecoderModelTest(unittest.TestCase):
         assert id(module.decoder.config) == id(model.config.decoder)
         assert id(module.encoder.config) == id(model.config.encoder)
 
-    # @slow
+    @slow
     def test_configuration_tie(self):
         model = self.get_from_encoderdecoder_pretrained_model()
         self._check_configuration_tie(model)

--- a/tests/test_modeling_flax_encoder_decoder.py
+++ b/tests/test_modeling_flax_encoder_decoder.py
@@ -360,7 +360,7 @@ class FlaxEncoderDecoderModelTest(unittest.TestCase):
         assert id(model.decoder.config) == id(model.config.decoder)
         assert id(model.encoder.config) == id(model.config.encoder)
 
-    @slow
+    # @slow
     def test_configuration_tie(self):
         model = self.get_from_encoderdecoder_pretrained_model()
         self._check_configuration_tie(model)


### PR DESCRIPTION
# What does this PR do?

Fix the `test_configuration_tie` in `FlaxEncoderDecoderModelTest`.

The `test_configuration_tie` in `FlaxEncoderDecoderModelTest` would fail, as shown in [run_tests_flax](https://app.circleci.com/pipelines/github/huggingface/transformers/29230/workflows/106da32f-9f2c-4cb0-99fc-dad7316701ac/jobs/292440). See below.

`FlaxEncoderDecoderModel` didn't have `encoder` and `decoder` - they are inside `FlaxEncoderDecoderModule`, and need an indirect way to access them.

However,  it might be too much to add these just for a test without other interesting use case.
If we don't want to add this to `FlaxEncoderDecoderModel`, we could probably move the changes to be inside `test_configuration_tie`. 

BTW, this test is `@slow`, so won't be run by CircleCI. I saw it is mentioned `CircleCI does not run the slow tests, but github actions does every night!` in [How to contribute to transformers?](https://huggingface.co/transformers/contributing.html).

So `test_configuration_tie` failed on github actions, and I am wondering when a slow test fails, what are the actions? Is it only for Hugging Face internal?
(I finally found the report under GitHub actions tab)





## CircleCI test results
```
    def _check_configuration_tie(self, model):
>       assert id(model.decoder.config) == id(model.config.decoder)
E       AttributeError: 'FlaxEncoderDecoderModel' object has no attribute 'decoder'
```