### PR TITLE
[TFWav2Vec2Model] Fix input shapes in TFWav2Vec2WeightNormConv1D

### DIFF
--- a/src/transformers/models/hubert/modeling_tf_hubert.py
+++ b/src/transformers/models/hubert/modeling_tf_hubert.py
@@ -526,6 +526,7 @@ class TFHubertWeightNormConv1D(tf.keras.layers.Conv1D):
     def build(self, input_shape):
         if not self.built:
             input_shape = input_shape.as_list()
+            # Conv1D output shapes are checked at build time since TF 2.7, so we need to account for padding
             input_shape[-2] += self.explicit_padding * 2
             super().build(input_shape)
 

--- a/src/transformers/models/hubert/modeling_tf_hubert.py
+++ b/src/transformers/models/hubert/modeling_tf_hubert.py
@@ -525,7 +525,10 @@ class TFHubertWeightNormConv1D(tf.keras.layers.Conv1D):
 
     def build(self, input_shape):
         if not self.built:
+            input_shape = input_shape.as_list()
+            input_shape[-2] += self.explicit_padding * 2
             super().build(input_shape)
+
             self.kernel = tf.Variable(tf.transpose(self.kernel), name="weight_v", trainable=True)
             self.weight_v = self.kernel
 

--- a/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py
@@ -524,7 +524,10 @@ class TFWav2Vec2WeightNormConv1D(tf.keras.layers.Conv1D):
 
     def build(self, input_shape):
         if not self.built:
+            input_shape = input_shape.as_list()
+            input_shape[-2] += self.explicit_padding * 2
             super().build(input_shape)
+
             self.kernel = tf.Variable(tf.transpose(self.kernel), name="weight_v", trainable=True)
             self.weight_v = self.kernel
 

--- a/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py
@@ -525,6 +525,7 @@ class TFWav2Vec2WeightNormConv1D(tf.keras.layers.Conv1D):
     def build(self, input_shape):
         if not self.built:
             input_shape = input_shape.as_list()
+            # Conv1D output shapes are checked at build time since TF 2.7, so we need to account for padding
             input_shape[-2] += self.explicit_padding * 2
             super().build(input_shape)
 


### PR DESCRIPTION
# What does this PR do?
**Context**
After updating to TF 2.7 the tests started failing with `ValueError('One of the dimensions in the output is <= 0...')` which is caused by the recently added check to `keras.layers.Conv.build()` https://github.com/keras-team/keras/blob/v2.7.0/keras/layers/convolutional.py#L197

This PR fixes the input shapes passed during `TFWav2Vec2WeightNormConv1D.build()` to account for padding.

