### PR TITLE
Require `tokenizers>=0.11.1`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ _deps = [
     "tf2onnx",
     "timeout-decorator",
     "timm",
-    "tokenizers>=0.10.1,!=0.11.3",
+    "tokenizers>=0.11.1,!=0.11.3",
     "torch>=1.0",
     "torchaudio",
     "pyctcdecode>=0.3.0",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -59,7 +59,7 @@ deps = {
     "tf2onnx": "tf2onnx",
     "timeout-decorator": "timeout-decorator",
     "timm": "timm",
-    "tokenizers": "tokenizers>=0.10.1,!=0.11.3",
+    "tokenizers": "tokenizers>=0.11.1,!=0.11.3",
     "torch": "torch>=1.0",
     "torchaudio": "torchaudio",
     "pyctcdecode": "pyctcdecode>=0.3.0",


### PR DESCRIPTION
# What does this PR do?

I discovered this bug by running on `master` (specifically <https://github.com/huggingface/transformers/commit/515ed3ad2a11a6b0cd9800b2ad4d3b313fdaea8c>). When running the following code, I get the error `Ignored unknown kwarg option direction`:

```python
from transformers import AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained("t5-base")
tokenizer("", truncation="longest_first")
```

This isn't a breaking error (the argument is ignored and training proceeds as normal), but given that I got the error message over 60,000 times in my log file that is 1,000 lines long with this message removed, it's very annoying to work with.

I did some digging, and it was caused when `direction` was added as an input parameter to `tokenizers.Tokenizer.enable_truncation()` in `src/transformers/tokenization_utils_fast.py` as part of <https://github.com/huggingface/transformers/commit/d33dc7966a8c7f04bbca7ae0ced75cbf26c38d9e>. However, the argument was just added to `tokenizers` in <https://github.com/huggingface/tokenizers/commit/152880ab3e5281003bdeee7d1406149e2af97951>, which was first released in `tokenizers==0.11.0`.

If support for `tokenizers>=0.10.1,<0.11` is still desired, I can create a different fix that modifies the code added in <https://github.com/huggingface/transformers/commit/08cb5718ec206bcf34fcd85a03e3e7cbfab8a9e6> to ensure unsupported arguments are filtered out. The code currently handles parameters that `tokenizers` uses but `transformers` does not. I would need to add code that also supports the opposite.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

tokenizers: @n1t0, @LysandreJik