### PR TITLE
Fix QA trainer to properly log eval metrics

### DIFF
--- a/examples/pytorch/question-answering/trainer_qa.py
+++ b/examples/pytorch/question-answering/trainer_qa.py
@@ -61,7 +61,7 @@ class QuestionAnsweringTrainer(Trainer):
                 if not key.startswith(f"{metric_key_prefix}_"):
                     metrics[f"{metric_key_prefix}_{key}"] = metrics.pop(key)
 
-            self.log(metrics)
+            self.log_metrics("eval", metrics)
         else:
             metrics = {}
 

--- a/examples/pytorch/question-answering/trainer_seq2seq_qa.py
+++ b/examples/pytorch/question-answering/trainer_seq2seq_qa.py
@@ -76,7 +76,7 @@ class QuestionAnsweringSeq2SeqTrainer(Seq2SeqTrainer):
                 if not key.startswith(f"{metric_key_prefix}_"):
                     metrics[f"{metric_key_prefix}_{key}"] = metrics.pop(key)
 
-            self.log(metrics)
+            self.log_metrics("eval", metrics)
         else:
             metrics = {}
 


### PR DESCRIPTION
# What does this PR do?

This PR updates the custom `QuestionAnsweringTrainer` in the examples. Previously, the trainer used `self.log()`, which does not add a prefix `"eval"`. This was a problem especially when reporting metrics to WanDB. Without a prefix, WanDB assumes the metrics come from training data, not evaluation data.

This problem can be solved by simply changing `self.log(metrics)` to `self.log_metrics("eval", metrics)` in both `evaluate()` methods. 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->