### PR TITLE
Fix preprocess_function in run_summarization_flax.py

### DIFF
--- a/examples/flax/summarization/run_summarization_flax.py
+++ b/examples/flax/summarization/run_summarization_flax.py
@@ -533,7 +533,7 @@ def main():
 
         model_inputs["labels"] = labels["input_ids"]
         decoder_input_ids = shift_tokens_right_fn(
-            jnp.array(labels["input_ids"]), config.pad_token_id, config.decoder_start_token_id
+            labels["input_ids"], config.pad_token_id, config.decoder_start_token_id
         )
         model_inputs["decoder_input_ids"] = np.asarray(decoder_input_ids)
 


### PR DESCRIPTION
# What does this PR do?

`run_summarization_flax.py` has 

https://github.com/huggingface/transformers/blob/e7ed7ffdcb66c78d3437ed4c3a63c3640f50f436/examples/flax/summarization/run_summarization_flax.py#L535-L537

Using `jnp.array` here will cause `preprocess_function` to hang forever when it is used by `datasets.Dataset.map()` with `num_proc > 1`, when this script is running on a TPU VM.

I think it is related to #12719 and #12720

## Who can review?

@patil-suraj  @patrickvonplaten 

 
