### PR TITLE
Fixed a bug for num_return_sequences don't take effect in Text2TextGenerationPipeline.

### DIFF
--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -155,12 +155,11 @@ class Text2TextGenerationPipeline(Pipeline):
         return {"output_ids": output_ids}
 
     def postprocess(self, model_outputs, return_type=ReturnType.TEXT, clean_up_tokenization_spaces=False):
-        record = {}
-        if return_type == ReturnType.TENSORS:
-            record = {f"{self.return_name}_token_ids": model_outputs}
-        elif return_type == ReturnType.TEXT:
-            record = []
-            for sequence in model_outputs["output_ids"]:
+        record = []
+        for sequence in model_outputs["output_ids"]:
+            if return_type == ReturnType.TENSORS:
+                item = {f"{self.return_name}_token_ids": model_outputs}
+            elif return_type == ReturnType.TEXT:
                 item = {
                     f"{self.return_name}_text": self.tokenizer.decode(
                         sequence,
@@ -168,7 +167,7 @@ class Text2TextGenerationPipeline(Pipeline):
                         clean_up_tokenization_spaces=clean_up_tokenization_spaces,
                     )
                 }
-                record.append(item)
+            record.append(item)
         return record
 
 

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -155,6 +155,7 @@ class Text2TextGenerationPipeline(Pipeline):
         return {"output_ids": output_ids}
 
     def postprocess(self, model_outputs, return_type=ReturnType.TEXT, clean_up_tokenization_spaces=False):
+        record = {}
         if return_type == ReturnType.TENSORS:
             record = {f"{self.return_name}_token_ids": model_outputs}
         elif return_type == ReturnType.TEXT:

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -155,7 +155,6 @@ class Text2TextGenerationPipeline(Pipeline):
         return {"output_ids": output_ids}
 
     def postprocess(self, model_outputs, return_type=ReturnType.TEXT, clean_up_tokenization_spaces=False):
-        record = {}
         if return_type == ReturnType.TENSORS:
             record = {f"{self.return_name}_token_ids": model_outputs}
         elif return_type == ReturnType.TEXT:

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -159,13 +159,16 @@ class Text2TextGenerationPipeline(Pipeline):
         if return_type == ReturnType.TENSORS:
             record = {f"{self.return_name}_token_ids": model_outputs}
         elif return_type == ReturnType.TEXT:
-            record = {
-                f"{self.return_name}_text": self.tokenizer.decode(
-                    model_outputs["output_ids"][0],
-                    skip_special_tokens=True,
-                    clean_up_tokenization_spaces=clean_up_tokenization_spaces,
-                )
-            }
+            record = []
+            for sequence in model_outputs["output_ids"]:
+                item = {
+                    f"{self.return_name}_text": self.tokenizer.decode(
+                        sequence,
+                        skip_special_tokens=True,
+                        clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+                    )
+                }
+                record.append(item)
         return record
 
 

--- a/tests/test_pipelines_text2text_generation.py
+++ b/tests/test_pipelines_text2text_generation.py
@@ -45,12 +45,20 @@ class Text2TextGenerationPipelineTests(unittest.TestCase, metaclass=PipelineTest
 
     @require_torch
     def test_small_model_pt(self):
-        num_return_sequences = 3
         generator = pipeline("text2text-generation", model="patrickvonplaten/t5-tiny-random", framework="pt")
+
         # do_sample=False necessary for reproducibility
+        outputs = generator("Something there", do_sample=False)
+        self.assertEqual(outputs, [{"generated_text": ""}])
+
+        num_return_sequences = 3
         outputs = generator("Something there", do_sample=False,
-                            num_return_sequences=num_return_sequences,num_beams=num_return_sequences)
-        self.assertEqual(outputs, [{"generated_text": ANY(str)} for _ in range(num_return_sequences)])
+                                     num_return_sequences=num_return_sequences,
+                                     num_beams=num_return_sequences)
+        tagret_outputs = [{'generated_text': 'Beide Beide Beide Beide Beide Beide Beide Beide Beide'},
+                          {'generated_text': 'Beide Beide Beide Beide Beide Beide Beide Beide'},
+                          {'generated_text': ''}]
+        self.assertEqual(outputs, tagret_outputs)
 
     @require_tf
     def test_small_model_tf(self):

