### PR TITLE
Revert open-in-colab and add perceiver

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -218,6 +218,8 @@
       title: GPT Neo
     - local: model_doc/hubert
       title: Hubert
+    - local: model_doc/perceiver
+      title: Perceiver
     - local: model_doc/pegasus
       title: Pegasus
     - local: model_doc/phobert

--- a/docs/source/benchmarks.mdx
+++ b/docs/source/benchmarks.mdx
@@ -12,8 +12,6 @@ specific language governing permissions and limitations under the License.
 
 # Benchmarks
 
-[[open-in-colab]]
-
 Let's take a look at how 🤗 Transformer models can be benchmarked, best practices, and already available benchmarks.
 
 A notebook explaining in more detail how to benchmark 🤗 Transformer models can be found [here](https://github.com/huggingface/transformers/tree/master/notebooks/05-benchmark.ipynb).

--- a/docs/source/custom_datasets.mdx
+++ b/docs/source/custom_datasets.mdx
@@ -12,8 +12,6 @@ specific language governing permissions and limitations under the License.
 
 # How to fine-tune a model for common downstream tasks
 
-[[open-in-colab]]
-
 This guide will show you how to fine-tune 🤗 Transformers models for common downstream tasks. You will use the 🤗
 Datasets library to quickly load and preprocess the datasets, getting them ready for training with PyTorch and
 TensorFlow.

--- a/docs/source/multilingual.mdx
+++ b/docs/source/multilingual.mdx
@@ -12,8 +12,6 @@ specific language governing permissions and limitations under the License.
 
 # Multi-lingual models
 
-[[open-in-colab]]
-
 Most of the models available in this library are mono-lingual models (English, Chinese and German). A few multi-lingual
 models are available and have a different mechanisms than mono-lingual models. This page details the usage of these
 models.

--- a/docs/source/perplexity.mdx
+++ b/docs/source/perplexity.mdx
@@ -12,8 +12,6 @@ specific language governing permissions and limitations under the License.
 
 # Perplexity of fixed-length models
 
-[[open-in-colab]]
-
 Perplexity (PPL) is one of the most common metrics for evaluating language models. Before diving in, we should note
 that the metric applies specifically to classical language models (sometimes called autoregressive or causal language
 models) and is not well defined for masked language models like BERT (see [summary of the models](model_summary)).

--- a/docs/source/preprocessing.mdx
+++ b/docs/source/preprocessing.mdx
@@ -12,8 +12,6 @@ specific language governing permissions and limitations under the License.
 
 # Preprocessing data
 
-[[open-in-colab]]
-
 In this tutorial, we'll explore how to preprocess your data using 🤗 Transformers. The main tool for this is what we
 call a [tokenizer](main_classes/tokenizer). You can build one using the tokenizer class associated to the model
 you would like to use, or directly with the [`AutoTokenizer`] class.

--- a/docs/source/quicktour.mdx
+++ b/docs/source/quicktour.mdx
@@ -12,8 +12,6 @@ specific language governing permissions and limitations under the License.
 
 # Quick tour
 
-[[open-in-colab]]
-
 Let's have a quick look at the 🤗 Transformers library features. The library downloads pretrained models for Natural
 Language Understanding (NLU) tasks, such as analyzing the sentiment of a text, and Natural Language Generation (NLG),
 such as completing a prompt with new text or translating in another language.

--- a/docs/source/task_summary.mdx
+++ b/docs/source/task_summary.mdx
@@ -12,8 +12,6 @@ specific language governing permissions and limitations under the License.
 
 # Summary of the tasks
 
-[[open-in-colab]]
-
 This page shows the most frequent use-cases when using the library. The models available allow for many different
 configurations and a great versatility in use-cases. The most simple ones are presented here, showcasing usage for
 tasks such as question answering, sequence classification, named entity recognition and others.

--- a/docs/source/tokenizer_summary.mdx
+++ b/docs/source/tokenizer_summary.mdx
@@ -12,8 +12,6 @@ specific language governing permissions and limitations under the License.
 
 # Summary of the tokenizers
 
-[[open-in-colab]]
-
 On this page, we will have a closer look at tokenization.
 
 <Youtube id="VFp38yj8h3A"/>

--- a/docs/source/training.mdx
+++ b/docs/source/training.mdx
@@ -12,8 +12,6 @@ specific language governing permissions and limitations under the License.
 
 # Fine-tuning a pretrained model
 
-[[open-in-colab]]
-
 In this tutorial, we will show you how to fine-tune a pretrained model from the Transformers library. In TensorFlow,
 models can be directly trained using Keras and the `fit` method. In PyTorch, there is no generic training loop so
 the 🤗 Transformers library provides an API with the class [`Trainer`] to let you fine-tune or train


### PR DESCRIPTION
# What does this PR do?

I merged a bit too fast #14665 so this PR reverts the [[open-in-colab]] markers since the corresponding Svelte component has not been merged yet.
This PR also adds Perceiver to the table of content. (cc @NielsRogge )