### PR TITLE
[Kernel Fusion] training benchmarks of AOTAutograd (multiple models)

### DIFF
--- a/scripts/aot_albert.py
+++ b/scripts/aot_albert.py
@@ -1,4 +1,4 @@
-from transformers import AutoConfig, AutoModelForMaskedLM
+from transformers import AutoConfig, AutoModelForCausalLM, AutoModelForMaskedLM, AutoModelForSeq2SeqLM, ReformerConfig, BigBirdConfig, BertConfig
 import transformers
 import torch
 from functorch.compile import memory_efficient_fusion, aot_module, draw_graph_compile, nop
@@ -9,79 +9,106 @@ import torch.nn as nn
 from torch.nn.utils import _stateless
 import pandas as pd
 
-device = 'cuda'
+pytree._register_pytree_node(transformers.modeling_outputs.MaskedLMOutput, lambda x: ([x.loss, x.logits], None), lambda values, _: transformers.modeling_outputs.MaskedLMOutput(loss=values[0], logits=values[1]))
+
+pytree._register_pytree_node(transformers.modeling_outputs.Seq2SeqLMOutput, lambda x: ([x.loss, x.logits], None), lambda values, _: transformers.modeling_outputs.Seq2SeqLMOutput(loss=values[0], logits=values[1]))
+
+pytree._register_pytree_node(transformers.modeling_outputs.CausalLMOutputWithCrossAttentions, lambda x: ([x.loss, x.logits], None), lambda values, _: transformers.modeling_outputs.CausalLMOutputWithCrossAttentions(loss=values[0], logits=values[1]))
+
+pytree._register_pytree_node(transformers.models.longformer.modeling_longformer.LongformerMaskedLMOutput, lambda x: ([x.loss, x.logits], None), lambda values, _: transformers.models.longformer.modeling_longformer.LongformerMaskedLMOutput(loss=values[0], logits=values[1]))
+
 torch.manual_seed(42)
-config = AutoConfig.from_pretrained("albert-base-v2")
-config.classifier_dropout_prob = 1e-15 # To have the computation but not the stochasticity
-model = AutoModelForMaskedLM.from_config(config).to(device)
+benchmarks = [
+    (AutoConfig.from_pretrained("albert-base-v2"), AutoModelForMaskedLM, (8, 512), []),
+    (AutoConfig.from_pretrained("gpt2"), AutoModelForCausalLM, (4, 512), []),
+    (BertConfig(), AutoModelForMaskedLM, (4, 512), []),
+    (AutoConfig.from_pretrained("allenai/longformer-base-4096"), AutoModelForMaskedLM, (2, 1024), [torch.float16, torch.bfloat16]), # hmm, nans with float16
+    # (AutoConfig.from_pretrained("t5-small"), AutoModelForSeq2SeqLM, (4, 1024), [torch.float16, torch.bfloat16]), # Doesn't work with nn.utils._stateless for some reason...
+    # (AutoConfig.from_pretrained("facebook/bert-base"), AutoModelForSeq2SeqLM, (4, 512), []), # Doesn't work with nn.utils._stateless for some reason...
+    # (ReformerConfig(), AutoModelForMaskedLM, (8, 4096), []), # not sure...
+    # (BigBirdConfig(attention_type="block_sparse"), AutoModelForMaskedLM, (2, 1024), []), # not sure...
+    # (AutoConfig.from_pretrained("distilbert-base-uncased"),  AutoModelForMaskedLM, (8, 512), []), # encounters inf as a global value
+]
 
-input_ids = torch.randint(0, config.vocab_size, (8, 512)).to(device)
-decoder_ids = torch.randint(0, config.vocab_size, (8, 512)).to(device)
-
-
-train_inputs = {'input_ids': input_ids, 'labels': decoder_ids}
-
-
-pytree._register_pytree_node(transformers.modeling_outputs.MaskedLMOutput, lambda x: ([x.loss, x.logits], None), lambda values, _: transformers.modeling_outputs.MaskedLMOutput(loss=values[0], logits=values[1])) # Used for
-
-def get_cur_memory():
-    torch.cuda.synchronize()
-    import gc; gc.collect()
-    torch.cuda.empty_cache()
-    stats = torch.cuda.memory_stats()
-    peak_bytes_requirement = stats["allocated_bytes.all.current"]
-    print(f"Current memory requirement: {peak_bytes_requirement / 1024 ** 3:.2f} GB")
-    return peak_bytes_requirement
-
-def bench_model(name, mod):
-    m = None
-    for i in range(5):
-        out = mod(**train_inputs).loss.abs().sum()
-        if i == 4:
-            m = get_cur_memory()
-        out.backward()
-    iters = 20
-    torch.cuda.synchronize()
-    begin = time.time()
-    for _ in range(iters):
-        mod(**train_inputs).loss.sum().backward()
-    torch.cuda.synchronize()
-    t = (time.time()-begin)/iters
-    print(name, (time.time()-begin)/iters)
-    return t, m
+device = 'cuda'
 
 results = []
