### PR TITLE
Take gradient accumulation into account when defining samplers

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -581,7 +581,7 @@ class Trainer:
             model_input_name = self.tokenizer.model_input_names[0] if self.tokenizer is not None else None
             if self.args.world_size <= 1:
                 return LengthGroupedSampler(
-                    self.args.train_batch_size,
+                    self.args.train_batch_size * self.args.gradient_accumulation_steps,
                     dataset=self.train_dataset,
                     lengths=lengths,
                     model_input_name=model_input_name,
@@ -589,7 +589,7 @@ class Trainer:
                 )
             else:
                 return DistributedLengthGroupedSampler(
-                    self.args.train_batch_size,
+                    self.args.train_batch_size  * self.args.gradient_accumulation_steps,
                     dataset=self.train_dataset,
                     num_replicas=self.args.world_size,
                     rank=self.args.process_index,

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -589,7 +589,7 @@ class Trainer:
                 )
             else:
                 return DistributedLengthGroupedSampler(
-                    self.args.train_batch_size  * self.args.gradient_accumulation_steps,
+                    self.args.train_batch_size * self.args.gradient_accumulation_steps,
                     dataset=self.train_dataset,
                     num_replicas=self.args.world_size,
                     rank=self.args.process_index,


### PR DESCRIPTION
# What does this PR do?

This PR takes the gradient accumulation steps into account when defining samplers that use the batch size (like the `LengthGroupedSampler`) so that training with large batch size or training with smaller batch size and gradient accumulation (e.g. batch size 64 or batch size 8 and gradient accumulation steps of 8) yield the same results.

Fixes #14638 