### PR TITLE
[Fix doc example] TFLayoutLMForTokenClassification: missing import tf

### DIFF
--- a/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
+++ b/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
@@ -1384,7 +1384,6 @@ class TFLayoutLMForTokenClassification(TFLayoutLMPreTrainedModel, TFTokenClassif
         ```python
         >>> import tensorflow as tf
         >>> from transformers import LayoutLMTokenizer, TFLayoutLMForTokenClassification
-        >>> import torch
 
         >>> tokenizer = LayoutLMTokenizer.from_pretrained("microsoft/layoutlm-base-uncased")
         >>> model = TFLayoutLMForTokenClassification.from_pretrained("microsoft/layoutlm-base-uncased")

--- a/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
+++ b/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
@@ -1382,6 +1382,7 @@ class TFLayoutLMForTokenClassification(TFLayoutLMPreTrainedModel, TFTokenClassif
         Examples:
 
         ```python
+        >>> import tensorflow as tf
         >>> from transformers import LayoutLMTokenizer, TFLayoutLMForTokenClassification
         >>> import torch
 


### PR DESCRIPTION
# What does this PR do?

The following line in the doc requires `>>> import tensorflow as tf`

```
>>> bbox = tf.convert_to_tensor([token_boxes])
```