### PR TITLE
Adapt build command to new CLI tools

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Make documentation
         run: |
-          python src/build.py transformers ./transformers/docs/source
+          doc-builder build transformers ./transformers/docs/source
 
       - name: Push to repository
         run: |


### PR DESCRIPTION
# What does this PR do?

This adapts the command to the new CLI tool introduced in [this PR](https://github.com/huggingface/doc-builder/pull/32) (should be merged after as a result).