### PR TITLE
[examples/summarization] deal with None in data records

### DIFF
--- a/examples/pytorch/summarization/run_summarization.py
+++ b/examples/pytorch/summarization/run_summarization.py
@@ -436,8 +436,19 @@ def main():
         )
 
     def preprocess_function(examples):
-        inputs = examples[text_column]
-        targets = examples[summary_column]
+
+        # remove pairs where at least one record is None
+        inputs, targets = map(
+            list,
+            zip(
+                *(
+                    [examples[text_column][i], examples[summary_column][i]]
+                    for i in range(len(examples[text_column]))
+                    if examples[text_column][i] is not None and examples[summary_column][i] is not None
+                )
+            ),
+        )
+
         inputs = [prefix + inp for inp in inputs]
         model_inputs = tokenizer(inputs, max_length=data_args.max_source_length, padding=padding, truncation=True)
 

--- a/examples/pytorch/summarization/run_summarization.py
+++ b/examples/pytorch/summarization/run_summarization.py
@@ -438,16 +438,11 @@ def main():
     def preprocess_function(examples):
 
         # remove pairs where at least one record is None
-        inputs, targets = map(
-            list,
-            zip(
-                *(
-                    [examples[text_column][i], examples[summary_column][i]]
-                    for i in range(len(examples[text_column]))
-                    if examples[text_column][i] is not None and examples[summary_column][i] is not None
-                )
-            ),
-        )
+        inputs, targets = [], []
+        for i in range(len(examples[text_column])):
+            if examples[text_column][i] is not None and examples[summary_column][i] is not None:
+                inputs.append(examples[text_column][i])
+                targets.append(examples[summary_column][i])
 
         inputs = [prefix + inp for inp in inputs]
         model_inputs = tokenizer(inputs, max_length=data_args.max_source_length, padding=padding, truncation=True)


### PR DESCRIPTION
When trying to use  https://huggingface.co/datasets/wikihow with `run_summarization.py` I run into incomplete records in the manually downloaded dataset (the data is not on the hub and requires a user to download it manually):

```
  [...]
  File "/mnt/nvme1/code/huggingface/datasets-master/src/datasets/arrow_dataset.py", line 1990, in decorated
    result = f(decorated_item, *args, **kwargs)
  File "examples/pytorch/summarization/run_summarization.py", line 450, in preprocess_function
    inputs = [prefix + inp for inp in inputs]
  File "examples/pytorch/summarization/run_summarization.py", line 450, in <listcomp>
    inputs = [prefix + inp for inp in inputs]
TypeError: can only concatenate str (not "NoneType") to str
```

This PR is fixing that by filtering out incomplete records. Now it's possible to run:

```
python examples/pytorch/summarization/run_summarization.py --model_name_or_path \
google/pegasus-wikihow --max_source_length 512 --max_target_length 256 --do_eval \
--per_device_eval_batch_size 8 --predict_with_generate --num_beams 8 --overwrite_output_dir \
--output_dir output_dir --validation_file data/wikihowAll.csv --text_column text --summary_column \
headline --max_eval_samples 10
```

For context: I was trying to deal with this issue https://github.com/huggingface/transformers/issues/14804 when I run into this problem. And this fix was needed for me to be able to reproduce the issue. In other words this wasn't me just randomly trying some random dataset for the heck of it, I was trying to deal with a bug report. And this dataset is not random, since we report a performance score on it for https://huggingface.co/google/pegasus-wikihow which was originally reported here: https://github.com/huggingface/transformers/issues/6844 and if we can't use our own tools to reproduce a report made by us, then I don't know how to move forward here.

@sgugger 