-aot_model = memory_efficient_fusion(model)
-t,m = bench_model("eager", model)
-nh, th, mh, tp, mp = "name", "time (s)", "mem (GB)", "time %", "mem %"
-results.append({nh:"eager", th:t, mh:m/2**30})
-with torch.jit.fuser("fuser2"):
-    t,m = bench_model("aot", aot_model)
-results.append({nh:"aot", th:t, mh:m/2**30})
+for config, model_type, input_size, not_supported_dtypes in benchmarks:
+    for dtype in [torch.float, torch.half, torch.bfloat16]:
+        if dtype in not_supported_dtypes:
+            continue
+        for attr in dir(config):
+            if 'drop' in attr:
+                setattr(config, attr, 1e-30) # So we can check for correct gradients without eliminating the dropout computation
+        model = model_type.from_config(config).to(device, dtype=dtype)
+        input_ids = torch.randint(0, config.vocab_size, input_size).to(device)
+        decoder_ids = torch.randint(0, config.vocab_size, input_size).to(device)
 
-# calculate relative improvements
-base_r = results[0]
-for r in results:
-    r[mp] = round(100 * (r[th] - base_r[th]) / base_r[th])
-    r[tp] = round(100 * (r[mh] - base_r[mh]) / base_r[mh])
+
+        train_inputs = {'input_ids': input_ids, 'labels': decoder_ids}
+
+        def get_cur_memory():
+            torch.cuda.synchronize()
+            import gc; gc.collect()
+            torch.cuda.empty_cache()
+            stats = torch.cuda.memory_stats()
+            peak_bytes_requirement = stats["allocated_bytes.all.current"]
+            print(f"Current memory requirement: {peak_bytes_requirement / 1024 ** 3:.2f} GB")
+            return peak_bytes_requirement
+
+        def bench_model(name, mod):
+            m = None
+            for i in range(5):
+                out = mod(**train_inputs).loss.abs().sum()
+                if i == 4:
+                    m = get_cur_memory()
+                out.backward()
+            iters = 20
+            torch.cuda.synchronize()
+            begin = time.time()
+            for _ in range(iters):
+                mod(**train_inputs).loss.sum().backward()
+            torch.cuda.synchronize()
+            t = (time.time()-begin)/iters
+            print(name, (time.time()-begin)/iters)
+            return t, m
+
+        aot_model = memory_efficient_fusion(model)
+        model_name = type(model).__name__
+        t,m = bench_model("eager", model)
+        model_header, dtype_header, nh, th, mh, tp, mp = "model", "dtype", "name", "time (s)", "mem (GB)", "time %", "mem %"
+        results.append({model_header: model_name, dtype_header: str(dtype), nh:"eager", th:t, mh:m/2**30})
+        with torch.jit.fuser("fuser2"):
+            t,m = bench_model("aot", aot_model)
+        results.append({model_header: model_name, dtype_header: str(dtype), nh:"aot", th:t, mh:m/2**30})
+
+        # calculate relative improvements
+        base_r = results[-2]
+        for r in results[-2:]:
+            r[tp] = round(100 * (r[th] - base_r[th]) / base_r[th])
+            r[mp] = round(100 * (r[mh] - base_r[mh]) / base_r[mh])
+        print(pd.DataFrame(results[-2:]).to_markdown(index=False, floatfmt=".3f"))
+
+        print()
+
+        ## Checking correctness
+        def clear_params(model):
+            for i in model.parameters(): i.grad = None
+
+        clear_params(model)
+        torch.manual_seed(0)
+        out1 = model(**train_inputs).loss
+        out1.sum().backward()
+        grad1 = [i.grad for i in model.parameters()]
+
+        clear_params(aot_model)
+        torch.manual_seed(0)
+        out2 = aot_model(**train_inputs).loss
+        out2.sum().backward()
+        grad2 = [i.grad for i in aot_model.parameters()]
+        print("Maximum output error: ", (out1 - out2).abs().max().item())
+        print("Maximum gradient error: ", max([(a-b).abs().max() for a, b in zip(grad1, grad2) if a is not None]).item())
+        print()
+
 
 print(pd.DataFrame(results).to_markdown(index=False, floatfmt=".3f"))
