### PR TITLE
Fixing flaky test (hopefully).

### DIFF
--- a/src/transformers/pipelines/question_answering.py
+++ b/src/transformers/pipelines/question_answering.py
@@ -439,7 +439,7 @@ class QuestionAnsweringPipeline(ChunkPipeline):
                 # the left hand side, since now we have different offsets
                 # everywhere.
                 if self.tokenizer.padding_side == "left":
-                    offset = (output["input_ids"] == self.tokenizer.pad_token_id).sum().item()
+                    offset = (output["input_ids"] == self.tokenizer.pad_token_id).numpy().sum()
                 else:
                     offset = 0
 

--- a/src/transformers/pipelines/question_answering.py
+++ b/src/transformers/pipelines/question_answering.py
@@ -434,11 +434,22 @@ class QuestionAnsweringPipeline(ChunkPipeline):
                 question_first = bool(self.tokenizer.padding_side == "right")
                 enc = output["encoding"]
 
+                # Encoding was *not* padded, input_ids *might*.
+                # It doesn't make a difference unless we're padding on
+                # the left hand side, since now we have different offsets
+                # everywhere.
+                if self.tokenizer.padding_side == "left":
+                    offset = (output["input_ids"] == self.tokenizer.pad_token_id).sum().item()
+                else:
+                    offset = 0
+
                 # Sometimes the max probability token is in the middle of a word so:
                 # - we start by finding the right word containing the token with `token_to_word`
                 # - then we convert this word in a character span with `word_to_chars`
                 sequence_index = 1 if question_first else 0
                 for s, e, score in zip(starts, ends, scores):
+                    s = s - offset
+                    e = e - offset
                     try:
                         start_word = enc.token_to_word(s)
                         end_word = enc.token_to_word(e)


### PR DESCRIPTION
# What does this PR do?

Fixed flaky test:

```
RUN_PIPELINE_TESTS=1 pytest -sv tests/test_pipelines_question_answering.py::QAPipelineTests::test_pt_XLNetConfig_XLNetForQuestionAnsweringSimple_XLNetTokenizer_nofeature_extractor
```

This was a real bug (contrary to `p_mask` invalid padding which was linked to a bad rebase).

Basically, qa pipeline can handle batching, but since there are some many elements being passed around everywhere in that pipeline, some get padded (tensors), some not(everything else), leading to issues down the line.

It was silent for most pipeline side padding is on the right (no issues for valid offsets) but XLNET has padding_side on the left, meaning the offsets were wrong:
 `input_ids = [pad pad, h, i]` and `offsets = [(0, 1), (1, 2)]`
 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->