### PR TITLE
Add soft length regulation for sequence generation

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -295,12 +295,7 @@ class PretrainedConfig(PushToHubMixin):
         self.forced_bos_token_id = kwargs.pop("forced_bos_token_id", None)
         self.forced_eos_token_id = kwargs.pop("forced_eos_token_id", None)
         self.remove_invalid_values = kwargs.pop("remove_invalid_values", False)
-<<<<<<< HEAD
         self.exponential_decay_length_penalty = kwargs.pop("exponential_decay_length_penalty", None)
-=======
-        self.length_regulation_start = kwargs.pop("length_regulation_start", None)
-        self.length_regulation_factor = kwargs.pop("length_regulation_factor", None)
->>>>>>> 00987e5dd (add possibility to softly regulate length when using sampling method in model.generate() function)
 
         # Fine-tuning task arguments
         self.architectures = kwargs.pop("architectures", None)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -295,7 +295,12 @@ class PretrainedConfig(PushToHubMixin):
         self.forced_bos_token_id = kwargs.pop("forced_bos_token_id", None)
         self.forced_eos_token_id = kwargs.pop("forced_eos_token_id", None)
         self.remove_invalid_values = kwargs.pop("remove_invalid_values", False)
+<<<<<<< HEAD
         self.exponential_decay_length_penalty = kwargs.pop("exponential_decay_length_penalty", None)
+=======
+        self.length_regulation_start = kwargs.pop("length_regulation_start", None)
+        self.length_regulation_factor = kwargs.pop("length_regulation_factor", None)
+>>>>>>> 89b0ef0bf (add possibility to softly regulate length when using sampling method in model.generate() function)
 
         # Fine-tuning task arguments
         self.architectures = kwargs.pop("architectures", None)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -295,6 +295,8 @@ class PretrainedConfig(PushToHubMixin):
         self.forced_bos_token_id = kwargs.pop("forced_bos_token_id", None)
         self.forced_eos_token_id = kwargs.pop("forced_eos_token_id", None)
         self.remove_invalid_values = kwargs.pop("remove_invalid_values", False)
+        self.length_regulation_start = kwargs.pop("length_regulation_start", None)
+        self.length_regulation_factor = kwargs.pop("length_regulation_factor", None)
 
         # Fine-tuning task arguments
         self.architectures = kwargs.pop("architectures", None)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -295,12 +295,7 @@ class PretrainedConfig(PushToHubMixin):
         self.forced_bos_token_id = kwargs.pop("forced_bos_token_id", None)
         self.forced_eos_token_id = kwargs.pop("forced_eos_token_id", None)
         self.remove_invalid_values = kwargs.pop("remove_invalid_values", False)
-<<<<<<< HEAD
         self.exponential_decay_length_penalty = kwargs.pop("exponential_decay_length_penalty", None)
-=======
-        self.length_regulation_start = kwargs.pop("length_regulation_start", None)
-        self.length_regulation_factor = kwargs.pop("length_regulation_factor", None)
->>>>>>> 89b0ef0bf (add possibility to softly regulate length when using sampling method in model.generate() function)
 
         # Fine-tuning task arguments
         self.architectures = kwargs.pop("architectures", None)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -295,8 +295,7 @@ class PretrainedConfig(PushToHubMixin):
         self.forced_bos_token_id = kwargs.pop("forced_bos_token_id", None)
         self.forced_eos_token_id = kwargs.pop("forced_eos_token_id", None)
         self.remove_invalid_values = kwargs.pop("remove_invalid_values", False)
-        self.length_regulation_start = kwargs.pop("length_regulation_start", None)
-        self.length_regulation_factor = kwargs.pop("length_regulation_factor", None)
+        self.exponential_decay_length_penalty = kwargs.pop("exponential_decay_length_penalty", None)
 
         # Fine-tuning task arguments
         self.architectures = kwargs.pop("architectures", None)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -295,7 +295,12 @@ class PretrainedConfig(PushToHubMixin):
         self.forced_bos_token_id = kwargs.pop("forced_bos_token_id", None)
         self.forced_eos_token_id = kwargs.pop("forced_eos_token_id", None)
         self.remove_invalid_values = kwargs.pop("remove_invalid_values", False)
+<<<<<<< HEAD
         self.exponential_decay_length_penalty = kwargs.pop("exponential_decay_length_penalty", None)
+=======
+        self.length_regulation_start = kwargs.pop("length_regulation_start", None)
+        self.length_regulation_factor = kwargs.pop("length_regulation_factor", None)
+>>>>>>> 00987e5dd (add possibility to softly regulate length when using sampling method in model.generate() function)
 
         # Fine-tuning task arguments
         self.architectures = kwargs.pop("architectures", None)

--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -656,8 +656,8 @@ class ExponentialDecayLengthPenalty(LogitsProcessor):
 
     Args:
         exponential_decay_length_penalty (`tuple(int, float)`, *optional*):
-            This tuple shall consist of: `(start_index, decay_factor)` where `start_index` indicates where
-            penalty starts and `decay_factor` represents the factor of exponential decay
+            This tuple shall consist of: `(start_index, decay_factor)` where `start_index` indicates where penalty
+            starts and `decay_factor` represents the factor of exponential decay
         eos_token_id (`int`):
             The id of the *end-of-sequence* token.
     """

--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -660,10 +660,12 @@ class ExponentialDecayLengthPenalty(LogitsProcessor):
             starts and `decay_factor` represents the factor of exponential decay
         eos_token_id (`int`):
             The id of the *end-of-sequence* token.
+        input_ids_seq_length (`int`):
+            The length of the input sequence.
     """
 
-    def __init__(self, exponential_decay_length_penalty: Tuple, eos_token_id: int, input_ids: torch.LongTensor):
-        self.regulation_start = exponential_decay_length_penalty[0] + input_ids.shape[-1]
+    def __init__(self, exponential_decay_length_penalty: Tuple, eos_token_id: int, input_ids_seq_length: int):
+        self.regulation_start = exponential_decay_length_penalty[0] + input_ids_seq_length
         self.regulation_factor = exponential_decay_length_penalty[1]
         self.eos_token_id = eos_token_id
 

--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -15,7 +15,8 @@
 
 import inspect
 import math
-from typing import Callable, Iterable, List, Optional
+from abc import ABC
+from typing import Callable, Iterable, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -649,7 +650,7 @@ class InfNanRemoveLogitsProcessor(LogitsProcessor):
         return scores
 
 
