### PR TITLE
[Tests] Fix test

### DIFF
--- a/src/transformers/models/swin/modeling_swin.py
+++ b/src/transformers/models/swin/modeling_swin.py
@@ -437,6 +437,9 @@ class SwinBlock(nn.Module):
         hidden_states_windows = window_partition(shifted_hidden_states, self.window_size)
         hidden_states_windows = hidden_states_windows.view(-1, self.window_size * self.window_size, channels)
 
+        if self.attn_mask is not None:
+            self.attn_mask = self.attn_mask.to(hidden_states_windows.device)
+
         self_attention_outputs = self.attention(
             hidden_states_windows,
             self.attn_mask,

--- a/tests/test_modeling_vilt.py
+++ b/tests/test_modeling_vilt.py
@@ -603,6 +603,5 @@ class ViltModelIntegrationTest(unittest.TestCase):
         expected_shape = torch.Size([1, 2])
         self.assertEqual(outputs.logits.shape, expected_shape)
 
-        print("Logits:", outputs.logits[0, :3])
         expected_slice = torch.tensor([-2.4013, 2.9342]).to(torch_device)
         self.assertTrue(torch.allclose(outputs.logits[0, :3], expected_slice, atol=1e-4))

--- a/tests/test_modeling_vilt.py
+++ b/tests/test_modeling_vilt.py
@@ -595,13 +595,14 @@ class ViltModelIntegrationTest(unittest.TestCase):
 
         # forward pass
         outputs = model(
-            input_ids=encoding_1.input_ids,
-            pixel_values=pixel_values,
+            input_ids=encoding_1.input_ids.to(torch_device),
+            pixel_values=pixel_values.to(torch_device),
         )
 
         # verify the logits
         expected_shape = torch.Size([1, 2])
         self.assertEqual(outputs.logits.shape, expected_shape)
 
+        print("Logits:", outputs.logits[0, :3])
         expected_slice = torch.tensor([-2.4013, 2.9342]).to(torch_device)
         self.assertTrue(torch.allclose(outputs.logits[0, :3], expected_slice, atol=1e-4))

--- a/tests/test_modeling_vit_mae.py
+++ b/tests/test_modeling_vit_mae.py
@@ -327,9 +327,6 @@ class ViTMAEModelTest(ModelTesterMixin, unittest.TestCase):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         for model_class in self.all_model_classes:
-
-            print("Model class:", model_class)
-
             model = model_class(config)
             model.to(torch_device)
             model.eval()


### PR DESCRIPTION
# What does this PR do?

This PR fixes the failing SwinModelIntegrationTest.test_inference_image_classification_head.

It also makes sure the appropriate device is used in one of ViLT's integration tests, although this test still fails due to the non-deterministic behaviour of the model. Setting torch.manual_seed(2) didn't help (it passes locally for me, but not on another machine).

Also removes a print statement in ViTMAE's test file.