### PR TITLE
Fixes tf_default_data_collator sometimes guessing the wrong dtype for labels

### DIFF
--- a/tests/test_data_collator.py
+++ b/tests/test_data_collator.py
@@ -353,6 +353,14 @@ class TFDataCollatorIntegrationTest(unittest.TestCase):
         self.assertEqual(batch["labels"].dtype, tf.int64)
         self.assertEqual(batch["inputs"].shape.as_list(), [8, 10])
 
+    def test_numpy_dtype_preservation(self):
+        data_collator = default_data_collator
+
+        # Confirms that numpy inputs are handled correctly even when scalars
+        features = [{"input_ids": np.array([0, 1, 2, 3, 4]), "label": np.int64(i)} for i in range(4)]
+        batch = data_collator(features, return_tensors="tf")
+        self.assertEqual(batch["labels"].dtype, tf.int64)
+
     def test_default_classification_and_regression(self):
         data_collator = default_data_collator
 


### PR DESCRIPTION
Fixes issues reported by @philschmid in [this notebook](https://colab.research.google.com/drive/13nMZPJpgJpqzdl2e5t4cnV26m_l2xwlw?usp=sharing) with `labels` occasionally ending up as `tf.float32` instead of `tf.int64`. 

The underlying cause was that the `dtype` checking code failed in cases when the label for a single example was a Numpy scalar - this caused `isinstance(np.ndarray)` to return `False`. Adding `or isinstance(np.generic)` correctly catches Numpy scalars as well as arrays.