### PR TITLE
[modeling_utils] respect original dtype in _get_resized_lm_head

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -862,7 +862,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # Build new lm head
         new_lm_head_shape = (old_lm_head_dim, new_num_tokens) if not transposed else (new_num_tokens, old_lm_head_dim)
         has_new_lm_head_bias = old_lm_head.bias is not None
-        new_lm_head = nn.Linear(*new_lm_head_shape, bias=has_new_lm_head_bias).to(self.device)
+        new_lm_head = nn.Linear(*new_lm_head_shape, bias=has_new_lm_head_bias).to(
+            self.device, dtype=old_lm_head.weight.dtype
+        )
 
         # initialize new lm head (in particular added tokens)
         self._init_weights(new_lm_head)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -789,9 +789,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             )
 
         # Build new embeddings
-        new_embeddings = nn.Embedding(new_num_tokens, old_embedding_dim).to(
-            self.device, dtype=old_embeddings.weight.dtype
-        )
+        new_embeddings = nn.Embedding(new_num_tokens, old_embedding_dim)
+        new_embeddings.to(self.device, dtype=old_embeddings.weight.dtype)
 
         # initialize all new embeddings (in particular added tokens)
         self._init_weights(new_embeddings)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -862,9 +862,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # Build new lm head
         new_lm_head_shape = (old_lm_head_dim, new_num_tokens) if not transposed else (new_num_tokens, old_lm_head_dim)
         has_new_lm_head_bias = old_lm_head.bias is not None
-        new_lm_head = nn.Linear(*new_lm_head_shape, bias=has_new_lm_head_bias).to(
-            self.device, dtype=old_lm_head.weight.dtype
-        )
+        new_lm_head = nn.Linear(*new_lm_head_shape, bias=has_new_lm_head_bias)
+        new_lm_head = new_lm_head.to(self.device, dtype=old_lm_head.weight.dtype)
 
         # initialize new lm head (in particular added tokens)
         self._init_weights(new_lm_head)


### PR DESCRIPTION
Currently `resize_token_embeddings`'s `_get_resized_lm_head` doesn't preserve the original dtype when creating a new param. This PR fixes it.

The fix is identical to:

https://github.com/huggingface/transformers/blob/232822f36d49598e68e152a9ca0a6d90be6f54b5/src/transformers/modeling_utils.py#L792-L794

The problem was detected by @VictorSanh who used  https://huggingface.co/google/t5-v1_1-small w/ deepspeed z3 - this model is different from t5 as it has `"tie_word_embeddings": false`, so it goes through a different code path. 

I will have a deepspeed test covering this path once a new tiny model is added to https://huggingface.co/hf-internal-testing/ to cover this variation of t5 models.

@sgugger, @LysandreJik 