### PR TITLE
Fixed a bug for num_return_sequences don't take effect in Text2TextGenerationPipeline

### DIFF
--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -154,19 +154,22 @@ class Text2TextGenerationPipeline(Pipeline):
         output_ids = self.model.generate(**model_inputs, **generate_kwargs)
         return {"output_ids": output_ids}
 
-    def postprocess(self, model_outputs, return_type=ReturnType.TEXT, clean_up_tokenization_spaces=False):
-        record = {}
-        if return_type == ReturnType.TENSORS:
-            record = {f"{self.return_name}_token_ids": model_outputs}
-        elif return_type == ReturnType.TEXT:
-            record = {
-                f"{self.return_name}_text": self.tokenizer.decode(
-                    model_outputs["output_ids"][0],
-                    skip_special_tokens=True,
-                    clean_up_tokenization_spaces=clean_up_tokenization_spaces,
-                )
-            }
-        return record
+	def postprocess(self, model_outputs, return_type=ReturnType.TEXT, clean_up_tokenization_spaces=False):
+		record = {}
+		if return_type == ReturnType.TENSORS:
+			record = {f"{self.return_name}_token_ids": model_outputs}
+		elif return_type == ReturnType.TEXT:
+			record =[]
+			for  sequence in model_outputs["output_ids"]:
+				item = {
+					f"{self.return_name}_text": self.tokenizer.decode(
+						sequence,
+						skip_special_tokens=True,
+						clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+					)
+				}
+				record.append(item)
+		return record
 
 
 @add_end_docstrings(PIPELINE_INIT_ARGS)


### PR DESCRIPTION
# Fixed a bug for num_return_sequences don't take effect in Text2TextGenerationPipeline.
The previous postprocess function always returns one result. This leads to num_return_sequences doesn't take effect in Text2TextGenerationPipeline and only can get one text result, no matter how we change the parameters.
We can get multiple text results in the postprocess method and get multiple results from Text2TextGenerationPipeline.



<!-- Remove if not applicable -->

Fixes https://github.com/huggingface/transformers/issues/13027#issuecomment-969899988


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.


