### PR TITLE
fix: Vocabulary build issue in run_speech_recognition.py

### DIFF
--- a/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
@@ -325,7 +325,11 @@ def create_vocabulary_from_data(
         lambda vocab_1, vocab_2: set(vocab_1["vocab"][0]) | set(vocab_2["vocab"][0]), vocabs.values()
     )
 
-    vocab_dict = {v: k for k, v in enumerate(sorted(list(vocab_set)))}
+    # remove | if its already present in dataset
+    vocab_list = list(vocab_set)
+    vocab_list.remove("|")
+
+    vocab_dict = {v: k for k, v in enumerate(sorted(vocab_list))}
 
     # replace white space with delimiter token
     if word_delimiter_token is not None:


### PR DESCRIPTION
# What does this PR do?
This PR fixes the issue of vocabulary building in run_speech_recognition_ctc.py (https://github.com/huggingface/transformers/blob/master/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py#L332). 

While building vocabulary we replace the blank token " " by pipe symbol as delimiter ("|"). But if the dataset already contains the pipe symbol, which is common in Hindi language as Hindi language uses a similar character "।" as a full stop, in this case we will get two pipe symbols in the vocabulary. This will mess up the further process of creating the dictionary which is adding special tokens. Specifically, the bos token "\<s\>" and the pad token "[PAD]" will get the same index in vocabulary. This will cause the index with [PAD] token to be replaced by \<s\> and the output of Wav2Vec2ForCTC model to contain the "\<s\>" token.   

<!-- Remove if not applicable -->

Fixes #15275

## Who can review?
@patrickvonplaten , @anton-l , @Narsil