### PR TITLE
add str hub token to repository when provided else fallback to default

### DIFF
--- a/src/transformers/keras_callbacks.py
+++ b/src/transformers/keras_callbacks.py
@@ -68,8 +68,12 @@ class PushToHubCallback(Callback):
             hub_model_id = output_dir.absolute().name
         if "/" not in hub_model_id:
             hub_model_id = get_full_repo_name(hub_model_id, token=hub_token)
+        
         self.output_dir = output_dir
-        self.repo = Repository(str(output_dir), clone_from=hub_model_id)
+        self.repo = Repository(
+            str(output_dir), 
+            clone_from=hub_model_id,
+            use_auth_token=hub_token if hub_token else True)
         self.tokenizer = tokenizer
         self.last_job = None
         self.checkpoint = checkpoint

--- a/src/transformers/keras_callbacks.py
+++ b/src/transformers/keras_callbacks.py
@@ -68,12 +68,11 @@ class PushToHubCallback(Callback):
             hub_model_id = output_dir.absolute().name
         if "/" not in hub_model_id:
             hub_model_id = get_full_repo_name(hub_model_id, token=hub_token)
-        
+
         self.output_dir = output_dir
         self.repo = Repository(
-            str(output_dir), 
-            clone_from=hub_model_id,
-            use_auth_token=hub_token if hub_token else True)
+            str(output_dir), clone_from=hub_model_id, use_auth_token=hub_token if hub_token else True
+        )
         self.tokenizer = tokenizer
         self.last_job = None
         self.checkpoint = checkpoint


### PR DESCRIPTION
# What does this PR do?

This PR fixes the Repository creation when using `PushToHubCallback`. Currently, the Repository is created assuming the `HF_TOKEN` is available on the machine, but that's not the case for every scenario. 
These changes check if the `hub_token` parameter is provided if yes then it is passed into the `Repository` if not the default value `True` is used. 
