### PR TITLE
Fix incorrect max_seq_length bug in pytorch training scripts

### DIFF
--- a/examples/pytorch/language-modeling/run_mlm.py
+++ b/examples/pytorch/language-modeling/run_mlm.py
@@ -377,12 +377,12 @@ def main():
             )
             max_seq_length = 1024
     else:
-        if data_args.max_seq_length > tokenizer.model_max_length:
+        if data_args.max_seq_length > config.max_position_embeddings:
             logger.warning(
                 f"The max_seq_length passed ({data_args.max_seq_length}) is larger than the maximum length for the"
-                f"model ({tokenizer.model_max_length}). Using max_seq_length={tokenizer.model_max_length}."
+                f"model ({config.max_position_embeddings}). Using max_seq_length={config.max_position_embeddings}."
             )
-        max_seq_length = min(data_args.max_seq_length, tokenizer.model_max_length)
+        max_seq_length = min(data_args.max_seq_length, config.max_position_embeddings)
 
     if data_args.line_by_line:
         # When using line_by_line, we just tokenize each nonempty line.


### PR DESCRIPTION
# What does this PR do?

Fixes #15181 

Input sequences are not correctly truncated to the correct length in the `run_mlm.py` script. Even if a model can support large sequence lengths (such as 1024 or 2048), the sequences are truncated to the tokenizer's default `model_max_length`. This bug is described [here](https://github.com/huggingface/transformers/issues/15181).

This pull request fixes this bug by comparing the `max_seq_length` passed by the user to the maximum sequence length supported by the model (`config.max_position_embeddings`), and sets `max_seq_length = min(data_args.max_seq_length, config.max_position_embeddings)`

If this is the correct fix, I can make the same change in other pytorch training scripts such as [run_plm.py](https://github.com/huggingface/transformers/blob/9a2dabae7002258e41419491c73dd43ad61b5de7/examples/pytorch/language-modeling/run_plm.py#L363), [run_qa.py](https://github.com/huggingface/transformers/blob/9a2dabae7002258e41419491c73dd43ad61b5de7/examples/pytorch/question-answering/run_qa.py#L333), etc.

## Who can review?

@NielsRogge @LysandreJik @sgugger 