### PR TITLE
Changed relative imports to absolute to allow convert_graph_to_onnx.py to run as a script.

### DIFF
--- a/src/transformers/onnx/convert.py
+++ b/src/transformers/onnx/convert.py
@@ -20,10 +20,10 @@ from typing import Iterable, List, Tuple, Union
 import numpy as np
 from packaging.version import Version, parse
 
-from .. import PreTrainedModel, PreTrainedTokenizer, TensorType, TFPreTrainedModel, is_torch_available
-from ..file_utils import is_torch_onnx_dict_inputs_support_available
-from ..utils import logging
-from .config import OnnxConfig
+from transformers import PreTrainedModel, PreTrainedTokenizer, TensorType, TFPreTrainedModel, is_torch_available
+from transformers.file_utils import is_torch_onnx_dict_inputs_support_available
+from transformers.utils import logging
+from transformers.onnx.config import OnnxConfig
 
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name

--- a/src/transformers/onnx/convert.py
+++ b/src/transformers/onnx/convert.py
@@ -22,8 +22,8 @@ from packaging.version import Version, parse
 
 from transformers import PreTrainedModel, PreTrainedTokenizer, TensorType, TFPreTrainedModel, is_torch_available
 from transformers.file_utils import is_torch_onnx_dict_inputs_support_available
-from transformers.utils import logging
 from transformers.onnx.config import OnnxConfig
+from transformers.utils import logging
 
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name


### PR DESCRIPTION
# What does this PR do?
Fixes relative imports in transformers.onnx.convert.  This allows convert_graph_to_onnx.py to run as a script again from outside the transformers repository.  This PR fixes issue #14314.


## Who can review?
@sgugger

