### PR TITLE
[trainer] add tf32-mode control

### DIFF
--- a/docs/source/performance.md
+++ b/docs/source/performance.md
@@ -358,7 +358,8 @@ Like all cases with reduced precision this may or may not be satisfactory for yo
 
 If you're already using fp16 or bf16 mixed precision it may help with the throughput as well.
 
-The 🤗 Trainer has this mode enabled by default but can be disabled automatically by passing `--tf32 0`.
+You can enable this mode in the 🤗 Trainer with `--tf32`, or disable it with `--tf32 0`.
+By default the PyTorch default is used.
 
 Note: tf32 mode is internal to CUDA and can't be accessed directly via `tensor.to(dtype=torch.tf32)` as `torch.tf32` doesn't exit.
 

--- a/docs/source/performance.md
+++ b/docs/source/performance.md
@@ -358,10 +358,11 @@ Like all cases with reduced precision this may or may not be satisfactory for yo
 
 If you're already using fp16 or bf16 mixed precision it may help with the throughput as well.
 
-Note: tf32 mode is internal to CUDA and can't be accessed directly via `tensor.to(dtype=torch.tf32)` as `torch.tf32` doesn't exit.
-
 The 🤗 Trainer has this mode disabled by default but can be enabled automatically by passing the `--tf32` argument.
 
+Note: tf32 mode is internal to CUDA and can't be accessed directly via `tensor.to(dtype=torch.tf32)` as `torch.tf32` doesn't exit.
+
+Note: you need `torch>=1.7` to enjoy this feature.
 
 
 ### Gradient Checkpointing

--- a/docs/source/performance.md
+++ b/docs/source/performance.md
@@ -358,7 +358,7 @@ Like all cases with reduced precision this may or may not be satisfactory for yo
 
 If you're already using fp16 or bf16 mixed precision it may help with the throughput as well.
 
-You can enable this mode in the 🤗 Trainer with `--tf32`, or disable it with `--tf32 0`.
+You can enable this mode in the 🤗 Trainer with `--tf32`, or disable it with `--tf32 0` or `--no_tf32`.
 By default the PyTorch default is used.
 
 Note: tf32 mode is internal to CUDA and can't be accessed directly via `tensor.to(dtype=torch.tf32)` as `torch.tf32` doesn't exit.

--- a/docs/source/performance.md
+++ b/docs/source/performance.md
@@ -360,6 +360,9 @@ If you're already using fp16 or bf16 mixed precision it may help with the throug
 
 Note: tf32 mode is internal to CUDA and can't be accessed directly via `tensor.to(dtype=torch.tf32)` as `torch.tf32` doesn't exit.
 
+The 🤗 Trainer has this mode disabled by default but can be enabled automatically by passing the `--tf32` argument.
+
+
 
 ### Gradient Checkpointing
 

--- a/docs/source/performance.md
+++ b/docs/source/performance.md
@@ -358,7 +358,7 @@ Like all cases with reduced precision this may or may not be satisfactory for yo
 
 If you're already using fp16 or bf16 mixed precision it may help with the throughput as well.
 
-The 🤗 Trainer has this mode disabled by default but can be enabled automatically by passing the `--tf32` argument.
+The 🤗 Trainer has this mode enabled by default but can be disabled automatically by passing `--tf32 0`.
 
 Note: tf32 mode is internal to CUDA and can't be accessed directly via `tensor.to(dtype=torch.tf32)` as `torch.tf32` doesn't exit.
 

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -361,7 +361,7 @@ def is_torch_tf32_available():
             return False
         if int(torch.version.cuda.split(".")[0]) < 11:
             return False
-        if not version.parse(torch.__version__) >= version.parse("1.9"):
+        if not version.parse(torch.__version__) >= version.parse("1.7"):
             return False
 
         return True

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -351,6 +351,24 @@ def is_torch_bf16_available():
         return False
 
 
+def is_torch_tf32_available():
+    if is_torch_available():
+        import torch
+
+        if not torch.cuda.is_available() or torch.version.cuda is None:
+            return False
+        if torch.cuda.get_device_properties(torch.cuda.current_device()).major < 8:
+            return False
+        if int(torch.version.cuda.split(".")[0]) < 11:
+            return False
+        if not version.parse(torch.__version__) >= version.parse("1.9"):
+            return False
+
+        return True
+    else:
+        return False
+
+
 _torch_fx_available = _torch_onnx_dict_inputs_support_available = False
 if _torch_available:
     torch_version = version.parse(importlib_metadata.version("torch"))

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -321,52 +321,52 @@ def is_torch_cuda_available():
 
 
 def is_torch_bf16_available():