-class SoftLengthLogitsProcessor(LogitsProcessor):
+class ExponentialDecayLengthPenalty(LogitsProcessor):
     r"""
     [`LogitsProcessor`] that exponentially increases the score of the eos_token_id after regulation_start has been
     reached.
@@ -663,9 +664,9 @@ class SoftLengthLogitsProcessor(LogitsProcessor):
             The id of the *end-of-sequence* token.
     """
 
-    def __init__(self, regulation_start: int, regulation_factor: int, eos_token_id: int):
-        self.regulation_start = regulation_start
-        self.regulation_factor = regulation_factor
+    def __init__(self, exponential_decay_length_penalty: Tuple, eos_token_id: int):
+        self.regulation_start = exponential_decay_length_penalty[0]
+        self.regulation_factor = exponential_decay_length_penalty[1]
         self.eos_token_id = eos_token_id
 
     def __call__(self, input_ids: torch.Tensor, scores: torch.Tensor) -> torch.FloatTensor:

--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -655,10 +655,9 @@ class ExponentialDecayLengthPenalty(LogitsProcessor):
     reached.
 
     Args:
-        regulation_start (`int`):
-            The index of the token to start the exponential increase.
-        regulation_factor (`float`):
-            The factor of the exponential increase.
+        exponential_decay_length_penalty (`tuple(int, float)`, *optional*):
+            This tuple shall consist of: `(start_index, decay_factor)` where `start_index` indicates where
+            penalty starts and `decay_factor` represents the factor of exponential decay
         eos_token_id (`int`):
             The id of the *end-of-sequence* token.
     """

--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -664,8 +664,8 @@ class ExponentialDecayLengthPenalty(LogitsProcessor):
             The id of the *end-of-sequence* token.
     """
 
-    def __init__(self, exponential_decay_length_penalty: Tuple, eos_token_id: int):
-        self.regulation_start = exponential_decay_length_penalty[0]
+    def __init__(self, exponential_decay_length_penalty: Tuple, eos_token_id: int, input_ids: torch.LongTensor):
+        self.regulation_start = exponential_decay_length_penalty[0] + input_ids.shape[-1]
         self.regulation_factor = exponential_decay_length_penalty[1]
         self.eos_token_id = eos_token_id
 

--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -15,6 +15,10 @@
 
 import inspect
 import math
+<<<<<<< HEAD
+=======
+from abc import ABC
+>>>>>>> 4c53400ff (change param to tuple, add test)
 from typing import Callable, Iterable, List, Optional, Tuple
 
 import numpy as np
@@ -663,8 +667,13 @@ class ExponentialDecayLengthPenalty(LogitsProcessor):
             The id of the *end-of-sequence* token.
     """
 
+<<<<<<< HEAD
     def __init__(self, exponential_decay_length_penalty: Tuple, eos_token_id: int, input_ids: torch.LongTensor):
         self.regulation_start = exponential_decay_length_penalty[0] + input_ids.shape[-1]
+=======
+    def __init__(self, exponential_decay_length_penalty: Tuple, eos_token_id: int):
+        self.regulation_start = exponential_decay_length_penalty[0]
+>>>>>>> 4c53400ff (change param to tuple, add test)
         self.regulation_factor = exponential_decay_length_penalty[1]
         self.eos_token_id = eos_token_id
 

--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -647,3 +647,27 @@ class InfNanRemoveLogitsProcessor(LogitsProcessor):
         scores[scores == float("inf")] = torch.finfo(scores.dtype).max
 
         return scores
+
+class SoftLengthLogitsProcessor(LogitsProcessor):
+    r"""
+    [`LogitsProcessor`] that exponentially increases the score of the eos_token_id after regulation_start has been reached.
+
+    Args:
+        regulation_start (`int`):
+            The index of the token to start the exponential increase.
+        regulation_factor (`float`):
+            The factor of the exponential increase.
+        eos_token_id (`int`):
+            The id of the token to force as the last generated token when `max_length` is reached.
+    """
+
+    def __init__(self, regulation_start: int, regulation_factor: int, eos_token_id: int):
+        self.regulation_start = regulation_start
+        self.regulation_factor = regulation_factor
+        self.eos_token_id = eos_token_id
+
+    def __call__(self, input_ids: torch.Tensor, scores: torch.Tensor) -> torch.FloatTensor:
+        cur_len = input_ids.shape[-1]
+        if cur_len > self.regulation_start:
+            scores[:, self.eos_token_id] = scores[:, self.eos_token_id] * pow(self.regulation_factor, cur_len-self.regulation_start)
+        return scores

--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -660,7 +660,7 @@ class SoftLengthLogitsProcessor(LogitsProcessor):
         regulation_factor (`float`):
             The factor of the exponential increase.
         eos_token_id (`int`):
-            The id of the token to force as the last generated token when `max_length` is reached.
+            The id of the *end-of-sequence* token.
     """
 
     def __init__(self, regulation_start: int, regulation_factor: int, eos_token_id: int):

--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -15,10 +15,6 @@
 
 import inspect
 import math
-<<<<<<< HEAD
-=======
-from abc import ABC
->>>>>>> 4c53400ff (change param to tuple, add test)
 from typing import Callable, Iterable, List, Optional, Tuple
 
 import numpy as np
@@ -667,13 +663,8 @@ class ExponentialDecayLengthPenalty(LogitsProcessor):
             The id of the *end-of-sequence* token.
     """
 
-<<<<<<< HEAD
     def __init__(self, exponential_decay_length_penalty: Tuple, eos_token_id: int, input_ids: torch.LongTensor):
         self.regulation_start = exponential_decay_length_penalty[0] + input_ids.shape[-1]
-=======
-    def __init__(self, exponential_decay_length_penalty: Tuple, eos_token_id: int):
-        self.regulation_start = exponential_decay_length_penalty[0]
->>>>>>> 4c53400ff (change param to tuple, add test)
         self.regulation_factor = exponential_decay_length_penalty[1]
         self.eos_token_id = eos_token_id
 

--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -15,7 +15,6 @@
 
 import inspect
 import math
-from abc import ABC
 from typing import Callable, Iterable, List, Optional, Tuple
 
 import numpy as np

--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -648,6 +648,7 @@ class InfNanRemoveLogitsProcessor(LogitsProcessor):
 
         return scores
 
+
 class SoftLengthLogitsProcessor(LogitsProcessor):
     r"""
     [`LogitsProcessor`] that exponentially increases the score of the eos_token_id after regulation_start has been reached.
