### PR TITLE
[Tests] Update audio classification tests to support torch 1.10

### DIFF
--- a/tests/test_pipelines_audio_classification.py
+++ b/tests/test_pipelines_audio_classification.py
@@ -82,7 +82,6 @@ class AudioClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTest
             ],
         )
 
-    @unittest.skip("Skip tests while investigating difference between PyTorch 1.9 and 1.10")
     @require_torch
     def test_small_model_pt(self):
         model = "anton-l/wav2vec2-random-tiny-classifier"
@@ -94,10 +93,10 @@ class AudioClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTest
         self.assertEqual(
             nested_simplify(output, decimals=4),
             [
-                {"score": 0.0843, "label": "on"},
-                {"score": 0.0840, "label": "left"},
-                {"score": 0.0837, "label": "off"},
-                {"score": 0.0835, "label": "yes"},
+                {"score": 0.0842, "label": "no"},
+                {"score": 0.0838, "label": "up"},
+                {"score": 0.0837, "label": "go"},
+                {"score": 0.0834, "label": "right"},
             ],
         )
 
@@ -117,7 +116,7 @@ class AudioClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTest
         self.assertEqual(
             nested_simplify(output, decimals=4),
             [
-                {"score": 0.981, "label": "go"},
+                {"score": 0.9809, "label": "go"},
                 {"score": 0.0073, "label": "up"},
                 {"score": 0.0064, "label": "_unknown_"},
                 {"score": 0.0015, "label": "down"},


### PR DESCRIPTION
# What does this PR do?

The recent changes to `torch.nn.GroupNorm()` algorithm made it work slightly differently for inputs with small standard deviations. This is most noticeable (`~1e-3`) for uniform inputs like `np.ones()` in `test_small_model_pt()` and less noticeable (`<1e-5`) for other audio classification tests. 
The ASR models are not affected, since they don't use mean-pooling over outputs and thus don't amplify the difference as much.

PyTorch response: https://github.com/pytorch/pytorch/issues/67907
