### PR TITLE
fix: #14486 do not use BertPooler in DPR

### DIFF
--- a/src/transformers/models/dpr/modeling_dpr.py
+++ b/src/transformers/models/dpr/modeling_dpr.py
@@ -204,11 +204,12 @@ class DPREncoder(DPRPreTrainedModel):
         )
         sequence_output = outputs[0]
         pooled_output = sequence_output[:, 0, :]
+
         if self.projection_dim > 0:
             pooled_output = self.encode_proj(pooled_output)
 
         if not return_dict:
-            return (sequence_output, pooled_output) + outputs[1:]
+            return (sequence_output, pooled_output) + outputs[2:]
 
         return BaseModelOutputWithPooling(
             last_hidden_state=sequence_output,

--- a/src/transformers/models/dpr/modeling_dpr.py
+++ b/src/transformers/models/dpr/modeling_dpr.py
@@ -208,7 +208,7 @@ class DPREncoder(DPRPreTrainedModel):
             pooled_output = self.encode_proj(pooled_output)
 
         if not return_dict:
-            return (sequence_output, pooled_output) + outputs[2:]
+            return (sequence_output, pooled_output) + outputs[1:]
 
         return BaseModelOutputWithPooling(
             last_hidden_state=sequence_output,

--- a/src/transformers/models/dpr/modeling_dpr.py
+++ b/src/transformers/models/dpr/modeling_dpr.py
@@ -175,7 +175,7 @@ class DPREncoder(DPRPreTrainedModel):
 
     def __init__(self, config: DPRConfig):
         super().__init__(config)
-        self.bert_model = BertModel(config)
+        self.bert_model = BertModel(config, add_pooling_layer=False)
         assert self.bert_model.config.hidden_size > 0, "Encoder hidden_size can't be zero"
         self.projection_dim = config.projection_dim
         if self.projection_dim > 0:
@@ -202,7 +202,7 @@ class DPREncoder(DPRPreTrainedModel):
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
         )
-        sequence_output, pooled_output = outputs[:2]
+        sequence_output = outputs[0]
         pooled_output = sequence_output[:, 0, :]
         if self.projection_dim > 0:
             pooled_output = self.encode_proj(pooled_output)

--- a/src/transformers/models/dpr/modeling_tf_dpr.py
+++ b/src/transformers/models/dpr/modeling_tf_dpr.py
@@ -152,7 +152,7 @@ class TFDPREncoderLayer(tf.keras.layers.Layer):
         super().__init__(**kwargs)
 
         # resolve name conflict with TFBertMainLayer instead of TFBertModel
-        self.bert_model = TFBertMainLayer(config, name="bert_model")
+        self.bert_model = TFBertMainLayer(config, add_pooling_layer=False, name="bert_model")
         self.config = config
 
         assert self.config.hidden_size > 0, "Encoder hidden_size can't be zero"
@@ -198,13 +198,13 @@ class TFDPREncoderLayer(tf.keras.layers.Layer):
             training=inputs["training"],
         )
 
-        sequence_output, pooled_output = outputs[:2]
+        sequence_output = outputs[0]
         pooled_output = sequence_output[:, 0, :]
         if self.projection_dim > 0:
             pooled_output = self.encode_proj(pooled_output)
 
         if not inputs["return_dict"]:
-            return (sequence_output, pooled_output) + outputs[2:]
+            return (sequence_output, pooled_output) + outputs[1:]
 
         return TFBaseModelOutputWithPooling(
             last_hidden_state=sequence_output,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #14486


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@patrickvonplaten


<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->

## What did I do?
Fixed the lines we discussed about.
`pytest tests/test_modeling_dpr.py` gives the same output before and after:
```
============================= test session starts ==============================
platform linux -- Python 3.7.11, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /people/lerner/code/transformers, configfile: setup.cfg
plugins: forked-1.4.0, xdist-2.5.0, dash-2.0.0, timeout-2.0.2, hypothesis-6.34.2
collected 52 items

tests/test_modeling_dpr.py .....ss...............s..ssss.s.............. [ 86%]
sss..ss                                                                  [100%]

=============================== warnings summary ===============================
../../.local/lib/python3.7/site-packages/pandas/util/testing.py:20
  /people/lerner/.local/lib/python3.7/site-packages/pandas/util/testing.py:20: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    from pandas._libs import testing as _testing

../../../../vol/work/lerner/anaconda3/envs/transformers/lib/python3.7/site-packages/flatbuffers/compat.py:19
  /vol/work/lerner/anaconda3/envs/transformers/lib/python3.7/site-packages/flatbuffers/compat.py:19: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================== 39 passed, 13 skipped, 2 warnings in 4.10s ==================
```

Ran all the other stuff as instructed in CONTRIBUTING:
```
$ make fixup
Checking/fixing src/transformers/models/dpr/modeling_dpr.py
All done! ✨ 🍰 ✨
1 file left unchanged.
python utils/custom_init_isort.py
python utils/style_doc.py src/transformers docs/source --max_len 119
running deps_table_update
updating src/transformers/dependency_versions_table.py
python utils/check_copies.py
python utils/check_table.py
python utils/check_dummies.py
python utils/check_repo.py
Checking all models are included.
Checking all models are public.
2022-01-07 13:53:00.515988: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda/lib64
Checking all models are properly tested.
Checking all objects are properly documented.
Checking all models are in at least one auto class.
python utils/check_inits.py
python utils/tests_fetcher.py --sanity_check
$ make quality
black --check examples tests src utils
All done! ✨ 🍰 ✨
1231 files would be left unchanged.
isort --check-only examples tests src utils
Skipped 1 files
python utils/custom_init_isort.py --check_only
flake8 examples tests src utils
python utils/style_doc.py src/transformers docs/source --max_len 119 --check_only
$ make repo-consistency
python utils/check_copies.py
python utils/check_table.py
python utils/check_dummies.py
python utils/check_repo.py
Checking all models are included.
Checking all models are public.
2022-01-07 13:54:31.057343: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda/lib64
Checking all models are properly tested.
Checking all objects are properly documented.
Checking all models are in at least one auto class.
python utils/check_inits.py
python utils/tests_fetcher.py --sanity_check
```