### PR TITLE
[TAPAS] Tiny fix

### DIFF
--- a/src/transformers/models/tapas/modeling_tapas.py
+++ b/src/transformers/models/tapas/modeling_tapas.py
@@ -1357,7 +1357,7 @@ class TapasForQuestionAnswering(TapasPreTrainedModel):
                     torch.ones_like(labels, dtype=torch.float32),
                     self.config.positive_label_weight * torch.ones_like(labels, dtype=torch.float32),
                 )
-                selection_loss_per_token = -dist_per_token.log_prob(labels) * weight
+                selection_loss_per_token = -dist_per_token.log_prob(labels.float()) * weight
                 selection_loss_per_example = torch.sum(selection_loss_per_token * input_mask_float, dim=1) / (
                     torch.sum(input_mask_float, dim=1) + EPSILON_ZERO_DIVISION
                 )

--- a/src/transformers/models/tapas/modeling_tapas.py
+++ b/src/transformers/models/tapas/modeling_tapas.py
@@ -1433,7 +1433,7 @@ class TapasForQuestionAnswering(TapasPreTrainedModel):
                 total_loss += torch.mean(per_example_additional_loss)
 
         else:
-            if config.select_one_column:
+            if self.config.select_one_column:
                 # if no label ids are provided, set them to zeros in order to properly compute logits
                 labels = torch.zeros_like(logits)
                 _, logits = _single_column_cell_selection_loss(


### PR DESCRIPTION
# What does this PR do?

This PR includes a finy fix for TAPAS. Namely, when `config.select_one_column` is set to `False`, the model should not recompute the token logits. 

Relevant to #13393