### PR TITLE
Fix the wrong attention mask in TransformerXL by shifting `mask_shift_len` with 1

### DIFF
--- a/src/transformers/models/transfo_xl/modeling_transfo_xl.py
+++ b/src/transformers/models/transfo_xl/modeling_transfo_xl.py
@@ -937,9 +937,9 @@ class TransfoXLModel(TransfoXLPreTrainedModel):
             all_ones = word_emb.new_ones((qlen, klen), dtype=torch.uint8)
             mask_len = klen - self.mem_len
             if mask_len > 0:
-                mask_shift_len = qlen - mask_len
+                mask_shift_len = qlen - mask_len + 1
             else:
-                mask_shift_len = qlen
+                mask_shift_len = qlen + 1
             dec_attn_mask = (torch.triu(all_ones, 1 + mlen) + torch.tril(all_ones, -mask_shift_len))[:, :, None]  # -1
         else:
             dec_attn_mask = torch.triu(word_emb.new_ones((qlen, klen), dtype=torch.uint8), diagonal=1 + mlen)[


### PR DESCRIPTION
# What does this PR do?

In `forward` of TransformerXL, the attention mask `dec_attn_mask` is set up by:
```
dec_attn_mask = (torch.triu(all_ones, 1 + mlen) + torch.tril(all_ones, -mask_shift_len))[:, :,     None]  # -1
```
But I noticed if `mask_shift_len` is zero (while the default memory length equals to the input memory length, which is the most case), it will make `dec_attn_mask[0,:,:]` all 1, which make the model unable to get any attention from the first memory embedding.
I fix this problem by shift `mask_shift_len` with 1.

@patrickvonplaten