### PR TITLE
Update fine-tune docs

### DIFF
--- a/docs/source/training.mdx
+++ b/docs/source/training.mdx
@@ -39,7 +39,7 @@ Begin by loading the [Yelp Reviews](https://huggingface.co/datasets/yelp_review_
  'text': 'My expectations for McDonalds are t rarely high. But for one to still fail so spectacularly...that takes something special!\\nThe cashier took my friends\'s order, then promptly ignored me. I had to force myself in front of a cashier who opened his register to wait on the person BEHIND me. I waited over five minutes for a gigantic order that included precisely one kid\'s meal. After watching two people who ordered after me be handed their food, I asked where mine was. The manager started yelling at the cashiers for \\"serving off their orders\\" when they didn\'t have their food. But neither cashier was anywhere near those controls, and the manager was the one serving food to customers and clearing the boards.\\nThe manager was rude when giving me my order. She didn\'t make sure that I had everything ON MY RECEIPT, and never even had the decency to apologize that I felt I was getting poor service.\\nI\'ve eaten at various McDonalds restaurants for over 30 years. I\'ve worked at more than one location. I expect bad days, bad moods, and the occasional mistake. But I have yet to have a decent experience at this store. It will remain a place I avoid unless someone in my party needs to avoid illness from low blood sugar. Perhaps I should go back to the racially biased service of Steak n Shake instead!'}
 ```
 
-As you now know, you need a tokenizer to process the text and include a padding and truncation strategy to handle any variable sequence lengths. To process your dataset in one step, use 🤗 Datasets [`map`](https://huggingface.co/docs/datasets/process.html#map) method to apply a preprocessing function over the entire dataset:
+As you now know, you need a tokenizer to process the text and include a padding and truncation strategy to handle any variable sequence lengths. To process your dataset in one step, use 🤗 Datasets [map](https://huggingface.co/docs/datasets/process.html#map) method to apply a preprocessing function over the entire dataset:
 
 ```py
 >>> from transformers import AutoTokenizer
@@ -168,7 +168,7 @@ First, you need a [`DataCollator`](main_classes/data_collator) to assemble your 
 
 </Tip>
 
-Next, convert the tokenized datasets to TensorFlow datasets with the [`to_tf_dataset`](https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasets.Dataset.to_tf_dataset) method. Specify your inputs in `columns`, and your label in `label_cols`:
+Next, convert the tokenized datasets to TensorFlow datasets with the [to_tf_dataset](https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasets.Dataset.to_tf_dataset) method. Specify your inputs in `columns`, and your label in `label_cols`:
 
 ```py
 >>> tf_train_dataset = small_train_dataset.to_tf_dataset(
@@ -199,7 +199,7 @@ Load a TensorFlow model with the expected number of labels:
 >>> model = TFAutoModelForSequenceClassification.from_pretrained("bert-base-cased", num_labels=5)
 ```
 
