### PR TITLE
Added missing code in exemplary notebook - custom datasets fine-tuning

### DIFF
--- a/docs/source/custom_datasets.mdx
+++ b/docs/source/custom_datasets.mdx
@@ -310,10 +310,6 @@ input and labels. Realign the labels and tokens by:
    them.
 3. Only labeling the first token of a given word. Assign `-100` to the other subtokens from the same word.
 
-```python
-label_all_tokens = False
-```
-
 Here is how you can create a function that will realign the labels and tokens:
 
 ```python
@@ -331,7 +327,7 @@ def tokenize_and_align_labels(examples):
             elif word_idx != previous_word_idx:  # Only label the first token of a given word.
                 label_ids.append(label[word_idx])
             else:
-                label_ids.append(label[word_idx] if label_all_tokens else -100)
+                label_ids.append(-100)
             previous_word_idx = word_idx
         labels.append(label_ids)
 

--- a/docs/source/custom_datasets.mdx
+++ b/docs/source/custom_datasets.mdx
@@ -310,6 +310,10 @@ input and labels. Realign the labels and tokens by:
    them.
 3. Only labeling the first token of a given word. Assign `-100` to the other subtokens from the same word.
 
+```python
+label_all_tokens = False
+```
+
 Here is how you can create a function that will realign the labels and tokens:
 
 ```python
@@ -326,7 +330,9 @@ def tokenize_and_align_labels(examples):
                 label_ids.append(-100)
             elif word_idx != previous_word_idx:  # Only label the first token of a given word.
                 label_ids.append(label[word_idx])
-
+            else:
+                label_ids.append(label[word_idx] if label_all_tokens else -100)
+            previous_word_idx = word_idx
         labels.append(label_ids)
 
     tokenized_inputs["labels"] = labels


### PR DESCRIPTION
# What does this PR do?

Added missing code in tokenize_and_align_labels function in the exemplary notebook on custom datasets - token classification.
The missing code concerns adding labels for all but the first token in a single word.
The added code was taken directly from huggingface official example - this [colab notebook](https://colab.research.google.com/github/huggingface/notebooks/blob/master/examples/token_classification.ipynb).

Fixes # (issue)

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

- maintained examples (not research project or legacy): @sgugger, @patil-suraj

