### PR TITLE
Fix processors

### DIFF
--- a/src/transformers/models/trocr/__init__.py
+++ b/src/transformers/models/trocr/__init__.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 from typing import TYPE_CHECKING
 
-from ...file_utils import _LazyModule, is_sentencepiece_available, is_speech_available, is_torch_available
+from ...file_utils import _LazyModule, is_torch_available, is_vision_available
 
 
 _import_structure = {
@@ -25,9 +25,10 @@ _import_structure = {
         "TROCR_PRETRAINED_CONFIG_ARCHIVE_MAP",
         "TrOCRConfig",
     ],
-    "processing_trocr": ["TrOCRProcessor"],
 }
 
+if is_vision_available():
+    _import_structure["tokenization_trocr"] = ["TrOCRProcessor"]
 
 if is_torch_available():
     _import_structure["modeling_trocr"] = [
@@ -39,7 +40,9 @@ if is_torch_available():
 
 if TYPE_CHECKING:
     from .configuration_trocr import TROCR_PRETRAINED_CONFIG_ARCHIVE_MAP, TrOCRConfig
-    from .processing_trocr import TrOCRProcessor
+
+    if is_vision_available():
+        from .processing_trocr import TrOCRProcessor
 
     if is_torch_available():
         from .modeling_trocr import TROCR_PRETRAINED_MODEL_ARCHIVE_LIST, TrOCRForCausalLM, TrOCRPreTrainedModel

--- a/src/transformers/models/trocr/__init__.py
+++ b/src/transformers/models/trocr/__init__.py
@@ -28,7 +28,7 @@ _import_structure = {
 }
 
 if is_vision_available():
-    _import_structure["tokenization_trocr"] = ["TrOCRProcessor"]
+    _import_structure["processing_trocr"] = ["TrOCRProcessor"]
 
 if is_torch_available():
     _import_structure["modeling_trocr"] = [

--- a/src/transformers/models/trocr/processing_trocr.py
+++ b/src/transformers/models/trocr/processing_trocr.py
@@ -20,9 +20,16 @@ from contextlib import contextmanager
 from transformers import AutoFeatureExtractor, AutoTokenizer
 from transformers.feature_extraction_utils import FeatureExtractionMixin
 from transformers.models.roberta.tokenization_roberta import RobertaTokenizer
-from transformers.models.roberta.tokenization_roberta_fast import RobertaTokenizerFast
-from transformers.models.xlm_roberta.tokenization_xlm_roberta import XLMRobertaTokenizer
-from transformers.models.xlm_roberta.tokenization_xlm_roberta_fast import XLMRobertaTokenizerFast
+
+from ...file_utils import is_sentencepiece_available, is_tokenizers_available
+
+
+if is_tokenizers_available():
+    from transformers.models.roberta.tokenization_roberta_fast import RobertaTokenizerFast
+
+if is_sentencepiece_available():
+    from transformers.models.xlm_roberta.tokenization_xlm_roberta import XLMRobertaTokenizer
+    from transformers.models.xlm_roberta.tokenization_xlm_roberta_fast import XLMRobertaTokenizerFast
 
 
 class TrOCRProcessor:

--- a/src/transformers/models/vilt/processing_vilt.py
+++ b/src/transformers/models/vilt/processing_vilt.py
@@ -18,12 +18,12 @@ Processor class for ViLT.
 
 from typing import List, Optional, Union
 
-from transformers import BertTokenizerFast
-
-from ...file_utils import TensorType
+from ...file_utils import TensorType, is_tokenizers_available
 from ...tokenization_utils_base import BatchEncoding, PaddingStrategy, PreTokenizedInput, TextInput, TruncationStrategy
 from .feature_extraction_vilt import ViltFeatureExtractor
 
+if is_tokenizers_available():
+    from transformers import BertTokenizerFast
 
 class ViltProcessor:
     r"""


### PR DESCRIPTION
# What does this PR do?

This PR aims to fix import checks for processors of multi-modal models, like those of LayoutLMv2, TrOCR and ViLT.

The bare minimum for a processor is PIL (assuming one creates a processor by combining a feature extractor and a slow tokenizer). If one combines a feature extractor and a fast tokenizer, both PIL and tokenizers should be available.

Questions:
- should I also update the general init file?
- should I add the availability to load both the slow and fast tokenizer to a processor? e.g. ViltProcessor currently only allows the fast one

To do:

- [ ] Fix AutoProcessor API for TrOCR (#14884) 
- [ ] Fix the slow integration tests (by not using the `AutoTokenizer` API in the `from_pretrained` method)