### PR TITLE
Fix dtype issue in TF BART

### DIFF
--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -1383,7 +1383,7 @@ class TFBartForConditionalGeneration(TFBartPretrainedModel, TFCausalLanguageMode
         if inputs["labels"] is not None:
             inputs["labels"] = tf.where(
                 inputs["labels"] == self.config.pad_token_id,
-                tf.fill(shape_list(inputs["labels"]), -100),
+                tf.cast(tf.fill(shape_list(inputs["labels"]), -100), inputs["labels"].dtype),
                 inputs["labels"],
             )
             inputs["use_cache"] = False


### PR DESCRIPTION
Fixes an issue in BART caused by implicit casting of Python ints to tf.int32, when other inputs are tf.int64. We usually get away with this, but tf.where() requires both inputs to have the same dtype.