### PR TITLE
[CI/pt-nightly] switch to cuda-11.3

### DIFF
--- a/.github/workflows/self-nightly-scheduled.yml
+++ b/.github/workflows/self-nightly-scheduled.yml
@@ -21,7 +21,7 @@ jobs:
     run_all_tests_torch_gpu:
         runs-on: [self-hosted, docker-gpu, single-gpu]
         container:
-            image: pytorch/pytorch:1.9.0-cuda11.1-cudnn8-runtime
+            image: pytorch/pytorch:1.10.0-cuda11.3-cudnn8-runtime
             options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
         steps:
             - name: Launcher docker
@@ -36,7 +36,7 @@ jobs:
                   apt -y update && apt install -y libsndfile1-dev git
                   pip install --upgrade pip
                   pip install .[integrations,sklearn,testing,onnxruntime,sentencepiece,torch-speech,vision,timm]
-                  pip install --pre torch torchvision torchaudio -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html -U
+                  pip install --pre torch torchvision torchaudio -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html -U
 
             - name: Are GPUs recognized by our DL frameworks
               run: |
@@ -87,7 +87,7 @@ jobs:
     run_all_tests_torch_multi_gpu:
         runs-on: [self-hosted, docker-gpu, multi-gpu]
         container:
-            image: pytorch/pytorch:1.9.0-cuda11.1-cudnn8-runtime
+            image: pytorch/pytorch:1.10.0-cuda11.3-cudnn8-runtime
             options: --gpus all --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
         steps:
             - name: Launcher docker
@@ -103,7 +103,7 @@ jobs:
                   apt -y update && apt install -y libsndfile1-dev git
                   pip install --upgrade pip
                   pip install .[integrations,sklearn,testing,onnxruntime,sentencepiece,torch-speech,vision,timm]
-                  pip install --pre torch torchvision torchaudio -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html -U
+                  pip install --pre torch torchvision torchaudio -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html -U
 
             - name: Are GPUs recognized by our DL frameworks
               run: |
@@ -154,7 +154,7 @@ jobs:
               run: |
                   apt -y update && apt install -y libaio-dev
                   pip install --upgrade pip
-                  pip install --pre torch torchvision torchaudio -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html -U
+                  pip install --pre torch torchvision torchaudio -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html -U
                   pip install .[testing,deepspeed]
                   pip install git+https://github.com/microsoft/DeepSpeed
 
@@ -195,7 +195,7 @@ jobs:
               run: |
                   apt -y update && apt install -y libaio-dev
                   pip install --upgrade pip
-                  pip install --pre torch torchvision torchaudio -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html -U
+                  pip install --pre torch torchvision torchaudio -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html -U
                   rm -rf ~/.cache/torch_extensions/ # shared between conflicting builds
                   pip install .[testing,fairscale]
                   pip install git+https://github.com/microsoft/DeepSpeed # testing bleeding edge


### PR DESCRIPTION
This PR updates the pt-nightly ci job to use a more recent cuda-11.3 for the docker image and pytorch install.

@LysandreJik 