### PR TITLE
remove absl workaround as it's no longer needed

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -24,18 +24,6 @@
 
 __version__ = "4.16.0.dev0"
 
-# Work around to update TensorFlow's absl.logging threshold which alters the
-# default Python logging output behavior when present.
-# see: https://github.com/abseil/abseil-py/issues/99
-# and: https://github.com/tensorflow/tensorflow/issues/26691#issuecomment-500369493
-try:
-    import absl.logging
-except ImportError:
-    pass
-else:
-    absl.logging.set_verbosity("info")
-    absl.logging.set_stderrthreshold("info")
-    absl.logging._warn_preinit_stderr = False
 
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
the `absl` workaround hasn't been needed since 2019-04 https://github.com/abseil/abseil-py/issues/99 so it should be safe to remove it.

Otherwise it's complaining about not finding TPUs, when there are no TPUs to be found when some of our libs load jax and not needing jax: https://github.com/huggingface/transformers/issues/14907#issuecomment-1000468384

if you feel that almost 3 years is not far enough to safely remove this, I can re-do this to check the explicit version of `absl`.

Fixes: https://github.com/huggingface/transformers/pull/14909

@patil-suraj, @patrickvonplaten, @LysandreJik, @sgugger 