### PR TITLE
Set syncfree AdamW as the default optimizer for xla:gpu device in amp mode

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -826,6 +826,19 @@ class Trainer:
 
             optimizer_cls, optimizer_kwargs = Trainer.get_optimizer_cls_and_kwargs(self.args)
 
+            # Try using syncfree optimizers first for better performance when using torch_xla gpu device in amp mode
+            if (
+                self.args.optim in (OptimizerNames.ADAMW_HF, OptimizerNames.ADAMW_TORCH)
+                and is_torch_tpu_available()
+                and self.do_grad_scaling
+            ):
+                try:
+                    from torch_xla.amp.syncfree import AdamW
+
+                    optimizer_cls = AdamW
+                except ImportError:
+                    pass
+
             if self.sharded_ddp == ShardedDDPOption.SIMPLE:
                 self.optimizer = OSS(
                     params=optimizer_grouped_parameters,

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -77,6 +77,7 @@ class OptimizerNames(ExplicitEnum):
 
     ADAMW_HF = "adamw_hf"
     ADAMW_TORCH = "adamw_torch"
+    ADAMW_TORCH_XLA = "adamw_torch_xla"
     ADAMW_APEX_FUSED = "adamw_apex_fused"
     ADAFACTOR = "adafactor"
 


### PR DESCRIPTION
This PR sets the syncfree AdamW ([#3294](https://github.com/pytorch/xla/pull/3294)) as the default optimizer for xla:gpu device in amp mode. The syncfree AdamW optimizer shows 20%+ throughput speedup in the run_mlm test case.

Tested with the following script:
```sh
GPU_NUM_DEVICES=1 python run_mlm.py \
    --model_name_or_path bert-base-uncased \
    --dataset_name wikitext \
    --dataset_config_name wikitext-2-raw-v1 \
    --overwrite_output_dir true \
    --output_dir /tmp/test-mlm \
    --per_device_train_batch_size 12 \
    --do_eval \
    --fp16 true \
    --do_train \
    --num_train_epochs 10
```
With normal AdamW:
```sh
***** train metrics *****
  epoch                    =       10.0
  train_loss               =     1.6235
  train_runtime            = 0:19:13.85
  train_samples            =       4627
  train_samples_per_second =       40.1
  train_steps_per_second   =      3.345
```
With syncfree AdamW:
```sh
***** train metrics *****
  epoch                    =       10.0
  train_loss               =     1.6166
  train_runtime            = 0:16:14.05
  train_samples            =       4627
  train_samples_per_second =     47.502
  train_steps_per_second   =      3.963
```

cc @sgugger