### PR TITLE
Add GitPython to quality tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -800,7 +800,6 @@ jobs:
                       - v0.4-code_quality-{{ checksum "setup.py" }}
                       - v0.4-{{ checksum "setup.py" }}
             - run: pip install --upgrade pip
-            - run: pip install isort GitPython
             - run: pip install .[all,quality]
             - save_cache:
                   key: v0.4-code_quality-{{ checksum "setup.py" }}
@@ -827,7 +826,6 @@ jobs:
                       - v0.4-repository_consistency-{{ checksum "setup.py" }}
                       - v0.4-{{ checksum "setup.py" }}
             - run: pip install --upgrade pip
-            - run: pip install isort GitPython
             - run: pip install .[all,quality]
             - save_cache:
                   key: v0.4-repository_consistency-{{ checksum "setup.py" }}

--- a/setup.py
+++ b/setup.py
@@ -280,7 +280,7 @@ extras["testing"] = (
     + extras["modelcreation"]
 )
 
-extras["quality"] = deps_list("black", "isort", "flake8")
+extras["quality"] = deps_list("black", "isort", "flake8", "gitpython)
 
 extras["all"] = (
     extras["tf"]

--- a/setup.py
+++ b/setup.py
@@ -280,7 +280,7 @@ extras["testing"] = (
     + extras["modelcreation"]
 )
 
-extras["quality"] = deps_list("black", "isort", "flake8", "gitpython")
+extras["quality"] = deps_list("black", "isort", "flake8", "GitPython")
 
 extras["all"] = (
     extras["tf"]

--- a/setup.py
+++ b/setup.py
@@ -280,7 +280,7 @@ extras["testing"] = (
     + extras["modelcreation"]
 )
 
-extras["quality"] = deps_list("black", "isort", "flake8", "gitpython)
+extras["quality"] = deps_list("black", "isort", "flake8", "gitpython")
 
 extras["all"] = (
     extras["tf"]


### PR DESCRIPTION
Adds gitpython to the `quality` command of the setup, as otherwise the quality tools cannot be used.

cc https://github.com/huggingface/transformers/pull/14379