### PR TITLE
Fixes Loss for TransfoXL when using Trainer API

### DIFF
--- a/src/transformers/models/transfo_xl/modeling_transfo_xl.py
+++ b/src/transformers/models/transfo_xl/modeling_transfo_xl.py
@@ -673,10 +673,12 @@ class TransfoXLLMHeadModelOutput(ModelOutput):
     Base class for model's outputs that may also contain a past key/values (to speed up sequential decoding).
 
     Args:
-        loss (:obj:`torch.FloatTensor` of shape `(batch_size, sequence_length-1)`, `optional`, returned when ``labels`` is provided)
+        loss (:obj:`torch.FloatTensor` of shape `()`, `optional`, returned when ``labels`` is provided)
             Reduced language modeling loss.
         prediction_scores (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, config.vocab_size)`):
             Prediction scores of the language modeling head (scores for each vocabulary token after SoftMax).
+        losses (:obj:`torch.FloatTensor` of shape `(batch_size, sequence_length-1)`, `optional`, returned when ``labels`` is provided)
+            Language modeling losses (not reduced).
         mems (:obj:`List[torch.FloatTensor]` of length :obj:`config.n_layers`):
             Contains pre-computed hidden-states (key and values in the attention blocks). Can be used (see :obj:`mems`
             input) to speed up sequential decoding. The token ids which have their past given to this model should not
@@ -696,6 +698,7 @@ class TransfoXLLMHeadModelOutput(ModelOutput):
 
     loss: Optional[torch.FloatTensor] = None
     prediction_scores: torch.FloatTensor = None
+    losses: Optional[torch.FloatTensor] = None
     mems: List[torch.FloatTensor] = None
     hidden_states: Optional[Tuple[torch.FloatTensor]] = None
     attentions: Optional[Tuple[torch.FloatTensor]] = None
@@ -1109,19 +1112,21 @@ class TransfoXLLMHeadModel(TransfoXLPreTrainedModel):
         prediction_scores = softmax_output.view(bsz, tgt_len, -1) if labels is None else ()
 
         if labels is not None:
-            loss = softmax_output.view(bsz, tgt_len - 1)
+            losses = softmax_output.view(bsz, tgt_len - 1)
             # Avoids from incorporating padding (-100) tokens into loss value
-            loss = loss[loss != 0].mean()
+            loss = losses[losses != 0].mean()
         else:
-            loss = None
+            losses, loss = None, None
 
         if not return_dict:
-            output = (prediction_scores,) + transformer_outputs[1:]
+            output = (prediction_scores, losses) if losses is not None else (prediction_scores,)
+            output += transformer_outputs[1:]
             return ((loss,) + output) if loss is not None else output
 
         return TransfoXLLMHeadModelOutput(
             loss=loss,
             prediction_scores=prediction_scores,
+            losses=losses,
             mems=transformer_outputs.mems,
             hidden_states=transformer_outputs.hidden_states,
             attentions=transformer_outputs.attentions,

--- a/src/transformers/models/transfo_xl/modeling_transfo_xl.py
+++ b/src/transformers/models/transfo_xl/modeling_transfo_xl.py
@@ -673,8 +673,8 @@ class TransfoXLLMHeadModelOutput(ModelOutput):
     Base class for model's outputs that may also contain a past key/values (to speed up sequential decoding).
 
     Args:
-        losses (:obj:`torch.FloatTensor` of shape `(batch_size, sequence_length-1)`, `optional`, returned when ``labels`` is provided)
-            Language modeling losses (not reduced).
+        loss (:obj:`torch.FloatTensor` of shape `(batch_size, sequence_length-1)`, `optional`, returned when ``labels`` is provided)
+            Reduced language modeling loss.
         prediction_scores (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_length, config.vocab_size)`):
             Prediction scores of the language modeling head (scores for each vocabulary token after SoftMax).
         mems (:obj:`List[torch.FloatTensor]` of length :obj:`config.n_layers`):
