### PR TITLE
doc: mismatch between pooler/d_output

### DIFF
--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -717,7 +717,7 @@ class CLIPTextModel(CLIPPreTrainedModel):
 
             >>> outputs = model(**inputs)
             >>> last_hidden_state = outputs.last_hidden_state
-            >>> pooled_output = outputs.pooled_output # pooled (EOS token) states
+            >>> pooled_output = outputs.pooler_output # pooled (EOS token) states
         """
         return self.text_model(
             input_ids=input_ids,
@@ -827,7 +827,7 @@ class CLIPVisionModel(CLIPPreTrainedModel):
 
             >>> outputs = model(**inputs)
             >>> last_hidden_state = outputs.last_hidden_state
-            >>> pooled_output = outputs.pooled_output # pooled CLS states
+            >>> pooled_output = outputs.pooler_output # pooled CLS states
         """
         return self.vision_model(
             pixel_values=pixel_values,


### PR DESCRIPTION
The model outputs a pooler_output whereas the doctype examples were using a pooled_output.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?

@sgugger

