### PR TITLE
Error when code examples are improperly closed

### DIFF
--- a/utils/style_doc.py
+++ b/utils/style_doc.py
@@ -445,6 +445,9 @@ def style_mdx_file(mdx_file, max_len=119, check_only=False):
         else:
             new_lines.append(line)
 
+    if in_code:
+        raise ValueError(f"There was a problem when styling {mdx_file}. A code block is opened without being closed.")
+
     clean_content = "\n".join(new_lines)
     diff = clean_content != content
     if not check_only and diff:


### PR DESCRIPTION
# What does this PR do?

When an MDX file has a code sample that is not properly closed, the doc styler ends up removing part of that file. This PR addresses that problem by raising an error before the file is overwritten, so the user knows what's wrong and can fix it.