### PR TITLE
[megatron convert] PYTHONPATH requirements

### DIFF
--- a/src/transformers/models/megatron_bert/convert_megatron_bert_checkpoint.py
+++ b/src/transformers/models/megatron_bert/convert_megatron_bert_checkpoint.py
@@ -16,6 +16,18 @@
 
 ####################################################################################################
 
+#
+# Note: If when running this conversion script you're getting an exception:
+#     ModuleNotFoundError: No module named 'megatron.model.enums'
+# you need to tell python where to find the clone of Megatron-LM, e.g.:
+#
+# cd /tmp
+# git clone https://github.com/NVIDIA/Megatron-LM
+# PYTHONPATH=/tmp/Megatron-LM python src/transformers/models/megatron_bert/convert_megatron_bert_checkpoint.py ...
+#
+# if you already have it cloned elsewhere, simply adjust the path to the existing path
+#
+
 import argparse
 import json
 import os

--- a/src/transformers/models/megatron_bert/convert_megatron_bert_checkpoint.py
+++ b/src/transformers/models/megatron_bert/convert_megatron_bert_checkpoint.py
@@ -27,6 +27,10 @@
 #
 # if you already have it cloned elsewhere, simply adjust the path to the existing path
 #
+# If the training was done using a Megatron-LM fork, e.g.,
+# https://github.com/microsoft/Megatron-DeepSpeed/ then chances are that you need to have that one
+# in your path, i.e., /path/to/Megatron-DeepSpeed/
+#
 
 import argparse
 import json

--- a/src/transformers/models/megatron_gpt2/convert_megatron_gpt2_checkpoint.py
+++ b/src/transformers/models/megatron_gpt2/convert_megatron_gpt2_checkpoint.py
@@ -16,6 +16,18 @@
 
 ####################################################################################################
 
+#
+# Note: If when running this conversion script you're getting an exception:
+#     ModuleNotFoundError: No module named 'megatron.model.enums'
+# you need to tell python where to find the clone of Megatron-LM, e.g.:
+#
+# cd /tmp
+# git clone https://github.com/NVIDIA/Megatron-LM
+# PYTHONPATH=/tmp/Megatron-LM python src/transformers/models/megatron_gpt2/convert_megatron_gpt2_checkpoint.py ...
+#
+# if you already have it cloned elsewhere, simply adjust the path to the existing path
+#
+
 import argparse
 import os
 import re

--- a/src/transformers/models/megatron_gpt2/convert_megatron_gpt2_checkpoint.py
+++ b/src/transformers/models/megatron_gpt2/convert_megatron_gpt2_checkpoint.py
@@ -27,6 +27,10 @@
 #
 # if you already have it cloned elsewhere, simply adjust the path to the existing path
 #
+# If the training was done using a Megatron-LM fork, e.g.,
+# https://github.com/microsoft/Megatron-DeepSpeed/ then chances are that you need to have that one
+# in your path, i.e., /path/to/Megatron-DeepSpeed/
+#
 
 import argparse
 import os


### PR DESCRIPTION
This PR documents how to tell the megatron conversion scripts to find the `Megatron-LM` repo, which is needed for recent checkpoints as it was reported at https://github.com/huggingface/transformers/issues/14939

Since one can't install Megatron-LM as a package we can't make the script require it, so documenting it here and will also document in the model cards.

Fixes: https://github.com/huggingface/transformers/issues/14939

@LysandreJik 

----

@jdemouth already updated these:

- https://huggingface.co/nvidia/megatron-gpt2-345m/blob/main/README.md
- https://huggingface.co/nvidia/megatron-bert-uncased-345m/blob/main/README.md
- https://huggingface.co/nvidia/megatron-bert-cased-345m/blob/main/README.md

I need to figure out how to get perms to do so. 