### PR TITLE
[CLIP] Fix TF test

### DIFF
--- a/tests/test_modeling_tf_clip.py
+++ b/tests/test_modeling_tf_clip.py
@@ -254,7 +254,7 @@ class TFCLIPVisionModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in TF_CLIP_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
-            model = TFCLIPVisionModel.from_pretrained(model_name, from_pt=True)
+            model = TFCLIPVisionModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 
@@ -359,7 +359,7 @@ class TFCLIPTextModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in TF_CLIP_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
-            model = TFCLIPTextModel.from_pretrained(model_name, from_pt=True)
+            model = TFCLIPTextModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 
@@ -618,7 +618,7 @@ class TFCLIPModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in TF_CLIP_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
-            model = TFCLIPModel.from_pretrained(model_name, from_pt=True)
+            model = TFCLIPModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 
@@ -630,11 +630,12 @@ def prepare_img():
 
 
 @require_vision
+@require_tf
 class TFCLIPModelIntegrationTest(unittest.TestCase):
     @slow
     def test_inference(self):
         model_name = "openai/clip-vit-base-patch32"
-        model = TFCLIPModel.from_pretrained(model_name, from_pt=True)
+        model = TFCLIPModel.from_pretrained(model_name)
         processor = CLIPProcessor.from_pretrained(model_name)
 
         image = prepare_img()


### PR DESCRIPTION
# What does this PR do?
Fixes the slow TFCLIP tests by using the TF checkpoint instead of converting from `PT`.