### PR TITLE
corrected typo in robust speech event README.md regarding OVH Cloud link

### DIFF
--- a/examples/research_projects/robust-speech-event/README.md
+++ b/examples/research_projects/robust-speech-event/README.md
@@ -481,7 +481,7 @@ hyperparameters.
 ### Creating an OVHCloud account
 *TIP*: If you haven't created a project on OVHcloud yet, make sure you've received your GPU voucher code *beforehand*, 
 so that you can skip entering the credit card information.
-1. If you're a US citizen, create an account via [OVHcloud.CA](https://ovhcloud.ca/). 
+1. If you're a US citizen, create an account via [OVHcloud.US](https://us.ovhcloud.com/). 
 If you're from anywhere else in the world, create an account via [OVHcloud.COM](https://ovhcloud.com/).
 2. Once logged in, click `Public Cloud` from the top menu and then click `Create your first OVH Public Cloud project`. 
 Then enter a project name (e.g. "huggingface"), enter your voucher code, and click `Continue` -> `Create my project`.


### PR DESCRIPTION
# What does this PR do?
Corrects a typo in robust speech event README that incorrectly directed US users to the Canadian OVH Cloud site.

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?
@patrickvonplaten @anton-l 
