### PR TITLE
TF Bert inference - support `np.ndarray` optional arguments

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1938,16 +1938,19 @@ class TFSequenceSummary(tf.keras.layers.Layer):
         return output
 
 
-def shape_list(tensor: tf.Tensor) -> List[int]:
+def shape_list(tensor: Union[tf.Tensor, np.ndarray]) -> List[int]:
     """
     Deal with dynamic shape in tensorflow cleanly.
 
     Args:
-        tensor (`tf.Tensor`): The tensor we want the shape of.
+        tensor (`tf.Tensor` or `np.ndarray`): The tensor we want the shape of.
 
     Returns:
         `List[int]`: The shape of the tensor as a list.
     """
+    if isinstance(tensor, np.ndarray):
+        return list(tensor.shape)
+
     dynamic = tf.shape(tensor)
 
     if tensor.shape == tf.TensorShape(None):

--- a/tests/test_modeling_tf_bert.py
+++ b/tests/test_modeling_tf_bert.py
@@ -26,6 +26,7 @@ from .test_modeling_tf_core import TFCoreModelTesterMixin
 
 
 if is_tf_available():
+    import numpy as np
     import tensorflow as tf
 
     from transformers import TF_MODEL_FOR_PRETRAINING_MAPPING
@@ -399,7 +400,8 @@ class TFBertModelIntegrationTest(unittest.TestCase):
     def test_inference_masked_lm(self):
         model = TFBertForPreTraining.from_pretrained("lysandre/tiny-bert-random")
         input_ids = tf.constant([[0, 1, 2, 3, 4, 5]])
-        output = model(input_ids)[0]
+        attention_mask = np.asarray([[1, 1, 1, 1, 1, 1]])
+        output = model(input_ids, attention_mask)[0]
 
         expected_shape = [1, 6, 32000]
         self.assertEqual(output.shape, expected_shape)

--- a/tests/test_modeling_tf_bert.py
+++ b/tests/test_modeling_tf_bert.py
@@ -26,7 +26,6 @@ from .test_modeling_tf_core import TFCoreModelTesterMixin
 
 
 if is_tf_available():
-    import numpy as np
     import tensorflow as tf
 
     from transformers import TF_MODEL_FOR_PRETRAINING_MAPPING
@@ -400,8 +399,7 @@ class TFBertModelIntegrationTest(unittest.TestCase):
     def test_inference_masked_lm(self):
         model = TFBertForPreTraining.from_pretrained("lysandre/tiny-bert-random")
         input_ids = tf.constant([[0, 1, 2, 3, 4, 5]])
-        attention_mask = np.asarray([[1, 1, 1, 1, 1, 1]])
-        output = model(input_ids, attention_mask)[0]
+        output = model(input_ids)[0]
 
         expected_shape = [1, 6, 32000]
         self.assertEqual(output.shape, expected_shape)

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -846,7 +846,9 @@ class TFModelTesterMixin:
             inputs = self._prepare_for_class(inputs_dict, model_class)
             inputs_np = prepare_numpy_arrays(inputs)
 
-            model(inputs_np)
+            output_for_dict_input = model(inputs_np)
+            output_for_kw_input = model(**inputs_np)
+            self.assert_outputs_same(output_for_dict_input, output_for_kw_input)
 
     def test_resize_token_embeddings(self):
         if not self.test_resize_embeddings:


### PR DESCRIPTION
# What does this PR do?

This PR allows running inference with TF Bert when the optional arguments (such as `attention_mask`) are a `np.ndarray`. Although these changes were made in response to particular issues, which were related to TF Bert, other models have the same pattern (e.g. [here](https://github.com/huggingface/transformers/blob/master/src/transformers/models/gpt2/modeling_tf_gpt2.py#L413)), so these changes may positively impact other models too.

EDIT: see root cause [here](https://github.com/huggingface/transformers/pull/15074#issuecomment-1009133852)

Fixes #14346 and #14404 

