### PR TITLE
[Fix doc example] UniSpeechSatForPreTraining

### DIFF
--- a/src/transformers/models/unispeech_sat/modeling_unispeech_sat.py
+++ b/src/transformers/models/unispeech_sat/modeling_unispeech_sat.py
@@ -1298,13 +1298,13 @@ class UniSpeechSatForPreTraining(UniSpeechSatPreTrainedModel):
 
         ```python
         >>> import torch
-        >>> from transformers import UniSpeechSatFeatureEncoder, UniSpeechSatForPreTraining
+        >>> from transformers import Wav2Vec2FeatureExtractor, UniSpeechSatForPreTraining
         >>> from transformers.models.unispeech_sat.modeling_unispeech_sat import _compute_mask_indices
         >>> from datasets import load_dataset
         >>> import soundfile as sf
 
-        >>> feature_extractor = UniSpeechSatFeatureEncoder.from_pretrained("patrickvonplaten/unispeech_sat-base")
-        >>> model = UniSpeechSatForPreTraining.from_pretrained("patrickvonplaten/unispeech_sat-base")
+        >>> feature_extractor = Wav2Vec2FeatureExtractor.from_pretrained("microsoft/unispeech_sat-base")
+        >>> model = UniSpeechSatForPreTraining.from_pretrained("microsoft/unispeech_sat-base")
 
 
         >>> def map_to_array(batch):

--- a/src/transformers/models/unispeech_sat/modeling_unispeech_sat.py
+++ b/src/transformers/models/unispeech_sat/modeling_unispeech_sat.py
@@ -1303,8 +1303,8 @@ class UniSpeechSatForPreTraining(UniSpeechSatPreTrainedModel):
         >>> from datasets import load_dataset
         >>> import soundfile as sf
 
-        >>> feature_extractor = Wav2Vec2FeatureExtractor.from_pretrained("microsoft/unispeech_sat-base")
-        >>> model = UniSpeechSatForPreTraining.from_pretrained("microsoft/unispeech_sat-base")
+        >>> feature_extractor = Wav2Vec2FeatureExtractor.from_pretrained("microsoft/unispeech-sat-base")
+        >>> model = UniSpeechSatForPreTraining.from_pretrained("microsoft/unispeech-sat-base")
 
 
         >>> def map_to_array(batch):


### PR DESCRIPTION
# What does this PR do?

In `UniSpeechSatForPreTraining`, this doc example fails

```
>>> feature_extractor = UniSpeechSatFeatureEncoder.from_pretrained("patrickvonplaten/unispeech_sat-base")
>>> model = UniSpeechSatForPreTraining.from_pretrained("patrickvonplaten/unispeech_sat-base")
```
(can't find this checkpoint on the Hub)

This PR changes it to

```
>>> feature_extractor = Wav2Vec2FeatureExtractor.from_pretrained("microsoft/unispeech-sat-base")
>>> model = UniSpeechSatForPreTraining.from_pretrained("microsoft/unispeech-sat-base")
```

## Who can review

@patrickvonplaten 