### PR TITLE
[test] add test for --config_overrides

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -324,6 +324,7 @@ def main():
         if model_args.config_overrides is not None:
             logger.info(f"Overriding config: {model_args.config_overrides}")
             config.update_from_string(model_args.config_overrides)
+            logger.info(f"New config: {config}")
 
     tokenizer_kwargs = {
         "cache_dir": model_args.cache_dir,

--- a/examples/pytorch/language-modeling/run_mlm.py
+++ b/examples/pytorch/language-modeling/run_mlm.py
@@ -326,6 +326,7 @@ def main():
         if model_args.config_overrides is not None:
             logger.info(f"Overriding config: {model_args.config_overrides}")
             config.update_from_string(model_args.config_overrides)
+            logger.info(f"New config: {config}")
 
     tokenizer_kwargs = {
         "cache_dir": model_args.cache_dir,

--- a/examples/pytorch/language-modeling/run_plm.py
+++ b/examples/pytorch/language-modeling/run_plm.py
@@ -318,6 +318,7 @@ def main():
         if model_args.config_overrides is not None:
             logger.info(f"Overriding config: {model_args.config_overrides}")
             config.update_from_string(model_args.config_overrides)
+            logger.info(f"New config: {config}")
 
     tokenizer_kwargs = {
         "cache_dir": model_args.cache_dir,

--- a/examples/pytorch/test_examples.py
+++ b/examples/pytorch/test_examples.py
@@ -167,15 +167,7 @@ class ExamplesTests(TestCasePlus):
             --model_type gpt2
             --tokenizer_name gpt2
             --train_file ./tests/fixtures/sample_text.txt
-            --validation_file ./tests/fixtures/sample_text.txt
-            --do_train
-            --do_eval
-            --block_size 128
-            --per_device_train_batch_size 5
-            --per_device_eval_batch_size 5
-            --num_train_epochs 2
             --output_dir {tmp_dir}
-            --overwrite_output_dir
             --config_overrides n_embd=10,n_head=2
             """.split()
 


### PR DESCRIPTION
https://github.com/huggingface/transformers/issues/14389 suggested that `--config_overrides` doesn't work.

The feature works just fine, it's just the multiple logging of the config done by the framework is confusing. I already flagged this issue here: https://github.com/huggingface/transformers/issues/11104 I have no idea why loading a tokenizer triggers dumping of model config - as its contents are mostly irrelevant to the tokenizer and surely doesn't contribute anything useful to the user, other than avoiding looking at the log completely.

So there will be no confusion I added an additional dump with the updated config (terrible!) and a test so that we don't accidentally break this feature.

I'm not sure how else to improve that other than revisiting the design of when the model config is dumped. IMHO:
1. it's dumped too soon for the model (before it can be updated)
2. it shouldn't be dumped at all for the tokenizer

Fixes: https://github.com/huggingface/transformers/issues/14389

@sgugger, @LysandreJik 