### PR TITLE
[Fix doc example] RagModel

### DIFF
--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -305,7 +305,7 @@ class RagPreTrainedModel(PreTrainedModel):
         >>> from transformers import RagModel
 
         >>> # initialize a RAG from two pretrained models.
-        >>> model = RagModel.from_question_encoder_generator_pretrained(
+        >>> model = RagModel.from_pretrained_question_encoder_generator(
         ...     "facebook/dpr-question_encoder-single-nq-base", "t5-small"
         ... )
         >>> # saving model after fine-tuning


### PR DESCRIPTION
# What does this PR do?

This part fails
https://github.com/huggingface/transformers/blob/623b4f7c63f60cce917677ee704d6c93ee960b4b/src/transformers/models/rag/modeling_rag.py#L308-L310

Change to `from_pretrained_question_encoder_generator` instead in this PR.

## Who can review?

@patrickvonplaten 