### PR TITLE
Removing Keras version pinning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,6 @@ _deps = [
     "jax>=0.2.8",
     "jaxlib>=0.1.65",
     "jieba",
-    "keras!=2.7.0", # Remove when they fix their release
     "keras2onnx",
     "nltk",
     "numpy>=1.17",
@@ -235,8 +234,8 @@ extras = {}
 extras["ja"] = deps_list("fugashi", "ipadic", "unidic_lite", "unidic")
 extras["sklearn"] = deps_list("scikit-learn")
 
-extras["tf"] = deps_list("tensorflow", "onnxconverter-common", "keras2onnx", "keras")
-extras["tf-cpu"] = deps_list("tensorflow-cpu", "onnxconverter-common", "keras2onnx", "keras")
+extras["tf"] = deps_list("tensorflow", "onnxconverter-common", "keras2onnx")
+extras["tf-cpu"] = deps_list("tensorflow-cpu", "onnxconverter-common", "keras2onnx")
 
 extras["torch"] = deps_list("torch")
 

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -25,7 +25,6 @@ deps = {
     "jax": "jax>=0.2.8",
     "jaxlib": "jaxlib>=0.1.65",
     "jieba": "jieba",
-    "keras": "keras!=2.7.0",
     "keras2onnx": "keras2onnx",
     "nltk": "nltk",
     "numpy": "numpy>=1.17",


### PR DESCRIPTION
They pushed a fixed release, so we can remove the Keras version pinning