### PR TITLE
Adds a git pull instruction to the documentation builder

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           git config --global user.name "Hugging Face"
           git config --global user.email transformers@huggingface.co
-          git pull origin master
+          git pull origin main
 
       - name: Make documentation
         run: |

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           git config --global user.name "Hugging Face"
           git config --global user.email transformers@huggingface.co
+          git pull origin master
 
       - name: Make documentation
         run: |


### PR DESCRIPTION
If two consecutive commits happen in rapid succession, then the clone of the doc-builder repository might not be updated by the time the pip installations are over. This greatly reduces the risk this happens by putting a `git pull` instruction after the environment setup.