### PR TITLE
[Fix doc example] Speech2TextForConditionalGeneration

### DIFF
--- a/src/transformers/models/speech_to_text/modeling_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/modeling_speech_to_text.py
@@ -1323,7 +1323,7 @@ class Speech2TextForConditionalGeneration(Speech2TextPreTrainedModel):
         >>> input_features = processor(
         ...     ds["speech"][0], sampling_rate=16000, return_tensors="pt"
         >>> ).input_features  # Batch size 1
-        >>> generated_ids = model.generate(input_ids=input_features)
+        >>> generated_ids = model.generate(inputs=input_features)
 
         >>> transcription = processor.batch_decode(generated_ids)
         ```"""


### PR DESCRIPTION
# What does this PR do?

This fails for `Speech2TextForConditionalGeneration`
```
>>> generated_ids = model.generate(input_ids=input_features)
```
I changed it to `model.generate(inputs=input_features)`.

## Who can review?

@patrickvonplaten 