### PR TITLE
Fixes Beit training for PyTorch 1.10+

### DIFF
--- a/src/transformers/models/beit/modeling_beit.py
+++ b/src/transformers/models/beit/modeling_beit.py
@@ -987,7 +987,7 @@ class BeitUperHead(nn.Module):
         used_backbone_levels = len(laterals)
         for i in range(used_backbone_levels - 1, 0, -1):
             prev_shape = laterals[i - 1].shape[2:]
-            laterals[i - 1] += nn.functional.interpolate(
+            laterals[i - 1] = laterals[i - 1] + nn.functional.interpolate(
                 laterals[i], size=prev_shape, mode="bilinear", align_corners=self.align_corners
             )
 


### PR DESCRIPTION
# What does this PR do?

This PR should fix the failing tests for Beit training in PyTorch 1.10+ (at least it does locally)