### PR TITLE
[Fix doc examples] missing from_pretrained

### DIFF
--- a/src/transformers/models/segformer/modeling_segformer.py
+++ b/src/transformers/models/segformer/modeling_segformer.py
@@ -491,7 +491,7 @@ class SegformerModel(SegformerPreTrainedModel):
         >>> import requests
 
         >>> feature_extractor = SegformerFeatureExtractor.from_pretrained("nvidia/segformer-b0-finetuned-ade-512-512")
-        >>> model = SegformerModel("nvidia/segformer-b0-finetuned-ade-512-512")
+        >>> model = SegformerModel.from_pretrained("nvidia/segformer-b0-finetuned-ade-512-512")
 
         >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw)

--- a/src/transformers/models/segformer/modeling_segformer.py
+++ b/src/transformers/models/segformer/modeling_segformer.py
@@ -491,7 +491,7 @@ class SegformerModel(SegformerPreTrainedModel):
         >>> import requests
 
         >>> feature_extractor = SegformerFeatureExtractor.from_pretrained("nvidia/segformer-b0-finetuned-ade-512-512")
-        >>> model = SegformerModel.from_pretrained("nvidia/segformer-b0-finetuned-ade-512-512")
+        >>> model = SegformerModel.from_pretrained("nvidia/mit-b0")
 
         >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw)

--- a/src/transformers/models/segformer/modeling_segformer.py
+++ b/src/transformers/models/segformer/modeling_segformer.py
@@ -490,7 +490,7 @@ class SegformerModel(SegformerPreTrainedModel):
         >>> from PIL import Image
         >>> import requests
 
-        >>> feature_extractor = SegformerFeatureExtractor.from_pretrained("nvidia/segformer-b0-finetuned-ade-512-512")
+        >>> feature_extractor = SegformerFeatureExtractor.from_pretrained("nvidia/mit-b0")
         >>> model = SegformerModel.from_pretrained("nvidia/mit-b0")
 
         >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"


### PR DESCRIPTION
# What does this PR do?

In a docstring,

```
model = SegformerModel("nvidia/segformer-b0-finetuned-ade-512-512")
```
fails -> should use `from_pretrained`.

This PR fixes it. 

## Who can review?

@NielsRogge 