### PR TITLE
fix: switch from slow to generic tokenizer class

### DIFF
--- a/examples/research_projects/codeparrot/scripts/bpe_training.py
+++ b/examples/research_projects/codeparrot/scripts/bpe_training.py
@@ -2,7 +2,7 @@ from datasets import load_dataset
 from tqdm import tqdm
 
 from arguments import TokenizerTrainingArguments
-from transformers import GPT2Tokenizer, HfArgumentParser
+from transformers import AutoTokenizer, HfArgumentParser
 from transformers.models.gpt2.tokenization_gpt2 import bytes_to_unicode
 
 
@@ -17,7 +17,7 @@ parser = HfArgumentParser(TokenizerTrainingArguments)
 args = parser.parse_args()
 
 # Base tokenizer
-tokenizer = GPT2Tokenizer.from_pretrained(args.base_tokenizer)
+tokenizer = AutoTokenizer.from_pretrained(args.base_tokenizer)
 base_vocab = list(bytes_to_unicode().values())
 
 # Load dataset


### PR DESCRIPTION
# What does this PR do?

This PR fixes #15077 where the slow tokenizer version is loaded which does not have a `train_new_from_iterator` method by replacing it with `AutoTokenizer` that loads the fast version by default.