### PR TITLE
[Flax] Fix eval and data_args usage in streaming example

### DIFF
--- a/examples/research_projects/jax-projects/dataset-streaming/run_mlm_flax_stream.py
+++ b/examples/research_projects/jax-projects/dataset-streaming/run_mlm_flax_stream.py
@@ -560,8 +560,7 @@ if __name__ == "__main__":
             tokenized_datasets.set_epoch(shuffle_seed)
 
             training_iter = iter(tokenized_datasets)
-
-            eval_dataset = advance_iter_and_group_samples(training_iter, data_args.num_eval_samples, max_seq_length)
+            eval_samples = advance_iter_and_group_samples(training_iter, data_args.num_eval_samples, max_seq_length)
             samples = advance_iter_and_group_samples(training_iter, train_batch_size, max_seq_length)
 
         # process input samples

--- a/examples/research_projects/jax-projects/dataset-streaming/run_mlm_flax_stream.py
+++ b/examples/research_projects/jax-projects/dataset-streaming/run_mlm_flax_stream.py
@@ -402,6 +402,8 @@ if __name__ == "__main__":
     tokenized_datasets = dataset.map(
         tokenize_function,
         batched=True,
+        num_proc=data_args.preprocessing_num_workers,
+        load_from_cache_file=not data_args.overwrite_cache,
     )
 
     shuffle_seed = training_args.seed


### PR DESCRIPTION
# What does this PR do?

This PR fixes the evaluation loop in `run_mlm_flax_stream.py`. Current behavior didn't update the correct variable, which leads to data leakage during evaluation.

It also takes the opportunity to improve some `DataTrainingArguments` usages.

-------

It's a draft PR because there is an open improvement that could be made: the script splits train-eval based solely in `data_args.{dataset_name,num_eval_samples}`, but also accepts unused args `train_file, validation_file, train_ref_file, validation_ref_file, validation_split_percentage`. Other data args that are unused: `pad_to_max_length`, `line_by_line`.

My suggestion would be to remove all these unused args. May I proceed with that?


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),  Request section?
- [x] Did you make sure to update the documentation with your changes?
    The script is mentioned in [`jax-projects/dataset-streaming/README`](https://github.com/huggingface/transformers/blob/95bab53868a91b4809bd5281a72b5f326853e31f/examples/research_projects/jax-projects/dataset-streaming/README.md#train-model), but no changes are required.


## Who can review?
@patrickvonplaten 