-    if is_torch_available():
-        import torch
-
-        # since currently no utility function is available we build our own.
-        # some bits come from https://github.com/pytorch/pytorch/blob/2289a12f21c54da93bf5d696e3f9aea83dd9c10d/torch/testing/_internal/common_cuda.py#L51
-        # with additional check for torch version
-        # to succeed:
-        # 1. the hardware needs to support bf16 (arch >= Ampere)
-        # 2. torch >= 1.10 (1.9 should be enough for AMP API has changed in 1.10, so using 1.10 as minimal)
-        # 3. CUDA >= 11
-        # 4. torch.autocast exists
-        # XXX: one problem here is that it may give invalid results on mixed gpus setup, so it's
-        # really only correct for the 0th gpu (or currently set default device if different from 0)
-
-        if not torch.cuda.is_available() or torch.version.cuda is None:
-            return False
-        if torch.cuda.get_device_properties(torch.cuda.current_device()).major < 8:
-            return False
-        if int(torch.version.cuda.split(".")[0]) < 11:
-            return False
-        if version.parse(torch.__version__) < version.parse("1.10"):
-            return False
-        if not hasattr(torch, "autocast"):
-            return False
-
-        return True
-    else:
+    if not is_torch_available():
         return False
+
+    import torch
+
+    # since currently no utility function is available we build our own.
+    # some bits come from https://github.com/pytorch/pytorch/blob/2289a12f21c54da93bf5d696e3f9aea83dd9c10d/torch/testing/_internal/common_cuda.py#L51
+    # with additional check for torch version
+    # to succeed:
+    # 1. the hardware needs to support bf16 (arch >= Ampere)
+    # 2. torch >= 1.10 (1.9 should be enough for AMP API has changed in 1.10, so using 1.10 as minimal)
+    # 3. CUDA >= 11
+    # 4. torch.autocast exists
+    # XXX: one problem here is that it may give invalid results on mixed gpus setup, so it's
+    # really only correct for the 0th gpu (or currently set default device if different from 0)
+
+    if not torch.cuda.is_available() or torch.version.cuda is None:
+        return False
+    if torch.cuda.get_device_properties(torch.cuda.current_device()).major < 8:
+        return False
+    if int(torch.version.cuda.split(".")[0]) < 11:
+        return False
+    if version.parse(torch.__version__) < version.parse("1.10"):
+        return False
+    if not hasattr(torch, "autocast"):
+        return False
+
+    return True
 
 
 def is_torch_tf32_available():
-    if is_torch_available():
-        import torch
-
-        if not torch.cuda.is_available() or torch.version.cuda is None:
-            return False
-        if torch.cuda.get_device_properties(torch.cuda.current_device()).major < 8:
-            return False
-        if int(torch.version.cuda.split(".")[0]) < 11:
-            return False
-        if version.parse(torch.__version__) < version.parse("1.7"):
-            return False
-
-        return True
-    else:
+    if not is_torch_available():
         return False
+
+    import torch
+
+    if not torch.cuda.is_available() or torch.version.cuda is None:
+        return False
+    if torch.cuda.get_device_properties(torch.cuda.current_device()).major < 8:
+        return False
+    if int(torch.version.cuda.split(".")[0]) < 11:
+        return False
+    if version.parse(torch.__version__) < version.parse("1.7"):
+        return False
+
+    return True
 
 
 _torch_fx_available = _torch_onnx_dict_inputs_support_available = False

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -341,7 +341,7 @@ def is_torch_bf16_available():
             return False
         if int(torch.version.cuda.split(".")[0]) < 11:
             return False
-        if not version.parse(torch.__version__) >= version.parse("1.10"):
+        if version.parse(torch.__version__) < version.parse("1.10"):
             return False
         if not hasattr(torch, "autocast"):
             return False
@@ -361,7 +361,7 @@ def is_torch_tf32_available():
             return False
         if int(torch.version.cuda.split(".")[0]) < 11:
             return False
