### PR TITLE
fix hook removal issue

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -22,9 +22,9 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
-from packaging import version
 
 import torch
+from packaging import version
 from torch import Tensor, device, nn
 from torch.nn import CrossEntropyLoss
 


### PR DESCRIPTION
Here is a possible workaround for an issue triggered by https://github.com/huggingface/transformers/pull/14408 and reported at https://github.com/huggingface/transformers/pull/14408#issuecomment-971004220. I repeat all the relevant information below.

This broke HF/deepspeed integration with pt-1.8 or pt-1.9 - works fine with pt-1.10. found with git bisecting and reported by @jeffra, as their CI broke with our master.

```
RUN_SLOW=1 pyt tests/deepspeed/test_deepspeed.py::TestDeepSpeedWithLauncher::test_clm_1_zero3 -sv
```


```
E           Traceback (most recent call last):
E             File "/mnt/nvme1/code/huggingface/transformers-master/examples/pytorch/language-modeling/run_clm.py", line 524, in <module>
E               main()
E             File "/mnt/nvme1/code/huggingface/transformers-master/examples/pytorch/language-modeling/run_clm.py", line 472, in main
E               train_result = trainer.train(resume_from_checkpoint=checkpoint)
E             File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/trainer.py", line 1316, in train
E               tr_loss_step = self.training_step(model, inputs)
E             File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/trainer.py", line 1849, in training_step
E               loss = self.compute_loss(model, inputs)
E             File "/mnt/nvme1/code/huggingface/transformers-master/src/transformers/trainer.py", line 1881, in compute_loss
E               outputs = model(**inputs)
E             File "/home/stas/anaconda3/envs/py38-pt19/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1051, in _call_impl
E               return forward_call(*input, **kwargs)
E             File "/mnt/nvme1/code/github/00optimize/deepspeed/deepspeed/runtime/engine.py", line 1580, in forward
E               loss = self.module(*inputs, **kwargs)
E             File "/home/stas/anaconda3/envs/py38-pt19/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1057, in _call_impl
E               for hook in itertools.chain(
E           RuntimeError: OrderedDict mutated during iteration
```

The issue is triggered by:

https://github.com/huggingface/transformers/blob/b567510cff606c9dd67cb7c56169bc596590e700/src/transformers/modeling_utils.py#L423

so it looks like Deepspeed is just a harbinger here, and any other application that also uses hooks that get inserted after this hook will trigger this issue.

It appears that what happens is that the hook is being removed from the dict while it being traversed one or more frames above.

Perhaps if the hook is last python doesn't report this issue. But if there are more hooks registered after that one, that's when the dict mutation is detected.

I looked at what others did to solve this and they had to move the hook removal outside of the hook itself and into the `forward` when it's safe to remove it. Except we don't have a `forward` for this super class.

For some reason I can't reproduce this with pt-1.10, which means that pytorch has reworked the loop that traverses the hooks dict to allow hooks to self-remove - probably using a copy to traverse the dict.

So this PR is an attempt to make things work, while rendering the hook a noop for subsequent calls. As it says this is a temporary hook and will be removed soon, perhaps it's OK? for pt-1.10 we can safely remove it.

Obviously, this is just a suggestion. now that you understand the issue, perhaps you will come up with a more efficient solution.

@sgugger 