### PR TITLE
Fix cookiecutter

### DIFF
--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/{{cookiecutter.lowercase_modelname}}.mdx
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/{{cookiecutter.lowercase_modelname}}.mdx
@@ -26,10 +26,6 @@ Tips:
 
 This model was contributed by [INSERT YOUR HF USERNAME HERE](<https://huggingface.co/<INSERT YOUR HF USERNAME HERE>)`. The original code can be found [here](<INSERT LINK TO GITHUB REPO HERE>).
 
-## XLNetConfig
-
-[[autodoc]] XLNetConfig
-
 ## {{cookiecutter.camelcase_modelname}}Config
 
 [[autodoc]] {{cookiecutter.camelcase_modelname}}Config


### PR DESCRIPTION
# What does this PR do?

Super tiny fix, XLNetConfig shouldn't be in the CookieCutter template.