-
-print()
-## Checking correctness
-def clear_params(model):
-    for i in model.parameters(): i.grad = None
-
-clear_params(model)
-torch.manual_seed(0)
-out1 = model(**train_inputs).loss
-out1.sum().backward()
-grad1 = [i.grad for i in model.parameters()]
-
-clear_params(aot_model)
-torch.manual_seed(0)
-out2 = aot_model(**train_inputs).loss
-out2.sum().backward()
-grad2 = [i.grad for i in aot_model.parameters()]
-print((out1 - out2).abs().max())
-print(max([(a-b).abs().max() for a, b in zip(grad1, grad2)]))

--- a/scripts/aot_albert.py
+++ b/scripts/aot_albert.py
@@ -1,0 +1,87 @@
+from transformers import AutoConfig, AutoModelForMaskedLM
+import transformers
+import torch
+from functorch.compile import memory_efficient_fusion, aot_module, draw_graph_compile, nop
+import torch.utils._pytree as pytree
+import time
+from torch import optim
+import torch.nn as nn
+from torch.nn.utils import _stateless
+import pandas as pd
+
+device = 'cuda'
+torch.manual_seed(42)
+config = AutoConfig.from_pretrained("albert-base-v2")
+config.classifier_dropout_prob = 1e-15 # To have the computation but not the stochasticity
+model = AutoModelForMaskedLM.from_config(config).to(device)
+
+input_ids = torch.randint(0, config.vocab_size, (8, 512)).to(device)
+decoder_ids = torch.randint(0, config.vocab_size, (8, 512)).to(device)
+
+
+train_inputs = {'input_ids': input_ids, 'labels': decoder_ids}
+
+
+pytree._register_pytree_node(transformers.modeling_outputs.MaskedLMOutput, lambda x: ([x.loss, x.logits], None), lambda values, _: transformers.modeling_outputs.MaskedLMOutput(loss=values[0], logits=values[1])) # Used for
+
+def get_cur_memory():
+    torch.cuda.synchronize()
+    import gc; gc.collect()
+    torch.cuda.empty_cache()
+    stats = torch.cuda.memory_stats()
+    peak_bytes_requirement = stats["allocated_bytes.all.current"]
+    print(f"Current memory requirement: {peak_bytes_requirement / 1024 ** 3:.2f} GB")
+    return peak_bytes_requirement
+
+def bench_model(name, mod):
+    m = None
+    for i in range(5):
+        out = mod(**train_inputs).loss.abs().sum()
+        if i == 4:
+            m = get_cur_memory()
+        out.backward()
+    iters = 20
+    torch.cuda.synchronize()
+    begin = time.time()
+    for _ in range(iters):
+        mod(**train_inputs).loss.sum().backward()
+    torch.cuda.synchronize()
+    t = (time.time()-begin)/iters
+    print(name, (time.time()-begin)/iters)
+    return t, m
+
+results = []
+aot_model = memory_efficient_fusion(model)
+t,m = bench_model("eager", model)
+nh, th, mh, tp, mp = "name", "time (s)", "mem (GB)", "time %", "mem %"
+results.append({nh:"eager", th:t, mh:m/2**30})
+with torch.jit.fuser("fuser2"):
+    t,m = bench_model("aot", aot_model)
+results.append({nh:"aot", th:t, mh:m/2**30})
+
+# calculate relative improvements
+base_r = results[0]
+for r in results:
+    r[mp] = round(100 * (r[th] - base_r[th]) / base_r[th])
+    r[tp] = round(100 * (r[mh] - base_r[mh]) / base_r[mh])
+
+print(pd.DataFrame(results).to_markdown(index=False, floatfmt=".3f"))
+
+print()
+## Checking correctness
+def clear_params(model):
+    for i in model.parameters(): i.grad = None
+
+clear_params(model)
+torch.manual_seed(0)
+out1 = model(**train_inputs).loss
+out1.sum().backward()
+grad1 = [i.grad for i in model.parameters()]
+
+clear_params(aot_model)
+torch.manual_seed(0)
+out2 = aot_model(**train_inputs).loss
+out2.sum().backward()
+grad2 = [i.grad for i in aot_model.parameters()]
+print((out1 - out2).abs().max())
+print(max([(a-b).abs().max() for a, b in zip(grad1, grad2)]))


