### PR TITLE
update the arguments `add_prefix_space` and `trim_offsets` in `backend_tokenizer.post_processor` of `RobertaTokenizerFast`

### DIFF
--- a/src/transformers/models/roberta/tokenization_roberta_fast.py
+++ b/src/transformers/models/roberta/tokenization_roberta_fast.py
@@ -177,38 +177,34 @@ class RobertaTokenizerFast(GPT2TokenizerFast):
             **kwargs,
         )
 
-        mapping_tokenizers_components = {
-            "pre_tokenizer": pre_tokenizers,
-            "decoder": decoders,
-            "post_processor": processors,
-        }
-        for tokenizer_component in mapping_tokenizers_components.keys():
-            tokenizer_component_instance = getattr(self.backend_tokenizer, tokenizer_component, None)
-            if not tokenizer_component_instance:
-                continue
+        # the pre_tokenizer is already updated in the GPT2TokenizerFast `__init__`
+        tokenizer_component = "post_processor"
+        tokenizer_component_instance = getattr(self.backend_tokenizer, tokenizer_component, None)
+        if not tokenizer_component_instance:
+            continue
 
-            state = json.loads(tokenizer_component_instance.__getstate__())
+        state = json.loads(tokenizer_component_instance.__getstate__())
 
-            # The lists 'sep' and 'cls' must be cased in tuples for the object `post_processor_class`
-            if "sep" in state:
-                state["sep"] = tuple(state["sep"])
-            if "cls" in state:
-                state["cls"] = tuple(state["cls"])
+        # The lists 'sep' and 'cls' must be cased in tuples for the object `post_processor_class`
+        if "sep" in state:
+            state["sep"] = tuple(state["sep"])
+        if "cls" in state:
+            state["cls"] = tuple(state["cls"])
 
-            changes_to_apply = False
+        changes_to_apply = False
 
-            if state.get("add_prefix_space", add_prefix_space) != add_prefix_space:
-                state["add_prefix_space"] = add_prefix_space
-                changes_to_apply = True
+        if state.get("add_prefix_space", add_prefix_space) != add_prefix_space:
+            state["add_prefix_space"] = add_prefix_space
+            changes_to_apply = True
 
-            if state.get("trim_offsets", trim_offsets) != trim_offsets:
-                state["trim_offsets"] = trim_offsets
-                changes_to_apply = True
+        if state.get("trim_offsets", trim_offsets) != trim_offsets:
+            state["trim_offsets"] = trim_offsets
+            changes_to_apply = True
 
-            if changes_to_apply:
-                component_class = getattr(mapping_tokenizers_components[tokenizer_component], state.pop("type"))
-                new_value = component_class(**state)
-                setattr(self.backend_tokenizer, tokenizer_component, new_value)
+        if changes_to_apply:
+            component_class = getattr(processors, state.pop("type"))
+            new_value = component_class(**state)
+            setattr(self.backend_tokenizer, tokenizer_component, new_value)
 
     @property
     def mask_token(self) -> str:

--- a/src/transformers/models/roberta/tokenization_roberta_fast.py
+++ b/src/transformers/models/roberta/tokenization_roberta_fast.py
@@ -16,7 +16,7 @@
 import json
 from typing import List, Optional
 
-from tokenizers import decoders, pre_tokenizers, processors
+from tokenizers import processors
 
 from ...tokenization_utils_base import AddedToken
 from ...utils import logging

--- a/tests/test_tokenization_roberta.py
+++ b/tests/test_tokenization_roberta.py
@@ -198,38 +198,6 @@ class RobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                     tokens_r_str, ["<s>", "A", ",", "<mask>", "ĠAllen", "N", "LP", "Ġsentence", ".", "</s>"]
                 )
 
