### PR TITLE
Add vision_encoder_decoder to models/__init__.py

### DIFF
--- a/src/transformers/models/__init__.py
+++ b/src/transformers/models/__init__.py
@@ -89,6 +89,7 @@ from . import (
     t5,
     tapas,
     transfo_xl,
+    vision_encoder_decoder,
     visual_bert,
     vit,
     wav2vec2,

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -167,6 +167,7 @@ def get_model_modules():
         "modeling_tf_pytorch_utils",
         "modeling_tf_utils",
         "modeling_tf_transfo_xl_utilities",
+        "modeling_vision_encoder_decoder",
     ]
     modules = []
     for model in dir(transformers.models):


### PR DESCRIPTION
# What does this PR do?

The recently added `vision_encoder_decoder` wasn't added to `models/__init__.py`. This had some consequence, like `utils.check_repo.get_model_modules()` missing `vision_encoder_decoder`, and therefore models like `VisionEncoderDecoderModel` (and the upcoming Flax/TF versions) would pass `check_all_models_are_tested` even without providing a test file.

This (one-line) PR fixes this issue.

## Who can review?

@sgugger @NielsRogge 