### PR TITLE
[GPT2] Add lm_attention_mask as a optional argument

### DIFF
--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -478,7 +478,8 @@ class GenerationMixin:
         if attention_mask is not None:
             model_kwargs["attention_mask"] = attention_mask.index_select(0, expanded_return_idx)
 
-        lm_attention_mask = model_kwargs.get("lm_attention_mask", None)
+        if "lm_attention_mask" in model_kwargs:
+            lm_attention_mask = model_kwargs["lm_attention_mask"]
         if lm_attention_mask is not None:
             if lm_attention_mask.shape[0] != 1:
                 model_kwargs["lm_attention_mask"] = lm_attention_mask.index_select(0, expanded_return_idx)

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -478,11 +478,18 @@ class GenerationMixin:
         if attention_mask is not None:
             model_kwargs["attention_mask"] = attention_mask.index_select(0, expanded_return_idx)
 
+<<<<<<< Updated upstream
         if "lm_attention_mask" in model_kwargs:
             lm_attention_mask = model_kwargs["lm_attention_mask"]
         if lm_attention_mask is not None:
             if lm_attention_mask.shape[0] != 1:
                 model_kwargs["lm_attention_mask"] = lm_attention_mask.index_select(0, expanded_return_idx)
+=======
+        attention_block_mask = model_kwargs.get("attention_block_mask", None)
+        if attention_block_mask is not None:
+            if attention_block_mask.shape[0] != 1:
+                model_kwargs["attention_block_mask"] = attention_block_mask.index_select(0, expanded_return_idx)
+>>>>>>> Stashed changes
 
         if is_encoder_decoder:
             if encoder_outputs is None:

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -478,18 +478,11 @@ class GenerationMixin:
         if attention_mask is not None:
             model_kwargs["attention_mask"] = attention_mask.index_select(0, expanded_return_idx)
 
-<<<<<<< Updated upstream
-        if "lm_attention_mask" in model_kwargs:
-            lm_attention_mask = model_kwargs["lm_attention_mask"]
-        if lm_attention_mask is not None:
-            if lm_attention_mask.shape[0] != 1:
-                model_kwargs["lm_attention_mask"] = lm_attention_mask.index_select(0, expanded_return_idx)
-=======
-        attention_block_mask = model_kwargs.get("attention_block_mask", None)
-        if attention_block_mask is not None:
-            if attention_block_mask.shape[0] != 1:
-                model_kwargs["attention_block_mask"] = attention_block_mask.index_select(0, expanded_return_idx)
->>>>>>> Stashed changes
+        if "attention_block_mask" in model_kwargs:
+            attention_block_mask = model_kwargs["attention_block_mask"]
+            if attention_block_mask is not None:
+                if attention_block_mask.shape[0] != 1:
+                    model_kwargs["attention_block_mask"] = attention_block_mask.index_select(0, expanded_return_idx)
 
         if is_encoder_decoder:
             if encoder_outputs is None:

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -478,6 +478,11 @@ class GenerationMixin:
         if attention_mask is not None:
             model_kwargs["attention_mask"] = attention_mask.index_select(0, expanded_return_idx)
 
+        lm_attention_mask = model_kwargs.get("lm_attention_mask", None)
+        if lm_attention_mask is not None:
+            if lm_attention_mask.shape[0] != 1:
+                model_kwargs["lm_attention_mask"] = lm_attention_mask.index_select(0, expanded_return_idx)
+
         if is_encoder_decoder:
             if encoder_outputs is None:
                 raise ValueError("If `is_encoder_decoder` is True, make sure that `encoder_outputs` is defined.")

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -206,7 +206,6 @@ class GPT2Attention(nn.Module):
                 query_length, key_length = query.size(-2), key.size(-2)
                 lm_attention_mask = self.bias[:, :, key_length - query_length : key_length, :key_length].bool()
             else:
-                assert head_mask is None, "Using both head_mask and lm_attention_mask can lead to ambiguity. Please on or the other"
                 lm_attention_mask = lm_attention_mask.bool()
             attn_weights = torch.where(lm_attention_mask, attn_weights, self.masked_bias.to(attn_weights.dtype))
 
