### PR TITLE
Fix TF Causal LM models' returned logits

### DIFF
--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -1542,9 +1542,9 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
 
         if inputs["labels"] is not None:
             # shift labels to the left and cut last logit token
-            logits = logits[:, :-1]
+            shifted_logits = logits[:, :-1]
             labels = inputs["labels"][:, 1:]
-            loss = self.hf_compute_loss(labels=labels, logits=logits)
+            loss = self.hf_compute_loss(labels=labels, logits=shifted_logits)
 
         if not inputs["return_dict"]:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/ctrl/modeling_tf_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_tf_ctrl.py
@@ -735,9 +735,9 @@ class TFCTRLLMHeadModel(TFCTRLPreTrainedModel, TFCausalLanguageModelingLoss):
         loss = None
         if inputs["labels"] is not None:
             # shift labels to the left and cut last logit token
-            logits = logits[:, :-1]
+            shifted_logits = logits[:, :-1]
             labels = inputs["labels"][:, 1:]
-            loss = self.hf_compute_loss(labels, logits)
+            loss = self.hf_compute_loss(labels, shifted_logits)
 
         if not inputs["return_dict"]:
             output = (logits,) + transformer_outputs[1:]

--- a/src/transformers/models/gpt2/modeling_tf_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_tf_gpt2.py
@@ -949,9 +949,9 @@ class TFGPT2LMHeadModel(TFGPT2PreTrainedModel, TFCausalLanguageModelingLoss):
         loss = None
         if inputs["labels"] is not None:
             # shift labels to the left and cut last logit token
-            logits = logits[:, :-1]
+            shifted_logits = logits[:, :-1]
             labels = inputs["labels"][:, 1:]
-            loss = self.hf_compute_loss(labels, logits)
+            loss = self.hf_compute_loss(labels, shifted_logits)
 
         if not inputs["return_dict"]:
             output = (logits,) + transformer_outputs[1:]

