### PR TITLE
Add Flax example tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -613,6 +613,69 @@ jobs:
             - store_artifacts:
                   path: ~/transformers/reports
 
+    run_examples_flax:
+        working_directory: ~/transformers
+        docker:
+            - image: circleci/python:3.7
+        environment:
+            OMP_NUM_THREADS: 1
+            TRANSFORMERS_IS_CI: yes
+        resource_class: xlarge
+        parallelism: 1
+        steps:
+            - checkout
+            - restore_cache:
+                keys:
+                    - v0.4-flax_examples-{{ checksum "setup.py" }}
+                    - v0.4-{{ checksum "setup.py" }}
+            - run: pip install --upgrade pip
+            - run: sudo pip install .[flax,testing,sentencepiece]
+            - run: pip install -r examples/flax/_tests_requirements.txt
+            - save_cache:
+                  key: v0.4-flax_examples-{{ checksum "setup.py" }}
+                  paths:
+                      - '~/.cache/pip'
+            - run: python utils/tests_fetcher.py --filters examples tests | tee test_preparation.txt
+            - store_artifacts:
+                  path: ~/transformers/test_preparation.txt
+            - run: |
+                  if [ -f test_list.txt ]; then
+                    python -m pytest -n 8 --dist=loadfile -s --make-reports=examples_flax ./examples/flax/ | tee tests_output.txt
+                  fi
+            - store_artifacts:
+                  path: ~/transformers/flax_examples_output.txt
+            - store_artifacts:
+                  path: ~/transformers/reports
+    
+    run_examples_flax_all:
+        working_directory: ~/transformers
+        docker:
+            - image: circleci/python:3.7
+        environment:
+            OMP_NUM_THREADS: 1
+            TRANSFORMERS_IS_CI: yes
+        resource_class: xlarge
+        parallelism: 1
+        steps:
+            - checkout
+            - restore_cache:
+                keys:
+                    - v0.4-flax_examples-{{ checksum "setup.py" }}
+                    - v0.4-{{ checksum "setup.py" }}
+            - run: pip install --upgrade pip
+            - run: sudo pip install .[flax,testing,sentencepiece]
+            - run: pip install -r examples/flax/_tests_requirements.txt
+            - save_cache:
+                  key: v0.4-flax_examples-{{ checksum "setup.py" }}
+                  paths:
+                      - '~/.cache/pip'
+            - run: |
+                  TRANSFORMERS_IS_CI=1 python -m pytest -n 8 --dist=loadfile -s --make-reports=examples_flax ./examples/flax/ | tee examples_output.txt
+            - store_artifacts:
+                  path: ~/transformers/flax_examples_output.txt
+            - store_artifacts:
+                  path: ~/transformers/reports
+
     run_tests_hub:
         working_directory: ~/transformers
         docker:

--- a/examples/flax/_tests_requirements.txt
+++ b/examples/flax/_tests_requirements.txt
@@ -1,0 +1,7 @@
+datasets >= 1.1.3
+pytest
+conllu
+nltk
+rouge-score
+seqeval
+tensorboard

--- a/examples/flax/language-modeling/run_clm_flax.py
+++ b/examples/flax/language-modeling/run_clm_flax.py
@@ -220,13 +220,6 @@ def write_eval_metric(summary_writer, eval_metrics, step):
         summary_writer.scalar(f"eval_{metric_name}", value, step)
 
 
-def save_metrics(split, output_dir, metrics):
-    metrics = {f"{split}_{metric_name}": value for metric_name, value in metrics.items()}
-    path = os.path.join(output_dir, f"{split}_results.json")
-    with open(path, "w") as f:
-        json.dump(metrics, f, indent=4, sort_keys=True)
-
-
 def create_learning_rate_fn(
     train_ds_size: int, train_batch_size: int, num_train_epochs: int, num_warmup_steps: int, learning_rate: float
 ) -> Callable[[int], jnp.array]:
@@ -701,7 +694,10 @@ def main():
             eval_metrics["perplexity"] = float("inf")
 
         if jax.process_index() == 0:
