### PR TITLE
Add forward method to dummy models

### DIFF
--- a/src/transformers/utils/dummy_flax_objects.py
+++ b/src/transformers/utils/dummy_flax_objects.py
@@ -76,7 +76,7 @@ class FlaxPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAlbertForMaskedLM:
@@ -88,7 +88,7 @@ class FlaxAlbertForMaskedLM:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAlbertForMultipleChoice:
@@ -100,7 +100,7 @@ class FlaxAlbertForMultipleChoice:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAlbertForPreTraining:
@@ -117,7 +117,7 @@ class FlaxAlbertForQuestionAnswering:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAlbertForSequenceClassification:
@@ -129,7 +129,7 @@ class FlaxAlbertForSequenceClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAlbertForTokenClassification:
@@ -141,7 +141,7 @@ class FlaxAlbertForTokenClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAlbertModel:
@@ -153,7 +153,7 @@ class FlaxAlbertModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAlbertPreTrainedModel:
@@ -165,7 +165,7 @@ class FlaxAlbertPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 FLAX_MODEL_FOR_CAUSAL_LM_MAPPING = None
@@ -213,7 +213,7 @@ class FlaxAutoModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAutoModelForCausalLM:
@@ -225,7 +225,7 @@ class FlaxAutoModelForCausalLM:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAutoModelForImageClassification:
@@ -237,7 +237,7 @@ class FlaxAutoModelForImageClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAutoModelForMaskedLM:
@@ -249,7 +249,7 @@ class FlaxAutoModelForMaskedLM:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAutoModelForMultipleChoice:
@@ -261,7 +261,7 @@ class FlaxAutoModelForMultipleChoice:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAutoModelForNextSentencePrediction:
@@ -273,7 +273,7 @@ class FlaxAutoModelForNextSentencePrediction:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAutoModelForPreTraining:
@@ -285,7 +285,7 @@ class FlaxAutoModelForPreTraining:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAutoModelForQuestionAnswering:
@@ -297,7 +297,7 @@ class FlaxAutoModelForQuestionAnswering:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAutoModelForSeq2SeqLM:
@@ -309,7 +309,7 @@ class FlaxAutoModelForSeq2SeqLM:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAutoModelForSequenceClassification:
@@ -321,7 +321,7 @@ class FlaxAutoModelForSequenceClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAutoModelForTokenClassification:
@@ -333,7 +333,7 @@ class FlaxAutoModelForTokenClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxAutoModelForVision2Seq:
@@ -345,7 +345,7 @@ class FlaxAutoModelForVision2Seq:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBartForConditionalGeneration:
@@ -357,7 +357,7 @@ class FlaxBartForConditionalGeneration:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBartForQuestionAnswering:
@@ -369,7 +369,7 @@ class FlaxBartForQuestionAnswering:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBartForSequenceClassification:
@@ -381,7 +381,7 @@ class FlaxBartForSequenceClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBartModel:
@@ -393,7 +393,7 @@ class FlaxBartModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBartPreTrainedModel:
@@ -405,7 +405,7 @@ class FlaxBartPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBeitForImageClassification:
@@ -422,7 +422,7 @@ class FlaxBeitForMaskedImageModeling:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBeitModel:
@@ -434,7 +434,7 @@ class FlaxBeitModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBeitPreTrainedModel:
@@ -446,7 +446,7 @@ class FlaxBeitPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBertForMaskedLM:
@@ -458,7 +458,7 @@ class FlaxBertForMaskedLM:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBertForMultipleChoice:
@@ -470,7 +470,7 @@ class FlaxBertForMultipleChoice:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBertForNextSentencePrediction:
@@ -492,7 +492,7 @@ class FlaxBertForQuestionAnswering:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBertForSequenceClassification:
@@ -504,7 +504,7 @@ class FlaxBertForSequenceClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBertForTokenClassification:
@@ -516,7 +516,7 @@ class FlaxBertForTokenClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBertModel:
@@ -528,7 +528,7 @@ class FlaxBertModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBertPreTrainedModel:
@@ -540,7 +540,7 @@ class FlaxBertPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBigBirdForMaskedLM:
@@ -552,7 +552,7 @@ class FlaxBigBirdForMaskedLM:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBigBirdForMultipleChoice:
@@ -564,7 +564,7 @@ class FlaxBigBirdForMultipleChoice:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBigBirdForPreTraining:
@@ -581,7 +581,7 @@ class FlaxBigBirdForQuestionAnswering:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBigBirdForSequenceClassification:
@@ -593,7 +593,7 @@ class FlaxBigBirdForSequenceClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBigBirdForTokenClassification:
@@ -605,7 +605,7 @@ class FlaxBigBirdForTokenClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBigBirdModel:
@@ -617,7 +617,7 @@ class FlaxBigBirdModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxBigBirdPreTrainedModel:
@@ -629,7 +629,7 @@ class FlaxBigBirdPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxCLIPModel:
@@ -641,7 +641,7 @@ class FlaxCLIPModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxCLIPPreTrainedModel:
@@ -653,7 +653,7 @@ class FlaxCLIPPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxCLIPTextModel:
@@ -665,7 +665,7 @@ class FlaxCLIPTextModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxCLIPTextPreTrainedModel:
@@ -677,7 +677,7 @@ class FlaxCLIPTextPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxCLIPVisionModel:
@@ -689,7 +689,7 @@ class FlaxCLIPVisionModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxCLIPVisionPreTrainedModel:
@@ -701,7 +701,7 @@ class FlaxCLIPVisionPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxDistilBertForMaskedLM:
@@ -713,7 +713,7 @@ class FlaxDistilBertForMaskedLM:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxDistilBertForMultipleChoice:
@@ -725,7 +725,7 @@ class FlaxDistilBertForMultipleChoice:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxDistilBertForQuestionAnswering:
@@ -737,7 +737,7 @@ class FlaxDistilBertForQuestionAnswering:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxDistilBertForSequenceClassification:
@@ -749,7 +749,7 @@ class FlaxDistilBertForSequenceClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxDistilBertForTokenClassification:
@@ -761,7 +761,7 @@ class FlaxDistilBertForTokenClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxDistilBertModel:
@@ -773,7 +773,7 @@ class FlaxDistilBertModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxDistilBertPreTrainedModel:
@@ -785,7 +785,7 @@ class FlaxDistilBertPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxElectraForMaskedLM:
@@ -797,7 +797,7 @@ class FlaxElectraForMaskedLM:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxElectraForMultipleChoice:
@@ -809,7 +809,7 @@ class FlaxElectraForMultipleChoice:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxElectraForPreTraining:
@@ -826,7 +826,7 @@ class FlaxElectraForQuestionAnswering:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxElectraForSequenceClassification:
@@ -838,7 +838,7 @@ class FlaxElectraForSequenceClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxElectraForTokenClassification:
@@ -850,7 +850,7 @@ class FlaxElectraForTokenClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxElectraModel:
@@ -862,7 +862,7 @@ class FlaxElectraModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxElectraPreTrainedModel:
@@ -874,7 +874,7 @@ class FlaxElectraPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxEncoderDecoderModel:
@@ -886,7 +886,7 @@ class FlaxEncoderDecoderModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxGPT2LMHeadModel:
@@ -898,7 +898,7 @@ class FlaxGPT2LMHeadModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxGPT2Model:
@@ -910,7 +910,7 @@ class FlaxGPT2Model:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxGPT2PreTrainedModel:
@@ -922,7 +922,7 @@ class FlaxGPT2PreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxGPTNeoForCausalLM:
@@ -934,7 +934,7 @@ class FlaxGPTNeoForCausalLM:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxGPTNeoModel:
@@ -946,7 +946,7 @@ class FlaxGPTNeoModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxGPTNeoPreTrainedModel:
@@ -958,7 +958,7 @@ class FlaxGPTNeoPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxMarianModel:
@@ -970,7 +970,7 @@ class FlaxMarianModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxMarianMTModel:
@@ -982,7 +982,7 @@ class FlaxMarianMTModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxMarianPreTrainedModel:
@@ -994,7 +994,7 @@ class FlaxMarianPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxMBartForConditionalGeneration:
@@ -1006,7 +1006,7 @@ class FlaxMBartForConditionalGeneration:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxMBartForQuestionAnswering:
@@ -1018,7 +1018,7 @@ class FlaxMBartForQuestionAnswering:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxMBartForSequenceClassification:
@@ -1030,7 +1030,7 @@ class FlaxMBartForSequenceClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxMBartModel:
@@ -1042,7 +1042,7 @@ class FlaxMBartModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxMBartPreTrainedModel:
@@ -1054,7 +1054,7 @@ class FlaxMBartPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxMT5ForConditionalGeneration:
@@ -1066,7 +1066,7 @@ class FlaxMT5ForConditionalGeneration:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxMT5Model:
@@ -1078,7 +1078,7 @@ class FlaxMT5Model:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxPegasusForConditionalGeneration:
@@ -1090,7 +1090,7 @@ class FlaxPegasusForConditionalGeneration:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxPegasusModel:
@@ -1102,7 +1102,7 @@ class FlaxPegasusModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxPegasusPreTrainedModel:
@@ -1114,7 +1114,7 @@ class FlaxPegasusPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxRobertaForMaskedLM:
@@ -1126,7 +1126,7 @@ class FlaxRobertaForMaskedLM:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxRobertaForMultipleChoice:
@@ -1138,7 +1138,7 @@ class FlaxRobertaForMultipleChoice:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxRobertaForQuestionAnswering:
@@ -1150,7 +1150,7 @@ class FlaxRobertaForQuestionAnswering:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxRobertaForSequenceClassification:
@@ -1162,7 +1162,7 @@ class FlaxRobertaForSequenceClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxRobertaForTokenClassification:
@@ -1174,7 +1174,7 @@ class FlaxRobertaForTokenClassification:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxRobertaModel:
@@ -1186,7 +1186,7 @@ class FlaxRobertaModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxRobertaPreTrainedModel:
@@ -1198,7 +1198,7 @@ class FlaxRobertaPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxT5ForConditionalGeneration:
@@ -1210,7 +1210,7 @@ class FlaxT5ForConditionalGeneration:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxT5Model:
@@ -1222,7 +1222,7 @@ class FlaxT5Model:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxT5PreTrainedModel:
@@ -1234,7 +1234,7 @@ class FlaxT5PreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxVisionEncoderDecoderModel:
@@ -1246,7 +1246,7 @@ class FlaxVisionEncoderDecoderModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxViTForImageClassification:
@@ -1263,7 +1263,7 @@ class FlaxViTModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxViTPreTrainedModel:
@@ -1275,7 +1275,7 @@ class FlaxViTPreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxWav2Vec2ForCTC:
@@ -1297,7 +1297,7 @@ class FlaxWav2Vec2Model:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])
 
 
 class FlaxWav2Vec2PreTrainedModel:
@@ -1309,4 +1309,4 @@ class FlaxWav2Vec2PreTrainedModel:
         requires_backends(cls, ["flax"])
 
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, ["flax"])
+        requires_backends(self, ["flax"])

--- a/src/transformers/utils/dummy_flax_objects.py
+++ b/src/transformers/utils/dummy_flax_objects.py
@@ -75,6 +75,9 @@ class FlaxPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxAlbertForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -84,6 +87,9 @@ class FlaxAlbertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxAlbertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -91,6 +97,9 @@ class FlaxAlbertForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -107,6 +116,9 @@ class FlaxAlbertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxAlbertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -114,6 +126,9 @@ class FlaxAlbertForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -125,6 +140,9 @@ class FlaxAlbertForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxAlbertModel:
     def __init__(self, *args, **kwargs):
@@ -134,6 +152,9 @@ class FlaxAlbertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxAlbertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -141,6 +162,9 @@ class FlaxAlbertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -188,6 +212,9 @@ class FlaxAutoModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxAutoModelForCausalLM:
     def __init__(self, *args, **kwargs):
@@ -195,6 +222,9 @@ class FlaxAutoModelForCausalLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -206,6 +236,9 @@ class FlaxAutoModelForImageClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxAutoModelForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -213,6 +246,9 @@ class FlaxAutoModelForMaskedLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -224,6 +260,9 @@ class FlaxAutoModelForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxAutoModelForNextSentencePrediction:
     def __init__(self, *args, **kwargs):
@@ -231,6 +270,9 @@ class FlaxAutoModelForNextSentencePrediction:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -242,6 +284,9 @@ class FlaxAutoModelForPreTraining:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxAutoModelForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -249,6 +294,9 @@ class FlaxAutoModelForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -260,6 +308,9 @@ class FlaxAutoModelForSeq2SeqLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxAutoModelForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -267,6 +318,9 @@ class FlaxAutoModelForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -278,6 +332,9 @@ class FlaxAutoModelForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxAutoModelForVision2Seq:
     def __init__(self, *args, **kwargs):
@@ -285,6 +342,9 @@ class FlaxAutoModelForVision2Seq:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -296,6 +356,9 @@ class FlaxBartForConditionalGeneration:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxBartForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -303,6 +366,9 @@ class FlaxBartForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -314,6 +380,9 @@ class FlaxBartForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxBartModel:
     def __init__(self, *args, **kwargs):
@@ -323,6 +392,9 @@ class FlaxBartModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxBartPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -330,6 +402,9 @@ class FlaxBartPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -346,6 +421,9 @@ class FlaxBeitForMaskedImageModeling:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxBeitModel:
     def __init__(self, *args, **kwargs):
@@ -353,6 +431,9 @@ class FlaxBeitModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -364,6 +445,9 @@ class FlaxBeitPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxBertForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -373,6 +457,9 @@ class FlaxBertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxBertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -380,6 +467,9 @@ class FlaxBertForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -401,6 +491,9 @@ class FlaxBertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxBertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -408,6 +501,9 @@ class FlaxBertForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -419,6 +515,9 @@ class FlaxBertForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxBertModel:
     def __init__(self, *args, **kwargs):
@@ -426,6 +525,9 @@ class FlaxBertModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -437,6 +539,9 @@ class FlaxBertPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxBigBirdForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -446,6 +551,9 @@ class FlaxBigBirdForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxBigBirdForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -453,6 +561,9 @@ class FlaxBigBirdForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -469,6 +580,9 @@ class FlaxBigBirdForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxBigBirdForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -476,6 +590,9 @@ class FlaxBigBirdForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -487,6 +604,9 @@ class FlaxBigBirdForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxBigBirdModel:
     def __init__(self, *args, **kwargs):
@@ -494,6 +614,9 @@ class FlaxBigBirdModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -505,6 +628,9 @@ class FlaxBigBirdPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxCLIPModel:
     def __init__(self, *args, **kwargs):
@@ -512,6 +638,9 @@ class FlaxCLIPModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -523,6 +652,9 @@ class FlaxCLIPPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxCLIPTextModel:
     def __init__(self, *args, **kwargs):
@@ -530,6 +662,9 @@ class FlaxCLIPTextModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -541,6 +676,9 @@ class FlaxCLIPTextPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxCLIPVisionModel:
     def __init__(self, *args, **kwargs):
@@ -548,6 +686,9 @@ class FlaxCLIPVisionModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -559,6 +700,9 @@ class FlaxCLIPVisionPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxDistilBertForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -566,6 +710,9 @@ class FlaxDistilBertForMaskedLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -577,6 +724,9 @@ class FlaxDistilBertForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxDistilBertForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -584,6 +734,9 @@ class FlaxDistilBertForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -595,6 +748,9 @@ class FlaxDistilBertForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxDistilBertForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -602,6 +758,9 @@ class FlaxDistilBertForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -613,6 +772,9 @@ class FlaxDistilBertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxDistilBertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -620,6 +782,9 @@ class FlaxDistilBertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -631,6 +796,9 @@ class FlaxElectraForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxElectraForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -638,6 +806,9 @@ class FlaxElectraForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -654,6 +825,9 @@ class FlaxElectraForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxElectraForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -661,6 +835,9 @@ class FlaxElectraForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -672,6 +849,9 @@ class FlaxElectraForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxElectraModel:
     def __init__(self, *args, **kwargs):
