### PR TITLE
Make OpenAIGPTTokenizer work with SpaCy 2.x and 3.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
                   path: ~/transformers/reports
-    
+
     run_tests_torch_and_tf_all:
         working_directory: ~/transformers
         docker:
@@ -169,7 +169,7 @@ jobs:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
                   path: ~/transformers/reports
-    
+
     run_tests_torch_and_flax_all:
         working_directory: ~/transformers
         docker:
@@ -237,7 +237,7 @@ jobs:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
                   path: ~/transformers/reports
-    
+
     run_tests_torch_all:
         working_directory: ~/transformers
         docker:
@@ -304,7 +304,7 @@ jobs:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
                   path: ~/transformers/reports
-    
+
     run_tests_tf_all:
         working_directory: ~/transformers
         docker:
@@ -370,7 +370,7 @@ jobs:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
                   path: ~/transformers/reports
-    
+
     run_tests_flax_all:
         working_directory: ~/transformers
         docker:
@@ -437,7 +437,7 @@ jobs:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
                   path: ~/transformers/reports
-    
+
     run_tests_pipelines_torch_all:
         working_directory: ~/transformers
         docker:
@@ -549,7 +549,7 @@ jobs:
                       - v0.4-custom_tokenizers-{{ checksum "setup.py" }}
                       - v0.4-{{ checksum "setup.py" }}
             - run: pip install --upgrade pip
-            - run: pip install .[ja,testing,sentencepiece,jieba]
+            - run: pip install .[ja,testing,sentencepiece,jieba,spacy,ftfy]
             - run: python -m unidic download
             - save_cache:
                   key: v0.4-custom_tokenizers-{{ checksum "setup.py" }}
@@ -557,7 +557,7 @@ jobs:
                       - '~/.cache/pip'
             - run: |
                   if [ -f test_list.txt ]; then
-                    python -m pytest -s --make-reports=tests_custom_tokenizers ./tests/test_tokenization_bert_japanese.py | tee tests_output.txt
+                    python -m pytest -s --make-reports=tests_custom_tokenizers ./tests/test_tokenization_bert_japanese.py ./tests/test_tokenization_openai.py | tee tests_output.txt
                   fi
             - store_artifacts:
                   path: ~/transformers/tests_output.txt
@@ -662,7 +662,7 @@ jobs:
                   path: ~/transformers/flax_examples_output.txt
             - store_artifacts:
                   path: ~/transformers/reports
-    
+
     run_examples_flax_all:
         working_directory: ~/transformers
         docker:
@@ -729,7 +729,7 @@ jobs:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
                   path: ~/transformers/reports
-    
+
     run_tests_hub_all:
         working_directory: ~/transformers
         docker:
@@ -795,7 +795,7 @@ jobs:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
                   path: ~/transformers/reports
-    
+
     run_tests_onnxruntime_all:
         working_directory: ~/transformers
         docker:

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -512,6 +512,14 @@ def is_pytesseract_available():
     return importlib.util.find_spec("pytesseract") is not None
 
 
+def is_spacy_available():
+    return importlib.util.find_spec("spacy") is not None
+
+
+def is_ftfy_available():
+    return importlib.util.find_spec("ftfy") is not None
+
+
 def is_in_notebook():
     try:
         # Test adapted from tqdm.autonotebook: https://github.com/tqdm/tqdm/blob/master/tqdm/autonotebook.py

--- a/src/transformers/models/openai/tokenization_openai.py
+++ b/src/transformers/models/openai/tokenization_openai.py
@@ -104,7 +104,7 @@ class OpenAIGPTTokenizer(PreTrainedTokenizer):
             from spacy.lang.en import English
 
             _nlp = English()
