### PR TITLE
Fix crash when logs are empty because Keras has wiped them out of spite

### DIFF
--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -706,6 +706,9 @@ def parse_keras_history(logs):
     """
     if hasattr(logs, "history"):
         # This looks like a `History` object
+        if not hasattr(logs, "epoch"):
+            # This history looks empty, return empty results
+            return None, [], dict()
         logs.history["epoch"] = logs.epoch
         logs = logs.history
     else:


### PR DESCRIPTION
In situations where the training history is empty, TF model card creation via `model.create_model_card()` or `model.push_to_hub()` no longer crashes.