### PR TITLE
[wav2vec2] Add missing --validation_split_percentage data arg

### DIFF
--- a/examples/research_projects/wav2vec2/run_pretrain.py
+++ b/examples/research_projects/wav2vec2/run_pretrain.py
@@ -120,6 +120,12 @@ class DataTrainingArguments:
     overwrite_cache: bool = field(
         default=False, metadata={"help": "Overwrite the cached preprocessed datasets or not."}
     )
+    validation_split_percentage: Optional[int] = field(
+        default=1,
+        metadata={
+            "help": "The percentage of the train set used as validation set in case there's no validation split"
+        },
+    )
     preprocessing_num_workers: Optional[int] = field(
         default=None,
         metadata={"help": "The number of processes to use for the preprocessing."},


### PR DESCRIPTION
# What does this PR do?

This PR adds the missing `--validation_split_percentage` arg in wav2vec2 examples.
Default value comes from [`run_wav2vec2_pretraining_no_trainer.py`](https://github.com/huggingface/transformers/blob/70f186f61ebff4ad87fd7cc0fc1e0e0660b485ea/examples/pytorch/speech-pretraining/run_wav2vec2_pretraining_no_trainer.py#L95).

@stas00, @patrickvonplaten