@@ -669,5 +670,7 @@ class SoftLengthLogitsProcessor(LogitsProcessor):
     def __call__(self, input_ids: torch.Tensor, scores: torch.Tensor) -> torch.FloatTensor:
         cur_len = input_ids.shape[-1]
         if cur_len > self.regulation_start:
-            scores[:, self.eos_token_id] = scores[:, self.eos_token_id] * pow(self.regulation_factor, cur_len-self.regulation_start)
+            scores[:, self.eos_token_id] = scores[:, self.eos_token_id] * pow(
+                self.regulation_factor, cur_len - self.regulation_start
+            )
         return scores

--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -651,7 +651,8 @@ class InfNanRemoveLogitsProcessor(LogitsProcessor):
 
 class SoftLengthLogitsProcessor(LogitsProcessor):
     r"""
-    [`LogitsProcessor`] that exponentially increases the score of the eos_token_id after regulation_start has been reached.
+    [`LogitsProcessor`] that exponentially increases the score of the eos_token_id after regulation_start has been
+    reached.
 
     Args:
         regulation_start (`int`):

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -983,8 +983,8 @@ class GenerationMixin:
                 Whether to continue running the while loop until max_length (needed for ZeRO stage 3)
             exponential_decay_length_penalty (`tuple(int, float)`, *optional*):
                 This Tuple adds an exponentially increasing length penalty, after a certain amount of tokens have been
-                generated. The tuple shall consist of: `(start_index, decay_factor)` where `start_index` indicates where
-                penalty starts and `decay_factor` represents the factor of exponential decay
+                generated. The tuple shall consist of: `(start_index, decay_factor)` where `start_index` indicates
+                where penalty starts and `decay_factor` represents the factor of exponential decay
 
             model_kwargs:
                 Additional model specific kwargs will be forwarded to the `forward` function of the model. If the model

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -738,7 +738,9 @@ class GenerationMixin:
         if remove_invalid_values is True:
             processors.append(InfNanRemoveLogitsProcessor())
         if exponential_decay_length_penalty is not None:
-            processors.append(ExponentialDecayLengthPenalty(exponential_decay_length_penalty, eos_token_id, input_ids_seq_length))
+            processors.append(
+                ExponentialDecayLengthPenalty(exponential_decay_length_penalty, eos_token_id, input_ids_seq_length)
+            )
         processors = self._merge_criteria_processor_list(processors, logits_processor)
         return processors
 

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -17,6 +17,7 @@
 import inspect
 import warnings
 from dataclasses import dataclass
+from lib2to3.pgen2.token import OP
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
@@ -39,7 +40,6 @@ from .generation_logits_process import (
     NoRepeatNGramLogitsProcessor,
     PrefixConstrainedLogitsProcessor,
     RepetitionPenaltyLogitsProcessor,
-    SoftLengthLogitsProcessor,
     TemperatureLogitsWarper,
     TopKLogitsWarper,
     TopPLogitsWarper,

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -982,11 +982,8 @@ class GenerationMixin:
                 Whether to continue running the while loop until max_length (needed for ZeRO stage 3)
             exponential_decay_length_penalty (`Tuple`, *optional*):
                 This Tuple adds an exponentially increasing length penalty, after a certain amount of tokens have been
-                generated. The tuple shall consists of: (start_index, decay_factor) where:
-                start_index (`int`): Index where penalty starts, input tokens are ignored
-                decay_factor (`float`): factor of exponential decay
-            length_regulation_factor (`int`, *optional*):
-                Growth factor of soft length regulation (exponential increase of EOS)
+                generated. The tuple shall consist of: (start_index, decay_factor) where start_index indicates where
+                penalty starts and decay_factor represents the factor of exponential decay
 
             model_kwargs:
                 Additional model specific kwargs will be forwarded to the `forward` function of the model. If the model

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -1145,12 +1145,6 @@ class GenerationMixin:
             # if decoder-only then inputs_tensor has to be `input_ids`
             input_ids = inputs_tensor
 
-        # Prepare exponential_decay_length_penalty, so decay start is applied to newly generated tokens
-        if exponential_decay_length_penalty is not None:
-            decay_start = exponential_decay_length_penalty[0] + input_ids.shape[-1]
-            decay_factor = exponential_decay_length_penalty[1]
-            exponential_decay_length_penalty = (decay_start, decay_factor)
-
         # 5. Prepare `max_length` depending on other stopping criteria
         # if `max_new_tokens` is passed, but not `max_length` -> set `max_length = max_new_tokens`
         if max_length is None and max_new_tokens is not None:

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -17,6 +17,7 @@
 import inspect
 import warnings
 from dataclasses import dataclass
+from lib2to3.pgen2.token import OP
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
@@ -39,7 +40,6 @@ from .generation_logits_process import (
     NoRepeatNGramLogitsProcessor,
     PrefixConstrainedLogitsProcessor,
     RepetitionPenaltyLogitsProcessor,
-    SoftLengthLogitsProcessor,
     TemperatureLogitsWarper,
     TopKLogitsWarper,
     TopPLogitsWarper,
@@ -1145,6 +1145,12 @@ class GenerationMixin:
         else:
             # if decoder-only then inputs_tensor has to be `input_ids`
             input_ids = inputs_tensor
+
+        # Prepare exponential_decay_length_penalty, so decay start is applied to newly generated tokens
+        if exponential_decay_length_penalty is not None:
+            decay_start = exponential_decay_length_penalty[0] + input_ids.shape[-1]
+            decay_factor = exponential_decay_length_penalty[1]
+            exponential_decay_length_penalty = (decay_start, decay_factor)
 
         # 5. Prepare `max_length` depending on other stopping criteria
         # if `max_new_tokens` is passed, but not `max_length` -> set `max_length = max_new_tokens`

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -17,7 +17,6 @@
 import inspect
 import warnings
 from dataclasses import dataclass
-from lib2to3.pgen2.token import OP
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
@@ -853,7 +852,7 @@ class GenerationMixin:
         forced_bos_token_id: Optional[int] = None,
         forced_eos_token_id: Optional[int] = None,
         remove_invalid_values: Optional[bool] = None,
-        synced_gpus: Optional[bool] = None,
+        synced_gpus: Optional[bool] = False,
         exponential_decay_length_penalty: Optional[Tuple] = None,
         **model_kwargs,
     ) -> Union[GreedySearchOutput, SampleOutput, BeamSearchOutput, BeamSampleOutput, torch.LongTensor]:

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -39,6 +39,7 @@ from .generation_logits_process import (
     NoRepeatNGramLogitsProcessor,
     PrefixConstrainedLogitsProcessor,
     RepetitionPenaltyLogitsProcessor,
+    SoftLengthLogitsProcessor,
     TemperatureLogitsWarper,
     TopKLogitsWarper,
     TopPLogitsWarper,

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -739,7 +739,9 @@ class GenerationMixin:
         if remove_invalid_values is True:
             processors.append(InfNanRemoveLogitsProcessor())
         if length_regulation_factor is not None and length_regulation_start is not None:
-            processors.append(SoftLengthLogitsProcessor(length_regulation_start, length_regulation_factor, eos_token_id))
+            processors.append(
+                SoftLengthLogitsProcessor(length_regulation_start, length_regulation_factor, eos_token_id)
+            )
         processors = self._merge_criteria_processor_list(processors, logits_processor)
         return processors
 

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -983,8 +983,8 @@ class GenerationMixin:
                 Whether to continue running the while loop until max_length (needed for ZeRO stage 3)
             exponential_decay_length_penalty (`Tuple`, *optional*):
                 This Tuple adds an exponentially increasing length penalty, after a certain amount of tokens have been
-                generated. The tuple shall consist of: (start_index, decay_factor) where start_index indicates where
-                penalty starts and decay_factor represents the factor of exponential decay
+                generated. The tuple shall consist of: `(start_index, decay_factor)` where `start_index` indicates where
+                penalty starts and `decay_factor` represents the factor of exponential decay
 
             model_kwargs:
                 Additional model specific kwargs will be forwarded to the `forward` function of the model. If the model

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -981,7 +981,7 @@ class GenerationMixin:
                 crash. Note that using `remove_invalid_values` can slow down generation.
             synced_gpus (`bool`, *optional*, defaults to `False`):
                 Whether to continue running the while loop until max_length (needed for ZeRO stage 3)
-            exponential_decay_length_penalty (`Tuple`, *optional*):
+            exponential_decay_length_penalty (`tuple(int, float)`, *optional*):
                 This Tuple adds an exponentially increasing length penalty, after a certain amount of tokens have been
                 generated. The tuple shall consist of: `(start_index, decay_factor)` where `start_index` indicates where
                 penalty starts and `decay_factor` represents the factor of exponential decay

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -854,7 +854,7 @@ class GenerationMixin:
         forced_eos_token_id: Optional[int] = None,
         remove_invalid_values: Optional[bool] = None,
         synced_gpus: Optional[bool] = False,
-        exponential_decay_length_penalty: Optional[Tuple] = None,
+        exponential_decay_length_penalty: Optional[Tuple[Union[int, float]]] = None,
         **model_kwargs,
     ) -> Union[GreedySearchOutput, SampleOutput, BeamSearchOutput, BeamSampleOutput, torch.LongTensor]:
         r"""

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -17,7 +17,6 @@
 import inspect
 import warnings
 from dataclasses import dataclass
