### PR TITLE
remove an irrelevant test from test_modeling_tf_layoutlm

### DIFF
--- a/tests/test_modeling_tf_layoutlm.py
+++ b/tests/test_modeling_tf_layoutlm.py
@@ -218,12 +218,6 @@ class LayoutLMModelTest(TFModelTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
 
-    def test_model_various_embeddings(self):
-        config_and_inputs = self.model_tester.prepare_config_and_inputs()
-        for type in ["absolute", "relative_key", "relative_key_query"]:
-            config_and_inputs[0].position_embedding_type = type
-            self.model_tester.create_and_check_model(*config_and_inputs)
-
     def test_for_masked_lm(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_for_masked_lm(*config_and_inputs)


### PR DESCRIPTION
# What does this PR do?

This PR remove `test_model_various_embeddings` from `test_modeling_tf_layoutlm.py`.

## More Information

Current version of `test_modeling_tf_layoutlm.py` has 

```
def test_model_various_embeddings(self):
    config_and_inputs = self.model_tester.prepare_config_and_inputs()
    for type in ["absolute", "relative_key", "relative_key_query"]:
        config_and_inputs[0].position_embedding_type = type
        self.model_tester.create_and_check_model(*config_and_inputs)
```

After a quick search inside the repo, I believe `position_embedding_type` is only for (some) PyTorch models, and `test_model_various_embeddings` is not necessary here. Furthermore, 

- `test_modeling_tf_layoutlm.py` is the only TF test script containing `position_embedding_type`
- `modeling_tf_layoutlm.py` has no usage of `config.position_embedding_type`.


Therefore, this PR remove `test_model_various_embeddings` from `test_modeling_tf_layoutlm.py`.