### PR TITLE
fix #14524 (IndexError when mask prob is too low)

### DIFF
--- a/src/transformers/models/hubert/configuration_hubert.py
+++ b/src/transformers/models/hubert/configuration_hubert.py
@@ -101,17 +101,30 @@ class HubertConfig(PretrainedConfig):
             `SpecAugment: A Simple Data Augmentation Method for Automatic Speech Recognition
             <https://arxiv.org/abs/1904.08779>`__.
         mask_time_prob (:obj:`float`, `optional`, defaults to 0.05):
-            Propability of each feature vector along the time axis to be chosen as the start of the vector span to be
-            masked. Approximately ``mask_time_prob * sequence_length // mask_time_length`` feature vectors will be
-            masked along the time axis. This is only relevant if ``apply_spec_augment is True``.
+            Percentage (between 0 and 1) of all feature vectors along the time axis which will be masked. The masking
+            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independ masks over the axis. If
+            reasoning from the propability of each feature vector to be chosen as the start of the vector span to be
+            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length`` Note that overlap may decrease
+            the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment is True``.
         mask_time_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the time axis.
+        mask_time_min_masks (:obj:`int`, `optional`, defaults to 2),:
+            The minimum number of masks of length ``mask_feature_length`` generated along the time axis, each time
+            step, irrespectively of ``mask_feature_prob``. Only relevant if
+            ''mask_time_prob*len(time_axis)/mask_time_length < mask_time_min_masks''
         mask_feature_prob (:obj:`float`, `optional`, defaults to 0.0):
-            Propability of each feature vector along the feature axis to be chosen as the start of the vector span to
-            be masked. Approximately ``mask_time_prob * hidden_size // mask_time_length`` feature vectors will be
-            masked along the time axis. This is only relevant if ``apply_spec_augment is True``.
+            Percentage (between 0 and 1) of all feature vectors along the feature axis which will be masked. The
+            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independ masks over
+            the axis. If reasoning from the propability of each feature vector to be chosen as the start of the vector
+            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length`` Note that
+            overlap may decrease the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment
+            is True``.
         mask_feature_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the feature axis.
+        mask_feature_min_masks (:obj:`int`, `optional`, defaults to 0),:
+            The minimum number of masks of length ``mask_feature_length`` generated along the feature axis, each time
+            step, irrespectively of ``mask_feature_prob``. Only relevant if
+            ''mask_feature_prob*len(feature_axis)/mask_feature_length < mask_feature_min_masks''
         ctc_loss_reduction (:obj:`str`, `optional`, defaults to :obj:`"sum"`):
             Specifies the reduction to apply to the output of ``torch.nn.CTCLoss``. Only relevant when training an
             instance of :class:`~transformers.HubertForCTC`.
@@ -169,8 +182,10 @@ class HubertConfig(PretrainedConfig):
         apply_spec_augment=True,
         mask_time_prob=0.05,
         mask_time_length=10,
+        mask_time_min_masks=2,
         mask_feature_prob=0.0,
         mask_feature_length=10,
+        mask_feature_min_masks=0,
         ctc_loss_reduction="sum",
         ctc_zero_infinity=False,
         use_weighted_layer_sum=False,
@@ -225,8 +240,10 @@ class HubertConfig(PretrainedConfig):
         self.apply_spec_augment = apply_spec_augment
         self.mask_time_prob = mask_time_prob
         self.mask_time_length = mask_time_length
+        self.mask_time_min_masks = mask_time_min_masks
         self.mask_feature_prob = mask_feature_prob
         self.mask_feature_length = mask_feature_length
+        self.mask_feature_min_masks = mask_feature_min_masks
 
         # ctc loss
         self.ctc_loss_reduction = ctc_loss_reduction

--- a/src/transformers/models/hubert/configuration_hubert.py
+++ b/src/transformers/models/hubert/configuration_hubert.py
@@ -102,9 +102,9 @@ class HubertConfig(PretrainedConfig):
             <https://arxiv.org/abs/1904.08779>`__.
         mask_time_prob (:obj:`float`, `optional`, defaults to 0.05):
             Percentage (between 0 and 1) of all feature vectors along the time axis which will be masked. The masking
-            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independ masks over the axis. If
+            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independent masks over the axis. If
             reasoning from the propability of each feature vector to be chosen as the start of the vector span to be
-            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length`` Note that overlap may decrease
+            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length``. Note that overlap may decrease
             the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment is True``.
         mask_time_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the time axis.
@@ -114,9 +114,9 @@ class HubertConfig(PretrainedConfig):
             ''mask_time_prob*len(time_axis)/mask_time_length < mask_time_min_masks''
         mask_feature_prob (:obj:`float`, `optional`, defaults to 0.0):
             Percentage (between 0 and 1) of all feature vectors along the feature axis which will be masked. The
-            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independ masks over
+            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independent masks over
             the axis. If reasoning from the propability of each feature vector to be chosen as the start of the vector
-            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length`` Note that
+            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length``. Note that
             overlap may decrease the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment
             is True``.
         mask_feature_length (:obj:`int`, `optional`, defaults to 10):

