### PR TITLE
Prepare ONNX export for torch v1.11

### DIFF
--- a/src/transformers/onnx/convert.py
+++ b/src/transformers/onnx/convert.py
@@ -112,19 +112,35 @@ def export(
 
         config.patch_ops()
 
-        # export can works with named args but the dict containing named args as to be last element of the args tuple
-        export(
-            model,
-            (model_inputs,),
-            f=output.as_posix(),
-            input_names=list(config.inputs.keys()),
-            output_names=onnx_outputs,
-            dynamic_axes={name: axes for name, axes in chain(config.inputs.items(), config.outputs.items())},
-            do_constant_folding=True,
-            use_external_data_format=config.use_external_data_format(model.num_parameters()),
-            enable_onnx_checker=True,
-            opset_version=opset,
-        )
+        # PyTorch deprecated the `enable_onnx_checker` and `use_external_data_format` arguments in v1.11,
+        # so we check the torch version for backwards compatibility
+        if parse(torch.__version__) < parse("1.11.0.dev0"):
+            # export can work with named args but the dict containing named args
+            # has to be the last element of the args tuple.
+            print(torch_version)
+            export(
+                model,
+                (model_inputs,),
+                f=output.as_posix(),
+                input_names=list(config.inputs.keys()),
+                output_names=onnx_outputs,
+                dynamic_axes={name: axes for name, axes in chain(config.inputs.items(), config.outputs.items())},
+                do_constant_folding=True,
+                use_external_data_format=config.use_external_data_format(model.num_parameters()),
+                enable_onnx_checker=True,
+                opset_version=opset,
+            )
+        else:
+            export(
+                model,
+                (model_inputs,),
+                f=output.as_posix(),
+                input_names=list(config.inputs.keys()),
+                output_names=onnx_outputs,
+                dynamic_axes={name: axes for name, axes in chain(config.inputs.items(), config.outputs.items())},
+                do_constant_folding=True,
+                opset_version=opset,
+            )
 
         config.restore_ops()
 

--- a/src/transformers/onnx/convert.py
+++ b/src/transformers/onnx/convert.py
@@ -117,7 +117,6 @@ def export(
         if parse(torch.__version__) < parse("1.11.0.dev0"):
             # export can work with named args but the dict containing named args
             # has to be the last element of the args tuple.
-            print(torch_version)
             export(
                 model,
                 (model_inputs,),

--- a/src/transformers/onnx/convert.py
+++ b/src/transformers/onnx/convert.py
@@ -114,7 +114,7 @@ def export(
 
         # PyTorch deprecated the `enable_onnx_checker` and `use_external_data_format` arguments in v1.11,
         # so we check the torch version for backwards compatibility
-        if parse(torch.__version__) < parse("1.11.0.dev0"):
+        if parse(torch.__version__) <= parse("1.10.99"):
             # export can work with named args but the dict containing named args
             # has to be the last element of the args tuple.
             export(


### PR DESCRIPTION
# What does this PR do?

This PR prepares the ONNX export for `torch` v1.11, where the following arguments from the [`torch.onnx.export()` ](https://pytorch.org/docs/stable/onnx.html#torch.onnx.export)function will be removed:

* `use_external_data_format`
* `enable_onnx_checker`

A simple check on the `torch` version is used to ensure backwards compatibility with versions < 1.11

I've also tested that the slow tests pass on the nightly version of `torch` by running:

```
RUN_SLOW=1 pytest tests/test_onnx_v2.py
```

