### PR TITLE
[Fix doc example] - ProphetNetDecoder

### DIFF
--- a/src/transformers/models/prophetnet/modeling_prophetnet.py
+++ b/src/transformers/models/prophetnet/modeling_prophetnet.py
@@ -1471,7 +1471,6 @@ class ProphetNetDecoder(ProphetNetPreTrainedModel):
 
         >>> tokenizer = ProphetNetTokenizer.from_pretrained("microsoft/prophetnet-large-uncased")
         >>> model = ProphetNetDecoder.from_pretrained("microsoft/prophetnet-large-uncased", add_cross_attention=False)
-        >>> assert model.config.is_decoder, f"{model.__class__} has to be configured as a decoder."
         >>> inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
         >>> outputs = model(**inputs)
 


### PR DESCRIPTION
# What does this PR do?

The doc example in `ProphetNetDecoder` will fail

https://github.com/huggingface/transformers/blob/68cc4ccde25b1ed8a9b77fdf6f78c833bdff0e9c/src/transformers/models/prophetnet/modeling_prophetnet.py#L1473-L1474


ProphetNetDecoder never set `is_decoder = True`. It is set only at the level at `ProphetNetModel` and `ProphetNetForCausalLM`.

This PR removes that assertion.



