### PR TITLE
Fix pytorch image classification example

### DIFF
--- a/examples/pytorch/image-classification/run_image_classification.py
+++ b/examples/pytorch/image-classification/run_image_classification.py
@@ -279,12 +279,14 @@ def main():
 
     def train_transforms(example_batch):
         """Apply _train_transforms across a batch."""
-        example_batch["pixel_values"] = [_train_transforms(pil_loader(f)) for f in example_batch["image_file_path"]]
+        example_batch["pixel_values"] = [
+            _train_transforms(pil_img.convert("RGB")) for pil_img in example_batch["image"]
+        ]
         return example_batch
 
     def val_transforms(example_batch):
         """Apply _val_transforms across a batch."""
-        example_batch["pixel_values"] = [_val_transforms(pil_loader(f)) for f in example_batch["image_file_path"]]
+        example_batch["pixel_values"] = [_val_transforms(pil_img.convert("RGB")) for pil_img in example_batch["image"]]
         return example_batch
 
     if training_args.do_train:

--- a/examples/pytorch/test_examples.py
+++ b/examples/pytorch/test_examples.py
@@ -19,7 +19,6 @@ import json
 import logging
 import os
 import sys
-import unittest
 from unittest.mock import patch
 
 import torch
@@ -409,7 +408,6 @@ class ExamplesTests(TestCasePlus):
             result = get_results(tmp_dir)
             self.assertGreaterEqual(result["eval_bleu"], 30)
 
-    @unittest.skip("Fix me Nate!")
     def test_run_image_classification(self):
         stream_handler = logging.StreamHandler(sys.stdout)
         logger.addHandler(stream_handler)


### PR DESCRIPTION
Updates the `examples/pytorch/image-classification/run_image_classification.py` script to use the new Image feature to pass the failing [CI test](https://app.circleci.com/pipelines/github/huggingface/transformers/31642/workflows/b1aa40eb-2edc-4b54-963b-f11058072a7e/jobs/327951/artifacts) (I've also updated the `hf-internal-testing/cats_vs_dogs_sample` dataset on the Hub for that).