### PR TITLE
[trainer] support UserDict inputs (torch-nightly)

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -27,6 +27,7 @@ import shutil
 import sys
 import time
 import warnings
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -1813,8 +1814,8 @@ class Trainer:
         """
         Prepares one :obj:`data` before feeding it to the model, be it a tensor or a nested list/dictionary of tensors.
         """
-        if isinstance(data, dict):
-            return type(data)(**{k: self._prepare_input(v) for k, v in data.items()})
+        if isinstance(data, Mapping):
+            return type(data)({k: self._prepare_input(v) for k, v in data.items()})
         elif isinstance(data, (tuple, list)):
             return type(data)(self._prepare_input(v) for v in data)
         elif isinstance(data, torch.Tensor):


### PR DESCRIPTION
torch-nightly has changed the behavior of DataLoader. Until now its iterator was returning a `dict` structure, but with pt-11 it now returns our custom `BatchEncoding` dict structure, which broke `_prepare_inputs` in Trainer as it misses the `dict` check.

This PR fixes the problem switching to checking if it's any kind of dict structure via Mappings and removes `**` as dict can be init'ed with any type of dict. (`**dict` breaks with `UserDict`)

Thanks to @sgugger for helping me to fix this one.

@sgugger 