### PR TITLE
fix typos in error messages in speech recognition example and modelcard.py

### DIFF
--- a/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
@@ -356,7 +356,7 @@ def main():
 
     if data_args.text_column_name not in raw_datasets["train"].column_names:
         raise ValueError(
-            f"--text_column_name {data_args.audio_column_name} not found in dataset '{data_args.dataset_name}'. "
+            f"--text_column_name {data_args.text_column_name} not found in dataset '{data_args.dataset_name}'. "
             "Make sure to set `--text_column_name` to the correct text column - one of "
             f"{', '.join(raw_datasets['train'].column_names)}."
         )

--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -446,7 +446,7 @@ class TrainingSummary:
             if "task" in result and "dataset" in result and "metrics" in result:
                 model_index["results"].append(result)
             else:
-                logger.info(f"Dropping the following result as it does not have all the necessary field:\n{result}")
+                logger.info(f"Dropping the following result as it does not have all the necessary fields:\n{result}")
 
         return [model_index]
 


### PR DESCRIPTION
# What does this PR do?
This PR fixes two minor typographical issues
1 - a typo in an example speech recognition script that misstates which columns is missing from the input data
2 - a typo in the modelcard.py function that explains when some field is missing from a dataset


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?

## Who can review?
@patrickvonplaten per git blame, but realistically anyone
@sgugger