### PR TITLE
Fix table formatting in SegFormer docs

### DIFF
--- a/docs/source/model_doc/segformer.mdx
+++ b/docs/source/model_doc/segformer.mdx
@@ -67,6 +67,7 @@ Tips:
 - As most models, SegFormer comes in different sizes, the details of which can be found in the table below.
 
 | **Model variant** | **Depths**    | **Hidden sizes**    | **Decoder hidden size** | **Params (M)** | **ImageNet-1k Top 1** |
+| :---------------: | ------------- | ------------------- | :---------------------: | :------------: | :-------------------: |
 | MiT-b0            | [2, 2, 2, 2]  | [32, 64, 160, 256]  | 256                     | 3.7            | 70.5                  |
 | MiT-b1            | [2, 2, 2, 2]  | [64, 128, 320, 512] | 256                     | 14.0           | 78.7                  |
 | MiT-b2            | [3, 4, 6, 3]  | [64, 128, 320, 512] | 768                     | 25.4           | 81.6                  |


### PR DESCRIPTION
# What does this PR do?

This PR fixes the Markdown table on the main SegFormer doc page. It was missing the line below the header that makes it a valid Markdown table.

Fixes #15334 


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?

@sgugger, @NielsRogge