### PR TITLE
fix bug for trainer_seq2seq, generation_inputs should be a dict befor…

### DIFF
--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -169,7 +169,8 @@ class Seq2SeqTrainer(Trainer):
             # very ugly hack to make it work
             generation_inputs["input_ids"] = generation_inputs.pop(self.tokenizer.model_input_names[0])
         else:
-            generation_inputs = inputs["input_ids"]
+            generation_inputs = dict()
+            generation_inputs['input_ids'] = inputs["input_ids"]
 
         generated_tokens = self.model.generate(
             **generation_inputs,


### PR DESCRIPTION
…e sending to model.generate (Arround Line 165 - Line 185)

# Fixing Bug

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

In `trainer_seq2seq.py / Seq2SeqTrainer / prediction_step`, Line 174 - Line 177 read:

```python
generated_tokens = self.model.generate(
    **generation_inputs,
    **gen_kwargs,
)
```

which require the generated_tokens to be a `dict`. However, in the `else` branch in Line 171, the `generation_inputs` is created as a `Tensor` object, which will cause a problem.

Fix this by creating `generation_inputs` as a dict, and add a key called `input_ids`.