### PR TITLE
Add a condition for checking labels

### DIFF
--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -196,9 +196,12 @@ class Seq2SeqTrainer(Trainer):
         if self.args.prediction_loss_only:
             return (loss, None, None)
 
-        labels = inputs["labels"]
-        if labels.shape[-1] < gen_kwargs["max_length"]:
-            labels = self._pad_tensors_to_max_len(labels, gen_kwargs["max_length"])
+        if has_labels:
+            labels = inputs["labels"]
+            if labels.shape[-1] < gen_kwargs["max_length"]:
+                labels = self._pad_tensors_to_max_len(labels, gen_kwargs["max_length"])
+        else:
+            labels = None
 
         return (loss, generated_tokens, labels)
 


### PR DESCRIPTION
# What does this PR do?

This PR adds stability by checking whether it has labels before returning it in `prediction_step` of `Seq2SeqTrainer`
There is a similar condition in [`prediction_step` of `Trainer`](https://github.com/huggingface/transformers/blob/master/src/transformers/trainer.py#L2460-L2465)
```python
if has_labels:
    labels = nested_detach(tuple(inputs.get(name) for name in self.label_names))
    if len(labels) == 1:
        labels = labels[0]
else:
    labels = None
```

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?


## Who can review?

For `trainer` : @sgugger