--- a/src/transformers/models/openai/modeling_tf_openai.py
+++ b/src/transformers/models/openai/modeling_tf_openai.py
@@ -656,9 +656,9 @@ class TFOpenAIGPTLMHeadModel(TFOpenAIGPTPreTrainedModel, TFCausalLanguageModelin
         loss = None
         if inputs["labels"] is not None:
             # shift labels to the left and cut last logit token
-            logits = logits[:, :-1]
+            shifted_logits = logits[:, :-1]
             labels = inputs["labels"][:, 1:]
-            loss = self.hf_compute_loss(labels, logits)
+            loss = self.hf_compute_loss(labels, shifted_logits)
 
         if not inputs["return_dict"]:
             output = (logits,) + transformer_outputs[1:]

--- a/src/transformers/models/rembert/modeling_tf_rembert.py
+++ b/src/transformers/models/rembert/modeling_tf_rembert.py
@@ -1275,9 +1275,9 @@ class TFRemBertForCausalLM(TFRemBertPreTrainedModel, TFCausalLanguageModelingLos
 
         if inputs["labels"] is not None:
             # shift labels to the left and cut last logit token
-            logits = logits[:, :-1]
+            shifted_logits = logits[:, :-1]
             labels = inputs["labels"][:, 1:]
-            loss = self.hf_compute_loss(labels=labels, logits=logits)
+            loss = self.hf_compute_loss(labels=labels, logits=shifted_logits)
 
         if not inputs["return_dict"]:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -1310,9 +1310,9 @@ class TFRobertaForCausalLM(TFRobertaPreTrainedModel, TFCausalLanguageModelingLos
 
         if inputs["labels"] is not None:
             # shift labels to the left and cut last logit token
-            logits = logits[:, :-1]
+            shifted_logits = logits[:, :-1]
             labels = inputs["labels"][:, 1:]
-            loss = self.hf_compute_loss(labels=labels, logits=logits)
+            loss = self.hf_compute_loss(labels=labels, logits=shifted_logits)
 
         if not inputs["return_dict"]:
             output = (logits,) + outputs[2:]

--- a/src/transformers/models/roformer/modeling_tf_roformer.py
+++ b/src/transformers/models/roformer/modeling_tf_roformer.py
@@ -1035,9 +1035,9 @@ class TFRoFormerForCausalLM(TFRoFormerPreTrainedModel, TFCausalLanguageModelingL
 
         if inputs["labels"] is not None:
             # shift labels to the left and cut last logit token
-            logits = logits[:, :-1]
+            shifted_logits = logits[:, :-1]
             labels = inputs["labels"][:, 1:]
-            loss = self.hf_compute_loss(labels=labels, logits=logits)
+            loss = self.hf_compute_loss(labels=labels, logits=shifted_logits)
 
         if not inputs["return_dict"]:
             output = (logits,) + outputs[2:]

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -1262,9 +1262,9 @@ class TF{{cookiecutter.camelcase_modelname}}ForCausalLM(TF{{cookiecutter.camelca
 
         if inputs["labels"] is not None:
             # shift labels to the left and cut last logit token
-            logits = logits[:, :-1]
+            shifted_logits = logits[:, :-1]
             labels = inputs["labels"][:, 1:]
-            loss = self.hf_compute_loss(labels=labels, logits=logits)
+            loss = self.hf_compute_loss(labels=labels, logits=shifted_logits)
 
         if not inputs["return_dict"]:
             output = (logits,) + outputs[2:]

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -438,11 +438,10 @@ class TFModelTesterMixin:
                     if not tf_nans:
                         max_diff = np.amax(np.abs(tf_loss - pt_loss))
                         # `TFFunnelForTokenClassification` (and potentially other TF token classification models) give
-                        # large difference (up to 0.1x). PR #15294 addresses this issue. Before it is merged, set a
-                        # higher threshold here to pass the test.
-                        # self.assertLessEqual(max_diff, 5e-5)
-                        if max_diff > 5e-5:
-                            self.assertEqual(model_class.__name__, "test")
+                        # large difference (up to 0.1x). PR #15294 addresses this issue.
+                        # There is also an inconsistency between PT/TF `XLNetLMHeadModel`.
+                        # Before these issues are fixed & merged, set a higher threshold here to pass the test.
+                        self.assertLessEqual(max_diff, 2e-1)
 
                     tf_hidden_states = tfo[1].numpy()
                     pt_hidden_states = pto[1].numpy()

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -440,7 +440,9 @@ class TFModelTesterMixin:
                         # `TFFunnelForTokenClassification` (and potentially other TF token classification models) give
                         # large difference (up to 0.1x). PR #15294 addresses this issue. Before it is merged, set a
                         # higher threshold here to pass the test.
-                        self.assertLessEqual(max_diff, 5e-5)
+                        # self.assertLessEqual(max_diff, 5e-5)
+                        if max_diff > 5e-5:
+                            self.assertEqual(model_class.__name__, "test")
 
                     tf_hidden_states = tfo[1].numpy()
                     pt_hidden_states = pto[1].numpy()

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -397,8 +397,8 @@ class TFModelTesterMixin:
             tf_hidden_states = tfo[0].numpy()
             pt_hidden_states = pto[0].numpy()
 
-            tf_nans = np.copy(np.isnan(tf_hidden_states))
-            pt_nans = np.copy(np.isnan(pt_hidden_states))
+            tf_nans = np.isnan(tf_hidden_states)
+            pt_nans = np.isnan(pt_hidden_states)
 
             pt_hidden_states[tf_nans] = 0
             tf_hidden_states[tf_nans] = 0
@@ -429,8 +429,8 @@ class TFModelTesterMixin:
                     tf_loss = tf.math.reduce_mean(tf_loss).numpy()
                     pt_loss = pt_loss.numpy()
 
-                    tf_nans = np.copy(np.isnan(tf_loss))
-                    pt_nans = np.copy(np.isnan(pt_loss))
+                    tf_nans = np.isnan(tf_loss)
+                    pt_nans = np.isnan(pt_loss)
                     # the 2 losses need to be both nan or both not nan
                     # (`TapasForQuestionAnswering` gives nan loss here)
                     self.assertEqual(tf_nans, pt_nans)
@@ -443,21 +443,21 @@ class TFModelTesterMixin:
                         # Before these issues are fixed & merged, set a higher threshold here to pass the test.
                         self.assertLessEqual(max_diff, 2e-1)
 
-                    tf_hidden_states = tfo[1].numpy()
-                    pt_hidden_states = pto[1].numpy()
+                    tf_logits = tfo[1].numpy()
+                    pt_logits = pto[1].numpy()
 
                     # check on the shape
-                    self.assertEqual(tf_hidden_states.shape, pt_hidden_states.shape)
+                    self.assertEqual(tf_logits.shape, pt_logits.shape)
 
-                    tf_nans = np.copy(np.isnan(tf_hidden_states))
-                    pt_nans = np.copy(np.isnan(pt_hidden_states))
+                    tf_nans = np.isnan(tf_logits)
+                    pt_nans = np.isnan(pt_logits)
 
-                    pt_hidden_states[tf_nans] = 0
-                    tf_hidden_states[tf_nans] = 0
-                    pt_hidden_states[pt_nans] = 0
-                    tf_hidden_states[pt_nans] = 0
+                    pt_logits[tf_nans] = 0
+                    tf_logits[tf_nans] = 0
+                    pt_logits[pt_nans] = 0
+                    tf_logits[pt_nans] = 0
 
-                    max_diff = np.amax(np.abs(tf_hidden_states - pt_hidden_states))
+                    max_diff = np.amax(np.abs(tf_logits - pt_logits))
                     self.assertLessEqual(max_diff, 4e-2)
 
             # Check we can load pt model in tf and vice-versa with checkpoint => model functions
@@ -492,8 +492,8 @@ class TFModelTesterMixin:
             tfo = tf_model(tf_inputs_dict)
             tfo = tfo[0].numpy()
             pto = pto[0].numpy()
-            tf_nans = np.copy(np.isnan(tfo))
-            pt_nans = np.copy(np.isnan(pto))
+            tf_nans = np.isnan(tfo)
+            pt_nans = np.isnan(pto)
 
             pto[tf_nans] = 0
             tfo[tf_nans] = 0

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -410,7 +410,10 @@ class TFModelTesterMixin:
 
             # Currently, let's check at least the case where `labels` is passed.
             # (ideally, we would like to test for all cases, like QA or NSP tasks)
-            if "labels" in tf_inputs_dict_maybe_with_labels:
+            has_labels = any(
+                x in tf_inputs_dict_maybe_with_labels for x in ["labels", "next_sentence_label", "start_positions"]
+            )
+            if has_labels:
 
                 with torch.no_grad():
                     pto = pt_model(**pt_inputs_dict_maybe_with_labels)

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -436,8 +436,9 @@ class TFModelTesterMixin:
 
                     if not tf_nans:
                         max_diff = np.amax(np.abs(tf_loss - pt_loss))
-                        # `TFFunnelForTokenClassification` gives large difference (up to 0.1x).
-                        # There might be some problem to check, but let's increase the tolerance for now to pass test.
+                        # `TFFunnelForTokenClassification` (and potentially other TF token classification models) give
+                        # large difference (up to 0.1x). PR #15294 addresses this issue. Before it is merged, set a
+                        # higher threshold here to pass the test.
                         self.assertLessEqual(max_diff, 2e-1)
 
                     tf_hidden_states = tfo[1].numpy()

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -408,8 +408,6 @@ class TFModelTesterMixin:
             max_diff = np.amax(np.abs(tf_hidden_states - pt_hidden_states))
             self.assertLessEqual(max_diff, 4e-2)
 
-            # Currently, let's check at least the case where `labels` is passed.
-            # (ideally, we would like to test for all cases, like QA or NSP tasks)
             has_labels = any(
                 x in tf_inputs_dict_maybe_with_labels for x in ["labels", "next_sentence_label", "start_positions"]
             )

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -357,9 +357,8 @@ class TFModelTesterMixin:
             tf_model = model_class(config)
             pt_model = pt_model_class(config)
 
+            tf_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
             tf_inputs_dict_maybe_with_labels = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
-            tf_inputs_dict = copy.copy(tf_inputs_dict_maybe_with_labels)
-            tf_inputs_dict.pop("labels", None)
 
             # Check we can load pt model in tf and vice-versa with model => model functions
 
@@ -406,7 +405,8 @@ class TFModelTesterMixin:
             max_diff = np.amax(np.abs(tf_hidden_states - pt_hidden_states))
             self.assertLessEqual(max_diff, 4e-2)
 
-            # Check the case where `labels` is passed
+            # Currently, let's check at least the case where `labels` is passed.
+            # (ideally, we would like to test for all cases, like QA or NSP tasks)
             if "labels" in tf_inputs_dict_maybe_with_labels:
 
                 with torch.no_grad():

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -423,7 +423,7 @@ class TFModelTesterMixin:
                 # Some models require extra condition to return loss. For example, `BertForPreTraining` requires both
                 # `labels` and `next_sentence_label`.
                 # Moreover, some PT models return loss while the corresponding TF/Flax models don't.
-                if tf_loss and pt_loss:
+                if tf_loss is not None and pt_loss is not None:
 
                     tf_loss = tf.math.reduce_mean(tf_loss)
                     max_diff = np.amax(np.abs(tf_loss - pt_loss))

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -416,8 +416,9 @@ class TFModelTesterMixin:
                     pto = pt_model(**pt_inputs_dict_maybe_with_labels)
                 tfo = tf_model(tf_inputs_dict_maybe_with_labels, training=False)
 
-                tf_loss = tfo.loss
-                pt_loss = pto.loss
+                # Some models' output class don't have `loss` attribute despite `labels` is used.
+                tf_loss = getattr(tfo, "loss", None)
+                pt_loss = getattr(pto, "loss", None)
                 # Some models require extra condition to return loss. For example, `BertForPreTraining` requires both
                 # `labels` and `next_sentence_label`.
                 self.assertTrue((tf_loss is not None and pt_loss is not None) or (tf_loss is None and pt_loss is None))

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -419,10 +419,11 @@ class TFModelTesterMixin:
                 # Some models' output class don't have `loss` attribute despite `labels` is used.
                 tf_loss = getattr(tfo, "loss", None)
                 pt_loss = getattr(pto, "loss", None)
+
                 # Some models require extra condition to return loss. For example, `BertForPreTraining` requires both
                 # `labels` and `next_sentence_label`.
-                self.assertTrue((tf_loss is not None and pt_loss is not None) or (tf_loss is None and pt_loss is None))
-                if tf_loss is not None:
+                # Moreover, some PT models return loss while the corresponding TF/Flax models don't.
+                if tf_loss and pt_loss:
 
                     tf_loss = tf.math.reduce_mean(tf_loss)
                     max_diff = np.amax(np.abs(tf_loss - pt_loss))

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -346,21 +346,6 @@ class TFModelTesterMixin:
 
         import transformers
 
-        def prepare_pt_inputs_from_tf_inputs(tf_inputs_dict):
-
-            pt_inputs_dict = {}
-            for name, key in tf_inputs_dict.items():
-                if type(key) == bool:
-                    pt_inputs_dict[name] = key
-                elif name == "input_values":
-                    pt_inputs_dict[name] = torch.from_numpy(key.numpy()).to(torch.float32)
-                elif name == "pixel_values":
-                    pt_inputs_dict[name] = torch.from_numpy(key.numpy()).to(torch.float32)
-                else:
-                    pt_inputs_dict[name] = torch.from_numpy(key.numpy()).to(torch.long)
-
-            return pt_inputs_dict
-
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         for model_class in self.all_model_classes:
@@ -372,19 +357,25 @@ class TFModelTesterMixin:
             tf_model = model_class(config)
             pt_model = pt_model_class(config)
 
-            tf_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
-            tf_inputs_dict_maybe_with_labels = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
-
             # Check we can load pt model in tf and vice-versa with model => model functions
 
-            tf_model = transformers.load_pytorch_model_in_tf2_model(tf_model, pt_model, tf_inputs=tf_inputs_dict)
+            tf_model = transformers.load_pytorch_model_in_tf2_model(
+                tf_model, pt_model, tf_inputs=self._prepare_for_class(inputs_dict, model_class)
+            )
             pt_model = transformers.load_tf2_model_in_pytorch_model(pt_model, tf_model)
 
-            # Check predictions on first output (logits/hidden-states) are close enough given low-level computational differences
+            # Check predictions on first output (logits/hidden-states) are close enought given low-level computational differences
             pt_model.eval()
-
-            pt_inputs_dict = prepare_pt_inputs_from_tf_inputs(tf_inputs_dict)
-            pt_inputs_dict_maybe_with_labels = prepare_pt_inputs_from_tf_inputs(tf_inputs_dict_maybe_with_labels)
+            pt_inputs_dict = {}
+            for name, key in self._prepare_for_class(inputs_dict, model_class).items():
+                if type(key) == bool:
+                    pt_inputs_dict[name] = key
+                elif name == "input_values":
+                    pt_inputs_dict[name] = torch.from_numpy(key.numpy()).to(torch.float32)
+                elif name == "pixel_values":
+                    pt_inputs_dict[name] = torch.from_numpy(key.numpy()).to(torch.float32)
+                else:
+                    pt_inputs_dict[name] = torch.from_numpy(key.numpy()).to(torch.long)
 
             # need to rename encoder-decoder "inputs" for PyTorch
             if "inputs" in pt_inputs_dict and self.is_encoder_decoder:
@@ -392,13 +383,13 @@ class TFModelTesterMixin:
 
             with torch.no_grad():
                 pto = pt_model(**pt_inputs_dict)
-            tfo = tf_model(tf_inputs_dict, training=False)
+            tfo = tf_model(self._prepare_for_class(inputs_dict, model_class), training=False)
 
             tf_hidden_states = tfo[0].numpy()
             pt_hidden_states = pto[0].numpy()
 
-            tf_nans = np.isnan(tf_hidden_states)
-            pt_nans = np.isnan(pt_hidden_states)
+            tf_nans = np.copy(np.isnan(tf_hidden_states))
+            pt_nans = np.copy(np.isnan(pt_hidden_states))
 
             pt_hidden_states[tf_nans] = 0
             tf_hidden_states[tf_nans] = 0
@@ -407,58 +398,6 @@ class TFModelTesterMixin:
 
             max_diff = np.amax(np.abs(tf_hidden_states - pt_hidden_states))
             self.assertLessEqual(max_diff, 4e-2)
-
-            has_labels = any(
-                x in tf_inputs_dict_maybe_with_labels for x in ["labels", "next_sentence_label", "start_positions"]
-            )
-            if has_labels:
-
-                with torch.no_grad():
-                    pto = pt_model(**pt_inputs_dict_maybe_with_labels)
-                tfo = tf_model(tf_inputs_dict_maybe_with_labels, training=False)
-
-                # Some models' output class don't have `loss` attribute despite `labels` is used.
-                tf_loss = getattr(tfo, "loss", None)
-                pt_loss = getattr(pto, "loss", None)
-
-                # Some models require extra condition to return loss. For example, `BertForPreTraining` requires both
-                # `labels` and `next_sentence_label`.
-                # Moreover, some PT models return loss while the corresponding TF/Flax models don't.
-                if tf_loss is not None and pt_loss is not None:
-
-                    tf_loss = tf.math.reduce_mean(tf_loss).numpy()
-                    pt_loss = pt_loss.numpy()
-
-                    tf_nans = np.isnan(tf_loss)
-                    pt_nans = np.isnan(pt_loss)
-                    # the 2 losses need to be both nan or both not nan
-                    # (`TapasForQuestionAnswering` gives nan loss here)
-                    self.assertEqual(tf_nans, pt_nans)
-
-                    if not tf_nans:
-                        max_diff = np.amax(np.abs(tf_loss - pt_loss))
-                        # `TFFunnelForTokenClassification` (and potentially other TF token classification models) give
-                        # large difference (up to 0.1x). PR #15294 addresses this issue.
-                        # There is also an inconsistency between PT/TF `XLNetLMHeadModel`.
-                        # Before these issues are fixed & merged, set a higher threshold here to pass the test.
-                        self.assertLessEqual(max_diff, 2e-1)
-
-                    tf_logits = tfo[1].numpy()
-                    pt_logits = pto[1].numpy()
-
-                    # check on the shape
-                    self.assertEqual(tf_logits.shape, pt_logits.shape)
-
-                    tf_nans = np.isnan(tf_logits)
-                    pt_nans = np.isnan(pt_logits)
-
-                    pt_logits[tf_nans] = 0
-                    tf_logits[tf_nans] = 0
-                    pt_logits[pt_nans] = 0
-                    tf_logits[pt_nans] = 0
-
-                    max_diff = np.amax(np.abs(tf_logits - pt_logits))
-                    self.assertLessEqual(max_diff, 4e-2)
 
             # Check we can load pt model in tf and vice-versa with checkpoint => model functions
             with tempfile.TemporaryDirectory() as tmpdirname:
@@ -470,10 +409,10 @@ class TFModelTesterMixin:
                 tf_model.save_weights(tf_checkpoint_path)
                 pt_model = transformers.load_tf2_checkpoint_in_pytorch_model(pt_model, tf_checkpoint_path)
 
-            # Check predictions on first output (logits/hidden-states) are close enough given low-level computational differences
+            # Check predictions on first output (logits/hidden-states) are close enought given low-level computational differences
             pt_model.eval()
             pt_inputs_dict = {}
-            for name, key in tf_inputs_dict.items():
+            for name, key in self._prepare_for_class(inputs_dict, model_class).items():
                 if type(key) == bool:
                     key = np.array(key, dtype=bool)
                     pt_inputs_dict[name] = torch.from_numpy(key).to(torch.long)
@@ -489,11 +428,11 @@ class TFModelTesterMixin:
 
             with torch.no_grad():
                 pto = pt_model(**pt_inputs_dict)
-            tfo = tf_model(tf_inputs_dict)
+            tfo = tf_model(self._prepare_for_class(inputs_dict, model_class))
             tfo = tfo[0].numpy()
             pto = pto[0].numpy()
-            tf_nans = np.isnan(tfo)
-            pt_nans = np.isnan(pto)
+            tf_nans = np.copy(np.isnan(tfo))
+            pt_nans = np.copy(np.isnan(pto))
 
             pto[tf_nans] = 0
             tfo[tf_nans] = 0

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -440,7 +440,7 @@ class TFModelTesterMixin:
                         # `TFFunnelForTokenClassification` (and potentially other TF token classification models) give
                         # large difference (up to 0.1x). PR #15294 addresses this issue. Before it is merged, set a
                         # higher threshold here to pass the test.
-                        self.assertLessEqual(max_diff, 2e-1)
+                        self.assertLessEqual(max_diff, 5e-5)
 
                     tf_hidden_states = tfo[1].numpy()
                     pt_hidden_states = pto[1].numpy()

--- a/tests/test_modeling_tf_encoder_decoder.py
+++ b/tests/test_modeling_tf_encoder_decoder.py
@@ -240,7 +240,7 @@ class TFEncoderDecoderMixin:
         assert "loss" in outputs_encoder_decoder
 
         batch_size, seq_len = decoder_input_ids.shape
-        expected_shape = (batch_size, seq_len - 1, decoder_config.vocab_size)
+        expected_shape = (batch_size, seq_len, decoder_config.vocab_size)
         self.assertEqual(outputs_encoder_decoder["logits"].shape, expected_shape)
         self.assertEqual(
             outputs_encoder_decoder["encoder_last_hidden_state"].shape, (input_ids.shape + (config.hidden_size,))

--- a/tests/test_modeling_tf_vision_encoder_decoder.py
+++ b/tests/test_modeling_tf_vision_encoder_decoder.py
@@ -231,7 +231,7 @@ class TFVisionEncoderDecoderMixin:
         self.assertIn("loss", outputs_encoder_decoder)
 
         batch_size, seq_len = decoder_input_ids.shape
-        expected_shape = (batch_size, seq_len - 1, decoder_config.vocab_size)
+        expected_shape = (batch_size, seq_len, decoder_config.vocab_size)
         self.assertEqual(outputs_encoder_decoder["logits"].shape, expected_shape)
         self.assertEqual(outputs_encoder_decoder["encoder_last_hidden_state"].shape[0], pixel_values.shape[0])
         self.assertEqual(outputs_encoder_decoder["encoder_last_hidden_state"].shape[-1], config.hidden_size)


### PR DESCRIPTION
# What does this PR do?

Fix TF causal LM models' returned logits

## Details

In TF causal LM models, the returned logits is the one being cut

```
        if inputs["labels"] is not None:
            # shift labels to the left and cut last logit token
            **logits = logits[:, :-1]**
            labels = inputs["labels"][:, 1:]
            loss = self.hf_compute_loss(labels=labels, logits=logits)

        return TFCausalLMOutputWithPast(
            loss=loss,
            **logits=logits,**
```

While for PyTorch causal LM models, the original logits is returned

```
        if labels is not None:
            # Shift so that tokens < n predict n
            **shift_logits = lm_logits[..., :-1, :].contiguous()**
            shift_labels = labels[..., 1:].contiguous()
            # Flatten the tokens
            loss_fct = CrossEntropyLoss()
            loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))

        return CausalLMOutputWithPast(
            loss=loss,
            **logits=lm_logits,**
```

This PR fixes this inconsistency + test the cases where `labels` is passed in PT/TF equivalence test.