@@ -694,7 +694,7 @@ class TransfoXLLMHeadModelOutput(ModelOutput):
             heads.
     """
 
-    losses: Optional[torch.FloatTensor] = None
+    loss: Optional[torch.FloatTensor] = None
     prediction_scores: torch.FloatTensor = None
     mems: List[torch.FloatTensor] = None
     hidden_states: Optional[Tuple[torch.FloatTensor]] = None
@@ -1097,16 +1097,30 @@ class TransfoXLLMHeadModel(TransfoXLPreTrainedModel):
         last_hidden = transformer_outputs[0]
         pred_hid = last_hidden[:, -tgt_len:]
 
+        if labels is not None:
+            # Prevents all labels being -100 and throwing an error
+            # when backwarding the loss
+            miss_valid_label = labels[0, 1:].sum() == (labels.size(1) - 1) * -100
+            if miss_valid_label:
+                # Sets an <EOS> token, just to prevent loss from being NaN
+                labels[0, 1] = self.config.eos_token_id
+
         softmax_output = self.crit(pred_hid, labels)
         prediction_scores = softmax_output.view(bsz, tgt_len, -1) if labels is None else ()
-        loss = softmax_output.view(bsz, tgt_len - 1) if labels is not None else None
+
+        if labels is not None:
+            loss = softmax_output.view(bsz, tgt_len - 1)
+            # Avoids from incorporating padding (-100) tokens into loss value
+            loss = loss[loss != 0].mean()
+        else:
+            loss = None
 
         if not return_dict:
             output = (prediction_scores,) + transformer_outputs[1:]
             return ((loss,) + output) if loss is not None else output
 
         return TransfoXLLMHeadModelOutput(
-            losses=loss,
+            loss=loss,
             prediction_scores=prediction_scores,
             mems=transformer_outputs.mems,
             hidden_states=transformer_outputs.hidden_states,

--- a/tests/test_modeling_transfo_xl.py
+++ b/tests/test_modeling_transfo_xl.py
@@ -133,9 +133,11 @@ class TransfoXLModelTester:
 
         outputs = {
             "loss_1": outputs1["loss"],
+            "losses_1": outputs1["losses"],
             "mems_1": outputs1["mems"],
             "lm_logits_1": lm_logits_1,
             "loss_2": outputs2["loss"],
+            "losses_2": outputs2["losses"],
             "mems_2": outputs2["mems"],
             "lm_logits_2": lm_logits_2,
         }
@@ -143,6 +145,7 @@ class TransfoXLModelTester:
 
     def check_transfo_xl_lm_head_output(self, result):
         self.parent.assertEqual(result["loss_1"].shape, ())
+        self.parent.assertEqual(result["losses_1"].shape, (self.batch_size, self.seq_length - 1))
         self.parent.assertEqual(result["lm_logits_1"].shape, (self.batch_size, self.seq_length, self.vocab_size))
         self.parent.assertListEqual(
             [mem.shape for mem in result["mems_1"]],
@@ -150,6 +153,7 @@ class TransfoXLModelTester:
         )
 
         self.parent.assertEqual(result["loss_2"].shape, ())
+        self.parent.assertEqual(result["losses_2"].shape, (self.batch_size, self.seq_length - 1))
         self.parent.assertEqual(result["lm_logits_2"].shape, (self.batch_size, self.seq_length, self.vocab_size))
         self.parent.assertListEqual(
             [mem.shape for mem in result["mems_2"]],

--- a/tests/test_modeling_transfo_xl.py
+++ b/tests/test_modeling_transfo_xl.py
@@ -132,22 +132,24 @@ class TransfoXLModelTester:
         outputs2 = model(input_ids_2, labels=lm_labels, mems=outputs1["mems"])
 
         outputs = {
-            "loss": outputs1["loss"],
+            "loss_1": outputs1["loss"],
             "mems_1": outputs1["mems"],
             "lm_logits_1": lm_logits_1,
+            "loss_2": outputs2["loss"],
             "mems_2": outputs2["mems"],
             "lm_logits_2": lm_logits_2,
         }
         return outputs
 
     def check_transfo_xl_lm_head_output(self, result):
-        self.parent.assertEqual(result["loss"].shape, ())
+        self.parent.assertEqual(result["loss_1"].shape, ())
         self.parent.assertEqual(result["lm_logits_1"].shape, (self.batch_size, self.seq_length, self.vocab_size))
         self.parent.assertListEqual(
             [mem.shape for mem in result["mems_1"]],
             [(self.mem_len, self.batch_size, self.hidden_size)] * self.num_hidden_layers,
         )
 
+        self.parent.assertEqual(result["loss_2"].shape, ())
         self.parent.assertEqual(result["lm_logits_2"].shape, (self.batch_size, self.seq_length, self.vocab_size))
         self.parent.assertListEqual(
             [mem.shape for mem in result["mems_2"]],

--- a/tests/test_modeling_transfo_xl.py
+++ b/tests/test_modeling_transfo_xl.py
@@ -132,24 +132,22 @@ class TransfoXLModelTester:
         outputs2 = model(input_ids_2, labels=lm_labels, mems=outputs1["mems"])
 
         outputs = {
-            "loss_1": outputs1["losses"],
+            "loss": outputs1["loss"],
             "mems_1": outputs1["mems"],
             "lm_logits_1": lm_logits_1,
-            "loss_2": outputs2["losses"],
             "mems_2": outputs2["mems"],
             "lm_logits_2": lm_logits_2,
         }
         return outputs
 
     def check_transfo_xl_lm_head_output(self, result):
-        self.parent.assertEqual(result["loss_1"].shape, (self.batch_size, self.seq_length - 1))
+        self.parent.assertEqual(result["loss"].shape, ())
         self.parent.assertEqual(result["lm_logits_1"].shape, (self.batch_size, self.seq_length, self.vocab_size))
         self.parent.assertListEqual(
             [mem.shape for mem in result["mems_1"]],
             [(self.mem_len, self.batch_size, self.hidden_size)] * self.num_hidden_layers,
         )
 
-        self.parent.assertEqual(result["loss_2"].shape, (self.batch_size, self.seq_length - 1))
         self.parent.assertEqual(result["lm_logits_2"].shape, (self.batch_size, self.seq_length, self.vocab_size))
         self.parent.assertListEqual(
             [mem.shape for mem in result["mems_2"]],


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR address the problem of using TransfoXL with the Trainer API by introducing straightforward changes, as follows:

- Changes the `losses` parameter from TransfoXL output to `loss`, allowing its usage with the Trainer API;
- Reduces the loss by mean calculation and by ignoring pad tokens;
- Adds a checker that will validate whether input labels are not only composed by pad tokens, which eventually breaks the loss calculation (tested on a full wikitext-103 version). 

I have been working and training TransfoXL from scratch for the past months, and so far this is the most stable code that I could get with huggingface/transformers.

Let me know if there is anything else that should be changed!

PS: fast testing script: `python examples/pytorch/language-modeling/run_clm.py --model_name_or_path transfo-xl-wt103 --dataset_name wikitext --dataset_config_name wikitext-103-raw-v1 --output_dir out`

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [X] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@patrickvonplaten 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->

🚨🚨 **Breaking change TransfoXL** 🚨🚨

This PR introduces a breaking change.
Previously the output attribute ``losses`` can be found at index 0. Now it is at index 2 in case `labels` are passed. 

This means if you code previously used:

```python
losses = model(input_ids, labels=labels)[0]
```

it should now change to:

```python
losses = model(input_ids, labels=labels)[2]
```