### PR TITLE
Fix RuntimeError on generation_utils.py

### DIFF
--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -1961,7 +1961,7 @@ class GenerationMixin:
                 next_token_scores, 2 * num_beams, dim=1, largest=True, sorted=True
             )
 
-            next_indices = (next_tokens / vocab_size).long()
+            next_indices = torch.true_divide(next_tokens, vocab_size).long()
             next_tokens = next_tokens % vocab_size
 
             # stateless


### PR DESCRIPTION
This PR fixes a below runtime error on generation_utils.py

```
RuntimeError: Integer division of tensors using div or / is no longer supported, and in a future release div will perform true division as in Python 3. Use true_divide or floor_divide (// in Python) instead.
```