### PR TITLE
Wrap Roberta integration test forward passes with torch.no_grad()

### DIFF
--- a/tests/test_modeling_roberta.py
+++ b/tests/test_modeling_roberta.py
@@ -485,7 +485,8 @@ class RobertaModelIntegrationTest(TestCasePlus):
         model = RobertaForMaskedLM.from_pretrained("roberta-base")
 
         input_ids = torch.tensor([[0, 31414, 232, 328, 740, 1140, 12695, 69, 46078, 1588, 2]])
-        output = model(input_ids)[0]
+        with torch.no_grad():
+            output = model(input_ids)[0]
         expected_shape = torch.Size((1, 11, 50265))
         self.assertEqual(output.shape, expected_shape)
         # compare the actual values for a slice.
@@ -504,7 +505,8 @@ class RobertaModelIntegrationTest(TestCasePlus):
         model = RobertaModel.from_pretrained("roberta-base")
 
         input_ids = torch.tensor([[0, 31414, 232, 328, 740, 1140, 12695, 69, 46078, 1588, 2]])
-        output = model(input_ids)[0]
+        with torch.no_grad():
+            output = model(input_ids)[0]
         # compare the actual values for a slice.
         expected_slice = torch.tensor(
             [[[-0.0231, 0.0782, 0.0074], [-0.1854, 0.0540, -0.0175], [0.0548, 0.0799, 0.1687]]]
@@ -521,7 +523,8 @@ class RobertaModelIntegrationTest(TestCasePlus):
         model = RobertaForSequenceClassification.from_pretrained("roberta-large-mnli")
 
         input_ids = torch.tensor([[0, 31414, 232, 328, 740, 1140, 12695, 69, 46078, 1588, 2]])
-        output = model(input_ids)[0]
+        with torch.no_grad():
+            output = model(input_ids)[0]
         expected_shape = torch.Size((1, 3))
         self.assertEqual(output.shape, expected_shape)
         expected_tensor = torch.tensor([[-0.9469, 0.3913, 0.5118]])


### PR DESCRIPTION
# What does this PR do?
This PR wraps forward passes in Roberta integration tests with torch.no_grad(). See issue #14642 

Fixes #14642 
[Issue link](https://github.com/huggingface/transformers/issues/14642)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@NielsRogge @LysandreJik @sgugger 
