### PR TITLE
Update Trainer code example

### DIFF
--- a/docs/source/main_classes/trainer.mdx
+++ b/docs/source/main_classes/trainer.mdx
@@ -47,22 +47,21 @@ when you use it on other models. When using it on your own model, make sure:
 
 </Tip>
 
-Here is an example of how to customize [`Trainer`] using a custom loss function for multi-label classification:
+Here is an example of how to customize [`Trainer`] to use a weighted loss (useful when you have an unbalanced training set):
 
 ```python
 from torch import nn
 from transformers import Trainer
 
-
-class MultilabelTrainer(Trainer):
+class CustomTrainer(Trainer):
     def compute_loss(self, model, inputs, return_outputs=False):
         labels = inputs.get("labels")
+        # forward pass
         outputs = model(**inputs)
-        logits = outputs.get("logits")
-        loss_fct = nn.BCEWithLogitsLoss()
-        loss = loss_fct(
-            logits.view(-1, self.model.config.num_labels), labels.float().view(-1, self.model.config.num_labels)
-        )
+        logits = outputs.get('logits')
+        # compute custom loss
+        loss_fct = nn.CrossEntropyLoss(weight=torch.tensor([1.0, 2.0, 3.0]))
+        loss = loss_fct(logits.view(-1, self.model.config.num_labels), labels.view(-1))
         return (loss, outputs) if return_outputs else loss
 ```
 

--- a/docs/source/main_classes/trainer.mdx
+++ b/docs/source/main_classes/trainer.mdx
@@ -53,12 +53,13 @@ Here is an example of how to customize [`Trainer`] to use a weighted loss (usefu
 from torch import nn
 from transformers import Trainer
 
+
 class CustomTrainer(Trainer):
     def compute_loss(self, model, inputs, return_outputs=False):
         labels = inputs.get("labels")
         # forward pass
         outputs = model(**inputs)
-        logits = outputs.get('logits')
+        logits = outputs.get("logits")
         # compute custom loss
         loss_fct = nn.CrossEntropyLoss(weight=torch.tensor([1.0, 2.0, 3.0]))
         loss = loss_fct(logits.view(-1, self.model.config.num_labels), labels.view(-1))

--- a/docs/source/main_classes/trainer.mdx
+++ b/docs/source/main_classes/trainer.mdx
@@ -60,7 +60,7 @@ class CustomTrainer(Trainer):
         # forward pass
         outputs = model(**inputs)
         logits = outputs.get("logits")
-        # compute custom loss
+        # compute custom loss (suppose one has 3 labels with different weights)
         loss_fct = nn.CrossEntropyLoss(weight=torch.tensor([1.0, 2.0, 3.0]))
         loss = loss_fct(logits.view(-1, self.model.config.num_labels), labels.view(-1))
         return (loss, outputs) if return_outputs else loss


### PR DESCRIPTION
# What does this PR do?

This PR updates the code example used in the Trainer docs. Previously, it shows how to overwrite the Trainer to do multi-label classification. However, this is not required anymore, as users can now pass the `problem_type` argument to the model's configuration (to use the appropriate loss function).

Instead, I show how to overwrite the Trainer to use a weighted loss, useful when you have an imbalanced dataset.