-from lib2to3.pgen2.token import OP
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1583,6 +1583,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
             dtype=torch.long,
             device=next(self.parameters()).device,
         )
+        input_ids_seq_length = input_ids.shape[-1]
         last_hidden_state = encoder_outputs["last_hidden_state"]
 
         def extend_enc_output(tensor, num_beams=None):
@@ -1609,7 +1610,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
             repetition_penalty=repetition_penalty,
             no_repeat_ngram_size=no_repeat_ngram_size,
             encoder_no_repeat_ngram_size=encoder_no_repeat_ngram_size,
-            input_ids=input_ids,
+            input_ids_seq_length=input_ids_seq_length,
             encoder_input_ids=context_input_ids,
             bad_words_ids=bad_words_ids,
             min_length=min_length,

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1405,6 +1405,8 @@ class RagTokenForGeneration(RagPreTrainedModel):
         forced_bos_token_id: Optional[int] = None,
         forced_eos_token_id: Optional[int] = None,
         remove_invalid_values: Optional[bool] = None,
+        length_regulation_start: Optional[int] = None,
+        length_regulation_factor: Optional[float] = None,
         **model_kwargs
     ):
         """
@@ -1534,6 +1536,12 @@ class RagTokenForGeneration(RagPreTrainedModel):
         remove_invalid_values = (
             remove_invalid_values if remove_invalid_values is not None else self.config.remove_invalid_values
         )
+        length_regulation_start = (
+            length_regulation_start if length_regulation_start is not None else self.config.length_regulation_start
+        )
+        length_regulation_factor = (
+            length_regulation_factor if length_regulation_factor is not None else self.config.length_regulation_factor
+        )
 
         # retrieve docs
         if self.retriever is not None and context_input_ids is None:
@@ -1615,6 +1623,8 @@ class RagTokenForGeneration(RagPreTrainedModel):
             num_beam_groups=num_beam_groups,
             diversity_penalty=diversity_penalty,
             remove_invalid_values=remove_invalid_values,
+            length_regulation_start=length_regulation_start,
+            length_regulation_factor=length_regulation_factor,
             logits_processor=logits_processor,
         )
 

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1405,7 +1405,12 @@ class RagTokenForGeneration(RagPreTrainedModel):
         forced_bos_token_id: Optional[int] = None,
         forced_eos_token_id: Optional[int] = None,
         remove_invalid_values: Optional[bool] = None,
+<<<<<<< HEAD
         exponential_decay_length_penalty: Optional[Tuple] = None,
+=======
+        length_regulation_start: Optional[int] = None,
+        length_regulation_factor: Optional[float] = None,
+>>>>>>> 68efd90a1 (fix rag integration, fix docstyling)
         **model_kwargs
     ):
         """
@@ -1535,10 +1540,18 @@ class RagTokenForGeneration(RagPreTrainedModel):
         remove_invalid_values = (
             remove_invalid_values if remove_invalid_values is not None else self.config.remove_invalid_values
         )
