### PR TITLE
Fix 'eval_split_name' described as defaulting to 'train'

### DIFF
--- a/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
@@ -152,7 +152,7 @@ class DataTrainingArguments:
     eval_split_name: str = field(
         default="test",
         metadata={
-            "help": "The name of the training data set split to use (via the datasets library). Defaults to 'train'"
+            "help": "The name of the training data set split to use (via the datasets library). Defaults to 'test'"
         },
     )
     audio_column_name: str = field(


### PR DESCRIPTION
# What does this PR do?

The default is correct (`test`) but the description is not.


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

Cc: @sgugger, @patil-suraj