### PR TITLE
Add `with torch.no_grad()` to DistilBERT integration test forward pass

### DIFF
--- a/tests/test_modeling_distilbert.py
+++ b/tests/test_modeling_distilbert.py
@@ -167,6 +167,7 @@ class DistilBertModelTester(object):
         model = DistilBertForTokenClassification(config=config)
         model.to(torch_device)
         model.eval()
+
         result = model(input_ids, attention_mask=input_mask, labels=token_labels)
         self.parent.assertEqual(result.logits.shape, (self.batch_size, self.seq_length, self.num_labels))
 

--- a/tests/test_modeling_distilbert.py
+++ b/tests/test_modeling_distilbert.py
@@ -125,9 +125,8 @@ class DistilBertModelTester(object):
         model = DistilBertModel(config=config)
         model.to(torch_device)
         model.eval()
-        with torch.no_grad():
-            result = model(input_ids, input_mask)
-            result = model(input_ids)
+        result = model(input_ids, input_mask)
+        result = model(input_ids)
         self.parent.assertEqual(result.last_hidden_state.shape, (self.batch_size, self.seq_length, self.hidden_size))
 
     def create_and_check_distilbert_for_masked_lm(
@@ -136,8 +135,7 @@ class DistilBertModelTester(object):
         model = DistilBertForMaskedLM(config=config)
         model.to(torch_device)
         model.eval()
-        with torch.no_grad():
-            result = model(input_ids, attention_mask=input_mask, labels=token_labels)
+        result = model(input_ids, attention_mask=input_mask, labels=token_labels)
         self.parent.assertEqual(result.logits.shape, (self.batch_size, self.seq_length, self.vocab_size))
 
     def create_and_check_distilbert_for_question_answering(
@@ -146,10 +144,9 @@ class DistilBertModelTester(object):
         model = DistilBertForQuestionAnswering(config=config)
         model.to(torch_device)
         model.eval()
-        with torch.no_grad():
-            result = model(
-                input_ids, attention_mask=input_mask, start_positions=sequence_labels, end_positions=sequence_labels
-            )
+        result = model(
+            input_ids, attention_mask=input_mask, start_positions=sequence_labels, end_positions=sequence_labels
+        )
         self.parent.assertEqual(result.start_logits.shape, (self.batch_size, self.seq_length))
         self.parent.assertEqual(result.end_logits.shape, (self.batch_size, self.seq_length))
 
@@ -160,8 +157,7 @@ class DistilBertModelTester(object):
         model = DistilBertForSequenceClassification(config)
         model.to(torch_device)
         model.eval()
-        with torch.no_grad():
-            result = model(input_ids, attention_mask=input_mask, labels=sequence_labels)
+        result = model(input_ids, attention_mask=input_mask, labels=sequence_labels)
         self.parent.assertEqual(result.logits.shape, (self.batch_size, self.num_labels))
 
     def create_and_check_distilbert_for_token_classification(
@@ -171,8 +167,7 @@ class DistilBertModelTester(object):
         model = DistilBertForTokenClassification(config=config)
         model.to(torch_device)
         model.eval()
-        with torch.no_grad():
-            result = model(input_ids, attention_mask=input_mask, labels=token_labels)
+        result = model(input_ids, attention_mask=input_mask, labels=token_labels)
         self.parent.assertEqual(result.logits.shape, (self.batch_size, self.seq_length, self.num_labels))
 
     def create_and_check_distilbert_for_multiple_choice(
@@ -184,12 +179,11 @@ class DistilBertModelTester(object):
         model.eval()
         multiple_choice_inputs_ids = input_ids.unsqueeze(1).expand(-1, self.num_choices, -1).contiguous()
         multiple_choice_input_mask = input_mask.unsqueeze(1).expand(-1, self.num_choices, -1).contiguous()
-        with torch.no_grad():
-            result = model(
-                multiple_choice_inputs_ids,
-                attention_mask=multiple_choice_input_mask,
-                labels=choice_labels,
-            )
+        result = model(
+            multiple_choice_inputs_ids,
+            attention_mask=multiple_choice_input_mask,
+            labels=choice_labels,
+        )
         self.parent.assertEqual(result.logits.shape, (self.batch_size, self.num_choices))
 
     def prepare_config_and_inputs_for_common(self):

--- a/tests/test_modeling_distilbert.py
+++ b/tests/test_modeling_distilbert.py
@@ -266,7 +266,7 @@ class DistilBertModelTest(ModelTesterMixin, unittest.TestCase):
 
             # BertForMultipleChoice behaves incorrectly in JIT environments.
             if model_class == DistilBertForMultipleChoice:
-                continue
+                return
 
             config.torchscript = True
             model = model_class(config=config)


### PR DESCRIPTION
# What does this PR do?

This PR encapsulates forward passes in DistilBERT unit tests with `with torch.no_grad():` as per #14642.

Also, a unit test seemed to terminate early due to a `return` in a loop; this was replaced with `continue`. (If this was not what was intended, I will rollback the modification.)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@NielsRogge @LysandreJik @sgugger 