### PR TITLE
Only create the model card on process 0

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2631,6 +2631,9 @@ class Trainer:
         dataset: Optional[Union[str, List[str]]] = None,
         dataset_args: Optional[Union[str, List[str]]] = None,
     ):
+        if not self.is_world_process_zero():
+            return
+
         training_summary = TrainingSummary.from_trainer(
             self,
             language=language,


### PR DESCRIPTION
# What does this PR do?

This PR makes sure the model card is only created and saved on process 0.
Fixes #14840