### PR TITLE
LayoutLMv2 functionality.

### DIFF
--- a/README_PULLREQUEST.md
+++ b/README_PULLREQUEST.md
@@ -1,0 +1,1 @@
+Pull request to add a LayoutLMv2ForMaskedLM, which adds a language modeling head on top of the base model in order to replicate the first pre-training objective of the model. https://github.com/huggingface/transformers/issues/14160#issuecomment-952024460


### PR DESCRIPTION
Support for new LayoutLMv2 as discussed in this issue: https://github.com/huggingface/transformers/issues/14160.

Namely, the addition of `LayoutLMv2ForMaskedLM`, which adds a language modeling head on top of the base model to replicate the first pre-training objective in the original paper. 