### PR TITLE
Ignore empty subfolders when identifying submodules

### DIFF
--- a/utils/check_inits.py
+++ b/utils/check_inits.py
@@ -215,7 +215,7 @@ def get_transformers_submodules():
             if folder.startswith("_"):
                 directories.remove(folder)
                 continue
-            # Ignore leftovers from branches (empty fodlers apart from pycache)
+            # Ignore leftovers from branches (empty folders apart from pycache)
             if len(list((Path(path) / folder).glob("*.py"))) == 0:
                 continue
             short_path = str((Path(path) / folder).relative_to(PATH_TO_TRANSFORMERS))

--- a/utils/check_inits.py
+++ b/utils/check_inits.py
@@ -211,8 +211,12 @@ def get_transformers_submodules():
     submodules = []
     for path, directories, files in os.walk(PATH_TO_TRANSFORMERS):
         for folder in directories:
+            # Ignore private modules
             if folder.startswith("_"):
                 directories.remove(folder)
+                continue
+            # Ignore leftovers from branches (empty fodlers apart from pycache)
+            if len(list((Path(path) / folder).glob("*.py"))) == 0:
                 continue
             short_path = str((Path(path) / folder).relative_to(PATH_TO_TRANSFORMERS))
             submodule = short_path.replace(os.path.sep, ".")


### PR DESCRIPTION
# What does this PR do?

As point out by @NielsRogge, when someone has an empty subfolder with just pycache in them (after checking out a branch for instance), the new check in `check_inits` will fail. This PR addresses that.