### PR TITLE
Cleanup load_weight_prefix in TFEncoderDecoderModel

### DIFF
--- a/src/transformers/models/encoder_decoder/modeling_tf_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_tf_encoder_decoder.py
@@ -155,7 +155,7 @@ class TFEncoderDecoderModel(TFPreTrainedModel):
     """
     config_class = EncoderDecoderConfig
     base_model_prefix = "encoder_decoder"
-    load_weight_prefix = "tf_encoder_decoder_model_1"
+    load_weight_prefix = "tf_encoder_decoder_model"
 
     def __init__(
         self,

--- a/tests/test_modeling_tf_encoder_decoder.py
+++ b/tests/test_modeling_tf_encoder_decoder.py
@@ -958,7 +958,7 @@ class TFEncoderDecoderModelSaveLoadTests(unittest.TestCase):
 
     @slow
     def test_encoder_decoder_from_pretrained(self):
-        load_weight_prefix = "tf_encoder_decoder_model_1"
+        load_weight_prefix = TFEncoderDecoderModel.load_weight_prefix
 
         config = self.get_encoder_decoder_config()
         encoder_tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")


### PR DESCRIPTION
# What does this PR do?

## Short
In `TFEncoderDecoderModel`, there is `tf_encoder_decoder_model_1` (with the strange ending `_1`)

https://github.com/huggingface/transformers/blob/68810aa26c083fd97d976cef7ac65fdd9cc9b520/src/transformers/models/encoder_decoder/modeling_tf_encoder_decoder.py#L158

This PR change it to `tf_encoder_decoder_model` to avoid confusion

## Long

I originally looked `TFRagModel` code during a (long) process to make checkpoint loading work.
While it works, it gave me the wrong impression that `_1` is necessary.

As @LysandreJik  and @NielsRogge  both asked this question

https://github.com/huggingface/transformers/pull/13222#discussion_r725279027
https://github.com/huggingface/transformers/pull/14148#discussion_r780361966

I gave it a try and also reviewed the code
https://github.com/ydshieh/transformers/blob/e68c3756fea7c811d02b8470539ae17ec3ec0e71/src/transformers/modeling_tf_utils.py#L496

It turns out that the `_1` is not necessary, and therefore the recent model `TFVisionEncoderDecoderModel` doesn't use `_1`.
To avoid further confusion (and avoid this confusion being copied in future TF composite models), I think it's better to clean it up here.

## Who can review?

 -->