-            self.nlp = _nlp.Defaults.create_tokenizer(_nlp)
+            self.nlp = _nlp.tokenizer
             self.fix_text = ftfy.fix_text
         except ImportError:
             logger.warning("ftfy or spacy is not installed using BERT BasicTokenizer instead of SpaCy & ftfy.")

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -34,6 +34,7 @@ from .file_utils import (
     is_detectron2_available,
     is_faiss_available,
     is_flax_available,
+    is_ftfy_available,
     is_keras2onnx_available,
     is_librosa_available,
     is_onnx_available,
@@ -46,6 +47,7 @@ from .file_utils import (
     is_scatter_available,
     is_sentencepiece_available,
     is_soundfile_availble,
+    is_spacy_available,
     is_tensorflow_probability_available,
     is_tf_available,
     is_timm_available,
@@ -408,6 +410,46 @@ def require_vision(test_case):
     """
     if not is_vision_available():
         return unittest.skip("test requires vision")(test_case)
+    else:
+        return test_case
+
+
+def require_ftfy(test_case):
+    """
+    Decorator marking a test that requires ftfy. These tests are skipped when ftfy isn't installed.
+    """
+    if not is_ftfy_available():
+        return unittest.skip("test requires ftfy")(test_case)
+    else:
+        return test_case
+
+
+def require_no_ftfy(test_case):
+    """
+    Decorator marking a test that requires ftfy NOT be installed. These tests are skipped when ftfy is installed.
+    """
+    if is_ftfy_available():
+        return unittest.skip("test requires no ftfy")(test_case)
+    else:
+        return test_case
+
+
+def require_spacy(test_case):
+    """
+    Decorator marking a test that requires SpaCy. These tests are skipped when SpaCy isn't installed.
+    """
+    if not is_spacy_available():
+        return unittest.skip("test requires spacy")(test_case)
+    else:
+        return test_case
+
+
+def require_no_spacy(test_case):
+    """
+    Decorator marking a test that requires SpaCy NOT be installed. These tests are skipped when SpaCy is installed.
+    """
+    if is_spacy_available():
+        return unittest.skip("test requires no spacy")(test_case)
     else:
         return test_case
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -424,32 +424,12 @@ def require_ftfy(test_case):
         return test_case
 
 
-def require_no_ftfy(test_case):
-    """
-    Decorator marking a test that requires ftfy NOT be installed. These tests are skipped when ftfy is installed.
-    """
-    if is_ftfy_available():
-        return unittest.skip("test requires no ftfy")(test_case)
-    else:
-        return test_case
-
-
 def require_spacy(test_case):
     """
     Decorator marking a test that requires SpaCy. These tests are skipped when SpaCy isn't installed.
     """
     if not is_spacy_available():
         return unittest.skip("test requires spacy")(test_case)
-    else:
-        return test_case
-
-
-def require_no_spacy(test_case):
-    """
-    Decorator marking a test that requires SpaCy NOT be installed. These tests are skipped when SpaCy is installed.
-    """
-    if is_spacy_available():
-        return unittest.skip("test requires no spacy")(test_case)
     else:
         return test_case
 

--- a/tests/test_tokenization_openai.py
+++ b/tests/test_tokenization_openai.py
@@ -22,8 +22,6 @@ from transformers import OpenAIGPTTokenizer, OpenAIGPTTokenizerFast
 from transformers.models.openai.tokenization_openai import VOCAB_FILES_NAMES
 from transformers.testing_utils import (
     require_ftfy,
-    require_no_ftfy,
-    require_no_spacy,
     require_spacy,
     require_tokenizers,
 )
@@ -31,8 +29,6 @@ from transformers.testing_utils import (
 from .test_tokenization_common import TokenizerTesterMixin
 
 
-@require_no_ftfy
-@require_no_spacy
 @require_tokenizers
 class OpenAIGPTTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     """Tests OpenAIGPTTokenizer that uses BERT BasicTokenizer."""
@@ -146,110 +142,7 @@ class OpenAIGPTTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 @require_ftfy
 @require_spacy
 @require_tokenizers
-class OpenAIGPTTokenizationTestWithSpacy(TokenizerTesterMixin, unittest.TestCase):
+class OpenAIGPTTokenizationTestWithSpacy(OpenAIGPTTokenizationTest):
     """Tests OpenAIGPTTokenizer that uses SpaCy and ftfy."""
 
-    tokenizer_class = OpenAIGPTTokenizer
-    rust_tokenizer_class = OpenAIGPTTokenizerFast
-    test_rust_tokenizer = True
-    test_seq2seq = False
-
-    def setUp(self):
-        super().setUp()
-
-        # Adapted from Sennrich et al. 2015 and https://github.com/rsennrich/subword-nmt
-        vocab = [
-            "l",
-            "o",
-            "w",
-            "e",
-            "r",
-            "s",
-            "t",
-            "i",
-            "d",
-            "n",
-            "w</w>",
-            "r</w>",
-            "t</w>",
-            "lo",
-            "low",
-            "er</w>",
-            "low</w>",
-            "lowest</w>",
-            "newer</w>",
-            "wider</w>",
-            "<unk>",
-        ]
-        vocab_tokens = dict(zip(vocab, range(len(vocab))))
-        merges = ["#version: 0.2", "l o", "lo w", "e r</w>", ""]
-
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
-        self.merges_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["merges_file"])
-        with open(self.vocab_file, "w") as fp:
-            fp.write(json.dumps(vocab_tokens))
-        with open(self.merges_file, "w") as fp:
-            fp.write("\n".join(merges))
-
-    def get_input_output_texts(self, tokenizer):
-        return "lower newer", "lower newer"
-
-    def test_full_tokenizer(self):
-        tokenizer = OpenAIGPTTokenizer(self.vocab_file, self.merges_file)
-
-        text = "lower"
-        bpe_tokens = ["low", "er</w>"]
-        tokens = tokenizer.tokenize(text)
-        self.assertListEqual(tokens, bpe_tokens)
-
-        input_tokens = tokens + ["<unk>"]
-        input_bpe_tokens = [14, 15, 20]
-        self.assertListEqual(tokenizer.convert_tokens_to_ids(input_tokens), input_bpe_tokens)
-
-    def test_padding(self, max_length=15):
-        for tokenizer, pretrained_name, kwargs in self.tokenizers_list:
-            with self.subTest(f"{tokenizer.__class__.__name__} ({pretrained_name})"):
-                tokenizer_r = self.rust_tokenizer_class.from_pretrained(pretrained_name, **kwargs)
-
-                # Simple input
-                s = "This is a simple input"
-                s2 = ["This is a simple input 1", "This is a simple input 2"]
-                p = ("This is a simple input", "This is a pair")
-                p2 = [
-                    ("This is a simple input 1", "This is a simple input 2"),
-                    ("This is a simple pair 1", "This is a simple pair 2"),
-                ]
-
-                # Simple input tests
-                self.assertRaises(ValueError, tokenizer_r.encode, s, max_length=max_length, padding="max_length")
-
-                # Simple input
-                self.assertRaises(ValueError, tokenizer_r.encode_plus, s, max_length=max_length, padding="max_length")
-
-                # Simple input
-                self.assertRaises(
-                    ValueError,
-                    tokenizer_r.batch_encode_plus,
-                    s2,
-                    max_length=max_length,
-                    padding="max_length",
-                )
-
-                # Pair input
-                self.assertRaises(ValueError, tokenizer_r.encode, p, max_length=max_length, padding="max_length")
-
-                # Pair input
-                self.assertRaises(ValueError, tokenizer_r.encode_plus, p, max_length=max_length, padding="max_length")
-
-                # Pair input
-                self.assertRaises(
-                    ValueError,
-                    tokenizer_r.batch_encode_plus,
-                    p2,
-                    max_length=max_length,
-                    padding="max_length",
-                )
-
-    # tokenizer has no padding token
-    def test_padding_different_model_input_name(self):
-        pass
+    pass

--- a/tests/test_tokenization_openai.py
+++ b/tests/test_tokenization_openai.py
@@ -20,11 +20,7 @@ import unittest
 
 from transformers import OpenAIGPTTokenizer, OpenAIGPTTokenizerFast
 from transformers.models.openai.tokenization_openai import VOCAB_FILES_NAMES
-from transformers.testing_utils import (
-    require_ftfy,
-    require_spacy,
-    require_tokenizers,
-)
+from transformers.testing_utils import require_ftfy, require_spacy, require_tokenizers
 
 from .test_tokenization_common import TokenizerTesterMixin
 

--- a/tests/test_tokenization_openai.py
+++ b/tests/test_tokenization_openai.py
@@ -20,13 +20,134 @@ import unittest
 
 from transformers import OpenAIGPTTokenizer, OpenAIGPTTokenizerFast
 from transformers.models.openai.tokenization_openai import VOCAB_FILES_NAMES
-from transformers.testing_utils import require_tokenizers
+from transformers.testing_utils import (
+    require_ftfy,
+    require_no_ftfy,
+    require_no_spacy,
+    require_spacy,
+    require_tokenizers,
+)
 
 from .test_tokenization_common import TokenizerTesterMixin
 
 
+@require_no_ftfy
+@require_no_spacy
 @require_tokenizers
 class OpenAIGPTTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+    """Tests OpenAIGPTTokenizer that uses BERT BasicTokenizer."""
+
+    tokenizer_class = OpenAIGPTTokenizer
+    rust_tokenizer_class = OpenAIGPTTokenizerFast
+    test_rust_tokenizer = True
+    test_seq2seq = False
+
+    def setUp(self):
+        super().setUp()
+
+        # Adapted from Sennrich et al. 2015 and https://github.com/rsennrich/subword-nmt
+        vocab = [
+            "l",
+            "o",
+            "w",
+            "e",
+            "r",
+            "s",
+            "t",
+            "i",
+            "d",
+            "n",
+            "w</w>",
+            "r</w>",
+            "t</w>",
+            "lo",
+            "low",
+            "er</w>",
+            "low</w>",
+            "lowest</w>",
+            "newer</w>",
+            "wider</w>",
+            "<unk>",
+        ]
+        vocab_tokens = dict(zip(vocab, range(len(vocab))))
+        merges = ["#version: 0.2", "l o", "lo w", "e r</w>", ""]
+
+        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        self.merges_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["merges_file"])
+        with open(self.vocab_file, "w") as fp:
+            fp.write(json.dumps(vocab_tokens))
+        with open(self.merges_file, "w") as fp:
+            fp.write("\n".join(merges))
+
+    def get_input_output_texts(self, tokenizer):
+        return "lower newer", "lower newer"
+
+    def test_full_tokenizer(self):
+        tokenizer = OpenAIGPTTokenizer(self.vocab_file, self.merges_file)
+
+        text = "lower"
+        bpe_tokens = ["low", "er</w>"]
+        tokens = tokenizer.tokenize(text)
+        self.assertListEqual(tokens, bpe_tokens)
+
+        input_tokens = tokens + ["<unk>"]
+        input_bpe_tokens = [14, 15, 20]
+        self.assertListEqual(tokenizer.convert_tokens_to_ids(input_tokens), input_bpe_tokens)
+
+    def test_padding(self, max_length=15):
+        for tokenizer, pretrained_name, kwargs in self.tokenizers_list:
+            with self.subTest(f"{tokenizer.__class__.__name__} ({pretrained_name})"):
+                tokenizer_r = self.rust_tokenizer_class.from_pretrained(pretrained_name, **kwargs)
+
+                # Simple input
+                s = "This is a simple input"
+                s2 = ["This is a simple input 1", "This is a simple input 2"]
+                p = ("This is a simple input", "This is a pair")
+                p2 = [
+                    ("This is a simple input 1", "This is a simple input 2"),
+                    ("This is a simple pair 1", "This is a simple pair 2"),
+                ]
+
+                # Simple input tests
+                self.assertRaises(ValueError, tokenizer_r.encode, s, max_length=max_length, padding="max_length")
+
+                # Simple input
+                self.assertRaises(ValueError, tokenizer_r.encode_plus, s, max_length=max_length, padding="max_length")
+
+                # Simple input
+                self.assertRaises(
+                    ValueError,
+                    tokenizer_r.batch_encode_plus,
+                    s2,
+                    max_length=max_length,
+                    padding="max_length",
+                )
+
+                # Pair input
+                self.assertRaises(ValueError, tokenizer_r.encode, p, max_length=max_length, padding="max_length")
+
+                # Pair input
+                self.assertRaises(ValueError, tokenizer_r.encode_plus, p, max_length=max_length, padding="max_length")
+
+                # Pair input
+                self.assertRaises(
+                    ValueError,
+                    tokenizer_r.batch_encode_plus,
+                    p2,
+                    max_length=max_length,
+                    padding="max_length",
+                )
+
+    # tokenizer has no padding token
+    def test_padding_different_model_input_name(self):
+        pass
+
+
+@require_ftfy
+@require_spacy
+@require_tokenizers
+class OpenAIGPTTokenizationTestWithSpacy(TokenizerTesterMixin, unittest.TestCase):
+    """Tests OpenAIGPTTokenizer that uses SpaCy and ftfy."""
 
     tokenizer_class = OpenAIGPTTokenizer
     rust_tokenizer_class = OpenAIGPTTokenizerFast


### PR DESCRIPTION
SpaCy 3.x introduced an API change to creating the tokenizer that
breaks OpenAIGPTTokenizer. The old API for creating the tokenizer in
SpaCy 2.x no longer works under SpaCy 3.x, but the new API for creating
the tokenizer in SpaCy 3.x DOES work under SpaCy 2.x. Switching to the
new API should allow OpenAIGPTTokenizer to work under both SpaCy 2.x and
SpaCy 3.x versions.

Fixes https://github.com/huggingface/transformers/issues/14449

