### PR TITLE
[Fix doc example] missing import

### DIFF
--- a/src/transformers/models/encoder_decoder/modeling_tf_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_tf_encoder_decoder.py
@@ -260,6 +260,7 @@ class TFEncoderDecoderModel(TFPreTrainedModel):
         ```python
         >>> # a workaround to load from pytorch checkpoint
         >>> from transformers import EncoderDecoderModel, TFEncoderDecoderModel
+
         >>> _model = EncoderDecoderModel.from_pretrained("patrickvonplaten/bert2bert-cnn_dailymail-fp16")
         >>> _model.encoder.save_pretrained("./encoder")
         >>> _model.decoder.save_pretrained("./decoder")

--- a/src/transformers/models/encoder_decoder/modeling_tf_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_tf_encoder_decoder.py
@@ -259,6 +259,7 @@ class TFEncoderDecoderModel(TFPreTrainedModel):
 
         ```python
         >>> # a workaround to load from pytorch checkpoint
+        >>> from transformers import EncoderDecoderModel, TFEncoderDecoderModel
         >>> _model = EncoderDecoderModel.from_pretrained("patrickvonplaten/bert2bert-cnn_dailymail-fp16")
         >>> _model.encoder.save_pretrained("./encoder")
         >>> _model.decoder.save_pretrained("./decoder")


### PR DESCRIPTION
# What does this PR do?

Add `from transformers import EncoderDecoderModel, TFEncoderDecoderModel` in a doc example.