@@ -679,6 +859,9 @@ class FlaxElectraModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -690,6 +873,9 @@ class FlaxElectraPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxEncoderDecoderModel:
     def __init__(self, *args, **kwargs):
@@ -697,6 +883,9 @@ class FlaxEncoderDecoderModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -708,6 +897,9 @@ class FlaxGPT2LMHeadModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxGPT2Model:
     def __init__(self, *args, **kwargs):
@@ -715,6 +907,9 @@ class FlaxGPT2Model:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -726,6 +921,9 @@ class FlaxGPT2PreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxGPTNeoForCausalLM:
     def __init__(self, *args, **kwargs):
@@ -733,6 +931,9 @@ class FlaxGPTNeoForCausalLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -744,6 +945,9 @@ class FlaxGPTNeoModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxGPTNeoPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -751,6 +955,9 @@ class FlaxGPTNeoPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -762,6 +969,9 @@ class FlaxMarianModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxMarianMTModel:
     def __init__(self, *args, **kwargs):
@@ -769,6 +979,9 @@ class FlaxMarianMTModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -780,6 +993,9 @@ class FlaxMarianPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxMBartForConditionalGeneration:
     def __init__(self, *args, **kwargs):
@@ -787,6 +1003,9 @@ class FlaxMBartForConditionalGeneration:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -798,6 +1017,9 @@ class FlaxMBartForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxMBartForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -805,6 +1027,9 @@ class FlaxMBartForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -816,6 +1041,9 @@ class FlaxMBartModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxMBartPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -823,6 +1051,9 @@ class FlaxMBartPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -834,6 +1065,9 @@ class FlaxMT5ForConditionalGeneration:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxMT5Model:
     def __init__(self, *args, **kwargs):
@@ -841,6 +1075,9 @@ class FlaxMT5Model:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -852,6 +1089,9 @@ class FlaxPegasusForConditionalGeneration:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxPegasusModel:
     def __init__(self, *args, **kwargs):
@@ -859,6 +1099,9 @@ class FlaxPegasusModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -870,6 +1113,9 @@ class FlaxPegasusPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxRobertaForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -877,6 +1123,9 @@ class FlaxRobertaForMaskedLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -888,6 +1137,9 @@ class FlaxRobertaForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxRobertaForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -895,6 +1147,9 @@ class FlaxRobertaForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -906,6 +1161,9 @@ class FlaxRobertaForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxRobertaForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -913,6 +1171,9 @@ class FlaxRobertaForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -924,6 +1185,9 @@ class FlaxRobertaModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxRobertaPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -931,6 +1195,9 @@ class FlaxRobertaPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -942,6 +1209,9 @@ class FlaxT5ForConditionalGeneration:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxT5Model:
     def __init__(self, *args, **kwargs):
@@ -949,6 +1219,9 @@ class FlaxT5Model:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -960,6 +1233,9 @@ class FlaxT5PreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxVisionEncoderDecoderModel:
     def __init__(self, *args, **kwargs):
@@ -967,6 +1243,9 @@ class FlaxVisionEncoderDecoderModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -983,6 +1262,9 @@ class FlaxViTModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxViTPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -990,6 +1272,9 @@ class FlaxViTPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
 
