### PR TITLE
[doc] normalize HF Transformers string

### DIFF
--- a/docs/source/benchmarks.mdx
+++ b/docs/source/benchmarks.mdx
@@ -14,13 +14,13 @@ specific language governing permissions and limitations under the License.
 
 [[open-in-colab]]
 
-Let's take a look at how 🤗 Transformer models can be benchmarked, best practices, and already available benchmarks.
+Let's take a look at how 🤗 Transformers models can be benchmarked, best practices, and already available benchmarks.
 
-A notebook explaining in more detail how to benchmark 🤗 Transformer models can be found [here](https://github.com/huggingface/notebooks/tree/master/examples/benchmark.ipynb).
+A notebook explaining in more detail how to benchmark 🤗 Transformers models can be found [here](https://github.com/huggingface/notebooks/tree/master/examples/benchmark.ipynb).
 
-## How to benchmark 🤗 Transformer models
+## How to benchmark 🤗 Transformers models
 
-The classes [`PyTorchBenchmark`] and [`TensorFlowBenchmark`] allow to flexibly benchmark 🤗 Transformer models. The benchmark classes allow us to measure the _peak memory usage_ and _required time_ for both _inference_ and _training_.
+The classes [`PyTorchBenchmark`] and [`TensorFlowBenchmark`] allow to flexibly benchmark 🤗 Transformers models. The benchmark classes allow us to measure the _peak memory usage_ and _required time_ for both _inference_ and _training_.
 
 <Tip>
 

--- a/docs/source/testing.mdx
+++ b/docs/source/testing.mdx
@@ -13,7 +13,7 @@ specific language governing permissions and limitations under the License.
 # Testing
 
 
-Let's take a look at how 🤗 Transformer models are tested and how you can write new tests and improve the existing ones.
+Let's take a look at how 🤗 Transformers models are tested and how you can write new tests and improve the existing ones.
 
 There are 2 test suites in the repository:
 


### PR DESCRIPTION
I noticed we use  🤗 Transformer instead of 🤗 Transformers in a couple of places, this PR fixes it.

That was a tricky one with UTF32 emoji. This worked.

```
LC_ALL=C find . -type d -name ".git" -prune -o -type f -exec perl -pi -e 's|(\xF0\x9F\xA4\x97 Transformer) |$1s |' {} \;
```
To grep I had to do:

```
LC_ALL=C grep -Ir -P '\xF0\x9F\xA4\x97 Transformer ' .
```

@sgugger 
