### PR TITLE
Fix wrong checkpoint paths in doc examples

### DIFF
--- a/src/transformers/models/big_bird/modeling_big_bird.py
+++ b/src/transformers/models/big_bird/modeling_big_bird.py
@@ -2310,8 +2310,8 @@ class BigBirdForPreTraining(BigBirdPreTrainedModel):
             >>> from transformers import BigBirdTokenizer, BigBirdForPreTraining
             >>> import torch
 
-            >>> tokenizer = BigBirdTokenizer.from_pretrained('bigbird-roberta-base')
-            >>> model = BigBirdForPreTraining.from_pretrained('bigbird-roberta-base')
+            >>> tokenizer = BigBirdTokenizer.from_pretrained('google/bigbird-roberta-base')
+            >>> model = BigBirdForPreTraining.from_pretrained('google/bigbird-roberta-base')
 
             >>> inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
             >>> outputs = model(**inputs)
@@ -2534,7 +2534,7 @@ class BigBirdForCausalLM(BigBirdPreTrainedModel):
             >>> import torch
 
             >>> tokenizer = BigBirdTokenizer.from_pretrained('google/bigbird-roberta-base')
-            >>> config = BigBirdConfig.from_pretrained("google/bigbird-base")
+            >>> config = BigBirdConfig.from_pretrained("google/bigbird-roberta-base")
             >>> config.is_decoder = True
             >>> model = BigBirdForCausalLM.from_pretrained('google/bigbird-roberta-base', config=config)
 

--- a/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
+++ b/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
@@ -1623,8 +1623,8 @@ BIGBIRD_PEGASUS_GENERATION_EXAMPLE = r"""
 
         >>> from transformers import PegasusTokenizer, BigBirdPegasusForConditionalGeneration, BigBirdPegasusConfig
 
-        >>> model = BigBirdPegasusForConditionalGeneration.from_pretrained('bigbird-pegasus-large-arxiv')
-        >>> tokenizer = PegasusTokenizer.from_pretrained('bigbird-pegasus-large-arxiv')
+        >>> model = BigBirdPegasusForConditionalGeneration.from_pretrained('google/bigbird-pegasus-large-arxiv')
+        >>> tokenizer = PegasusTokenizer.from_pretrained('google/bigbird-pegasus-large-arxiv')
 
         >>> ARTICLE_TO_SUMMARIZE = "My friends are cool but they eat too many carbs."
         >>> inputs = tokenizer([ARTICLE_TO_SUMMARIZE], max_length=4096, return_tensors='pt', truncation=True)

--- a/src/transformers/models/rembert/modeling_rembert.py
+++ b/src/transformers/models/rembert/modeling_rembert.py
@@ -1087,10 +1087,10 @@ class RemBertForCausalLM(RemBertPreTrainedModel):
             >>> from transformers import RemBertTokenizer, RemBertForCausalLM, RemBertConfig
             >>> import torch
 
-            >>> tokenizer = RemBertTokenizer.from_pretrained('rembert')
-            >>> config = RemBertConfig.from_pretrained("rembert")
+            >>> tokenizer = RemBertTokenizer.from_pretrained('google/rembert')
+            >>> config = RemBertConfig.from_pretrained("google/rembert")
             >>> config.is_decoder = True
-            >>> model = RemBertForCausalLM.from_pretrained('rembert', config=config)
+            >>> model = RemBertForCausalLM.from_pretrained('google/rembert', config=config)
 
             >>> inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
             >>> outputs = model(**inputs)

--- a/src/transformers/models/segformer/modeling_segformer.py
+++ b/src/transformers/models/segformer/modeling_segformer.py
@@ -490,8 +490,8 @@ class SegformerModel(SegformerPreTrainedModel):
             >>> from PIL import Image
             >>> import requests
 
-            >>> feature_extractor = SegformerFeatureExtractor.from_pretrained("nvidia/segformer-b0")
-            >>> model = SegformerModel("nvidia/segformer-b0")
+            >>> feature_extractor = SegformerFeatureExtractor.from_pretrained("nvidia/segformer-b0-finetuned-ade-512-512")
+            >>> model = SegformerModel("nvidia/segformer-b0-finetuned-ade-512-512")
 
             >>> url = 'http://images.cocodataset.org/val2017/000000039769.jpg'
             >>> image = Image.open(requests.get(url, stream=True).raw)
@@ -726,7 +726,7 @@ class SegformerForSemanticSegmentation(SegformerPreTrainedModel):
             >>> import requests
 
             >>> feature_extractor = SegformerFeatureExtractor.from_pretrained("nvidia/segformer-b0-finetuned-ade-512-512")
-            >>> model = SegformerForSemanticSegmentation("nvidia/segformer-b0-finetuned-ade-512-512")
+            >>> model = SegformerForSemanticSegmentation.from_pretrained("nvidia/segformer-b0-finetuned-ade-512-512")
 
             >>> url = 'http://images.cocodataset.org/val2017/000000039769.jpg'
             >>> image = Image.open(requests.get(url, stream=True).raw)


### PR DESCRIPTION
# What does this PR do?

In some (PT) model files, there are doc examples with the wrong checkpoint paths. For example, 

```
model = BigBirdPegasusForConditionalGeneration.from_pretrained('bigbird-pegasus-large-arxiv')
```
which should be `'google/bigbird-pegasus-large-arxiv'`

This PR fixes this issue.


There is
```
MegatronBertLMHeadModel.from_pretrained('nvidia/megatron-bert-cased-345m', is_decoder=True)
```
but there is no model file at all when I searched `megatron-bert`. I am not sure what to do in this case.

## Who can review?

@sgugger @LysandreJik 