### PR TITLE
Pin TF until tests are fixed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ _deps = [
     "sphinxext-opengraph==0.4.1",
     "sphinx-intl",
     "starlette",
-    "tensorflow-cpu>=2.3",
+    "tensorflow-cpu>=2.3,<2.7",
     "tensorflow>=2.3,<2.7",
     "timeout-decorator",
     "timm",

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ _deps = [
     "sphinx-intl",
     "starlette",
     "tensorflow-cpu>=2.3",
-    "tensorflow>=2.3",
+    "tensorflow>=2.3,<2.7",
     "timeout-decorator",
     "timm",
     "tokenizers>=0.10.1,<0.11",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -62,7 +62,7 @@ deps = {
     "sphinxext-opengraph": "sphinxext-opengraph==0.4.1",
     "sphinx-intl": "sphinx-intl",
     "starlette": "starlette",
-    "tensorflow-cpu": "tensorflow-cpu>=2.3",
+    "tensorflow-cpu": "tensorflow-cpu>=2.3,<2.7",
     "tensorflow": "tensorflow>=2.3,<2.7",
     "timeout-decorator": "timeout-decorator",
     "timm": "timm",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -63,7 +63,7 @@ deps = {
     "sphinx-intl": "sphinx-intl",
     "starlette": "starlette",
     "tensorflow-cpu": "tensorflow-cpu>=2.3",
-    "tensorflow": "tensorflow>=2.3",
+    "tensorflow": "tensorflow>=2.3,<2.7",
     "timeout-decorator": "timeout-decorator",
     "timm": "timm",
     "tokenizers": "tokenizers>=0.10.1,<0.11",


### PR DESCRIPTION
# What does this PR do?

The new release of Transformers breaks TF Wav2Vec2, TF Hubert and TF Roformer. This pins to < 2.7 until we have fixed those issues.