### PR TITLE
Fix syntax for class references

### DIFF
--- a/src/transformers/generation_flax_utils.py
+++ b/src/transformers/generation_flax_utils.py
@@ -326,8 +326,8 @@ class FlaxGenerationMixin:
         self, top_k: int = None, top_p: float = None, temperature: float = None
     ) -> FlaxLogitsProcessorList:
         """
-        This class returns a :obj:`~transformers.FlaxLogitsProcessorList` list object that contains all relevant
-        :obj:`~transformers.FlaxLogitsWarper` instances used for multinomial sampling.
+        This class returns a :class:`~transformers.FlaxLogitsProcessorList` list object that contains all relevant
+        :class:`~transformers.FlaxLogitsWarper` instances used for multinomial sampling.
         """
 
         # init warp parameters
@@ -358,8 +358,8 @@ class FlaxGenerationMixin:
         forced_eos_token_id: int,
     ) -> FlaxLogitsProcessorList:
         """
-        This class returns a :obj:`~transformers.FlaxLogitsProcessorList` list object that contains all relevant
-        :obj:`~transformers.FlaxLogitsProcessor` instances used to modify the scores of the language model head.
+        This class returns a :class:`~transformers.FlaxLogitsProcessorList` list object that contains all relevant
+        :class:`~transformers.FlaxLogitsProcessor` instances used to modify the scores of the language model head.
         """
         processors = FlaxLogitsProcessorList()
 

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -535,8 +535,8 @@ class GenerationMixin:
         self, top_k: int = None, top_p: float = None, temperature: float = None, num_beams: int = None
     ) -> LogitsProcessorList:
         """
-        This class returns a :obj:`~transformers.LogitsProcessorList` list object that contains all relevant
-        :obj:`~transformers.LogitsWarper` instances used for multinomial sampling.
+        This class returns a :class:`~transformers.LogitsProcessorList` list object that contains all relevant
+        :class:`~transformers.LogitsWarper` instances used for multinomial sampling.
         """
 
         # init warp parameters
@@ -575,8 +575,8 @@ class GenerationMixin:
         remove_invalid_values: bool,
     ) -> LogitsProcessorList:
         """
-        This class returns a :obj:`~transformers.LogitsProcessorList` list object that contains all relevant
-        :obj:`~transformers.LogitsProcessor` instances used to modify the scores of the language model head.
+        This class returns a :class:`~transformers.LogitsProcessorList` list object that contains all relevant
+        :class:`~transformers.LogitsProcessor` instances used to modify the scores of the language model head.
         """
         processors = LogitsProcessorList()
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -737,7 +737,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         Prepare the output of the saved model. Each model must implement this function.
 
         Args:
