### PR TITLE
[M2M100Tokenizer] fix _build_translation_inputs

### DIFF
--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -327,9 +327,7 @@ class M2M100Tokenizer(PreTrainedTokenizer):
         self.set_src_lang_special_tokens(self.src_lang)
         return super().prepare_seq2seq_batch(src_texts, tgt_texts, **kwargs)
 
-    def _build_translation_inputs(
-        self, raw_inputs, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs
-    ):
+    def _build_translation_inputs(self, raw_inputs, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs):
         """Used by translation pipeline, to prepare inputs for the generate function"""
         if src_lang is None or tgt_lang is None:
             raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")

--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -328,13 +328,13 @@ class M2M100Tokenizer(PreTrainedTokenizer):
         return super().prepare_seq2seq_batch(src_texts, tgt_texts, **kwargs)
 
     def _build_translation_inputs(
-        self, raw_inputs, return_tensors: str, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs
+        self, raw_inputs, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs
     ):
         """Used by translation pipeline, to prepare inputs for the generate function"""
         if src_lang is None or tgt_lang is None:
             raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
         self.src_lang = src_lang
-        inputs = self(raw_inputs, add_special_tokens=True, return_tensors=return_tensors, **extra_kwargs)
+        inputs = self(raw_inputs, add_special_tokens=True, **extra_kwargs)
         tgt_lang_id = self.get_lang_id(tgt_lang)
         inputs["forced_bos_token_id"] = tgt_lang_id
         return inputs

--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -327,12 +327,14 @@ class M2M100Tokenizer(PreTrainedTokenizer):
         self.set_src_lang_special_tokens(self.src_lang)
         return super().prepare_seq2seq_batch(src_texts, tgt_texts, **kwargs)
 
-    def _build_translation_inputs(self, raw_inputs, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs):
+    def _build_translation_inputs(
+        self, raw_inputs, return_tensors: str, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs
+    ):
         """Used by translation pipeline, to prepare inputs for the generate function"""
         if src_lang is None or tgt_lang is None:
             raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
         self.src_lang = src_lang
-        inputs = self(raw_inputs, add_special_tokens=True, return_tensors="pt", **extra_kwargs)
+        inputs = self(raw_inputs, add_special_tokens=True, return_tensors=return_tensors, **extra_kwargs)
         tgt_lang_id = self.get_lang_id(tgt_lang)
         inputs["forced_bos_token_id"] = tgt_lang_id
         return inputs

--- a/tests/test_tokenization_m2m_100.py
+++ b/tests/test_tokenization_m2m_100.py
@@ -226,7 +226,7 @@ class M2M100TokenizerIntegrationTest(unittest.TestCase):
 
     @require_torch
     def test_tokenizer_translation(self):
-        inputs = self.tokenizer._build_translation_inputs("A test", src_lang="en", tgt_lang="ar")
+        inputs = self.tokenizer._build_translation_inputs("A test", return_tensors="pt", src_lang="en", tgt_lang="ar")
 
         self.assertEqual(
             nested_simplify(inputs),


### PR DESCRIPTION
# What does this PR do?

The `_build_translation_inputs` method of `M2M100Tokenizer` hardcodes the `return_tensors` argument, but it's also passed as a `extra_kwargs` in translation pipeline. So the pipeline fails with the error

```TypeError: M2M100Tokenizer object got multiple values for keyword argument 'return_tensors'```

This PR adds `return_tensors` parameter to `_build_translation_inputs`. 
