### PR TITLE
Fix encoder-decoder models when labels is passed

### DIFF
--- a/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
@@ -523,7 +523,7 @@ class EncoderDecoderModel(PreTrainedModel):
         loss = None
         if labels is not None:
             warnings.warn(DEPRECATION_WARNING, FutureWarning)
-            logits = decoder_outputs.logits if return_dict else decoder_outputs[1]
+            logits = decoder_outputs.logits if return_dict else decoder_outputs[0]
             loss_fct = CrossEntropyLoss()
             loss = loss_fct(logits.reshape(-1, self.decoder.config.vocab_size), labels.view(-1))
 

--- a/src/transformers/models/speech_encoder_decoder/modeling_speech_encoder_decoder.py
+++ b/src/transformers/models/speech_encoder_decoder/modeling_speech_encoder_decoder.py
@@ -543,7 +543,7 @@ class SpeechEncoderDecoderModel(PreTrainedModel):
         # Compute loss independent from decoder (as some shift the logits inside them)
         loss = None
         if labels is not None:
-            logits = decoder_outputs.logits if return_dict else decoder_outputs[1]
+            logits = decoder_outputs.logits if return_dict else decoder_outputs[0]
             loss_fct = CrossEntropyLoss()
             loss = loss_fct(logits.reshape(-1, self.decoder.config.vocab_size), labels.view(-1))
 

--- a/src/transformers/models/vision_encoder_decoder/modeling_vision_encoder_decoder.py
+++ b/src/transformers/models/vision_encoder_decoder/modeling_vision_encoder_decoder.py
@@ -497,7 +497,7 @@ class VisionEncoderDecoderModel(PreTrainedModel):
         # Compute loss independent from decoder (as some shift the logits inside them)
         loss = None
         if labels is not None:
-            logits = decoder_outputs.logits if return_dict else decoder_outputs[1]
+            logits = decoder_outputs.logits if return_dict else decoder_outputs[0]
             loss_fct = CrossEntropyLoss()
             loss = loss_fct(logits.reshape(-1, self.decoder.config.vocab_size), labels.view(-1))
 


### PR DESCRIPTION
# What does this PR do?

Fix encoder-decoder models when labels is passed and `return_dict` is `False`.

## Details

This line 

https://github.com/huggingface/transformers/blob/669e3c50c98ad5b506555a551d2ecbf72ceb3c99/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py#L526

fails when `labels` is passed to `EncoderDecoderModel` + `return_dict = False`
Since we don't pass `labels` to decoder, `decoder_outputs` won't return `loss`. When `return_dict` is `False`, `logits` will be the first element in the returned tuple `decoder_outputs`.

## The issue

```
import os, tempfile
from transformers import EncoderDecoderModel, BertConfig, AutoTokenizer, BertModel, BertLMHeadModel


config = BertConfig(num_hidden_layers=2, hidden_size=4, num_attention_heads=2, intermediate_size=4)
enc = BertModel(config)
dec = BertLMHeadModel(config)

with tempfile.TemporaryDirectory() as tmpdir:
    enc.save_pretrained(os.path.join(tmpdir, "enc"))
    dec.save_pretrained(os.path.join(tmpdir, "dec"))
    enc_dec = EncoderDecoderModel.from_encoder_decoder_pretrained(
        os.path.join(tmpdir, "enc"), os.path.join(tmpdir, "dec")
    )

enc_dec.config.pad_token_id = 0
enc_dec.config.decoder_start_token_id = 1

tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")

enc_text = "i love cats"
dec_text = "my cat is cute"

enc_inputs = tokenizer(enc_text, return_tensors="pt")
dec_inputs = tokenizer(dec_text, return_tensors="pt")

# This fails
inputs = {
    "input_ids": enc_inputs["input_ids"],
    "labels": dec_inputs["input_ids"]
}
outputs = enc_dec(**inputs, return_dict=False)
```
This gives the error
```
    loss = loss_fct(logits.reshape(-1, self.decoder.config.vocab_size), labels.view(-1))
AttributeError: 'tuple' object has no attribute 'reshape'
```

## Who can review?

@NielsRogge 