### PR TITLE
Fix dummy objects for quantization

### DIFF
--- a/src/transformers/utils/dummy_flax_objects.py
+++ b/src/transformers/utils/dummy_flax_objects.py
@@ -477,6 +477,13 @@ class FlaxBertForNextSentencePrediction:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["flax"])
 
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["flax"])
+
+    def __call__(self, *args, **kwargs):
+        requires_backends(self, ["flax"])
+
 
 class FlaxBertForPreTraining:
     def __init__(self, *args, **kwargs):

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -56,6 +56,13 @@ class TextDatasetForNextSentencePrediction:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])
 
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
+        requires_backends(self, ["torch"])
+
 
 class BeamScorer:
     def __init__(self, *args, **kwargs):
@@ -781,6 +788,13 @@ class BertForMultipleChoice:
 
 class BertForNextSentencePrediction:
     def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torch"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(self, ["torch"])
 
 
@@ -2106,6 +2120,13 @@ class FNetForNextSentencePrediction:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])
 
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
+        requires_backends(self, ["torch"])
+
 
 class FNetForPreTraining:
     def __init__(self, *args, **kwargs):
@@ -3254,6 +3275,13 @@ class MegatronBertForNextSentencePrediction:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])
 
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
+        requires_backends(self, ["torch"])
+
 
 class MegatronBertForPreTraining:
     def __init__(self, *args, **kwargs):
@@ -3371,6 +3399,13 @@ class MobileBertForMultipleChoice:
 
 class MobileBertForNextSentencePrediction:
     def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torch"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch"])
+
+    def forward(self, *args, **kwargs):
         requires_backends(self, ["torch"])
 
 

--- a/src/transformers/utils/dummy_pytorch_quantization_and_torch_objects.py
+++ b/src/transformers/utils/dummy_pytorch_quantization_and_torch_objects.py
@@ -13,6 +13,9 @@ class QDQBertForMaskedLM:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["pytorch_quantization", "torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(self, ["pytorch_quantization", "torch"])
+
 
 class QDQBertForMultipleChoice:
     def __init__(self, *args, **kwargs):
@@ -21,6 +24,9 @@ class QDQBertForMultipleChoice:
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["pytorch_quantization", "torch"])
+
+    def forward(self, *args, **kwargs):
+        requires_backends(self, ["pytorch_quantization", "torch"])
 
 
 class QDQBertForNextSentencePrediction:
@@ -36,6 +42,9 @@ class QDQBertForQuestionAnswering:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["pytorch_quantization", "torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(self, ["pytorch_quantization", "torch"])
+
 
 class QDQBertForSequenceClassification:
     def __init__(self, *args, **kwargs):
@@ -45,6 +54,9 @@ class QDQBertForSequenceClassification:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["pytorch_quantization", "torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(self, ["pytorch_quantization", "torch"])
+
 
 class QDQBertForTokenClassification:
     def __init__(self, *args, **kwargs):
@@ -53,6 +65,9 @@ class QDQBertForTokenClassification:
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["pytorch_quantization", "torch"])
+
+    def forward(self, *args, **kwargs):
+        requires_backends(self, ["pytorch_quantization", "torch"])
 
 
 class QDQBertLayer:
@@ -68,6 +83,9 @@ class QDQBertLMHeadModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["pytorch_quantization", "torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(self, ["pytorch_quantization", "torch"])
+
 
 class QDQBertModel:
     def __init__(self, *args, **kwargs):
@@ -77,6 +95,9 @@ class QDQBertModel:
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["pytorch_quantization", "torch"])
 
+    def forward(self, *args, **kwargs):
+        requires_backends(self, ["pytorch_quantization", "torch"])
+
 
 class QDQBertPreTrainedModel:
     def __init__(self, *args, **kwargs):
@@ -85,6 +106,9 @@ class QDQBertPreTrainedModel:
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["pytorch_quantization", "torch"])
+
+    def forward(self, *args, **kwargs):
+        requires_backends(self, ["pytorch_quantization", "torch"])
 
 
 def load_tf_weights_in_qdqbert(*args, **kwargs):

--- a/src/transformers/utils/dummy_pytorch_quantization_and_torch_objects.py
+++ b/src/transformers/utils/dummy_pytorch_quantization_and_torch_objects.py
@@ -33,6 +33,13 @@ class QDQBertForNextSentencePrediction:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["pytorch_quantization", "torch"])
 
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["pytorch_quantization", "torch"])
+
+    def forward(self, *args, **kwargs):
+        requires_backends(self, ["pytorch_quantization", "torch"])
+
 
 class QDQBertForQuestionAnswering:
     def __init__(self, *args, **kwargs):

--- a/src/transformers/utils/dummy_tf_objects.py
+++ b/src/transformers/utils/dummy_tf_objects.py
@@ -452,6 +452,13 @@ class TFBertForNextSentencePrediction:
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["tf"])
 
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
+        requires_backends(self, ["tf"])
+
 
 class TFBertForPreTraining:
     def __init__(self, *args, **kwargs):
@@ -1772,6 +1779,13 @@ class TFMobileBertForMultipleChoice:
 
 class TFMobileBertForNextSentencePrediction:
     def __init__(self, *args, **kwargs):
+        requires_backends(self, ["tf"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["tf"])
+
+    def call(self, *args, **kwargs):
         requires_backends(self, ["tf"])
 
 

--- a/utils/check_dummies.py
+++ b/utils/check_dummies.py
@@ -131,6 +131,7 @@ def create_dummy_object(name, backend_name):
         "ForConditionalGeneration",
         "ForMaskedLM",
         "ForMultipleChoice",
+        "ForNextSentencePrediction",
         "ForObjectDetection",
         "ForQuestionAnswering",
         "ForSegmentation",

--- a/utils/check_dummies.py
+++ b/utils/check_dummies.py
@@ -23,7 +23,7 @@ import re
 PATH_TO_TRANSFORMERS = "src/transformers"
 
 # Matches is_xxx_available()
-_re_backend = re.compile(r"is\_([a-z]*)_available()")
+_re_backend = re.compile(r"is\_([a-z_]*)_available()")
 # Matches from xxx import bla
 _re_single_line_import = re.compile(r"\s+from\s+\S*\s+import\s+([^\(\s].*)\n")
 _re_test_backend = re.compile(r"^\s+if\s+is\_[a-z]*\_available\(\)")


### PR DESCRIPTION
# What does this PR do?

The dummy objects introduced recently are actually not generated and maintained by the dummy scripts, because the `is_xxx_available` test they rely on contains an _ in the xxx. This PR fixes that.
Another fix concerns the models `ForNextSentencePrediction` which were not included in the list yet (a better fix will use the model mapping names from the auto mapping one day when I have more time :-) )

This is blocking the doc building for the new frontend so merging as soon as it's green.