### PR TITLE
Mark bad tokenizers version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ _deps = [
     "tf2onnx",
     "timeout-decorator",
     "timm",
-    "tokenizers>=0.10.1",
+    "tokenizers>=0.10.1,!=0.11.3",
     "torch>=1.0",
     "torchaudio",
     "pyctcdecode>=0.2.0",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -59,7 +59,7 @@ deps = {
     "tf2onnx": "tf2onnx",
     "timeout-decorator": "timeout-decorator",
     "timm": "timm",
-    "tokenizers": "tokenizers>=0.10.1",
+    "tokenizers": "tokenizers>=0.10.1,!=0.11.3",
     "torch": "torch>=1.0",
     "torchaudio": "torchaudio",
     "pyctcdecode": "pyctcdecode>=0.2.0",


### PR DESCRIPTION
# What does this PR do?

Last release of tokenizers breaks many tests, this makes sure the bad version is not installed.