### PR TITLE
[examples/flax/language-modeling] set loglevel

### DIFF
--- a/examples/flax/language-modeling/run_mlm_flax.py
+++ b/examples/flax/language-modeling/run_mlm_flax.py
@@ -362,7 +362,7 @@ def main():
     # Setup logging
     logging.basicConfig(
         format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
-        level="NOTSET",
+        level=logging.INFO,
         datefmt="[%X]",
     )
 

--- a/examples/flax/language-modeling/run_t5_mlm_flax.py
+++ b/examples/flax/language-modeling/run_t5_mlm_flax.py
@@ -492,7 +492,7 @@ def main():
     # Setup logging
     logging.basicConfig(
         format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s",
-        level="NOTSET",
+        level=logging.INFO,
         datefmt="[%X]",
     )
 


### PR DESCRIPTION
This PR sets the unset loglevel to a `info` like the rest of flax examples where it wasn't done so.

Fixes a report in https://github.com/huggingface/transformers/pull/14909#issuecomment-1011467609

@patil-suraj, @sgugger 