+<<<<<<< HEAD
         exponential_decay_length_penalty = (
             exponential_decay_length_penalty
             if exponential_decay_length_penalty is not None
             else self.config.exponential_decay_length_penalty
+=======
+        length_regulation_start = (
+            length_regulation_start if length_regulation_start is not None else self.config.length_regulation_start
+        )
+        length_regulation_factor = (
+            length_regulation_factor if length_regulation_factor is not None else self.config.length_regulation_factor
+>>>>>>> 68efd90a1 (fix rag integration, fix docstyling)
         )
 
         # retrieve docs

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -15,7 +15,7 @@
 """RAG model implementation."""
 
 from dataclasses import dataclass
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -1405,7 +1405,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
         forced_bos_token_id: Optional[int] = None,
         forced_eos_token_id: Optional[int] = None,
         remove_invalid_values: Optional[bool] = None,
-        exponential_decay_length_penalty: Optional[Tuple] = None,
+        exponential_decay_length_penalty: Optional[Tuple[Union[int, float]]] = None,
         **model_kwargs
     ):
         """

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1405,12 +1405,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
         forced_bos_token_id: Optional[int] = None,
         forced_eos_token_id: Optional[int] = None,
         remove_invalid_values: Optional[bool] = None,
-<<<<<<< HEAD
         exponential_decay_length_penalty: Optional[Tuple] = None,
-=======
-        length_regulation_start: Optional[int] = None,
-        length_regulation_factor: Optional[float] = None,
->>>>>>> 68efd90a1 (fix rag integration, fix docstyling)
         **model_kwargs
     ):
         """
@@ -1540,18 +1535,10 @@ class RagTokenForGeneration(RagPreTrainedModel):
         remove_invalid_values = (
             remove_invalid_values if remove_invalid_values is not None else self.config.remove_invalid_values
         )
-<<<<<<< HEAD
         exponential_decay_length_penalty = (
             exponential_decay_length_penalty
             if exponential_decay_length_penalty is not None
             else self.config.exponential_decay_length_penalty
-=======
-        length_regulation_start = (
-            length_regulation_start if length_regulation_start is not None else self.config.length_regulation_start
-        )
-        length_regulation_factor = (
-            length_regulation_factor if length_regulation_factor is not None else self.config.length_regulation_factor
->>>>>>> 68efd90a1 (fix rag integration, fix docstyling)
         )
 
         # retrieve docs

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1609,6 +1609,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
             repetition_penalty=repetition_penalty,
             no_repeat_ngram_size=no_repeat_ngram_size,
             encoder_no_repeat_ngram_size=encoder_no_repeat_ngram_size,
+            input_ids=input_ids,
             encoder_input_ids=context_input_ids,
             bad_words_ids=bad_words_ids,
             min_length=min_length,

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1405,12 +1405,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
         forced_bos_token_id: Optional[int] = None,
         forced_eos_token_id: Optional[int] = None,
         remove_invalid_values: Optional[bool] = None,
-<<<<<<< HEAD
         exponential_decay_length_penalty: Optional[Tuple] = None,
-=======
-        length_regulation_start: Optional[int] = None,
-        length_regulation_factor: Optional[float] = None,
->>>>>>> 19563a722 (fix rag integration, fix docstyling)
         **model_kwargs
     ):
         """
@@ -1627,12 +1622,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
             num_beam_groups=num_beam_groups,
             diversity_penalty=diversity_penalty,
             remove_invalid_values=remove_invalid_values,
-<<<<<<< HEAD
             exponential_decay_length_penalty=exponential_decay_length_penalty,
-=======
-            length_regulation_start=length_regulation_start,
-            length_regulation_factor=length_regulation_factor,
->>>>>>> 19563a722 (fix rag integration, fix docstyling)
             logits_processor=logits_processor,
         )
 

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1535,10 +1535,18 @@ class RagTokenForGeneration(RagPreTrainedModel):
         remove_invalid_values = (
             remove_invalid_values if remove_invalid_values is not None else self.config.remove_invalid_values
         )
+<<<<<<< HEAD
         exponential_decay_length_penalty = (
             exponential_decay_length_penalty
             if exponential_decay_length_penalty is not None
             else self.config.exponential_decay_length_penalty
+=======
+        length_regulation_start = (
+            length_regulation_start if length_regulation_start is not None else self.config.length_regulation_start
+        )
+        length_regulation_factor = (
+            length_regulation_factor if length_regulation_factor is not None else self.config.length_regulation_factor
+>>>>>>> d8752bb64 (fix rag integration, fix docstyling)
         )
 
         # retrieve docs
@@ -1622,7 +1630,12 @@ class RagTokenForGeneration(RagPreTrainedModel):
             num_beam_groups=num_beam_groups,
             diversity_penalty=diversity_penalty,
             remove_invalid_values=remove_invalid_values,
+<<<<<<< HEAD
             exponential_decay_length_penalty=exponential_decay_length_penalty,
+=======
+            length_regulation_start=length_regulation_start,
+            length_regulation_factor=length_regulation_factor,
+>>>>>>> d8752bb64 (fix rag integration, fix docstyling)
             logits_processor=logits_processor,
         )
 

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1536,7 +1536,9 @@ class RagTokenForGeneration(RagPreTrainedModel):
             remove_invalid_values if remove_invalid_values is not None else self.config.remove_invalid_values
         )
         exponential_decay_length_penalty = (
-            exponential_decay_length_penalty if exponential_decay_length_penalty is not None else self.config.exponential_decay_length_penalty
+            exponential_decay_length_penalty
+            if exponential_decay_length_penalty is not None
+            else self.config.exponential_decay_length_penalty
         )
 
         # retrieve docs

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1405,7 +1405,12 @@ class RagTokenForGeneration(RagPreTrainedModel):
         forced_bos_token_id: Optional[int] = None,
         forced_eos_token_id: Optional[int] = None,
         remove_invalid_values: Optional[bool] = None,
+<<<<<<< HEAD
         exponential_decay_length_penalty: Optional[Tuple] = None,
+=======
+        length_regulation_start: Optional[int] = None,
+        length_regulation_factor: Optional[float] = None,
+>>>>>>> 19563a722 (fix rag integration, fix docstyling)
         **model_kwargs
     ):
         """
@@ -1535,10 +1540,18 @@ class RagTokenForGeneration(RagPreTrainedModel):
         remove_invalid_values = (
             remove_invalid_values if remove_invalid_values is not None else self.config.remove_invalid_values
         )
