### PR TITLE
Add a job to test the documentation build

### DIFF
--- a/.github/workflows/build_doc_test.yml
+++ b/.github/workflows/build_doc_test.yml
@@ -1,0 +1,51 @@
+name: Documentation test build
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "docs/**"
+
+jobs:
+  build_and_package:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'huggingface/doc-builder'
+          token: ${{ secrets.HUGGINGFACE_PUSH }}
+
+      - name: Clone transformers
+        run: |
+          git clone https://github.com/huggingface/transformers
+
+      - name: Setup environment
+        run: |
+          sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev
+
+          pip install git+https://github.com/huggingface/doc-builder
+          pip install git+https://github.com/huggingface/transformers#egg=transformers[dev]
+
+          export TORCH_VERSION=$(python -c "from torch import version; print(version.__version__.split('+')[0])")
+          pip install torch-scatter -f https://data.pyg.org/whl/torch-${TORCH_VERSION}+cpu.html
+
+          pip install torchvision
+          python -m pip install 'git+https://github.com/facebookresearch/detectron2.git'
+
+          sudo apt install tesseract-ocr
+          pip install pytesseract
+          pip install pytorch-quantization --extra-index-url https://pypi.ngc.nvidia.com
+
+      - name: Setup git
+        run: |
+          git config --global user.name "Hugging Face"
+          git config --global user.email transformers@huggingface.co
+          git pull origin main
+
+      - name: Make documentation
+        run: |
+          doc-builder build transformers ./transformers/docs/source

--- a/.github/workflows/build_doc_test.yml
+++ b/.github/workflows/build_doc_test.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "src/**"
       - "docs/**"
+      - ".github/**"
 
 jobs:
   build_and_package:
@@ -22,6 +23,16 @@ jobs:
       - name: Clone transformers
         run: |
           git clone https://github.com/huggingface/transformers
+      
+      - name: Loading cache.
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: ~/.cache/pip
+          key: v1-test_build_doc
+          restore-keys: |
+            v1-test_build_doc-${{ hashFiles('setup.py') }}
+            v1-test_build_doc
 
       - name: Setup environment
         run: |

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -21,6 +21,16 @@ jobs:
       - name: Clone transformers
         run: |
           git clone https://github.com/huggingface/transformers
+      
+      - name: Loading cache.
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: ~/.cache/pip
+          key: v1-test_build_doc
+          restore-keys: |
+            v1-test_build_doc-${{ hashFiles('setup.py') }}
+            v1-test_build_doc
 
       - name: Setup environment
         run: |


### PR DESCRIPTION
# What does this PR do?

This PR adds a GitHub action to test the documentation build. While we will in the future have something to check the built documentation, it's important to test right now that there is no failure in the build at least, even if we can't see the result.