### PR TITLE
Fix doc examples: unexpected keyword argument

### DIFF
--- a/src/transformers/models/prophetnet/modeling_prophetnet.py
+++ b/src/transformers/models/prophetnet/modeling_prophetnet.py
@@ -1299,6 +1299,7 @@ class ProphetNetEncoder(ProphetNetPreTrainedModel):
             >>> tokenizer = ProphetNetTokenizer.from_pretrained('microsoft/prophetnet-large-uncased')
             >>> model = ProphetNetEncoder.from_pretrained('patrickvonplaten/prophetnet-large-uncased-standalone')
             >>> inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
+            >>> del inputs["token_type_ids"]  # `ProphetNetEncoder` doesn't use `token_type_ids`
             >>> outputs = model(**inputs)
 
             >>> last_hidden_states = outputs.last_hidden_state
@@ -2177,6 +2178,7 @@ class ProphetNetForCausalLM(ProphetNetPreTrainedModel):
             >>> model = ProphetNetForCausalLM.from_pretrained('microsoft/prophetnet-large-uncased')
             >>> assert model.config.is_decoder, f"{model.__class__} has to be configured as a decoder."
             >>> inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
+            >>> del inputs["token_type_ids"]  # `ProphetNetEncoder` doesn't use `token_type_ids`
             >>> outputs = model(**inputs)
 
             >>> logits = outputs.logits

--- a/src/transformers/models/prophetnet/modeling_prophetnet.py
+++ b/src/transformers/models/prophetnet/modeling_prophetnet.py
@@ -1299,7 +1299,6 @@ class ProphetNetEncoder(ProphetNetPreTrainedModel):
             >>> tokenizer = ProphetNetTokenizer.from_pretrained('microsoft/prophetnet-large-uncased')
             >>> model = ProphetNetEncoder.from_pretrained('patrickvonplaten/prophetnet-large-uncased-standalone')
             >>> inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
-            >>> del inputs["token_type_ids"]  # `ProphetNetEncoder` doesn't use `token_type_ids`
             >>> outputs = model(**inputs)
 
             >>> last_hidden_states = outputs.last_hidden_state
@@ -2178,7 +2177,6 @@ class ProphetNetForCausalLM(ProphetNetPreTrainedModel):
             >>> model = ProphetNetForCausalLM.from_pretrained('microsoft/prophetnet-large-uncased')
             >>> assert model.config.is_decoder, f"{model.__class__} has to be configured as a decoder."
             >>> inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
-            >>> del inputs["token_type_ids"]  # `ProphetNetEncoder` doesn't use `token_type_ids`
             >>> outputs = model(**inputs)
 
             >>> logits = outputs.logits

--- a/src/transformers/models/unispeech/modeling_unispeech.py
+++ b/src/transformers/models/unispeech/modeling_unispeech.py
@@ -1262,7 +1262,7 @@ class UniSpeechForPreTraining(UniSpeechPreTrainedModel):
             >>> # compute masked indices
             >>> batch_size, raw_sequence_length = input_values.shape
             >>> sequence_length = model._get_feat_extract_output_lengths(raw_sequence_length)
-            >>> mask_time_indices = _compute_mask_indices((batch_size, sequence_length), mask_prob=0.2, mask_length=2, device=model.device)
+            >>> mask_time_indices = _compute_mask_indices((batch_size, sequence_length), mask_prob=0.2, mask_length=2)
 
             >>> with torch.no_grad():
             ...     outputs = model(input_values, mask_time_indices=mask_time_indices)

--- a/src/transformers/models/unispeech_sat/modeling_unispeech_sat.py
+++ b/src/transformers/models/unispeech_sat/modeling_unispeech_sat.py
@@ -1260,7 +1260,7 @@ class UniSpeechSatForPreTraining(UniSpeechSatPreTrainedModel):
             >>> # compute masked indices
             >>> batch_size, raw_sequence_length = input_values.shape
             >>> sequence_length = model._get_feat_extract_output_lengths(raw_sequence_length)
-            >>> mask_time_indices = _compute_mask_indices((batch_size, sequence_length), mask_prob=0.2, mask_length=2, device=model.device)
+            >>> mask_time_indices = _compute_mask_indices((batch_size, sequence_length), mask_prob=0.2, mask_length=2)
 
             >>> with torch.no_grad():
             ...     outputs = model(input_values, mask_time_indices=mask_time_indices)

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -1372,7 +1372,7 @@ class Wav2Vec2ForPreTraining(Wav2Vec2PreTrainedModel):
             >>> # compute masked indices
             >>> batch_size, raw_sequence_length = input_values.shape
             >>> sequence_length = model._get_feat_extract_output_lengths(raw_sequence_length)
-            >>> mask_time_indices = _compute_mask_indices((batch_size, sequence_length), mask_prob=0.2, mask_length=2, device=model.device)
+            >>> mask_time_indices = _compute_mask_indices((batch_size, sequence_length), mask_prob=0.2, mask_length=2)
 
             >>> with torch.no_grad():
             ...     outputs = model(input_values, mask_time_indices=mask_time_indices)


### PR DESCRIPTION
# What does this PR do?

Fix `unexpected keyword argument` in doc examples (in PT model files)


## Who can review?

@sgugger 