+<<<<<<< HEAD
         exponential_decay_length_penalty = (
             exponential_decay_length_penalty
             if exponential_decay_length_penalty is not None
             else self.config.exponential_decay_length_penalty
+=======
+        length_regulation_start = (
+            length_regulation_start if length_regulation_start is not None else self.config.length_regulation_start
+        )
+        length_regulation_factor = (
+            length_regulation_factor if length_regulation_factor is not None else self.config.length_regulation_factor
+>>>>>>> 19563a722 (fix rag integration, fix docstyling)
         )
 
         # retrieve docs

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1405,12 +1405,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
         forced_bos_token_id: Optional[int] = None,
         forced_eos_token_id: Optional[int] = None,
         remove_invalid_values: Optional[bool] = None,
-<<<<<<< HEAD
         exponential_decay_length_penalty: Optional[Tuple] = None,
-=======
-        length_regulation_start: Optional[int] = None,
-        length_regulation_factor: Optional[float] = None,
->>>>>>> 19563a722 (fix rag integration, fix docstyling)
         **model_kwargs
     ):
         """
@@ -1540,18 +1535,10 @@ class RagTokenForGeneration(RagPreTrainedModel):
         remove_invalid_values = (
             remove_invalid_values if remove_invalid_values is not None else self.config.remove_invalid_values
         )
-<<<<<<< HEAD
         exponential_decay_length_penalty = (
             exponential_decay_length_penalty
             if exponential_decay_length_penalty is not None
             else self.config.exponential_decay_length_penalty
-=======
-        length_regulation_start = (
-            length_regulation_start if length_regulation_start is not None else self.config.length_regulation_start
-        )
-        length_regulation_factor = (
-            length_regulation_factor if length_regulation_factor is not None else self.config.length_regulation_factor
->>>>>>> 19563a722 (fix rag integration, fix docstyling)
         )
 
         # retrieve docs

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1405,8 +1405,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
         forced_bos_token_id: Optional[int] = None,
         forced_eos_token_id: Optional[int] = None,
         remove_invalid_values: Optional[bool] = None,
-        length_regulation_start: Optional[int] = None,
-        length_regulation_factor: Optional[float] = None,
+        exponential_decay_length_penalty: Optional[Tuple] = None,
         **model_kwargs
     ):
         """
@@ -1536,11 +1535,8 @@ class RagTokenForGeneration(RagPreTrainedModel):
         remove_invalid_values = (
             remove_invalid_values if remove_invalid_values is not None else self.config.remove_invalid_values
         )
-        length_regulation_start = (
-            length_regulation_start if length_regulation_start is not None else self.config.length_regulation_start
-        )
-        length_regulation_factor = (
-            length_regulation_factor if length_regulation_factor is not None else self.config.length_regulation_factor
+        exponential_decay_length_penalty = (
+            exponential_decay_length_penalty if exponential_decay_length_penalty is not None else self.config.exponential_decay_length_penalty
         )
 
         # retrieve docs
@@ -1623,8 +1619,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
             num_beam_groups=num_beam_groups,
             diversity_penalty=diversity_penalty,
             remove_invalid_values=remove_invalid_values,
-            length_regulation_start=length_regulation_start,
-            length_regulation_factor=length_regulation_factor,
+            exponential_decay_length_penalty=exponential_decay_length_penalty,
             logits_processor=logits_processor,
         )
 

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1535,18 +1535,10 @@ class RagTokenForGeneration(RagPreTrainedModel):
         remove_invalid_values = (
             remove_invalid_values if remove_invalid_values is not None else self.config.remove_invalid_values
         )
-<<<<<<< HEAD
         exponential_decay_length_penalty = (
             exponential_decay_length_penalty
             if exponential_decay_length_penalty is not None
             else self.config.exponential_decay_length_penalty
-=======
-        length_regulation_start = (
-            length_regulation_start if length_regulation_start is not None else self.config.length_regulation_start
-        )
-        length_regulation_factor = (
-            length_regulation_factor if length_regulation_factor is not None else self.config.length_regulation_factor
->>>>>>> d8752bb64 (fix rag integration, fix docstyling)
         )
 
         # retrieve docs
@@ -1630,12 +1622,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
             num_beam_groups=num_beam_groups,
             diversity_penalty=diversity_penalty,
             remove_invalid_values=remove_invalid_values,
-<<<<<<< HEAD
             exponential_decay_length_penalty=exponential_decay_length_penalty,
-=======
-            length_regulation_start=length_regulation_start,
-            length_regulation_factor=length_regulation_factor,
->>>>>>> d8752bb64 (fix rag integration, fix docstyling)
             logits_processor=logits_processor,
         )
 

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1405,7 +1405,12 @@ class RagTokenForGeneration(RagPreTrainedModel):
         forced_bos_token_id: Optional[int] = None,
         forced_eos_token_id: Optional[int] = None,
         remove_invalid_values: Optional[bool] = None,
+<<<<<<< HEAD
         exponential_decay_length_penalty: Optional[Tuple] = None,