-            output (:obj:`~transformers.TFBaseModelOutput`):
+            output (:class:`~transformers.TFBaseModelOutput`):
                 The output returned by the model.
         """
         raise NotImplementedError

--- a/src/transformers/models/tapas/tokenization_tapas.py
+++ b/src/transformers/models/tapas/tokenization_tapas.py
@@ -1277,7 +1277,7 @@ class TapasTokenizer(PreTrainedTokenizer):
                 Total number of table columns
             max_length (:obj:`int`):
                 Total maximum length.
-            truncation_strategy (:obj:`str` or :obj:`~transformers.TapasTruncationStrategy`):
+            truncation_strategy (:obj:`str` or :class:`~transformers.TapasTruncationStrategy`):
                 Truncation strategy to use. Seeing as this method should only be called when truncating, the only
                 available strategy is the :obj:`"drop_rows_to_fit"` strategy.
 

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -372,13 +372,13 @@ def pipeline(
             - :obj:`"summarization"`: will return a :class:`~transformers.SummarizationPipeline`:.
             - :obj:`"zero-shot-classification"`: will return a :class:`~transformers.ZeroShotClassificationPipeline`:.
 
-        model (:obj:`str` or :obj:`~transformers.PreTrainedModel` or :obj:`~transformers.TFPreTrainedModel`, `optional`):
+        model (:obj:`str` or :class:`~transformers.PreTrainedModel` or :class:`~transformers.TFPreTrainedModel`, `optional`):
             The model that will be used by the pipeline to make predictions. This can be a model identifier or an
             actual instance of a pretrained model inheriting from :class:`~transformers.PreTrainedModel` (for PyTorch)
             or :class:`~transformers.TFPreTrainedModel` (for TensorFlow).
 
             If not provided, the default for the :obj:`task` will be loaded.
-        config (:obj:`str` or :obj:`~transformers.PretrainedConfig`, `optional`):
+        config (:obj:`str` or :class:`~transformers.PretrainedConfig`, `optional`):
             The configuration that will be used by the pipeline to instantiate the model. This can be a model
             identifier or an actual pretrained model configuration inheriting from
             :class:`~transformers.PretrainedConfig`.
@@ -386,7 +386,7 @@ def pipeline(
             If not provided, the default configuration file for the requested model will be used. That means that if
             :obj:`model` is given, its default configuration will be used. However, if :obj:`model` is not supplied,
             this :obj:`task`'s default model's config is used instead.
-        tokenizer (:obj:`str` or :obj:`~transformers.PreTrainedTokenizer`, `optional`):
+        tokenizer (:obj:`str` or :class:`~transformers.PreTrainedTokenizer`, `optional`):
             The tokenizer that will be used by the pipeline to encode data for the model. This can be a model
             identifier or an actual pretrained tokenizer inheriting from :class:`~transformers.PreTrainedTokenizer`.
 
@@ -394,7 +394,7 @@ def pipeline(
             :obj:`model` is not specified or not a string, then the default tokenizer for :obj:`config` is loaded (if
             it is a string). However, if :obj:`config` is also not given or not a string, then the default tokenizer
             for the given :obj:`task` will be loaded.
-        feature_extractor (:obj:`str` or :obj:`~transformers.PreTrainedFeatureExtractor`, `optional`):
+        feature_extractor (:obj:`str` or :class:`~transformers.PreTrainedFeatureExtractor`, `optional`):
             The feature extractor that will be used by the pipeline to encode data for the model. This can be a model
             identifier or an actual pretrained feature extractor inheriting from
             :class:`~transformers.PreTrainedFeatureExtractor`.

--- a/src/transformers/pipelines/audio_classification.py
+++ b/src/transformers/pipelines/audio_classification.py
@@ -93,7 +93,7 @@ class AudioClassificationPipeline(Pipeline):
         **kwargs,
     ):
         """
-        Classify the sequence(s) given as inputs. See the :obj:`~transformers.AutomaticSpeechRecognitionPipeline`
+        Classify the sequence(s) given as inputs. See the :class:`~transformers.AutomaticSpeechRecognitionPipeline`
         documentation for more information.
 
         Args:

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -77,13 +77,13 @@ class AutomaticSpeechRecognitionPipeline(Pipeline):
     def __init__(self, feature_extractor: Union["SequenceFeatureExtractor", str], *args, **kwargs):
         """
         Arguments:
-            feature_extractor (:obj:`~transformers.SequenceFeatureExtractor`):
+            feature_extractor (:class:`~transformers.SequenceFeatureExtractor`):
                 The feature extractor that will be used by the pipeline to encode waveform for the model.
-            model (:obj:`~transformers.PreTrainedModel` or :obj:`~transformers.TFPreTrainedModel`):
+            model (:class:`~transformers.PreTrainedModel` or :class:`~transformers.TFPreTrainedModel`):
                 The model that will be used by the pipeline to make predictions. This needs to be a model inheriting
                 from :class:`~transformers.PreTrainedModel` for PyTorch and :class:`~transformers.TFPreTrainedModel`
                 for TensorFlow.
-            tokenizer (:obj:`~transformers.PreTrainedTokenizer`):
+            tokenizer (:class:`~transformers.PreTrainedTokenizer`):
                 The tokenizer that will be used by the pipeline to encode data for the model. This object inherits from
                 :class:`~transformers.PreTrainedTokenizer`.
             modelcard (:obj:`str` or :class:`~transformers.ModelCard`, `optional`):
@@ -114,7 +114,7 @@ class AutomaticSpeechRecognitionPipeline(Pipeline):
         **kwargs,
     ):
         """
