### PR TITLE
Super-small fix stops us confusing Keras console logging by modifying…

### DIFF
--- a/src/transformers/keras_callbacks.py
+++ b/src/transformers/keras_callbacks.py
@@ -324,6 +324,7 @@ class PushToHubCallback(Callback):
             )
 
     def on_epoch_end(self, epoch, logs=None):
+        logs = logs.copy()  # Don't accidentally write things that Keras will read later
         if "epoch" not in logs:
             logs["epoch"] = epoch
         self.training_history.append(logs)


### PR DESCRIPTION
Super-small PR - some small cosmetic issues were caused by me editing the Keras `logs` dict without realizing that it would get used by Keras again afterwards.