### PR TITLE
Better logic for getting tokenizer config in AutoTokenizer

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -50,6 +50,7 @@ from tqdm.auto import tqdm
 import requests
 from filelock import FileLock
 from huggingface_hub import HfFolder, Repository, create_repo, list_repo_files, whoami
+from requests.exceptions import HTTPError
 from transformers.utils.versions import importlib_metadata
 
 from . import __version__
@@ -2100,7 +2101,13 @@ def get_list_of_files(
         token = HfFolder.get_token()
     else:
         token = None
-    return list_repo_files(path_or_repo, revision=revision, token=token)
+
+    try:
+        return list_repo_files(path_or_repo, revision=revision, token=token)
+    except HTTPError as e:
+        raise ValueError(
+            f"{path_or_repo} is not a local path or a model identifier on the model Hub. Did you make a typo?"
+        ) from e
 
 
 class cached_property(property):

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -18,11 +18,13 @@ import importlib
 import json
 import os
 from collections import OrderedDict
+from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
 
 from ...configuration_utils import PretrainedConfig
 from ...file_utils import (
     cached_path,
+    get_list_of_files,
     hf_bucket_url,
     is_offline_mode,
     is_sentencepiece_available,
@@ -30,7 +32,7 @@ from ...file_utils import (
 )
 from ...tokenization_utils import PreTrainedTokenizer
 from ...tokenization_utils_base import TOKENIZER_CONFIG_FILE
-from ...tokenization_utils_fast import PreTrainedTokenizerFast
+from ...tokenization_utils_fast import TOKENIZER_FILE, PreTrainedTokenizerFast
 from ...utils import logging
 from ..encoder_decoder import EncoderDecoderConfig
 from .auto_factory import _LazyAutoMapping
@@ -330,6 +332,17 @@ def get_tokenizer_config(
         logger.info("Offline mode: forcing local_files_only=True")
         local_files_only = True
 
+    # Will raise a ValueError if `pretrained_model_name_or_path` is not a valid path or model identifier
+    repo_files = get_list_of_files(
+        pretrained_model_name_or_path,
+        revision=revision,
+        use_auth_token=use_auth_token,
+        local_files_only=local_files_only,
+    )
+    if TOKENIZER_CONFIG_FILE not in [Path(f).name for f in repo_files]:
+        print("No TOKENIZER_CONFIG_FILE, aborting")
+        return {}
+
     pretrained_model_name_or_path = str(pretrained_model_name_or_path)
     if os.path.isdir(pretrained_model_name_or_path):
         config_file = os.path.join(pretrained_model_name_or_path, TOKENIZER_CONFIG_FILE)
@@ -350,7 +363,7 @@ def get_tokenizer_config(
             use_auth_token=use_auth_token,
         )
 
-    except (EnvironmentError, ValueError):
+    except EnvironmentError:
         logger.info("Could not locate the tokenizer configuration file, will try to use the model config instead.")
         return {}
 

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -340,7 +340,6 @@ def get_tokenizer_config(
         local_files_only=local_files_only,
     )
     if TOKENIZER_CONFIG_FILE not in [Path(f).name for f in repo_files]:
-        print("No TOKENIZER_CONFIG_FILE, aborting")
         return {}
 
     pretrained_model_name_or_path = str(pretrained_model_name_or_path)

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -32,7 +32,7 @@ from ...file_utils import (
 )
 from ...tokenization_utils import PreTrainedTokenizer
 from ...tokenization_utils_base import TOKENIZER_CONFIG_FILE
-from ...tokenization_utils_fast import TOKENIZER_FILE, PreTrainedTokenizerFast
+from ...tokenization_utils_fast import PreTrainedTokenizerFast
 from ...utils import logging
 from ..encoder_decoder import EncoderDecoderConfig
 from .auto_factory import _LazyAutoMapping

--- a/tests/test_tokenization_auto.py
+++ b/tests/test_tokenization_auto.py
@@ -149,7 +149,7 @@ class AutoTokenizerTest(unittest.TestCase):
     @require_tokenizers
     def test_tokenizer_identifier_non_existent(self):
         for tokenizer_class in [BertTokenizer, BertTokenizerFast, AutoTokenizer]:
-            with self.assertRaises(EnvironmentError):
+            with self.assertRaises(ValueError):
                 _ = tokenizer_class.from_pretrained("julien-c/herlolip-not-exists")
 
     def test_parents_and_children_in_mappings(self):
@@ -237,6 +237,7 @@ class AutoTokenizerTest(unittest.TestCase):
         tokenizer = AutoTokenizer.from_pretrained(SMALL_MODEL_IDENTIFIER)
         with tempfile.TemporaryDirectory() as tmp_dir:
             tokenizer.save_pretrained(tmp_dir)
+            print(os.listdir(tmp_dir))
             config = get_tokenizer_config(tmp_dir)
 
         # Check the class of the tokenizer was properly saved (note that it always saves the slow class).

--- a/tests/test_tokenization_auto.py
+++ b/tests/test_tokenization_auto.py
@@ -149,7 +149,9 @@ class AutoTokenizerTest(unittest.TestCase):
     @require_tokenizers
     def test_tokenizer_identifier_non_existent(self):
         for tokenizer_class in [BertTokenizer, BertTokenizerFast, AutoTokenizer]:
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(
+                ValueError, ".*is not a local path or a model identifier on the model Hub. Did you make a typo?"
+            ):
                 _ = tokenizer_class.from_pretrained("julien-c/herlolip-not-exists")
 
     def test_parents_and_children_in_mappings(self):
@@ -237,7 +239,6 @@ class AutoTokenizerTest(unittest.TestCase):
         tokenizer = AutoTokenizer.from_pretrained(SMALL_MODEL_IDENTIFIER)
         with tempfile.TemporaryDirectory() as tmp_dir:
             tokenizer.save_pretrained(tmp_dir)
-            print(os.listdir(tmp_dir))
             config = get_tokenizer_config(tmp_dir)
 
         # Check the class of the tokenizer was properly saved (note that it always saves the slow class).


### PR DESCRIPTION
# What does this PR do?

In this PR, we make the logic in `AutoTokenizer` a little bit better by checking the tokenizer config is in the list of files of the repo when trying to get it, instead of bluntly trying to load it. This makes the function fail early with a clear error message if the repo name passed contains a typo.