### PR TITLE
Make the onnx submodule init lazy

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -2337,6 +2337,7 @@ class _LazyModule(ModuleType):
         return result
 
     def __getattr__(self, name: str) -> Any:
+        print(f"Requesting {name} from {self.__name__}")
         if name in self._objects:
             return self._objects[name]
         if name in self._modules:
@@ -2351,6 +2352,7 @@ class _LazyModule(ModuleType):
         return value
 
     def _get_module(self, module_name: str):
+        print(f"Importing {self.__name__}.{module_name}")
         try:
             return importlib.import_module("." + module_name, self.__name__)
         except Exception as e:

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -2337,7 +2337,6 @@ class _LazyModule(ModuleType):
         return result
 
     def __getattr__(self, name: str) -> Any:
-        print(f"Requesting {name} from {self.__name__}")
         if name in self._objects:
             return self._objects[name]
         if name in self._modules:
@@ -2352,7 +2351,6 @@ class _LazyModule(ModuleType):
         return value
 
     def _get_module(self, module_name: str):
-        print(f"Importing {self.__name__}.{module_name}")
         try:
             return importlib.import_module("." + module_name, self.__name__)
         except Exception as e:

--- a/src/transformers/onnx/__init__.py
+++ b/src/transformers/onnx/__init__.py
@@ -13,6 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .config import EXTERNAL_DATA_FORMAT_SIZE_LIMIT, OnnxConfig, OnnxConfigWithPast, PatchingSpec
-from .convert import export, validate_model_outputs
-from .utils import ParameterFormat, compute_serialized_parameters_size
+from typing import TYPE_CHECKING
+
+from ..file_utils import _LazyModule
+
+
+_import_structure = {
+    "config": ["EXTERNAL_DATA_FORMAT_SIZE_LIMIT", "OnnxConfig", "OnnxConfigWithPast", "PatchingSpec"],
+    "convert": ["export", "validate_model_outputs"],
+    "utils": ["ParameterFormat", "compute_serialized_parameters_size"],
+}
+
+
+if TYPE_CHECKING:
+    from .config import EXTERNAL_DATA_FORMAT_SIZE_LIMIT, OnnxConfig, OnnxConfigWithPast, PatchingSpec
+    from .convert import export, validate_model_outputs
+    from .utils import ParameterFormat, compute_serialized_parameters_size
+
+else:
+    import sys
+
+    sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], _import_structure)


### PR DESCRIPTION
# What does this PR do?

The `onnx` submodule does not use a lazy init like the other ones. This results in importing a given model/tokenzier/config, which imports OnnxConfig, initializing the onnx submodule completely, and in turn importing `PreTrainedModel` and `TFPreTrainedModel` (so PyTorch and TensorFlow).

This PR solves this issue by making the init lazy like all the others.