### PR TITLE
Allow training to resume even if RNG states are not properly loaded

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1553,7 +1553,13 @@ class Trainer:
             if self.args.local_rank != -1:
                 torch.cuda.random.set_rng_state(checkpoint_rng_state["cuda"])
             else:
-                torch.cuda.random.set_rng_state_all(checkpoint_rng_state["cuda"])
+                try:
+                    torch.cuda.random.set_rng_state_all(checkpoint_rng_state["cuda"])
+                except Exception as e:
+                    logger.infor(
+                        "Didn't manage to set back the RNG states of the GPU because of the following error:\n {e}"
+                        "\nThis won't yield the same results as if the training had not been interrupted."
+                    )
         if is_torch_tpu_available():
             xm.set_rng_state(checkpoint_rng_state["xla"])
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1557,7 +1557,7 @@ class Trainer:
                     torch.cuda.random.set_rng_state_all(checkpoint_rng_state["cuda"])
                 except Exception as e:
                     logger.infor(
-                        "Didn't manage to set back the RNG states of the GPU because of the following error:\n {e}"
+                        f"Didn't manage to set back the RNG states of the GPU because of the following error:\n {e}"
                         "\nThis won't yield the same results as if the training had not been interrupted."
                     )
         if is_torch_tpu_available():


### PR DESCRIPTION
# What does this PR do?

This PR allows training to resume even if the loading of the RNG state fail in multi-GPU DataParallel mode because less GPUs are used than during the original training.

Fixes #14554