### PR TITLE
Fix generation docstring

### DIFF
--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -849,11 +849,11 @@ class GenerationMixin:
             >>> outputs = model.generate(input_ids=input_ids, max_length=20, repetition_penalty=1.2)
             >>> print("Generated:", tokenizer.decode(outputs[0], skip_special_tokens=True))
 
-            >>> tokenizer = AutoTokenizer.from_pretrained("gpt2")
+            >>> tokenizer = AutoTokenizer.from_pretrained("gpt2", use_fast=False)
             >>> model = AutoModelForCausalLM.from_pretrained("gpt2")
             >>> input_context = "My cute dog"
             >>> # get tokens of words that should not be generated
-            >>> bad_words_ids = [tokenizer(bad_word, add_prefix_space=True).input_ids for bad_word in ["idiot", "stupid", "shut up"]]
+            >>> bad_words_ids = tokenizer(["idiot", "stupid", "shut up"], add_prefix_space=True).input_ids
             >>> # encode input context
             >>> input_ids = tokenizer(input_context, return_tensors="pt").input_ids
             >>> # generate sequences without allowing bad_words to be generated

--- a/src/transformers/models/gpt2/tokenization_gpt2_fast.py
+++ b/src/transformers/models/gpt2/tokenization_gpt2_fast.py
@@ -84,8 +84,8 @@ class GPT2TokenizerFast(PreTrainedTokenizerFast):
         >>> tokenizer(" Hello world")['input_ids']
         [18435, 995]
 
-    You can get around that behavior by passing ``add_prefix_space=True`` when instantiating this tokenizer or when you
-    call it on some text, but since the model was not pretrained this way, it might yield a decrease in performance.
+    You can get around that behavior by passing ``add_prefix_space=True`` when instantiating this tokenizer, but since
+    the model was not pretrained this way, it might yield a decrease in performance.
 
     .. note::
 


### PR DESCRIPTION
# What does this PR do?

As mentioned in this [comment](https://github.com/huggingface/transformers/issues/14206#issuecomment-955607275), the `add_prefix_space` argument is not available in `GPT2TokenizerFast.__call__` but `GPT2Tokenizer.__call__`. 

Therefore, this PR fixes this error by switching the fast tokenizer to the slow one.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@patrickvonplaten, @LysandreJik