--- a/src/transformers/models/hubert/modeling_hubert.py
+++ b/src/transformers/models/hubert/modeling_hubert.py
@@ -69,13 +69,15 @@ def _compute_mask_indices(
     on CPU as part of the preprocessing during training.
 
     Args:
-        shape: the the shape for which to compute masks.
-            should be of size 2 where first element is batch size and 2nd is timesteps
-        mask_prob: probability for each token to be chosen as start of the span to be masked. this will be multiplied by
-            number of timesteps divided by length of mask span to mask approximately this percentage of all elements.
-            however due to overlaps, the actual number will be smaller (unless no_overlap is True)
+        shape: The shape for which to compute masks. This should be of a tuple of size 2 where
+               the first element is the batch size and the second element is the length of the axis to span.
+        mask_prob: The probability for each token to be chosen as start of the span to be masked. This will results in
+                   at most `ceil(mask_prob * shape[1]) * mask_length` masked tokens. Due to overlapping spans the
+                   expected amount of masked tokens will be fewer.
         mask_length: size of the mask
         min_masks: minimum number of masked spans
+        attention_mask: A (right-padded) attention mask which independently shortens the feature axis of
+                        each batch dimension.
     """
     batch_size, sequence_length = shape
 
@@ -84,21 +86,27 @@ def _compute_mask_indices(
 
     if mask_length > sequence_length:
         raise ValueError(
-            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length} and `sequence_length`: {sequence_length}`"
+            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length} "
+            f"and `sequence_length`: {sequence_length}`"
         )
 
-    epsilon = np.random.rand(1).item()
-
-    def compute_num_masked_span(input_length):
+    def compute_num_masked_span(feature_axis_length: int, use_probabilistic_rounding: bool):
         """Given input length, compute how many spans should be masked"""
-        num_masked_span = int(mask_prob * input_length / mask_length + epsilon)
-        num_masked_span = max(num_masked_span, min_masks)
+        assert feature_axis_length <= sequence_length
 
-        # make sure num masked indices <= sequence_length
-        if num_masked_span * mask_length > sequence_length:
-            num_masked_span = sequence_length // mask_length
+        if use_probabilistic_rounding:
+            epsilon = np.random.rand(1).item()
+            num_selected_start_tokens = math.floor(mask_prob * feature_axis_length + epsilon)
+        else:
+            num_selected_start_tokens = math.ceil(mask_prob * feature_axis_length)
 
-        return num_masked_span
+        num_selected_start_tokens = max(num_selected_start_tokens, min_masks)
+
+        # make sure num masked indices <= length of sequence to mask
+        if num_selected_start_tokens > feature_axis_length:
+            num_selected_start_tokens = feature_axis_length
+
+        return num_selected_start_tokens
 
     # compute number of masked spans in batch
     input_lengths = (
@@ -107,21 +115,33 @@ def _compute_mask_indices(
         else [sequence_length for _ in range(batch_size)]
     )
 
-    # SpecAugment mask to fill
-    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
+    # select the indexes which will start a span of length `mask_length`
     spec_aug_mask_idxs = []
+    non_masked_batch_dimensions = []
 
-    max_num_masked_span = compute_num_masked_span(sequence_length)
+    max_num_masked_span = compute_num_masked_span(sequence_length, use_probabilistic_rounding=False)
 
-    for input_length in input_lengths:
+    for batch_idx, input_length in enumerate(input_lengths):
         # compute num of masked spans for this input
-        num_masked_span = compute_num_masked_span(input_length)
+        num_masked_span = compute_num_masked_span(input_length, use_probabilistic_rounding=True)
+
         # get random indices to mask
-        spec_aug_mask_idx = np.random.choice(
-            np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
-        )
+        if num_masked_span == 0:
+            # in this case we pretend to choose index 0, but at the end
+            # we revert the masking in this dimension.
+            # Note that we have to choose 'a' index to make sure the `dummy_mask_idx`
+            # can be selected, which is needed to keep the dimensionality equal.
+            spec_aug_mask_idx = np.array([0])
+            non_masked_batch_dimensions.append(batch_idx)
+            num_masked_span += 1  # to ensure we don't pad this
+        else:
+            spec_aug_mask_idx = np.random.choice(
+                np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
+            )
 
         # pick first sampled index that will serve as a dummy index to pad vector
+        # to ensure same dimension for all batches due to probabilistic rounding
+        # Picking first sample just pads those vectors twice.
         dummy_mask_idx = spec_aug_mask_idx[0]
 
         spec_aug_mask_idx = np.concatenate(
@@ -137,14 +157,20 @@ def _compute_mask_indices(
     )
     spec_aug_mask_idxs = spec_aug_mask_idxs.reshape(batch_size, max_num_masked_span * mask_length)
 
+    # add offset to the starting indexes so that that indexes now create a span
     offsets = np.arange(mask_length)[None, None, :]
     offsets = np.broadcast_to(offsets, (batch_size, max_num_masked_span, mask_length)).reshape(
         batch_size, max_num_masked_span * mask_length
     )
     spec_aug_mask_idxs = spec_aug_mask_idxs + offsets
 
-    # scatter indices to mask
+    # create the zero mask and scatter indices
+    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
     np.put_along_axis(spec_aug_mask, spec_aug_mask_idxs, 1, -1)
+
+    # revert any masks in dimensions where 0 spans were selected
+    if len(non_masked_batch_dimensions) >= 1:
+        spec_aug_mask[non_masked_batch_dimensions, :] = 0
 
     return spec_aug_mask
 
@@ -930,7 +956,7 @@ class HubertModel(HubertPreTrainedModel):
                 mask_prob=self.config.mask_time_prob,
                 mask_length=self.config.mask_time_length,
                 attention_mask=attention_mask,
-                min_masks=2,
+                min_masks=self.config.mask_time_min_masks,
             )
             mask_time_indices = torch.tensor(mask_time_indices, device=hidden_states.device, dtype=torch.bool)
             hidden_states[mask_time_indices] = self.masked_spec_embed.to(hidden_states.dtype)
@@ -941,6 +967,7 @@ class HubertModel(HubertPreTrainedModel):
                 (batch_size, hidden_size),
                 mask_prob=self.config.mask_feature_prob,
                 mask_length=self.config.mask_feature_length,
+                min_masks=self.config.mask_feature_min_masks,
             )
             mask_feature_indices = torch.tensor(mask_feature_indices, device=hidden_states.device, dtype=torch.bool)
             mask_feature_indices = mask_feature_indices[:, None].expand(-1, sequence_length, -1)

--- a/src/transformers/models/sew/configuration_sew.py
+++ b/src/transformers/models/sew/configuration_sew.py
@@ -96,9 +96,9 @@ class SEWConfig(PretrainedConfig):
             <https://arxiv.org/abs/1904.08779>`__.
         mask_time_prob (:obj:`float`, `optional`, defaults to 0.05):
             Percentage (between 0 and 1) of all feature vectors along the time axis which will be masked. The masking
-            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independ masks over the axis. If
+            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independent masks over the axis. If
             reasoning from the propability of each feature vector to be chosen as the start of the vector span to be
-            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length`` Note that overlap may decrease
+            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length``. Note that overlap may decrease
             the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment is True``.
         mask_time_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the time axis.
@@ -108,9 +108,9 @@ class SEWConfig(PretrainedConfig):
             ''mask_time_prob*len(time_axis)/mask_time_length < mask_time_min_masks''
         mask_feature_prob (:obj:`float`, `optional`, defaults to 0.0):
             Percentage (between 0 and 1) of all feature vectors along the feature axis which will be masked. The
-            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independ masks over
+            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independent masks over
             the axis. If reasoning from the propability of each feature vector to be chosen as the start of the vector
-            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length`` Note that
+            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length``. Note that
             overlap may decrease the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment
             is True``.
         mask_feature_length (:obj:`int`, `optional`, defaults to 10):

--- a/src/transformers/models/sew/configuration_sew.py
+++ b/src/transformers/models/sew/configuration_sew.py
@@ -95,17 +95,30 @@ class SEWConfig(PretrainedConfig):
             `SpecAugment: A Simple Data Augmentation Method for Automatic Speech Recognition
             <https://arxiv.org/abs/1904.08779>`__.
         mask_time_prob (:obj:`float`, `optional`, defaults to 0.05):
-            Propability of each feature vector along the time axis to be chosen as the start of the vector span to be
-            masked. Approximately ``mask_time_prob * sequence_length // mask_time_length`` feature vectors will be
-            masked along the time axis. This is only relevant if ``apply_spec_augment is True``.
+            Percentage (between 0 and 1) of all feature vectors along the time axis which will be masked. The masking
+            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independ masks over the axis. If
+            reasoning from the propability of each feature vector to be chosen as the start of the vector span to be
+            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length`` Note that overlap may decrease
+            the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment is True``.
         mask_time_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the time axis.
+        mask_time_min_masks (:obj:`int`, `optional`, defaults to 2),:
+            The minimum number of masks of length ``mask_feature_length`` generated along the time axis, each time
+            step, irrespectively of ``mask_feature_prob``. Only relevant if
+            ''mask_time_prob*len(time_axis)/mask_time_length < mask_time_min_masks''
         mask_feature_prob (:obj:`float`, `optional`, defaults to 0.0):
-            Propability of each feature vector along the feature axis to be chosen as the start of the vector span to
-            be masked. Approximately ``mask_time_prob * hidden_size // mask_time_length`` feature vectors will be
-            masked along the time axis. This is only relevant if ``apply_spec_augment is True``.
+            Percentage (between 0 and 1) of all feature vectors along the feature axis which will be masked. The
+            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independ masks over
+            the axis. If reasoning from the propability of each feature vector to be chosen as the start of the vector
+            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length`` Note that
+            overlap may decrease the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment
+            is True``.
         mask_feature_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the feature axis.
+        mask_feature_min_masks (:obj:`int`, `optional`, defaults to 0),:
+            The minimum number of masks of length ``mask_feature_length`` generated along the feature axis, each time
+            step, irrespectively of ``mask_feature_prob``. Only relevant if
+            ''mask_feature_prob*len(feature_axis)/mask_feature_length < mask_feature_min_masks''
         ctc_loss_reduction (:obj:`str`, `optional`, defaults to :obj:`"sum"`):
             Specifies the reduction to apply to the output of ``torch.nn.CTCLoss``. Only relevant when training an
             instance of :class:`~transformers.SEWForCTC`.
@@ -162,8 +175,10 @@ class SEWConfig(PretrainedConfig):
         apply_spec_augment=True,
         mask_time_prob=0.05,
         mask_time_length=10,
+        mask_time_min_masks=2,
         mask_feature_prob=0.0,
         mask_feature_length=10,
+        mask_feature_min_masks=0,
         ctc_loss_reduction="mean",
         ctc_zero_infinity=False,
         use_weighted_layer_sum=False,
@@ -215,8 +230,10 @@ class SEWConfig(PretrainedConfig):
         self.apply_spec_augment = apply_spec_augment
         self.mask_time_prob = mask_time_prob
         self.mask_time_length = mask_time_length
+        self.mask_time_min_masks = mask_time_min_masks
         self.mask_feature_prob = mask_feature_prob
         self.mask_feature_length = mask_feature_length
+        self.mask_feature_min_masks = mask_feature_min_masks
 
         # ctc loss
         self.ctc_loss_reduction = ctc_loss_reduction

--- a/src/transformers/models/sew/modeling_sew.py
+++ b/src/transformers/models/sew/modeling_sew.py
@@ -69,9 +69,10 @@ def _compute_mask_indices(
     Args:
         shape: The shape for which to compute masks. This should be of a tuple of size 2 where
                the first element is the batch size and the second element is the length of the axis to span.
-        mask_prob: The probability for each token to be chosen as start of the span to be masked. This will results in
-                   at most `ceil(mask_prob * shape[1]) * mask_length` masked tokens. Due to overlapping spans the
-                   expected amount of masked tokens will be fewer.
+        mask_prob:  The percentage of the whole axis (between 0 and 1) which will be masked. The number of
+                    independently generated mask spans of length `mask_length` is computed by
+                    `mask_prob*shape[1]/mask_length`. Note that due to overlaps, `mask_prob` is an upper bound and the
+                    actual percentage will be smaller.
         mask_length: size of the mask
         min_masks: minimum number of masked spans
         attention_mask: A (right-padded) attention mask which independently shortens the feature axis of
@@ -84,27 +85,23 @@ def _compute_mask_indices(
 
     if mask_length > sequence_length:
         raise ValueError(
-            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length} "
-            f"and `sequence_length`: {sequence_length}`"
+            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length}"
+            f" and `sequence_length`: {sequence_length}`"
         )
 
-    def compute_num_masked_span(feature_axis_length: int, use_probabilistic_rounding: bool):
+    # epsilon is used for probabilistic rounding
+    epsilon = np.random.rand(1).item()
+
+    def compute_num_masked_span(input_length):
         """Given input length, compute how many spans should be masked"""
-        assert feature_axis_length <= sequence_length
+        num_masked_span = int(mask_prob * input_length / mask_length + epsilon)
+        num_masked_span = max(num_masked_span, min_masks)
 
-        if use_probabilistic_rounding:
-            epsilon = np.random.rand(1).item()
-            num_selected_start_tokens = math.floor(mask_prob * feature_axis_length + epsilon)
-        else:
-            num_selected_start_tokens = math.ceil(mask_prob * feature_axis_length)
+        # make sure num masked indices <= sequence_length
+        if num_masked_span * mask_length > sequence_length:
+            num_masked_span = sequence_length // mask_length
 
-        num_selected_start_tokens = max(num_selected_start_tokens, min_masks)
-
-        # make sure num masked indices <= length of sequence to mask
-        if num_selected_start_tokens > feature_axis_length:
-            num_selected_start_tokens = feature_axis_length
-
-        return num_selected_start_tokens
+        return num_masked_span
 
     # compute number of masked spans in batch
     input_lengths = (
@@ -113,29 +110,23 @@ def _compute_mask_indices(
         else [sequence_length for _ in range(batch_size)]
     )
 
-    # select the indexes which will start a span of length `mask_length`
+    # SpecAugment mask to fill
+    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
     spec_aug_mask_idxs = []
-    non_masked_batch_dimensions = []
 
-    max_num_masked_span = compute_num_masked_span(sequence_length, use_probabilistic_rounding=False)
+    max_num_masked_span = compute_num_masked_span(sequence_length)
 
-    for batch_idx, input_length in enumerate(input_lengths):
+    if max_num_masked_span == 0:
+        return spec_aug_mask
+
+    for input_length in input_lengths:
         # compute num of masked spans for this input
-        num_masked_span = compute_num_masked_span(input_length, use_probabilistic_rounding=True)
+        num_masked_span = compute_num_masked_span(input_length)
 
         # get random indices to mask
-        if num_masked_span == 0:
-            # in this case we pretend to choose index 0, but at the end
-            # we revert the masking in this dimension.
-            # Note that we have to choose 'a' index to make sure the `dummy_mask_idx`
-            # can be selected, which is needed to keep the dimensionality equal.
-            spec_aug_mask_idx = np.array([0])
-            non_masked_batch_dimensions.append(batch_idx)
-            num_masked_span += 1  # to ensure we don't pad this
-        else:
-            spec_aug_mask_idx = np.random.choice(
-                np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
-            )
+        spec_aug_mask_idx = np.random.choice(
+            np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
+        )
 
         # pick first sampled index that will serve as a dummy index to pad vector
         # to ensure same dimension for all batches due to probabilistic rounding
@@ -162,13 +153,8 @@ def _compute_mask_indices(
     )
     spec_aug_mask_idxs = spec_aug_mask_idxs + offsets
 
-    # create the zero mask and scatter indices
-    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
+    # scatter indices to mask
     np.put_along_axis(spec_aug_mask, spec_aug_mask_idxs, 1, -1)
-
-    # revert any masks in dimensions where 0 spans were selected
-    if len(non_masked_batch_dimensions) >= 1:
-        spec_aug_mask[non_masked_batch_dimensions, :] = 0
 
     return spec_aug_mask
 

--- a/src/transformers/models/sew/modeling_sew.py
+++ b/src/transformers/models/sew/modeling_sew.py
@@ -67,13 +67,15 @@ def _compute_mask_indices(
     on CPU as part of the preprocessing during training.
 
     Args:
-        shape: the the shape for which to compute masks.
-            should be of size 2 where first element is batch size and 2nd is timesteps
-        mask_prob: probability for each token to be chosen as start of the span to be masked. this will be multiplied by
-            number of timesteps divided by length of mask span to mask approximately this percentage of all elements.
-            however due to overlaps, the actual number will be smaller (unless no_overlap is True)
+        shape: The shape for which to compute masks. This should be of a tuple of size 2 where
+               the first element is the batch size and the second element is the length of the axis to span.
+        mask_prob: The probability for each token to be chosen as start of the span to be masked. This will results in
+                   at most `ceil(mask_prob * shape[1]) * mask_length` masked tokens. Due to overlapping spans the
+                   expected amount of masked tokens will be fewer.
         mask_length: size of the mask
         min_masks: minimum number of masked spans
+        attention_mask: A (right-padded) attention mask which independently shortens the feature axis of
+                        each batch dimension.
     """
     batch_size, sequence_length = shape
 
@@ -82,21 +84,27 @@ def _compute_mask_indices(
 
     if mask_length > sequence_length:
         raise ValueError(
-            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length} and `sequence_length`: {sequence_length}`"
+            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length} "
+            f"and `sequence_length`: {sequence_length}`"
         )
 
-    epsilon = np.random.rand(1).item()
-
-    def compute_num_masked_span(input_length):
+    def compute_num_masked_span(feature_axis_length: int, use_probabilistic_rounding: bool):
         """Given input length, compute how many spans should be masked"""
-        num_masked_span = int(mask_prob * input_length / mask_length + epsilon)
-        num_masked_span = max(num_masked_span, min_masks)
+        assert feature_axis_length <= sequence_length
 
-        # make sure num masked indices <= sequence_length
-        if num_masked_span * mask_length > sequence_length:
-            num_masked_span = sequence_length // mask_length
+        if use_probabilistic_rounding:
+            epsilon = np.random.rand(1).item()
+            num_selected_start_tokens = math.floor(mask_prob * feature_axis_length + epsilon)
+        else:
+            num_selected_start_tokens = math.ceil(mask_prob * feature_axis_length)
 
-        return num_masked_span
+        num_selected_start_tokens = max(num_selected_start_tokens, min_masks)
+
+        # make sure num masked indices <= length of sequence to mask
+        if num_selected_start_tokens > feature_axis_length:
+            num_selected_start_tokens = feature_axis_length
+
+        return num_selected_start_tokens
 
     # compute number of masked spans in batch
     input_lengths = (
@@ -105,21 +113,33 @@ def _compute_mask_indices(
         else [sequence_length for _ in range(batch_size)]
     )
 
-    # SpecAugment mask to fill
-    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
+    # select the indexes which will start a span of length `mask_length`
     spec_aug_mask_idxs = []
+    non_masked_batch_dimensions = []
 
-    max_num_masked_span = compute_num_masked_span(sequence_length)
+    max_num_masked_span = compute_num_masked_span(sequence_length, use_probabilistic_rounding=False)
 
-    for input_length in input_lengths:
+    for batch_idx, input_length in enumerate(input_lengths):
         # compute num of masked spans for this input
-        num_masked_span = compute_num_masked_span(input_length)
+        num_masked_span = compute_num_masked_span(input_length, use_probabilistic_rounding=True)
+
         # get random indices to mask
-        spec_aug_mask_idx = np.random.choice(
-            np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
-        )
+        if num_masked_span == 0:
+            # in this case we pretend to choose index 0, but at the end
+            # we revert the masking in this dimension.
+            # Note that we have to choose 'a' index to make sure the `dummy_mask_idx`
+            # can be selected, which is needed to keep the dimensionality equal.
+            spec_aug_mask_idx = np.array([0])
+            non_masked_batch_dimensions.append(batch_idx)
+            num_masked_span += 1  # to ensure we don't pad this
+        else:
+            spec_aug_mask_idx = np.random.choice(
+                np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
+            )
 
         # pick first sampled index that will serve as a dummy index to pad vector
+        # to ensure same dimension for all batches due to probabilistic rounding
+        # Picking first sample just pads those vectors twice.
         dummy_mask_idx = spec_aug_mask_idx[0]
 
         spec_aug_mask_idx = np.concatenate(
@@ -135,14 +155,20 @@ def _compute_mask_indices(
     )
     spec_aug_mask_idxs = spec_aug_mask_idxs.reshape(batch_size, max_num_masked_span * mask_length)
 
+    # add offset to the starting indexes so that that indexes now create a span
     offsets = np.arange(mask_length)[None, None, :]
     offsets = np.broadcast_to(offsets, (batch_size, max_num_masked_span, mask_length)).reshape(
         batch_size, max_num_masked_span * mask_length
     )
     spec_aug_mask_idxs = spec_aug_mask_idxs + offsets
 
-    # scatter indices to mask
+    # create the zero mask and scatter indices
+    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
     np.put_along_axis(spec_aug_mask, spec_aug_mask_idxs, 1, -1)
+
+    # revert any masks in dimensions where 0 spans were selected
+    if len(non_masked_batch_dimensions) >= 1:
+        spec_aug_mask[non_masked_batch_dimensions, :] = 0
 
     return spec_aug_mask
 
@@ -829,7 +855,7 @@ class SEWModel(SEWPreTrainedModel):
                 mask_prob=self.config.mask_time_prob,
                 mask_length=self.config.mask_time_length,
                 attention_mask=attention_mask,
-                min_masks=2,
+                min_masks=self.config.mask_time_min_masks,
             )
             mask_time_indices = torch.tensor(mask_time_indices, device=hidden_states.device, dtype=torch.bool)
             hidden_states[mask_time_indices] = self.masked_spec_embed.to(hidden_states.dtype)
@@ -840,6 +866,7 @@ class SEWModel(SEWPreTrainedModel):
                 (batch_size, hidden_size),
                 mask_prob=self.config.mask_feature_prob,
                 mask_length=self.config.mask_feature_length,
+                min_masks=self.config.mask_feature_min_masks,
             )
             mask_feature_indices = torch.tensor(mask_feature_indices, device=hidden_states.device, dtype=torch.bool)
             mask_feature_indices = mask_feature_indices[:, None].expand(-1, sequence_length, -1)

--- a/src/transformers/models/sew_d/configuration_sew_d.py
+++ b/src/transformers/models/sew_d/configuration_sew_d.py
@@ -114,9 +114,9 @@ class SEWDConfig(PretrainedConfig):
             <https://arxiv.org/abs/1904.08779>`__.
         mask_time_prob (:obj:`float`, `optional`, defaults to 0.05):
             Percentage (between 0 and 1) of all feature vectors along the time axis which will be masked. The masking
-            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independ masks over the axis. If
+            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independent masks over the axis. If
             reasoning from the propability of each feature vector to be chosen as the start of the vector span to be
-            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length`` Note that overlap may decrease
+            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length``. Note that overlap may decrease
             the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment is True``.
         mask_time_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the time axis.
@@ -126,9 +126,9 @@ class SEWDConfig(PretrainedConfig):
             ''mask_time_prob*len(time_axis)/mask_time_length < mask_time_min_masks''
         mask_feature_prob (:obj:`float`, `optional`, defaults to 0.0):
             Percentage (between 0 and 1) of all feature vectors along the feature axis which will be masked. The
-            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independ masks over
+            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independent masks over
             the axis. If reasoning from the propability of each feature vector to be chosen as the start of the vector
-            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length`` Note that
+            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length``. Note that
             overlap may decrease the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment
             is True``.
         mask_feature_length (:obj:`int`, `optional`, defaults to 10):

--- a/src/transformers/models/sew_d/configuration_sew_d.py
+++ b/src/transformers/models/sew_d/configuration_sew_d.py
@@ -113,17 +113,30 @@ class SEWDConfig(PretrainedConfig):
             `SpecAugment: A Simple Data Augmentation Method for Automatic Speech Recognition
             <https://arxiv.org/abs/1904.08779>`__.
         mask_time_prob (:obj:`float`, `optional`, defaults to 0.05):
-            Propability of each feature vector along the time axis to be chosen as the start of the vector span to be
-            masked. Approximately ``mask_time_prob * sequence_length // mask_time_length`` feature vectors will be
-            masked along the time axis. This is only relevant if ``apply_spec_augment is True``.
+            Percentage (between 0 and 1) of all feature vectors along the time axis which will be masked. The masking
+            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independ masks over the axis. If
+            reasoning from the propability of each feature vector to be chosen as the start of the vector span to be
+            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length`` Note that overlap may decrease
+            the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment is True``.
         mask_time_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the time axis.
+        mask_time_min_masks (:obj:`int`, `optional`, defaults to 2),:
+            The minimum number of masks of length ``mask_feature_length`` generated along the time axis, each time
+            step, irrespectively of ``mask_feature_prob``. Only relevant if
+            ''mask_time_prob*len(time_axis)/mask_time_length < mask_time_min_masks''
         mask_feature_prob (:obj:`float`, `optional`, defaults to 0.0):
-            Propability of each feature vector along the feature axis to be chosen as the start of the vector span to
-            be masked. Approximately ``mask_time_prob * hidden_size // mask_time_length`` feature vectors will be
-            masked along the time axis. This is only relevant if ``apply_spec_augment is True``.
+            Percentage (between 0 and 1) of all feature vectors along the feature axis which will be masked. The
+            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independ masks over
+            the axis. If reasoning from the propability of each feature vector to be chosen as the start of the vector
+            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length`` Note that
+            overlap may decrease the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment
+            is True``.
         mask_feature_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the feature axis.
+        mask_feature_min_masks (:obj:`int`, `optional`, defaults to 0),:
+            The minimum number of masks of length ``mask_feature_length`` generated along the feature axis, each time
+            step, irrespectively of ``mask_feature_prob``. Only relevant if
+            ''mask_feature_prob*len(feature_axis)/mask_feature_length < mask_feature_min_masks''
         diversity_loss_weight (:obj:`int`, `optional`, defaults to 0.1):
             The weight of the codebook diversity loss component.
         ctc_loss_reduction (:obj:`str`, `optional`, defaults to :obj:`"sum"`):
@@ -190,8 +203,10 @@ class SEWDConfig(PretrainedConfig):
         apply_spec_augment=True,
         mask_time_prob=0.05,
         mask_time_length=10,
+        mask_time_min_masks=2,
         mask_feature_prob=0.0,
         mask_feature_length=10,
+        mask_feature_min_masks=0,
         ctc_loss_reduction="mean",
         ctc_zero_infinity=False,
         use_weighted_layer_sum=False,
@@ -251,8 +266,10 @@ class SEWDConfig(PretrainedConfig):
         self.apply_spec_augment = apply_spec_augment
         self.mask_time_prob = mask_time_prob
         self.mask_time_length = mask_time_length
+        self.mask_time_min_masks = mask_time_min_masks
         self.mask_feature_prob = mask_feature_prob
         self.mask_feature_length = mask_feature_length
+        self.mask_feature_min_masks = mask_feature_min_masks
 
         # ctc loss
         self.ctc_loss_reduction = ctc_loss_reduction

--- a/src/transformers/models/sew_d/modeling_sew_d.py
+++ b/src/transformers/models/sew_d/modeling_sew_d.py
@@ -75,9 +75,10 @@ def _compute_mask_indices(
     Args:
         shape: The shape for which to compute masks. This should be of a tuple of size 2 where
                the first element is the batch size and the second element is the length of the axis to span.
-        mask_prob: The probability for each token to be chosen as start of the span to be masked. This will results in
-                   at most `ceil(mask_prob * shape[1]) * mask_length` masked tokens. Due to overlapping spans the
-                   expected amount of masked tokens will be fewer.
+        mask_prob:  The percentage of the whole axis (between 0 and 1) which will be masked. The number of
+                    independently generated mask spans of length `mask_length` is computed by
+                    `mask_prob*shape[1]/mask_length`. Note that due to overlaps, `mask_prob` is an upper bound and the
+                    actual percentage will be smaller.
         mask_length: size of the mask
         min_masks: minimum number of masked spans
         attention_mask: A (right-padded) attention mask which independently shortens the feature axis of
@@ -90,27 +91,23 @@ def _compute_mask_indices(
 
     if mask_length > sequence_length:
         raise ValueError(
-            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length} "
-            f"and `sequence_length`: {sequence_length}`"
+            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length}"
+            f" and `sequence_length`: {sequence_length}`"
         )
 
-    def compute_num_masked_span(feature_axis_length: int, use_probabilistic_rounding: bool):
+    # epsilon is used for probabilistic rounding
+    epsilon = np.random.rand(1).item()
+
+    def compute_num_masked_span(input_length):
         """Given input length, compute how many spans should be masked"""
-        assert feature_axis_length <= sequence_length
+        num_masked_span = int(mask_prob * input_length / mask_length + epsilon)
+        num_masked_span = max(num_masked_span, min_masks)
 
-        if use_probabilistic_rounding:
-            epsilon = np.random.rand(1).item()
-            num_selected_start_tokens = math.floor(mask_prob * feature_axis_length + epsilon)
-        else:
-            num_selected_start_tokens = math.ceil(mask_prob * feature_axis_length)
+        # make sure num masked indices <= sequence_length
+        if num_masked_span * mask_length > sequence_length:
+            num_masked_span = sequence_length // mask_length
 
-        num_selected_start_tokens = max(num_selected_start_tokens, min_masks)
-
-        # make sure num masked indices <= length of sequence to mask
-        if num_selected_start_tokens > feature_axis_length:
-            num_selected_start_tokens = feature_axis_length
-
-        return num_selected_start_tokens
+        return num_masked_span
 
     # compute number of masked spans in batch
     input_lengths = (
@@ -119,29 +116,23 @@ def _compute_mask_indices(
         else [sequence_length for _ in range(batch_size)]
     )
 
-    # select the indexes which will start a span of length `mask_length`
+    # SpecAugment mask to fill
+    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
     spec_aug_mask_idxs = []
-    non_masked_batch_dimensions = []
 
-    max_num_masked_span = compute_num_masked_span(sequence_length, use_probabilistic_rounding=False)
+    max_num_masked_span = compute_num_masked_span(sequence_length)
 
-    for batch_idx, input_length in enumerate(input_lengths):
+    if max_num_masked_span == 0:
+        return spec_aug_mask
+
+    for input_length in input_lengths:
         # compute num of masked spans for this input
-        num_masked_span = compute_num_masked_span(input_length, use_probabilistic_rounding=True)
+        num_masked_span = compute_num_masked_span(input_length)
 
         # get random indices to mask
-        if num_masked_span == 0:
-            # in this case we pretend to choose index 0, but at the end
-            # we revert the masking in this dimension.
-            # Note that we have to choose 'a' index to make sure the `dummy_mask_idx`
-            # can be selected, which is needed to keep the dimensionality equal.
-            spec_aug_mask_idx = np.array([0])
-            non_masked_batch_dimensions.append(batch_idx)
-            num_masked_span += 1  # to ensure we don't pad this
-        else:
-            spec_aug_mask_idx = np.random.choice(
-                np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
-            )
+        spec_aug_mask_idx = np.random.choice(
+            np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
+        )
 
         # pick first sampled index that will serve as a dummy index to pad vector
         # to ensure same dimension for all batches due to probabilistic rounding
@@ -168,13 +159,8 @@ def _compute_mask_indices(
     )
     spec_aug_mask_idxs = spec_aug_mask_idxs + offsets
 
-    # create the zero mask and scatter indices
-    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
+    # scatter indices to mask
     np.put_along_axis(spec_aug_mask, spec_aug_mask_idxs, 1, -1)
-
-    # revert any masks in dimensions where 0 spans were selected
-    if len(non_masked_batch_dimensions) >= 1:
-        spec_aug_mask[non_masked_batch_dimensions, :] = 0
 
     return spec_aug_mask
 

--- a/src/transformers/models/sew_d/modeling_sew_d.py
+++ b/src/transformers/models/sew_d/modeling_sew_d.py
@@ -73,13 +73,15 @@ def _compute_mask_indices(
     on CPU as part of the preprocessing during training.
 
     Args:
-        shape: the the shape for which to compute masks.
-            should be of size 2 where first element is batch size and 2nd is timesteps
-        mask_prob: probability for each token to be chosen as start of the span to be masked. this will be multiplied by
-            number of timesteps divided by length of mask span to mask approximately this percentage of all elements.
-            however due to overlaps, the actual number will be smaller (unless no_overlap is True)
+        shape: The shape for which to compute masks. This should be of a tuple of size 2 where
+               the first element is the batch size and the second element is the length of the axis to span.
+        mask_prob: The probability for each token to be chosen as start of the span to be masked. This will results in
+                   at most `ceil(mask_prob * shape[1]) * mask_length` masked tokens. Due to overlapping spans the
+                   expected amount of masked tokens will be fewer.
         mask_length: size of the mask
         min_masks: minimum number of masked spans
+        attention_mask: A (right-padded) attention mask which independently shortens the feature axis of
+                        each batch dimension.
     """
     batch_size, sequence_length = shape
 
@@ -88,21 +90,27 @@ def _compute_mask_indices(
 
     if mask_length > sequence_length:
         raise ValueError(
-            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length} and `sequence_length`: {sequence_length}`"
+            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length} "
+            f"and `sequence_length`: {sequence_length}`"
         )
 
-    epsilon = np.random.rand(1).item()
-
-    def compute_num_masked_span(input_length):
+    def compute_num_masked_span(feature_axis_length: int, use_probabilistic_rounding: bool):
         """Given input length, compute how many spans should be masked"""
-        num_masked_span = int(mask_prob * input_length / mask_length + epsilon)
-        num_masked_span = max(num_masked_span, min_masks)
+        assert feature_axis_length <= sequence_length
 
-        # make sure num masked indices <= sequence_length
-        if num_masked_span * mask_length > sequence_length:
-            num_masked_span = sequence_length // mask_length
+        if use_probabilistic_rounding:
+            epsilon = np.random.rand(1).item()
+            num_selected_start_tokens = math.floor(mask_prob * feature_axis_length + epsilon)
+        else:
+            num_selected_start_tokens = math.ceil(mask_prob * feature_axis_length)
 
-        return num_masked_span
+        num_selected_start_tokens = max(num_selected_start_tokens, min_masks)
+
+        # make sure num masked indices <= length of sequence to mask
+        if num_selected_start_tokens > feature_axis_length:
+            num_selected_start_tokens = feature_axis_length
+
+        return num_selected_start_tokens
 
     # compute number of masked spans in batch
     input_lengths = (
@@ -111,21 +119,33 @@ def _compute_mask_indices(
         else [sequence_length for _ in range(batch_size)]
     )
 
-    # SpecAugment mask to fill
-    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
+    # select the indexes which will start a span of length `mask_length`
     spec_aug_mask_idxs = []
+    non_masked_batch_dimensions = []
 
-    max_num_masked_span = compute_num_masked_span(sequence_length)
+    max_num_masked_span = compute_num_masked_span(sequence_length, use_probabilistic_rounding=False)
 
-    for input_length in input_lengths:
+    for batch_idx, input_length in enumerate(input_lengths):
         # compute num of masked spans for this input
-        num_masked_span = compute_num_masked_span(input_length)
+        num_masked_span = compute_num_masked_span(input_length, use_probabilistic_rounding=True)
+
         # get random indices to mask
-        spec_aug_mask_idx = np.random.choice(
-            np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
-        )
+        if num_masked_span == 0:
+            # in this case we pretend to choose index 0, but at the end
+            # we revert the masking in this dimension.
+            # Note that we have to choose 'a' index to make sure the `dummy_mask_idx`
+            # can be selected, which is needed to keep the dimensionality equal.
+            spec_aug_mask_idx = np.array([0])
+            non_masked_batch_dimensions.append(batch_idx)
+            num_masked_span += 1  # to ensure we don't pad this
+        else:
+            spec_aug_mask_idx = np.random.choice(
+                np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
+            )
 
         # pick first sampled index that will serve as a dummy index to pad vector
+        # to ensure same dimension for all batches due to probabilistic rounding
+        # Picking first sample just pads those vectors twice.
         dummy_mask_idx = spec_aug_mask_idx[0]
 
         spec_aug_mask_idx = np.concatenate(
@@ -141,14 +161,20 @@ def _compute_mask_indices(
     )
     spec_aug_mask_idxs = spec_aug_mask_idxs.reshape(batch_size, max_num_masked_span * mask_length)
 
+    # add offset to the starting indexes so that that indexes now create a span
     offsets = np.arange(mask_length)[None, None, :]
     offsets = np.broadcast_to(offsets, (batch_size, max_num_masked_span, mask_length)).reshape(
         batch_size, max_num_masked_span * mask_length
     )
     spec_aug_mask_idxs = spec_aug_mask_idxs + offsets
 
-    # scatter indices to mask
+    # create the zero mask and scatter indices
+    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
     np.put_along_axis(spec_aug_mask, spec_aug_mask_idxs, 1, -1)
+
+    # revert any masks in dimensions where 0 spans were selected
+    if len(non_masked_batch_dimensions) >= 1:
+        spec_aug_mask[non_masked_batch_dimensions, :] = 0
 
     return spec_aug_mask
 
@@ -1360,7 +1386,7 @@ class SEWDModel(SEWDPreTrainedModel):
                 mask_prob=self.config.mask_time_prob,
                 mask_length=self.config.mask_time_length,
                 attention_mask=attention_mask,
-                min_masks=2,
+                min_masks=self.config.mask_time_min_masks,
             )
             mask_time_indices = torch.tensor(mask_time_indices, device=hidden_states.device, dtype=torch.bool)
             hidden_states[mask_time_indices] = self.masked_spec_embed.to(hidden_states.dtype)
@@ -1371,6 +1397,7 @@ class SEWDModel(SEWDPreTrainedModel):
                 (batch_size, hidden_size),
                 mask_prob=self.config.mask_feature_prob,
                 mask_length=self.config.mask_feature_length,
+                min_masks=self.config.mask_feature_min_masks,
             )
             mask_feature_indices = torch.tensor(mask_feature_indices, device=hidden_states.device, dtype=torch.bool)
             mask_feature_indices = mask_feature_indices[:, None].expand(-1, sequence_length, -1)

--- a/src/transformers/models/unispeech/configuration_unispeech.py
+++ b/src/transformers/models/unispeech/configuration_unispeech.py
@@ -101,17 +101,30 @@ class UniSpeechConfig(PretrainedConfig):
             `SpecAugment: A Simple Data Augmentation Method for Automatic Speech Recognition
             <https://arxiv.org/abs/1904.08779>`__.
         mask_time_prob (:obj:`float`, `optional`, defaults to 0.05):
-            Propability of each feature vector along the time axis to be chosen as the start of the vector span to be
-            masked. Approximately ``mask_time_prob * sequence_length // mask_time_length`` feature vectors will be
-            masked along the time axis. This is only relevant if ``apply_spec_augment is True``.
+            Percentage (between 0 and 1) of all feature vectors along the time axis which will be masked. The masking
+            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independ masks over the axis. If
+            reasoning from the propability of each feature vector to be chosen as the start of the vector span to be
+            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length`` Note that overlap may decrease
+            the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment is True``.
         mask_time_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the time axis.
+        mask_time_min_masks (:obj:`int`, `optional`, defaults to 2),:
+            The minimum number of masks of length ``mask_feature_length`` generated along the time axis, each time
+            step, irrespectively of ``mask_feature_prob``. Only relevant if
+            ''mask_time_prob*len(time_axis)/mask_time_length < mask_time_min_masks''
         mask_feature_prob (:obj:`float`, `optional`, defaults to 0.0):
-            Propability of each feature vector along the feature axis to be chosen as the start of the vector span to
-            be masked. Approximately ``mask_time_prob * hidden_size // mask_time_length`` feature vectors will be
-            masked along the time axis. This is only relevant if ``apply_spec_augment is True``.
+            Percentage (between 0 and 1) of all feature vectors along the feature axis which will be masked. The
+            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independ masks over
+            the axis. If reasoning from the propability of each feature vector to be chosen as the start of the vector
+            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length`` Note that
+            overlap may decrease the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment
+            is True``.
         mask_feature_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the feature axis.
+        mask_feature_min_masks (:obj:`int`, `optional`, defaults to 0),:
+            The minimum number of masks of length ``mask_feature_length`` generated along the feature axis, each time
+            step, irrespectively of ``mask_feature_prob``. Only relevant if
+            ''mask_feature_prob*len(feature_axis)/mask_feature_length < mask_feature_min_masks''
         num_codevectors_per_group (:obj:`int`, `optional`, defaults to 320):
             Number of entries in each quantization codebook (group).
         num_codevector_groups (:obj:`int`, `optional`, defaults to 2):
@@ -187,8 +200,10 @@ class UniSpeechConfig(PretrainedConfig):
         apply_spec_augment=True,
         mask_time_prob=0.05,
         mask_time_length=10,
+        mask_time_min_masks=2,
         mask_feature_prob=0.0,
         mask_feature_length=10,
+        mask_feature_min_masks=0,
         num_codevectors_per_group=320,
         num_codevector_groups=2,
         contrastive_logits_temperature=0.1,
@@ -252,8 +267,10 @@ class UniSpeechConfig(PretrainedConfig):
         self.apply_spec_augment = apply_spec_augment
         self.mask_time_prob = mask_time_prob
         self.mask_time_length = mask_time_length
+        self.mask_time_min_masks = mask_time_min_masks
         self.mask_feature_prob = mask_feature_prob
         self.mask_feature_length = mask_feature_length
+        self.mask_feature_min_masks = mask_feature_min_masks
 
         # parameters for pretraining with codevector quantized representations
         self.num_codevectors_per_group = num_codevectors_per_group

--- a/src/transformers/models/unispeech/configuration_unispeech.py
+++ b/src/transformers/models/unispeech/configuration_unispeech.py
@@ -102,9 +102,9 @@ class UniSpeechConfig(PretrainedConfig):
             <https://arxiv.org/abs/1904.08779>`__.
         mask_time_prob (:obj:`float`, `optional`, defaults to 0.05):
             Percentage (between 0 and 1) of all feature vectors along the time axis which will be masked. The masking
-            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independ masks over the axis. If
+            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independent masks over the axis. If
             reasoning from the propability of each feature vector to be chosen as the start of the vector span to be
-            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length`` Note that overlap may decrease
+            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length``. Note that overlap may decrease
             the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment is True``.
         mask_time_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the time axis.
@@ -114,9 +114,9 @@ class UniSpeechConfig(PretrainedConfig):
             ''mask_time_prob*len(time_axis)/mask_time_length < mask_time_min_masks''
         mask_feature_prob (:obj:`float`, `optional`, defaults to 0.0):
             Percentage (between 0 and 1) of all feature vectors along the feature axis which will be masked. The
-            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independ masks over
+            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independent masks over
             the axis. If reasoning from the propability of each feature vector to be chosen as the start of the vector
-            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length`` Note that
+            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length``. Note that
             overlap may decrease the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment
             is True``.
         mask_feature_length (:obj:`int`, `optional`, defaults to 10):

--- a/src/transformers/models/unispeech/modeling_unispeech.py
+++ b/src/transformers/models/unispeech/modeling_unispeech.py
@@ -136,13 +136,15 @@ def _compute_mask_indices(
     on CPU as part of the preprocessing during training.
 
     Args:
-        shape: the the shape for which to compute masks.
-            should be of size 2 where first element is batch size and 2nd is timesteps
-        mask_prob: probability for each token to be chosen as start of the span to be masked. this will be multiplied by
-            number of timesteps divided by length of mask span to mask approximately this percentage of all elements.
-            however due to overlaps, the actual number will be smaller (unless no_overlap is True)
+        shape: The shape for which to compute masks. This should be of a tuple of size 2 where
+               the first element is the batch size and the second element is the length of the axis to span.
+        mask_prob: The probability for each token to be chosen as start of the span to be masked. This will results in
+                   at most `ceil(mask_prob * shape[1]) * mask_length` masked tokens. Due to overlapping spans the
+                   expected amount of masked tokens will be fewer.
         mask_length: size of the mask
         min_masks: minimum number of masked spans
+        attention_mask: A (right-padded) attention mask which independently shortens the feature axis of
+                        each batch dimension.
     """
     batch_size, sequence_length = shape
 
@@ -151,21 +153,27 @@ def _compute_mask_indices(
 
     if mask_length > sequence_length:
         raise ValueError(
-            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length} and `sequence_length`: {sequence_length}`"
+            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length} "
+            f"and `sequence_length`: {sequence_length}`"
         )
 
-    epsilon = np.random.rand(1).item()
-
-    def compute_num_masked_span(input_length):
+    def compute_num_masked_span(feature_axis_length: int, use_probabilistic_rounding: bool):
         """Given input length, compute how many spans should be masked"""
-        num_masked_span = int(mask_prob * input_length / mask_length + epsilon)
-        num_masked_span = max(num_masked_span, min_masks)
+        assert feature_axis_length <= sequence_length
 
-        # make sure num masked indices <= sequence_length
-        if num_masked_span * mask_length > sequence_length:
-            num_masked_span = sequence_length // mask_length
+        if use_probabilistic_rounding:
+            epsilon = np.random.rand(1).item()
+            num_selected_start_tokens = math.floor(mask_prob * feature_axis_length + epsilon)
+        else:
+            num_selected_start_tokens = math.ceil(mask_prob * feature_axis_length)
 
-        return num_masked_span
+        num_selected_start_tokens = max(num_selected_start_tokens, min_masks)
+
+        # make sure num masked indices <= length of sequence to mask
+        if num_selected_start_tokens > feature_axis_length:
+            num_selected_start_tokens = feature_axis_length
+
+        return num_selected_start_tokens
 
     # compute number of masked spans in batch
     input_lengths = (
@@ -174,21 +182,33 @@ def _compute_mask_indices(
         else [sequence_length for _ in range(batch_size)]
     )
 
-    # SpecAugment mask to fill
-    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
+    # select the indexes which will start a span of length `mask_length`
     spec_aug_mask_idxs = []
+    non_masked_batch_dimensions = []
 
-    max_num_masked_span = compute_num_masked_span(sequence_length)
+    max_num_masked_span = compute_num_masked_span(sequence_length, use_probabilistic_rounding=False)
 
-    for input_length in input_lengths:
+    for batch_idx, input_length in enumerate(input_lengths):
         # compute num of masked spans for this input
-        num_masked_span = compute_num_masked_span(input_length)
+        num_masked_span = compute_num_masked_span(input_length, use_probabilistic_rounding=True)
+
         # get random indices to mask
-        spec_aug_mask_idx = np.random.choice(
-            np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
-        )
+        if num_masked_span == 0:
+            # in this case we pretend to choose index 0, but at the end
+            # we revert the masking in this dimension.
+            # Note that we have to choose 'a' index to make sure the `dummy_mask_idx`
+            # can be selected, which is needed to keep the dimensionality equal.
+            spec_aug_mask_idx = np.array([0])
+            non_masked_batch_dimensions.append(batch_idx)
+            num_masked_span += 1  # to ensure we don't pad this
+        else:
+            spec_aug_mask_idx = np.random.choice(
+                np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
+            )
 
         # pick first sampled index that will serve as a dummy index to pad vector
+        # to ensure same dimension for all batches due to probabilistic rounding
+        # Picking first sample just pads those vectors twice.
         dummy_mask_idx = spec_aug_mask_idx[0]
 
         spec_aug_mask_idx = np.concatenate(
@@ -204,14 +224,20 @@ def _compute_mask_indices(
     )
     spec_aug_mask_idxs = spec_aug_mask_idxs.reshape(batch_size, max_num_masked_span * mask_length)
 
+    # add offset to the starting indexes so that that indexes now create a span
     offsets = np.arange(mask_length)[None, None, :]
     offsets = np.broadcast_to(offsets, (batch_size, max_num_masked_span, mask_length)).reshape(
         batch_size, max_num_masked_span * mask_length
     )
     spec_aug_mask_idxs = spec_aug_mask_idxs + offsets
 
-    # scatter indices to mask
+    # create the zero mask and scatter indices
+    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
     np.put_along_axis(spec_aug_mask, spec_aug_mask_idxs, 1, -1)
+
+    # revert any masks in dimensions where 0 spans were selected
+    if len(non_masked_batch_dimensions) >= 1:
+        spec_aug_mask[non_masked_batch_dimensions, :] = 0
 
     return spec_aug_mask
 
@@ -1076,7 +1102,7 @@ class UniSpeechModel(UniSpeechPreTrainedModel):
                 mask_prob=self.config.mask_time_prob,
                 mask_length=self.config.mask_time_length,
                 attention_mask=attention_mask,
-                min_masks=2,
+                min_masks=self.config.mask_time_min_masks,
             )
             mask_time_indices = torch.tensor(mask_time_indices, device=hidden_states.device, dtype=torch.bool)
             hidden_states[mask_time_indices] = self.masked_spec_embed.to(hidden_states.dtype)
@@ -1087,6 +1113,7 @@ class UniSpeechModel(UniSpeechPreTrainedModel):
                 (batch_size, hidden_size),
                 mask_prob=self.config.mask_feature_prob,
                 mask_length=self.config.mask_feature_length,
+                min_masks=self.config.mask_feature_min_masks,
             )
             mask_feature_indices = torch.tensor(mask_feature_indices, device=hidden_states.device, dtype=torch.bool)
             mask_feature_indices = mask_feature_indices[:, None].expand(-1, sequence_length, -1)

--- a/src/transformers/models/unispeech/modeling_unispeech.py
+++ b/src/transformers/models/unispeech/modeling_unispeech.py
@@ -138,9 +138,10 @@ def _compute_mask_indices(
     Args:
         shape: The shape for which to compute masks. This should be of a tuple of size 2 where
                the first element is the batch size and the second element is the length of the axis to span.
-        mask_prob: The probability for each token to be chosen as start of the span to be masked. This will results in
-                   at most `ceil(mask_prob * shape[1]) * mask_length` masked tokens. Due to overlapping spans the
-                   expected amount of masked tokens will be fewer.
+        mask_prob:  The percentage of the whole axis (between 0 and 1) which will be masked. The number of
+                    independently generated mask spans of length `mask_length` is computed by
+                    `mask_prob*shape[1]/mask_length`. Note that due to overlaps, `mask_prob` is an upper bound and the
+                    actual percentage will be smaller.
         mask_length: size of the mask
         min_masks: minimum number of masked spans
         attention_mask: A (right-padded) attention mask which independently shortens the feature axis of
@@ -153,27 +154,23 @@ def _compute_mask_indices(
 
     if mask_length > sequence_length:
         raise ValueError(
-            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length} "
-            f"and `sequence_length`: {sequence_length}`"
+            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length}"
+            f" and `sequence_length`: {sequence_length}`"
         )
 
-    def compute_num_masked_span(feature_axis_length: int, use_probabilistic_rounding: bool):
+    # epsilon is used for probabilistic rounding
+    epsilon = np.random.rand(1).item()
+
+    def compute_num_masked_span(input_length):
         """Given input length, compute how many spans should be masked"""
-        assert feature_axis_length <= sequence_length
+        num_masked_span = int(mask_prob * input_length / mask_length + epsilon)
+        num_masked_span = max(num_masked_span, min_masks)
 
-        if use_probabilistic_rounding:
-            epsilon = np.random.rand(1).item()
-            num_selected_start_tokens = math.floor(mask_prob * feature_axis_length + epsilon)
-        else:
-            num_selected_start_tokens = math.ceil(mask_prob * feature_axis_length)
+        # make sure num masked indices <= sequence_length
+        if num_masked_span * mask_length > sequence_length:
+            num_masked_span = sequence_length // mask_length
 
-        num_selected_start_tokens = max(num_selected_start_tokens, min_masks)
-
-        # make sure num masked indices <= length of sequence to mask
-        if num_selected_start_tokens > feature_axis_length:
-            num_selected_start_tokens = feature_axis_length
-
-        return num_selected_start_tokens
+        return num_masked_span
 
     # compute number of masked spans in batch
     input_lengths = (
@@ -182,29 +179,23 @@ def _compute_mask_indices(
         else [sequence_length for _ in range(batch_size)]
     )
 
-    # select the indexes which will start a span of length `mask_length`
+    # SpecAugment mask to fill
+    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
     spec_aug_mask_idxs = []
-    non_masked_batch_dimensions = []
 
-    max_num_masked_span = compute_num_masked_span(sequence_length, use_probabilistic_rounding=False)
+    max_num_masked_span = compute_num_masked_span(sequence_length)
 
-    for batch_idx, input_length in enumerate(input_lengths):
+    if max_num_masked_span == 0:
+        return spec_aug_mask
+
+    for input_length in input_lengths:
         # compute num of masked spans for this input
-        num_masked_span = compute_num_masked_span(input_length, use_probabilistic_rounding=True)
+        num_masked_span = compute_num_masked_span(input_length)
 
         # get random indices to mask
-        if num_masked_span == 0:
-            # in this case we pretend to choose index 0, but at the end
-            # we revert the masking in this dimension.
-            # Note that we have to choose 'a' index to make sure the `dummy_mask_idx`
-            # can be selected, which is needed to keep the dimensionality equal.
-            spec_aug_mask_idx = np.array([0])
-            non_masked_batch_dimensions.append(batch_idx)
-            num_masked_span += 1  # to ensure we don't pad this
-        else:
-            spec_aug_mask_idx = np.random.choice(
-                np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
-            )
+        spec_aug_mask_idx = np.random.choice(
+            np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
+        )
 
         # pick first sampled index that will serve as a dummy index to pad vector
         # to ensure same dimension for all batches due to probabilistic rounding
@@ -231,13 +222,8 @@ def _compute_mask_indices(
     )
     spec_aug_mask_idxs = spec_aug_mask_idxs + offsets
 
-    # create the zero mask and scatter indices
-    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
+    # scatter indices to mask
     np.put_along_axis(spec_aug_mask, spec_aug_mask_idxs, 1, -1)
-
-    # revert any masks in dimensions where 0 spans were selected
-    if len(non_masked_batch_dimensions) >= 1:
-        spec_aug_mask[non_masked_batch_dimensions, :] = 0
 
     return spec_aug_mask
 

--- a/src/transformers/models/unispeech_sat/configuration_unispeech_sat.py
+++ b/src/transformers/models/unispeech_sat/configuration_unispeech_sat.py
@@ -102,9 +102,9 @@ class UniSpeechSatConfig(PretrainedConfig):
             <https://arxiv.org/abs/1904.08779>`__.
         mask_time_prob (:obj:`float`, `optional`, defaults to 0.05):
             Percentage (between 0 and 1) of all feature vectors along the time axis which will be masked. The masking
-            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independ masks over the axis. If
+            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independent masks over the axis. If
             reasoning from the propability of each feature vector to be chosen as the start of the vector span to be
-            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length`` Note that overlap may decrease
+            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length``. Note that overlap may decrease
             the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment is True``.
         mask_time_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the time axis.
@@ -114,9 +114,9 @@ class UniSpeechSatConfig(PretrainedConfig):
             ''mask_time_prob*len(time_axis)/mask_time_length < mask_time_min_masks''
         mask_feature_prob (:obj:`float`, `optional`, defaults to 0.0):
             Percentage (between 0 and 1) of all feature vectors along the feature axis which will be masked. The
-            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independ masks over
+            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independent masks over
             the axis. If reasoning from the propability of each feature vector to be chosen as the start of the vector
-            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length`` Note that
+            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length``. Note that
             overlap may decrease the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment
             is True``.
         mask_feature_length (:obj:`int`, `optional`, defaults to 10):

--- a/src/transformers/models/unispeech_sat/configuration_unispeech_sat.py
+++ b/src/transformers/models/unispeech_sat/configuration_unispeech_sat.py
@@ -101,17 +101,30 @@ class UniSpeechSatConfig(PretrainedConfig):
             `SpecAugment: A Simple Data Augmentation Method for Automatic Speech Recognition
             <https://arxiv.org/abs/1904.08779>`__.
         mask_time_prob (:obj:`float`, `optional`, defaults to 0.05):
-            Propability of each feature vector along the time axis to be chosen as the start of the vector span to be
-            masked. Approximately ``mask_time_prob * sequence_length // mask_time_length`` feature vectors will be
-            masked along the time axis. This is only relevant if ``apply_spec_augment is True``.
+            Percentage (between 0 and 1) of all feature vectors along the time axis which will be masked. The masking
+            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independ masks over the axis. If
+            reasoning from the propability of each feature vector to be chosen as the start of the vector span to be
+            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length`` Note that overlap may decrease
+            the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment is True``.
         mask_time_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the time axis.
+        mask_time_min_masks (:obj:`int`, `optional`, defaults to 2),:
+            The minimum number of masks of length ``mask_feature_length`` generated along the time axis, each time
+            step, irrespectively of ``mask_feature_prob``. Only relevant if
+            ''mask_time_prob*len(time_axis)/mask_time_length < mask_time_min_masks''
         mask_feature_prob (:obj:`float`, `optional`, defaults to 0.0):
-            Propability of each feature vector along the feature axis to be chosen as the start of the vector span to
-            be masked. Approximately ``mask_time_prob * hidden_size // mask_time_length`` feature vectors will be
-            masked along the time axis. This is only relevant if ``apply_spec_augment is True``.
+            Percentage (between 0 and 1) of all feature vectors along the feature axis which will be masked. The
+            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independ masks over
+            the axis. If reasoning from the propability of each feature vector to be chosen as the start of the vector
+            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length`` Note that
+            overlap may decrease the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment
+            is True``.
         mask_feature_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the feature axis.
+        mask_feature_min_masks (:obj:`int`, `optional`, defaults to 0),:
+            The minimum number of masks of length ``mask_feature_length`` generated along the feature axis, each time
+            step, irrespectively of ``mask_feature_prob``. Only relevant if
+            ''mask_feature_prob*len(feature_axis)/mask_feature_length < mask_feature_min_masks''
         num_codevectors_per_group (:obj:`int`, `optional`, defaults to 320):
             Number of entries in each quantization codebook (group).
         num_codevector_groups (:obj:`int`, `optional`, defaults to 2):
@@ -185,8 +198,10 @@ class UniSpeechSatConfig(PretrainedConfig):
         apply_spec_augment=True,
         mask_time_prob=0.05,
         mask_time_length=10,
+        mask_time_min_masks=2,
         mask_feature_prob=0.0,
         mask_feature_length=10,
+        mask_feature_min_masks=0,
         num_codevectors_per_group=320,
         num_codevector_groups=2,
         contrastive_logits_temperature=0.1,
@@ -249,8 +264,10 @@ class UniSpeechSatConfig(PretrainedConfig):
         self.apply_spec_augment = apply_spec_augment
         self.mask_time_prob = mask_time_prob
         self.mask_time_length = mask_time_length
+        self.mask_time_min_masks = mask_time_min_masks
         self.mask_feature_prob = mask_feature_prob
         self.mask_feature_length = mask_feature_length
+        self.mask_feature_min_masks = mask_feature_min_masks
 
         # parameters for pretraining with codevector quantized representations
         self.num_codevectors_per_group = num_codevectors_per_group

--- a/src/transformers/models/unispeech_sat/modeling_unispeech_sat.py
+++ b/src/transformers/models/unispeech_sat/modeling_unispeech_sat.py
@@ -139,9 +139,10 @@ def _compute_mask_indices(
     Args:
         shape: The shape for which to compute masks. This should be of a tuple of size 2 where
                the first element is the batch size and the second element is the length of the axis to span.
-        mask_prob: The probability for each token to be chosen as start of the span to be masked. This will results in
-                   at most `ceil(mask_prob * shape[1]) * mask_length` masked tokens. Due to overlapping spans the
-                   expected amount of masked tokens will be fewer.
+        mask_prob:  The percentage of the whole axis (between 0 and 1) which will be masked. The number of
+                    independently generated mask spans of length `mask_length` is computed by
+                    `mask_prob*shape[1]/mask_length`. Note that due to overlaps, `mask_prob` is an upper bound and the
+                    actual percentage will be smaller.
         mask_length: size of the mask
         min_masks: minimum number of masked spans
         attention_mask: A (right-padded) attention mask which independently shortens the feature axis of
@@ -154,27 +155,23 @@ def _compute_mask_indices(
 
     if mask_length > sequence_length:
         raise ValueError(
-            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length} "
-            f"and `sequence_length`: {sequence_length}`"
+            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length}"
+            f" and `sequence_length`: {sequence_length}`"
         )
 
-    def compute_num_masked_span(feature_axis_length: int, use_probabilistic_rounding: bool):
+    # epsilon is used for probabilistic rounding
+    epsilon = np.random.rand(1).item()
+
+    def compute_num_masked_span(input_length):
         """Given input length, compute how many spans should be masked"""
-        assert feature_axis_length <= sequence_length
+        num_masked_span = int(mask_prob * input_length / mask_length + epsilon)
+        num_masked_span = max(num_masked_span, min_masks)
 
-        if use_probabilistic_rounding:
-            epsilon = np.random.rand(1).item()
-            num_selected_start_tokens = math.floor(mask_prob * feature_axis_length + epsilon)
-        else:
-            num_selected_start_tokens = math.ceil(mask_prob * feature_axis_length)
+        # make sure num masked indices <= sequence_length
+        if num_masked_span * mask_length > sequence_length:
+            num_masked_span = sequence_length // mask_length
 
-        num_selected_start_tokens = max(num_selected_start_tokens, min_masks)
-
-        # make sure num masked indices <= length of sequence to mask
-        if num_selected_start_tokens > feature_axis_length:
-            num_selected_start_tokens = feature_axis_length
-
-        return num_selected_start_tokens
+        return num_masked_span
 
     # compute number of masked spans in batch
     input_lengths = (
@@ -183,29 +180,23 @@ def _compute_mask_indices(
         else [sequence_length for _ in range(batch_size)]
     )
 
-    # select the indexes which will start a span of length `mask_length`
+    # SpecAugment mask to fill
+    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
     spec_aug_mask_idxs = []
-    non_masked_batch_dimensions = []
 
-    max_num_masked_span = compute_num_masked_span(sequence_length, use_probabilistic_rounding=False)
+    max_num_masked_span = compute_num_masked_span(sequence_length)
 
-    for batch_idx, input_length in enumerate(input_lengths):
+    if max_num_masked_span == 0:
+        return spec_aug_mask
+
+    for input_length in input_lengths:
         # compute num of masked spans for this input
-        num_masked_span = compute_num_masked_span(input_length, use_probabilistic_rounding=True)
+        num_masked_span = compute_num_masked_span(input_length)
 
         # get random indices to mask
-        if num_masked_span == 0:
-            # in this case we pretend to choose index 0, but at the end
-            # we revert the masking in this dimension.
-            # Note that we have to choose 'a' index to make sure the `dummy_mask_idx`
-            # can be selected, which is needed to keep the dimensionality equal.
-            spec_aug_mask_idx = np.array([0])
-            non_masked_batch_dimensions.append(batch_idx)
-            num_masked_span += 1  # to ensure we don't pad this
-        else:
-            spec_aug_mask_idx = np.random.choice(
-                np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
-            )
+        spec_aug_mask_idx = np.random.choice(
+            np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
+        )
 
         # pick first sampled index that will serve as a dummy index to pad vector
         # to ensure same dimension for all batches due to probabilistic rounding
@@ -232,13 +223,8 @@ def _compute_mask_indices(
     )
     spec_aug_mask_idxs = spec_aug_mask_idxs + offsets
 
-    # create the zero mask and scatter indices
-    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
+    # scatter indices to mask
     np.put_along_axis(spec_aug_mask, spec_aug_mask_idxs, 1, -1)
-
-    # revert any masks in dimensions where 0 spans were selected
-    if len(non_masked_batch_dimensions) >= 1:
-        spec_aug_mask[non_masked_batch_dimensions, :] = 0
 
     return spec_aug_mask
 

--- a/src/transformers/models/unispeech_sat/modeling_unispeech_sat.py
+++ b/src/transformers/models/unispeech_sat/modeling_unispeech_sat.py
@@ -137,13 +137,15 @@ def _compute_mask_indices(
     on CPU as part of the preprocessing during training.
 
     Args:
-        shape: the the shape for which to compute masks.
-            should be of size 2 where first element is batch size and 2nd is timesteps
-        mask_prob: probability for each token to be chosen as start of the span to be masked. this will be multiplied by
-            number of timesteps divided by length of mask span to mask approximately this percentage of all elements.
-            however due to overlaps, the actual number will be smaller (unless no_overlap is True)
+        shape: The shape for which to compute masks. This should be of a tuple of size 2 where
+               the first element is the batch size and the second element is the length of the axis to span.
+        mask_prob: The probability for each token to be chosen as start of the span to be masked. This will results in
+                   at most `ceil(mask_prob * shape[1]) * mask_length` masked tokens. Due to overlapping spans the
+                   expected amount of masked tokens will be fewer.
         mask_length: size of the mask
         min_masks: minimum number of masked spans
+        attention_mask: A (right-padded) attention mask which independently shortens the feature axis of
+                        each batch dimension.
     """
     batch_size, sequence_length = shape
 
@@ -152,21 +154,27 @@ def _compute_mask_indices(
 
     if mask_length > sequence_length:
         raise ValueError(
-            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length} and `sequence_length`: {sequence_length}`"
+            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length} "
+            f"and `sequence_length`: {sequence_length}`"
         )
 
-    epsilon = np.random.rand(1).item()
-
-    def compute_num_masked_span(input_length):
+    def compute_num_masked_span(feature_axis_length: int, use_probabilistic_rounding: bool):
         """Given input length, compute how many spans should be masked"""
-        num_masked_span = int(mask_prob * input_length / mask_length + epsilon)
-        num_masked_span = max(num_masked_span, min_masks)
+        assert feature_axis_length <= sequence_length
 
-        # make sure num masked indices <= sequence_length
-        if num_masked_span * mask_length > sequence_length:
-            num_masked_span = sequence_length // mask_length
+        if use_probabilistic_rounding:
+            epsilon = np.random.rand(1).item()
+            num_selected_start_tokens = math.floor(mask_prob * feature_axis_length + epsilon)
+        else:
+            num_selected_start_tokens = math.ceil(mask_prob * feature_axis_length)
 
-        return num_masked_span
+        num_selected_start_tokens = max(num_selected_start_tokens, min_masks)
+
+        # make sure num masked indices <= length of sequence to mask
+        if num_selected_start_tokens > feature_axis_length:
+            num_selected_start_tokens = feature_axis_length
+
+        return num_selected_start_tokens
 
     # compute number of masked spans in batch
     input_lengths = (
@@ -175,21 +183,33 @@ def _compute_mask_indices(
         else [sequence_length for _ in range(batch_size)]
     )
 
-    # SpecAugment mask to fill
-    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
+    # select the indexes which will start a span of length `mask_length`
     spec_aug_mask_idxs = []
+    non_masked_batch_dimensions = []
 
-    max_num_masked_span = compute_num_masked_span(sequence_length)
+    max_num_masked_span = compute_num_masked_span(sequence_length, use_probabilistic_rounding=False)
 
-    for input_length in input_lengths:
+    for batch_idx, input_length in enumerate(input_lengths):
         # compute num of masked spans for this input
-        num_masked_span = compute_num_masked_span(input_length)
+        num_masked_span = compute_num_masked_span(input_length, use_probabilistic_rounding=True)
+
         # get random indices to mask
-        spec_aug_mask_idx = np.random.choice(
-            np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
-        )
+        if num_masked_span == 0:
+            # in this case we pretend to choose index 0, but at the end
+            # we revert the masking in this dimension.
+            # Note that we have to choose 'a' index to make sure the `dummy_mask_idx`
+            # can be selected, which is needed to keep the dimensionality equal.
+            spec_aug_mask_idx = np.array([0])
+            non_masked_batch_dimensions.append(batch_idx)
+            num_masked_span += 1  # to ensure we don't pad this
+        else:
+            spec_aug_mask_idx = np.random.choice(
+                np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
+            )
 
         # pick first sampled index that will serve as a dummy index to pad vector
+        # to ensure same dimension for all batches due to probabilistic rounding
+        # Picking first sample just pads those vectors twice.
         dummy_mask_idx = spec_aug_mask_idx[0]
 
         spec_aug_mask_idx = np.concatenate(
@@ -205,14 +225,20 @@ def _compute_mask_indices(
     )
     spec_aug_mask_idxs = spec_aug_mask_idxs.reshape(batch_size, max_num_masked_span * mask_length)
 
+    # add offset to the starting indexes so that that indexes now create a span
     offsets = np.arange(mask_length)[None, None, :]
     offsets = np.broadcast_to(offsets, (batch_size, max_num_masked_span, mask_length)).reshape(
         batch_size, max_num_masked_span * mask_length
     )
     spec_aug_mask_idxs = spec_aug_mask_idxs + offsets
 
-    # scatter indices to mask
+    # create the zero mask and scatter indices
+    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
     np.put_along_axis(spec_aug_mask, spec_aug_mask_idxs, 1, -1)
+
+    # revert any masks in dimensions where 0 spans were selected
+    if len(non_masked_batch_dimensions) >= 1:
+        spec_aug_mask[non_masked_batch_dimensions, :] = 0
 
     return spec_aug_mask
 
@@ -1077,7 +1103,7 @@ class UniSpeechSatModel(UniSpeechSatPreTrainedModel):
                 mask_prob=self.config.mask_time_prob,
                 mask_length=self.config.mask_time_length,
                 attention_mask=attention_mask,
-                min_masks=2,
+                min_masks=self.config.mask_time_min_masks,
             )
             mask_time_indices = torch.tensor(mask_time_indices, device=hidden_states.device, dtype=torch.bool)
             hidden_states[mask_time_indices] = self.masked_spec_embed.to(hidden_states.dtype)
@@ -1088,6 +1114,7 @@ class UniSpeechSatModel(UniSpeechSatPreTrainedModel):
                 (batch_size, hidden_size),
                 mask_prob=self.config.mask_feature_prob,
                 mask_length=self.config.mask_feature_length,
+                min_masks=self.config.mask_feature_min_masks,
             )
             mask_feature_indices = torch.tensor(mask_feature_indices, device=hidden_states.device, dtype=torch.bool)
             mask_feature_indices = mask_feature_indices[:, None].expand(-1, sequence_length, -1)

--- a/src/transformers/models/wav2vec2/configuration_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/configuration_wav2vec2.py
@@ -102,9 +102,9 @@ class Wav2Vec2Config(PretrainedConfig):
             <https://arxiv.org/abs/1904.08779>`__.
         mask_time_prob (:obj:`float`, `optional`, defaults to 0.05):
             Percentage (between 0 and 1) of all feature vectors along the time axis which will be masked. The masking
-            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independ masks over the axis. If
+            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independent masks over the axis. If
             reasoning from the propability of each feature vector to be chosen as the start of the vector span to be
-            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length`` Note that overlap may decrease
+            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length``. Note that overlap may decrease
             the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment is True``.
         mask_time_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the time axis.
@@ -114,9 +114,9 @@ class Wav2Vec2Config(PretrainedConfig):
             ''mask_time_prob*len(time_axis)/mask_time_length < mask_time_min_masks''
         mask_feature_prob (:obj:`float`, `optional`, defaults to 0.0):
             Percentage (between 0 and 1) of all feature vectors along the feature axis which will be masked. The
-            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independ masks over
+            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independent masks over
             the axis. If reasoning from the propability of each feature vector to be chosen as the start of the vector
-            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length`` Note that
+            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length``. Note that
             overlap may decrease the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment
             is True``.
         mask_feature_length (:obj:`int`, `optional`, defaults to 10):

--- a/src/transformers/models/wav2vec2/configuration_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/configuration_wav2vec2.py
@@ -102,16 +102,28 @@ class Wav2Vec2Config(PretrainedConfig):
             <https://arxiv.org/abs/1904.08779>`__.
         mask_time_prob (:obj:`float`, `optional`, defaults to 0.05):
             Propability of each feature vector along the time axis to be chosen as the start of the vector span to be
-            masked. Approximately ``mask_time_prob * sequence_length // mask_time_length`` feature vectors will be
-            masked along the time axis. This is only relevant if ``apply_spec_augment is True``.
+            masked. At most ``mask_time_prob * sequence_length * mask_time_length`` feature vectors will be
+            masked along the time axis. Note that overlap may decrease the total amount of masked vectors.
+            This is only relevant if ``apply_spec_augment is True``.
         mask_time_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the time axis.
+        mask_time_min_masks (:obj:`int`, `optional`, defaults to 2),:
+            The minimum number of feature vectors along the time axis which will be masked each time step,
+            irrespectively of ``mask_time_prob``. Note that 1 mask is of length ``mask_time_length`` and therefore
+            setting ``mask_time_min_masks=n`` will cause at minimum approximately ``n*mask_time_length`` feature
+            vectors to be masked (assuming no overlap).
         mask_feature_prob (:obj:`float`, `optional`, defaults to 0.0):
             Propability of each feature vector along the feature axis to be chosen as the start of the vector span to
-            be masked. Approximately ``mask_time_prob * hidden_size // mask_time_length`` feature vectors will be
-            masked along the time axis. This is only relevant if ``apply_spec_augment is True``.
+            be masked. At most ``mask_feature_prob * sequence_length * mask_feature_length`` feature vectors will be
+            masked along the feature axis. Note that overlap may decrease the total amount of masked vectors.
+            This is only relevant if ``apply_spec_augment is True``.
         mask_feature_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the feature axis.
+        mask_feature_min_masks (:obj:`int`, `optional`, defaults to 0),:
+            The minimum number of feature vectors along the feature axis which will be masked each time step,
+            irrespectively of ``mask_feature_prob``. Note that 1 mask is of length ``mask_feature_length`` and therefore
+            setting ``mask_feature_min_masks=n`` will cause at minimum approximately ``n*mask_feature_length`` feature
+            vectors to be masked (assuming no overlap).
         num_codevectors_per_group (:obj:`int`, `optional`, defaults to 320):
             Number of entries in each quantization codebook (group).
         num_codevector_groups (:obj:`int`, `optional`, defaults to 2):
@@ -198,8 +210,10 @@ class Wav2Vec2Config(PretrainedConfig):
         apply_spec_augment=True,
         mask_time_prob=0.05,
         mask_time_length=10,
+        mask_time_min_masks=2,
         mask_feature_prob=0.0,
         mask_feature_length=10,
+        mask_feature_min_masks=0,
         num_codevectors_per_group=320,
         num_codevector_groups=2,
         contrastive_logits_temperature=0.1,
@@ -265,8 +279,10 @@ class Wav2Vec2Config(PretrainedConfig):
         self.apply_spec_augment = apply_spec_augment
         self.mask_time_prob = mask_time_prob
         self.mask_time_length = mask_time_length
+        self.mask_time_min_masks = mask_time_min_masks
         self.mask_feature_prob = mask_feature_prob
         self.mask_feature_length = mask_feature_length
+        self.mask_feature_min_masks = mask_feature_min_masks
 
         # parameters for pretraining with codevector quantized representations
         self.num_codevectors_per_group = num_codevectors_per_group

--- a/src/transformers/models/wav2vec2/configuration_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/configuration_wav2vec2.py
@@ -102,9 +102,9 @@ class Wav2Vec2Config(PretrainedConfig):
             <https://arxiv.org/abs/1904.08779>`__.
         mask_time_prob (:obj:`float`, `optional`, defaults to 0.05):
             Propability of each feature vector along the time axis to be chosen as the start of the vector span to be
-            masked. At most ``mask_time_prob * sequence_length * mask_time_length`` feature vectors will be
-            masked along the time axis. Note that overlap may decrease the total amount of masked vectors.
-            This is only relevant if ``apply_spec_augment is True``.
+            masked. At most ``ceil(mask_time_prob * sequence_length) * mask_time_length`` feature vectors will be
+            masked along the time axis. Note that overlap may decrease the total amount of masked vectors. This is only
+            relevant if ``apply_spec_augment is True``.
         mask_time_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the time axis.
         mask_time_min_masks (:obj:`int`, `optional`, defaults to 2),:
@@ -114,16 +114,16 @@ class Wav2Vec2Config(PretrainedConfig):
             vectors to be masked (assuming no overlap).
         mask_feature_prob (:obj:`float`, `optional`, defaults to 0.0):
             Propability of each feature vector along the feature axis to be chosen as the start of the vector span to
-            be masked. At most ``mask_feature_prob * sequence_length * mask_feature_length`` feature vectors will be
-            masked along the feature axis. Note that overlap may decrease the total amount of masked vectors.
-            This is only relevant if ``apply_spec_augment is True``.
+            be masked. At most ``ceil(mask_feature_prob * sequence_length) * mask_feature_length`` feature vectors will
+            be masked along the feature axis. Note that overlap may decrease the total amount of masked vectors. This
+            is only relevant if ``apply_spec_augment is True``.
         mask_feature_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the feature axis.
         mask_feature_min_masks (:obj:`int`, `optional`, defaults to 0),:
             The minimum number of feature vectors along the feature axis which will be masked each time step,
-            irrespectively of ``mask_feature_prob``. Note that 1 mask is of length ``mask_feature_length`` and therefore
-            setting ``mask_feature_min_masks=n`` will cause at minimum approximately ``n*mask_feature_length`` feature
-            vectors to be masked (assuming no overlap).
+            irrespectively of ``mask_feature_prob``. Note that 1 mask is of length ``mask_feature_length`` and
+            therefore setting ``mask_feature_min_masks=n`` will cause at minimum approximately
+            ``n*mask_feature_length`` feature vectors to be masked (assuming no overlap).
         num_codevectors_per_group (:obj:`int`, `optional`, defaults to 320):
             Number of entries in each quantization codebook (group).
         num_codevector_groups (:obj:`int`, `optional`, defaults to 2):

--- a/src/transformers/models/wav2vec2/configuration_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/configuration_wav2vec2.py
@@ -101,29 +101,30 @@ class Wav2Vec2Config(PretrainedConfig):
             `SpecAugment: A Simple Data Augmentation Method for Automatic Speech Recognition
             <https://arxiv.org/abs/1904.08779>`__.
         mask_time_prob (:obj:`float`, `optional`, defaults to 0.05):
-            Propability of each feature vector along the time axis to be chosen as the start of the vector span to be
-            masked. At most ``ceil(mask_time_prob * sequence_length) * mask_time_length`` feature vectors will be
-            masked along the time axis. Note that overlap may decrease the total amount of masked vectors. This is only
-            relevant if ``apply_spec_augment is True``.
+            Percentage (between 0 and 1) of all feature vectors along the time axis which will be masked. The masking
+            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independ masks over the axis. If
+            reasoning from the propability of each feature vector to be chosen as the start of the vector span to be
+            masked, `mask_time_prob` should be ``prob_vector_start*mask_time_length`` Note that overlap may decrease
+            the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment is True``.
         mask_time_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the time axis.
         mask_time_min_masks (:obj:`int`, `optional`, defaults to 2),:
-            The minimum number of feature vectors along the time axis which will be masked each time step,
-            irrespectively of ``mask_time_prob``. Note that 1 mask is of length ``mask_time_length`` and therefore
-            setting ``mask_time_min_masks=n`` will cause at minimum approximately ``n*mask_time_length`` feature
-            vectors to be masked (assuming no overlap).
+            The minimum number of masks of length ``mask_feature_length`` generated along the time axis, each time
+            step, irrespectively of ``mask_feature_prob``. Only relevant if
+            ''mask_time_prob*len(time_axis)/mask_time_length < mask_time_min_masks''
         mask_feature_prob (:obj:`float`, `optional`, defaults to 0.0):
-            Propability of each feature vector along the feature axis to be chosen as the start of the vector span to
-            be masked. At most ``ceil(mask_feature_prob * sequence_length) * mask_feature_length`` feature vectors will
-            be masked along the feature axis. Note that overlap may decrease the total amount of masked vectors. This
-            is only relevant if ``apply_spec_augment is True``.
+            Percentage (between 0 and 1) of all feature vectors along the feature axis which will be masked. The
+            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independ masks over
+            the axis. If reasoning from the propability of each feature vector to be chosen as the start of the vector
+            span to be masked, `mask_feature_prob` should be ``prob_vector_start*mask_feature_length`` Note that
+            overlap may decrease the actual percentage of masked vectors. This is only relevant if ``apply_spec_augment
+            is True``.
         mask_feature_length (:obj:`int`, `optional`, defaults to 10):
             Length of vector span along the feature axis.
         mask_feature_min_masks (:obj:`int`, `optional`, defaults to 0),:
-            The minimum number of feature vectors along the feature axis which will be masked each time step,
-            irrespectively of ``mask_feature_prob``. Note that 1 mask is of length ``mask_feature_length`` and
-            therefore setting ``mask_feature_min_masks=n`` will cause at minimum approximately
-            ``n*mask_feature_length`` feature vectors to be masked (assuming no overlap).
+            The minimum number of masks of length ``mask_feature_length`` generated along the feature axis, each time
+            step, irrespectively of ``mask_feature_prob``. Only relevant if
+            ''mask_feature_prob*len(feature_axis)/mask_feature_length < mask_feature_min_masks''
         num_codevectors_per_group (:obj:`int`, `optional`, defaults to 320):
             Number of entries in each quantization codebook (group).
         num_codevector_groups (:obj:`int`, `optional`, defaults to 2):

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -147,9 +147,10 @@ def _compute_mask_indices(
     Args:
         shape: The shape for which to compute masks. This should be of a tuple of size 2 where
                the first element is the batch size and the second element is the length of the axis to span.
-        mask_prob: The probability for each token to be chosen as start of the span to be masked. This will results in
-                   at most `ceil(mask_prob * shape[1]) * mask_length` masked tokens. Due to overlapping spans the
-                   expected amount of masked tokens will be fewer.
+        mask_prob:  The percentage of the whole axis (between 0 and 1) which will be masked. The number of
+                    independently generated mask spans of length `mask_length` is computed by
+                    `mask_prob*shape[1]/mask_length`. Note that due to overlaps, `mask_prob` is an upper bound and the
+                    actual percentage will be smaller.
         mask_length: size of the mask
         min_masks: minimum number of masked spans
         attention_mask: A (right-padded) attention mask which independently shortens the feature axis of
@@ -162,27 +163,23 @@ def _compute_mask_indices(
 
     if mask_length > sequence_length:
         raise ValueError(
-            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length} "
-            f"and `sequence_length`: {sequence_length}`"
+            f"`mask_length` has to be smaller than `sequence_length`, but got `mask_length`: {mask_length}"
+            f" and `sequence_length`: {sequence_length}`"
         )
 
-    def compute_num_masked_span(feature_axis_length: int, use_probabilistic_rounding: bool):
+    # epsilon is used for probabilistic rounding
+    epsilon = np.random.rand(1).item()
+
+    def compute_num_masked_span(input_length):
         """Given input length, compute how many spans should be masked"""
-        assert feature_axis_length <= sequence_length
+        num_masked_span = int(mask_prob * input_length / mask_length + epsilon)
+        num_masked_span = max(num_masked_span, min_masks)
 
-        if use_probabilistic_rounding:
-            epsilon = np.random.rand(1).item()
-            num_selected_start_tokens = math.floor(mask_prob * feature_axis_length + epsilon)
-        else:
-            num_selected_start_tokens = math.ceil(mask_prob * feature_axis_length)
+        # make sure num masked indices <= sequence_length
+        if num_masked_span * mask_length > sequence_length:
+            num_masked_span = sequence_length // mask_length
 
-        num_selected_start_tokens = max(num_selected_start_tokens, min_masks)
-
-        # make sure num masked indices <= length of sequence to mask
-        if num_selected_start_tokens > feature_axis_length:
-            num_selected_start_tokens = feature_axis_length
-
-        return num_selected_start_tokens
+        return num_masked_span
 
     # compute number of masked spans in batch
     input_lengths = (
@@ -191,29 +188,23 @@ def _compute_mask_indices(
         else [sequence_length for _ in range(batch_size)]
     )
 
-    # select the indexes which will start a span of length `mask_length`
+    # SpecAugment mask to fill
+    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
     spec_aug_mask_idxs = []
-    non_masked_batch_dimensions = []
 
-    max_num_masked_span = compute_num_masked_span(sequence_length, use_probabilistic_rounding=False)
+    max_num_masked_span = compute_num_masked_span(sequence_length)
 
-    for batch_idx, input_length in enumerate(input_lengths):
+    if max_num_masked_span == 0:
+        return spec_aug_mask
+
+    for input_length in input_lengths:
         # compute num of masked spans for this input
-        num_masked_span = compute_num_masked_span(input_length, use_probabilistic_rounding=True)
+        num_masked_span = compute_num_masked_span(input_length)
 
         # get random indices to mask
-        if num_masked_span == 0:
-            # in this case we pretend to choose index 0, but at the end
-            # we revert the masking in this dimension.
-            # Note that we have to choose 'a' index to make sure the `dummy_mask_idx`
-            # can be selected, which is needed to keep the dimensionality equal.
-            spec_aug_mask_idx = np.array([0])
-            non_masked_batch_dimensions.append(batch_idx)
-            num_masked_span += 1  # to ensure we don't pad this
-        else:
-            spec_aug_mask_idx = np.random.choice(
-                np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
-            )
+        spec_aug_mask_idx = np.random.choice(
+            np.arange(input_length - (mask_length - 1)), num_masked_span, replace=False
+        )
 
         # pick first sampled index that will serve as a dummy index to pad vector
         # to ensure same dimension for all batches due to probabilistic rounding
@@ -240,13 +231,8 @@ def _compute_mask_indices(
     )
     spec_aug_mask_idxs = spec_aug_mask_idxs + offsets
 
-    # create the zero mask and scatter indices
-    spec_aug_mask = np.zeros((batch_size, sequence_length), dtype=np.bool)
+    # scatter indices to mask
     np.put_along_axis(spec_aug_mask, spec_aug_mask_idxs, 1, -1)
-
-    # revert any masks in dimensions where 0 spans were selected
-    if len(non_masked_batch_dimensions) >= 1:
-        spec_aug_mask[non_masked_batch_dimensions, :] = 0
 
     return spec_aug_mask
 

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -1193,6 +1193,7 @@ class Wav2Vec2Model(Wav2Vec2PreTrainedModel):
                 (batch_size, hidden_size),
                 mask_prob=self.config.mask_feature_prob,
                 mask_length=self.config.mask_feature_length,
+                min_masks=1
             )
             mask_feature_indices = torch.tensor(mask_feature_indices, device=hidden_states.device, dtype=torch.bool)
             mask_feature_indices = mask_feature_indices[:, None].expand(-1, sequence_length, -1)

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -1193,7 +1193,7 @@ class Wav2Vec2Model(Wav2Vec2PreTrainedModel):
                 (batch_size, hidden_size),
                 mask_prob=self.config.mask_feature_prob,
                 mask_length=self.config.mask_feature_length,
-                min_masks=1
+                min_masks=1,
             )
             mask_feature_indices = torch.tensor(mask_feature_indices, device=hidden_states.device, dtype=torch.bool)
             mask_feature_indices = mask_feature_indices[:, None].expand(-1, sequence_length, -1)


### PR DESCRIPTION
# What does this PR do?

This fixes the issue described in #14524. This assumes that users are okay with at least some masking if they set the probability to something > 0. I assume this is an okay fix because for time masking `min_masks=2`.

## Who can review?

@patrickvonplaten 
