### PR TITLE
[VisionTextDualEncoder] Fix doc example

### DIFF
--- a/src/transformers/models/vision_text_dual_encoder/modeling_vision_text_dual_encoder.py
+++ b/src/transformers/models/vision_text_dual_encoder/modeling_vision_text_dual_encoder.py
@@ -341,7 +341,7 @@ class VisionTextDualEncoderModel(PreTrainedModel):
         ...     pixel_values=inputs.pixel_values,
         ...     return_loss=True,
         ... )
-        >>> loss, logits_per_image = outputs.loss, outputs.logits_per_imag  # this is the image-text similarity score
+        >>> loss, logits_per_image = outputs.loss, outputs.logits_per_image  # this is the image-text similarity score
 
         >>> # save and load from pretrained
         >>> model.save_pretrained("vit-bert")


### PR DESCRIPTION
# What does this PR do?

In `modeling_vision_text_dual_encoder.py`, this line (doc example) will fail
```
>>> loss, logits_per_image = outputs.loss, outputs.logits_per_imag
```

It should be `outputs.logits_per_image` (`CLIPOutput`)

## Who can review?

@patil-suraj 