### PR TITLE
Enable AMP for xla:gpu device in trainer class

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1508,6 +1508,9 @@ class Trainer:
 
     def _maybe_log_save_evaluate(self, tr_loss, model, trial, epoch, ignore_keys_for_eval):
         if self.control.should_log:
+            if is_torch_tpu_available():
+                xm.mark_step()
+
             logs: Dict[str, float] = {}
 
             # all_gather + mean() to get average loss over all processes

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -811,7 +811,7 @@ class TrainingArguments:
                 raise ValueError("sharded_ddp is not supported with bf16")
         if (
             is_torch_available()
-            and self.device.type != "cuda"
+            and (self.device.type != "cuda" and self.device.type != "xla")
             and (self.fp16 or self.fp16_full_eval or self.bf16 or self.bf16_full_eval)
         ):
             raise ValueError(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -811,7 +811,8 @@ class TrainingArguments:
                 raise ValueError("sharded_ddp is not supported with bf16")
         if (
             is_torch_available()
-            and (self.device.type != "cuda" and self.device.type != "xla")
+            and (self.device.type != "cuda")
+            and not (self.device.type == "xla" and "GPU_NUM_DEVICES" in os.environ)
             and (self.fp16 or self.fp16_full_eval or self.bf16 or self.bf16_full_eval)
         ):
             raise ValueError(


### PR DESCRIPTION
# What does this PR do?
This PR enables AMP in trainer class for xla:gpu device.

# Discussion
It looks like the torch_xla support in trainer class is primarily for xla:tpu device. 
I found the following features may be useful but not essential and I can include them in this PR if necessary:
1. Rename `tpu` to `xla` in the codebase.
2. Currently xla device is always turned on when torch_xla is installed. It may be useful to allow users to optionally turn it off without uninstalling torch_xla.
3. Currently users need to set `GPU_NUM_DEVICES` manually when using xla:gpu device. It may be useful to set a default value for it when torch_xla and cuda devices are available.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->