@@ -262,7 +261,6 @@ class GPT2Attention(nn.Module):
                 query_length, key_length = query.size(-2), key.size(-2)
                 lm_attention_mask = self.bias[:, :, key_length - query_length: key_length, :key_length].bool()
             else:
-                assert head_mask is None, "Using both head_mask and lm_attention_mask can lead to ambiguity. Please on or the other"
                 lm_attention_mask = lm_attention_mask.bool()
             attn_weights = torch.where(lm_attention_mask, attn_weights, self.masked_bias.to(attn_weights.dtype))
 

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -526,13 +526,15 @@ class GPT2PreTrainedModel(PreTrainedModel):
         elif attention_block_mask is not None:
             # either the first time we run this method, or users has set use_cache = False
             _, sequence_length = input_ids.shape
-            attn_block_mask_bs=attention_block_mask.shape[0]
-            attn_block_mask_nh=attention_block_mask.shape[1]
-            attn_block_mask_queries_length=attention_block_mask.shape[2]
-            attn_block_mask_keys_length=attention_block_mask.shape[3]
+            attn_block_mask_bs = attention_block_mask.shape[0]
+            attn_block_mask_nh = attention_block_mask.shape[1]
+            attn_block_mask_queries_length = attention_block_mask.shape[2]
+            attn_block_mask_keys_length = attention_block_mask.shape[3]
 
             if attn_block_mask_queries_length == attn_block_mask_keys_length:
