### PR TITLE
Fix the inconsistency of loss calculation between PT/TF XLNetLMHeadModel

### DIFF
--- a/src/transformers/models/xlnet/modeling_tf_xlnet.py
+++ b/src/transformers/models/xlnet/modeling_tf_xlnet.py
@@ -1390,10 +1390,7 @@ class TFXLNetLMHeadModel(TFXLNetPreTrainedModel, TFCausalLanguageModelingLoss):
 
         loss = None
         if inputs["labels"] is not None:
-            # shift labels to the left and cut last logit token
-            logits = logits[:, :-1]
-            labels = inputs["labels"][:, 1:]
-            loss = self.hf_compute_loss(labels, logits)
+            loss = self.hf_compute_loss(inputs["labels"], logits)
 
         if not inputs["return_dict"]:
             output = (logits,) + transformer_outputs[1:]


### PR DESCRIPTION
# What does this PR do?

The loss calculation in `XLNetLMHeadModel` doesn't cut the logits/labels (unlike other models say `BertLMHeadModel`).
However, `TFXLNetLMHeadModel` works as other TF Causal LM models, and cut the logits.
This causes the loss difference higher than `4e-2` sometimes.

I believe `XLNet` works somehow differently from the usual causal LM models, and the provided labels and computed logits shouldn't be cut, as  `XLNetLMHeadModel` does.

This PR fixes this inconsistency.