-Then compile and fine-tune your model with [`fit`](https://keras.io/api/models/model_training_apis/) as you would with any other Keras model:
+Then compile and fine-tune your model with [fit](https://keras.io/api/models/model_training_apis/) as you would with any other Keras model:
 
 ```py
 >>> model.compile(
@@ -276,7 +276,7 @@ Load your model with the number of expected labels:
 
 ### Optimizer and learning rate scheduler
 
-Create an optimizer and learning rate scheduler to fine-tune the model. Let's use the [`AdamW`](https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html) optimizer from PyTorch:
+Create an optimizer and learning rate scheduler to fine-tune the model. Let's use the [AdamW](https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html) optimizer from PyTorch:
 
 ```py
 >>> from torch.optim import AdamW
@@ -338,7 +338,7 @@ To keep track of your training progress, use the [tqdm](https://tqdm.github.io/)
 
 ### Metrics
 
-Just like how you need to add an evaluation function to [`Trainer`], you need to do the same when you write your own training loop. But instead of calculating and reporting the metric at the end of each epoch, this time you will accumulate all the batches with [`add_batch`](https://huggingface.co/docs/datasets/package_reference/main_classes.html?highlight=add_batch#datasets.Metric.add_batch) and calculate the metric at the very end.
+Just like how you need to add an evaluation function to [`Trainer`], you need to do the same when you write your own training loop. But instead of calculating and reporting the metric at the end of each epoch, this time you will accumulate all the batches with [add_batch](https://huggingface.co/docs/datasets/package_reference/main_classes.html?highlight=add_batch#datasets.Metric.add_batch) and calculate the metric at the very end.
 
 ```py
 >>> metric = load_metric("accuracy")

--- a/docs/source/training.mdx
+++ b/docs/source/training.mdx
@@ -14,9 +14,9 @@ specific language governing permissions and limitations under the License.
 
 [[open-in-colab]]
 
-There are significant benefits when you use a pretrained model. It reduces computation costs and your carbon footprint, and allows you to use state-of-the-art models without having to train them from scratch. 🤗 Transformers provides access to thousands of pretrained models you can use across many domains. When you use a pretrained model, you just need to train it on a dataset specific to your task. This is referred to as fine-tuning, an incredibly powerful training technique. In this tutorial, you will fine-tune a pretrained model with a deep learning framework of your choice:
+There are significant benefits when you use a pretrained model. It reduces computation costs and your carbon footprint, and allows you to use state-of-the-art models without having to train them from scratch. 🤗 Transformers provides access to thousands of pretrained models you can use for a wide range of tasks. When you use a pretrained model, you just need to train it on a dataset specific to your task. This is referred to as fine-tuning, an incredibly powerful training technique. In this tutorial, you will fine-tune a pretrained model with a deep learning framework of your choice:
 
-* Fine-tune a pretrained model with 🤗 Transformers [`Trainer`] API.
+* Fine-tune a pretrained model with 🤗 Transformers [`Trainer`].
 * Fine-tune a pretrained model in TensorFlow with Keras.
 * Fine-tune a pretrained model in native PyTorch.
 
@@ -45,15 +45,19 @@ As you now know, you will need a tokenizer to process the text, and include a pa
 >>> from transformers import AutoTokenizer
 
 >>> tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
+
+
 >>> def tokenize_function(examples):
 ...     return tokenizer(examples["text"], padding="max_length", truncation=True)
+
+
 >>> tokenized_datasets = dataset.map(tokenize_function, batched=True)
 ```
 
 To speed things up in this tutorial, create a smaller subset of the full dataset to train on:
 
 ```py
->>> small_train_dataset = tokenized_datasets["train"].shuffle(seed=42).select(range(1000)) 
+>>> small_train_dataset = tokenized_datasets["train"].shuffle(seed=42).select(range(1000))
 >>> small_eval_dataset = tokenized_datasets["test"].shuffle(seed=42).select(range(1000))
 ```
 
@@ -61,11 +65,11 @@ Nice, your preprocessed dataset is now ready for fine-tuning!
 
 <a id='trainer'></a>
 
-## Fine-tune with the Trainer API
+## Fine-tune with `Trainer`
 
 <Youtube id="nvBXf7s7vTI"/>
 
-PyTorch does not provide a training loop, so you would have to manually write one (see how [here](training#fine-tune-in-native-pytorch)). For greater user ease, 🤗 Transformers has a [`Trainer`] class optimized for training 🤗 Transformers models. The [`Trainer`] API supports a wide range of training options and features such as logging, gradient accumulation, and mixed precision.
+PyTorch does not provide a training loop, so you would have to manually write one (see how [here](training#fine-tune-in-native-pytorch)). To make it easier for you to start training without writing your own training loop, 🤗 Transformers has a [`Trainer`] class optimized for training 🤗 Transformers models. The [`Trainer`] API supports a wide range of training options and features such as logging, gradient accumulation, and mixed precision.
 
 Start by loading your model, and specify the number of expected labels. From the Yelp Review [dataset card](https://huggingface.co/datasets/yelp_review_full#data-fields), you can see there are five labels:
 
@@ -78,14 +82,13 @@ Start by loading your model, and specify the number of expected labels. From the
 <Tip>
 
 You will see a warning about some of the pretrained weights not being used and some weights being randomly
-initialized. Don't worry, this is completely normal! The pretrained head of the BERT model is discarded, and replaced it with a randomly initialized classification head. You will fine-tune this new model head on your sequence classification task, transferring the knowledge
-of the pretrained model to it (which is why this is called transfer learning).
+initialized. Don't worry, this is completely normal! The pretrained head of the BERT model is discarded, and replaced with a randomly initialized classification head. You will fine-tune this new model head on your sequence classification task, transferring the knowledge of the pretrained model to it (which is why this is called transfer learning).
 
 </Tip>
 
 ### Training hyperparameters
 
-Next, create a [`TrainingArguments`] class which contains all the hyperparameters you can tune, as well as flags to activate for different training options. For this tutorial, you can start with the default training hyperparameters (but feel free to experiment with these if you'd like). All you need to do is specify where to save the checkpoints from your training:
+Next, create a [`TrainingArguments`] class which contains all the hyperparameters you can tune, as well as flags for activating different training options. For this tutorial, you can start with the default training hyperparameters (but feel free to experiment with these if you'd like). All you need to do is specify where to save the checkpoints from your training:
 
 ```python
 from transformers import TrainingArguments
@@ -104,7 +107,7 @@ training_args = TrainingArguments(output_dir="test_trainer")
 >>> metric = load_metric("accuracy")
 ```
 
-The `metric` has a `compute` method which calculates the accuracy of your predictions. But before you can pass your predictions to the `compute` method, you need to convert the predictions to logits (remember all 🤗 Transformers models return logits):
+`metric` has a `compute` method which calculates the accuracy of your predictions. But before you can pass your predictions to the `compute` method, you need to convert the predictions to logits (remember all 🤗 Transformers models return logits):
 
 ```py
 >>> def compute_metrics(eval_pred):
@@ -132,12 +135,12 @@ Create a [`Trainer`] with your model, training arguments, training and test data
 ...     train_dataset=small_train_dataset,
 ...     eval_dataset=small_eval_dataset,
 ...     compute_metrics=compute_metrics,
-)
+... )
 ```
 
 Then fine-tune your model by calling `train()`:
 
-```python
+```py
 >>> trainer.train()
 ```
 
@@ -147,11 +150,11 @@ Then fine-tune your model by calling `train()`:
 
 <Youtube id="rnTGBy2ax1c"/>
 
-🤗 Transformers models can also be trained natively in TensorFlow with the Keras API. There are only a few changes to make before you can fine-tune.
+🤗 Transformers models can also be trained natively in TensorFlow with the Keras API. You only need to make a few changes before you can fine-tune.
 
 ### Convert dataset to TensorFlow format
 
-First, you need a [`DataCollator`](main_classes/data_collator) to assemble your tensors into a batch. In this tutorial, you will use [`transformers.DataCollatorWithPadding`] to also apply a padding strategy. This will pad each input to the longest length in each batch (also known as _dynamic padding_), which will speed up your training. Make sure you specify `return_tensors` to return TensorFlow tensors:
+First, you need a [`DataCollator`](main_classes/data_collator) to assemble your tensors into a batch. You can use [`transformers.DataCollatorWithPadding`] to also apply a padding strategy. This will pad each input to the longest length in each batch (also known as _dynamic padding_), which will speed up your training. Make sure you specify `return_tensors` to return TensorFlow tensors:
 
 ```py
 >>> from transformers import DataCollatorWithPadding
@@ -161,7 +164,7 @@ First, you need a [`DataCollator`](main_classes/data_collator) to assemble your 
 
 <Tip>
 
-[`Trainer`] uses [`transformers.DataCollatorWithPadding`] by default, so you don't have to explicitly specify it.
+[`Trainer`] uses [`transformers.DataCollatorWithPadding`] by default so you don't have to explicitly specify it.
 
 </Tip>
 
@@ -174,7 +177,7 @@ Next, convert the tokenized datasets to TensorFlow datasets with the [`to_tf_dat
 ...     shuffle=True,
 ...     collate_fn=data_collator,
 ...     batch_size=8,
-)
+... )
 
 >>> tf_validation_dataset = small_eval_dataset.to_tf_dataset(
 ...     columns=["attention_mask", "input_ids", "token_type_ids"],
@@ -182,14 +185,14 @@ Next, convert the tokenized datasets to TensorFlow datasets with the [`to_tf_dat
 ...     shuffle=False,
 ...     collate_fn=data_collator,
 ...     batch_size=8,
-)
+... )
 ```
 
 ### Compile and fit
 
 Load a TensorFlow model with the expected number of labels:
 
-```python
+```py
 >>> import tensorflow as tf
 >>> from transformers import TFAutoModelForSequenceClassification
 
@@ -198,14 +201,14 @@ Load a TensorFlow model with the expected number of labels:
 
 Then you can compile and fine-tune your model with the `fit()` method as you would with any other Keras model:
 
-```python
+```py
 >>> model.compile(
-...    optimizer=tf.keras.optimizers.Adam(learning_rate=5e-5),
-...    loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
-...    metrics=tf.metrics.SparseCategoricalAccuracy(),
-)
+...     optimizer=tf.keras.optimizers.Adam(learning_rate=5e-5),
+...     loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+...     metrics=tf.metrics.SparseCategoricalAccuracy(),
+... )
 
->>> model.fit(train_tf_dataset, validation_data=eval_tf_dataset, epochs=3)
+>>> model.fit(tf_train_dataset, validation_data=tf_validation_dataset, epochs=3)
 ```
 
 <a id='pytorch_native'></a>
@@ -214,9 +217,9 @@ Then you can compile and fine-tune your model with the `fit()` method as you wou
 
 <Youtube id="Dh9CL8fyG80"/>
 
-[`Trainer`] takes care of the training loop, and allows you to fine-tune a model in a single line of code. For users who'd like to tinker with the code more and see what's happening behind the curtains, you can also fine-tune a 🤗 Transformers model natively with PyTorch.
+[`Trainer`] takes care of the training loop, and allows you to fine-tune a model in a single line of code. For users who prefer to write their own training loop, you can also fine-tune a 🤗 Transformers model natively with PyTorch.
 
-At this stage, you may need to restart your notebook or you can also execute the following code to free some memory:
+At this stage, you may need to restart your notebook or execute the following code to free some memory:
 
 ```py
 del model
@@ -225,9 +228,9 @@ del trainer
 torch.cuda.empty_cache()
 ```
 
-Next, you need to post-process your `tokenized_dataset` to get it ready for training.
+Next, post-process your `tokenized_dataset` to prepare it for training.
 
-1. Remove the `text` column because the model does not accept it as an input:
+1. Remove the `text` column because the model does not accept the raw text as an input:
 
     ```py
     >>> tokenized_datasets = tokenized_datasets.remove_columns(["text"])
@@ -248,7 +251,7 @@ Next, you need to post-process your `tokenized_dataset` to get it ready for trai
 Then you can create a smaller subset of the dataset as previously shown:
 
 ```py
->>> small_train_dataset = tokenized_datasets["train"].shuffle(seed=42).select(range(1000)) 
+>>> small_train_dataset = tokenized_datasets["train"].shuffle(seed=42).select(range(1000))
 >>> small_eval_dataset = tokenized_datasets["test"].shuffle(seed=42).select(range(1000))
 ```
 
@@ -266,9 +269,8 @@ Create a `DataLoader` for your training and test datasets:
 Load your model with the number of expected labels:
 
 ```py
->> from transformers import AutoModelForSequenceClassification
-
->>> model = AutoModelForSequenceClassification.from_pretrained("bert-base-cased", num_labels=5)
+>>> from transformers import AutoModelForSequenceClassification
+model = AutoModelForSequenceClassification.from_pretrained("bert-base-cased", num_labels=5)
 ```
 
 ### Optimizer and learning rate scheduler
@@ -289,11 +291,8 @@ Next, create the default learning rate scheduler used in [`Trainer`]:
 >>> num_epochs = 3
 >>> num_training_steps = num_epochs * len(train_dataloader)
 >>> lr_scheduler = get_scheduler(
-...    name="linear",
-...    optimizer=optimizer,
-...    num_warmup_steps=0,
-...    num_training_steps=num_training_steps
-)
+...     name="linear", optimizer=optimizer, num_warmup_steps=0, num_training_steps=num_training_steps
+... )
 ```
 
 Lastly, specify `device` to use a GPU if you have access to one. Otherwise, training on a CPU may take several hours instead of a couple of minutes.
@@ -318,16 +317,16 @@ Let's use the [tqdm](https://tqdm.github.io/) library to add a progress bar over
 
 >>> model.train()
 >>> for epoch in range(num_epochs):
-...    for batch in train_dataloader:
-...        batch = {k: v.to(device) for k, v in batch.items()}
-...        outputs = model(**batch)
-...        loss = outputs.loss
-...        loss.backward()
+...     for batch in train_dataloader:
+...         batch = {k: v.to(device) for k, v in batch.items()}
+...         outputs = model(**batch)
+...         loss = outputs.loss
+...         loss.backward()
 
-...        optimizer.step()
-...        lr_scheduler.step()
-...        optimizer.zero_grad()
-...        progress_bar.update(1)
+...         optimizer.step()
+...         lr_scheduler.step()
+...         optimizer.zero_grad()
+...         progress_bar.update(1)
 ```
 
 ### Metrics
@@ -338,13 +337,13 @@ Just like the [`Trainer`] class, you need to manually add an evaluation function
 >>> metric = load_metric("accuracy")
 >>> model.eval()
 >>> for batch in eval_dataloader:
-...    batch = {k: v.to(device) for k, v in batch.items()}
-...    with torch.no_grad():
-...        outputs = model(**batch)
-...
-...    logits = outputs.logits
-...    predictions = torch.argmax(logits, dim=-1)
-...    metric.add_batch(predictions=predictions, references=batch["labels"])
+...     batch = {k: v.to(device) for k, v in batch.items()}
+...     with torch.no_grad():
+...         outputs = model(**batch)
+
+...     logits = outputs.logits
+...     predictions = torch.argmax(logits, dim=-1)
+...     metric.add_batch(predictions=predictions, references=batch["labels"])
 
 >>> metric.compute()
 ```

--- a/docs/source/training.mdx
+++ b/docs/source/training.mdx
@@ -154,17 +154,17 @@ Then fine-tune your model by calling [`~transformers.Trainer.train`]:
 
 ### Convert dataset to TensorFlow format
 
-First, you need a [`DataCollator`](main_classes/data_collator) to assemble your tensors into a batch. You can use [`DataCollatorWithPadding`] to also apply a padding strategy. This will pad each input to the longest length in each batch (also known as _dynamic padding_), which will speed up your training. Make sure you specify `return_tensors` to return TensorFlow tensors:
+The [`DefaultDataCollator`] assembles tensors into a batch for the model to train on. Make sure you specify `return_tensors` to return TensorFlow tensors:
 
 ```py
->>> from transformers import DataCollatorWithPadding
+>>> from transformers import DefaultDataCollator
 
->>> data_collator = DataCollatorWithPadding(tokenizer=tokenizer, return_tensors="tf")
+>>> data_collator = DefaultDataCollator(return_tensors="tf")
 ```
 
 <Tip>
 
-[`Trainer`] uses [`transformers.DataCollatorWithPadding`] by default so you don't have to explicitly specify it.
+[`Trainer`] uses [`DataCollatorWithPadding`] by default so you don't need to explicitly specify a data collator.
 
 </Tip>
 

--- a/docs/source/training.mdx
+++ b/docs/source/training.mdx
@@ -26,7 +26,7 @@ There are significant benefits to using a pretrained model. It reduces computati
 
 <Youtube id="_BZearw7f0w"/>
 
-Before you can fine-tune a pretrained model, download a dataset and prepare it for training. The previous tutorial showed you how to process data for training, and now is an opportunity to put those skills to the test!
+Before you can fine-tune a pretrained model, download a dataset and prepare it for training. The previous tutorial showed you how to process data for training, and now you get an opportunity to put those skills to the test!
 
 Begin by loading the [Yelp Reviews](https://huggingface.co/datasets/yelp_review_full) dataset:
 
@@ -39,7 +39,7 @@ Begin by loading the [Yelp Reviews](https://huggingface.co/datasets/yelp_review_
  'text': 'My expectations for McDonalds are t rarely high. But for one to still fail so spectacularly...that takes something special!\\nThe cashier took my friends\'s order, then promptly ignored me. I had to force myself in front of a cashier who opened his register to wait on the person BEHIND me. I waited over five minutes for a gigantic order that included precisely one kid\'s meal. After watching two people who ordered after me be handed their food, I asked where mine was. The manager started yelling at the cashiers for \\"serving off their orders\\" when they didn\'t have their food. But neither cashier was anywhere near those controls, and the manager was the one serving food to customers and clearing the boards.\\nThe manager was rude when giving me my order. She didn\'t make sure that I had everything ON MY RECEIPT, and never even had the decency to apologize that I felt I was getting poor service.\\nI\'ve eaten at various McDonalds restaurants for over 30 years. I\'ve worked at more than one location. I expect bad days, bad moods, and the occasional mistake. But I have yet to have a decent experience at this store. It will remain a place I avoid unless someone in my party needs to avoid illness from low blood sugar. Perhaps I should go back to the racially biased service of Steak n Shake instead!'}
 ```
 
-As you now know, you need a tokenizer to process the text and include a padding and truncation strategy to handle any variable sequence lengths. To process your dataset in one step, use 🤗 Datasets [map](https://huggingface.co/docs/datasets/process.html#map) method to apply a preprocessing function over the entire dataset:
+As you now know, you need a tokenizer to process the text and include a padding and truncation strategy to handle any variable sequence lengths. To process your dataset in one step, use 🤗 Datasets [`map`](https://huggingface.co/docs/datasets/process.html#map) method to apply a preprocessing function over the entire dataset:
 
 ```py
 >>> from transformers import AutoTokenizer
@@ -98,7 +98,7 @@ Specify where to save the checkpoints from your training:
 
 ### Metrics
 
-[`Trainer`] does not automatically evaluate model performance during training. You will need to pass [`Trainer`] a function to compute and report metrics. The 🤗 Datasets library provides a simple [accuracy](https://huggingface.co/metrics/accuracy) function you can load with the `load_metric` (see this [tutorial](https://huggingface.co/docs/datasets/metrics.html) for more information) function:
+[`Trainer`] does not automatically evaluate model performance during training. You will need to pass [`Trainer`] a function to compute and report metrics. The 🤗 Datasets library provides a simple [`accuracy`](https://huggingface.co/metrics/accuracy) function you can load with the `load_metric` (see this [tutorial](https://huggingface.co/docs/datasets/metrics.html) for more information) function:
 
 ```py
 >>> import numpy as np
@@ -168,7 +168,7 @@ First, you need a [`DataCollator`](main_classes/data_collator) to assemble your 
 
 </Tip>
 
-Next, convert the tokenized datasets to TensorFlow datasets with the [to_tf_dataset](https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasets.Dataset.to_tf_dataset) method. Specify your inputs in `columns`, and your label in `label_cols`:
+Next, convert the tokenized datasets to TensorFlow datasets with the [`to_tf_dataset`](https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasets.Dataset.to_tf_dataset) method. Specify your inputs in `columns`, and your label in `label_cols`:
 
 ```py
 >>> tf_train_dataset = small_train_dataset.to_tf_dataset(
@@ -199,7 +199,7 @@ Load a TensorFlow model with the expected number of labels:
 >>> model = TFAutoModelForSequenceClassification.from_pretrained("bert-base-cased", num_labels=5)
 ```
 
-Then compile and fine-tune your model with [fit](https://keras.io/api/models/model_training_apis/) as you would with any other Keras model:
+Then compile and fine-tune your model with [`fit`](https://keras.io/api/models/model_training_apis/) as you would with any other Keras model:
 
 ```py
 >>> model.compile(
@@ -228,7 +228,7 @@ del trainer
 torch.cuda.empty_cache()
 ```
 
-Next, manually post-process `tokenized_dataset` to prepare it for training.
+Next, manually postprocess `tokenized_dataset` to prepare it for training.
 
 1. Remove the `text` column because the model does not accept raw text as an input:
 
@@ -276,7 +276,7 @@ Load your model with the number of expected labels:
 
 ### Optimizer and learning rate scheduler
 
-Create an optimizer and learning rate scheduler to fine-tune the model. Let's use the [AdamW](https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html) optimizer from PyTorch:
+Create an optimizer and learning rate scheduler to fine-tune the model. Let's use the [`AdamW`](https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html) optimizer from PyTorch:
 
 ```py
 >>> from torch.optim import AdamW
@@ -338,7 +338,7 @@ To keep track of your training progress, use the [tqdm](https://tqdm.github.io/)
 
 ### Metrics
 
-Just like how you need to add an evaluation function to [`Trainer`], you need to do the same when you write your own training loop. But instead of calculating and reporting the metric at the end of each epoch, this time you will accumulate all the batches with [add_batch](https://huggingface.co/docs/datasets/package_reference/main_classes.html?highlight=add_batch#datasets.Metric.add_batch) and calculate the metric at the very end.
+Just like how you need to add an evaluation function to [`Trainer`], you need to do the same when you write your own training loop. But instead of calculating and reporting the metric at the end of each epoch, this time you will accumulate all the batches with [`add_batch`](https://huggingface.co/docs/datasets/package_reference/main_classes.html?highlight=add_batch#datasets.Metric.add_batch) and calculate the metric at the very end.
 
 ```py
 >>> metric = load_metric("accuracy")

--- a/docs/source/training.mdx
+++ b/docs/source/training.mdx
@@ -1,4 +1,4 @@
-<!--Copyright 2020 The HuggingFace Team. All rights reserved.
+<!--Copyright 2022 The HuggingFace Team. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 the License. You may obtain a copy of the License at
@@ -14,7 +14,7 @@ specific language governing permissions and limitations under the License.
 
 [[open-in-colab]]
 
-There are significant benefits when you use a pretrained model. It reduces computation costs and your carbon footprint, and allows you to use state-of-the-art models without having to train them from scratch. 🤗 Transformers provides access to thousands of pretrained models you can use for a wide range of tasks. When you use a pretrained model, you just need to train it on a dataset specific to your task. This is referred to as fine-tuning, an incredibly powerful training technique. In this tutorial, you will fine-tune a pretrained model with a deep learning framework of your choice:
+There are significant benefits to using a pretrained model. It reduces computation costs, your carbon footprint, and allows you to use state-of-the-art models without having to train one from scratch. 🤗 Transformers provides access to thousands of pretrained models for a wide range of tasks. When you use a pretrained model, you train it on a dataset specific to your task. This is known as fine-tuning, an incredibly powerful training technique. In this tutorial, you will fine-tune a pretrained model with a deep learning framework of your choice:
 
 * Fine-tune a pretrained model with 🤗 Transformers [`Trainer`].
 * Fine-tune a pretrained model in TensorFlow with Keras.
@@ -26,7 +26,7 @@ There are significant benefits when you use a pretrained model. It reduces compu
 
 <Youtube id="_BZearw7f0w"/>
 
-Before you fine-tune a pretrained model, you will need to download a dataset and prepare it for training. In the previous tutorial, you learned how to process data for training. Now you will put those skills to the test!
+Before you can fine-tune a pretrained model, download a dataset and prepare it for training. The previous tutorial showed you how to process data for training, and now is an opportunity to put those skills to the test!
 
 Begin by loading the [Yelp Reviews](https://huggingface.co/datasets/yelp_review_full) dataset:
 
@@ -39,9 +39,9 @@ Begin by loading the [Yelp Reviews](https://huggingface.co/datasets/yelp_review_
  'text': 'My expectations for McDonalds are t rarely high. But for one to still fail so spectacularly...that takes something special!\\nThe cashier took my friends\'s order, then promptly ignored me. I had to force myself in front of a cashier who opened his register to wait on the person BEHIND me. I waited over five minutes for a gigantic order that included precisely one kid\'s meal. After watching two people who ordered after me be handed their food, I asked where mine was. The manager started yelling at the cashiers for \\"serving off their orders\\" when they didn\'t have their food. But neither cashier was anywhere near those controls, and the manager was the one serving food to customers and clearing the boards.\\nThe manager was rude when giving me my order. She didn\'t make sure that I had everything ON MY RECEIPT, and never even had the decency to apologize that I felt I was getting poor service.\\nI\'ve eaten at various McDonalds restaurants for over 30 years. I\'ve worked at more than one location. I expect bad days, bad moods, and the occasional mistake. But I have yet to have a decent experience at this store. It will remain a place I avoid unless someone in my party needs to avoid illness from low blood sugar. Perhaps I should go back to the racially biased service of Steak n Shake instead!'}
 ```
 
-As you now know, you will need a tokenizer to process the text, and include a padding and truncation strategy to handle any variable sequence lengths. Use 🤗 Datasets [`map`](https://huggingface.co/docs/datasets/process.html#map) method to apply a preprocessing function over the entire dataset. This way, you process your data in one step:
+As you now know, you need a tokenizer to process the text and include a padding and truncation strategy to handle any variable sequence lengths. To process your dataset in one step, use 🤗 Datasets [`map`](https://huggingface.co/docs/datasets/process.html#map) method to apply a preprocessing function over the entire dataset:
 
-```python
+```py
 >>> from transformers import AutoTokenizer
 
 >>> tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
@@ -54,14 +54,12 @@ As you now know, you will need a tokenizer to process the text, and include a pa
 >>> tokenized_datasets = dataset.map(tokenize_function, batched=True)
 ```
 
-To speed things up in this tutorial, create a smaller subset of the full dataset to train on:
+If you like, you can create a smaller subset of the full dataset to fine-tune on to reduce the time it takes:
 
 ```py
 >>> small_train_dataset = tokenized_datasets["train"].shuffle(seed=42).select(range(1000))
 >>> small_eval_dataset = tokenized_datasets["test"].shuffle(seed=42).select(range(1000))
 ```
-
-Nice, your preprocessed dataset is now ready for fine-tuning!
 
 <a id='trainer'></a>
 
@@ -69,11 +67,11 @@ Nice, your preprocessed dataset is now ready for fine-tuning!
 
 <Youtube id="nvBXf7s7vTI"/>
 
-PyTorch does not provide a training loop, so you would have to manually write one (see how [here](training#fine-tune-in-native-pytorch)). To make it easier for you to start training without writing your own training loop, 🤗 Transformers has a [`Trainer`] class optimized for training 🤗 Transformers models. The [`Trainer`] API supports a wide range of training options and features such as logging, gradient accumulation, and mixed precision.
+🤗 Transformers provides a [`Trainer`] class optimized for training 🤗 Transformers models, making it easier to start training without manually writing your own training loop. The [`Trainer`] API supports a wide range of training options and features such as logging, gradient accumulation, and mixed precision.
 
-Start by loading your model, and specify the number of expected labels. From the Yelp Review [dataset card](https://huggingface.co/datasets/yelp_review_full#data-fields), you can see there are five labels:
+Start by loading your model and specify the number of expected labels. From the Yelp Review [dataset card](https://huggingface.co/datasets/yelp_review_full#data-fields), you know there are five labels:
 
-```python
+```py
 >>> from transformers import AutoModelForSequenceClassification
 
 >>> model = AutoModelForSequenceClassification.from_pretrained("bert-base-cased", num_labels=5)
@@ -82,23 +80,25 @@ Start by loading your model, and specify the number of expected labels. From the
 <Tip>
 
 You will see a warning about some of the pretrained weights not being used and some weights being randomly
-initialized. Don't worry, this is completely normal! The pretrained head of the BERT model is discarded, and replaced with a randomly initialized classification head. You will fine-tune this new model head on your sequence classification task, transferring the knowledge of the pretrained model to it (which is why this is called transfer learning).
+initialized. Don't worry, this is completely normal! The pretrained head of the BERT model is discarded, and replaced with a randomly initialized classification head. You will fine-tune this new model head on your sequence classification task, transferring the knowledge of the pretrained model to it.
 
 </Tip>
 
 ### Training hyperparameters
 
-Next, create a [`TrainingArguments`] class which contains all the hyperparameters you can tune, as well as flags for activating different training options. For this tutorial, you can start with the default training hyperparameters (but feel free to experiment with these if you'd like). All you need to do is specify where to save the checkpoints from your training:
+Next, create a [`TrainingArguments`] class which contains all the hyperparameters you can tune as well as flags for activating different training options. For this tutorial you can start with the default training [hyperparameters](https://huggingface.co/docs/transformers/main_classes/trainer#transformers.TrainingArguments), but feel free to experiment with these to find your optimal settings.
 
-```python
-from transformers import TrainingArguments
+Specify where to save the checkpoints from your training:
 
-training_args = TrainingArguments(output_dir="test_trainer")
+```py
+>>> from transformers import TrainingArguments
+
+>>> training_args = TrainingArguments(output_dir="test_trainer")
 ```
 
 ### Metrics
 
-[`Trainer`] does not automatically evaluate model performance during training. You will need to pass [`Trainer`] a function to compute and report metrics. The 🤗 Datasets library provides a simple accuracy function you can load with the `load_metric` (see this [tutorial](https://huggingface.co/docs/datasets/metrics.html) for more information) function:
+[`Trainer`] does not automatically evaluate model performance during training. You will need to pass [`Trainer`] a function to compute and report metrics. The 🤗 Datasets library provides a simple [accuracy](https://huggingface.co/metrics/accuracy) function you can load with the `load_metric` (see this [tutorial](https://huggingface.co/docs/datasets/metrics.html) for more information) function:
 
 ```py
 >>> import numpy as np
@@ -107,7 +107,7 @@ training_args = TrainingArguments(output_dir="test_trainer")
 >>> metric = load_metric("accuracy")
 ```
 
-`metric` has a `compute` method which calculates the accuracy of your predictions. But before you can pass your predictions to the `compute` method, you need to convert the predictions to logits (remember all 🤗 Transformers models return logits):
+Call `compute` on `metric` to calculate the accuracy of your predictions. Before passing your predictions to `compute`, you need to convert the predictions to logits (remember all 🤗 Transformers models return logits):
 
 ```py
 >>> def compute_metrics(eval_pred):
@@ -126,7 +126,7 @@ If you'd like to monitor your evaluation metrics during fine-tuning, specify the
 
 ### Trainer
 
-Create a [`Trainer`] with your model, training arguments, training and test datasets, and evaluation function:
+Create a [`Trainer`] object with your model, training arguments, training and test datasets, and evaluation function:
 
 ```py
 >>> trainer = Trainer(
@@ -138,7 +138,7 @@ Create a [`Trainer`] with your model, training arguments, training and test data
 ... )
 ```
 
-Then fine-tune your model by calling `train()`:
+Then fine-tune your model by calling [`~transformers.Trainer.train`]:
 
 ```py
 >>> trainer.train()
@@ -150,11 +150,11 @@ Then fine-tune your model by calling `train()`:
 
 <Youtube id="rnTGBy2ax1c"/>
 
-🤗 Transformers models can also be trained natively in TensorFlow with the Keras API. You only need to make a few changes before you can fine-tune.
+🤗 Transformers models also supports training in TensorFlow with the Keras API. You only need to make a few changes before you can fine-tune.
 
 ### Convert dataset to TensorFlow format
 
-First, you need a [`DataCollator`](main_classes/data_collator) to assemble your tensors into a batch. You can use [`transformers.DataCollatorWithPadding`] to also apply a padding strategy. This will pad each input to the longest length in each batch (also known as _dynamic padding_), which will speed up your training. Make sure you specify `return_tensors` to return TensorFlow tensors:
+First, you need a [`DataCollator`](main_classes/data_collator) to assemble your tensors into a batch. You can use [`DataCollatorWithPadding`] to also apply a padding strategy. This will pad each input to the longest length in each batch (also known as _dynamic padding_), which will speed up your training. Make sure you specify `return_tensors` to return TensorFlow tensors:
 
 ```py
 >>> from transformers import DataCollatorWithPadding
@@ -199,7 +199,7 @@ Load a TensorFlow model with the expected number of labels:
 >>> model = TFAutoModelForSequenceClassification.from_pretrained("bert-base-cased", num_labels=5)
 ```
 
-Then you can compile and fine-tune your model with the `fit()` method as you would with any other Keras model:
+Then compile and fine-tune your model with [`fit`](https://keras.io/api/models/model_training_apis/) as you would with any other Keras model:
 
 ```py
 >>> model.compile(
@@ -217,9 +217,9 @@ Then you can compile and fine-tune your model with the `fit()` method as you wou
 
 <Youtube id="Dh9CL8fyG80"/>
 
-[`Trainer`] takes care of the training loop, and allows you to fine-tune a model in a single line of code. For users who prefer to write their own training loop, you can also fine-tune a 🤗 Transformers model natively with PyTorch.
+[`Trainer`] takes care of the training loop and allows you to fine-tune a model in a single line of code. For users who prefer to write their own training loop, you can also fine-tune a 🤗 Transformers model in native PyTorch.
 
-At this stage, you may need to restart your notebook or execute the following code to free some memory:
+At this point, you may need to restart your notebook or execute the following code to free some memory:
 
 ```py
 del model
@@ -228,9 +228,9 @@ del trainer
 torch.cuda.empty_cache()
 ```
 
-Next, post-process your `tokenized_dataset` to prepare it for training.
+Next, manually post-process `tokenized_dataset` to prepare it for training.
 
-1. Remove the `text` column because the model does not accept the raw text as an input:
+1. Remove the `text` column because the model does not accept raw text as an input:
 
     ```py
     >>> tokenized_datasets = tokenized_datasets.remove_columns(["text"])
@@ -248,7 +248,7 @@ Next, post-process your `tokenized_dataset` to prepare it for training.
     >>> tokenized_datasets.set_format("torch")
     ```
 
-Then you can create a smaller subset of the dataset as previously shown:
+Then create a smaller subset of the dataset as previously shown to speed up the fine-tuning:
 
 ```py
 >>> small_train_dataset = tokenized_datasets["train"].shuffle(seed=42).select(range(1000))
@@ -257,7 +257,7 @@ Then you can create a smaller subset of the dataset as previously shown:
 
 ### DataLoader
 
-Create a `DataLoader` for your training and test datasets:
+Create a `DataLoader` for your training and test datasets so you can iterate over batches of data:
 
 ```py
 >>> from torch.utils.data import DataLoader
@@ -270,20 +270,21 @@ Load your model with the number of expected labels:
 
 ```py
 >>> from transformers import AutoModelForSequenceClassification
-model = AutoModelForSequenceClassification.from_pretrained("bert-base-cased", num_labels=5)
+
+>>> model = AutoModelForSequenceClassification.from_pretrained("bert-base-cased", num_labels=5)
 ```
 
 ### Optimizer and learning rate scheduler
 
-Create an optimizer and learning rate scheduler to fine-tune the model with. Let's use the default optimizer used in [`Trainer`], [`AdamW`]:
+Create an optimizer and learning rate scheduler to fine-tune the model. Let's use the [`AdamW`](https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html) optimizer from PyTorch:
 
 ```py
->>> from transformers import AdamW
+>>> from torch.optim import AdamW
 
 >>> optimizer = AdamW(model.parameters(), lr=5e-5)
 ```
 
-Next, create the default learning rate scheduler used in [`Trainer`]:
+Create the default learning rate scheduler from [`Trainer`]:
 
 ```py
 >>> from transformers import get_scheduler
@@ -304,11 +305,17 @@ Lastly, specify `device` to use a GPU if you have access to one. Otherwise, trai
 >>> model.to(device)
 ```
 
+<Tip>
+
+Get free access to a cloud GPU if you don't have one with a hosted notebook like [Colaboratory](https://colab.research.google.com/) or [SageMaker StudioLab](https://studiolab.sagemaker.aws/).
+
+</Tip>
+
 Great, now you are ready to train! 🥳 
 
 ### Training loop
 
-Let's use the [tqdm](https://tqdm.github.io/) library to add a progress bar over the number of training steps so you know how far along the training is:
+To keep track of your training progress, use the [tqdm](https://tqdm.github.io/) library to add a progress bar over the number of training steps:
 
 ```py
 >>> from tqdm.auto import tqdm
@@ -331,7 +338,7 @@ Let's use the [tqdm](https://tqdm.github.io/) library to add a progress bar over
 
 ### Metrics
 
-Just like the [`Trainer`] class, you need to manually add an evaluation function to compute a metric. But instead of calculating and reporting the metric at the end of each epoch, this time you will accumulate all the batches with the [`add_batch`](https://huggingface.co/docs/datasets/package_reference/main_classes.html?highlight=add_batch#datasets.Metric.add_batch) method and calculate the metric at the very end.
+Just like how you need to add an evaluation function to [`Trainer`], you need to do the same when you write your own training loop. But instead of calculating and reporting the metric at the end of each epoch, this time you will accumulate all the batches with [`add_batch`](https://huggingface.co/docs/datasets/package_reference/main_classes.html?highlight=add_batch#datasets.Metric.add_batch) and calculate the metric at the very end.
 
 ```py
 >>> metric = load_metric("accuracy")
@@ -352,7 +359,7 @@ Just like the [`Trainer`] class, you need to manually add an evaluation function
 
 ## Additional resources
 
-For more fine-tuning examples, you can refer to:
+For more fine-tuning examples, refer to:
 
 - [🤗 Transformers Examples](https://github.com/huggingface/transformers/tree/master/examples) includes scripts
   to train common NLP tasks in PyTorch and TensorFlow.

--- a/docs/source/training.mdx
+++ b/docs/source/training.mdx
@@ -10,385 +10,352 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 -->
 
-# Fine-tuning a pretrained model
+# Fine-tune a pretrained model
 
 [[open-in-colab]]
 
-In this tutorial, we will show you how to fine-tune a pretrained model from the Transformers library. In TensorFlow,
-models can be directly trained using Keras and the `fit` method. In PyTorch, there is no generic training loop so
-the 🤗 Transformers library provides an API with the class [`Trainer`] to let you fine-tune or train
-a model from scratch easily. Then we will show you how to alternatively write the whole training loop in PyTorch.
+There are significant benefits when you use a pretrained model. It reduces computation costs and your carbon footprint, and allows you to use state-of-the-art models without having to train them from scratch. 🤗 Transformers provides access to thousands of pretrained models you can use across many domains. When you use a pretrained model, you just need to train it on a dataset specific to your task. This is referred to as fine-tuning, an incredibly powerful training technique. In this tutorial, you will fine-tune a pretrained model with a deep learning framework of your choice:
 
-Before we can fine-tune a model, we need a dataset. In this tutorial, we will show you how to fine-tune BERT on the
-[IMDB dataset](https://www.imdb.com/interfaces/): the task is to classify whether movie reviews are positive or
-negative. For examples of other tasks, refer to the [additional-resources](#additional-resources) section!
+* Fine-tune a pretrained model with 🤗 Transformers [`Trainer`] API.
+* Fine-tune a pretrained model in TensorFlow with Keras.
+* Fine-tune a pretrained model in native PyTorch.
 
 <a id='data-processing'></a>
 
-## Preparing the datasets
+## Prepare a dataset
 
 <Youtube id="_BZearw7f0w"/>
 
-We will use the [🤗 Datasets](https://github.com/huggingface/datasets/) library to download and preprocess the IMDB
-datasets. We will go over this part pretty quickly. Since the focus of this tutorial is on training, you should refer
-to the 🤗 Datasets [documentation](https://huggingface.co/docs/datasets/) or the [preprocessing](preprocessing) tutorial for
-more information.
+Before you fine-tune a pretrained model, you will need to download a dataset and prepare it for training. In the previous tutorial, you learned how to process data for training. Now you will put those skills to the test!
 
-First, we can use the `load_dataset` function to download and cache the dataset:
+Begin by loading the [Yelp Reviews](https://huggingface.co/datasets/yelp_review_full) dataset:
 
-```python
-from datasets import load_dataset
+```py
+>>> from datasets import load_dataset
 
-raw_datasets = load_dataset("imdb")
+>>> dataset = load_dataset("yelp_review_full")
+>>> dataset[100]
+{'label': 0,
+ 'text': 'My expectations for McDonalds are t rarely high. But for one to still fail so spectacularly...that takes something special!\\nThe cashier took my friends\'s order, then promptly ignored me. I had to force myself in front of a cashier who opened his register to wait on the person BEHIND me. I waited over five minutes for a gigantic order that included precisely one kid\'s meal. After watching two people who ordered after me be handed their food, I asked where mine was. The manager started yelling at the cashiers for \\"serving off their orders\\" when they didn\'t have their food. But neither cashier was anywhere near those controls, and the manager was the one serving food to customers and clearing the boards.\\nThe manager was rude when giving me my order. She didn\'t make sure that I had everything ON MY RECEIPT, and never even had the decency to apologize that I felt I was getting poor service.\\nI\'ve eaten at various McDonalds restaurants for over 30 years. I\'ve worked at more than one location. I expect bad days, bad moods, and the occasional mistake. But I have yet to have a decent experience at this store. It will remain a place I avoid unless someone in my party needs to avoid illness from low blood sugar. Perhaps I should go back to the racially biased service of Steak n Shake instead!'}
 ```
 
-This works like the `from_pretrained` method we saw for the models and tokenizers (except the cache directory is
-_~/.cache/huggingface/dataset_ by default).
-
-The `raw_datasets` object is a dictionary with three keys: `"train"`, `"test"` and `"unsupervised"`
-(which correspond to the three splits of that dataset). We will use the `"train"` split for training and the
-`"test"` split for validation.
-
-To preprocess our data, we will need a tokenizer:
+As you now know, you will need a tokenizer to process the text, and include a padding and truncation strategy to handle any variable sequence lengths. Use 🤗 Datasets [`map`](https://huggingface.co/docs/datasets/process.html#map) method to apply a preprocessing function over the entire dataset. This way, you process your data in one step:
 
 ```python
-from transformers import AutoTokenizer
+>>> from transformers import AutoTokenizer
 
-tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
+>>> tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
+>>> def tokenize_function(examples):
+...     return tokenizer(examples["text"], padding="max_length", truncation=True)
+>>> tokenized_datasets = dataset.map(tokenize_function, batched=True)
 ```
 
-As we saw in [preprocessing](preprocessing), we can prepare the text inputs for the model with the following command (this is an
-example, not a command you can execute):
+To speed things up in this tutorial, create a smaller subset of the full dataset to train on:
 
-```python
-inputs = tokenizer(sentences, padding="max_length", truncation=True)
+```py
+>>> small_train_dataset = tokenized_datasets["train"].shuffle(seed=42).select(range(1000)) 
+>>> small_eval_dataset = tokenized_datasets["test"].shuffle(seed=42).select(range(1000))
 ```
 
-This will make all the samples have the maximum length the model can accept (here 512), either by padding or truncating
-them.
-
-However, we can instead apply these preprocessing steps to all the splits of our dataset at once by using the
-`map` method:
-
-```python
-def tokenize_function(examples):
-    return tokenizer(examples["text"], padding="max_length", truncation=True)
-
-
-tokenized_datasets = raw_datasets.map(tokenize_function, batched=True)
-```
-
-You can learn more about the map method or the other ways to preprocess the data in the 🤗 Datasets [documentation](https://huggingface.co/docs/datasets/).
-
-Next we will generate a small subset of the training and validation set, to enable faster training:
-
-```python
-small_train_dataset = tokenized_datasets["train"].shuffle(seed=42).select(range(1000))
-small_eval_dataset = tokenized_datasets["test"].shuffle(seed=42).select(range(1000))
-full_train_dataset = tokenized_datasets["train"]
-full_eval_dataset = tokenized_datasets["test"]
-```
-
-In all the examples below, we will always use `small_train_dataset` and `small_eval_dataset`. Just replace
-them by their _full_ equivalent to train or evaluate on the full dataset.
+Nice, your preprocessed dataset is now ready for fine-tuning!
 
 <a id='trainer'></a>
 
-## Fine-tuning in PyTorch with the Trainer API
+## Fine-tune with the Trainer API
 
 <Youtube id="nvBXf7s7vTI"/>
 
-Since PyTorch does not provide a training loop, the 🤗 Transformers library provides a [`Trainer`]
-API that is optimized for 🤗 Transformers models, with a wide range of training options and with built-in features like
-logging, gradient accumulation, and mixed precision.
+PyTorch does not provide a training loop, so you would have to manually write one (see how [here](training#fine-tune-in-native-pytorch)). For greater user ease, 🤗 Transformers has a [`Trainer`] class optimized for training 🤗 Transformers models. The [`Trainer`] API supports a wide range of training options and features such as logging, gradient accumulation, and mixed precision.
 
-First, let's define our model:
+Start by loading your model, and specify the number of expected labels. From the Yelp Review [dataset card](https://huggingface.co/datasets/yelp_review_full#data-fields), you can see there are five labels:
 
 ```python
-from transformers import AutoModelForSequenceClassification
+>>> from transformers import AutoModelForSequenceClassification
 
-model = AutoModelForSequenceClassification.from_pretrained("bert-base-cased", num_labels=2)
+>>> model = AutoModelForSequenceClassification.from_pretrained("bert-base-cased", num_labels=5)
 ```
 
-This will issue a warning about some of the pretrained weights not being used and some weights being randomly
-initialized. That's because we are throwing away the pretraining head of the BERT model to replace it with a
-classification head which is randomly initialized. We will fine-tune this model on our task, transferring the knowledge
-of the pretrained model to it (which is why doing this is called transfer learning).
+<Tip>
 
-Then, to define our [`Trainer`], we will need to instantiate a
-[`TrainingArguments`]. This class contains all the hyperparameters we can tune for the
-[`Trainer`] or the flags to activate the different training options it supports. Let's begin by
-using all the defaults, the only thing we then have to provide is a directory in which the checkpoints will be saved:
+You will see a warning about some of the pretrained weights not being used and some weights being randomly
+initialized. Don't worry, this is completely normal! The pretrained head of the BERT model is discarded, and replaced it with a randomly initialized classification head. You will fine-tune this new model head on your sequence classification task, transferring the knowledge
+of the pretrained model to it (which is why this is called transfer learning).
+
+</Tip>
+
+### Training hyperparameters
+
+Next, create a [`TrainingArguments`] class which contains all the hyperparameters you can tune, as well as flags to activate for different training options. For this tutorial, you can start with the default training hyperparameters (but feel free to experiment with these if you'd like). All you need to do is specify where to save the checkpoints from your training:
 
 ```python
 from transformers import TrainingArguments
 
-training_args = TrainingArguments("test_trainer")
+training_args = TrainingArguments(output_dir="test_trainer")
 ```
 
-Then we can instantiate a [`Trainer`] like this:
+### Metrics
 
-```python
-from transformers import Trainer
+[`Trainer`] does not automatically evaluate model performance during training. You will need to pass [`Trainer`] a function to compute and report metrics. The 🤗 Datasets library provides a simple accuracy function you can load with the `load_metric` (see this [tutorial](https://huggingface.co/docs/datasets/metrics.html) for more information) function:
 
-trainer = Trainer(model=model, args=training_args, train_dataset=small_train_dataset, eval_dataset=small_eval_dataset)
+```py
+>>> import numpy as np
+>>> from datasets import load_metric
+
+>>> metric = load_metric("accuracy")
 ```
 
-To fine-tune our model, we just need to call
+The `metric` has a `compute` method which calculates the accuracy of your predictions. But before you can pass your predictions to the `compute` method, you need to convert the predictions to logits (remember all 🤗 Transformers models return logits):
 
-```python
-trainer.train()
+```py
+>>> def compute_metrics(eval_pred):
+...     logits, labels = eval_pred
+...     predictions = np.argmax(logits, axis=-1)
+...     return metric.compute(predictions=predictions, references=labels)
 ```
 
-which will start a training that you can follow with a progress bar, which should take a couple of minutes to complete
-(as long as you have access to a GPU). It won't actually tell you anything useful about how well (or badly) your model
-is performing however as by default, there is no evaluation during training, and we didn't tell the
-[`Trainer`] to compute any metrics. Let's have a look on how to do that now!
+If you'd like to monitor your evaluation metrics during fine-tuning, specify the `evaluation_strategy` parameter in your training arguments to report the evaluation metric at the end of each epoch:
 
-To have the [`Trainer`] compute and report metrics, we need to give it a `compute_metrics`
-function that takes predictions and labels (grouped in a namedtuple called [`EvalPrediction`]) and
-return a dictionary with string items (the metric names) and float values (the metric values).
+```py
+>>> from transformers import TrainingArguments
 
-The 🤗 Datasets library provides an easy way to get the common metrics used in NLP with the `load_metric` function.
-here we simply use accuracy. Then we define the `compute_metrics` function that just convert logits to predictions
-(remember that all 🤗 Transformers models return the logits) and feed them to `compute` method of this metric.
-
-```python
-import numpy as np
-from datasets import load_metric
-
-metric = load_metric("accuracy")
-
-
-def compute_metrics(eval_pred):
-    logits, labels = eval_pred
-    predictions = np.argmax(logits, axis=-1)
-    return metric.compute(predictions=predictions, references=labels)
+>>> training_args = TrainingArguments(output_dir="test_trainer", evaluation_strategy="epoch")
 ```
 
-The compute function needs to receive a tuple (with logits and labels) and has to return a dictionary with string keys
-(the name of the metric) and float values. It will be called at the end of each evaluation phase on the whole arrays of
-predictions/labels.
+### Trainer
 
-To check if this works on practice, let's create a new [`Trainer`] with our fine-tuned model:
+Create a [`Trainer`] with your model, training arguments, training and test datasets, and evaluation function:
 
-```python
-trainer = Trainer(
-    model=model,
-    args=training_args,
-    train_dataset=small_train_dataset,
-    eval_dataset=small_eval_dataset,
-    compute_metrics=compute_metrics,
+```py
+>>> trainer = Trainer(
+...     model=model,
+...     args=training_args,
+...     train_dataset=small_train_dataset,
+...     eval_dataset=small_eval_dataset,
+...     compute_metrics=compute_metrics,
 )
-trainer.evaluate()
 ```
 
-which showed an accuracy of 87.5% in our case.
-
-If you want to fine-tune your model and regularly report the evaluation metrics (for instance at the end of each
-epoch), here is how you should define your training arguments:
+Then fine-tune your model by calling `train()`:
 
 ```python
-from transformers import TrainingArguments
-
-training_args = TrainingArguments("test_trainer", evaluation_strategy="epoch")
+>>> trainer.train()
 ```
-
-See the documentation of [`TrainingArguments`] for more options.
-
 
 <a id='keras'></a>
 
-## Fine-tuning with Keras
+## Fine-tune with Keras
 
 <Youtube id="rnTGBy2ax1c"/>
 
-Models can also be trained natively in TensorFlow using the Keras API. First, let's define our model:
+🤗 Transformers models can also be trained natively in TensorFlow with the Keras API. There are only a few changes to make before you can fine-tune.
 
-```python
-import tensorflow as tf
-from transformers import TFAutoModelForSequenceClassification
+### Convert dataset to TensorFlow format
 
-model = TFAutoModelForSequenceClassification.from_pretrained("bert-base-cased", num_labels=2)
+First, you need a [`DataCollator`](main_classes/data_collator) to assemble your tensors into a batch. In this tutorial, you will use [`transformers.DataCollatorWithPadding`] to also apply a padding strategy. This will pad each input to the longest length in each batch (also known as _dynamic padding_), which will speed up your training. Make sure you specify `return_tensors` to return TensorFlow tensors:
+
+```py
+>>> from transformers import DataCollatorWithPadding
+
+>>> data_collator = DataCollatorWithPadding(tokenizer=tokenizer, return_tensors="tf")
 ```
 
-Then we will need to convert our datasets from before in standard `tf.data.Dataset`. Since we have fixed shapes,
-it can easily be done like this. First we remove the _"text"_ column from our datasets and set them in TensorFlow
-format:
+<Tip>
 
-```python
-tf_train_dataset = small_train_dataset.remove_columns(["text"]).with_format("tensorflow")
-tf_eval_dataset = small_eval_dataset.remove_columns(["text"]).with_format("tensorflow")
-```
+[`Trainer`] uses [`transformers.DataCollatorWithPadding`] by default, so you don't have to explicitly specify it.
 
-Then we convert everything in big tensors and use the `tf.data.Dataset.from_tensor_slices` method:
+</Tip>
 
-```python
-train_features = {x: tf_train_dataset[x] for x in tokenizer.model_input_names}
-train_tf_dataset = tf.data.Dataset.from_tensor_slices((train_features, tf_train_dataset["label"]))
-train_tf_dataset = train_tf_dataset.shuffle(len(tf_train_dataset)).batch(8)
+Next, convert the tokenized datasets to TensorFlow datasets with the [`to_tf_dataset`](https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasets.Dataset.to_tf_dataset) method. Specify your inputs in `columns`, and your label in `label_cols`:
 
-eval_features = {x: tf_eval_dataset[x] for x in tokenizer.model_input_names}
-eval_tf_dataset = tf.data.Dataset.from_tensor_slices((eval_features, tf_eval_dataset["label"]))
-eval_tf_dataset = eval_tf_dataset.batch(8)
-```
-
-With this done, the model can then be compiled and trained as any Keras model:
-
-```python
-model.compile(
-    optimizer=tf.keras.optimizers.Adam(learning_rate=5e-5),
-    loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
-    metrics=tf.metrics.SparseCategoricalAccuracy(),
+```py
+>>> tf_train_dataset = small_train_dataset.to_tf_dataset(
+...     columns=["attention_mask", "input_ids", "token_type_ids"],
+...     label_cols=["labels"],
+...     shuffle=True,
+...     collate_fn=data_collator,
+...     batch_size=8,
 )
 
-model.fit(train_tf_dataset, validation_data=eval_tf_dataset, epochs=3)
+>>> tf_validation_dataset = small_eval_dataset.to_tf_dataset(
+...     columns=["attention_mask", "input_ids", "token_type_ids"],
+...     label_cols=["labels"],
+...     shuffle=False,
+...     collate_fn=data_collator,
+...     batch_size=8,
+)
 ```
 
-With the tight interoperability between TensorFlow and PyTorch models, you can even save the model and then reload it
-as a PyTorch model (or vice-versa):
+### Compile and fit
+
+Load a TensorFlow model with the expected number of labels:
 
 ```python
-from transformers import AutoModelForSequenceClassification
+>>> import tensorflow as tf
+>>> from transformers import TFAutoModelForSequenceClassification
 
-model.save_pretrained("my_imdb_model")
-pytorch_model = AutoModelForSequenceClassification.from_pretrained("my_imdb_model", from_tf=True)
+>>> model = TFAutoModelForSequenceClassification.from_pretrained("bert-base-cased", num_labels=5)
+```
+
+Then you can compile and fine-tune your model with the `fit()` method as you would with any other Keras model:
+
+```python
+>>> model.compile(
+...    optimizer=tf.keras.optimizers.Adam(learning_rate=5e-5),
+...    loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+...    metrics=tf.metrics.SparseCategoricalAccuracy(),
+)
+
+>>> model.fit(train_tf_dataset, validation_data=eval_tf_dataset, epochs=3)
 ```
 
 <a id='pytorch_native'></a>
 
-## Fine-tuning in native PyTorch
+## Fine-tune in native PyTorch
 
 <Youtube id="Dh9CL8fyG80"/>
 
-You might need to restart your notebook at this stage to free some memory, or execute the following code:
+[`Trainer`] takes care of the training loop, and allows you to fine-tune a model in a single line of code. For users who'd like to tinker with the code more and see what's happening behind the curtains, you can also fine-tune a 🤗 Transformers model natively with PyTorch.
 
-```python
+At this stage, you may need to restart your notebook or you can also execute the following code to free some memory:
+
+```py
 del model
 del pytorch_model
 del trainer
 torch.cuda.empty_cache()
 ```
 
-Let's now see how to achieve the same results as in [trainer section](#trainer) in PyTorch. First we need to
-define the dataloaders, which we will use to iterate over batches. We just need to apply a bit of post-processing to
-our `tokenized_datasets` before doing that to:
+Next, you need to post-process your `tokenized_dataset` to get it ready for training.
 
-- remove the columns corresponding to values the model does not expect (here the `"text"` column)
-- rename the column `"label"` to `"labels"` (because the model expect the argument to be named `labels`)
-- set the format of the datasets so they return PyTorch Tensors instead of lists.
+1. Remove the `text` column because the model does not accept it as an input:
 
-Our _tokenized_datasets_ has one method for each of those steps:
+    ```py
+    >>> tokenized_datasets = tokenized_datasets.remove_columns(["text"])
+    ```
 
-```python
-tokenized_datasets = tokenized_datasets.remove_columns(["text"])
-tokenized_datasets = tokenized_datasets.rename_column("label", "labels")
-tokenized_datasets.set_format("torch")
+2. Rename the `label` column to `labels` because the model expects the argument to be named `labels`:
 
-small_train_dataset = tokenized_datasets["train"].shuffle(seed=42).select(range(1000))
-small_eval_dataset = tokenized_datasets["test"].shuffle(seed=42).select(range(1000))
+    ```py
+    >>> tokenized_datasets = tokenized_datasets.rename_column("label", "labels")
+    ```
+
+3. Set the format of the dataset to return PyTorch tensors instead of lists:
+
+    ```py
+    >>> tokenized_datasets.set_format("torch")
+    ```
+
+Then you can create a smaller subset of the dataset as previously shown:
+
+```py
+>>> small_train_dataset = tokenized_datasets["train"].shuffle(seed=42).select(range(1000)) 
+>>> small_eval_dataset = tokenized_datasets["test"].shuffle(seed=42).select(range(1000))
 ```
 
-Now that this is done, we can easily define our dataloaders:
+### DataLoader
 
-```python
-from torch.utils.data import DataLoader
+Create a `DataLoader` for your training and test datasets:
 
-train_dataloader = DataLoader(small_train_dataset, shuffle=True, batch_size=8)
-eval_dataloader = DataLoader(small_eval_dataset, batch_size=8)
+```py
+>>> from torch.utils.data import DataLoader
+
+>>> train_dataloader = DataLoader(small_train_dataset, shuffle=True, batch_size=8)
+>>> eval_dataloader = DataLoader(small_eval_dataset, batch_size=8)
 ```
 
-Next, we define our model:
+Load your model with the number of expected labels:
 
-```python
-from transformers import AutoModelForSequenceClassification
+```py
+>> from transformers import AutoModelForSequenceClassification
 
-model = AutoModelForSequenceClassification.from_pretrained("bert-base-cased", num_labels=2)
+>>> model = AutoModelForSequenceClassification.from_pretrained("bert-base-cased", num_labels=5)
 ```
 
-We are almost ready to write our training loop, the only two things are missing are an optimizer and a learning rate
-scheduler. The default optimizer used by the [`Trainer`] is [`AdamW`]:
+### Optimizer and learning rate scheduler
 
-```python
-from transformers import AdamW
+Create an optimizer and learning rate scheduler to fine-tune the model with. Let's use the default optimizer used in [`Trainer`], [`AdamW`]:
 
-optimizer = AdamW(model.parameters(), lr=5e-5)
+```py
+>>> from transformers import AdamW
+
+>>> optimizer = AdamW(model.parameters(), lr=5e-5)
 ```
 
-Finally, the learning rate scheduler used by default is just a linear decay from the maximum value (5e-5 here) to 0:
+Next, create the default learning rate scheduler used in [`Trainer`]:
 
-```python
-from transformers import get_scheduler
+```py
+>>> from transformers import get_scheduler
 
-num_epochs = 3
-num_training_steps = num_epochs * len(train_dataloader)
-lr_scheduler = get_scheduler("linear", optimizer=optimizer, num_warmup_steps=0, num_training_steps=num_training_steps)
+>>> num_epochs = 3
+>>> num_training_steps = num_epochs * len(train_dataloader)
+>>> lr_scheduler = get_scheduler(
+...    name="linear",
+...    optimizer=optimizer,
+...    num_warmup_steps=0,
+...    num_training_steps=num_training_steps
+)
 ```
 
-One last thing, we will want to use the GPU if we have access to one (otherwise training might take several hours
-instead of a couple of minutes). To do this, we define a `device` we will put our model and our batches on.
+Lastly, specify `device` to use a GPU if you have access to one. Otherwise, training on a CPU may take several hours instead of a couple of minutes.
 
-```python
-import torch
+```py
+>>> import torch
 
-device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
-model.to(device)
+>>> device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+>>> model.to(device)
 ```
 
-We now are ready to train! To get some sense of when it will be finished, we add a progress bar over our number of
-training steps, using the _tqdm_ library.
+Great, now you are ready to train! 🥳 
 
-```python
-from tqdm.auto import tqdm
+### Training loop
 
-progress_bar = tqdm(range(num_training_steps))
+Let's use the [tqdm](https://tqdm.github.io/) library to add a progress bar over the number of training steps so you know how far along the training is:
 
-model.train()
-for epoch in range(num_epochs):
-    for batch in train_dataloader:
-        batch = {k: v.to(device) for k, v in batch.items()}
-        outputs = model(**batch)
-        loss = outputs.loss
-        loss.backward()
+```py
+>>> from tqdm.auto import tqdm
 
-        optimizer.step()
-        lr_scheduler.step()
-        optimizer.zero_grad()
-        progress_bar.update(1)
+>>> progress_bar = tqdm(range(num_training_steps))
+
+>>> model.train()
+>>> for epoch in range(num_epochs):
+...    for batch in train_dataloader:
+...        batch = {k: v.to(device) for k, v in batch.items()}
+...        outputs = model(**batch)
+...        loss = outputs.loss
+...        loss.backward()
+
+...        optimizer.step()
+...        lr_scheduler.step()
+...        optimizer.zero_grad()
+...        progress_bar.update(1)
 ```
 
-Note that if you are used to freezing the body of your pretrained model (like in computer vision) the above may seem a
-bit strange, as we are directly fine-tuning the whole model without taking any precaution. It actually works better
-this way for Transformers model (so this is not an oversight on our side). If you're not familiar with what "freezing
-the body" of the model means, forget you read this paragraph.
+### Metrics
 
-Now to check the results, we need to write the evaluation loop. Like in the [trainer section](#trainer) we will
-use a metric from the datasets library. Here we accumulate the predictions at each batch before computing the final
-result when the loop is finished.
+Just like the [`Trainer`] class, you need to manually add an evaluation function to compute a metric. But instead of calculating and reporting the metric at the end of each epoch, this time you will accumulate all the batches with the [`add_batch`](https://huggingface.co/docs/datasets/package_reference/main_classes.html?highlight=add_batch#datasets.Metric.add_batch) method and calculate the metric at the very end.
 
-```python
-metric = load_metric("accuracy")
-model.eval()
-for batch in eval_dataloader:
-    batch = {k: v.to(device) for k, v in batch.items()}
-    with torch.no_grad():
-        outputs = model(**batch)
+```py
+>>> metric = load_metric("accuracy")
+>>> model.eval()
+>>> for batch in eval_dataloader:
+...    batch = {k: v.to(device) for k, v in batch.items()}
+...    with torch.no_grad():
+...        outputs = model(**batch)
+...
+...    logits = outputs.logits
+...    predictions = torch.argmax(logits, dim=-1)
+...    metric.add_batch(predictions=predictions, references=batch["labels"])
 
-    logits = outputs.logits
-    predictions = torch.argmax(logits, dim=-1)
-    metric.add_batch(predictions=predictions, references=batch["labels"])
-
-metric.compute()
+>>> metric.compute()
 ```
 
 <a id='additional-resources'></a>
 
 ## Additional resources
 
-To look at more fine-tuning examples you can refer to:
+For more fine-tuning examples, you can refer to:
 
-- [🤗 Transformers Examples](https://github.com/huggingface/transformers/tree/master/examples) which includes scripts
-  to train on all common NLP tasks in PyTorch and TensorFlow.
+- [🤗 Transformers Examples](https://github.com/huggingface/transformers/tree/master/examples) includes scripts
+  to train common NLP tasks in PyTorch and TensorFlow.
 
-- [🤗 Transformers Notebooks](notebooks) which contains various notebooks and in particular one per task (look for
-  the _how to finetune a model on xxx_).
+- [🤗 Transformers Notebooks](notebooks) contains various notebooks on how to fine-tune a model for specific tasks in PyTorch and TensorFlow.


### PR DESCRIPTION
This is a first draft of the updated fine-tune tutorial. Main updates include:

- Preprocess a different dataset (users are probably very used to seeing `imdb` now) to include more diverse examples so users don't feel like they are doing the same thing over and over.
- Update the `Trainer` example to include evaluating accuracy before you fine-tune. It seems like a good practice to include evaluating metrics during training, so we should present it first. Let me know if this is not common or generally applicable, and we can revert it!
- Update Keras example to use `to_tf_dataset` to convert a dataset to a TensorFlow format (cc @Rocketknight1 please feel free to let me know if I'm missing anything!)