### PR TITLE
Replace commit sha by commit url for update jobs

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -84,7 +84,7 @@ jobs:
           cd doc-builder
           if [[ `git status --porcelain` ]]; then
             git add build
-            git commit -m "Updated with commit ${{ github.sha }}"
+            git commit -m "Updated with commit https://github.com/huggingface/transformers/commit/${{ github.sha }}"
             git push origin main
           else
             echo "No diff in the documentation."
@@ -94,7 +94,7 @@ jobs:
           cd notebooks
           if [[ `git status --porcelain` ]]; then
             git add transformers_doc
-            git commit -m "Updated Transformer doc notebooks with commit ${{ github.sha }}"
+            git commit -m "Updated Transformer doc notebooks with commit https://github.com/huggingface/transformers/commit/${{ github.sha }}"
             git push origin master
           else
             echo "No diff in the notebooks."

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -94,7 +94,7 @@ jobs:
           cd notebooks
           if [[ `git status --porcelain` ]]; then
             git add transformers_doc
-            git commit -m "Updated Transformer doc notebooks with commit https://github.com/huggingface/transformers/commit/${{ github.sha }}"
+            git commit -m "Updated Transformer doc notebooks with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/transformers/commit/${{ github.sha }}"
             git push origin master
           else
             echo "No diff in the notebooks."

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -84,7 +84,7 @@ jobs:
           cd doc-builder
           if [[ `git status --porcelain` ]]; then
             git add build
-            git commit -m "Updated with commit https://github.com/huggingface/transformers/commit/${{ github.sha }}"
+            git commit -m "Updated with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/transformers/commit/${{ github.sha }}"
             git push origin main
           else
             echo "No diff in the documentation."

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -221,7 +221,10 @@ def update_metadata(token, commit_sha):
         if repo.is_repo_clean():
             print("Nothing to commit!")
         else:
-            commit_message = f"Update with commit {commit_sha}" if commit_sha is not None else "Update"
+            if commit_sha is not None
+                commit_message = f"Update with commit https://github.com/huggingface/transformers/commit/{commit_sha}"
+            else:
+                commit_message = "Update"
             repo.push_to_hub(commit_message)
 
 

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -222,7 +222,10 @@ def update_metadata(token, commit_sha):
             print("Nothing to commit!")
         else:
             if commit_sha is not None:
-                commit_message = f"Update with commit https://github.com/huggingface/transformers/commit/{commit_sha}"
+                commit_message = (
+                    f"Update with commit {commit_sha}\n\nSee: "
+                    f"https://github.com/huggingface/transformers/commit/{commit_sha}"
+                )
             else:
                 commit_message = "Update"
             repo.push_to_hub(commit_message)

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -221,7 +221,7 @@ def update_metadata(token, commit_sha):
         if repo.is_repo_clean():
             print("Nothing to commit!")
         else:
-            if commit_sha is not None
+            if commit_sha is not None:
                 commit_message = f"Update with commit https://github.com/huggingface/transformers/commit/{commit_sha}"
             else:
                 commit_message = "Update"


### PR DESCRIPTION
# What does this PR do?

As requested by @julien-c , this PR replaces the commit shas by the full urls in the update jobs:
- for the documentation
- for the transformers metadata dataset