### PR TITLE
Fix the build documentation job

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - doc-builder*
+      - v*-release
 
 jobs:
   build_and_package:
@@ -46,7 +47,7 @@ jobs:
           sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev
 
           pip install git+https://github.com/huggingface/doc-builder
-          pip install git+https://github.com/huggingface/transformers#egg=transformers[dev]
+          pip install .
 
           export TORCH_VERSION=$(python -c "from torch import version; print(version.__version__.split('+')[0])")
           pip install torch-scatter -f https://data.pyg.org/whl/torch-${TORCH_VERSION}+cpu.html

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -47,7 +47,9 @@ jobs:
           sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev
 
           pip install git+https://github.com/huggingface/doc-builder
+          cd transformers
           pip install .
+          cd ..
 
           export TORCH_VERSION=$(python -c "from torch import version; print(version.__version__.split('+')[0])")
           pip install torch-scatter -f https://data.pyg.org/whl/torch-${TORCH_VERSION}+cpu.html

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -48,7 +48,7 @@ jobs:
 
           pip install git+https://github.com/huggingface/doc-builder
           cd transformers
-          pip install .
+          pip install .[dev]
           cd ..
 
           export TORCH_VERSION=$(python -c "from torch import version; print(version.__version__.split('+')[0])")


### PR DESCRIPTION
# What does this PR do?

The last two releases were not automatically documented. That's fine for v4.14.0 since we yanked it, and I did a manual update for v4.14.1, but in the future it would be nice to not have to do this!

The first fix is to make sure Transformers is installed from the current checked out branch and not the content of the master branch. The second fix is to run that job on branches with the patter vxxx-release