-    def test_offsets_mapping_with_add_prefix_space(self):
-        # Test which aims to verify that the offsets are well adapted to the argument `add_prefix_space`.
-        for tokenizer, pretrained_name, kwargs in self.tokenizers_list:
-            with self.subTest(f"{tokenizer.__class__.__name__} ({pretrained_name})"):
-                text_of_1_token = "hello"  # this is a token in the vocabulary of `pretrained_name`
-
-                tokenizer_r = self.rust_tokenizer_class.from_pretrained(
-                    pretrained_name, use_fast=True, add_prefix_space=True
-                )
-                encoding = tokenizer_r(text_of_1_token, return_offsets_mapping=True, add_special_tokens=False)
-                self.assertEqual(encoding.offset_mapping[0], (0, len(text_of_1_token)))
-
-                tokenizer_r = self.rust_tokenizer_class.from_pretrained(
-                    pretrained_name, use_fast=True, add_prefix_space=False
-                )
-                encoding = tokenizer_r(text_of_1_token, return_offsets_mapping=True, add_special_tokens=False)
-                self.assertEqual(encoding.offset_mapping[0], (0, len(text_of_1_token)))
-
-                text_of_1_token = f" {text_of_1_token}"
-
-                tokenizer_r = self.rust_tokenizer_class.from_pretrained(
-                    pretrained_name, use_fast=True, add_prefix_space=True
-                )
-                encoding = tokenizer_r(text_of_1_token, return_offsets_mapping=True, add_special_tokens=False)
-                self.assertEqual(encoding.offset_mapping[0], (1, len(text_of_1_token)))
-
-                tokenizer_r = self.rust_tokenizer_class.from_pretrained(
-                    pretrained_name, use_fast=True, add_prefix_space=False
-                )
-                encoding = tokenizer_r(text_of_1_token, return_offsets_mapping=True, add_special_tokens=False)
-                self.assertEqual(encoding.offset_mapping[0], (1, len(text_of_1_token)))
-
     def test_change_add_prefix_space_and_trim_offsets_args(self):
         for trim_offsets, add_prefix_space in itertools.product([True, False], repeat=2):
             tokenizer_r = self.rust_tokenizer_class.from_pretrained(

--- a/tests/test_tokenization_roberta.py
+++ b/tests/test_tokenization_roberta.py
@@ -213,7 +213,8 @@ class RobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             self.assertEqual(post_processor_state["trim_offsets"], trim_offsets)
 
     def test_offsets_mapping_with_different_add_prefix_space_and_trim_space_arguments(self):
-        # Test which aims to verify that the offsets are well adapted to the argument `add_prefix_space`.
+        # Test which aims to verify that the offsets are well adapted to the argument `add_prefix_space` and
+        # `trim_offsets`
         for tokenizer, pretrained_name, kwargs in self.tokenizers_list:
             with self.subTest(f"{tokenizer.__class__.__name__} ({pretrained_name})"):
                 text_of_1_token = "hello"  # `hello` is a token in the vocabulary of `pretrained_name`
@@ -261,7 +262,6 @@ class RobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
                 text = f" {text}"
 
-                # The result is not what I expect
                 # tokenizer_r = self.rust_tokenizer_class.from_pretrained(
                 #     pretrained_name, use_fast=True, add_prefix_space=True, trim_offsets=True
                 # )

--- a/tests/test_tokenization_roberta.py
+++ b/tests/test_tokenization_roberta.py
@@ -240,7 +240,6 @@ class RobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             post_processor_state = json.loads(tokenizer_r.backend_tokenizer.post_processor.__getstate__())
 
             self.assertEqual(pre_tokenizer_state["add_prefix_space"], add_prefix_space)
-            self.assertEqual(pre_tokenizer_state["trim_offsets"], trim_offsets)
 
             self.assertEqual(post_processor_state["add_prefix_space"], add_prefix_space)
             self.assertEqual(post_processor_state["trim_offsets"], trim_offsets)

--- a/tests/test_tokenization_roberta.py
+++ b/tests/test_tokenization_roberta.py
@@ -211,3 +211,93 @@ class RobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
             self.assertEqual(post_processor_state["add_prefix_space"], add_prefix_space)
             self.assertEqual(post_processor_state["trim_offsets"], trim_offsets)
+
+    def test_offsets_mapping_with_different_add_prefix_space_and_trim_space_arguments(self):
+        # Test which aims to verify that the offsets are well adapted to the argument `add_prefix_space`.
+        for tokenizer, pretrained_name, kwargs in self.tokenizers_list:
+            with self.subTest(f"{tokenizer.__class__.__name__} ({pretrained_name})"):
+                text_of_1_token = "hello"  # `hello` is a token in the vocabulary of `pretrained_name`
+                text = f"{text_of_1_token} {text_of_1_token}"
+
+                tokenizer_r = self.rust_tokenizer_class.from_pretrained(
+                    pretrained_name, use_fast=True, add_prefix_space=True, trim_offsets=True
+                )
+                encoding = tokenizer_r(text, return_offsets_mapping=True, add_special_tokens=False)
+                self.assertEqual(encoding.offset_mapping[0], (0, len(text_of_1_token)))
+                self.assertEqual(
+                    encoding.offset_mapping[1],
+                    (len(text_of_1_token) + 1, len(text_of_1_token) + 1 + len(text_of_1_token)),
+                )
+
+                tokenizer_r = self.rust_tokenizer_class.from_pretrained(
+                    pretrained_name, use_fast=True, add_prefix_space=False, trim_offsets=True
+                )
+                encoding = tokenizer_r(text, return_offsets_mapping=True, add_special_tokens=False)
+                self.assertEqual(encoding.offset_mapping[0], (0, len(text_of_1_token)))
+                self.assertEqual(
+                    encoding.offset_mapping[1],
+                    (len(text_of_1_token) + 1, len(text_of_1_token) + 1 + len(text_of_1_token)),
+                )
+
+                tokenizer_r = self.rust_tokenizer_class.from_pretrained(
+                    pretrained_name, use_fast=True, add_prefix_space=True, trim_offsets=False
+                )
+                encoding = tokenizer_r(text, return_offsets_mapping=True, add_special_tokens=False)
+                self.assertEqual(encoding.offset_mapping[0], (0, len(text_of_1_token)))
+                self.assertEqual(
+                    encoding.offset_mapping[1],
+                    (len(text_of_1_token), len(text_of_1_token) + 1 + len(text_of_1_token)),
+                )
+
+                tokenizer_r = self.rust_tokenizer_class.from_pretrained(
+                    pretrained_name, use_fast=True, add_prefix_space=False, trim_offsets=False
+                )
+                encoding = tokenizer_r(text, return_offsets_mapping=True, add_special_tokens=False)
+                self.assertEqual(encoding.offset_mapping[0], (0, len(text_of_1_token)))
+                self.assertEqual(
+                    encoding.offset_mapping[1],
+                    (len(text_of_1_token), len(text_of_1_token) + 1 + len(text_of_1_token)),
+                )
+
+                text = f" {text}"
+
+                # The result is not what I expect
+                # tokenizer_r = self.rust_tokenizer_class.from_pretrained(
+                #     pretrained_name, use_fast=True, add_prefix_space=True, trim_offsets=True
+                # )
+                # encoding = tokenizer_r(text, return_offsets_mapping=True, add_special_tokens=False)
+                # self.assertEqual(encoding.offset_mapping[0], (1, 1 + len(text_of_1_token)))
+                # self.assertEqual(
+                #     encoding.offset_mapping[1],
+                #     (1 + len(text_of_1_token) + 1, 1 + len(text_of_1_token) + 1 + len(text_of_1_token)),
+                # )
+
+                tokenizer_r = self.rust_tokenizer_class.from_pretrained(
+                    pretrained_name, use_fast=True, add_prefix_space=False, trim_offsets=True
+                )
+                encoding = tokenizer_r(text, return_offsets_mapping=True, add_special_tokens=False)
+                self.assertEqual(encoding.offset_mapping[0], (1, 1 + len(text_of_1_token)))
+                self.assertEqual(
+                    encoding.offset_mapping[1],
+                    (1 + len(text_of_1_token) + 1, 1 + len(text_of_1_token) + 1 + len(text_of_1_token)),
+                )
+
+                tokenizer_r = self.rust_tokenizer_class.from_pretrained(
+                    pretrained_name, use_fast=True, add_prefix_space=True, trim_offsets=False
+                )
+                encoding = tokenizer_r(text, return_offsets_mapping=True, add_special_tokens=False)
+                self.assertEqual(encoding.offset_mapping[0], (0, 1 + len(text_of_1_token)))
+                self.assertEqual(
+                    encoding.offset_mapping[1],
+                    (1 + len(text_of_1_token), 1 + len(text_of_1_token) + 1 + len(text_of_1_token)),
+                )
+
+                tokenizer_r = self.rust_tokenizer_class.from_pretrained(
+                    pretrained_name, use_fast=True, add_prefix_space=False, trim_offsets=False
+                )
+                encoding = tokenizer_r(text, return_offsets_mapping=True, add_special_tokens=False)
+                self.assertEqual(encoding.offset_mapping[0], (0, 1 + len(text_of_1_token)))
+                self.assertEqual(
+                    encoding.offset_mapping[1],
+                    (1 + len(text_of_1_token), 1 + len(text_of_1_token) + 1 + len(text_of_1_token)),
+                )

--- a/tests/test_tokenization_roberta.py
+++ b/tests/test_tokenization_roberta.py
@@ -230,7 +230,7 @@ class RobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 encoding = tokenizer_r(text_of_1_token, return_offsets_mapping=True, add_special_tokens=False)
                 self.assertEqual(encoding.offset_mapping[0], (1, len(text_of_1_token)))
 
-    def test_change_add_prefix_space_arg(self):
+    def test_change_add_prefix_space_and_trim_offsets_args(self):
         for trim_offsets, add_prefix_space in itertools.product([True, False], repeat=2):
             tokenizer_r = self.rust_tokenizer_class.from_pretrained(
                 self.tmpdirname, use_fast=True, add_prefix_space=add_prefix_space, trim_offsets=trim_offsets
@@ -238,13 +238,9 @@ class RobertaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
             pre_tokenizer_state = json.loads(tokenizer_r.backend_tokenizer.pre_tokenizer.__getstate__())
             post_processor_state = json.loads(tokenizer_r.backend_tokenizer.post_processor.__getstate__())
-            decoder_state = json.loads(tokenizer_r.backend_tokenizer.decoder.__getstate__())
 
             self.assertEqual(pre_tokenizer_state["add_prefix_space"], add_prefix_space)
             self.assertEqual(pre_tokenizer_state["trim_offsets"], trim_offsets)
 
             self.assertEqual(post_processor_state["add_prefix_space"], add_prefix_space)
             self.assertEqual(post_processor_state["trim_offsets"], trim_offsets)
-
-            self.assertEqual(decoder_state["add_prefix_space"], add_prefix_space)
-            self.assertEqual(decoder_state["trim_offsets"], trim_offsets)


### PR DESCRIPTION
# What does this PR do?

Roberta's tokenizer fast has `add_prefix_space` and `trim_offsets` as arguments. It seems to me that these last 2 arguments should be updated accordingly in the post processor `RobertaProcessing` of its `backend_tokenizer`. 

This PR proposes to automate this update with a strategy similar to the update of the `pre_tokenizer` done inside the `__init__` of `GPT2TokenizerFast` (from which `RobertaTokenizerFast` inherits).

It is the issue #14305 that allowed me to notice that this update was not done when changing `add_prefix_space` or `trim_offsets`.

I would ideally like to wait until I have an opinion on [this issue](https://github.com/huggingface/tokenizers/issues/843) on the Tokenizers library before merging this PR.

Edit: So I had the confirmation that there was a bug on the Tokenizer side, which was solved in [this PR](https://github.com/huggingface/tokenizers/pull/844) which confirms my understanding of the `RobertaTokenizerFast` component.
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Maybe @LysandreJik, @sgugger what do you think of this change? (and in particular of the fact that the behavior will not be entirely satisfactory before the fix on the tokenizers side is released)

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