-        if not version.parse(torch.__version__) >= version.parse("1.7"):
+        if version.parse(torch.__version__) < version.parse("1.7"):
             return False
 
         return True

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -50,6 +50,7 @@ from .file_utils import (
     is_tokenizers_available,
     is_torch_available,
     is_torch_bf16_available,
+    is_torch_tf32_available,
     is_torch_tpu_available,
     is_torchaudio_available,
     is_vision_available,
@@ -495,9 +496,17 @@ def require_torch_gpu(test_case):
 
 
 def require_torch_bf16(test_case):
-    """Decorator marking a test that requires CUDA hardware supporting bf16 and PyTorch >= 1.10."""
+    """Decorator marking a test that requires Ampere or a newer GPU arch, cuda>=11 and torch>=1.10."""
     if not is_torch_bf16_available():
-        return unittest.skip("test requires CUDA hardware supporting bf16 and PyTorch >= 1.10")(test_case)
+        return unittest.skip("test requires Ampere or a newer GPU arch, cuda>=11 and torch>=1.10")(test_case)
+    else:
+        return test_case
+
+
+def require_torch_tf32(test_case):
+    """Decorator marking a test that requires Ampere or a newer GPU arch, cuda>=11 and torch>=1.9."""
+    if not is_torch_tf32_available():
+        return unittest.skip("test requires Ampere or a newer GPU arch, cuda>=11 and torch>=1.9")(test_case)
     else:
         return test_case
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -504,9 +504,9 @@ def require_torch_bf16(test_case):
 
 
 def require_torch_tf32(test_case):
-    """Decorator marking a test that requires Ampere or a newer GPU arch, cuda>=11 and torch>=1.9."""
+    """Decorator marking a test that requires Ampere or a newer GPU arch, cuda>=11 and torch>=1.7."""
     if not is_torch_tf32_available():
-        return unittest.skip("test requires Ampere or a newer GPU arch, cuda>=11 and torch>=1.9")(test_case)
+        return unittest.skip("test requires Ampere or a newer GPU arch, cuda>=11 and torch>=1.7")(test_case)
     else:
         return test_case
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -228,7 +228,7 @@ class TrainingArguments:
         fp16_full_eval (:obj:`bool`, `optional`, defaults to :obj:`False`):
             Whether to use full float16 evaluation instead of 32-bit. This will be faster and save memory but can harm
             metric values.
-        tf32 (:obj:`bool`, `optional`, defaults to :obj:`None`):
+        tf32 (:obj:`bool`, `optional`):
             Whether to enable tf32 mode, available in Ampere and newer GPU architectures. This is an experimental API
             and it may change.
         local_rank (:obj:`int`, `optional`, defaults to -1):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -29,6 +29,7 @@ from .file_utils import (
     is_sagemaker_dp_enabled,
     is_sagemaker_mp_enabled,
     is_torch_available,
+    is_torch_tf32_available,
     is_torch_tpu_available,
     torch_required,
 )
@@ -227,6 +228,8 @@ class TrainingArguments:
         fp16_full_eval (:obj:`bool`, `optional`, defaults to :obj:`False`):
             Whether to use full float16 evaluation instead of 32-bit. This will be faster and save memory but can harm
             metric values.
+        tf32 (:obj:`bool`, `optional`, defaults to :obj:`False`):
+            Whether to enable tf32 mode, available in Ampere or newer gpus.
         local_rank (:obj:`int`, `optional`, defaults to -1):
             Rank of the process during distributed training.
         xpu_backend (:obj:`str`, `optional`):
@@ -548,6 +551,10 @@ class TrainingArguments:
         default=False,
         metadata={"help": "Whether to use full float16 evaluation instead of 32-bit"},
     )
