### PR TITLE
Fix a Bug, modeling_bert.py, erroneosly switched BCE and CrossEntropy

### DIFF
--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -1560,9 +1560,10 @@ class BertForSequenceClassification(BertPreTrainedModel):
                 if self.num_labels == 1:
                     self.config.problem_type = "regression"
                 elif self.num_labels > 1 and (labels.dtype == torch.long or labels.dtype == torch.int):
-                    self.config.problem_type = "single_label_classification"
-                else:
                     self.config.problem_type = "multi_label_classification"
+                else:
+                    self.config.problem_type = "single_label_classification"
+                    
 
             if self.config.problem_type == "regression":
                 loss_fct = MSELoss()
@@ -1571,11 +1572,12 @@ class BertForSequenceClassification(BertPreTrainedModel):
                 else:
                     loss = loss_fct(logits, labels)
             elif self.config.problem_type == "single_label_classification":
-                loss_fct = CrossEntropyLoss()
-                loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))
-            elif self.config.problem_type == "multi_label_classification":
                 loss_fct = BCEWithLogitsLoss()
                 loss = loss_fct(logits, labels)
+            elif self.config.problem_type == "multi_label_classification":
+                loss_fct = CrossEntropyLoss()
+                loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))
+
         if not return_dict:
             output = (logits,) + outputs[2:]
             return ((loss,) + output) if loss is not None else output


### PR DESCRIPTION
_In BertForSequenceClassification when detecting what type of loss to use, based on self.config.problem_type  BCEWithLogitsLoss and CrossEntropyLoss erroneosly switched. It works correctly in case when self.config.problem_type not defined, because it switched in detection and application code, but if problem_type  correctly defined by model it fail(or if "single_label_classification" selected CrossEntropy works as replacement for BCE obviously without errors). I found it when trying to fine-tune "unitary/toxic-bert" model._

Update:
Sorry i'm incorectly read mulit-label vs multi-class problem. i'm just use this model "unitary/toxic-bert" with removed head to fine-tune multi-class and get errors with multi-label defined loss. :(
## 
@LysandreJik