### PR TITLE
bump flax version

### DIFF
--- a/examples/flax/language-modeling/requirements.txt
+++ b/examples/flax/language-modeling/requirements.txt
@@ -1,5 +1,5 @@
 datasets >= 1.1.3
 jax>=0.2.8
 jaxlib>=0.1.59
-flax>=0.3.4
+flax>=0.3.5
 optax>=0.0.9

--- a/examples/flax/question-answering/requirements.txt
+++ b/examples/flax/question-answering/requirements.txt
@@ -1,5 +1,5 @@
 datasets >= 1.8.0
 jax>=0.2.17
 jaxlib>=0.1.68
-flax>=0.3.4
+flax>=0.3.5
 optax>=0.0.8

--- a/examples/flax/summarization/requirements.txt
+++ b/examples/flax/summarization/requirements.txt
@@ -1,5 +1,5 @@
 datasets >= 1.1.3
 jax>=0.2.8
 jaxlib>=0.1.59
-flax>=0.3.4
+flax>=0.3.5
 optax>=0.0.8

--- a/examples/flax/text-classification/requirements.txt
+++ b/examples/flax/text-classification/requirements.txt
@@ -1,5 +1,5 @@
 datasets >= 1.1.3
 jax>=0.2.8
 jaxlib>=0.1.59
-flax>=0.3.4
+flax>=0.3.5
 optax>=0.0.8

--- a/examples/flax/token-classification/requirements.txt
+++ b/examples/flax/token-classification/requirements.txt
@@ -1,6 +1,6 @@
 datasets >= 1.8.0
 jax>=0.2.8
 jaxlib>=0.1.59
-flax>=0.3.4
+flax>=0.3.5
 optax>=0.0.8
 seqeval

--- a/examples/flax/vision/requirements.txt
+++ b/examples/flax/vision/requirements.txt
@@ -1,6 +1,6 @@
 jax>=0.2.8
 jaxlib>=0.1.59
-flax>=0.3.4
+flax>=0.3.5
 optax>=0.0.8
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.9.0+cpu 

--- a/examples/research_projects/jax-projects/hybrid_clip/requirements.txt
+++ b/examples/research_projects/jax-projects/hybrid_clip/requirements.txt
@@ -1,6 +1,6 @@
 jax>=0.2.8
 jaxlib>=0.1.59
-flax>=0.3.4
+flax>=0.3.5
 optax>=0.0.8
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.9.0+cpu 

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ _deps = [
     "fastapi",
     "filelock",
     "flake8>=3.8.3",
-    "flax>=0.3.4",
+    "flax>=0.3.5",
     "fugashi>=1.0",
     "GitPython<3.1.19",
     "huggingface-hub>=0.1.0,<1.0",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -15,7 +15,7 @@ deps = {
     "fastapi": "fastapi",
     "filelock": "filelock",
     "flake8": "flake8>=3.8.3",
-    "flax": "flax>=0.3.4",
+    "flax": "flax>=0.3.5",
     "fugashi": "fugashi>=1.0",
     "GitPython": "GitPython<3.1.19",
     "huggingface-hub": "huggingface-hub>=0.1.0,<1.0",


### PR DESCRIPTION
# What does this PR do?

jax `v0.2.21` introduced a slight breaking change, `jnp.ndarray` now only returns `True` for `jax` arrays and not `numpy` arrays. so for standard `numpy` array x, `isinstance(x, jnp.ndarray)` will
now return `False` . (cf [here](https://github.com/google/jax/releases/tag/jax-v0.2.21), the last point under breaking changes)

And the `jax.random.split` method returns numpy array instead of jax. We use this method during random init of the model to create the `rngs`  `dict`.

Flax has a check for valid rngs where it expects `jnp.ndarray` , but since `split` returns np array and jax now does not treat np arrays as `jnp.ndarray` the check returns `False` and raises an error.

This has been fixed in `flax==0.3.5` (cf [here](https://github.com/google/flax/blob/v0.3.5/flax/core/scope.py#L753)).  So all of our models fail with `jax>=0.2.21` and `flax<0.3.5`.

To fix this, this PR bumps the flax version to `0.3.5`.