### PR TITLE
[deepspeed tests] fix summarization

### DIFF
--- a/tests/deepspeed/test_model_zoo.py
+++ b/tests/deepspeed/test_model_zoo.py
@@ -157,6 +157,7 @@ def make_task_cmds():
         --train_file {data_dir_xsum}/sample.json
         --max_source_length 12
         --max_target_length 12
+        --lang en
         """,
         clm=f"""
         {scripts_dir}/language-modeling/run_clm.py


### PR DESCRIPTION
https://github.com/huggingface/transformers/pull/15125 has broken deepspeed tests by introducing a new required flag in summarization examples. This PR adapts to this change.