@@ -1011,6 +1296,9 @@ class FlaxWav2Vec2Model:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["flax"])
 
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
 
 class FlaxWav2Vec2PreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1018,4 +1306,7 @@ class FlaxWav2Vec2PreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
         requires_backends(cls, ["flax"])

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -224,7 +224,7 @@ class PreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def apply_chunking_to_forward(*args, **kwargs):
@@ -247,7 +247,7 @@ class AlbertForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AlbertForMultipleChoice:
@@ -259,7 +259,7 @@ class AlbertForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AlbertForPreTraining:
@@ -276,7 +276,7 @@ class AlbertForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AlbertForSequenceClassification:
@@ -288,7 +288,7 @@ class AlbertForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AlbertForTokenClassification:
@@ -300,7 +300,7 @@ class AlbertForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AlbertModel:
@@ -312,7 +312,7 @@ class AlbertModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AlbertPreTrainedModel:
@@ -324,7 +324,7 @@ class AlbertPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_albert(*args, **kwargs):
@@ -397,7 +397,7 @@ class AutoModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForAudioClassification:
@@ -409,7 +409,7 @@ class AutoModelForAudioClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForCausalLM:
@@ -421,7 +421,7 @@ class AutoModelForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForCTC:
@@ -433,7 +433,7 @@ class AutoModelForCTC:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForImageClassification:
@@ -445,7 +445,7 @@ class AutoModelForImageClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForImageSegmentation:
@@ -457,7 +457,7 @@ class AutoModelForImageSegmentation:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForMaskedLM:
@@ -469,7 +469,7 @@ class AutoModelForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForMultipleChoice:
@@ -481,7 +481,7 @@ class AutoModelForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForNextSentencePrediction:
@@ -493,7 +493,7 @@ class AutoModelForNextSentencePrediction:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForObjectDetection:
@@ -505,7 +505,7 @@ class AutoModelForObjectDetection:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForPreTraining:
@@ -517,7 +517,7 @@ class AutoModelForPreTraining:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForQuestionAnswering:
@@ -529,7 +529,7 @@ class AutoModelForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForSeq2SeqLM:
@@ -541,7 +541,7 @@ class AutoModelForSeq2SeqLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForSequenceClassification:
@@ -553,7 +553,7 @@ class AutoModelForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForSpeechSeq2Seq:
@@ -565,7 +565,7 @@ class AutoModelForSpeechSeq2Seq:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForTableQuestionAnswering:
@@ -577,7 +577,7 @@ class AutoModelForTableQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForTokenClassification:
@@ -589,7 +589,7 @@ class AutoModelForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelForVision2Seq:
@@ -601,7 +601,7 @@ class AutoModelForVision2Seq:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class AutoModelWithLMHead:
@@ -613,7 +613,7 @@ class AutoModelWithLMHead:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 BART_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -628,7 +628,7 @@ class BartForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BartForConditionalGeneration:
@@ -640,7 +640,7 @@ class BartForConditionalGeneration:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BartForQuestionAnswering:
@@ -652,7 +652,7 @@ class BartForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BartForSequenceClassification:
@@ -664,7 +664,7 @@ class BartForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BartModel:
@@ -676,7 +676,7 @@ class BartModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BartPretrainedModel:
@@ -688,7 +688,7 @@ class BartPretrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class PretrainedBartModel:
@@ -700,7 +700,7 @@ class PretrainedBartModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 BEIT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -720,7 +720,7 @@ class BeitForMaskedImageModeling:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BeitForSemanticSegmentation:
@@ -737,7 +737,7 @@ class BeitModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BeitPreTrainedModel:
@@ -749,7 +749,7 @@ class BeitPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 BERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -764,7 +764,7 @@ class BertForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BertForMultipleChoice:
@@ -776,7 +776,7 @@ class BertForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BertForNextSentencePrediction:
@@ -798,7 +798,7 @@ class BertForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BertForSequenceClassification:
@@ -810,7 +810,7 @@ class BertForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BertForTokenClassification:
@@ -822,7 +822,7 @@ class BertForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BertLayer:
@@ -839,7 +839,7 @@ class BertLMHeadModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BertModel:
@@ -851,7 +851,7 @@ class BertModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BertPreTrainedModel:
@@ -863,7 +863,7 @@ class BertPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_bert(*args, **kwargs):
@@ -889,7 +889,7 @@ class BertGenerationPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_bert_generation(*args, **kwargs):
@@ -908,7 +908,7 @@ class BigBirdForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BigBirdForMaskedLM:
@@ -920,7 +920,7 @@ class BigBirdForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BigBirdForMultipleChoice:
@@ -932,7 +932,7 @@ class BigBirdForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BigBirdForPreTraining:
@@ -949,7 +949,7 @@ class BigBirdForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BigBirdForSequenceClassification:
@@ -961,7 +961,7 @@ class BigBirdForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BigBirdForTokenClassification:
@@ -973,7 +973,7 @@ class BigBirdForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BigBirdLayer:
@@ -990,7 +990,7 @@ class BigBirdModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BigBirdPreTrainedModel:
@@ -1002,7 +1002,7 @@ class BigBirdPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_big_bird(*args, **kwargs):
@@ -1021,7 +1021,7 @@ class BigBirdPegasusForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BigBirdPegasusForConditionalGeneration:
@@ -1033,7 +1033,7 @@ class BigBirdPegasusForConditionalGeneration:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BigBirdPegasusForQuestionAnswering:
@@ -1045,7 +1045,7 @@ class BigBirdPegasusForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BigBirdPegasusForSequenceClassification:
@@ -1057,7 +1057,7 @@ class BigBirdPegasusForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BigBirdPegasusModel:
@@ -1069,7 +1069,7 @@ class BigBirdPegasusModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BigBirdPegasusPreTrainedModel:
@@ -1081,7 +1081,7 @@ class BigBirdPegasusPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 BLENDERBOT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1096,7 +1096,7 @@ class BlenderbotForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BlenderbotForConditionalGeneration:
@@ -1108,7 +1108,7 @@ class BlenderbotForConditionalGeneration:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BlenderbotModel:
@@ -1120,7 +1120,7 @@ class BlenderbotModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BlenderbotPreTrainedModel:
@@ -1132,7 +1132,7 @@ class BlenderbotPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 BLENDERBOT_SMALL_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1147,7 +1147,7 @@ class BlenderbotSmallForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BlenderbotSmallForConditionalGeneration:
@@ -1159,7 +1159,7 @@ class BlenderbotSmallForConditionalGeneration:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BlenderbotSmallModel:
@@ -1171,7 +1171,7 @@ class BlenderbotSmallModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class BlenderbotSmallPreTrainedModel:
@@ -1183,7 +1183,7 @@ class BlenderbotSmallPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 CAMEMBERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1198,7 +1198,7 @@ class CamembertForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CamembertForMaskedLM:
@@ -1210,7 +1210,7 @@ class CamembertForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CamembertForMultipleChoice:
@@ -1222,7 +1222,7 @@ class CamembertForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CamembertForQuestionAnswering:
@@ -1234,7 +1234,7 @@ class CamembertForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CamembertForSequenceClassification:
@@ -1246,7 +1246,7 @@ class CamembertForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CamembertForTokenClassification:
@@ -1258,7 +1258,7 @@ class CamembertForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CamembertModel:
@@ -1270,7 +1270,7 @@ class CamembertModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 CANINE_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1285,7 +1285,7 @@ class CanineForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CanineForQuestionAnswering:
@@ -1297,7 +1297,7 @@ class CanineForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CanineForSequenceClassification:
@@ -1309,7 +1309,7 @@ class CanineForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CanineForTokenClassification:
@@ -1321,7 +1321,7 @@ class CanineForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CanineLayer:
@@ -1338,7 +1338,7 @@ class CanineModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CaninePreTrainedModel:
@@ -1350,7 +1350,7 @@ class CaninePreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_canine(*args, **kwargs):
@@ -1369,7 +1369,7 @@ class CLIPModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CLIPPreTrainedModel:
@@ -1381,7 +1381,7 @@ class CLIPPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CLIPTextModel:
@@ -1393,7 +1393,7 @@ class CLIPTextModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CLIPVisionModel:
@@ -1405,7 +1405,7 @@ class CLIPVisionModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 CONVBERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1420,7 +1420,7 @@ class ConvBertForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ConvBertForMultipleChoice:
@@ -1432,7 +1432,7 @@ class ConvBertForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ConvBertForQuestionAnswering:
@@ -1444,7 +1444,7 @@ class ConvBertForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ConvBertForSequenceClassification:
@@ -1456,7 +1456,7 @@ class ConvBertForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ConvBertForTokenClassification:
@@ -1468,7 +1468,7 @@ class ConvBertForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ConvBertLayer:
@@ -1485,7 +1485,7 @@ class ConvBertModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ConvBertPreTrainedModel:
@@ -1497,7 +1497,7 @@ class ConvBertPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_convbert(*args, **kwargs):
@@ -1516,7 +1516,7 @@ class CTRLForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CTRLLMHeadModel:
@@ -1528,7 +1528,7 @@ class CTRLLMHeadModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CTRLModel:
@@ -1540,7 +1540,7 @@ class CTRLModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class CTRLPreTrainedModel:
@@ -1552,7 +1552,7 @@ class CTRLPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 DEBERTA_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1567,7 +1567,7 @@ class DebertaForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DebertaForQuestionAnswering:
@@ -1579,7 +1579,7 @@ class DebertaForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DebertaForSequenceClassification:
@@ -1591,7 +1591,7 @@ class DebertaForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DebertaForTokenClassification:
@@ -1603,7 +1603,7 @@ class DebertaForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DebertaModel:
@@ -1615,7 +1615,7 @@ class DebertaModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DebertaPreTrainedModel:
@@ -1627,7 +1627,7 @@ class DebertaPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 DEBERTA_V2_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1642,7 +1642,7 @@ class DebertaV2ForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DebertaV2ForQuestionAnswering:
@@ -1654,7 +1654,7 @@ class DebertaV2ForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DebertaV2ForSequenceClassification:
@@ -1666,7 +1666,7 @@ class DebertaV2ForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DebertaV2ForTokenClassification:
@@ -1678,7 +1678,7 @@ class DebertaV2ForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DebertaV2Model:
@@ -1690,7 +1690,7 @@ class DebertaV2Model:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DebertaV2PreTrainedModel:
@@ -1702,7 +1702,7 @@ class DebertaV2PreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 DEIT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1727,7 +1727,7 @@ class DeiTModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DeiTPreTrainedModel:
@@ -1739,7 +1739,7 @@ class DeiTPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 DISTILBERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1754,7 +1754,7 @@ class DistilBertForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DistilBertForMultipleChoice:
@@ -1766,7 +1766,7 @@ class DistilBertForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DistilBertForQuestionAnswering:
@@ -1778,7 +1778,7 @@ class DistilBertForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DistilBertForSequenceClassification:
@@ -1790,7 +1790,7 @@ class DistilBertForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DistilBertForTokenClassification:
@@ -1802,7 +1802,7 @@ class DistilBertForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DistilBertModel:
@@ -1814,7 +1814,7 @@ class DistilBertModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DistilBertPreTrainedModel:
@@ -1826,7 +1826,7 @@ class DistilBertPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 DPR_CONTEXT_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1857,7 +1857,7 @@ class DPRPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class DPRPretrainedQuestionEncoder:
@@ -1892,7 +1892,7 @@ class ElectraForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ElectraForMultipleChoice:
@@ -1904,7 +1904,7 @@ class ElectraForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ElectraForPreTraining:
@@ -1921,7 +1921,7 @@ class ElectraForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ElectraForSequenceClassification:
@@ -1933,7 +1933,7 @@ class ElectraForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ElectraForTokenClassification:
@@ -1945,7 +1945,7 @@ class ElectraForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ElectraModel:
@@ -1957,7 +1957,7 @@ class ElectraModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ElectraPreTrainedModel:
@@ -1969,7 +1969,7 @@ class ElectraPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_electra(*args, **kwargs):
@@ -1985,7 +1985,7 @@ class EncoderDecoderModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 FLAUBERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2000,7 +2000,7 @@ class FlaubertForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FlaubertForQuestionAnswering:
@@ -2012,7 +2012,7 @@ class FlaubertForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FlaubertForQuestionAnsweringSimple:
@@ -2024,7 +2024,7 @@ class FlaubertForQuestionAnsweringSimple:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FlaubertForSequenceClassification:
@@ -2036,7 +2036,7 @@ class FlaubertForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FlaubertForTokenClassification:
@@ -2048,7 +2048,7 @@ class FlaubertForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FlaubertModel:
@@ -2060,7 +2060,7 @@ class FlaubertModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FlaubertWithLMHeadModel:
@@ -2072,7 +2072,7 @@ class FlaubertWithLMHeadModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 FNET_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2087,7 +2087,7 @@ class FNetForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FNetForMultipleChoice:
@@ -2099,7 +2099,7 @@ class FNetForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FNetForNextSentencePrediction:
@@ -2121,7 +2121,7 @@ class FNetForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FNetForSequenceClassification:
@@ -2133,7 +2133,7 @@ class FNetForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FNetForTokenClassification:
@@ -2145,7 +2145,7 @@ class FNetForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FNetLayer:
@@ -2162,7 +2162,7 @@ class FNetModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FNetPreTrainedModel:
@@ -2174,7 +2174,7 @@ class FNetPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FSMTForConditionalGeneration:
@@ -2186,7 +2186,7 @@ class FSMTForConditionalGeneration:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FSMTModel:
@@ -2198,7 +2198,7 @@ class FSMTModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class PretrainedFSMTModel:
@@ -2210,7 +2210,7 @@ class PretrainedFSMTModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 FUNNEL_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2225,7 +2225,7 @@ class FunnelBaseModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FunnelForMaskedLM:
@@ -2237,7 +2237,7 @@ class FunnelForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FunnelForMultipleChoice:
@@ -2249,7 +2249,7 @@ class FunnelForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FunnelForPreTraining:
@@ -2266,7 +2266,7 @@ class FunnelForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FunnelForSequenceClassification:
@@ -2278,7 +2278,7 @@ class FunnelForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FunnelForTokenClassification:
@@ -2290,7 +2290,7 @@ class FunnelForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FunnelModel:
@@ -2302,7 +2302,7 @@ class FunnelModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class FunnelPreTrainedModel:
@@ -2314,7 +2314,7 @@ class FunnelPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_funnel(*args, **kwargs):
@@ -2333,7 +2333,7 @@ class GPT2DoubleHeadsModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class GPT2ForSequenceClassification:
@@ -2345,7 +2345,7 @@ class GPT2ForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class GPT2ForTokenClassification:
@@ -2357,7 +2357,7 @@ class GPT2ForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class GPT2LMHeadModel:
@@ -2369,7 +2369,7 @@ class GPT2LMHeadModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class GPT2Model:
@@ -2381,7 +2381,7 @@ class GPT2Model:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class GPT2PreTrainedModel:
@@ -2393,7 +2393,7 @@ class GPT2PreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_gpt2(*args, **kwargs):
@@ -2412,7 +2412,7 @@ class GPTNeoForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class GPTNeoForSequenceClassification:
@@ -2424,7 +2424,7 @@ class GPTNeoForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class GPTNeoModel:
@@ -2436,7 +2436,7 @@ class GPTNeoModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class GPTNeoPreTrainedModel:
@@ -2448,7 +2448,7 @@ class GPTNeoPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_gpt_neo(*args, **kwargs):
@@ -2467,7 +2467,7 @@ class GPTJForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class GPTJForSequenceClassification:
@@ -2479,7 +2479,7 @@ class GPTJForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class GPTJModel:
@@ -2491,7 +2491,7 @@ class GPTJModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class GPTJPreTrainedModel:
@@ -2503,7 +2503,7 @@ class GPTJPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 HUBERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2523,7 +2523,7 @@ class HubertForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class HubertModel:
@@ -2535,7 +2535,7 @@ class HubertModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class HubertPreTrainedModel:
@@ -2547,7 +2547,7 @@ class HubertPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 IBERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2562,7 +2562,7 @@ class IBertForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class IBertForMultipleChoice:
@@ -2574,7 +2574,7 @@ class IBertForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class IBertForQuestionAnswering:
@@ -2586,7 +2586,7 @@ class IBertForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class IBertForSequenceClassification:
@@ -2598,7 +2598,7 @@ class IBertForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class IBertForTokenClassification:
@@ -2610,7 +2610,7 @@ class IBertForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class IBertModel:
@@ -2622,7 +2622,7 @@ class IBertModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class IBertPreTrainedModel:
@@ -2634,7 +2634,7 @@ class IBertPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 LAYOUTLM_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2649,7 +2649,7 @@ class LayoutLMForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LayoutLMForSequenceClassification:
@@ -2661,7 +2661,7 @@ class LayoutLMForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LayoutLMForTokenClassification:
@@ -2673,7 +2673,7 @@ class LayoutLMForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LayoutLMModel:
@@ -2685,7 +2685,7 @@ class LayoutLMModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LayoutLMPreTrainedModel:
@@ -2697,7 +2697,7 @@ class LayoutLMPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 LAYOUTLMV2_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2712,7 +2712,7 @@ class LayoutLMv2ForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LayoutLMv2ForSequenceClassification:
@@ -2724,7 +2724,7 @@ class LayoutLMv2ForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LayoutLMv2ForTokenClassification:
@@ -2736,7 +2736,7 @@ class LayoutLMv2ForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LayoutLMv2Model:
@@ -2748,7 +2748,7 @@ class LayoutLMv2Model:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LayoutLMv2PreTrainedModel:
@@ -2760,7 +2760,7 @@ class LayoutLMv2PreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 LED_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2775,7 +2775,7 @@ class LEDForConditionalGeneration:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LEDForQuestionAnswering:
@@ -2787,7 +2787,7 @@ class LEDForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LEDForSequenceClassification:
@@ -2799,7 +2799,7 @@ class LEDForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LEDModel:
@@ -2811,7 +2811,7 @@ class LEDModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LEDPreTrainedModel:
@@ -2823,7 +2823,7 @@ class LEDPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 LONGFORMER_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2838,7 +2838,7 @@ class LongformerForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LongformerForMultipleChoice:
@@ -2850,7 +2850,7 @@ class LongformerForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LongformerForQuestionAnswering:
@@ -2862,7 +2862,7 @@ class LongformerForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LongformerForSequenceClassification:
@@ -2874,7 +2874,7 @@ class LongformerForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LongformerForTokenClassification:
@@ -2886,7 +2886,7 @@ class LongformerForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LongformerModel:
@@ -2898,7 +2898,7 @@ class LongformerModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LongformerPreTrainedModel:
@@ -2910,7 +2910,7 @@ class LongformerPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LongformerSelfAttention:
@@ -2945,7 +2945,7 @@ class LukeModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LukePreTrainedModel:
@@ -2957,7 +2957,7 @@ class LukePreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LxmertEncoder:
@@ -2979,7 +2979,7 @@ class LxmertForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LxmertModel:
@@ -2991,7 +2991,7 @@ class LxmertModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LxmertPreTrainedModel:
@@ -3003,7 +3003,7 @@ class LxmertPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class LxmertVisualFeatureEncoder:
@@ -3028,7 +3028,7 @@ class M2M100ForConditionalGeneration:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class M2M100Model:
@@ -3040,7 +3040,7 @@ class M2M100Model:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class M2M100PreTrainedModel:
@@ -3052,7 +3052,7 @@ class M2M100PreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MarianForCausalLM:
@@ -3064,7 +3064,7 @@ class MarianForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MarianModel:
@@ -3076,7 +3076,7 @@ class MarianModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MarianMTModel:
@@ -3088,7 +3088,7 @@ class MarianMTModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MBartForCausalLM:
@@ -3100,7 +3100,7 @@ class MBartForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MBartForConditionalGeneration:
@@ -3112,7 +3112,7 @@ class MBartForConditionalGeneration:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MBartForQuestionAnswering:
@@ -3124,7 +3124,7 @@ class MBartForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MBartForSequenceClassification:
@@ -3136,7 +3136,7 @@ class MBartForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MBartModel:
@@ -3148,7 +3148,7 @@ class MBartModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MBartPreTrainedModel:
@@ -3160,7 +3160,7 @@ class MBartPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 MEGATRON_BERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -3175,7 +3175,7 @@ class MegatronBertForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MegatronBertForMaskedLM:
@@ -3187,7 +3187,7 @@ class MegatronBertForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MegatronBertForMultipleChoice:
@@ -3199,7 +3199,7 @@ class MegatronBertForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MegatronBertForNextSentencePrediction:
@@ -3221,7 +3221,7 @@ class MegatronBertForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MegatronBertForSequenceClassification:
@@ -3233,7 +3233,7 @@ class MegatronBertForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MegatronBertForTokenClassification:
@@ -3245,7 +3245,7 @@ class MegatronBertForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MegatronBertModel:
@@ -3257,7 +3257,7 @@ class MegatronBertModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MegatronBertPreTrainedModel:
@@ -3269,7 +3269,7 @@ class MegatronBertPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MMBTForClassification:
@@ -3286,7 +3286,7 @@ class MMBTModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ModalEmbeddings:
@@ -3306,7 +3306,7 @@ class MobileBertForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MobileBertForMultipleChoice:
@@ -3318,7 +3318,7 @@ class MobileBertForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MobileBertForNextSentencePrediction:
@@ -3340,7 +3340,7 @@ class MobileBertForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MobileBertForSequenceClassification:
@@ -3352,7 +3352,7 @@ class MobileBertForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MobileBertForTokenClassification:
@@ -3364,7 +3364,7 @@ class MobileBertForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MobileBertLayer:
@@ -3381,7 +3381,7 @@ class MobileBertModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MobileBertPreTrainedModel:
@@ -3393,7 +3393,7 @@ class MobileBertPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_mobilebert(*args, **kwargs):
@@ -3412,7 +3412,7 @@ class MPNetForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MPNetForMultipleChoice:
@@ -3424,7 +3424,7 @@ class MPNetForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MPNetForQuestionAnswering:
@@ -3436,7 +3436,7 @@ class MPNetForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MPNetForSequenceClassification:
@@ -3448,7 +3448,7 @@ class MPNetForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MPNetForTokenClassification:
@@ -3460,7 +3460,7 @@ class MPNetForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MPNetLayer:
@@ -3477,7 +3477,7 @@ class MPNetModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MPNetPreTrainedModel:
@@ -3489,7 +3489,7 @@ class MPNetPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MT5EncoderModel:
@@ -3501,7 +3501,7 @@ class MT5EncoderModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MT5ForConditionalGeneration:
@@ -3513,7 +3513,7 @@ class MT5ForConditionalGeneration:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class MT5Model:
@@ -3525,7 +3525,7 @@ class MT5Model:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 OPENAI_GPT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -3540,7 +3540,7 @@ class OpenAIGPTDoubleHeadsModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class OpenAIGPTForSequenceClassification:
@@ -3552,7 +3552,7 @@ class OpenAIGPTForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class OpenAIGPTLMHeadModel:
@@ -3564,7 +3564,7 @@ class OpenAIGPTLMHeadModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class OpenAIGPTModel:
@@ -3576,7 +3576,7 @@ class OpenAIGPTModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class OpenAIGPTPreTrainedModel:
@@ -3588,7 +3588,7 @@ class OpenAIGPTPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_openai_gpt(*args, **kwargs):
@@ -3604,7 +3604,7 @@ class PegasusForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class PegasusForConditionalGeneration:
@@ -3616,7 +3616,7 @@ class PegasusForConditionalGeneration:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class PegasusModel:
@@ -3628,7 +3628,7 @@ class PegasusModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class PegasusPreTrainedModel:
@@ -3640,7 +3640,7 @@ class PegasusPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 PROPHETNET_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -3665,7 +3665,7 @@ class ProphetNetForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ProphetNetForConditionalGeneration:
@@ -3677,7 +3677,7 @@ class ProphetNetForConditionalGeneration:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ProphetNetModel:
@@ -3689,7 +3689,7 @@ class ProphetNetModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ProphetNetPreTrainedModel:
@@ -3701,7 +3701,7 @@ class ProphetNetPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RagModel:
@@ -3713,7 +3713,7 @@ class RagModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RagPreTrainedModel:
@@ -3725,7 +3725,7 @@ class RagPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RagSequenceForGeneration:
@@ -3755,7 +3755,7 @@ class ReformerForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ReformerForQuestionAnswering:
@@ -3767,7 +3767,7 @@ class ReformerForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ReformerForSequenceClassification:
@@ -3779,7 +3779,7 @@ class ReformerForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ReformerLayer:
@@ -3796,7 +3796,7 @@ class ReformerModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ReformerModelWithLMHead:
@@ -3808,7 +3808,7 @@ class ReformerModelWithLMHead:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ReformerPreTrainedModel:
@@ -3820,7 +3820,7 @@ class ReformerPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 REMBERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -3835,7 +3835,7 @@ class RemBertForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RemBertForMaskedLM:
@@ -3847,7 +3847,7 @@ class RemBertForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RemBertForMultipleChoice:
@@ -3859,7 +3859,7 @@ class RemBertForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RemBertForQuestionAnswering:
@@ -3871,7 +3871,7 @@ class RemBertForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RemBertForSequenceClassification:
@@ -3883,7 +3883,7 @@ class RemBertForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RemBertForTokenClassification:
@@ -3895,7 +3895,7 @@ class RemBertForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RemBertLayer:
@@ -3912,7 +3912,7 @@ class RemBertModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RemBertPreTrainedModel:
@@ -3924,7 +3924,7 @@ class RemBertPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_rembert(*args, **kwargs):
@@ -3943,7 +3943,7 @@ class RetriBertModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RetriBertPreTrainedModel:
@@ -3955,7 +3955,7 @@ class RetriBertPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -3970,7 +3970,7 @@ class RobertaForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RobertaForMaskedLM:
@@ -3982,7 +3982,7 @@ class RobertaForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RobertaForMultipleChoice:
@@ -3994,7 +3994,7 @@ class RobertaForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RobertaForQuestionAnswering:
@@ -4006,7 +4006,7 @@ class RobertaForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RobertaForSequenceClassification:
@@ -4018,7 +4018,7 @@ class RobertaForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RobertaForTokenClassification:
@@ -4030,7 +4030,7 @@ class RobertaForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RobertaModel:
@@ -4042,7 +4042,7 @@ class RobertaModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RobertaPreTrainedModel:
@@ -4054,7 +4054,7 @@ class RobertaPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 ROFORMER_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -4069,7 +4069,7 @@ class RoFormerForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RoFormerForMaskedLM:
@@ -4081,7 +4081,7 @@ class RoFormerForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RoFormerForMultipleChoice:
@@ -4093,7 +4093,7 @@ class RoFormerForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RoFormerForQuestionAnswering:
@@ -4105,7 +4105,7 @@ class RoFormerForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RoFormerForSequenceClassification:
@@ -4117,7 +4117,7 @@ class RoFormerForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RoFormerForTokenClassification:
@@ -4129,7 +4129,7 @@ class RoFormerForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RoFormerLayer:
@@ -4146,7 +4146,7 @@ class RoFormerModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class RoFormerPreTrainedModel:
@@ -4158,7 +4158,7 @@ class RoFormerPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_roformer(*args, **kwargs):
@@ -4197,7 +4197,7 @@ class SegformerModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class SegformerPreTrainedModel:
@@ -4209,7 +4209,7 @@ class SegformerPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 SEW_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -4229,7 +4229,7 @@ class SEWForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class SEWModel:
@@ -4241,7 +4241,7 @@ class SEWModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class SEWPreTrainedModel:
@@ -4253,7 +4253,7 @@ class SEWPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 SEW_D_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -4273,7 +4273,7 @@ class SEWDForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class SEWDModel:
@@ -4285,7 +4285,7 @@ class SEWDModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class SEWDPreTrainedModel:
@@ -4297,7 +4297,7 @@ class SEWDPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class SpeechEncoderDecoderModel:
@@ -4309,7 +4309,7 @@ class SpeechEncoderDecoderModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 SPEECH_TO_TEXT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -4324,7 +4324,7 @@ class Speech2TextForConditionalGeneration:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class Speech2TextModel:
@@ -4336,7 +4336,7 @@ class Speech2TextModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class Speech2TextPreTrainedModel:
@@ -4348,7 +4348,7 @@ class Speech2TextPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class Speech2Text2ForCausalLM:
@@ -4360,7 +4360,7 @@ class Speech2Text2ForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class Speech2Text2PreTrainedModel:
@@ -4372,7 +4372,7 @@ class Speech2Text2PreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 SPLINTER_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -4387,7 +4387,7 @@ class SplinterForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class SplinterLayer:
@@ -4404,7 +4404,7 @@ class SplinterModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class SplinterPreTrainedModel:
@@ -4416,7 +4416,7 @@ class SplinterPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 SQUEEZEBERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -4431,7 +4431,7 @@ class SqueezeBertForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class SqueezeBertForMultipleChoice:
@@ -4443,7 +4443,7 @@ class SqueezeBertForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class SqueezeBertForQuestionAnswering:
@@ -4455,7 +4455,7 @@ class SqueezeBertForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class SqueezeBertForSequenceClassification:
@@ -4467,7 +4467,7 @@ class SqueezeBertForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class SqueezeBertForTokenClassification:
@@ -4479,7 +4479,7 @@ class SqueezeBertForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class SqueezeBertModel:
@@ -4491,7 +4491,7 @@ class SqueezeBertModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class SqueezeBertModule:
@@ -4508,7 +4508,7 @@ class SqueezeBertPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 T5_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -4523,7 +4523,7 @@ class T5EncoderModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class T5ForConditionalGeneration:
@@ -4535,7 +4535,7 @@ class T5ForConditionalGeneration:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class T5Model:
@@ -4547,7 +4547,7 @@ class T5Model:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class T5PreTrainedModel:
@@ -4559,7 +4559,7 @@ class T5PreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_t5(*args, **kwargs):
@@ -4583,7 +4583,7 @@ class TransfoXLForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class TransfoXLLMHeadModel:
@@ -4595,7 +4595,7 @@ class TransfoXLLMHeadModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class TransfoXLModel:
@@ -4607,7 +4607,7 @@ class TransfoXLModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class TransfoXLPreTrainedModel:
@@ -4619,7 +4619,7 @@ class TransfoXLPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_transfo_xl(*args, **kwargs):
@@ -4638,7 +4638,7 @@ class TrOCRForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class TrOCRPreTrainedModel:
@@ -4650,7 +4650,7 @@ class TrOCRPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 UNISPEECH_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -4675,7 +4675,7 @@ class UniSpeechForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class UniSpeechModel:
@@ -4687,7 +4687,7 @@ class UniSpeechModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class UniSpeechPreTrainedModel:
@@ -4699,7 +4699,7 @@ class UniSpeechPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 UNISPEECH_SAT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -4724,7 +4724,7 @@ class UniSpeechSatForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class UniSpeechSatModel:
@@ -4736,7 +4736,7 @@ class UniSpeechSatModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class UniSpeechSatPreTrainedModel:
@@ -4748,7 +4748,7 @@ class UniSpeechSatPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class VisionEncoderDecoderModel:
@@ -4760,7 +4760,7 @@ class VisionEncoderDecoderModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 VISUAL_BERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -4775,7 +4775,7 @@ class VisualBertForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class VisualBertForPreTraining:
@@ -4792,7 +4792,7 @@ class VisualBertForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class VisualBertForRegionToPhraseAlignment:
@@ -4819,7 +4819,7 @@ class VisualBertModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class VisualBertPreTrainedModel:
@@ -4831,7 +4831,7 @@ class VisualBertPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 VIT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -4851,7 +4851,7 @@ class ViTModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class ViTPreTrainedModel:
@@ -4863,7 +4863,7 @@ class ViTPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -4883,7 +4883,7 @@ class Wav2Vec2ForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class Wav2Vec2ForPreTraining:
@@ -4900,7 +4900,7 @@ class Wav2Vec2ForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class Wav2Vec2Model:
@@ -4912,7 +4912,7 @@ class Wav2Vec2Model:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class Wav2Vec2PreTrainedModel:
@@ -4924,7 +4924,7 @@ class Wav2Vec2PreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 XLM_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -4939,7 +4939,7 @@ class XLMForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLMForQuestionAnswering:
@@ -4951,7 +4951,7 @@ class XLMForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLMForQuestionAnsweringSimple:
@@ -4963,7 +4963,7 @@ class XLMForQuestionAnsweringSimple:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLMForSequenceClassification:
@@ -4975,7 +4975,7 @@ class XLMForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLMForTokenClassification:
@@ -4987,7 +4987,7 @@ class XLMForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLMModel:
@@ -4999,7 +4999,7 @@ class XLMModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLMPreTrainedModel:
@@ -5011,7 +5011,7 @@ class XLMPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLMWithLMHeadModel:
@@ -5023,7 +5023,7 @@ class XLMWithLMHeadModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 XLM_PROPHETNET_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -5048,7 +5048,7 @@ class XLMProphetNetForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLMProphetNetForConditionalGeneration:
@@ -5060,7 +5060,7 @@ class XLMProphetNetForConditionalGeneration:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLMProphetNetModel:
@@ -5072,7 +5072,7 @@ class XLMProphetNetModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 XLM_ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -5087,7 +5087,7 @@ class XLMRobertaForCausalLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLMRobertaForMaskedLM:
@@ -5099,7 +5099,7 @@ class XLMRobertaForMaskedLM:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLMRobertaForMultipleChoice:
@@ -5111,7 +5111,7 @@ class XLMRobertaForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLMRobertaForQuestionAnswering:
@@ -5123,7 +5123,7 @@ class XLMRobertaForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLMRobertaForSequenceClassification:
@@ -5135,7 +5135,7 @@ class XLMRobertaForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLMRobertaForTokenClassification:
@@ -5147,7 +5147,7 @@ class XLMRobertaForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLMRobertaModel:
@@ -5159,7 +5159,7 @@ class XLMRobertaModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 XLNET_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -5174,7 +5174,7 @@ class XLNetForMultipleChoice:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLNetForQuestionAnswering:
@@ -5186,7 +5186,7 @@ class XLNetForQuestionAnswering:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLNetForQuestionAnsweringSimple:
@@ -5198,7 +5198,7 @@ class XLNetForQuestionAnsweringSimple:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLNetForSequenceClassification:
@@ -5210,7 +5210,7 @@ class XLNetForSequenceClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLNetForTokenClassification:
@@ -5222,7 +5222,7 @@ class XLNetForTokenClassification:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLNetLMHeadModel:
@@ -5234,7 +5234,7 @@ class XLNetLMHeadModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLNetModel:
@@ -5246,7 +5246,7 @@ class XLNetModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 class XLNetPreTrainedModel:
@@ -5258,7 +5258,7 @@ class XLNetPreTrainedModel:
         requires_backends(cls, ["torch"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["torch"])
+        requires_backends(self, ["torch"])
 
 
 def load_tf_weights_in_xlnet(*args, **kwargs):

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -223,6 +223,9 @@ class PreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 def apply_chunking_to_forward(*args, **kwargs):
     requires_backends(apply_chunking_to_forward, ["torch"])
@@ -243,6 +246,9 @@ class AlbertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class AlbertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -250,6 +256,9 @@ class AlbertForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -266,6 +275,9 @@ class AlbertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class AlbertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -273,6 +285,9 @@ class AlbertForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -284,6 +299,9 @@ class AlbertForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class AlbertModel:
     def __init__(self, *args, **kwargs):
@@ -293,6 +311,9 @@ class AlbertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class AlbertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -300,6 +321,9 @@ class AlbertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -372,6 +396,9 @@ class AutoModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class AutoModelForAudioClassification:
     def __init__(self, *args, **kwargs):
@@ -379,6 +406,9 @@ class AutoModelForAudioClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -390,6 +420,9 @@ class AutoModelForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class AutoModelForCTC:
     def __init__(self, *args, **kwargs):
@@ -397,6 +430,9 @@ class AutoModelForCTC:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -408,6 +444,9 @@ class AutoModelForImageClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class AutoModelForImageSegmentation:
     def __init__(self, *args, **kwargs):
@@ -415,6 +454,9 @@ class AutoModelForImageSegmentation:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -426,6 +468,9 @@ class AutoModelForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class AutoModelForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -433,6 +478,9 @@ class AutoModelForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -444,6 +492,9 @@ class AutoModelForNextSentencePrediction:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class AutoModelForObjectDetection:
     def __init__(self, *args, **kwargs):
@@ -451,6 +502,9 @@ class AutoModelForObjectDetection:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -462,6 +516,9 @@ class AutoModelForPreTraining:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class AutoModelForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -469,6 +526,9 @@ class AutoModelForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -480,6 +540,9 @@ class AutoModelForSeq2SeqLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class AutoModelForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -487,6 +550,9 @@ class AutoModelForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -498,6 +564,9 @@ class AutoModelForSpeechSeq2Seq:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class AutoModelForTableQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -505,6 +574,9 @@ class AutoModelForTableQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -516,6 +588,9 @@ class AutoModelForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class AutoModelForVision2Seq:
     def __init__(self, *args, **kwargs):
@@ -525,6 +600,9 @@ class AutoModelForVision2Seq:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class AutoModelWithLMHead:
     def __init__(self, *args, **kwargs):
@@ -532,6 +610,9 @@ class AutoModelWithLMHead:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -546,6 +627,9 @@ class BartForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BartForConditionalGeneration:
     def __init__(self, *args, **kwargs):
@@ -553,6 +637,9 @@ class BartForConditionalGeneration:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -564,6 +651,9 @@ class BartForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BartForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -571,6 +661,9 @@ class BartForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -582,6 +675,9 @@ class BartModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BartPretrainedModel:
     def __init__(self, *args, **kwargs):
@@ -591,6 +687,9 @@ class BartPretrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class PretrainedBartModel:
     def __init__(self, *args, **kwargs):
@@ -598,6 +697,9 @@ class PretrainedBartModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -617,6 +719,9 @@ class BeitForMaskedImageModeling:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BeitForSemanticSegmentation:
     def __init__(self, *args, **kwargs):
@@ -631,6 +736,9 @@ class BeitModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BeitPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -638,6 +746,9 @@ class BeitPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -652,6 +763,9 @@ class BertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -659,6 +773,9 @@ class BertForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -680,6 +797,9 @@ class BertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -689,6 +809,9 @@ class BertForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BertForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -696,6 +819,9 @@ class BertForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -712,6 +838,9 @@ class BertLMHeadModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BertModel:
     def __init__(self, *args, **kwargs):
@@ -721,6 +850,9 @@ class BertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -728,6 +860,9 @@ class BertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -753,6 +888,9 @@ class BertGenerationPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 def load_tf_weights_in_bert_generation(*args, **kwargs):
     requires_backends(load_tf_weights_in_bert_generation, ["torch"])
@@ -769,6 +907,9 @@ class BigBirdForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BigBirdForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -778,6 +919,9 @@ class BigBirdForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BigBirdForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -785,6 +929,9 @@ class BigBirdForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -801,6 +948,9 @@ class BigBirdForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BigBirdForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -810,6 +960,9 @@ class BigBirdForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BigBirdForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -817,6 +970,9 @@ class BigBirdForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -833,6 +989,9 @@ class BigBirdModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BigBirdPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -840,6 +999,9 @@ class BigBirdPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -858,6 +1020,9 @@ class BigBirdPegasusForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BigBirdPegasusForConditionalGeneration:
     def __init__(self, *args, **kwargs):
@@ -865,6 +1030,9 @@ class BigBirdPegasusForConditionalGeneration:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -876,6 +1044,9 @@ class BigBirdPegasusForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BigBirdPegasusForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -883,6 +1054,9 @@ class BigBirdPegasusForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -894,6 +1068,9 @@ class BigBirdPegasusModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BigBirdPegasusPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -901,6 +1078,9 @@ class BigBirdPegasusPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -915,6 +1095,9 @@ class BlenderbotForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BlenderbotForConditionalGeneration:
     def __init__(self, *args, **kwargs):
@@ -922,6 +1105,9 @@ class BlenderbotForConditionalGeneration:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -933,6 +1119,9 @@ class BlenderbotModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BlenderbotPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -940,6 +1129,9 @@ class BlenderbotPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -954,6 +1146,9 @@ class BlenderbotSmallForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BlenderbotSmallForConditionalGeneration:
     def __init__(self, *args, **kwargs):
@@ -961,6 +1156,9 @@ class BlenderbotSmallForConditionalGeneration:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -972,6 +1170,9 @@ class BlenderbotSmallModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class BlenderbotSmallPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -979,6 +1180,9 @@ class BlenderbotSmallPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -993,6 +1197,9 @@ class CamembertForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class CamembertForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -1000,6 +1207,9 @@ class CamembertForMaskedLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1011,6 +1221,9 @@ class CamembertForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class CamembertForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -1018,6 +1231,9 @@ class CamembertForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1029,6 +1245,9 @@ class CamembertForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class CamembertForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -1038,6 +1257,9 @@ class CamembertForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class CamembertModel:
     def __init__(self, *args, **kwargs):
@@ -1045,6 +1267,9 @@ class CamembertModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1059,6 +1284,9 @@ class CanineForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class CanineForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -1066,6 +1294,9 @@ class CanineForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1077,6 +1308,9 @@ class CanineForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class CanineForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -1084,6 +1318,9 @@ class CanineForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1100,6 +1337,9 @@ class CanineModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class CaninePreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1107,6 +1347,9 @@ class CaninePreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1125,6 +1368,9 @@ class CLIPModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class CLIPPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1132,6 +1378,9 @@ class CLIPPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1143,6 +1392,9 @@ class CLIPTextModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class CLIPVisionModel:
     def __init__(self, *args, **kwargs):
@@ -1150,6 +1402,9 @@ class CLIPVisionModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1164,6 +1419,9 @@ class ConvBertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class ConvBertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -1171,6 +1429,9 @@ class ConvBertForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1182,6 +1443,9 @@ class ConvBertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class ConvBertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -1191,6 +1455,9 @@ class ConvBertForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class ConvBertForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -1198,6 +1465,9 @@ class ConvBertForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1214,6 +1484,9 @@ class ConvBertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class ConvBertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1221,6 +1494,9 @@ class ConvBertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1239,6 +1515,9 @@ class CTRLForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class CTRLLMHeadModel:
     def __init__(self, *args, **kwargs):
@@ -1246,6 +1525,9 @@ class CTRLLMHeadModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1257,6 +1539,9 @@ class CTRLModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class CTRLPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1264,6 +1549,9 @@ class CTRLPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1278,6 +1566,9 @@ class DebertaForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class DebertaForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -1285,6 +1576,9 @@ class DebertaForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1296,6 +1590,9 @@ class DebertaForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class DebertaForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -1303,6 +1600,9 @@ class DebertaForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1314,6 +1614,9 @@ class DebertaModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class DebertaPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1321,6 +1624,9 @@ class DebertaPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1335,6 +1641,9 @@ class DebertaV2ForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class DebertaV2ForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -1342,6 +1651,9 @@ class DebertaV2ForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1353,6 +1665,9 @@ class DebertaV2ForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class DebertaV2ForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -1360,6 +1675,9 @@ class DebertaV2ForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1371,6 +1689,9 @@ class DebertaV2Model:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class DebertaV2PreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1378,6 +1699,9 @@ class DebertaV2PreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1402,6 +1726,9 @@ class DeiTModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class DeiTPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1409,6 +1736,9 @@ class DeiTPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1423,6 +1753,9 @@ class DistilBertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class DistilBertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -1430,6 +1763,9 @@ class DistilBertForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1441,6 +1777,9 @@ class DistilBertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class DistilBertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -1448,6 +1787,9 @@ class DistilBertForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1459,6 +1801,9 @@ class DistilBertForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class DistilBertModel:
     def __init__(self, *args, **kwargs):
@@ -1468,6 +1813,9 @@ class DistilBertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class DistilBertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1475,6 +1823,9 @@ class DistilBertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1503,6 +1854,9 @@ class DPRPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1537,6 +1891,9 @@ class ElectraForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class ElectraForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -1544,6 +1901,9 @@ class ElectraForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1560,6 +1920,9 @@ class ElectraForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class ElectraForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -1567,6 +1930,9 @@ class ElectraForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1578,6 +1944,9 @@ class ElectraForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class ElectraModel:
     def __init__(self, *args, **kwargs):
@@ -1587,6 +1956,9 @@ class ElectraModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class ElectraPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1594,6 +1966,9 @@ class ElectraPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1609,6 +1984,9 @@ class EncoderDecoderModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 FLAUBERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
 
@@ -1621,6 +1999,9 @@ class FlaubertForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class FlaubertForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -1628,6 +2009,9 @@ class FlaubertForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1639,6 +2023,9 @@ class FlaubertForQuestionAnsweringSimple:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class FlaubertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -1646,6 +2033,9 @@ class FlaubertForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1657,6 +2047,9 @@ class FlaubertForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class FlaubertModel:
     def __init__(self, *args, **kwargs):
@@ -1666,6 +2059,9 @@ class FlaubertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class FlaubertWithLMHeadModel:
     def __init__(self, *args, **kwargs):
@@ -1673,6 +2069,9 @@ class FlaubertWithLMHeadModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1687,6 +2086,9 @@ class FNetForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class FNetForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -1694,6 +2096,9 @@ class FNetForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1715,6 +2120,9 @@ class FNetForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class FNetForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -1724,6 +2132,9 @@ class FNetForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class FNetForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -1731,6 +2142,9 @@ class FNetForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1747,6 +2161,9 @@ class FNetModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class FNetPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1754,6 +2171,9 @@ class FNetPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1765,6 +2185,9 @@ class FSMTForConditionalGeneration:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class FSMTModel:
     def __init__(self, *args, **kwargs):
@@ -1774,6 +2197,9 @@ class FSMTModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class PretrainedFSMTModel:
     def __init__(self, *args, **kwargs):
@@ -1781,6 +2207,9 @@ class PretrainedFSMTModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1795,6 +2224,9 @@ class FunnelBaseModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class FunnelForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -1804,6 +2236,9 @@ class FunnelForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class FunnelForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -1811,6 +2246,9 @@ class FunnelForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1827,6 +2265,9 @@ class FunnelForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class FunnelForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -1834,6 +2275,9 @@ class FunnelForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1845,6 +2289,9 @@ class FunnelForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class FunnelModel:
     def __init__(self, *args, **kwargs):
@@ -1854,6 +2301,9 @@ class FunnelModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class FunnelPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1861,6 +2311,9 @@ class FunnelPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1879,6 +2332,9 @@ class GPT2DoubleHeadsModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class GPT2ForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -1886,6 +2342,9 @@ class GPT2ForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1897,6 +2356,9 @@ class GPT2ForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class GPT2LMHeadModel:
     def __init__(self, *args, **kwargs):
@@ -1904,6 +2366,9 @@ class GPT2LMHeadModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1915,6 +2380,9 @@ class GPT2Model:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class GPT2PreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1922,6 +2390,9 @@ class GPT2PreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1940,6 +2411,9 @@ class GPTNeoForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class GPTNeoForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -1947,6 +2421,9 @@ class GPTNeoForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1958,6 +2435,9 @@ class GPTNeoModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class GPTNeoPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1965,6 +2445,9 @@ class GPTNeoPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -1983,6 +2466,9 @@ class GPTJForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class GPTJForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -1990,6 +2476,9 @@ class GPTJForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2001,6 +2490,9 @@ class GPTJModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class GPTJPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2008,6 +2500,9 @@ class GPTJPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2027,6 +2522,9 @@ class HubertForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class HubertModel:
     def __init__(self, *args, **kwargs):
@@ -2036,6 +2534,9 @@ class HubertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class HubertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2043,6 +2544,9 @@ class HubertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2057,6 +2561,9 @@ class IBertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class IBertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -2064,6 +2571,9 @@ class IBertForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2075,6 +2585,9 @@ class IBertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class IBertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -2082,6 +2595,9 @@ class IBertForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2093,6 +2609,9 @@ class IBertForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class IBertModel:
     def __init__(self, *args, **kwargs):
@@ -2102,6 +2621,9 @@ class IBertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class IBertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2109,6 +2631,9 @@ class IBertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2123,6 +2648,9 @@ class LayoutLMForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LayoutLMForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -2130,6 +2658,9 @@ class LayoutLMForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2141,6 +2672,9 @@ class LayoutLMForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LayoutLMModel:
     def __init__(self, *args, **kwargs):
@@ -2150,6 +2684,9 @@ class LayoutLMModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LayoutLMPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2157,6 +2694,9 @@ class LayoutLMPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2171,6 +2711,9 @@ class LayoutLMv2ForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LayoutLMv2ForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -2178,6 +2721,9 @@ class LayoutLMv2ForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2189,6 +2735,9 @@ class LayoutLMv2ForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LayoutLMv2Model:
     def __init__(self, *args, **kwargs):
@@ -2198,6 +2747,9 @@ class LayoutLMv2Model:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LayoutLMv2PreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2205,6 +2757,9 @@ class LayoutLMv2PreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2219,6 +2774,9 @@ class LEDForConditionalGeneration:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LEDForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -2226,6 +2784,9 @@ class LEDForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2237,6 +2798,9 @@ class LEDForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LEDModel:
     def __init__(self, *args, **kwargs):
@@ -2246,6 +2810,9 @@ class LEDModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LEDPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2253,6 +2820,9 @@ class LEDPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2267,6 +2837,9 @@ class LongformerForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LongformerForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -2274,6 +2847,9 @@ class LongformerForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2285,6 +2861,9 @@ class LongformerForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LongformerForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -2292,6 +2871,9 @@ class LongformerForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2303,6 +2885,9 @@ class LongformerForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LongformerModel:
     def __init__(self, *args, **kwargs):
@@ -2312,6 +2897,9 @@ class LongformerModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LongformerPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2319,6 +2907,9 @@ class LongformerPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2353,6 +2944,9 @@ class LukeModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LukePreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2360,6 +2954,9 @@ class LukePreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2381,6 +2978,9 @@ class LxmertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LxmertModel:
     def __init__(self, *args, **kwargs):
@@ -2390,6 +2990,9 @@ class LxmertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class LxmertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2397,6 +3000,9 @@ class LxmertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2421,6 +3027,9 @@ class M2M100ForConditionalGeneration:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class M2M100Model:
     def __init__(self, *args, **kwargs):
@@ -2428,6 +3037,9 @@ class M2M100Model:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2439,6 +3051,9 @@ class M2M100PreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MarianForCausalLM:
     def __init__(self, *args, **kwargs):
@@ -2446,6 +3061,9 @@ class MarianForCausalLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2457,6 +3075,9 @@ class MarianModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MarianMTModel:
     def __init__(self, *args, **kwargs):
@@ -2464,6 +3085,9 @@ class MarianMTModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2475,6 +3099,9 @@ class MBartForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MBartForConditionalGeneration:
     def __init__(self, *args, **kwargs):
@@ -2482,6 +3109,9 @@ class MBartForConditionalGeneration:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2493,6 +3123,9 @@ class MBartForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MBartForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -2500,6 +3133,9 @@ class MBartForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2511,6 +3147,9 @@ class MBartModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MBartPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2518,6 +3157,9 @@ class MBartPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2532,6 +3174,9 @@ class MegatronBertForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MegatronBertForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -2541,6 +3186,9 @@ class MegatronBertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MegatronBertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -2548,6 +3196,9 @@ class MegatronBertForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2569,6 +3220,9 @@ class MegatronBertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MegatronBertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -2576,6 +3230,9 @@ class MegatronBertForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2587,6 +3244,9 @@ class MegatronBertForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MegatronBertModel:
     def __init__(self, *args, **kwargs):
@@ -2596,6 +3256,9 @@ class MegatronBertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MegatronBertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2603,6 +3266,9 @@ class MegatronBertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2617,6 +3283,9 @@ class MMBTModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2636,6 +3305,9 @@ class MobileBertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MobileBertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -2643,6 +3315,9 @@ class MobileBertForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2664,6 +3339,9 @@ class MobileBertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MobileBertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -2673,6 +3351,9 @@ class MobileBertForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MobileBertForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -2680,6 +3361,9 @@ class MobileBertForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2696,6 +3380,9 @@ class MobileBertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MobileBertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2703,6 +3390,9 @@ class MobileBertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2721,6 +3411,9 @@ class MPNetForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MPNetForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -2728,6 +3421,9 @@ class MPNetForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2739,6 +3435,9 @@ class MPNetForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MPNetForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -2748,6 +3447,9 @@ class MPNetForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MPNetForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -2755,6 +3457,9 @@ class MPNetForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2771,6 +3476,9 @@ class MPNetModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MPNetPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2778,6 +3486,9 @@ class MPNetPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2789,6 +3500,9 @@ class MT5EncoderModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MT5ForConditionalGeneration:
     def __init__(self, *args, **kwargs):
@@ -2798,6 +3512,9 @@ class MT5ForConditionalGeneration:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class MT5Model:
     def __init__(self, *args, **kwargs):
@@ -2805,6 +3522,9 @@ class MT5Model:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2819,6 +3539,9 @@ class OpenAIGPTDoubleHeadsModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class OpenAIGPTForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -2826,6 +3549,9 @@ class OpenAIGPTForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2837,6 +3563,9 @@ class OpenAIGPTLMHeadModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class OpenAIGPTModel:
     def __init__(self, *args, **kwargs):
@@ -2846,6 +3575,9 @@ class OpenAIGPTModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class OpenAIGPTPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2853,6 +3585,9 @@ class OpenAIGPTPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2868,6 +3603,9 @@ class PegasusForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class PegasusForConditionalGeneration:
     def __init__(self, *args, **kwargs):
@@ -2875,6 +3613,9 @@ class PegasusForConditionalGeneration:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2886,6 +3627,9 @@ class PegasusModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class PegasusPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2893,6 +3637,9 @@ class PegasusPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2917,6 +3664,9 @@ class ProphetNetForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class ProphetNetForConditionalGeneration:
     def __init__(self, *args, **kwargs):
@@ -2924,6 +3674,9 @@ class ProphetNetForConditionalGeneration:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2935,6 +3688,9 @@ class ProphetNetModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class ProphetNetPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2942,6 +3698,9 @@ class ProphetNetPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2953,6 +3712,9 @@ class RagModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class RagPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2960,6 +3722,9 @@ class RagPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -2989,6 +3754,9 @@ class ReformerForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class ReformerForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -2998,6 +3766,9 @@ class ReformerForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class ReformerForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -3005,6 +3776,9 @@ class ReformerForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3021,6 +3795,9 @@ class ReformerModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class ReformerModelWithLMHead:
     def __init__(self, *args, **kwargs):
@@ -3030,6 +3807,9 @@ class ReformerModelWithLMHead:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class ReformerPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -3037,6 +3817,9 @@ class ReformerPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3051,6 +3834,9 @@ class RemBertForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class RemBertForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -3058,6 +3844,9 @@ class RemBertForMaskedLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3069,6 +3858,9 @@ class RemBertForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class RemBertForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -3076,6 +3868,9 @@ class RemBertForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3087,6 +3882,9 @@ class RemBertForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class RemBertForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -3094,6 +3892,9 @@ class RemBertForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3110,6 +3911,9 @@ class RemBertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class RemBertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -3117,6 +3921,9 @@ class RemBertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3135,6 +3942,9 @@ class RetriBertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class RetriBertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -3142,6 +3952,9 @@ class RetriBertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3156,6 +3969,9 @@ class RobertaForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class RobertaForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -3163,6 +3979,9 @@ class RobertaForMaskedLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3174,6 +3993,9 @@ class RobertaForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class RobertaForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -3181,6 +4003,9 @@ class RobertaForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3192,6 +4017,9 @@ class RobertaForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class RobertaForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -3199,6 +4027,9 @@ class RobertaForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3210,6 +4041,9 @@ class RobertaModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class RobertaPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -3217,6 +4051,9 @@ class RobertaPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3231,6 +4068,9 @@ class RoFormerForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class RoFormerForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -3238,6 +4078,9 @@ class RoFormerForMaskedLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3249,6 +4092,9 @@ class RoFormerForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class RoFormerForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -3256,6 +4102,9 @@ class RoFormerForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3267,6 +4116,9 @@ class RoFormerForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class RoFormerForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -3274,6 +4126,9 @@ class RoFormerForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3290,6 +4145,9 @@ class RoFormerModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class RoFormerPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -3297,6 +4155,9 @@ class RoFormerPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3335,6 +4196,9 @@ class SegformerModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class SegformerPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -3342,6 +4206,9 @@ class SegformerPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3361,6 +4228,9 @@ class SEWForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class SEWModel:
     def __init__(self, *args, **kwargs):
@@ -3370,6 +4240,9 @@ class SEWModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class SEWPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -3377,6 +4250,9 @@ class SEWPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3396,6 +4272,9 @@ class SEWDForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class SEWDModel:
     def __init__(self, *args, **kwargs):
@@ -3403,6 +4282,9 @@ class SEWDModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3414,6 +4296,9 @@ class SEWDPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class SpeechEncoderDecoderModel:
     def __init__(self, *args, **kwargs):
@@ -3421,6 +4306,9 @@ class SpeechEncoderDecoderModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3435,6 +4323,9 @@ class Speech2TextForConditionalGeneration:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class Speech2TextModel:
     def __init__(self, *args, **kwargs):
@@ -3442,6 +4333,9 @@ class Speech2TextModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3453,6 +4347,9 @@ class Speech2TextPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class Speech2Text2ForCausalLM:
     def __init__(self, *args, **kwargs):
@@ -3462,6 +4359,9 @@ class Speech2Text2ForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class Speech2Text2PreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -3469,6 +4369,9 @@ class Speech2Text2PreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3481,6 +4384,9 @@ class SplinterForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3497,6 +4403,9 @@ class SplinterModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class SplinterPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -3504,6 +4413,9 @@ class SplinterPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3518,6 +4430,9 @@ class SqueezeBertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class SqueezeBertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -3525,6 +4440,9 @@ class SqueezeBertForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3536,6 +4454,9 @@ class SqueezeBertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class SqueezeBertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -3543,6 +4464,9 @@ class SqueezeBertForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3554,6 +4478,9 @@ class SqueezeBertForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class SqueezeBertModel:
     def __init__(self, *args, **kwargs):
@@ -3561,6 +4488,9 @@ class SqueezeBertModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3577,6 +4507,9 @@ class SqueezeBertPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 T5_PRETRAINED_MODEL_ARCHIVE_LIST = None
 
@@ -3589,6 +4522,9 @@ class T5EncoderModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class T5ForConditionalGeneration:
     def __init__(self, *args, **kwargs):
@@ -3596,6 +4532,9 @@ class T5ForConditionalGeneration:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3607,6 +4546,9 @@ class T5Model:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class T5PreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -3614,6 +4556,9 @@ class T5PreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3637,6 +4582,9 @@ class TransfoXLForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class TransfoXLLMHeadModel:
     def __init__(self, *args, **kwargs):
@@ -3644,6 +4592,9 @@ class TransfoXLLMHeadModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3655,6 +4606,9 @@ class TransfoXLModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class TransfoXLPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -3662,6 +4616,9 @@ class TransfoXLPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3680,6 +4637,9 @@ class TrOCRForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class TrOCRPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -3687,6 +4647,9 @@ class TrOCRPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3711,6 +4674,9 @@ class UniSpeechForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class UniSpeechModel:
     def __init__(self, *args, **kwargs):
@@ -3720,6 +4686,9 @@ class UniSpeechModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class UniSpeechPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -3727,6 +4696,9 @@ class UniSpeechPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3751,6 +4723,9 @@ class UniSpeechSatForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class UniSpeechSatModel:
     def __init__(self, *args, **kwargs):
@@ -3758,6 +4733,9 @@ class UniSpeechSatModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3769,6 +4747,9 @@ class UniSpeechSatPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class VisionEncoderDecoderModel:
     def __init__(self, *args, **kwargs):
@@ -3776,6 +4757,9 @@ class VisionEncoderDecoderModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3790,6 +4774,9 @@ class VisualBertForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class VisualBertForPreTraining:
     def __init__(self, *args, **kwargs):
@@ -3802,6 +4789,9 @@ class VisualBertForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3828,6 +4818,9 @@ class VisualBertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class VisualBertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -3835,6 +4828,9 @@ class VisualBertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3854,6 +4850,9 @@ class ViTModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class ViTPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -3861,6 +4860,9 @@ class ViTPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3880,6 +4882,9 @@ class Wav2Vec2ForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class Wav2Vec2ForPreTraining:
     def __init__(self, *args, **kwargs):
@@ -3894,6 +4899,9 @@ class Wav2Vec2ForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class Wav2Vec2Model:
     def __init__(self, *args, **kwargs):
@@ -3903,6 +4911,9 @@ class Wav2Vec2Model:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class Wav2Vec2PreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -3910,6 +4921,9 @@ class Wav2Vec2PreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3924,6 +4938,9 @@ class XLMForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class XLMForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -3931,6 +4948,9 @@ class XLMForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3942,6 +4962,9 @@ class XLMForQuestionAnsweringSimple:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class XLMForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -3949,6 +4972,9 @@ class XLMForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3960,6 +4986,9 @@ class XLMForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class XLMModel:
     def __init__(self, *args, **kwargs):
@@ -3967,6 +4996,9 @@ class XLMModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -3978,6 +5010,9 @@ class XLMPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class XLMWithLMHeadModel:
     def __init__(self, *args, **kwargs):
@@ -3985,6 +5020,9 @@ class XLMWithLMHeadModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -4009,6 +5047,9 @@ class XLMProphetNetForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class XLMProphetNetForConditionalGeneration:
     def __init__(self, *args, **kwargs):
@@ -4018,6 +5059,9 @@ class XLMProphetNetForConditionalGeneration:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class XLMProphetNetModel:
     def __init__(self, *args, **kwargs):
@@ -4025,6 +5069,9 @@ class XLMProphetNetModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -4039,6 +5086,9 @@ class XLMRobertaForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class XLMRobertaForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -4046,6 +5096,9 @@ class XLMRobertaForMaskedLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -4057,6 +5110,9 @@ class XLMRobertaForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class XLMRobertaForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -4064,6 +5120,9 @@ class XLMRobertaForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -4075,6 +5134,9 @@ class XLMRobertaForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class XLMRobertaForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -4084,6 +5146,9 @@ class XLMRobertaForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class XLMRobertaModel:
     def __init__(self, *args, **kwargs):
@@ -4091,6 +5156,9 @@ class XLMRobertaModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -4105,6 +5173,9 @@ class XLNetForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class XLNetForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -4112,6 +5183,9 @@ class XLNetForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -4123,6 +5197,9 @@ class XLNetForQuestionAnsweringSimple:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class XLNetForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -4130,6 +5207,9 @@ class XLNetForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -4141,6 +5221,9 @@ class XLNetForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class XLNetLMHeadModel:
     def __init__(self, *args, **kwargs):
@@ -4148,6 +5231,9 @@ class XLNetLMHeadModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 
@@ -4159,6 +5245,9 @@ class XLNetModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
 
 class XLNetPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -4166,6 +5255,9 @@ class XLNetPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["torch"])
 
 

