### PR TITLE
 fix: verify jsonlines file in run_translation (#14660)

### DIFF
--- a/examples/pytorch/translation/run_translation.py
+++ b/examples/pytorch/translation/run_translation.py
@@ -216,12 +216,16 @@ class DataTrainingArguments:
         elif self.source_lang is None or self.target_lang is None:
             raise ValueError("Need to specify the source language and the target language.")
 
+        # accepting both json and jsonl file extensions, as
+        # many jsonlines files actually have a .json extension
+        valid_jsonl_file_extensions = ["json", "jsonl"]
+        
         if self.train_file is not None:
             extension = self.train_file.split(".")[-1]
-            assert extension == "jsonl", "`train_file` should be a jsonlines file."
+            assert extension in valid_jsonl_file_extensions, "`train_file` should be a jsonlines file."
         if self.validation_file is not None:
             extension = self.validation_file.split(".")[-1]
-            assert extension == "jsonl", "`validation_file` should be a jsonlines file."
+            assert extension in valid_jsonl_file_extensions, "`validation_file` should be a jsonlines file."
         if self.val_max_target_length is None:
             self.val_max_target_length = self.max_target_length
 

--- a/examples/pytorch/translation/run_translation.py
+++ b/examples/pytorch/translation/run_translation.py
@@ -219,7 +219,7 @@ class DataTrainingArguments:
         # accepting both json and jsonl file extensions, as
         # many jsonlines files actually have a .json extension
         valid_extensions = ["json", "jsonl"]
-        
+
         if self.train_file is not None:
             extension = self.train_file.split(".")[-1]
             assert extension in valid_extensions, "`train_file` should be a jsonlines file."

--- a/examples/pytorch/translation/run_translation.py
+++ b/examples/pytorch/translation/run_translation.py
@@ -218,14 +218,14 @@ class DataTrainingArguments:
 
         # accepting both json and jsonl file extensions, as
         # many jsonlines files actually have a .json extension
-        valid_jsonl_file_extensions = ["json", "jsonl"]
+        valid_extensions = ["json", "jsonl"]
         
         if self.train_file is not None:
             extension = self.train_file.split(".")[-1]
-            assert extension in valid_jsonl_file_extensions, "`train_file` should be a jsonlines file."
+            assert extension in valid_extensions, "`train_file` should be a jsonlines file."
         if self.validation_file is not None:
             extension = self.validation_file.split(".")[-1]
-            assert extension in valid_jsonl_file_extensions, "`validation_file` should be a jsonlines file."
+            assert extension in valid_extensions, "`validation_file` should be a jsonlines file."
         if self.val_max_target_length is None:
             self.val_max_target_length = self.max_target_length
 

--- a/examples/pytorch/translation/run_translation.py
+++ b/examples/pytorch/translation/run_translation.py
@@ -218,10 +218,10 @@ class DataTrainingArguments:
 
         if self.train_file is not None:
             extension = self.train_file.split(".")[-1]
-            assert extension == "json", "`train_file` should be a json file."
+            assert extension == "jsonl", "`train_file` should be a jsonlines file."
         if self.validation_file is not None:
             extension = self.validation_file.split(".")[-1]
-            assert extension == "json", "`validation_file` should be a json file."
+            assert extension == "jsonl", "`validation_file` should be a jsonlines file."
         if self.val_max_target_length is None:
             self.val_max_target_length = self.max_target_length
 


### PR DESCRIPTION
# What does this PR do?

Fixes #14660 

The documentation and the code everywhere mention jsonlines file except in the actual code where the verification was for json file instead.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj


