### PR TITLE
Allow per-version configurations

### DIFF
--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -330,7 +330,7 @@ class ConfigurationVersioningTest(unittest.TestCase):
             self.assertEqual(new_configuration.hidden_size, 768)
 
     def test_repo_versioning_before(self):
-        # This repo has two configuration files, one for v4.0.0 and above with an added token, one for versions lower.
+        # This repo has two configuration files, one for v5.0.0 and above with an added token, one for versions lower.
         repo = "microsoft/layoutxlm-base"
 
         import transformers as new_transformers

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -324,7 +324,7 @@ class ConfigurationVersioningTest(unittest.TestCase):
             self.assertEqual(new_configuration.hidden_size, 2)
 
             # Will need to be adjusted if we reach v42 and this test is still here.
-            # Should pick the old configuration file as the version of Transformers is < 4.0.0
+            # Should pick the old configuration file as the version of Transformers is < 4.42.0
             shutil.move(os.path.join(tmp_dir, "config.4.0.0.json"), os.path.join(tmp_dir, "config.42.0.0.json"))
             new_configuration = AutoConfig.from_pretrained(tmp_dir)
             self.assertEqual(new_configuration.hidden_size, 768)

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -16,8 +16,10 @@
 import copy
 import json
 import os
+import shutil
 import tempfile
 import unittest
+import unittest.mock
 
 from huggingface_hub import Repository, delete_repo, login
 from requests.exceptions import HTTPError
@@ -306,3 +308,40 @@ class ConfigTestUtils(unittest.TestCase):
                 "The following keys are set with the default values in `test_configuration_common.config_common_kwargs` "
                 f"pick another value for them: {', '.join(keys_with_defaults)}."
             )
+
+
+class ConfigurationVersioningTest(unittest.TestCase):
+    def test_local_versioning(self):
+        configuration = AutoConfig.from_pretrained("bert-base-cased")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            configuration.save_pretrained(tmp_dir)
+            configuration.hidden_size = 2
+            json.dump(configuration.to_dict(), open(os.path.join(tmp_dir, "config.4.0.0.json"), "w"))
+
+            # This should pick the new configuration file as the version of Transformers is > 4.0.0
+            new_configuration = AutoConfig.from_pretrained(tmp_dir)
+            self.assertEqual(new_configuration.hidden_size, 2)
+
+            # Will need to be adjusted if we reach v42 and this test is still here.
+            # Should pick the old configuration file as the version of Transformers is < 4.0.0
+            shutil.move(os.path.join(tmp_dir, "config.4.0.0.json"), os.path.join(tmp_dir, "config.42.0.0.json"))
+            new_configuration = AutoConfig.from_pretrained(tmp_dir)
+            self.assertEqual(new_configuration.hidden_size, 768)
+
+    def test_repo_versioning_before(self):
+        # This repo has two configuration files, one for v4.0.0 and above with an added token, one for versions lower.
+        repo = "microsoft/layoutxlm-base"
+
+        import transformers as new_transformers
+
+        new_transformers.configuration_utils.__version__ = "v5.0.0"
+        new_configuration = new_transformers.models.auto.AutoConfig.from_pretrained(repo)
+        self.assertEqual(new_configuration.tokenizer_class, None)
+
+        # Testing an older version by monkey-patching the version in the module it's used.
+        import transformers as old_transformers
+
+        old_transformers.configuration_utils.__version__ = "v3.0.0"
+        old_configuration = old_transformers.models.auto.AutoConfig.from_pretrained(repo)
+        self.assertEqual(old_configuration.tokenizer_class, "XLMRobertaTokenizer")


### PR DESCRIPTION
Similarly to https://github.com/huggingface/transformers/pull/12713, this allows per-version configurations. This is necessary for LayoutXLM, which up to now was using the configuration-defined `XLMRobertaTokenizer`, but which should now use the `LayoutXLMTokenizer`.

Updating the configuration would mean breaking all previous versions of `transformers` that were using LayoutXLM. Not updating this parameter means that LayoutXLM will never benefit from `LayoutXLMTokenizer` through the `AutoTokenizer` API.

Resolves https://github.com/huggingface/transformers/issues/14275

This implements similar tests to the tokenizer, but instead of using `bert-base-cased`, it uses the actual model that is at issue (`microsoft/layoutxlm-base`). This model should continue using the `XLMRobertaTokenizer` until a new minor version is released, as the configuration I uploaded is named `config.4.13.0.json`: https://huggingface.co/microsoft/layoutxlm-base/blob/main/config.4.13.0.json