### PR TITLE
Fix gelu test for torch 1.10

### DIFF
--- a/tests/test_activations.py
+++ b/tests/test_activations.py
@@ -29,8 +29,8 @@ class TestActivations(unittest.TestCase):
     def test_gelu_versions(self):
         x = torch.tensor([-100, -1, -0.1, 0, 0.1, 1.0, 100])
         torch_builtin = get_activation("gelu")
-        self.assertTrue(torch.eq(_gelu_python(x), torch_builtin(x)).all().item())
-        self.assertFalse(torch.eq(_gelu_python(x), gelu_new(x)).all().item())
+        self.assertTrue(torch.allclose(_gelu_python(x), torch_builtin(x)))
+        self.assertFalse(torch.allclose(_gelu_python(x), gelu_new(x)))
 
     def test_get_activation(self):
         get_activation("swish")


### PR DESCRIPTION
Torch 1.10 introduced a change in the way gelu is computed, resulting in a 1e-9 to 1e-10 difference in results.
This checks that the results are close enough.