### PR DESCRIPTION
Note to maintainers: We are using this PR to collaborate and there is no intention yet to merge anything, so please ignore unless you want to experiment with the latest auto-speedups.

We are experimenting with the latest https://github.com/pytorch/functorch against pytorch nightly to automatically speed up the execution and reduce memory usage:

So the idea is this. Given an existing `model`, you speed it up by doing just this:

```
from functorch.compile import memory_efficient_fusion
aot_model = memory_efficient_fusion(model)
with torch.jit.fuser("fuser2"):
    train(aot_model)
```

So for example HF Trainer could automate this with just adding a new flag, like `--fusion aot`.

Notably, as long as the part being compiled with AOTAutograd is static, you can do whatever you want outside of the model, and autograd will still work with the AOTAutograd compiled model.

So, things like this work fine
```
foo = aot_model(*inps)
loss = foo.sum()
if loss < 0:
    print("awesome")
loss.backward()
```

Here are some benchmarks:

-------------

A100 training (from @Chillee):
```
$ python  scripts/aot_albert.py
Current memory requirement: 5.69 GB
eager 0.08250337839126587
Current memory requirement: 4.00 GB
aot 0.05442763566970825

Maximum output error:  9.5367431640625e-07
Maximum gradient error:  1.5096273273229599e-05
```

| model                 | dtype          | name   |   time (s) |   mem (GB) |   time % |   mem % |
|:----------------------|:---------------|:-------|-----------:|-----------:|---------:|--------:|
| AlbertForMaskedLM     | torch.float32  | eager  |      0.087 |      7.133 |        0 |       0 |
| AlbertForMaskedLM     | torch.float32  | aot    |      0.057 |      5.438 |      -35 |     -24 |
| AlbertForMaskedLM     | torch.float16  | eager  |      0.051 |      3.901 |        0 |       0 |
| AlbertForMaskedLM     | torch.float16  | aot    |      0.034 |      3.054 |      -34 |     -22 |
| AlbertForMaskedLM     | torch.bfloat16 | eager  |      0.053 |      3.931 |        0 |       0 |
| AlbertForMaskedLM     | torch.bfloat16 | aot    |      0.034 |      3.083 |      -36 |     -22 |
| GPT2LMHeadModel       | torch.float32  | eager  |      0.056 |      5.174 |        0 |       0 |
| GPT2LMHeadModel       | torch.float32  | aot    |      0.045 |      4.328 |      -19 |     -16 |
| GPT2LMHeadModel       | torch.float16  | eager  |      0.033 |      4.645 |        0 |       0 |
| GPT2LMHeadModel       | torch.float16  | aot    |      0.029 |      4.223 |      -13 |      -9 |
| GPT2LMHeadModel       | torch.bfloat16 | eager  |      0.034 |      4.965 |        0 |       0 |
| GPT2LMHeadModel       | torch.bfloat16 | aot    |      0.029 |      4.541 |      -15 |      -9 |
| BertForMaskedLM       | torch.float32  | eager  |      0.041 |      6.764 |        0 |       0 |
| BertForMaskedLM       | torch.float32  | aot    |      0.036 |      6.759 |      -13 |       0 |
| BertForMaskedLM       | torch.float16  | eager  |      0.025 |      6.228 |        0 |       0 |
| BertForMaskedLM       | torch.float16  | aot    |      0.021 |      6.226 |      -16 |       0 |
| BertForMaskedLM       | torch.bfloat16 | eager  |      0.026 |      6.505 |        0 |       0 |
| BertForMaskedLM       | torch.bfloat16 | aot    |      0.021 |      6.503 |      -19 |       0 |
| LongformerForMaskedLM | torch.float32  | eager  |      0.122 |      9.921 |        0 |       0 |
| LongformerForMaskedLM | torch.float32  | aot    |      0.111 |      9.933 |       -9 |       0 |