-        Classify the sequence(s) given as inputs. See the :obj:`~transformers.AutomaticSpeechRecognitionPipeline`
+        Classify the sequence(s) given as inputs. See the :class:`~transformers.AutomaticSpeechRecognitionPipeline`
         documentation for more information.
 
         Args:

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -644,11 +644,11 @@ class _ScikitCompat(ABC):
 
 PIPELINE_INIT_ARGS = r"""
     Arguments:
-        model (:obj:`~transformers.PreTrainedModel` or :obj:`~transformers.TFPreTrainedModel`):
+        model (:class:`~transformers.PreTrainedModel` or :class:`~transformers.TFPreTrainedModel`):
             The model that will be used by the pipeline to make predictions. This needs to be a model inheriting from
             :class:`~transformers.PreTrainedModel` for PyTorch and :class:`~transformers.TFPreTrainedModel` for
             TensorFlow.
-        tokenizer (:obj:`~transformers.PreTrainedTokenizer`):
+        tokenizer (:class:`~transformers.PreTrainedTokenizer`):
             The tokenizer that will be used by the pipeline to encode data for the model. This object inherits from
             :class:`~transformers.PreTrainedTokenizer`.
         modelcard (:obj:`str` or :class:`~transformers.ModelCard`, `optional`):

--- a/src/transformers/pipelines/feature_extraction.py
+++ b/src/transformers/pipelines/feature_extraction.py
@@ -16,11 +16,11 @@ class FeatureExtractionPipeline(Pipeline):
     `huggingface.co/models <https://huggingface.co/models>`__.
 
     Arguments:
-        model (:obj:`~transformers.PreTrainedModel` or :obj:`~transformers.TFPreTrainedModel`):
+        model (:class:`~transformers.PreTrainedModel` or :class:`~transformers.TFPreTrainedModel`):
             The model that will be used by the pipeline to make predictions. This needs to be a model inheriting from
             :class:`~transformers.PreTrainedModel` for PyTorch and :class:`~transformers.TFPreTrainedModel` for
             TensorFlow.
-        tokenizer (:obj:`~transformers.PreTrainedTokenizer`):
+        tokenizer (:class:`~transformers.PreTrainedTokenizer`):
             The tokenizer that will be used by the pipeline to encode data for the model. This object inherits from
             :class:`~transformers.PreTrainedTokenizer`.
         modelcard (:obj:`str` or :class:`~transformers.ModelCard`, `optional`):

--- a/src/transformers/pipelines/zero_shot_classification.py
+++ b/src/transformers/pipelines/zero_shot_classification.py
@@ -154,7 +154,7 @@ class ZeroShotClassificationPipeline(Pipeline):
         **kwargs,
     ):
         """
-        Classify the sequence(s) given as inputs. See the :obj:`~transformers.ZeroShotClassificationPipeline`
+        Classify the sequence(s) given as inputs. See the :class:`~transformers.ZeroShotClassificationPipeline`
         documentation for more information.
 
         Args:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -239,7 +239,7 @@ class Trainer:
         compute_metrics (:obj:`Callable[[EvalPrediction], Dict]`, `optional`):
             The function that will be used to compute metrics at evaluation. Must take a
             :class:`~transformers.EvalPrediction` and return a dictionary string to metric values.
-        callbacks (List of :obj:`~transformers.TrainerCallback`, `optional`):
+        callbacks (List of :class:`~transformers.TrainerCallback`, `optional`):
             A list of callbacks to customize the training loop. Will add those to the list of default callbacks
             detailed in :doc:`here <callback>`.
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes the documentation links made of the form :obj:`~transformers.ObjectName`. Those are not detected by `doc-builder` (and can't really be added since we use `:obj:` very often) so I searched and fixed the docstrings instead.

See the [TextClassificationPipeline](https://huggingface.co/docs/transformers/master/en/main_classes/pipelines#transformers.TextClassificationPipeline) in the current doc for an example of the problem:

![image](https://user-images.githubusercontent.com/35901082/144895213-013c0bce-5f40-499a-8631-bd97adb3720e.png)

cc @mishig25 @LysandreJik (merging to fix but will address any comment you have on your return Lysandre).