-            save_metrics("eval", training_args.output_dir, eval_metrics)
+            eval_metrics = {f"eval_{metric_name}": value for metric_name, value in eval_metrics.items()}
+            path = os.path.join(training_args.output_dir, "eval_results.json")
+            with open(path, "w") as f:
+                json.dump(eval_metrics, f, indent=4, sort_keys=True)
 
 
 if __name__ == "__main__":

--- a/examples/flax/language-modeling/run_clm_flax.py
+++ b/examples/flax/language-modeling/run_clm_flax.py
@@ -693,7 +693,7 @@ def main():
 
         # normalize eval metrics
         eval_metrics = get_metrics(eval_metrics)
-        eval_metrics = jax.tree_map(jnp.mean, eval_metrics)
+        eval_metrics = jax.tree_map(lambda x: jnp.mean(x).item(), eval_metrics)
 
         try:
             eval_metrics["perplexity"] = math.exp(eval_metrics["loss"])

--- a/examples/flax/language-modeling/run_clm_flax.py
+++ b/examples/flax/language-modeling/run_clm_flax.py
@@ -679,7 +679,7 @@ def main():
                     tokenizer.save_pretrained(training_args.output_dir)
                     if training_args.push_to_hub:
                         repo.push_to_hub(commit_message=f"Saving weights and logs of step {cur_step}", blocking=False)
-    
+
     # Eval after training
     if training_args.do_eval:
         eval_metrics = []
@@ -699,7 +699,7 @@ def main():
             eval_metrics["perplexity"] = math.exp(eval_metrics["loss"])
         except OverflowError:
             eval_metrics["perplexity"] = float("inf")
-        
+
         if jax.process_index() == 0:
             save_metrics("eval", training_args.output_dir, eval_metrics)
 

--- a/examples/flax/language-modeling/run_mlm_flax.py
+++ b/examples/flax/language-modeling/run_mlm_flax.py
@@ -20,7 +20,9 @@ text file or a dataset.
 Here is the full list of checkpoints on the hub that can be fine-tuned by this script:
 https://huggingface.co/models?filter=masked-lm
 """
+import json
 import logging
+import math
 import os
 import sys
 import time
@@ -271,7 +273,7 @@ def write_eval_metric(summary_writer, eval_metrics, step):
         summary_writer.scalar(f"eval_{metric_name}", value, step)
 
 
-if __name__ == "__main__":
+def main():
     # See all possible arguments in src/transformers/training_args.py
     # or by passing the --help flag to this script.
     # We now keep distinct sets of args, for a cleaner separation of concerns.
@@ -700,3 +702,41 @@ if __name__ == "__main__":
                     tokenizer.save_pretrained(training_args.output_dir)
                     if training_args.push_to_hub:
                         repo.push_to_hub(commit_message=f"Saving weights and logs of step {cur_step}", blocking=False)
+
+    # Eval after training
+    if training_args.do_eval:
+        num_eval_samples = len(tokenized_datasets["validation"])
+        eval_samples_idx = jnp.arange(num_eval_samples)
+        eval_batch_idx = generate_batch_splits(eval_samples_idx, eval_batch_size)
+
+        eval_metrics = []
+        for _, batch_idx in enumerate(tqdm(eval_batch_idx, desc="Evaluating ...", position=2)):
+            samples = [tokenized_datasets["validation"][int(idx)] for idx in batch_idx]
+            model_inputs = data_collator(samples, pad_to_multiple_of=16)
+
+            # Model forward
+            model_inputs = shard(model_inputs.data)
+            metrics = p_eval_step(state.params, model_inputs)
+            eval_metrics.append(metrics)
+
+        # normalize eval metrics
+        eval_metrics = get_metrics(eval_metrics)
+        eval_metrics = jax.tree_map(lambda metric: jnp.sum(metric).item(), eval_metrics)
+        eval_normalizer = eval_metrics.pop("normalizer")
+        eval_metrics = jax.tree_map(lambda x: x / eval_normalizer, eval_metrics)
+
+        try:
+            perplexity = math.exp(metrics["loss"])
+        except OverflowError:
+            perplexity = float("inf")
+        eval_metrics["perplexity"] = perplexity
+
+        if jax.process_index() == 0:
+            eval_metrics = {f"eval_{metric_name}": value for metric_name, value in eval_metrics.items()}
+            path = os.path.join(training_args.output_dir, "eval_results.json")
+            with open(path, "w") as f:
+                json.dump(eval_metrics, f, indent=4, sort_keys=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/flax/language-modeling/run_mlm_flax.py
+++ b/examples/flax/language-modeling/run_mlm_flax.py
@@ -726,7 +726,7 @@ def main():
         eval_metrics = jax.tree_map(lambda x: x / eval_normalizer, eval_metrics)
 
         try:
-            perplexity = math.exp(metrics["loss"])
+            perplexity = math.exp(eval_metrics["loss"])
         except OverflowError:
             perplexity = float("inf")
         eval_metrics["perplexity"] = perplexity

--- a/examples/flax/language-modeling/run_t5_mlm_flax.py
+++ b/examples/flax/language-modeling/run_t5_mlm_flax.py
@@ -523,9 +523,7 @@ def main():
             model_args.config_name, cache_dir=model_args.cache_dir, vocab_size=len(tokenizer)
         )
     elif model_args.model_name_or_path:
-        config = T5Config.from_pretrained(
-            model_args.model_name_or_path, cache_dir=model_args.cache_dir, vocab_size=len(tokenizer)
-        )
+        config = T5Config.from_pretrained(model_args.model_name_or_path, cache_dir=model_args.cache_dir)
     else:
         config = CONFIG_MAPPING[model_args.model_type]()
         logger.warning("You are instantiating a new config instance from scratch.")

--- a/examples/flax/language-modeling/run_t5_mlm_flax.py
+++ b/examples/flax/language-modeling/run_t5_mlm_flax.py
@@ -616,6 +616,7 @@ def main():
             model_args.model_name_or_path, config=config, seed=training_args.seed, dtype=getattr(jnp, model_args.dtype)
         )
     else:
+        config.vocab_size = len(tokenizer)
         model = FlaxT5ForConditionalGeneration(config, seed=training_args.seed, dtype=getattr(jnp, model_args.dtype))
 
     # Data collator

--- a/examples/flax/language-modeling/run_t5_mlm_flax.py
+++ b/examples/flax/language-modeling/run_t5_mlm_flax.py
@@ -20,6 +20,7 @@ Here is the full list of checkpoints on the hub that can be pretrained by this s
 https://huggingface.co/models?filter=t5
 """
 # You can also adapt this script on your own masked language modeling task. Pointers for this are left as comments.
