### PR TITLE
Fix: change tooslow to slow

### DIFF
--- a/tests/test_modeling_tf_vit.py
+++ b/tests/test_modeling_tf_vit.py
@@ -22,7 +22,7 @@ import unittest
 
 from transformers import ViTConfig
 from transformers.file_utils import cached_property, is_tf_available, is_vision_available
-from transformers.testing_utils import require_tf, require_vision, slow, tooslow
+from transformers.testing_utils import require_tf, require_vision, slow
 
 from .test_configuration_common import ConfigTester
 from .test_modeling_tf_common import TFModelTesterMixin, floats_tensor, ids_tensor
@@ -200,7 +200,7 @@ class TFViTModelTest(TFModelTesterMixin, unittest.TestCase):
 
     # overwrite from common since `encoder_seq_length` and `encoder_key_length` are calculated
     # in a different way than in text models.
-    @tooslow
+    @slow
     def test_saved_model_creation_extended(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.output_hidden_states = True


### PR DESCRIPTION
# What does this PR do?

`test_saved_model_creation_extended` in `TFViT` test is currently `tooslow`. It was copied from TF common test.
#14415 move it from common test to TF core test + changed it to `slow`.

This PR fix this inconsistency.

## Who can review?

@Rocketknight1 