### PR TITLE
[doc] post-porting

### DIFF
--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -240,11 +240,9 @@ def enable_propagation() -> None:
 def enable_explicit_format() -> None:
     """
     Enable explicit formatting for every HuggingFace Transformers's logger. The explicit formatter is as follows:
-
-    ::
-
+    ```
         [LEVELNAME|FILENAME|LINE NUMBER] TIME >> MESSAGE
-
+    ```
     All handlers currently bound to the root logger are affected by this method.
     """
     handlers = _get_library_root_logger().handlers


### PR DESCRIPTION
This PR fixes a `::` leftover

See:
https://huggingface.co/docs/transformers/main_classes/logging#transformers.utils.logging.enable_explicit_format

converted it into a formatted section

@sgugger 