+import json
 import logging
 import os
 import sys
@@ -401,7 +402,7 @@ def write_eval_metric(summary_writer, eval_metrics, step):
         summary_writer.scalar(f"eval_{metric_name}", value, step)
 
 
-if __name__ == "__main__":
+def main():
     # See all possible arguments in src/transformers/training_args.py
     # or by passing the --help flag to this script.
     # We now keep distinct sets of args, for a cleaner separation of concerns.
@@ -808,3 +809,33 @@ if __name__ == "__main__":
                     tokenizer.save_pretrained(training_args.output_dir)
                     if training_args.push_to_hub:
                         repo.push_to_hub(commit_message=f"Saving weights and logs of step {cur_step}", blocking=False)
+
+    # Eval after training
+    if training_args.do_eval:
+        num_eval_samples = len(tokenized_datasets["validation"])
+        eval_samples_idx = jnp.arange(num_eval_samples)
+        eval_batch_idx = generate_batch_splits(eval_samples_idx, eval_batch_size)
+
+        eval_metrics = []
+        for i, batch_idx in enumerate(tqdm(eval_batch_idx, desc="Evaluating ...", position=2)):
+            samples = [tokenized_datasets["validation"][int(idx)] for idx in batch_idx]
+            model_inputs = data_collator(samples)
+
+            # Model forward
+            model_inputs = shard(model_inputs.data)
+            metrics = p_eval_step(state.params, model_inputs)
+            eval_metrics.append(metrics)
+
+        # get eval metrics
+        eval_metrics = get_metrics(eval_metrics)
+        eval_metrics = jax.tree_map(lambda metric: jnp.mean(metric).item(), eval_metrics)
+
+        if jax.process_index() == 0:
+            eval_metrics = {f"eval_{metric_name}": value for metric_name, value in eval_metrics.items()}
+            path = os.path.join(training_args.output_dir, "eval_results.json")
+            with open(path, "w") as f:
+                json.dump(eval_metrics, f, indent=4, sort_keys=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/flax/summarization/run_summarization_flax.py
+++ b/examples/flax/summarization/run_summarization_flax.py
@@ -279,13 +279,6 @@ def write_metric(summary_writer, train_metrics, eval_metrics, train_time, step):
         summary_writer.scalar(f"eval_{metric_name}", value, step)
 
 
-def save_metrics(split, output_dir, metrics):
-    metrics = {f"{split}_{metric_name}": value for metric_name, value in metrics.items()}
-    path = os.path.join(output_dir, f"{split}_results.json")
-    with open(path, "w") as f:
-        json.dump(metrics, f, indent=4, sort_keys=True)
-
-
 def create_learning_rate_fn(
     train_ds_size: int, train_batch_size: int, num_train_epochs: int, num_warmup_steps: int, learning_rate: float
 ) -> Callable[[int], jnp.array]:
@@ -826,7 +819,10 @@ def main():
 
         # save final metrics in json
         if jax.process_index() == 0:
-            save_metrics("test", training_args.output_dir, rouge_metrics)
+            rouge_metrics = {f"eval_{metric_name}": value for metric_name, value in rouge_metrics.items()}
+            path = os.path.join(training_args.output_dir, "eval_results.json")
+            with open(path, "w") as f:
+                json.dump(rouge_metrics, f, indent=4, sort_keys=True)
 
 
 if __name__ == "__main__":

--- a/examples/flax/summarization/run_summarization_flax.py
+++ b/examples/flax/summarization/run_summarization_flax.py
@@ -819,8 +819,8 @@ def main():
 
         # save final metrics in json
         if jax.process_index() == 0:
-            rouge_metrics = {f"eval_{metric_name}": value for metric_name, value in rouge_metrics.items()}
-            path = os.path.join(training_args.output_dir, "eval_results.json")
+            rouge_metrics = {f"test_{metric_name}": value for metric_name, value in rouge_metrics.items()}
+            path = os.path.join(training_args.output_dir, "test_results.json")
             with open(path, "w") as f:
                 json.dump(rouge_metrics, f, indent=4, sort_keys=True)
 

--- a/examples/flax/summarization/run_summarization_flax.py
+++ b/examples/flax/summarization/run_summarization_flax.py
@@ -18,6 +18,7 @@ Fine-tuning the library models for summarization.
 """
 # You can also adapt this script on your own sequence to sequence task. Pointers for this are left as comments.
 
+import json
 import logging
 import os
 import sys
@@ -276,6 +277,13 @@ def write_metric(summary_writer, train_metrics, eval_metrics, train_time, step):
 
     for metric_name, value in eval_metrics.items():
         summary_writer.scalar(f"eval_{metric_name}", value, step)
+
+
+def save_metrics(split, output_dir, metrics):
+    metrics = {f"{split}_{metric_name}": value for metric_name, value in metrics.items()}
+    path = os.path.join(output_dir, f"{split}_results.json")
+    with open(path, "w") as f:
+        json.dump(metrics, f, indent=4, sort_keys=True)
 
 
 def create_learning_rate_fn(
@@ -815,6 +823,10 @@ def main():
         # Print metrics
         desc = f"Predict Loss: {pred_metrics['loss']} | {rouge_desc})"
         logger.info(desc)
+
+        # save final metrics in json
+        if jax.process_index() == 0:
+            save_metrics("test", training_args.output_dir, rouge_metrics)
 
 
 if __name__ == "__main__":

--- a/examples/flax/test_examples.py
+++ b/examples/flax/test_examples.py
@@ -180,6 +180,36 @@ class ExamplesTests(TestCasePlus):
             result = get_results(tmp_dir)
             self.assertLess(result["perplexity"], 42)
 
+    def test_run_t5_mlm(self):
+        stream_handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(stream_handler)
+
+        tmp_dir = self.get_auto_remove_tmp_dir()
+        testargs = f"""
+            run_t5_mlm_flax.py
+            --model_name_or_path t5-small
+            --train_file ./tests/fixtures/sample_text.txt
+            --validation_file ./tests/fixtures/sample_text.txt
+            --do_train
+            --do_eval
+            --max_seq_length 128
+            --per_device_train_batch_size 4
+            --per_device_eval_batch_size 4
+            --num_train_epochs 2
+            --logging_steps 2 --eval_steps 2
+            --output_dir {tmp_dir}
+            --overwrite_output_dir
+            """.split()
+
+        # if torch.cuda.device_count() > 1:
+        # Skipping because there are not enough batches to train the model + would need a drop_last to work.
+        # return
+
+        with patch.object(sys, "argv", testargs):
+            run_clm_flax.main()
+            result = get_results(tmp_dir)
+            self.assertLess(result["eval_accuracy"], 100)
+
     def test_run_ner(self):
         stream_handler = logging.StreamHandler(sys.stdout)
         logger.addHandler(stream_handler)

--- a/examples/flax/test_examples.py
+++ b/examples/flax/test_examples.py
@@ -1,0 +1,90 @@
+# coding=utf-8
+# Copyright 2021 HuggingFace Inc..
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+import json
+import logging
+import os
+import sys
+from unittest.mock import patch
+
+from transformers.testing_utils import CaptureLogger, TestCasePlus, get_gpu_count, slow, torch_device
+
+
+SRC_DIRS = [
+    os.path.join(os.path.dirname(__file__), dirname)
+    for dirname in [
+        "text-classification",
+    ]
+]
+sys.path.extend(SRC_DIRS)
+
+
+if SRC_DIRS is not None:
+    import run_flax_glue
+
+
+logging.basicConfig(level=logging.DEBUG)
+
+logger = logging.getLogger()
+
+
+def get_setup_file():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-f")
+    args = parser.parse_args()
+    return args.f
+
+
+def get_results(output_dir):
+    results = {}
+    path = os.path.join(output_dir, "all_results.json")
+    if os.path.exists(path):
+        with open(path, "r") as f:
+            results = json.load(f)
+    else:
+        raise ValueError(f"can't find {path}")
+    return results
+
+
+class ExamplesTests(TestCasePlus):
+    def test_run_glue(self):
+        stream_handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(stream_handler)
+
+        tmp_dir = self.get_auto_remove_tmp_dir()
+        testargs = f"""
+            run_glue.py
+            --model_name_or_path distilbert-base-uncased
+            --output_dir {tmp_dir}
+            --overwrite_output_dir
+            --train_file ./tests/fixtures/tests_samples/MRPC/train.csv
+            --validation_file ./tests/fixtures/tests_samples/MRPC/dev.csv
+            --do_train
+            --do_eval
+            --per_device_train_batch_size=2
+            --per_device_eval_batch_size=1
+            --learning_rate=1e-4
+            --max_train_steps=10
+            --num_warmup_steps=2
+            --seed=42
+            --max_length=128
+            """.split()
+
+        with patch.object(sys, "argv", testargs):
+            run_flax_glue.main()
+            result = get_results(tmp_dir)
+            self.assertGreaterEqual(result["eval_accuracy"], 0.75)

--- a/examples/flax/test_examples.py
+++ b/examples/flax/test_examples.py
@@ -105,6 +105,7 @@ class ExamplesTests(TestCasePlus):
             --per_device_train_batch_size 5
             --per_device_eval_batch_size 5
             --num_train_epochs 2
+            --logging_steps 2 --eval_steps 2
             --output_dir {tmp_dir}
             --overwrite_output_dir
             """.split()

--- a/examples/flax/test_examples.py
+++ b/examples/flax/test_examples.py
@@ -21,7 +21,7 @@ import os
 import sys
 from unittest.mock import patch
 
-from transformers.testing_utils import CaptureLogger, TestCasePlus, get_gpu_count, slow
+from transformers.testing_utils import TestCasePlus, get_gpu_count, slow
 
 
 SRC_DIRS = [
@@ -44,6 +44,7 @@ if SRC_DIRS is not None:
     import run_mlm_flax
     import run_qa
     import run_summarization_flax
+    import run_t5_mlm_flax
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -125,7 +126,7 @@ class ExamplesTests(TestCasePlus):
             result = get_results(tmp_dir)
             self.assertLess(result["eval_perplexity"], 100)
 
-    # @slow
+    @slow
     def test_run_summarization(self):
         stream_handler = logging.StreamHandler(sys.stdout)
         logger.addHandler(stream_handler)
@@ -180,6 +181,7 @@ class ExamplesTests(TestCasePlus):
             result = get_results(tmp_dir)
             self.assertLess(result["perplexity"], 42)
 
+    @slow
     def test_run_t5_mlm(self):
         stream_handler = logging.StreamHandler(sys.stdout)
         logger.addHandler(stream_handler)
@@ -206,9 +208,9 @@ class ExamplesTests(TestCasePlus):
         # return
 
         with patch.object(sys, "argv", testargs):
-            run_clm_flax.main()
+            run_t5_mlm_flax.main()
             result = get_results(tmp_dir)
-            self.assertLess(result["eval_accuracy"], 100)
+            self.assertGreaterEqual(result["eval_accuracy"], 0.42)
 
     def test_run_ner(self):
         stream_handler = logging.StreamHandler(sys.stdout)

--- a/examples/flax/test_examples.py
+++ b/examples/flax/test_examples.py
@@ -199,6 +199,7 @@ class ExamplesTests(TestCasePlus):
             --do_eval
             --warmup_steps=2
             --learning_rate=2e-4
+            --logging_steps 2 --eval_steps 2
             --per_device_train_batch_size=2
             --per_device_eval_batch_size=2
             --num_train_epochs={epochs}
@@ -209,7 +210,7 @@ class ExamplesTests(TestCasePlus):
             run_flax_ner.main()
             result = get_results(tmp_dir)
             self.assertGreaterEqual(result["eval_accuracy"], 0.75)
-            self.assertLess(result["eval_loss"], 0.5)
+            self.assertGreaterEqual(result["eval_f1"], 0.3)
 
     def test_run_qa(self):
         stream_handler = logging.StreamHandler(sys.stdout)
@@ -228,6 +229,7 @@ class ExamplesTests(TestCasePlus):
             --warmup_steps=2
             --do_train
             --do_eval
+            --logging_steps 2 --eval_steps 2
             --learning_rate=2e-4
             --per_device_train_batch_size=2
             --per_device_eval_batch_size=1

--- a/examples/flax/test_examples.py
+++ b/examples/flax/test_examples.py
@@ -21,13 +21,14 @@ import os
 import sys
 from unittest.mock import patch
 
-from transformers.testing_utils import CaptureLogger, TestCasePlus, get_gpu_count, slow, torch_device
+from transformers.testing_utils import CaptureLogger, TestCasePlus, get_gpu_count, slow
 
 
 SRC_DIRS = [
     os.path.join(os.path.dirname(__file__), dirname)
     for dirname in [
         "text-classification",
+        "language-modeling",
     ]
 ]
 sys.path.extend(SRC_DIRS)
@@ -35,6 +36,7 @@ sys.path.extend(SRC_DIRS)
 
 if SRC_DIRS is not None:
     import run_flax_glue
+    import run_clm_flax
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -51,7 +53,7 @@ def get_setup_file():
 
 def get_results(output_dir):
     results = {}
-    path = os.path.join(output_dir, "all_results.json")
+    path = os.path.join(output_dir, "eval_results.json")
     if os.path.exists(path):
         with open(path, "r") as f:
             results = json.load(f)
@@ -70,11 +72,8 @@ class ExamplesTests(TestCasePlus):
             run_glue.py
             --model_name_or_path distilbert-base-uncased
             --output_dir {tmp_dir}
-            --overwrite_output_dir
             --train_file ./tests/fixtures/tests_samples/MRPC/train.csv
             --validation_file ./tests/fixtures/tests_samples/MRPC/dev.csv
-            --do_train
-            --do_eval
             --per_device_train_batch_size=2
             --per_device_eval_batch_size=1
             --learning_rate=1e-4
@@ -88,3 +87,33 @@ class ExamplesTests(TestCasePlus):
             run_flax_glue.main()
             result = get_results(tmp_dir)
             self.assertGreaterEqual(result["eval_accuracy"], 0.75)
+    
+
+    def test_run_clm(self):
+        stream_handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(stream_handler)
+
+        tmp_dir = self.get_auto_remove_tmp_dir()
+        testargs = f"""
+            run_clm_flax.py
+            --model_name_or_path distilgpt2
+            --train_file ./tests/fixtures/sample_text.txt
+            --validation_file ./tests/fixtures/sample_text.txt
+            --do_train
+            --do_eval
+            --block_size 128
+            --per_device_train_batch_size 5
+            --per_device_eval_batch_size 5
+            --num_train_epochs 2
+            --output_dir {tmp_dir}
+            --overwrite_output_dir
+            """.split()
+
+        # if torch.cuda.device_count() > 1:
+            # Skipping because there are not enough batches to train the model + would need a drop_last to work.
+            # return
+
+        with patch.object(sys, "argv", testargs):
+            run_clm_flax.main()
+            result = get_results(tmp_dir)
+            self.assertLess(result["eval_perplexity"], 100)

--- a/examples/flax/test_examples.py
+++ b/examples/flax/test_examples.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2021 HuggingFace Inc..
+# Copyright 2021 HuggingFace Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -109,17 +109,13 @@ class ExamplesTests(TestCasePlus):
             --do_train
             --do_eval
             --block_size 128
-            --per_device_train_batch_size 5
-            --per_device_eval_batch_size 5
+            --per_device_train_batch_size 4
+            --per_device_eval_batch_size 4
             --num_train_epochs 2
             --logging_steps 2 --eval_steps 2
             --output_dir {tmp_dir}
             --overwrite_output_dir
             """.split()
-
-        # if torch.cuda.device_count() > 1:
-        # Skipping because there are not enough batches to train the model + would need a drop_last to work.
-        # return
 
         with patch.object(sys, "argv", testargs):
             run_clm_flax.main()
@@ -171,6 +167,10 @@ class ExamplesTests(TestCasePlus):
             --validation_file ./tests/fixtures/sample_text.txt
             --output_dir {tmp_dir}
             --overwrite_output_dir
+            --max_seq_length 128
+            --per_device_train_batch_size 4
+            --per_device_eval_batch_size 4
+            --logging_steps 2 --eval_steps 2
             --do_train
             --do_eval
             --num_train_epochs=1
@@ -179,7 +179,7 @@ class ExamplesTests(TestCasePlus):
         with patch.object(sys, "argv", testargs):
             run_mlm_flax.main()
             result = get_results(tmp_dir)
-            self.assertLess(result["perplexity"], 42)
+            self.assertLess(result["eval_perplexity"], 42)
 
     @slow
     def test_run_t5_mlm(self):
@@ -202,10 +202,6 @@ class ExamplesTests(TestCasePlus):
             --output_dir {tmp_dir}
             --overwrite_output_dir
             """.split()
-
-        # if torch.cuda.device_count() > 1:
-        # Skipping because there are not enough batches to train the model + would need a drop_last to work.
-        # return
 
         with patch.object(sys, "argv", testargs):
             run_t5_mlm_flax.main()

--- a/examples/flax/test_examples.py
+++ b/examples/flax/test_examples.py
@@ -30,6 +30,8 @@ SRC_DIRS = [
         "text-classification",
         "language-modeling",
         "summarization",
+        "token-classification",
+        "question-answering",
     ]
 ]
 sys.path.extend(SRC_DIRS)
@@ -38,6 +40,9 @@ sys.path.extend(SRC_DIRS)
 if SRC_DIRS is not None:
     import run_clm_flax
     import run_flax_glue
+    import run_flax_ner
+    import run_mlm_flax
+    import run_qa
     import run_summarization_flax
 
 
@@ -152,3 +157,84 @@ class ExamplesTests(TestCasePlus):
             self.assertGreaterEqual(result["test_rouge2"], 2)
             self.assertGreaterEqual(result["test_rougeL"], 7)
             self.assertGreaterEqual(result["test_rougeLsum"], 7)
+
+    def test_run_mlm(self):
+        stream_handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(stream_handler)
+
+        tmp_dir = self.get_auto_remove_tmp_dir()
+        testargs = f"""
+            run_mlm.py
+            --model_name_or_path distilroberta-base
+            --train_file ./tests/fixtures/sample_text.txt
+            --validation_file ./tests/fixtures/sample_text.txt
+            --output_dir {tmp_dir}
+            --overwrite_output_dir
+            --do_train
+            --do_eval
+            --num_train_epochs=1
+        """.split()
+
+        with patch.object(sys, "argv", testargs):
+            run_mlm_flax.main()
+            result = get_results(tmp_dir)
+            self.assertLess(result["perplexity"], 42)
+
+    def test_run_ner(self):
+        stream_handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(stream_handler)
+
+        # with so little data distributed training needs more epochs to get the score on par with 0/1 gpu
+        epochs = 7 if get_gpu_count() > 1 else 2
+
+        tmp_dir = self.get_auto_remove_tmp_dir()
+        testargs = f"""
+            run_flax_ner.py
+            --model_name_or_path bert-base-uncased
+            --train_file tests/fixtures/tests_samples/conll/sample.json
+            --validation_file tests/fixtures/tests_samples/conll/sample.json
+            --output_dir {tmp_dir}
+            --overwrite_output_dir
+            --do_train
+            --do_eval
+            --warmup_steps=2
+            --learning_rate=2e-4
+            --per_device_train_batch_size=2
+            --per_device_eval_batch_size=2
+            --num_train_epochs={epochs}
+            --seed 7
+        """.split()
+
+        with patch.object(sys, "argv", testargs):
+            run_flax_ner.main()
+            result = get_results(tmp_dir)
+            self.assertGreaterEqual(result["eval_accuracy"], 0.75)
+            self.assertLess(result["eval_loss"], 0.5)
+
+    def test_run_qa(self):
+        stream_handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(stream_handler)
+
+        tmp_dir = self.get_auto_remove_tmp_dir()
+        testargs = f"""
+            run_qa.py
+            --model_name_or_path bert-base-uncased
+            --version_2_with_negative
+            --train_file tests/fixtures/tests_samples/SQUAD/sample.json
+            --validation_file tests/fixtures/tests_samples/SQUAD/sample.json
+            --output_dir {tmp_dir}
+            --overwrite_output_dir
+            --max_steps=10
+            --warmup_steps=2
+            --do_train
+            --do_eval
+            --learning_rate=2e-4
+            --per_device_train_batch_size=2
+            --per_device_eval_batch_size=1
+        """.split()
+
+        with patch.object(sys, "argv", testargs):
+            run_qa.main()
+            result = get_results(tmp_dir)
+            self.assertGreaterEqual(result["eval_f1"], 30)
+            self.assertGreaterEqual(result["eval_exact"], 30)

--- a/examples/flax/text-classification/run_flax_glue.py
+++ b/examples/flax/text-classification/run_flax_glue.py
@@ -260,13 +260,6 @@ def glue_eval_data_collator(dataset: Dataset, batch_size: int):
         yield batch
 
 
-def save_metrics(split, output_dir, metrics):
-    metrics = {f"{split}_{metric_name}": value for metric_name, value in metrics.items()}
-    path = os.path.join(output_dir, f"{split}_results.json")
-    with open(path, "w") as f:
-        json.dump(metrics, f, indent=4, sort_keys=True)
-
-
 def main():
     args = parse_args()
 
@@ -532,7 +525,10 @@ def main():
 
     # save the eval metrics in json
     if jax.process_index() == 0:
-        save_metrics("eval", args.output_dir, eval_metric)
+        eval_metric = {f"eval_{metric_name}": value for metric_name, value in eval_metric.items()}
+        path = os.path.join(args.output_dir, "eval_results.json")
+        with open(path, "w") as f:
+            json.dump(eval_metric, f, indent=4, sort_keys=True)
 
 
 if __name__ == "__main__":

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -591,7 +591,7 @@ def require_deepspeed(test_case):
 
 def get_gpu_count():
     """
-    Return the number of available gpus (regardless of whether torch or tf is used)
+    Return the number of available gpus (regardless of whether torch, tf or jax is used)
     """
     if is_torch_available():
         import torch
@@ -601,6 +601,10 @@ def get_gpu_count():
         import tensorflow as tf
 
         return len(tf.config.list_physical_devices("GPU"))
+    elif is_flax_available():
+        import jax
+
+        return jax.device_count()
     else:
         return 0
 


### PR DESCRIPTION
# What does this PR do?

This PR adds tests for flax examples. 

The test for image-classification example is not added since the script uses a manual dataset with `torchvision`.  The test will be added once the script is refactored to use `datasets`.
