### PR TITLE
Fix tests_fetcher

### DIFF
--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -197,7 +197,10 @@ def get_test_dependencies(test_fname):
     # Tests only have relative imports for other test files
     relative_imports = re.findall(r"from\s+\.(\S+)\s+import\s+([^\n]+)\n", content)
     relative_imports = [test for test, imp in relative_imports if "# tests_ignore" not in imp]
-    return [os.path.join("tests", f"{test}.py") for test in relative_imports]
+    dependencies = [os.path.join("tests", f"{test}.py") for test in relative_imports]
+    # Some tests use docstrings with relative imports in them and this could catch them, so we check the files
+    # actually exist
+    return [f for f in dependencies if os.path.isfile(f)]
 
 
 def create_reverse_dependency_map():


### PR DESCRIPTION
# What does this PR do?

This fixes the `test_fetcher` module which was broken by the "add-new-model-like" PR. The reason is that its test file has some relative imports in example modules that are picked by the test fetcher.