### PR TITLE
Use `AlbertConverter` for FNet instead of using FNet's own converter

### DIFF
--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -542,7 +542,7 @@ class FNetConverter(SpmConverter):
         list_normalizers.append(normalizers.Precompiled(precompiled_charsmap))
         list_normalizers.append(normalizers.Replace(Regex(" {2,}"), " "))
         return normalizers.Sequence(list_normalizers)
-    
+
     def post_processor(self):
         return processors.TemplateProcessing(
             single="[CLS]:0 $A:0 [SEP]:0",

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -527,6 +527,22 @@ class AlbertConverter(SpmConverter):
 
 
 class FNetConverter(SpmConverter):
+    def normalizer(self, proto):
+        list_normalizers = [
+            normalizers.Replace("``", '"'),
+            normalizers.Replace("''", '"'),
+        ]
+        if not self.original_tokenizer.keep_accents:
+            list_normalizers.append(normalizers.NFKD())
+            list_normalizers.append(normalizers.StripAccents())
+        if self.original_tokenizer.do_lower_case:
+            list_normalizers.append(normalizers.Lowercase())
+
+        precompiled_charsmap = proto.normalizer_spec.precompiled_charsmap
+        list_normalizers.append(normalizers.Precompiled(precompiled_charsmap))
+        list_normalizers.append(normalizers.Replace(Regex(" {2,}"), " "))
+        return normalizers.Sequence(list_normalizers)
+    
     def post_processor(self):
         return processors.TemplateProcessing(
             single="[CLS]:0 $A:0 [SEP]:0",

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -526,34 +526,6 @@ class AlbertConverter(SpmConverter):
         )
 
 
-class FNetConverter(SpmConverter):
-    def normalizer(self, proto):
-        list_normalizers = [
-            normalizers.Replace("``", '"'),
-            normalizers.Replace("''", '"'),
-        ]
-        if not self.original_tokenizer.keep_accents:
-            list_normalizers.append(normalizers.NFKD())
-            list_normalizers.append(normalizers.StripAccents())
-        if self.original_tokenizer.do_lower_case:
-            list_normalizers.append(normalizers.Lowercase())
-
-        precompiled_charsmap = proto.normalizer_spec.precompiled_charsmap
-        list_normalizers.append(normalizers.Precompiled(precompiled_charsmap))
-        list_normalizers.append(normalizers.Replace(Regex(" {2,}"), " "))
-        return normalizers.Sequence(list_normalizers)
-
-    def post_processor(self):
-        return processors.TemplateProcessing(
-            single="[CLS]:0 $A:0 [SEP]:0",
-            pair="[CLS]:0 $A:0 [SEP]:0 $B:1 [SEP]:1",
-            special_tokens=[
-                ("[CLS]", self.original_tokenizer.convert_tokens_to_ids("[CLS]")),
-                ("[SEP]", self.original_tokenizer.convert_tokens_to_ids("[SEP]")),
-            ],
-        )
-
-
 class BarthezConverter(SpmConverter):
     def unk_id(self, proto):
         unk_id = 3
@@ -954,7 +926,7 @@ SLOW_TO_FAST_CONVERTERS = {
     "DPRQuestionEncoderTokenizer": BertConverter,
     "DPRContextEncoderTokenizer": BertConverter,
     "ElectraTokenizer": BertConverter,
-    "FNetTokenizer": FNetConverter,
+    "FNetTokenizer": AlbertConverter,
     "FunnelTokenizer": FunnelConverter,
     "GPT2Tokenizer": GPT2Converter,
     "HerbertTokenizer": HerbertConverter,


### PR DESCRIPTION
# What does this PR do?

**Edited: Finally using `AlbertConverter` directly because the slow tokenizers between `Albert` and `FNet` are basically identical. (FNet doesn't have `bos_token` and `eos_token` while Albert does, but this difference doesn't matter.)**

---

This PR adds normalizer to `FNetConverter`, making `do_lower_case` and `keep_accents` options of `FNetTokenizerFast` work.

This normalizer is copied from that of `Albert` as FNetTokenizerFast is adepted from `Albert`.


https://github.com/huggingface/transformers/blob/3ea15d27832d47d44ad046c3a776c7b582b0984b/src/transformers/models/fnet/tokenization_fnet_fast.py#L57-L61

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@LysandreJik @SaulLu @sgugger 