On rtx3090 (from @stas00):

| model                 | dtype          | name   |   time (s) |   mem (GB) |   time % |   mem % |
|:----------------------|:---------------|:-------|-----------:|-----------:|---------:|--------:|
| AlbertForMaskedLM     | torch.float32  | eager  |      0.173 |      7.078 |        0 |       0 |
| AlbertForMaskedLM     | torch.float32  | aot    |      0.125 |      5.382 |      -28 |     -24 |
| AlbertForMaskedLM     | torch.float16  | eager  |      0.089 |      3.829 |        0 |       0 |
| AlbertForMaskedLM     | torch.float16  | aot    |      0.064 |      2.982 |      -28 |     -22 |
| AlbertForMaskedLM     | torch.bfloat16 | eager  |      0.092 |      3.852 |        0 |       0 |
| AlbertForMaskedLM     | torch.bfloat16 | aot    |      0.064 |      3.005 |      -30 |     -22 |
| GPT2LMHeadModel       | torch.float32  | eager  |      0.112 |      4.822 |        0 |       0 |
| GPT2LMHeadModel       | torch.float32  | aot    |      0.094 |      3.977 |      -16 |     -18 |
| GPT2LMHeadModel       | torch.float16  | eager  |      0.060 |      4.013 |        0 |       0 |
| GPT2LMHeadModel       | torch.float16  | aot    |      0.051 |      3.591 |      -15 |     -11 |
| GPT2LMHeadModel       | torch.bfloat16 | eager  |      0.061 |      4.736 |        0 |       0 |
| GPT2LMHeadModel       | torch.bfloat16 | aot    |      0.051 |      4.313 |      -16 |      -9 |
| BertForMaskedLM       | torch.float32  | eager  |      0.086 |      6.343 |        0 |       0 |
| BertForMaskedLM       | torch.float32  | aot    |      0.076 |      6.338 |      -11 |       0 |
| BertForMaskedLM       | torch.float16  | eager  |      0.046 |      5.717 |        0 |       0 |
| BertForMaskedLM       | torch.float16  | aot    |      0.041 |      5.714 |      -11 |       0 |
| BertForMaskedLM       | torch.bfloat16 | eager  |      0.046 |      5.952 |        0 |       0 |
| BertForMaskedLM       | torch.bfloat16 | aot    |      0.040 |      5.950 |      -13 |       0 |
| LongformerForMaskedLM | torch.float32  | eager  |      0.209 |      9.080 |        0 |       0 |
| LongformerForMaskedLM | torch.float32  | aot    |      0.194 |      9.092 |       -7 |       0 |


------------

Instructions from @stas00 on how to build functorch to reproduce these results.

```
# install torch-nightly
conda install pytorch torchvision torchaudio cudatoolkit=11.3 -c pytorch-nightly

# install functorch (and reinstall after `git pull` later if need to sync up)
git clone https://github.com/pytorch/functorch
cd functorch
rm -rf build
pip install -e .[aot]
```

As this is a constantly evolving code-base, make sure to `git pull` and rebuild above if you have the version that is some days old. Or at least if you try the code and it fails the first thing to do is to update and rebuild `functorch` and then retry the benchmarks.

Note that there is currently a correctness issue on one of the gradients on PyTorch nightly, the above was run with this patch (https://github.com/pytorch/pytorch/pull/71542), which fixes the correctness issue.

--------------------------

Notes:

- AOT = Ahead of Time
- eager = normal python/pytorch code - i.e. the way our models are written now

Q: What is the pytree registration [here](https://github.com/huggingface/transformers/pull/15264/files#diff-a271afd7d9556b5f3a5aa2df08fa1d10114569272db373956b108446468f476fR25) for? 
A: AOTAutograd tries to present the simplest possible graphs for backends, and so it primarily works with lists of tensors for both the input and the output. So, these pytrees are needed so that we can flatten the input data structures into a list, and unflatten the output back into the correct data structure. PS: This is very much inspired by Jax <3

Resources on AOTAutograd:
AOTAutograd: https://docs.google.com/presentation/d/1rTt0BR2KChDQQTks2hHUtvHxtHQKwgQHVNrmbhj0byk/edit?usp=sharing
Min-Cut recomputation: https://dev-discuss.pytorch.org/t/min-cut-optimal-recomputation-i-e-activation-checkpointing-with-aotautograd/467