### PR TITLE
[Fix doc example] - OpenAIGPTDoubleHeadsModel

### DIFF
--- a/src/transformers/models/openai/modeling_openai.py
+++ b/src/transformers/models/openai/modeling_openai.py
@@ -687,7 +687,7 @@ class OpenAIGPTDoubleHeadsModel(OpenAIGPTPreTrainedModel):
         >>> mc_token_ids = torch.tensor([input_ids.size(-1) - 1, input_ids.size(-1) - 1]).unsqueeze(0)  # Batch size 1
 
         >>> outputs = model(input_ids, mc_token_ids=mc_token_ids)
-        >>> lm_logits = outputs.lm_logits
+        >>> lm_logits = outputs.logits
         >>> mc_logits = outputs.mc_logits
         ```"""
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict


### PR DESCRIPTION
# What does this PR do?

This line fails

https://github.com/huggingface/transformers/blob/7b83feb50a8965e9d8f13b6c4042239710b97c76/src/transformers/models/openai/modeling_openai.py#L690

Should change from `lm_logits` to `logits` (See `OpenAIGPTDoubleHeadsModelOutput`)

## Who can review

@patrickvonplaten, @LysandreJik