### PR TITLE
Add BigBird/BigBird Pegasus to models exportable with ONNX

### DIFF
--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -43,6 +43,8 @@ Ready-made configurations include the following models:
 - ALBERT
 - BART
 - BERT
+- BigBird
+- BigBirdPegasus
 - CamemBERT
 - DistilBERT
 - GPT Neo

--- a/src/transformers/models/big_bird/__init__.py
+++ b/src/transformers/models/big_bird/__init__.py
@@ -28,7 +28,7 @@ from ...file_utils import (
 
 
 _import_structure = {
-    "configuration_big_bird": ["BIG_BIRD_PRETRAINED_CONFIG_ARCHIVE_MAP", "BigBirdConfig"],
+    "configuration_big_bird": ["BIG_BIRD_PRETRAINED_CONFIG_ARCHIVE_MAP", "BigBirdConfig", "BigBirdOnnxConfig"],
 }
 
 if is_sentencepiece_available():
@@ -66,7 +66,7 @@ if is_flax_available():
     ]
 
 if TYPE_CHECKING:
-    from .configuration_big_bird import BIG_BIRD_PRETRAINED_CONFIG_ARCHIVE_MAP, BigBirdConfig
+    from .configuration_big_bird import BIG_BIRD_PRETRAINED_CONFIG_ARCHIVE_MAP, BigBirdConfig, BigBirdOnnxConfig
 
     if is_sentencepiece_available():
         from .tokenization_big_bird import BigBirdTokenizer

--- a/src/transformers/models/bigbird_pegasus/__init__.py
+++ b/src/transformers/models/bigbird_pegasus/__init__.py
@@ -21,7 +21,11 @@ from ...file_utils import _LazyModule, is_torch_available
 
 
 _import_structure = {
-    "configuration_bigbird_pegasus": ["BIGBIRD_PEGASUS_PRETRAINED_CONFIG_ARCHIVE_MAP", "BigBirdPegasusConfig"],
+    "configuration_bigbird_pegasus": [
+        "BIGBIRD_PEGASUS_PRETRAINED_CONFIG_ARCHIVE_MAP",
+        "BigBirdPegasusConfig",
+        "BigBirdPegasusOnnxConfig",
+    ],
 }
 
 if is_torch_available():
@@ -37,7 +41,11 @@ if is_torch_available():
 
 
 if TYPE_CHECKING:
-    from .configuration_bigbird_pegasus import BIGBIRD_PEGASUS_PRETRAINED_CONFIG_ARCHIVE_MAP, BigBirdPegasusConfig
+    from .configuration_bigbird_pegasus import (
+        BIGBIRD_PEGASUS_PRETRAINED_CONFIG_ARCHIVE_MAP,
+        BigBirdPegasusConfig,
+        BigBirdPegasusOnnxConfig,
+    )
 
     if is_torch_available():
         from .modeling_bigbird_pegasus import (

--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -5,6 +5,8 @@ from .. import is_torch_available
 from ..models.albert import AlbertOnnxConfig
 from ..models.bart import BartOnnxConfig
 from ..models.bert import BertOnnxConfig
+from ..models.big_bird import BigBirdOnnxConfig
+from ..models.bigbird_pegasus import BigBirdPegasusOnnxConfig
 from ..models.camembert import CamembertOnnxConfig
 from ..models.distilbert import DistilBertOnnxConfig
 from ..models.gpt2 import GPT2OnnxConfig
@@ -22,6 +24,7 @@ if is_torch_available():
     from transformers.models.auto import (
         AutoModel,
         AutoModelForCausalLM,
+        AutoModelForMaskedLM,
         AutoModelForMultipleChoice,
         AutoModelForQuestionAnswering,
         AutoModelForSeq2SeqLM,
@@ -55,6 +58,7 @@ class FeaturesManager:
         "token-classification": AutoModelForTokenClassification,
         "multiple-choice": AutoModelForMultipleChoice,
         "question-answering": AutoModelForQuestionAnswering,
+        "masked-lm": AutoModelForMaskedLM,
     }
 
     # Set of model topologies we support associated to the features supported by each topology and the factory
@@ -70,6 +74,36 @@ class FeaturesManager:
             "token-classification",
             "question-answering",
             onnx_config_cls=CamembertOnnxConfig,
+        ),
+        "big-bird": supported_features_mapping(
+            "default",
+            "causal-lm",
+            "seq2seq-lm",
+            "masked-lm",
+            "sequence-classification",
+            "token-classification",
+            "multiple-choice",
+            "question-answering",
+            "default-with-past",
+            "causal-lm-with-past",
+            "seq2seq-lm-with-past",
+            "masked-lm-with-past",
+            "sequence-classification-with-past",
+            "token-classification-with-past",
+            "multiple-choice-with-past",
+            "question-answering-with-past",
+            onnx_config_cls=BigBirdOnnxConfig,
+        ),
+        "bigbird-pegasus": supported_features_mapping(
+            "default",
+            "causal-lm",
+            "sequence-classification",
+            "question-answering",
+            "default-with-past",
+            "causal-lm-with-past",
+            "sequence-classification-with-past",
+            "question-answering-with-past",
+            onnx_config_cls=BigBirdPegasusOnnxConfig,
         ),
         "distilbert": supported_features_mapping("default", onnx_config_cls=DistilBertOnnxConfig),
         "gpt2": supported_features_mapping("default", onnx_config_cls=GPT2OnnxConfig),

