### PR TITLE
change metric_key_prefix in seq2seq_trainer.py

### DIFF
--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -73,7 +73,7 @@ class Seq2SeqTrainer(Trainer):
         self,
         test_dataset: Dataset,
         ignore_keys: Optional[List[str]] = None,
-        metric_key_prefix: str = "eval",
+        metric_key_prefix: str = "test",
         max_length: Optional[int] = None,
         num_beams: Optional[int] = None,
     ) -> PredictionOutput:


### PR DESCRIPTION

# What does this PR do?

In the trainer, the metric_key_prefix of the predict is set as "test", and in the seq2seq trainer, it is set as "eval", so the same result does not come out.
To solve this problem, the metric_key_prefix for the seq2seq trainer was modified to "test".

## Who can review?

 --> trainer: @sgugger
