### PR TITLE
fix bug in run_clm.py

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -421,6 +421,12 @@ def main():
             for k, t in concatenated_examples.items()
         }
         result["labels"] = result["input_ids"].copy()
+        # padding if one group shorter than block_size
+        if total_length < block_size:
+            result = {
+            k: [t + [0] * (block_size - len(t))]
+            for k, t in result.items()
+        }
         return result
 
     # Note that with `batched=True`, this map processes 1,000 texts together, so group_texts throws away a remainder

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -424,7 +424,7 @@ def main():
         # padding if one group shorter than block_size
         if total_length < block_size:
             result = {
-            k: [t + [0] * (block_size - len(t))]
+            k: [t[0] + [0] * (block_size - len(t[0]))]
             for k, t in result.items()
         }
         return result

--- a/examples/pytorch/language-modeling/run_clm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_clm_no_trainer.py
@@ -379,6 +379,12 @@ def main():
             for k, t in concatenated_examples.items()
         }
         result["labels"] = result["input_ids"].copy()
+        # padding if one group shorter than block_size
+        if total_length < block_size:
+            result = {
+            k: [t + [0] * (block_size - len(t))]
+            for k, t in result.items()
+        }
         return result
 
     # Note that with `batched=True`, this map processes 1,000 texts together, so group_texts throws away a remainder

--- a/examples/pytorch/language-modeling/run_clm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_clm_no_trainer.py
@@ -382,7 +382,7 @@ def main():
         # padding if one group shorter than block_size
         if total_length < block_size:
             result = {
-            k: [t + [0] * (block_size - len(t))]
+            k: [t[0] + [0] * (block_size - len(t[0]))]
             for k, t in result.items()
         }
         return result


### PR DESCRIPTION
Sorry I don't have time to follow contributor guideline. 

group_texts function in transformers/examples/pytorch/language-modeling/run_clm.py will lead to training failure.

This is because the possibility that the length of a batch is too small is not considered.

I hope this can help some people. 
