### PR TITLE
Fix saving FlaubertTokenizer configs

### DIFF
--- a/src/transformers/models/flaubert/tokenization_flaubert.py
+++ b/src/transformers/models/flaubert/tokenization_flaubert.py
@@ -96,7 +96,7 @@ class FlaubertTokenizer(XLMTokenizer):
     max_model_input_sizes = PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES
 
     def __init__(self, do_lowercase=False, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(do_lowercase=do_lowercase, **kwargs)
         self.do_lowercase = do_lowercase
         self.do_lowercase_and_remove_accent = False
 


### PR DESCRIPTION
All specific tokenizer config properties must be passed to its base
class (XLMTokenizer) in order to be saved. This was not the case for
do_lowercase config. Thus it was not saved by save_pretrained() method
and saving and reloading the tokenizer changed its behaviour.

This commit fixes it.

# What does this PR do?

Fixes # 14489

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@n1t0, @LysandreJik

## Comment:

As I have said in the issue, a similar problem may happen to other models. For me, it is not obvious, that one should pass a model-specific config to the general base class constructor for the config to be saved later.

I feel like some comment should be left somewhere for future developers, but I cannot come up with a good place for it. On the other hand, maybe it is obvious from all the base class' descriptions, and I'm just not experienced enough.