+    tf32: bool = field(
+        default=False,
+        metadata={"help": "Whether to enable tf32 mode, available in Ampere or newer gpus."},
+    )
     local_rank: int = field(default=-1, metadata={"help": "For distributed training: local_rank"})
     xpu_backend: str = field(
         default=None,
@@ -801,6 +808,12 @@ class TrainingArguments:
             raise ValueError(
                 "Mixed precision training with AMP or APEX (`--fp16` or `--bf16`) and half precision evaluation (`--fp16_full_eval` or `--bf16_full_eval`) can only be used on CUDA devices."
             )
+
+        if is_torch_available():
+            if is_torch_tf32_available():
+                torch.backends.cuda.matmul.allow_tf32 = True if self.tf32 else False
+            elif self.tf32:
+                raise ValueError("--tf32 was passed but you need torch>=1.9, cuda>=11 and Ampere GPU to use it")
 
         if self.report_to is None:
             logger.info(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -821,7 +821,7 @@ class TrainingArguments:
             else:
                 if is_torch_tf32_available():
                     torch.backends.cuda.matmul.allow_tf32 = False
-                # nothing need to assert on else
+                # no need to assert on else
 
         if self.report_to is None:
             logger.info(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -229,7 +229,7 @@ class TrainingArguments:
             Whether to use full float16 evaluation instead of 32-bit. This will be faster and save memory but can harm
             metric values.
         tf32 (:obj:`bool`, `optional`, defaults to :obj:`True`):
-            Whether to enable tf32 mode, available in Ampere and newer GPU architectures.
+            Whether to enable tf32 mode, available in Ampere and newer GPU architectures. This is an experimental API and it may change.
         local_rank (:obj:`int`, `optional`, defaults to -1):
             Rank of the process during distributed training.
         xpu_backend (:obj:`str`, `optional`):
@@ -553,7 +553,7 @@ class TrainingArguments:
     )
     tf32: bool = field(
         default=True,
-        metadata={"help": "Whether to enable tf32 mode, available in Ampere and newer GPU architectures"},
+        metadata={"help": "Whether to enable tf32 mode, available in Ampere and newer GPU architectures. This is an experimental API and it may change."},
     )
     local_rank: int = field(default=-1, metadata={"help": "For distributed training: local_rank"})
     xpu_backend: str = field(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -229,7 +229,8 @@ class TrainingArguments:
             Whether to use full float16 evaluation instead of 32-bit. This will be faster and save memory but can harm
             metric values.
         tf32 (:obj:`bool`, `optional`, defaults to :obj:`True`):
-            Whether to enable tf32 mode, available in Ampere and newer GPU architectures. This is an experimental API and it may change.
+            Whether to enable tf32 mode, available in Ampere and newer GPU architectures. This is an experimental API
+            and it may change.
         local_rank (:obj:`int`, `optional`, defaults to -1):
             Rank of the process during distributed training.
         xpu_backend (:obj:`str`, `optional`):
@@ -553,7 +554,9 @@ class TrainingArguments:
     )
     tf32: bool = field(
         default=True,
-        metadata={"help": "Whether to enable tf32 mode, available in Ampere and newer GPU architectures. This is an experimental API and it may change."},
+        metadata={
+            "help": "Whether to enable tf32 mode, available in Ampere and newer GPU architectures. This is an experimental API and it may change."
+        },
     )
     local_rank: int = field(default=-1, metadata={"help": "For distributed training: local_rank"})
     xpu_backend: str = field(

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -57,6 +57,7 @@ from transformers.testing_utils import (
     require_torch_gpu,
     require_torch_multi_gpu,
     require_torch_non_multi_gpu,
+    require_torch_tf32,
     require_torch_up_to_2_gpus,
     slow,
 )
@@ -491,6 +492,15 @@ class TrainerIntegrationPrerunTest(TestCasePlus, TrainerIntegrationCommon):
             trainer = get_regression_trainer(learning_rate=0.1, bf16=True, half_precision_backend="apex")
 
         # will add more specific tests once there are some bugs to fix
+
+    @require_torch_gpu
+    @require_torch_tf32
+    def test_tf32(self):
+
+        # very basic test
+        trainer = get_regression_trainer(learning_rate=0.1, tf32=True)
+        trainer.train()
+        self.check_trained_model(trainer.model)
 
 
 @require_torch


### PR DESCRIPTION
This PR adds tr32-mode control support for HF Trainer for Ampere cards. RFC: https://github.com/huggingface/transformers/issues/14450

pytorch had this mode on by default since pt-1.7, but are discussing to turn it off in the coming new release. https://github.com/pytorch/pytorch/issues/67384

Here is the proposed logic: 
1. by default HF Trainer will set it to Enabled,  This is marked as experimental should we discover that this is not a safe default down the road.
2. and `--tf32 0` will disable it. 
3. If the setup uses a wrong gpu or too low torch version - it will silently do nothing as it's irrelevant.

The PR adds:
- `is_torch_tf32_available` and `require_torch_tf32` helper utils
- adds basic test

Fixes: https://github.com/huggingface/transformers/issues/14450

@sgugger, @LysandreJik 