--- a/tests/test_pipelines_text2text_generation.py
+++ b/tests/test_pipelines_text2text_generation.py
@@ -43,15 +43,15 @@ class Text2TextGenerationPipelineTests(unittest.TestCase, metaclass=PipelineTest
         with self.assertRaises(ValueError):
             generator(4)
 
-	@require_torch
-	def test_small_model_pt(self):
-		num_return_sequences = 3
-		generator = pipeline("text2text-generation", model="patrickvonplaten/t5-tiny-random", framework="pt")
-		# do_sample=False necessary for reproducibility
-		outputs = generator("Something there", do_sample=False,
-		                    num_return_sequences=num_return_sequences,
-		                    num_beams=num_return_sequences)
-		self.assertEqual(outputs, [{"generated_text": ANY(str)} for _ in range(num_return_sequences)])
+    @require_torch
+    def test_small_model_pt(self):
+        num_return_sequences = 3
+        generator = pipeline("text2text-generation", model="patrickvonplaten/t5-tiny-random", framework="pt")
+        # do_sample=False necessary for reproducibility
+        outputs = generator("Something there", do_sample=False,
+                            num_return_sequences=num_return_sequences,
+                            num_beams=num_return_sequences)
+        self.assertEqual(outputs, [{"generated_text": ANY(str)} for _ in range(num_return_sequences)])
 
     @require_tf
     def test_small_model_tf(self):

--- a/tests/test_pipelines_text2text_generation.py
+++ b/tests/test_pipelines_text2text_generation.py
@@ -49,8 +49,7 @@ class Text2TextGenerationPipelineTests(unittest.TestCase, metaclass=PipelineTest
         generator = pipeline("text2text-generation", model="patrickvonplaten/t5-tiny-random", framework="pt")
         # do_sample=False necessary for reproducibility
         outputs = generator("Something there", do_sample=False,
-                            num_return_sequences=num_return_sequences,
-                            num_beams=num_return_sequences)
+                            num_return_sequences=num_return_sequences,num_beams=num_return_sequences)
         self.assertEqual(outputs, [{"generated_text": ANY(str)} for _ in range(num_return_sequences)])
 
     @require_tf

--- a/tests/test_pipelines_text2text_generation.py
+++ b/tests/test_pipelines_text2text_generation.py
@@ -43,12 +43,15 @@ class Text2TextGenerationPipelineTests(unittest.TestCase, metaclass=PipelineTest
         with self.assertRaises(ValueError):
             generator(4)
 
-    @require_torch
-    def test_small_model_pt(self):
-        generator = pipeline("text2text-generation", model="patrickvonplaten/t5-tiny-random", framework="pt")
-        # do_sample=False necessary for reproducibility
-        outputs = generator("Something there", do_sample=False)
-        self.assertEqual(outputs, [{"generated_text": ""}])
+	@require_torch
+	def test_small_model_pt(self):
+		num_return_sequences = 3
+		generator = pipeline("text2text-generation", model="patrickvonplaten/t5-tiny-random", framework="pt")
+		# do_sample=False necessary for reproducibility
+		outputs = generator("Something there", do_sample=False,
+		                    num_return_sequences=num_return_sequences,
+		                    num_beams=num_return_sequences)
+		self.assertEqual(outputs, [{"generated_text": ANY(str)} for _ in range(num_return_sequences)])
 
     @require_tf
     def test_small_model_tf(self):

--- a/tests/test_pipelines_text2text_generation.py
+++ b/tests/test_pipelines_text2text_generation.py
@@ -15,10 +15,10 @@
 import unittest
 
 from transformers import (
-    MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
-    TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
-    Text2TextGenerationPipeline,
-    pipeline,
+	MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
+	TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
+	Text2TextGenerationPipeline,
+	pipeline,
 )
 from transformers.testing_utils import is_pipeline_test, require_tf, require_torch
 
@@ -27,42 +27,42 @@ from .test_pipelines_common import ANY, PipelineTestCaseMeta
 
 @is_pipeline_test
 class Text2TextGenerationPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta):
-    model_mapping = MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING
-    tf_model_mapping = TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING
+	model_mapping = MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING
+	tf_model_mapping = TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING
 
-    def get_test_pipeline(self, model, tokenizer, feature_extractor):
-        generator = Text2TextGenerationPipeline(model=model, tokenizer=tokenizer)
-        return generator, ["Something to write", "Something else"]
+	def get_test_pipeline(self, model, tokenizer, feature_extractor):
+		generator = Text2TextGenerationPipeline(model=model, tokenizer=tokenizer)
+		return generator, ["Something to write", "Something else"]
 
-    def run_pipeline_test(self, generator, _):
-        outputs = generator("Something there")
-        self.assertEqual(outputs, [{"generated_text": ANY(str)}])
-        # These are encoder decoder, they don't just append to incoming string
-        self.assertFalse(outputs[0]["generated_text"].startswith("Something there"))
+	def run_pipeline_test(self, generator, _):
+		outputs = generator("Something there")
+		self.assertEqual(outputs, [{"generated_text": ANY(str)}])
+		# These are encoder decoder, they don't just append to incoming string
+		self.assertFalse(outputs[0]["generated_text"].startswith("Something there"))
 
-        with self.assertRaises(ValueError):
-            generator(4)
+		with self.assertRaises(ValueError):
+			generator(4)
 
-    @require_torch
-    def test_small_model_pt(self):
-        generator = pipeline("text2text-generation", model="patrickvonplaten/t5-tiny-random", framework="pt")
+	@require_torch
+	def test_small_model_pt(self):
+		generator = pipeline("text2text-generation", model="patrickvonplaten/t5-tiny-random", framework="pt")
 
-        # do_sample=False necessary for reproducibility
-        outputs = generator("Something there", do_sample=False)
-        self.assertEqual(outputs, [{"generated_text": ""}])
+		# do_sample=False necessary for reproducibility
+		outputs = generator("Something there", do_sample=False)
+		self.assertEqual(outputs, [{"generated_text": ""}])
 
-        num_return_sequences = 3
-        outputs = generator("Something there", do_sample=False,
-                                     num_return_sequences=num_return_sequences,
-                                     num_beams=num_return_sequences)
-        tagret_outputs = [{'generated_text': 'Beide Beide Beide Beide Beide Beide Beide Beide Beide'},
-                          {'generated_text': 'Beide Beide Beide Beide Beide Beide Beide Beide'},
-                          {'generated_text': ''}]
-        self.assertEqual(outputs, tagret_outputs)
+		num_return_sequences = 3
+		outputs = generator("Something there", do_sample=False,
+		                    num_return_sequences=num_return_sequences,
+		                    num_beams=num_return_sequences)
+		tagret_outputs = [{'generated_text': 'Beide Beide Beide Beide Beide Beide Beide Beide Beide'},
+		                  {'generated_text': 'Beide Beide Beide Beide Beide Beide Beide Beide'},
+		                  {'generated_text': ''}]
+		self.assertEqual(outputs, tagret_outputs)
 
-    @require_tf
-    def test_small_model_tf(self):
-        generator = pipeline("text2text-generation", model="patrickvonplaten/t5-tiny-random", framework="tf")
-        # do_sample=False necessary for reproducibility
-        outputs = generator("Something there", do_sample=False)
-        self.assertEqual(outputs, [{"generated_text": ""}])
+	@require_tf
+	def test_small_model_tf(self):
+		generator = pipeline("text2text-generation", model="patrickvonplaten/t5-tiny-random", framework="tf")
+		# do_sample=False necessary for reproducibility
+		outputs = generator("Something there", do_sample=False)
+		self.assertEqual(outputs, [{"generated_text": ""}])


### PR DESCRIPTION
# Fixed a bug for num_return_sequences don't take effect in Text2TextGenerationPipeline.
The previous postprocess function always returns one result. This leads to num_return_sequences doesn't take effect in Text2TextGenerationPipeline and only can get one text result, no matter how we change the parameters.
We can get multiple text results in the postprocess method and get multiple results from Text2TextGenerationPipeline.



<!-- Remove if not applicable -->

Fixes https://github.com/huggingface/transformers/issues/13027#issuecomment-969899988


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?





