### PR TITLE
[doc] :class: hunt

### DIFF
--- a/src/transformers/feature_extraction_sequence_utils.py
+++ b/src/transformers/feature_extraction_sequence_utils.py
@@ -139,7 +139,7 @@ class SequenceFeatureExtractor(FeatureExtractionMixin):
         # The model's main input name, usually `input_values`, has be passed for padding
         if self.model_input_names[0] not in processed_features:
             raise ValueError(
-                "You should supply an instance of :class:`~transformers.BatchFeature` or list of :class:`~transformers.BatchFeature` to this method "
+                "You should supply an instance of [`~transformers.BatchFeature`] or list of [`~transformers.BatchFeature`] to this method "
                 f"that includes {self.model_input_names[0]}, but you provided {list(processed_features.keys())}"
             )
 

--- a/src/transformers/feature_extraction_sequence_utils.py
+++ b/src/transformers/feature_extraction_sequence_utils.py
@@ -139,7 +139,7 @@ class SequenceFeatureExtractor(FeatureExtractionMixin):
         # The model's main input name, usually `input_values`, has be passed for padding
         if self.model_input_names[0] not in processed_features:
             raise ValueError(
-                "You should supply an instance of [`~transformers.BatchFeature`] or list of [`~transformers.BatchFeature`] to this method "
+                "You should supply an instance of `transformers.BatchFeature` or list of `transformers.BatchFeature` to this method "
                 f"that includes {self.model_input_names[0]}, but you provided {list(processed_features.keys())}"
             )
 

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -411,8 +411,8 @@ ALL_PRETRAINED_CONFIG_ARCHIVE_MAP = _LazyLoadAllMappings(CONFIG_ARCHIVE_MAP_MAPP
 
 def _get_class_name(model_class: Union[str, List[str]]):
     if isinstance(model_class, (list, tuple)):
-        return " or ".join([f":class:`~transformers.{c}`" for c in model_class if c is not None])
-    return f":class:`~transformers.{model_class}`"
+        return " or ".join([f"[`~transformers.{c}`]" for c in model_class if c is not None])
+    return f"[`~transformers.{model_class}`]"
 
 
 def _list_model_options(indent, config_to_class=None, use_model_types=True):
@@ -421,7 +421,7 @@ def _list_model_options(indent, config_to_class=None, use_model_types=True):
     if use_model_types:
         if config_to_class is None:
             model_type_to_name = {
-                model_type: f":class:`~transformers.{config}`" for model_type, config in CONFIG_MAPPING_NAMES.items()
+                model_type: f"[`~transformers.{config}`]" for model_type, config in CONFIG_MAPPING_NAMES.items()
             }
         else:
             model_type_to_name = {
@@ -443,7 +443,7 @@ def _list_model_options(indent, config_to_class=None, use_model_types=True):
             config: MODEL_NAMES_MAPPING[model_type] for model_type, config in CONFIG_MAPPING_NAMES.items()
         }
         lines = [
-            f"{indent}- :class:`~transformers.{config_name}` configuration class: {config_to_name[config_name]} ({config_to_model_name[config_name]} model)"
+            f"{indent}- [`~transformers.{config_name}`] configuration class: {config_to_name[config_name]} ({config_to_model_name[config_name]} model)"
             for config_name in sorted(config_to_name.keys())
         ]
     return "\n".join(lines)

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -412,7 +412,7 @@ ALL_PRETRAINED_CONFIG_ARCHIVE_MAP = _LazyLoadAllMappings(CONFIG_ARCHIVE_MAP_MAPP
 def _get_class_name(model_class: Union[str, List[str]]):
     if isinstance(model_class, (list, tuple)):
         return " or ".join([f"[`{c}`]" for c in model_class if c is not None])
-    return f"[`model_class`]"
+    return f"[`{model_class}`]"
 
 
 def _list_model_options(indent, config_to_class=None, use_model_types=True):
@@ -420,9 +420,7 @@ def _list_model_options(indent, config_to_class=None, use_model_types=True):
         raise ValueError("Using `use_model_types=False` requires a `config_to_class` dictionary.")
     if use_model_types:
         if config_to_class is None:
-            model_type_to_name = {
-                model_type: f"[`{config}`]" for model_type, config in CONFIG_MAPPING_NAMES.items()
-            }
+            model_type_to_name = {model_type: f"[`{config}`]" for model_type, config in CONFIG_MAPPING_NAMES.items()}
         else:
             model_type_to_name = {
                 model_type: _get_class_name(model_class)

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -411,8 +411,8 @@ ALL_PRETRAINED_CONFIG_ARCHIVE_MAP = _LazyLoadAllMappings(CONFIG_ARCHIVE_MAP_MAPP
 
 def _get_class_name(model_class: Union[str, List[str]]):
     if isinstance(model_class, (list, tuple)):
-        return " or ".join([f"[`~transformers.{c}`]" for c in model_class if c is not None])
-    return f"[`~transformers.{model_class}`]"
+        return " or ".join([f"[`{c}`]" for c in model_class if c is not None])
+    return f"[`model_class`]"
 
 
 def _list_model_options(indent, config_to_class=None, use_model_types=True):
@@ -421,7 +421,7 @@ def _list_model_options(indent, config_to_class=None, use_model_types=True):
     if use_model_types:
         if config_to_class is None:
             model_type_to_name = {
-                model_type: f"[`~transformers.{config}`]" for model_type, config in CONFIG_MAPPING_NAMES.items()
+                model_type: f"[`{config}`]" for model_type, config in CONFIG_MAPPING_NAMES.items()
             }
         else:
             model_type_to_name = {
@@ -443,7 +443,7 @@ def _list_model_options(indent, config_to_class=None, use_model_types=True):
             config: MODEL_NAMES_MAPPING[model_type] for model_type, config in CONFIG_MAPPING_NAMES.items()
         }
         lines = [
-            f"{indent}- [`~transformers.{config_name}`] configuration class: {config_to_name[config_name]} ({config_to_model_name[config_name]} model)"
+            f"{indent}- [`{config_name}`] configuration class: {config_to_name[config_name]} ({config_to_model_name[config_name]} model)"
             for config_name in sorted(config_to_name.keys())
         ]
     return "\n".join(lines)

--- a/src/transformers/models/mmbt/modeling_mmbt.py
+++ b/src/transformers/models/mmbt/modeling_mmbt.py
@@ -94,9 +94,9 @@ MMBT_START_DOCSTRING = r"""
         config ([`MMBTConfig`]): Model configuration class with all the parameters of the model.
             Initializing with a config file does not load the weights associated with the model, only the
             configuration.
-        transformer (:class: *~nn.Module*): A text transformer that is used by MMBT.
+        transformer ([`~nn.Module`]): A text transformer that is used by MMBT.
             It should have embeddings, encoder, and pooler attributes.
-        encoder (:class: *~nn.Module*): Encoder for the second modality.
+        encoder ([`~nn.Module`]): Encoder for the second modality.
             It should take in a batch of modal inputs and return k, n dimension embeddings.
 """
 

--- a/src/transformers/models/mmbt/modeling_mmbt.py
+++ b/src/transformers/models/mmbt/modeling_mmbt.py
@@ -94,9 +94,9 @@ MMBT_START_DOCSTRING = r"""
         config ([`MMBTConfig`]): Model configuration class with all the parameters of the model.
             Initializing with a config file does not load the weights associated with the model, only the
             configuration.
-        transformer ([`~nn.Module`]): A text transformer that is used by MMBT.
+        transformer (`nn.Module`): A text transformer that is used by MMBT.
             It should have embeddings, encoder, and pooler attributes.
-        encoder ([`~nn.Module`]): Encoder for the second modality.
+        encoder (`nn.Module`): Encoder for the second modality.
             It should take in a batch of modal inputs and return k, n dimension embeddings.
 """
 

--- a/src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
+++ b/src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
@@ -737,7 +737,7 @@ class Speech2Text2DecoderWrapper(Speech2Text2PreTrainedModel):
 
 
 @add_start_docstrings(
-    "The Speech2Text2 Decoder with a language modeling head. Can be used as the decoder part of [`~transformers.EncoderDecoderModel`] and [`~transformers.SpeechEncoderDecoder`].",
+    "The Speech2Text2 Decoder with a language modeling head. Can be used as the decoder part of [`EncoderDecoderModel`] and [`SpeechEncoderDecoder`].",
     SPEECH_TO_TEXT_2_START_DOCSTRING,
 )
 class Speech2Text2ForCausalLM(Speech2Text2PreTrainedModel):

--- a/src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
+++ b/src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
@@ -737,7 +737,7 @@ class Speech2Text2DecoderWrapper(Speech2Text2PreTrainedModel):
 
 
 @add_start_docstrings(
-    "The Speech2Text2 Decoder with a language modeling head. Can be used as the decoder part of :class:`~transformers.EncoderDecoderModel` and :class:`~transformers.SpeechEncoderDecoder`.",
+    "The Speech2Text2 Decoder with a language modeling head. Can be used as the decoder part of [`~transformers.EncoderDecoderModel`] and [`~transformers.SpeechEncoderDecoder`].",
     SPEECH_TO_TEXT_2_START_DOCSTRING,
 )
 class Speech2Text2ForCausalLM(Speech2Text2PreTrainedModel):

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -770,7 +770,7 @@ class TrOCRDecoderWrapper(TrOCRPreTrainedModel):
 
 
 @add_start_docstrings(
-    "The TrOCR Decoder with a language modeling head. Can be used as the decoder part of [`~transformers.EncoderDecoderModel`] and [`~transformers.VisionEncoderDecoder`].",
+    "The TrOCR Decoder with a language modeling head. Can be used as the decoder part of [`EncoderDecoderModel`] and [`VisionEncoderDecoder`].",
     TROCR_START_DOCSTRING,
 )
 class TrOCRForCausalLM(TrOCRPreTrainedModel):

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -770,7 +770,7 @@ class TrOCRDecoderWrapper(TrOCRPreTrainedModel):
 
 
 @add_start_docstrings(
-    "The TrOCR Decoder with a language modeling head. Can be used as the decoder part of :class:`~transformers.EncoderDecoderModel` and :class:`~transformers.VisionEncoderDecoder`.",
+    "The TrOCR Decoder with a language modeling head. Can be used as the decoder part of [`~transformers.EncoderDecoderModel`] and [`~transformers.VisionEncoderDecoder`].",
     TROCR_START_DOCSTRING,
 )
 class TrOCRForCausalLM(TrOCRPreTrainedModel):

--- a/tests/test_modeling_rag.py
+++ b/tests/test_modeling_rag.py
@@ -84,7 +84,7 @@ def _assert_tensors_equal(a, b, atol=1e-12, prefix=""):
 def require_retrieval(test_case):
     """
     Decorator marking a test that requires a set of dependencies necessary for pefrorm retrieval with
-    [`~transformers.RagRetriever`].
+    [`RagRetriever`].
 
     These tests are skipped when respective libraries are not installed.
 

--- a/tests/test_modeling_rag.py
+++ b/tests/test_modeling_rag.py
@@ -84,7 +84,7 @@ def _assert_tensors_equal(a, b, atol=1e-12, prefix=""):
 def require_retrieval(test_case):
     """
     Decorator marking a test that requires a set of dependencies necessary for pefrorm retrieval with
-    :class:`~transformers.RagRetriever`.
+    [`~transformers.RagRetriever`].
 
     These tests are skipped when respective libraries are not installed.
 

--- a/tests/test_modeling_tf_rag.py
+++ b/tests/test_modeling_tf_rag.py
@@ -44,7 +44,7 @@ TOLERANCE = 1e-3
 def require_retrieval(test_case):
     """
     Decorator marking a test that requires a set of dependencies necessary for pefrorm retrieval with
-    :class:`~transformers.RagRetriever`.
+    [`~transformers.RagRetriever`].
 
     These tests are skipped when respective libraries are not installed.
 

--- a/tests/test_modeling_tf_rag.py
+++ b/tests/test_modeling_tf_rag.py
@@ -44,7 +44,7 @@ TOLERANCE = 1e-3
 def require_retrieval(test_case):
     """
     Decorator marking a test that requires a set of dependencies necessary for pefrorm retrieval with
-    [`~transformers.RagRetriever`].
+    [`RagRetriever`].
 
     These tests are skipped when respective libraries are not installed.
 


### PR DESCRIPTION
part 2 Doc clean up continued from https://github.com/huggingface/transformers/pull/14954

- `:meth:`, `:func` - all is good
- `:class:`

```
find . -type d -name ".git" -prune -o -type f -exec perl -pi -e 's#:class: ?`([^`]+)`#[`$1`]#g' {} \;
find . -type d -name ".git" -prune -o -type f -exec perl -pi -e 's#:class: ?\*([^\*]+)\*#[`$1`]#g' {} \;
git checkout examples utils/check_repo.py
```

let me know if there are any other left-over rst tags to hunt down.

@sgugger 
