### PR TITLE
Fix doc examples: KeyError

### DIFF
--- a/src/transformers/models/blenderbot_small/modeling_blenderbot_small.py
+++ b/src/transformers/models/blenderbot_small/modeling_blenderbot_small.py
@@ -512,7 +512,6 @@ BLENDERBOT_SMALL_GENERATION_EXAMPLE = r"""
         >>> UTTERANCE = "My friends are cool but they eat too many carbs."
         >>> print("Human: ", UTTERANCE)
         >>> inputs = tokenizer([UTTERANCE], return_tensors='pt')
-        >>> inputs.pop("token_type_ids")
         >>> reply_ids = model.generate(**inputs)
         >>> print("Bot: ", tokenizer.batch_decode(reply_ids, skip_special_tokens=True)[0])
         what kind of carbs do they eat? i don't know much about carbs.

--- a/src/transformers/models/blenderbot_small/modeling_tf_blenderbot_small.py
+++ b/src/transformers/models/blenderbot_small/modeling_tf_blenderbot_small.py
@@ -517,12 +517,11 @@ BLENDERBOT_SMALL_GENERATION_EXAMPLE = r"""
         >>> from transformers import BlenderbotSmallTokenizer, TFBlenderbotSmallForConditionalGeneration
         >>> mname = 'facebook/blenderbot_small-90M'
         >>> model = BlenderbotSmallForConditionalGeneration.from_pretrained(mname)
-        >>> tokenizer = TFBlenderbotSmallTokenizer.from_pretrained(mname)
+        >>> tokenizer = BlenderbotSmallTokenizer.from_pretrained(mname)
 
         >>> UTTERANCE = "My friends are cool but they eat too many carbs."
         >>> print("Human: ", UTTERANCE)
         >>> inputs = tokenizer([UTTERANCE], return_tensors='tf')
-        >>> inputs.pop("token_type_ids")
 
         >>> reply_ids = model.generate(**inputs)
         >>> print("Bot: ", tokenizer.batch_decode(reply_ids, skip_special_tokens=True)[0])


### PR DESCRIPTION
# What does this PR do?

The doc examples in `BlenderbotSmall` have

```
        >>> inputs = tokenizer([UTTERANCE], return_tensors='pt')
        >>> inputs.pop("token_type_ids")
```
However, `BlenderbotSmallTokenizer` doesn't give `token_type_ids`, and cause `KeyError` here.

This PR fix this.

## Who can review?


@patrickvonplaten @patil-suraj