--- a/tests/test_onnx_v2.py
+++ b/tests/test_onnx_v2.py
@@ -7,6 +7,8 @@ from transformers import (  # LongformerConfig,; T5Config,
     AlbertConfig,
     AutoTokenizer,
     BartConfig,
+    BigBirdConfig,
+    BigBirdPegasusConfig,
     DistilBertConfig,
     GPT2Config,
     GPTNeoConfig,
@@ -19,6 +21,8 @@ from transformers import (  # LongformerConfig,; T5Config,
 from transformers.models.albert import AlbertOnnxConfig
 from transformers.models.bart import BartOnnxConfig
 from transformers.models.bert.configuration_bert import BertConfig, BertOnnxConfig
+from transformers.models.big_bird.configuration_big_bird import BigBirdOnnxConfig
+from transformers.models.bigbird_pegasus.configuration_bigbird_pegasus import BigBirdPegasusOnnxConfig
 from transformers.models.distilbert import DistilBertOnnxConfig
 
 # from transformers.models.longformer import LongformerOnnxConfig
@@ -192,6 +196,8 @@ if is_torch_available():
         AlbertModel,
         BartModel,
         BertModel,
+        BigBirdModel,
+        BigBirdPegasusModel,
         DistilBertModel,
         GPT2Model,
         GPTNeoModel,
@@ -205,6 +211,14 @@ if is_torch_available():
         ("ALBERT", "hf-internal-testing/tiny-albert", AlbertModel, AlbertConfig, AlbertOnnxConfig),
         ("BART", "facebook/bart-base", BartModel, BartConfig, BartOnnxConfig),
         ("BERT", "bert-base-cased", BertModel, BertConfig, BertOnnxConfig),
+        ("Big-Bird", "google/bigbird-roberta-base", BigBirdModel, BigBirdConfig, BigBirdOnnxConfig),
+        (
+            "BigBird-Pegasus",
+            "google/bigbird-roberta-base",
+            BigBirdPegasusModel,
+            BigBirdPegasusConfig,
+            BigBirdPegasusOnnxConfig,
+        ),
         ("DistilBERT", "distilbert-base-cased", DistilBertModel, DistilBertConfig, DistilBertOnnxConfig),
         ("GPT2", "gpt2", GPT2Model, GPT2Config, GPT2OnnxConfig),
         ("GPT-Neo", "EleutherAI/gpt-neo-125M", GPTNeoModel, GPTNeoConfig, GPTNeoOnnxConfig),


### PR DESCRIPTION
This PR adds BigBird and BigBird Pegasus to models exportable with ONNX and also adds them in test_onnx_v2.py