--- a/src/transformers/utils/dummy_scatter_objects.py
+++ b/src/transformers/utils/dummy_scatter_objects.py
@@ -13,6 +13,9 @@ class TapasForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["scatter"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["scatter"])
+
 
 class TapasForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -20,6 +23,9 @@ class TapasForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["scatter"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["scatter"])
 
 
@@ -31,6 +37,9 @@ class TapasForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["scatter"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["scatter"])
+
 
 class TapasModel:
     def __init__(self, *args, **kwargs):
@@ -40,6 +49,9 @@ class TapasModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["scatter"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["scatter"])
+
 
 class TapasPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -47,6 +59,9 @@ class TapasPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["scatter"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["scatter"])
 
 

--- a/src/transformers/utils/dummy_scatter_objects.py
+++ b/src/transformers/utils/dummy_scatter_objects.py
@@ -14,7 +14,7 @@ class TapasForMaskedLM:
         requires_backends(cls, ["scatter"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["scatter"])
+        requires_backends(self, ["scatter"])
 
 
 class TapasForQuestionAnswering:
@@ -26,7 +26,7 @@ class TapasForQuestionAnswering:
         requires_backends(cls, ["scatter"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["scatter"])
+        requires_backends(self, ["scatter"])
 
 
 class TapasForSequenceClassification:
@@ -38,7 +38,7 @@ class TapasForSequenceClassification:
         requires_backends(cls, ["scatter"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["scatter"])
+        requires_backends(self, ["scatter"])
 
 
 class TapasModel:
@@ -50,7 +50,7 @@ class TapasModel:
         requires_backends(cls, ["scatter"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["scatter"])
+        requires_backends(self, ["scatter"])
 
 
 class TapasPreTrainedModel:
@@ -62,7 +62,7 @@ class TapasPreTrainedModel:
         requires_backends(cls, ["scatter"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["scatter"])
+        requires_backends(self, ["scatter"])
 
 
 def load_tf_weights_in_tapas(*args, **kwargs):

--- a/src/transformers/utils/dummy_tf_objects.py
+++ b/src/transformers/utils/dummy_tf_objects.py
@@ -33,7 +33,7 @@ class TFLayoutLMForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFLayoutLMForSequenceClassification:
@@ -45,7 +45,7 @@ class TFLayoutLMForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFLayoutLMForTokenClassification:
@@ -57,7 +57,7 @@ class TFLayoutLMForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFLayoutLMMainLayer:
@@ -74,7 +74,7 @@ class TFLayoutLMModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFLayoutLMPreTrainedModel:
@@ -86,7 +86,7 @@ class TFLayoutLMPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFPreTrainedModel:
@@ -98,7 +98,7 @@ class TFPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFSequenceSummary:
@@ -127,7 +127,7 @@ class TFAlbertForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFAlbertForMultipleChoice:
@@ -139,7 +139,7 @@ class TFAlbertForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFAlbertForPreTraining:
@@ -156,7 +156,7 @@ class TFAlbertForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFAlbertForSequenceClassification:
@@ -168,7 +168,7 @@ class TFAlbertForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFAlbertForTokenClassification:
@@ -180,7 +180,7 @@ class TFAlbertForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFAlbertMainLayer:
@@ -197,7 +197,7 @@ class TFAlbertModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFAlbertPreTrainedModel:
@@ -209,7 +209,7 @@ class TFAlbertPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_MODEL_FOR_CAUSAL_LM_MAPPING = None
@@ -257,7 +257,7 @@ class TFAutoModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFAutoModelForCausalLM:
@@ -269,7 +269,7 @@ class TFAutoModelForCausalLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFAutoModelForImageClassification:
@@ -281,7 +281,7 @@ class TFAutoModelForImageClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFAutoModelForMaskedLM:
@@ -293,7 +293,7 @@ class TFAutoModelForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFAutoModelForMultipleChoice:
@@ -305,7 +305,7 @@ class TFAutoModelForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFAutoModelForPreTraining:
@@ -317,7 +317,7 @@ class TFAutoModelForPreTraining:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFAutoModelForQuestionAnswering:
@@ -329,7 +329,7 @@ class TFAutoModelForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFAutoModelForSeq2SeqLM:
@@ -341,7 +341,7 @@ class TFAutoModelForSeq2SeqLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFAutoModelForSequenceClassification:
@@ -353,7 +353,7 @@ class TFAutoModelForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFAutoModelForTokenClassification:
@@ -365,7 +365,7 @@ class TFAutoModelForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFAutoModelWithLMHead:
@@ -377,7 +377,7 @@ class TFAutoModelWithLMHead:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFBartForConditionalGeneration:
@@ -389,7 +389,7 @@ class TFBartForConditionalGeneration:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFBartModel:
@@ -401,7 +401,7 @@ class TFBartModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFBartPretrainedModel:
@@ -413,7 +413,7 @@ class TFBartPretrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_BERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -433,7 +433,7 @@ class TFBertForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFBertForMultipleChoice:
@@ -445,7 +445,7 @@ class TFBertForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFBertForNextSentencePrediction:
@@ -467,7 +467,7 @@ class TFBertForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFBertForSequenceClassification:
@@ -479,7 +479,7 @@ class TFBertForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFBertForTokenClassification:
@@ -491,7 +491,7 @@ class TFBertForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFBertLMHeadModel:
@@ -503,7 +503,7 @@ class TFBertLMHeadModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFBertMainLayer:
@@ -520,7 +520,7 @@ class TFBertModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFBertPreTrainedModel:
@@ -532,7 +532,7 @@ class TFBertPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFBlenderbotForConditionalGeneration:
@@ -544,7 +544,7 @@ class TFBlenderbotForConditionalGeneration:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFBlenderbotModel:
@@ -556,7 +556,7 @@ class TFBlenderbotModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFBlenderbotPreTrainedModel:
@@ -568,7 +568,7 @@ class TFBlenderbotPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFBlenderbotSmallForConditionalGeneration:
@@ -580,7 +580,7 @@ class TFBlenderbotSmallForConditionalGeneration:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFBlenderbotSmallModel:
@@ -592,7 +592,7 @@ class TFBlenderbotSmallModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFBlenderbotSmallPreTrainedModel:
@@ -604,7 +604,7 @@ class TFBlenderbotSmallPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_CAMEMBERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -619,7 +619,7 @@ class TFCamembertForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFCamembertForMultipleChoice:
@@ -631,7 +631,7 @@ class TFCamembertForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFCamembertForQuestionAnswering:
@@ -643,7 +643,7 @@ class TFCamembertForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFCamembertForSequenceClassification:
@@ -655,7 +655,7 @@ class TFCamembertForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFCamembertForTokenClassification:
@@ -667,7 +667,7 @@ class TFCamembertForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFCamembertModel:
@@ -679,7 +679,7 @@ class TFCamembertModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_CONVBERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -694,7 +694,7 @@ class TFConvBertForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFConvBertForMultipleChoice:
@@ -706,7 +706,7 @@ class TFConvBertForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFConvBertForQuestionAnswering:
@@ -718,7 +718,7 @@ class TFConvBertForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFConvBertForSequenceClassification:
@@ -730,7 +730,7 @@ class TFConvBertForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFConvBertForTokenClassification:
@@ -742,7 +742,7 @@ class TFConvBertForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFConvBertLayer:
@@ -759,7 +759,7 @@ class TFConvBertModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFConvBertPreTrainedModel:
@@ -771,7 +771,7 @@ class TFConvBertPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_CTRL_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -786,7 +786,7 @@ class TFCTRLForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFCTRLLMHeadModel:
@@ -798,7 +798,7 @@ class TFCTRLLMHeadModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFCTRLModel:
@@ -810,7 +810,7 @@ class TFCTRLModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFCTRLPreTrainedModel:
@@ -822,7 +822,7 @@ class TFCTRLPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_DEBERTA_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -837,7 +837,7 @@ class TFDebertaForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFDebertaForQuestionAnswering:
@@ -849,7 +849,7 @@ class TFDebertaForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFDebertaForSequenceClassification:
@@ -861,7 +861,7 @@ class TFDebertaForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFDebertaForTokenClassification:
@@ -873,7 +873,7 @@ class TFDebertaForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFDebertaModel:
@@ -885,7 +885,7 @@ class TFDebertaModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFDebertaPreTrainedModel:
@@ -897,7 +897,7 @@ class TFDebertaPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_DEBERTA_V2_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -912,7 +912,7 @@ class TFDebertaV2ForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFDebertaV2ForQuestionAnswering:
@@ -924,7 +924,7 @@ class TFDebertaV2ForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFDebertaV2ForSequenceClassification:
@@ -936,7 +936,7 @@ class TFDebertaV2ForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFDebertaV2ForTokenClassification:
@@ -948,7 +948,7 @@ class TFDebertaV2ForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFDebertaV2Model:
@@ -960,7 +960,7 @@ class TFDebertaV2Model:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFDebertaV2PreTrainedModel:
@@ -972,7 +972,7 @@ class TFDebertaV2PreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_DISTILBERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -987,7 +987,7 @@ class TFDistilBertForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFDistilBertForMultipleChoice:
@@ -999,7 +999,7 @@ class TFDistilBertForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFDistilBertForQuestionAnswering:
@@ -1011,7 +1011,7 @@ class TFDistilBertForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFDistilBertForSequenceClassification:
@@ -1023,7 +1023,7 @@ class TFDistilBertForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFDistilBertForTokenClassification:
@@ -1035,7 +1035,7 @@ class TFDistilBertForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFDistilBertMainLayer:
@@ -1052,7 +1052,7 @@ class TFDistilBertModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFDistilBertPreTrainedModel:
@@ -1064,7 +1064,7 @@ class TFDistilBertPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_DPR_CONTEXT_ENCODER_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1118,7 +1118,7 @@ class TFElectraForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFElectraForMultipleChoice:
@@ -1130,7 +1130,7 @@ class TFElectraForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFElectraForPreTraining:
@@ -1147,7 +1147,7 @@ class TFElectraForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFElectraForSequenceClassification:
@@ -1159,7 +1159,7 @@ class TFElectraForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFElectraForTokenClassification:
@@ -1171,7 +1171,7 @@ class TFElectraForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFElectraModel:
@@ -1183,7 +1183,7 @@ class TFElectraModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFElectraPreTrainedModel:
@@ -1195,7 +1195,7 @@ class TFElectraPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFEncoderDecoderModel:
@@ -1207,7 +1207,7 @@ class TFEncoderDecoderModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_FLAUBERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1222,7 +1222,7 @@ class TFFlaubertForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFFlaubertForQuestionAnsweringSimple:
@@ -1234,7 +1234,7 @@ class TFFlaubertForQuestionAnsweringSimple:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFFlaubertForSequenceClassification:
@@ -1246,7 +1246,7 @@ class TFFlaubertForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFFlaubertForTokenClassification:
@@ -1258,7 +1258,7 @@ class TFFlaubertForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFFlaubertModel:
@@ -1270,7 +1270,7 @@ class TFFlaubertModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFFlaubertPreTrainedModel:
@@ -1282,7 +1282,7 @@ class TFFlaubertPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFFlaubertWithLMHeadModel:
@@ -1294,7 +1294,7 @@ class TFFlaubertWithLMHeadModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_FUNNEL_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1309,7 +1309,7 @@ class TFFunnelBaseModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFFunnelForMaskedLM:
@@ -1321,7 +1321,7 @@ class TFFunnelForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFFunnelForMultipleChoice:
@@ -1333,7 +1333,7 @@ class TFFunnelForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFFunnelForPreTraining:
@@ -1350,7 +1350,7 @@ class TFFunnelForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFFunnelForSequenceClassification:
@@ -1362,7 +1362,7 @@ class TFFunnelForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFFunnelForTokenClassification:
@@ -1374,7 +1374,7 @@ class TFFunnelForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFFunnelModel:
@@ -1386,7 +1386,7 @@ class TFFunnelModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFFunnelPreTrainedModel:
@@ -1398,7 +1398,7 @@ class TFFunnelPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_GPT2_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1413,7 +1413,7 @@ class TFGPT2DoubleHeadsModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFGPT2ForSequenceClassification:
@@ -1425,7 +1425,7 @@ class TFGPT2ForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFGPT2LMHeadModel:
@@ -1437,7 +1437,7 @@ class TFGPT2LMHeadModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFGPT2MainLayer:
@@ -1454,7 +1454,7 @@ class TFGPT2Model:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFGPT2PreTrainedModel:
@@ -1466,7 +1466,7 @@ class TFGPT2PreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_HUBERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1486,7 +1486,7 @@ class TFHubertModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFHubertPreTrainedModel:
@@ -1498,7 +1498,7 @@ class TFHubertPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFLEDForConditionalGeneration:
@@ -1510,7 +1510,7 @@ class TFLEDForConditionalGeneration:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFLEDModel:
@@ -1522,7 +1522,7 @@ class TFLEDModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFLEDPreTrainedModel:
@@ -1534,7 +1534,7 @@ class TFLEDPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_LONGFORMER_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1549,7 +1549,7 @@ class TFLongformerForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFLongformerForMultipleChoice:
@@ -1561,7 +1561,7 @@ class TFLongformerForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFLongformerForQuestionAnswering:
@@ -1573,7 +1573,7 @@ class TFLongformerForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFLongformerForSequenceClassification:
@@ -1585,7 +1585,7 @@ class TFLongformerForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFLongformerForTokenClassification:
@@ -1597,7 +1597,7 @@ class TFLongformerForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFLongformerModel:
@@ -1609,7 +1609,7 @@ class TFLongformerModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFLongformerPreTrainedModel:
@@ -1621,7 +1621,7 @@ class TFLongformerPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFLongformerSelfAttention:
@@ -1651,7 +1651,7 @@ class TFLxmertModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFLxmertPreTrainedModel:
@@ -1663,7 +1663,7 @@ class TFLxmertPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFLxmertVisualFeatureEncoder:
@@ -1680,7 +1680,7 @@ class TFMarianModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMarianMTModel:
@@ -1692,7 +1692,7 @@ class TFMarianMTModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMarianPreTrainedModel:
@@ -1704,7 +1704,7 @@ class TFMarianPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMBartForConditionalGeneration:
@@ -1716,7 +1716,7 @@ class TFMBartForConditionalGeneration:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMBartModel:
@@ -1728,7 +1728,7 @@ class TFMBartModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMBartPreTrainedModel:
@@ -1740,7 +1740,7 @@ class TFMBartPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_MOBILEBERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1755,7 +1755,7 @@ class TFMobileBertForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMobileBertForMultipleChoice:
@@ -1767,7 +1767,7 @@ class TFMobileBertForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMobileBertForNextSentencePrediction:
@@ -1789,7 +1789,7 @@ class TFMobileBertForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMobileBertForSequenceClassification:
@@ -1801,7 +1801,7 @@ class TFMobileBertForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMobileBertForTokenClassification:
@@ -1813,7 +1813,7 @@ class TFMobileBertForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMobileBertMainLayer:
@@ -1830,7 +1830,7 @@ class TFMobileBertModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMobileBertPreTrainedModel:
@@ -1842,7 +1842,7 @@ class TFMobileBertPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_MPNET_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1857,7 +1857,7 @@ class TFMPNetForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMPNetForMultipleChoice:
@@ -1869,7 +1869,7 @@ class TFMPNetForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMPNetForQuestionAnswering:
@@ -1881,7 +1881,7 @@ class TFMPNetForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMPNetForSequenceClassification:
@@ -1893,7 +1893,7 @@ class TFMPNetForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMPNetForTokenClassification:
@@ -1905,7 +1905,7 @@ class TFMPNetForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMPNetMainLayer:
@@ -1922,7 +1922,7 @@ class TFMPNetModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMPNetPreTrainedModel:
@@ -1934,7 +1934,7 @@ class TFMPNetPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMT5EncoderModel:
@@ -1946,7 +1946,7 @@ class TFMT5EncoderModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMT5ForConditionalGeneration:
@@ -1958,7 +1958,7 @@ class TFMT5ForConditionalGeneration:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFMT5Model:
@@ -1970,7 +1970,7 @@ class TFMT5Model:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_OPENAI_GPT_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -1985,7 +1985,7 @@ class TFOpenAIGPTDoubleHeadsModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFOpenAIGPTForSequenceClassification:
@@ -1997,7 +1997,7 @@ class TFOpenAIGPTForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFOpenAIGPTLMHeadModel:
@@ -2009,7 +2009,7 @@ class TFOpenAIGPTLMHeadModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFOpenAIGPTMainLayer:
@@ -2026,7 +2026,7 @@ class TFOpenAIGPTModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFOpenAIGPTPreTrainedModel:
@@ -2038,7 +2038,7 @@ class TFOpenAIGPTPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFPegasusForConditionalGeneration:
@@ -2050,7 +2050,7 @@ class TFPegasusForConditionalGeneration:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFPegasusModel:
@@ -2062,7 +2062,7 @@ class TFPegasusModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFPegasusPreTrainedModel:
@@ -2074,7 +2074,7 @@ class TFPegasusPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRagModel:
@@ -2086,7 +2086,7 @@ class TFRagModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRagPreTrainedModel:
@@ -2098,7 +2098,7 @@ class TFRagPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRagSequenceForGeneration:
@@ -2123,7 +2123,7 @@ class TFRemBertForCausalLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRemBertForMaskedLM:
@@ -2135,7 +2135,7 @@ class TFRemBertForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRemBertForMultipleChoice:
@@ -2147,7 +2147,7 @@ class TFRemBertForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRemBertForQuestionAnswering:
@@ -2159,7 +2159,7 @@ class TFRemBertForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRemBertForSequenceClassification:
@@ -2171,7 +2171,7 @@ class TFRemBertForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRemBertForTokenClassification:
@@ -2183,7 +2183,7 @@ class TFRemBertForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRemBertLayer:
@@ -2200,7 +2200,7 @@ class TFRemBertModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRemBertPreTrainedModel:
@@ -2212,7 +2212,7 @@ class TFRemBertPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2227,7 +2227,7 @@ class TFRobertaForCausalLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRobertaForMaskedLM:
@@ -2239,7 +2239,7 @@ class TFRobertaForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRobertaForMultipleChoice:
@@ -2251,7 +2251,7 @@ class TFRobertaForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRobertaForQuestionAnswering:
@@ -2263,7 +2263,7 @@ class TFRobertaForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRobertaForSequenceClassification:
@@ -2275,7 +2275,7 @@ class TFRobertaForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRobertaForTokenClassification:
@@ -2287,7 +2287,7 @@ class TFRobertaForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRobertaMainLayer:
@@ -2304,7 +2304,7 @@ class TFRobertaModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRobertaPreTrainedModel:
@@ -2316,7 +2316,7 @@ class TFRobertaPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_ROFORMER_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2331,7 +2331,7 @@ class TFRoFormerForCausalLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRoFormerForMaskedLM:
@@ -2343,7 +2343,7 @@ class TFRoFormerForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRoFormerForMultipleChoice:
@@ -2355,7 +2355,7 @@ class TFRoFormerForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRoFormerForQuestionAnswering:
@@ -2367,7 +2367,7 @@ class TFRoFormerForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRoFormerForSequenceClassification:
@@ -2379,7 +2379,7 @@ class TFRoFormerForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRoFormerForTokenClassification:
@@ -2391,7 +2391,7 @@ class TFRoFormerForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRoFormerLayer:
@@ -2408,7 +2408,7 @@ class TFRoFormerModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFRoFormerPreTrainedModel:
@@ -2420,7 +2420,7 @@ class TFRoFormerPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_T5_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2435,7 +2435,7 @@ class TFT5EncoderModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFT5ForConditionalGeneration:
@@ -2447,7 +2447,7 @@ class TFT5ForConditionalGeneration:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFT5Model:
@@ -2459,7 +2459,7 @@ class TFT5Model:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFT5PreTrainedModel:
@@ -2471,7 +2471,7 @@ class TFT5PreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_TRANSFO_XL_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2491,7 +2491,7 @@ class TFTransfoXLForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFTransfoXLLMHeadModel:
@@ -2503,7 +2503,7 @@ class TFTransfoXLLMHeadModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFTransfoXLMainLayer:
@@ -2520,7 +2520,7 @@ class TFTransfoXLModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFTransfoXLPreTrainedModel:
@@ -2532,7 +2532,7 @@ class TFTransfoXLPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFViTForImageClassification:
@@ -2549,7 +2549,7 @@ class TFViTModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFViTPreTrainedModel:
@@ -2561,7 +2561,7 @@ class TFViTPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_WAV_2_VEC_2_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2581,7 +2581,7 @@ class TFWav2Vec2Model:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFWav2Vec2PreTrainedModel:
@@ -2593,7 +2593,7 @@ class TFWav2Vec2PreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_XLM_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2608,7 +2608,7 @@ class TFXLMForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLMForQuestionAnsweringSimple:
@@ -2620,7 +2620,7 @@ class TFXLMForQuestionAnsweringSimple:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLMForSequenceClassification:
@@ -2632,7 +2632,7 @@ class TFXLMForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLMForTokenClassification:
@@ -2644,7 +2644,7 @@ class TFXLMForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLMMainLayer:
@@ -2661,7 +2661,7 @@ class TFXLMModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLMPreTrainedModel:
@@ -2673,7 +2673,7 @@ class TFXLMPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLMWithLMHeadModel:
@@ -2685,7 +2685,7 @@ class TFXLMWithLMHeadModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_XLM_ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2700,7 +2700,7 @@ class TFXLMRobertaForMaskedLM:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLMRobertaForMultipleChoice:
@@ -2712,7 +2712,7 @@ class TFXLMRobertaForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLMRobertaForQuestionAnswering:
@@ -2724,7 +2724,7 @@ class TFXLMRobertaForQuestionAnswering:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLMRobertaForSequenceClassification:
@@ -2736,7 +2736,7 @@ class TFXLMRobertaForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLMRobertaForTokenClassification:
@@ -2748,7 +2748,7 @@ class TFXLMRobertaForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLMRobertaModel:
@@ -2760,7 +2760,7 @@ class TFXLMRobertaModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 TF_XLNET_PRETRAINED_MODEL_ARCHIVE_LIST = None
@@ -2775,7 +2775,7 @@ class TFXLNetForMultipleChoice:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLNetForQuestionAnsweringSimple:
@@ -2787,7 +2787,7 @@ class TFXLNetForQuestionAnsweringSimple:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLNetForSequenceClassification:
@@ -2799,7 +2799,7 @@ class TFXLNetForSequenceClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLNetForTokenClassification:
@@ -2811,7 +2811,7 @@ class TFXLNetForTokenClassification:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLNetLMHeadModel:
@@ -2823,7 +2823,7 @@ class TFXLNetLMHeadModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLNetMainLayer:
@@ -2840,7 +2840,7 @@ class TFXLNetModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class TFXLNetPreTrainedModel:
@@ -2852,7 +2852,7 @@ class TFXLNetPreTrainedModel:
         requires_backends(cls, ["tf"])
 
     def call(self, *args, **kwargs):
-        requires_backends(cls, ["tf"])
+        requires_backends(self, ["tf"])
 
 
 class AdamWeightDecay:

--- a/src/transformers/utils/dummy_tf_objects.py
+++ b/src/transformers/utils/dummy_tf_objects.py
@@ -32,6 +32,9 @@ class TFLayoutLMForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFLayoutLMForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -41,6 +44,9 @@ class TFLayoutLMForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFLayoutLMForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -48,6 +54,9 @@ class TFLayoutLMForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -64,6 +73,9 @@ class TFLayoutLMModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFLayoutLMPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -73,6 +85,9 @@ class TFLayoutLMPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -80,6 +95,9 @@ class TFPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -108,6 +126,9 @@ class TFAlbertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFAlbertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -115,6 +136,9 @@ class TFAlbertForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -131,6 +155,9 @@ class TFAlbertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFAlbertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -140,6 +167,9 @@ class TFAlbertForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFAlbertForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -147,6 +177,9 @@ class TFAlbertForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -163,6 +196,9 @@ class TFAlbertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFAlbertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -170,6 +206,9 @@ class TFAlbertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -217,6 +256,9 @@ class TFAutoModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFAutoModelForCausalLM:
     def __init__(self, *args, **kwargs):
@@ -224,6 +266,9 @@ class TFAutoModelForCausalLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -235,6 +280,9 @@ class TFAutoModelForImageClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFAutoModelForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -242,6 +290,9 @@ class TFAutoModelForMaskedLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -253,6 +304,9 @@ class TFAutoModelForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFAutoModelForPreTraining:
     def __init__(self, *args, **kwargs):
@@ -260,6 +314,9 @@ class TFAutoModelForPreTraining:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -271,6 +328,9 @@ class TFAutoModelForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFAutoModelForSeq2SeqLM:
     def __init__(self, *args, **kwargs):
@@ -278,6 +338,9 @@ class TFAutoModelForSeq2SeqLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -289,6 +352,9 @@ class TFAutoModelForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFAutoModelForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -296,6 +362,9 @@ class TFAutoModelForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -307,6 +376,9 @@ class TFAutoModelWithLMHead:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFBartForConditionalGeneration:
     def __init__(self, *args, **kwargs):
@@ -314,6 +386,9 @@ class TFBartForConditionalGeneration:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -325,6 +400,9 @@ class TFBartModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFBartPretrainedModel:
     def __init__(self, *args, **kwargs):
@@ -332,6 +410,9 @@ class TFBartPretrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -351,6 +432,9 @@ class TFBertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFBertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -358,6 +442,9 @@ class TFBertForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -379,6 +466,9 @@ class TFBertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFBertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -386,6 +476,9 @@ class TFBertForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -397,6 +490,9 @@ class TFBertForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFBertLMHeadModel:
     def __init__(self, *args, **kwargs):
@@ -404,6 +500,9 @@ class TFBertLMHeadModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -420,6 +519,9 @@ class TFBertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFBertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -427,6 +529,9 @@ class TFBertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -438,6 +543,9 @@ class TFBlenderbotForConditionalGeneration:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFBlenderbotModel:
     def __init__(self, *args, **kwargs):
@@ -445,6 +553,9 @@ class TFBlenderbotModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -456,6 +567,9 @@ class TFBlenderbotPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFBlenderbotSmallForConditionalGeneration:
     def __init__(self, *args, **kwargs):
@@ -463,6 +577,9 @@ class TFBlenderbotSmallForConditionalGeneration:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -474,6 +591,9 @@ class TFBlenderbotSmallModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFBlenderbotSmallPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -481,6 +601,9 @@ class TFBlenderbotSmallPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -495,6 +618,9 @@ class TFCamembertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFCamembertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -502,6 +628,9 @@ class TFCamembertForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -513,6 +642,9 @@ class TFCamembertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFCamembertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -520,6 +652,9 @@ class TFCamembertForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -531,6 +666,9 @@ class TFCamembertForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFCamembertModel:
     def __init__(self, *args, **kwargs):
@@ -538,6 +676,9 @@ class TFCamembertModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -552,6 +693,9 @@ class TFConvBertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFConvBertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -559,6 +703,9 @@ class TFConvBertForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -570,6 +717,9 @@ class TFConvBertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFConvBertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -579,6 +729,9 @@ class TFConvBertForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFConvBertForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -586,6 +739,9 @@ class TFConvBertForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -602,6 +758,9 @@ class TFConvBertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFConvBertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -609,6 +768,9 @@ class TFConvBertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -623,6 +785,9 @@ class TFCTRLForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFCTRLLMHeadModel:
     def __init__(self, *args, **kwargs):
@@ -630,6 +795,9 @@ class TFCTRLLMHeadModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -641,6 +809,9 @@ class TFCTRLModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFCTRLPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -648,6 +819,9 @@ class TFCTRLPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -662,6 +836,9 @@ class TFDebertaForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFDebertaForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -669,6 +846,9 @@ class TFDebertaForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -680,6 +860,9 @@ class TFDebertaForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFDebertaForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -687,6 +870,9 @@ class TFDebertaForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -698,6 +884,9 @@ class TFDebertaModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFDebertaPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -705,6 +894,9 @@ class TFDebertaPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -719,6 +911,9 @@ class TFDebertaV2ForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFDebertaV2ForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -726,6 +921,9 @@ class TFDebertaV2ForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -737,6 +935,9 @@ class TFDebertaV2ForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFDebertaV2ForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -744,6 +945,9 @@ class TFDebertaV2ForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -755,6 +959,9 @@ class TFDebertaV2Model:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFDebertaV2PreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -762,6 +969,9 @@ class TFDebertaV2PreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -776,6 +986,9 @@ class TFDistilBertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFDistilBertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -783,6 +996,9 @@ class TFDistilBertForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -794,6 +1010,9 @@ class TFDistilBertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFDistilBertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -803,6 +1022,9 @@ class TFDistilBertForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFDistilBertForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -810,6 +1032,9 @@ class TFDistilBertForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -826,6 +1051,9 @@ class TFDistilBertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFDistilBertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -833,6 +1061,9 @@ class TFDistilBertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -886,6 +1117,9 @@ class TFElectraForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFElectraForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -893,6 +1127,9 @@ class TFElectraForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -909,6 +1146,9 @@ class TFElectraForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFElectraForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -916,6 +1156,9 @@ class TFElectraForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -927,6 +1170,9 @@ class TFElectraForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFElectraModel:
     def __init__(self, *args, **kwargs):
@@ -934,6 +1180,9 @@ class TFElectraModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -945,6 +1194,9 @@ class TFElectraPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFEncoderDecoderModel:
     def __init__(self, *args, **kwargs):
@@ -952,6 +1204,9 @@ class TFEncoderDecoderModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -966,6 +1221,9 @@ class TFFlaubertForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFFlaubertForQuestionAnsweringSimple:
     def __init__(self, *args, **kwargs):
@@ -973,6 +1231,9 @@ class TFFlaubertForQuestionAnsweringSimple:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -984,6 +1245,9 @@ class TFFlaubertForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFFlaubertForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -991,6 +1255,9 @@ class TFFlaubertForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1002,6 +1269,9 @@ class TFFlaubertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFFlaubertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1011,6 +1281,9 @@ class TFFlaubertPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFFlaubertWithLMHeadModel:
     def __init__(self, *args, **kwargs):
@@ -1018,6 +1291,9 @@ class TFFlaubertWithLMHeadModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1032,6 +1308,9 @@ class TFFunnelBaseModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFFunnelForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -1041,6 +1320,9 @@ class TFFunnelForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFFunnelForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -1048,6 +1330,9 @@ class TFFunnelForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1064,6 +1349,9 @@ class TFFunnelForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFFunnelForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -1071,6 +1359,9 @@ class TFFunnelForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1082,6 +1373,9 @@ class TFFunnelForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFFunnelModel:
     def __init__(self, *args, **kwargs):
@@ -1091,6 +1385,9 @@ class TFFunnelModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFFunnelPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1098,6 +1395,9 @@ class TFFunnelPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1112,6 +1412,9 @@ class TFGPT2DoubleHeadsModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFGPT2ForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -1121,6 +1424,9 @@ class TFGPT2ForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFGPT2LMHeadModel:
     def __init__(self, *args, **kwargs):
@@ -1128,6 +1434,9 @@ class TFGPT2LMHeadModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1144,6 +1453,9 @@ class TFGPT2Model:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFGPT2PreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1151,6 +1463,9 @@ class TFGPT2PreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1170,6 +1485,9 @@ class TFHubertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFHubertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1177,6 +1495,9 @@ class TFHubertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1188,6 +1509,9 @@ class TFLEDForConditionalGeneration:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFLEDModel:
     def __init__(self, *args, **kwargs):
@@ -1197,6 +1521,9 @@ class TFLEDModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFLEDPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1204,6 +1531,9 @@ class TFLEDPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1218,6 +1548,9 @@ class TFLongformerForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFLongformerForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -1225,6 +1558,9 @@ class TFLongformerForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1236,6 +1572,9 @@ class TFLongformerForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFLongformerForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -1243,6 +1582,9 @@ class TFLongformerForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1254,6 +1596,9 @@ class TFLongformerForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFLongformerModel:
     def __init__(self, *args, **kwargs):
@@ -1263,6 +1608,9 @@ class TFLongformerModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFLongformerPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1270,6 +1618,9 @@ class TFLongformerPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1299,6 +1650,9 @@ class TFLxmertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFLxmertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1306,6 +1660,9 @@ class TFLxmertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1322,6 +1679,9 @@ class TFMarianModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFMarianMTModel:
     def __init__(self, *args, **kwargs):
@@ -1329,6 +1689,9 @@ class TFMarianMTModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1340,6 +1703,9 @@ class TFMarianPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFMBartForConditionalGeneration:
     def __init__(self, *args, **kwargs):
@@ -1347,6 +1713,9 @@ class TFMBartForConditionalGeneration:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1358,6 +1727,9 @@ class TFMBartModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFMBartPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1365,6 +1737,9 @@ class TFMBartPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1379,6 +1754,9 @@ class TFMobileBertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFMobileBertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -1386,6 +1764,9 @@ class TFMobileBertForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1407,6 +1788,9 @@ class TFMobileBertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFMobileBertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -1416,6 +1800,9 @@ class TFMobileBertForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFMobileBertForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -1423,6 +1810,9 @@ class TFMobileBertForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1439,6 +1829,9 @@ class TFMobileBertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFMobileBertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1446,6 +1839,9 @@ class TFMobileBertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1460,6 +1856,9 @@ class TFMPNetForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFMPNetForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -1467,6 +1866,9 @@ class TFMPNetForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1478,6 +1880,9 @@ class TFMPNetForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFMPNetForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -1487,6 +1892,9 @@ class TFMPNetForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFMPNetForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -1494,6 +1902,9 @@ class TFMPNetForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1510,6 +1921,9 @@ class TFMPNetModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFMPNetPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1517,6 +1931,9 @@ class TFMPNetPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1528,6 +1945,9 @@ class TFMT5EncoderModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFMT5ForConditionalGeneration:
     def __init__(self, *args, **kwargs):
@@ -1537,6 +1957,9 @@ class TFMT5ForConditionalGeneration:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFMT5Model:
     def __init__(self, *args, **kwargs):
@@ -1544,6 +1967,9 @@ class TFMT5Model:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1558,6 +1984,9 @@ class TFOpenAIGPTDoubleHeadsModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFOpenAIGPTForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -1567,6 +1996,9 @@ class TFOpenAIGPTForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFOpenAIGPTLMHeadModel:
     def __init__(self, *args, **kwargs):
@@ -1574,6 +2006,9 @@ class TFOpenAIGPTLMHeadModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1590,6 +2025,9 @@ class TFOpenAIGPTModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFOpenAIGPTPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1597,6 +2035,9 @@ class TFOpenAIGPTPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1608,6 +2049,9 @@ class TFPegasusForConditionalGeneration:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFPegasusModel:
     def __init__(self, *args, **kwargs):
@@ -1615,6 +2059,9 @@ class TFPegasusModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1626,6 +2073,9 @@ class TFPegasusPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFRagModel:
     def __init__(self, *args, **kwargs):
@@ -1635,6 +2085,9 @@ class TFRagModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFRagPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1642,6 +2095,9 @@ class TFRagPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1666,6 +2122,9 @@ class TFRemBertForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFRemBertForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -1673,6 +2132,9 @@ class TFRemBertForMaskedLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1684,6 +2146,9 @@ class TFRemBertForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFRemBertForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -1691,6 +2156,9 @@ class TFRemBertForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1702,6 +2170,9 @@ class TFRemBertForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFRemBertForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -1709,6 +2180,9 @@ class TFRemBertForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1725,6 +2199,9 @@ class TFRemBertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFRemBertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1732,6 +2209,9 @@ class TFRemBertPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1746,6 +2226,9 @@ class TFRobertaForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFRobertaForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -1753,6 +2236,9 @@ class TFRobertaForMaskedLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1764,6 +2250,9 @@ class TFRobertaForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFRobertaForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -1771,6 +2260,9 @@ class TFRobertaForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1782,6 +2274,9 @@ class TFRobertaForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFRobertaForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -1789,6 +2284,9 @@ class TFRobertaForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1805,6 +2303,9 @@ class TFRobertaModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFRobertaPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1812,6 +2313,9 @@ class TFRobertaPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1826,6 +2330,9 @@ class TFRoFormerForCausalLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFRoFormerForMaskedLM:
     def __init__(self, *args, **kwargs):
@@ -1833,6 +2340,9 @@ class TFRoFormerForMaskedLM:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1844,6 +2354,9 @@ class TFRoFormerForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFRoFormerForQuestionAnswering:
     def __init__(self, *args, **kwargs):
@@ -1851,6 +2364,9 @@ class TFRoFormerForQuestionAnswering:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1862,6 +2378,9 @@ class TFRoFormerForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFRoFormerForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -1869,6 +2388,9 @@ class TFRoFormerForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1885,6 +2407,9 @@ class TFRoFormerModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFRoFormerPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1892,6 +2417,9 @@ class TFRoFormerPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1906,6 +2434,9 @@ class TFT5EncoderModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFT5ForConditionalGeneration:
     def __init__(self, *args, **kwargs):
@@ -1913,6 +2444,9 @@ class TFT5ForConditionalGeneration:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1924,6 +2458,9 @@ class TFT5Model:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFT5PreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1931,6 +2468,9 @@ class TFT5PreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1950,6 +2490,9 @@ class TFTransfoXLForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFTransfoXLLMHeadModel:
     def __init__(self, *args, **kwargs):
@@ -1957,6 +2500,9 @@ class TFTransfoXLLMHeadModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1973,6 +2519,9 @@ class TFTransfoXLModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFTransfoXLPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -1980,6 +2529,9 @@ class TFTransfoXLPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -1996,6 +2548,9 @@ class TFViTModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFViTPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2003,6 +2558,9 @@ class TFViTPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -2022,6 +2580,9 @@ class TFWav2Vec2Model:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFWav2Vec2PreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2029,6 +2590,9 @@ class TFWav2Vec2PreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -2043,6 +2607,9 @@ class TFXLMForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFXLMForQuestionAnsweringSimple:
     def __init__(self, *args, **kwargs):
@@ -2050,6 +2617,9 @@ class TFXLMForQuestionAnsweringSimple:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -2061,6 +2631,9 @@ class TFXLMForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFXLMForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -2068,6 +2641,9 @@ class TFXLMForTokenClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -2084,6 +2660,9 @@ class TFXLMModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFXLMPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2093,6 +2672,9 @@ class TFXLMPreTrainedModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFXLMWithLMHeadModel:
     def __init__(self, *args, **kwargs):
@@ -2100,6 +2682,9 @@ class TFXLMWithLMHeadModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -2114,6 +2699,9 @@ class TFXLMRobertaForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFXLMRobertaForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -2121,6 +2709,9 @@ class TFXLMRobertaForMultipleChoice:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -2132,6 +2723,9 @@ class TFXLMRobertaForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFXLMRobertaForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -2139,6 +2733,9 @@ class TFXLMRobertaForSequenceClassification:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -2150,6 +2747,9 @@ class TFXLMRobertaForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFXLMRobertaModel:
     def __init__(self, *args, **kwargs):
@@ -2157,6 +2757,9 @@ class TFXLMRobertaModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -2171,6 +2774,9 @@ class TFXLNetForMultipleChoice:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFXLNetForQuestionAnsweringSimple:
     def __init__(self, *args, **kwargs):
@@ -2178,6 +2784,9 @@ class TFXLNetForQuestionAnsweringSimple:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -2189,6 +2798,9 @@ class TFXLNetForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFXLNetForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -2198,6 +2810,9 @@ class TFXLNetForTokenClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFXLNetLMHeadModel:
     def __init__(self, *args, **kwargs):
@@ -2205,6 +2820,9 @@ class TFXLNetLMHeadModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 
@@ -2221,6 +2839,9 @@ class TFXLNetModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
+    def call(self, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
 
 class TFXLNetPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -2228,6 +2849,9 @@ class TFXLNetPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(cls, ["tf"])
 
 

--- a/src/transformers/utils/dummy_timm_and_vision_objects.py
+++ b/src/transformers/utils/dummy_timm_and_vision_objects.py
@@ -13,6 +13,9 @@ class DetrForObjectDetection:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["timm", "vision"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["timm", "vision"])
+
 
 class DetrForSegmentation:
     def __init__(self, *args, **kwargs):
@@ -20,6 +23,9 @@ class DetrForSegmentation:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["timm", "vision"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["timm", "vision"])
 
 
@@ -31,6 +37,9 @@ class DetrModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["timm", "vision"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, ["timm", "vision"])
+
 
 class DetrPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -38,4 +47,7 @@ class DetrPreTrainedModel:
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["timm", "vision"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(cls, ["timm", "vision"])

--- a/src/transformers/utils/dummy_timm_and_vision_objects.py
+++ b/src/transformers/utils/dummy_timm_and_vision_objects.py
@@ -14,7 +14,7 @@ class DetrForObjectDetection:
         requires_backends(cls, ["timm", "vision"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["timm", "vision"])
+        requires_backends(self, ["timm", "vision"])
 
 
 class DetrForSegmentation:
@@ -26,7 +26,7 @@ class DetrForSegmentation:
         requires_backends(cls, ["timm", "vision"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["timm", "vision"])
+        requires_backends(self, ["timm", "vision"])
 
 
 class DetrModel:
@@ -38,7 +38,7 @@ class DetrModel:
         requires_backends(cls, ["timm", "vision"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["timm", "vision"])
+        requires_backends(self, ["timm", "vision"])
 
 
 class DetrPreTrainedModel:
@@ -50,4 +50,4 @@ class DetrPreTrainedModel:
         requires_backends(cls, ["timm", "vision"])
 
     def forward(self, *args, **kwargs):
-        requires_backends(cls, ["timm", "vision"])
+        requires_backends(self, ["timm", "vision"])

--- a/utils/check_dummies.py
+++ b/utils/check_dummies.py
@@ -43,6 +43,30 @@ class {0}:
         requires_backends(cls, {1})
 """
 
+PT_DUMMY_PRETRAINED_CLASS = (
+    DUMMY_PRETRAINED_CLASS
+    + """
+    def forward(self, *args, **kwargs):
+        requires_backends(cls, {1})
+"""
+)
+
+TF_DUMMY_PRETRAINED_CLASS = (
+    DUMMY_PRETRAINED_CLASS
+    + """
+    def call(self, *args, **kwargs):
+        requires_backends(cls, {1})
+"""
+)
+
+FLAX_DUMMY_PRETRAINED_CLASS = (
+    DUMMY_PRETRAINED_CLASS
+    + """
+    def __call__(self, *args, **kwargs):
+        requires_backends(cls, {1})
+"""
+)
+
 DUMMY_CLASS = """
 class {0}:
     def __init__(self, *args, **kwargs):
@@ -102,8 +126,7 @@ def read_init():
 
 def create_dummy_object(name, backend_name):
     """Create the code for the dummy object corresponding to `name`."""
-    _pretrained = [
-        "Config",
+    _models = [
         "ForCausalLM",
         "ForConditionalGeneration",
         "ForMaskedLM",
@@ -114,14 +137,24 @@ def create_dummy_object(name, backend_name):
         "ForSequenceClassification",
         "ForTokenClassification",
         "Model",
-        "Tokenizer",
-        "Processor",
     ]
+    _pretrained = ["Config", "Tokenizer", "Processor"]
     if name.isupper():
         return DUMMY_CONSTANT.format(name)
     elif name.islower():
         return DUMMY_FUNCTION.format(name, backend_name)
     else:
+        is_model = False
+        for part in _models:
+            if part in name:
+                is_model = True
+                break
+        if is_model:
+            if name.startswith("TF"):
+                return TF_DUMMY_PRETRAINED_CLASS.format(name, backend_name)
+            if name.startswith("Flax"):
+                return FLAX_DUMMY_PRETRAINED_CLASS.format(name, backend_name)
+            return PT_DUMMY_PRETRAINED_CLASS.format(name, backend_name)
         is_pretrained = False
         for part in _pretrained:
             if part in name:

--- a/utils/check_dummies.py
+++ b/utils/check_dummies.py
@@ -47,7 +47,7 @@ PT_DUMMY_PRETRAINED_CLASS = (
     DUMMY_PRETRAINED_CLASS
     + """
     def forward(self, *args, **kwargs):
-        requires_backends(cls, {1})
+        requires_backends(self, {1})
 """
 )
 
@@ -55,7 +55,7 @@ TF_DUMMY_PRETRAINED_CLASS = (
     DUMMY_PRETRAINED_CLASS
     + """
     def call(self, *args, **kwargs):
-        requires_backends(cls, {1})
+        requires_backends(self, {1})
 """
 )
 
@@ -63,7 +63,7 @@ FLAX_DUMMY_PRETRAINED_CLASS = (
     DUMMY_PRETRAINED_CLASS
     + """
     def __call__(self, *args, **kwargs):
-        requires_backends(cls, {1})
+        requires_backends(self, {1})
 """
 )
 


### PR DESCRIPTION
# What does this PR do?

This PR adds a forward/call/__call__ method to the dummy models (depending on the framework) so that one can build the doc even if not all dependencies are present (torch-scatter in particular is annoying).