### PR TITLE
[Pipelines] Fix ASR model types check

### DIFF
--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -106,7 +106,7 @@ class AutomaticSpeechRecognitionPipeline(Pipeline):
         if self.framework == "tf":
             raise ValueError("The AutomaticSpeechRecognitionPipeline is only available in PyTorch.")
 
-        self.check_model_type(MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING.items() + MODEL_FOR_CTC_MAPPING.items())
+        self.check_model_type(dict(MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING.items() + MODEL_FOR_CTC_MAPPING.items()))
 
     def __call__(
         self,


### PR DESCRIPTION
# What does this PR do?

This changes `list` to `dict` in the ASR pipeline's `check_model_type()`. 
Previously, a list was passed to the checker, so the model name extraction was never preformed [here](https://github.com/huggingface/transformers/blob/8ddbfe975264a94f124684a138a2a5ca89a2bd0d/src/transformers/pipelines/base.py#L810) and an error was raised:
```
The model 'SEWDForCTC' is not supported for automatic-speech-recognition.
```

cc @Narsil 