### PR TITLE
Fix missing eps arg for LayerNorm in ElectraGeneratorPredictions

### DIFF
--- a/src/transformers/models/albert/modeling_albert.py
+++ b/src/transformers/models/albert/modeling_albert.py
@@ -856,7 +856,7 @@ class AlbertMLMHead(nn.Module):
     def __init__(self, config):
         super().__init__()
 
-        self.LayerNorm = nn.LayerNorm(config.embedding_size)
+        self.LayerNorm = nn.LayerNorm(config.embedding_size, eps=config.layer_norm_eps)
         self.bias = nn.Parameter(torch.zeros(config.vocab_size))
         self.dense = nn.Linear(config.hidden_size, config.embedding_size)
         self.decoder = nn.Linear(config.embedding_size, config.vocab_size)

--- a/src/transformers/models/convbert/modeling_convbert.py
+++ b/src/transformers/models/convbert/modeling_convbert.py
@@ -865,7 +865,7 @@ class ConvBertGeneratorPredictions(nn.Module):
     def __init__(self, config):
         super().__init__()
 
-        self.LayerNorm = nn.LayerNorm(config.embedding_size)
+        self.LayerNorm = nn.LayerNorm(config.embedding_size, eps=config.layer_norm_eps)
         self.dense = nn.Linear(config.hidden_size, config.embedding_size)
 
     def forward(self, generator_hidden_states):

--- a/src/transformers/models/electra/modeling_electra.py
+++ b/src/transformers/models/electra/modeling_electra.py
@@ -647,7 +647,7 @@ class ElectraGeneratorPredictions(nn.Module):
     def __init__(self, config):
         super().__init__()
 
-        self.LayerNorm = nn.LayerNorm(config.embedding_size)
+        self.LayerNorm = nn.LayerNorm(config.embedding_size, eps=config.layer_norm_eps)
         self.dense = nn.Linear(config.hidden_size, config.embedding_size)
 
     def forward(self, generator_hidden_states):


### PR DESCRIPTION
# What does this PR do?

`ElectraGeneratorPredictions`  doesn't specify `eps`

https://github.com/huggingface/transformers/blob/0501beb84601651bf6a44c5a16ab0e5b98948f78/src/transformers/models/electra/modeling_electra.py#L650

but`TFElectraGeneratorPredictions` does
https://github.com/huggingface/transformers/blob/0501beb84601651bf6a44c5a16ab0e5b98948f78/src/transformers/models/electra/modeling_tf_electra.py#L572

This causes the differences of logits/loss in PT/TF `ElectraForMaskedLM` as high as `1e-3`.
With this PR, the difference is in the range `5e-7 ~ 2e-6`.

This PR also makes the new added test introduced #15256 pass without error.

----
It's unclear to me why PyTorch `ElectraGeneratorPredictions` doesn't specify `eps` though. I assume it is a mistake.
I saw many other PyTorch models use this arg for `nn.LayerNorm`

## Question:
Should I add some deprecation warning in this case?
