### PR TITLE
Properly indent return block

### DIFF
--- a/src/transformers/models/luke/tokenization_luke.py
+++ b/src/transformers/models/luke/tokenization_luke.py
@@ -102,7 +102,7 @@ ENCODE_PLUS_ADDITIONAL_KWARGS_DOCSTRING = r"""
                 Whether or not to print more information and warnings.
             **kwargs: passed to the `self.tokenize()` method
 
-            Return:
+        Return:
             [`BatchEncoding`]: A [`BatchEncoding`] with the following fields:
 
             - **input_ids** -- List of token ids to be fed to a model.

--- a/src/transformers/models/mluke/tokenization_mluke.py
+++ b/src/transformers/models/mluke/tokenization_mluke.py
@@ -100,7 +100,7 @@ ENCODE_PLUS_ADDITIONAL_KWARGS_DOCSTRING = r"""
                 Whether or not to print more information and warnings.
             **kwargs: passed to the `self.tokenize()` method
 
-            Return:
+        Return:
             [`BatchEncoding`]: A [`BatchEncoding`] with the following fields:
 
             - **input_ids** -- List of token ids to be fed to a model.

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1343,7 +1343,7 @@ ENCODE_PLUS_ADDITIONAL_KWARGS_DOCSTRING = r"""
                 Whether or not to print more information and warnings.
             **kwargs: passed to the `self.tokenize()` method
 
-            Return:
+        Return:
             [`BatchEncoding`]: A [`BatchEncoding`] with the following fields:
 
             - **input_ids** -- List of token ids to be fed to a model.


### PR DESCRIPTION
# What does this PR do?

This fixes the indentation for some return blocks. A check in the `doc-builder` will soon error for bad blocks like this.