### PR TITLE
fix model table cell text alignment

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -190,7 +190,7 @@ Flax), PyTorch, and/or TensorFlow.
 <!--This table is updated automatically from the auto modules with _make fix-copies_. Do not update manually!-->
 
 |            Model            | Tokenizer slow | Tokenizer fast | PyTorch support | TensorFlow support | Flax Support |
-|-----------------------------|----------------|----------------|-----------------|--------------------|--------------|
+|:---------------------------:|:--------------:|:--------------:|:---------------:|:------------------:|:------------:|
 |           ALBERT            |       ✅       |       ✅       |       ✅        |         ✅         |      ✅      |
 |            BART             |       ✅       |       ✅       |       ✅        |         ✅         |      ✅      |
 |            BEiT             |       ❌       |       ❌       |       ✅        |         ❌         |      ✅      |

--- a/utils/check_table.py
+++ b/utils/check_table.py
@@ -140,7 +140,8 @@ def get_model_table_from_auto_modules():
 
     # Build the table per se
     table = "|" + "|".join([_center_text(c, w) for c, w in zip(columns, widths)]) + "|\n"
-    table += "|" + "|".join(["-" * w for w in widths]) + "|\n"
+    # Use ":-----:" format to center-aligned table cell texts
+    table += "|" + "|".join([":" + "-" * (w - 2) + ":" for w in widths]) + "|\n"
 
     check = {True: "✅", False: "❌"}
     for name in model_names:


### PR DESCRIPTION
# What does this PR do?

The current new model table in [index.mdx](https://github.com/ydshieh/transformers/blob/master/docs/source/index.mdx) left align table cell texts. This PR makes them center-aligned.

On master:

![Capture](https://user-images.githubusercontent.com/2521628/147839482-9ed2520e-3622-4f66-bdfe-3c98f2d8e655.JPG)

On this PR [index.mdx](https://github.com/ydshieh/transformers/blob/center-align-model-table/docs/source/index.mdx):

![Capture2](https://user-images.githubusercontent.com/2521628/147839492-a4a2ee48-e8ab-49c5-86f3-71a4e7b1e05a.JPG)

(Hope centralized instead of decentralized is intended in this context 🤗 )

## Who can review?

@sgugger  @LysandreJik 