-                raise ValueError(f"attention_block_mask should have the two last dimension be equal, got {attn_block_mask_queries_length} and {attn_block_mask_keys_length}.")
+                raise ValueError(
+                    f"attention_block_mask should have the two last dimension be equal, got {attn_block_mask_queries_length} and {attn_block_mask_keys_length}."
+                )
 
             if attn_block_mask_keys_length <= sequence_length:
                 raise ValueError(f"Expected {attn_block_mask_keys_length} <= {sequence_length}.")

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -543,7 +543,7 @@ class GPT2PreTrainedModel(PreTrainedModel):
                 # build new attention_block_mask by adding autoregressive parts at the end.
                 new_attention_block_mask = torch.tril(
                     torch.ones(
-                        attention_block_mask,
+                        attn_block_mask_bs,
                         attn_block_mask_nh,
                         sequence_length,
                         sequence_length,

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -526,14 +526,16 @@ class GPT2PreTrainedModel(PreTrainedModel):
         elif lm_attention_mask is not None:
             # either the first time we run this method, or users has set use_cache = False
             _, sequence_length = input_ids.shape
-            (
-                lm_attn_mask_bs,
-                lm_attn_mask_nh,
-                lm_attn_mask_queries_length,
-                lm_attn_mask_keys_length,
-            ) = lm_attention_mask.shape
-            assert lm_attn_mask_queries_length == lm_attn_mask_keys_length
-            assert lm_attn_mask_keys_length <= sequence_length
+            lm_attn_mask_bs=lm_attention_mask.shape[0]
+            lm_attn_mask_nh=lm_attention_mask.shape[1]
+            lm_attn_mask_queries_length=lm_attention_mask.shape[2]
+            lm_attn_mask_keys_length=lm_attention_mask.shape[3]
+
+            if lm_attn_mask_queries_length == lm_attn_mask_keys_length:
+                raise ValueError(f"lm_attention_mask should have the two last dimension be equal, got {lm_attn_mask_queries_length} and {lm_attn_mask_keys_length}.")
+
+            if lm_attn_mask_keys_length <= sequence_length:
+                raise ValueError(f"Expected {lm_attn_mask_keys_length} <= {sequence_length}.")
             if lm_attn_mask_keys_length < sequence_length:
                 # build new lm_attention_mask by adding autoregressive parts at the end.
                 new_lm_attention_mask = torch.tril(
@@ -661,8 +663,8 @@ GPT2_INPUTS_DOCSTRING = r"""
         lm_attention_mask (:obj:`torch.BoolTensor` of shape or broadcastable to :obj:`(batch_size, num_heads, sequence_length, sequence_length)`, `optional`):
             Mask to override causal masking for any generic masking:
 
-            - True for attention weights that are **not masked**,
-            - False for attention weights that are **masked**.
+            - :obj:`True` for attention weights that are **not masked**,
+            - :obj:`False` for attention weights that are **masked**.
 
         token_type_ids (:obj:`torch.LongTensor` of shape :obj:`(batch_size, input_ids_length)`, `optional`):
             Segment token indices to indicate first and second portions of the inputs. Indices are selected in ``[0,

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -523,7 +523,7 @@ class GPT2PreTrainedModel(PreTrainedModel):
                 token_type_ids = token_type_ids[:, -1].unsqueeze(-1)
             # autoregressively decode tokens
             lm_attention_mask = None
-        elid lm_attention_mask is not None:
+        elif lm_attention_mask is not None:
             # either the first time we run this method, or users has set use_cache = False
             _, sequence_length = input_ids.shape
             (

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -664,7 +664,7 @@ GPT2_INPUTS_DOCSTRING = r"""
 
             `What are attention masks? <../glossary.html#attention-mask>`__
         attention_block_mask (:obj:`torch.BoolTensor` of shape or broadcastable to :obj:`(batch_size, num_heads, sequence_length, sequence_length)`, `optional`):
-            Mask to override causal masking for any generic masking:
+            If None, defaults to causal masking. Else, overrides causal masking for any generic masking:
 
             - :obj:`True` for attention weights that are **not masked**,
             - :obj:`False` for attention weights that are **masked**.

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -536,6 +536,7 @@ class GPT2PreTrainedModel(PreTrainedModel):
 
             if lm_attn_mask_keys_length <= sequence_length:
                 raise ValueError(f"Expected {lm_attn_mask_keys_length} <= {sequence_length}.")
+
             if lm_attn_mask_keys_length < sequence_length:
                 # build new lm_attention_mask by adding autoregressive parts at the end.
                 new_lm_attention_mask = torch.tril(

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -523,7 +523,7 @@ class GPT2PreTrainedModel(PreTrainedModel):
                 token_type_ids = token_type_ids[:, -1].unsqueeze(-1)
             # autoregressively decode tokens
             lm_attention_mask = None
-        else:
+        elid lm_attention_mask is not None:
             # either the first time we run this method, or users has set use_cache = False
             _, sequence_length = input_ids.shape
             (

--- a/tests/test_modeling_gpt2.py
+++ b/tests/test_modeling_gpt2.py
@@ -479,7 +479,7 @@ class GPT2ModelTester:
         new_token_id = randint(0, sequence_length - 1, blacklist=(random_token_id,))
         modified_inputs_other_token = input_ids.clone()
         blacklisted_values_other_token = set(input_ids[:, new_token_id])
-        modified_inputs_other_token[:, random_token_id] = randint(
+        modified_inputs_other_token[:, new_token_id] = randint(
             0, config.vocab_size, blacklist=blacklisted_values_other_token
         )
 

--- a/tests/test_modeling_gpt2.py
+++ b/tests/test_modeling_gpt2.py
@@ -471,7 +471,7 @@ class GPT2ModelTester:
         self.parent.assertTrue(
             torch.allclose(
                 output[:, random_token_id + 1 :, :],
-                output_that_token[:, : random_token_id + 1 :, :],
+                output_that_token[:, random_token_id + 1 :, :],
             )
         )
 
@@ -496,7 +496,7 @@ class GPT2ModelTester:
         self.parent.assertFalse(
             torch.allclose(
                 output[:, new_token_id + 1 :, :],
-                output_other_token[:, : new_token_id + 1 :, :],
+                output_other_token[:, new_token_id + 1 :, :],
             )
         )
 

--- a/tests/test_modeling_gpt2.py
+++ b/tests/test_modeling_gpt2.py
@@ -483,7 +483,7 @@ class GPT2ModelTester:
             0, config.vocab_size, blacklist=blacklisted_values_other_token
         )
 
-        output_other_token, past_other_token = model(
+        output_other_token = model(
             modified_inputs_other_token, attention_block_mask=attention_block_mask
         ).last_hidden_state
 

--- a/tests/test_modeling_gpt2.py
+++ b/tests/test_modeling_gpt2.py
@@ -462,6 +462,8 @@ class GPT2ModelTester:
             modified_inputs_that_token, attention_block_mask=attention_block_mask
         ).last_hidden_state
 
+        # We check that our model outputs are unchanges as the attention_block_mask would prevent the model from
+        # attending that token anyway.
         self.parent.assertTrue(
             torch.allclose(
                 output[:, :random_token_id, :],
@@ -487,18 +489,22 @@ class GPT2ModelTester:
             modified_inputs_other_token, attention_block_mask=attention_block_mask
         ).last_hidden_state
 
-        self.parent.assertFalse(
-            torch.allclose(
-                output[:, :new_token_id, :],
-                output_other_token[:, :new_token_id, :],
+        if new_token_id > 0:
+            # Otherwise torch.allclose of empty tensor is true.
+            self.parent.assertFalse(
+                torch.allclose(
+                    output[:, :new_token_id, :],
+                    output_other_token[:, :new_token_id, :],
+                )
             )
-        )
-        self.parent.assertFalse(
-            torch.allclose(
-                output[:, new_token_id + 1 :, :],
-                output_other_token[:, new_token_id + 1 :, :],
+        if new_token_id + 1 < sequence_length:
+            # Otherwise torch.allclose of empty tensor is true.
+            self.parent.assertFalse(
+                torch.allclose(
+                    output[:, new_token_id + 1 :, :],
+                    output_other_token[:, new_token_id + 1 :, :],
+                )
             )
-        )
 
 
 @require_torch

--- a/tests/test_modeling_gpt2.py
+++ b/tests/test_modeling_gpt2.py
@@ -436,7 +436,7 @@ class GPT2ModelTester:
         )
 
         # first forward pass
-        model(input_ids, attention_block_mask=attention_block_mask).to_tuple()
+        model(input_ids, attention_block_mask=attention_block_mask)
 
         # create full attention masking except for one token who can only attend to itself
         attention_block_mask = torch.ones(
@@ -445,7 +445,7 @@ class GPT2ModelTester:
         random_token_id = global_rng.randint(0, sequence_length - 1)
         attention_block_mask[:, :, :, random_token_id] = False
 
-        output, past = model(input_ids, attention_block_mask=attention_block_mask).to_tuple()
+        output, past = model(input_ids, attention_block_mask=attention_block_mask)
 
         def randint(a, b, blacklist):
             while True:


### PR DESCRIPTION
# What does this PR do?

We provide a new optional argument in order to pass down a mask that should be applied on attention layers. As the naming conflicts with `attention_mask` (which is use to determine which ones are pad values see https://huggingface.co/transformers/v3.1.0/glossary.html#attention-mask).

Context: we want to be able to obtain a prefixlm like behaviour: Full attention mask on a prefix, and auto regressive masking on suffix.

Some changes that were unrelated to the feature introduction:
 - We've also factorised code from `prepare_inputs_for_generation` into GPT2PretrainedModel as this was duplicated.
 
What this PR doesn't do:
 - Essentially `attention_mask` can we added into `lm_attention_mask` (ie you can put 0's for all pad values and such). However we won't remove `attention_mask` for backward compatibility.
 
TODO:
 - add tests
 
 Example of codes:
 
 ```python
 model = GPT2LMHeadModel.from_pretrained("<MODEL_NAME>")
 model.generate(random_inputs) # autoregressive
 
 lm_attention_mask = torch.ones(1, 1 , random_inputs.shape[1], random_inputs.shape[1], dtype=torch.bool, device=random_inputs.device)
 model.generate(random_inputs, lm_attention_mask=lm_attention_mask) # prefixlm
 
 lm_attention_mask = torch.triu(torch.ones(1, 1 , random_inputs.shape[1], random_inputs.shape[1], dtype=torch.bool, device=random_inputs.device))
 model.generate(random_inputs, lm_attention_mask=lm_attention_mask) # fancy prefixlm
 ```
 
## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

cc @patrickvonplaten @LysandreJik @sgugger 
