### PR TITLE
Experimenting with adding proper get_config() and from_config() methods

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -692,6 +692,13 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         self.config = config
         self.name_or_path = config.name_or_path
 
+    def get_config(self):
+        return self.config
+
+    @classmethod
+    def from_config(cls, config, **kwargs):
+        return cls._from_config(config, **kwargs)
+
     @classmethod
     def _from_config(cls, config, **kwargs):
         """

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -171,8 +171,9 @@ class TFModelTesterMixin:
             outputs = model(self._prepare_for_class(inputs_dict, model_class))
 
             new_model = model_class.from_config(model.get_config())
+            _ = new_model(self._prepare_for_class(inputs_dict, model_class))  # Build model
             new_model.set_weights(model.get_weights())
-            after_outputs = model(self._prepare_for_class(inputs_dict, model_class))
+            after_outputs = new_model(self._prepare_for_class(inputs_dict, model_class))
 
             self.assert_outputs_same(after_outputs, outputs)
 

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -163,6 +163,19 @@ class TFModelTesterMixin:
 
                 self.assert_outputs_same(after_outputs, outputs)
 
+    def test_save_load_config(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            outputs = model(self._prepare_for_class(inputs_dict, model_class))
+
+            new_model = model_class.from_config(model.get_config())
+            new_model.set_weights(model.get_weights())
+            after_outputs = model(self._prepare_for_class(inputs_dict, model_class))
+
+            self.assert_outputs_same(after_outputs, outputs)
+
     @tooslow
     def test_graph_mode(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
Should fix issues with saving/loading Keras models containing Transformers models as layers, among other problems.