+=======
+        length_regulation_start: Optional[int] = None,
+        length_regulation_factor: Optional[float] = None,
+>>>>>>> 19563a722 (fix rag integration, fix docstyling)
         **model_kwargs
     ):
         """
@@ -1622,7 +1627,12 @@ class RagTokenForGeneration(RagPreTrainedModel):
             num_beam_groups=num_beam_groups,
             diversity_penalty=diversity_penalty,
             remove_invalid_values=remove_invalid_values,
+<<<<<<< HEAD
             exponential_decay_length_penalty=exponential_decay_length_penalty,
+=======
+            length_regulation_start=length_regulation_start,
+            length_regulation_factor=length_regulation_factor,
+>>>>>>> 19563a722 (fix rag integration, fix docstyling)
             logits_processor=logits_processor,
         )
 

--- a/tests/generation/test_generation_logits_process.py
+++ b/tests/generation/test_generation_logits_process.py
@@ -515,11 +515,12 @@ class LogitsProcessorTest(unittest.TestCase):
         penalty_factor = 1.1
 
         input_ids = ids_tensor((batch_size, 2), vocab_size=vocab_size)
+        input_ids_seq_length = input_ids.shape[-1]
 
         length_decay_processor = ExponentialDecayLengthPenalty(
             exponential_decay_length_penalty=(penalty_start, penalty_factor),
             eos_token_id=eos_token_id,
-            input_ids=input_ids,
+            input_ids_seq_length=input_ids_seq_length,
         )
 
         # check that penalty is not applied before start

--- a/tests/generation/test_generation_logits_process.py
+++ b/tests/generation/test_generation_logits_process.py
@@ -528,7 +528,7 @@ class LogitsProcessorTest(unittest.TestCase):
         input_ids = ids_tensor((batch_size, 20), vocab_size=vocab_size)
         scores = self._get_uniform_logits(batch_size, vocab_size)
         scores_after_start = length_decay_processor(input_ids, scores)
-        self.assertGreater(
+        self.assertTrue(
             torch.gt(
                 scores_after_start[penalty_start + 1 :, eos_token_id], scores[penalty_start + 1 :, eos_token_id]
             ).all()

--- a/tests/generation/test_generation_logits_process.py
+++ b/tests/generation/test_generation_logits_process.py
@@ -514,12 +514,14 @@ class LogitsProcessorTest(unittest.TestCase):
         penalty_start = 5
         penalty_factor = 1.1
 
+        input_ids = ids_tensor((batch_size, 2), vocab_size=vocab_size)
+
         length_decay_processor = ExponentialDecayLengthPenalty(
-            exponential_decay_length_penalty=(penalty_start, penalty_factor), eos_token_id=eos_token_id
+            exponential_decay_length_penalty=(penalty_start, penalty_factor), eos_token_id=eos_token_id,
+            input_ids=input_ids
         )
 
         # check that penalty is not applied before start
-        input_ids = ids_tensor((batch_size, 2), vocab_size=vocab_size)
         scores = self._get_uniform_logits(batch_size, vocab_size)
         scores_before_start = length_decay_processor(input_ids, scores)
         self.assertListEqual(scores_before_start[:, eos_token_id].tolist(), scores[:, eos_token_id].tolist())

--- a/tests/generation/test_generation_logits_process.py
+++ b/tests/generation/test_generation_logits_process.py
@@ -28,6 +28,7 @@ if is_torch_available():
 
     from transformers.generation_logits_process import (
         EncoderNoRepeatNGramLogitsProcessor,
+        ExponentialDecayLengthPenalty,
         ForcedBOSTokenLogitsProcessor,
         ForcedEOSTokenLogitsProcessor,
         HammingDiversityLogitsProcessor,
@@ -503,4 +504,32 @@ class LogitsProcessorTest(unittest.TestCase):
                 ),
                 atol=1e-6,
             )
+        )
+
+    def test_exponential_decay_length_penalty(self):
+        vocab_size = 20
+        batch_size = 4
+        eos_token_id = 0
+
+        penalty_start = 5
+        penalty_factor = 1.1
+
+        length_decay_processor = ExponentialDecayLengthPenalty(
+            exponential_decay_length_penalty=(penalty_start, penalty_factor), eos_token_id=eos_token_id
+        )
+
+        # check that penalty is not applied before start
+        input_ids = ids_tensor((batch_size, 2), vocab_size=vocab_size)
+        scores = self._get_uniform_logits(batch_size, vocab_size)
+        scores_before_start = length_decay_processor(input_ids, scores)
+        self.assertListEqual(scores_before_start[:, eos_token_id].tolist(), scores[:, eos_token_id].tolist())
+
+        # check that penalty is applied after start
+        input_ids = ids_tensor((batch_size, 20), vocab_size=vocab_size)
+        scores = self._get_uniform_logits(batch_size, vocab_size)
+        scores_after_start = length_decay_processor(input_ids, scores)
+        self.assertGreater(
+            torch.gt(
+                scores_after_start[penalty_start + 1 :, eos_token_id], scores[penalty_start + 1 :, eos_token_id]
+            ).all()
         )

--- a/tests/generation/test_generation_logits_process.py
+++ b/tests/generation/test_generation_logits_process.py
@@ -517,8 +517,9 @@ class LogitsProcessorTest(unittest.TestCase):
         input_ids = ids_tensor((batch_size, 2), vocab_size=vocab_size)
 
         length_decay_processor = ExponentialDecayLengthPenalty(
-            exponential_decay_length_penalty=(penalty_start, penalty_factor), eos_token_id=eos_token_id,
-            input_ids=input_ids
+            exponential_decay_length_penalty=(penalty_start, penalty_factor),
+            eos_token_id=eos_token_id,
+            input_ids=input_ids,
         )
 
         # check that penalty is not applied before start

--- a/tests/generation/test_generation_logits_process.py
+++ b/tests/generation/test_generation_logits_process.py
@@ -514,7 +514,6 @@ class LogitsProcessorTest(unittest.TestCase):
         penalty_start = 5
         penalty_factor = 1.1
 
-<<<<<<< HEAD:tests/generation/test_generation_logits_process.py
         input_ids = ids_tensor((batch_size, 2), vocab_size=vocab_size)
 
         length_decay_processor = ExponentialDecayLengthPenalty(
@@ -524,14 +523,6 @@ class LogitsProcessorTest(unittest.TestCase):
         )
 
         # check that penalty is not applied before start
-=======
-        length_decay_processor = ExponentialDecayLengthPenalty(
-            exponential_decay_length_penalty=(penalty_start, penalty_factor), eos_token_id=eos_token_id
-        )
-
-        # check that penalty is not applied before start
-        input_ids = ids_tensor((batch_size, 2), vocab_size=vocab_size)
->>>>>>> 4c53400ff (change param to tuple, add test):tests/test_generation_logits_process.py
         scores = self._get_uniform_logits(batch_size, vocab_size)
         scores_before_start = length_decay_processor(input_ids, scores)
         self.assertListEqual(scores_before_start[:, eos_token_id].tolist(), scores[:, eos_token_id].tolist())
@@ -540,11 +531,7 @@ class LogitsProcessorTest(unittest.TestCase):
         input_ids = ids_tensor((batch_size, 20), vocab_size=vocab_size)
         scores = self._get_uniform_logits(batch_size, vocab_size)
         scores_after_start = length_decay_processor(input_ids, scores)
-<<<<<<< HEAD:tests/generation/test_generation_logits_process.py
         self.assertTrue(
-=======
-        self.assertGreater(
->>>>>>> 4c53400ff (change param to tuple, add test):tests/test_generation_logits_process.py
             torch.gt(
                 scores_after_start[penalty_start + 1 :, eos_token_id], scores[penalty_start + 1 :, eos_token_id]
             ).all()

--- a/tests/generation/test_generation_logits_process.py
+++ b/tests/generation/test_generation_logits_process.py
@@ -514,6 +514,7 @@ class LogitsProcessorTest(unittest.TestCase):
         penalty_start = 5
         penalty_factor = 1.1
 
+<<<<<<< HEAD:tests/generation/test_generation_logits_process.py
         input_ids = ids_tensor((batch_size, 2), vocab_size=vocab_size)
 
         length_decay_processor = ExponentialDecayLengthPenalty(
@@ -523,6 +524,14 @@ class LogitsProcessorTest(unittest.TestCase):
         )
 
         # check that penalty is not applied before start
+=======
+        length_decay_processor = ExponentialDecayLengthPenalty(
+            exponential_decay_length_penalty=(penalty_start, penalty_factor), eos_token_id=eos_token_id
+        )
+
+        # check that penalty is not applied before start
+        input_ids = ids_tensor((batch_size, 2), vocab_size=vocab_size)
+>>>>>>> 4c53400ff (change param to tuple, add test):tests/test_generation_logits_process.py
         scores = self._get_uniform_logits(batch_size, vocab_size)
         scores_before_start = length_decay_processor(input_ids, scores)
         self.assertListEqual(scores_before_start[:, eos_token_id].tolist(), scores[:, eos_token_id].tolist())
@@ -531,7 +540,11 @@ class LogitsProcessorTest(unittest.TestCase):
         input_ids = ids_tensor((batch_size, 20), vocab_size=vocab_size)
         scores = self._get_uniform_logits(batch_size, vocab_size)
         scores_after_start = length_decay_processor(input_ids, scores)
+<<<<<<< HEAD:tests/generation/test_generation_logits_process.py
         self.assertTrue(
+=======
+        self.assertGreater(
+>>>>>>> 4c53400ff (change param to tuple, add test):tests/test_generation_logits_process.py
             torch.gt(
                 scores_after_start[penalty_start + 1 :, eos_token_id], scores[penalty_start + 1 :, eos_token_id]
             ).all()

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -82,6 +82,8 @@ config_common_kwargs = {
     "eos_token_id": 8,
     "sep_token_id": 9,
     "decoder_start_token_id": 10,
+    "length_regulation_start": 5,
+    "length_regulation_factor": 1.01,
     "task_specific_params": {"translation": "some_params"},
     "problem_type": "regression",
 }

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -82,12 +82,7 @@ config_common_kwargs = {
     "eos_token_id": 8,
     "sep_token_id": 9,
     "decoder_start_token_id": 10,
-<<<<<<< HEAD
     "exponential_decay_length_penalty": (5, 1.01),
-=======
-    "length_regulation_start": 5,
-    "length_regulation_factor": 1.01,
->>>>>>> 4bcca750f (fix test config, fix formatting)
     "task_specific_params": {"translation": "some_params"},
     "problem_type": "regression",
 }

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -82,7 +82,12 @@ config_common_kwargs = {
     "eos_token_id": 8,
     "sep_token_id": 9,
     "decoder_start_token_id": 10,
+<<<<<<< HEAD
     "exponential_decay_length_penalty": (5, 1.01),
+=======
+    "length_regulation_start": 5,
+    "length_regulation_factor": 1.01,
+>>>>>>> 4bcca750f (fix test config, fix formatting)
     "task_specific_params": {"translation": "some_params"},
     "problem_type": "regression",
 }

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -82,8 +82,7 @@ config_common_kwargs = {
     "eos_token_id": 8,
     "sep_token_id": 9,
     "decoder_start_token_id": 10,
-    "length_regulation_start": 5,
-    "length_regulation_factor": 1.01,
+    "exponential_decay_length_penalty": (5, 1.01),
     "task_specific_params": {"translation": "some_params"},
     "problem_type": "regression",
 }


### PR DESCRIPTION
# What does this PR do?

This PR enables users to softly regulate the length when using sampling method in model.generate(). We had the use case where we wanted to keep a generated sequence adequately short with no "hard" cutoff - we wanted the model to come to an end without just setting max_length, so that the end_token is also predicted at a meaningful position.

The SoftLengthLogitsProcessor exponentially increases the score of the eos_token_id until it is generated. It can be configured by these parameters inside model.generate():
- length_regulation_start
- length_regulation_factor

I am aware that there is already a length_penalty in place, but as far as I understood it is used in beam search and did not fulfil our need.

Usage:
```python
gen_tokens = model.generate(input_ids, do_sample=True, temperature=0.9, max_length=600, length_regulation_start=300, length_regulation_factor=1.01)
```

Example:
Here are the lengths of 5 samples generated for a length-regulated and default sequence-generation. The goal was to end the sequence between 300 and 400 tokens without a hard cutoff.
Code
```python
print("Regular output with max_length=600")
for index in range(5):
    gen_tokens = model.generate(input_ids, do_sample=True, temperature=0.9, max_length=600, pad_token_id=50256)
    print(gen_tokens.shape[1])

print("--------------")
print("Soft regulation (length_regulation_start=300, length_regulation_factor=1.01):")
for index in range(5):
    gen_tokens = model.generate(input_ids, do_sample=True, temperature=0.9, max_length=600, length_regulation_start=300, length_regulation_factor=1.01, pad_token_id=50256)
    print(gen_tokens.shape[1])
```
Results
```
Regular output with max_length=600
600
600
600
600
600
--------------
Soft regulation (length_regulation_start=300, length_regulation_factor=1.01)
361
365
381
370
396
```

Here we see one length-regulated example output. The <endoftext> token is being reasonably placed:
```
In recent events the conflict between Elon Musk and Donald Trump heated up. Trump criticised Musk after he was quoted by The New York Times saying that a ‘solution’ to the US’s problems in the technology industry might be “a bullet to the head”.

In return Musk sent the president a series of tweets where he called the president “a traitor”, and “an idiot” as well as said he wouldn’t take the challenge of building the president a $10 million Tesla Roadster.

“It’s not my style to engage in such juvenile behaviour — it’s never been my style to engage in such juvenile behaviour — but the stakes for positive change have become that important,” said Musk in an interview with Forbes magazine, which is to be published on Wednesday.

The interview was published a few days before Musk went public about buying the Boring Company, which he described in the interview as a “vertical tunnel boring machine.”

After a few hours after this, Musk issued a statement about his tweet regarding the Roadster and the $10 million challenge to the president.

“The idea that the government could take ownership of all privately owned infrastructure in the U.S., just because I want it, is absurd on its face.”

He said he was being “clearly sarcastic.”

This was enough for Trump and his advisors to get angry, with Trump telling CNN that Musk is “a very, very, different kind of person than me.”

“I just think that he’s very, very smart,” Trump added.<|endoftext|>
```

This works as well with other EOS tokens that may be used in few shot learning scenarios such as "\n".


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
@patrickvonplaten
