### PR TITLE
Force use_cache to be False in PyTorch

### DIFF
--- a/src/transformers/models/bart/modeling_bart.py
+++ b/src/transformers/models/bart/modeling_bart.py
@@ -1318,6 +1318,8 @@ class BartForConditionalGeneration(BartPretrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            if use_cache:
+                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None and decoder_inputs_embeds is None:
                 decoder_input_ids = shift_tokens_right(

--- a/src/transformers/models/bart/modeling_bart.py
+++ b/src/transformers/models/bart/modeling_bart.py
@@ -1319,7 +1319,7 @@ class BartForConditionalGeneration(BartPretrainedModel):
 
         if labels is not None:
             if use_cache:
-                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
+                logger.warning("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None and decoder_inputs_embeds is None:
                 decoder_input_ids = shift_tokens_right(

--- a/src/transformers/models/bart/modeling_bart.py
+++ b/src/transformers/models/bart/modeling_bart.py
@@ -1318,6 +1318,7 @@ class BartForConditionalGeneration(BartPretrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            use_cache = False
             if decoder_input_ids is None and decoder_inputs_embeds is None:
                 decoder_input_ids = shift_tokens_right(
                     labels, self.config.pad_token_id, self.config.decoder_start_token_id

--- a/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
+++ b/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
@@ -18,6 +18,7 @@
 import copy
 import math
 import random
+import warnings
 from typing import Optional, Tuple
 
 import numpy as np
@@ -2513,6 +2514,8 @@ class BigBirdPegasusForConditionalGeneration(BigBirdPegasusPreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            if use_cache:
+                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None and decoder_inputs_embeds is None:
                 decoder_input_ids = shift_tokens_right(

--- a/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
+++ b/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
@@ -18,7 +18,6 @@
 import copy
 import math
 import random
-import warnings
 from typing import Optional, Tuple
 
 import numpy as np
@@ -2515,7 +2514,7 @@ class BigBirdPegasusForConditionalGeneration(BigBirdPegasusPreTrainedModel):
 
         if labels is not None:
             if use_cache:
-                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
+                logger.warning("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None and decoder_inputs_embeds is None:
                 decoder_input_ids = shift_tokens_right(

--- a/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
+++ b/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
@@ -2513,6 +2513,7 @@ class BigBirdPegasusForConditionalGeneration(BigBirdPegasusPreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            use_cache = False
             if decoder_input_ids is None and decoder_inputs_embeds is None:
                 decoder_input_ids = shift_tokens_right(
                     labels, self.config.pad_token_id, self.config.decoder_start_token_id

--- a/src/transformers/models/blenderbot/modeling_blenderbot.py
+++ b/src/transformers/models/blenderbot/modeling_blenderbot.py
@@ -1287,6 +1287,7 @@ class BlenderbotForConditionalGeneration(BlenderbotPreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(
                     labels, self.config.pad_token_id, self.config.decoder_start_token_id

--- a/src/transformers/models/blenderbot/modeling_blenderbot.py
+++ b/src/transformers/models/blenderbot/modeling_blenderbot.py
@@ -1288,7 +1288,7 @@ class BlenderbotForConditionalGeneration(BlenderbotPreTrainedModel):
 
         if labels is not None:
             if use_cache:
-                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
+                logger.warning("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(

--- a/src/transformers/models/blenderbot/modeling_blenderbot.py
+++ b/src/transformers/models/blenderbot/modeling_blenderbot.py
@@ -1287,6 +1287,8 @@ class BlenderbotForConditionalGeneration(BlenderbotPreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            if use_cache:
+                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(

--- a/src/transformers/models/blenderbot_small/modeling_blenderbot_small.py
+++ b/src/transformers/models/blenderbot_small/modeling_blenderbot_small.py
@@ -1258,6 +1258,7 @@ class BlenderbotSmallForConditionalGeneration(BlenderbotSmallPreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(
                     labels, self.config.pad_token_id, self.config.decoder_start_token_id

--- a/src/transformers/models/blenderbot_small/modeling_blenderbot_small.py
+++ b/src/transformers/models/blenderbot_small/modeling_blenderbot_small.py
@@ -18,6 +18,7 @@
 import copy
 import math
 import random
+import warnings
 from typing import Optional, Tuple
 
 import torch
@@ -1258,6 +1259,8 @@ class BlenderbotSmallForConditionalGeneration(BlenderbotSmallPreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            if use_cache:
+                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(

--- a/src/transformers/models/blenderbot_small/modeling_blenderbot_small.py
+++ b/src/transformers/models/blenderbot_small/modeling_blenderbot_small.py
@@ -18,7 +18,6 @@
 import copy
 import math
 import random
-import warnings
 from typing import Optional, Tuple
 
 import torch
@@ -1260,7 +1259,7 @@ class BlenderbotSmallForConditionalGeneration(BlenderbotSmallPreTrainedModel):
 
         if labels is not None:
             if use_cache:
-                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
+                logger.warning("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(

--- a/src/transformers/models/led/modeling_led.py
+++ b/src/transformers/models/led/modeling_led.py
@@ -2366,6 +2366,7 @@ class LEDForConditionalGeneration(LEDPreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(
                     labels, self.config.pad_token_id, self.config.decoder_start_token_id

--- a/src/transformers/models/led/modeling_led.py
+++ b/src/transformers/models/led/modeling_led.py
@@ -17,6 +17,7 @@
 
 import math
 import random
+import warnings
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
@@ -2366,6 +2367,8 @@ class LEDForConditionalGeneration(LEDPreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            if use_cache:
+                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(

--- a/src/transformers/models/led/modeling_led.py
+++ b/src/transformers/models/led/modeling_led.py
@@ -17,7 +17,6 @@
 
 import math
 import random
-import warnings
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
@@ -2368,7 +2367,7 @@ class LEDForConditionalGeneration(LEDPreTrainedModel):
 
         if labels is not None:
             if use_cache:
-                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
+                logger.warning("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(

--- a/src/transformers/models/marian/modeling_marian.py
+++ b/src/transformers/models/marian/modeling_marian.py
@@ -18,6 +18,7 @@
 import copy
 import math
 import random
+import warnings
 from typing import Optional, Tuple
 
 import numpy as np
@@ -1291,6 +1292,8 @@ class MarianMTModel(MarianPreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            if use_cache:
+                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(

--- a/src/transformers/models/marian/modeling_marian.py
+++ b/src/transformers/models/marian/modeling_marian.py
@@ -1291,6 +1291,7 @@ class MarianMTModel(MarianPreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(
                     labels, self.config.pad_token_id, self.config.decoder_start_token_id

--- a/src/transformers/models/marian/modeling_marian.py
+++ b/src/transformers/models/marian/modeling_marian.py
@@ -18,7 +18,6 @@
 import copy
 import math
 import random
-import warnings
 from typing import Optional, Tuple
 
 import numpy as np
@@ -1293,7 +1292,7 @@ class MarianMTModel(MarianPreTrainedModel):
 
         if labels is not None:
             if use_cache:
-                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
+                logger.warning("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(

--- a/src/transformers/models/mbart/modeling_mbart.py
+++ b/src/transformers/models/mbart/modeling_mbart.py
@@ -16,6 +16,7 @@
 import copy
 import math
 import random
+import warnings
 from typing import Optional, Tuple
 
 import torch
@@ -1314,6 +1315,8 @@ class MBartForConditionalGeneration(MBartPreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            if use_cache:
+                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(labels, self.config.pad_token_id)

--- a/src/transformers/models/mbart/modeling_mbart.py
+++ b/src/transformers/models/mbart/modeling_mbart.py
@@ -1314,6 +1314,7 @@ class MBartForConditionalGeneration(MBartPreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(labels, self.config.pad_token_id)
 

--- a/src/transformers/models/mbart/modeling_mbart.py
+++ b/src/transformers/models/mbart/modeling_mbart.py
@@ -16,7 +16,6 @@
 import copy
 import math
 import random
-import warnings
 from typing import Optional, Tuple
 
 import torch
@@ -1316,7 +1315,7 @@ class MBartForConditionalGeneration(MBartPreTrainedModel):
 
         if labels is not None:
             if use_cache:
-                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
+                logger.warning("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(labels, self.config.pad_token_id)

--- a/src/transformers/models/pegasus/modeling_pegasus.py
+++ b/src/transformers/models/pegasus/modeling_pegasus.py
@@ -17,7 +17,6 @@
 import copy
 import math
 import random
-import warnings
 from typing import Optional, Tuple
 
 import numpy as np
@@ -1383,7 +1382,7 @@ class PegasusForConditionalGeneration(PegasusPreTrainedModel):
 
         if labels is not None:
             if use_cache:
-                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
+                logger.warning("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(

--- a/src/transformers/models/pegasus/modeling_pegasus.py
+++ b/src/transformers/models/pegasus/modeling_pegasus.py
@@ -17,6 +17,7 @@
 import copy
 import math
 import random
+import warnings
 from typing import Optional, Tuple
 
 import numpy as np
@@ -1381,6 +1382,8 @@ class PegasusForConditionalGeneration(PegasusPreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            if use_cache:
+                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(

--- a/src/transformers/models/pegasus/modeling_pegasus.py
+++ b/src/transformers/models/pegasus/modeling_pegasus.py
@@ -1381,6 +1381,7 @@ class PegasusForConditionalGeneration(PegasusPreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(
                     labels, self.config.pad_token_id, self.config.decoder_start_token_id

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_{{cookiecutter.lowercase_modelname}}.py
@@ -2832,6 +2832,7 @@ class {{cookiecutter.camelcase_modelname}}ForConditionalGeneration({{cookiecutte
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(labels, self.config.pad_token_id, self.config.decoder_start_token_id)
 

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_{{cookiecutter.lowercase_modelname}}.py
@@ -1571,6 +1571,7 @@ class {{cookiecutter.camelcase_modelname}}ForQuestionAnswering({{cookiecutter.ca
 import math
 import copy
 import random
+import warnings
 from typing import Optional, Tuple
 
 import torch
@@ -2832,6 +2833,8 @@ class {{cookiecutter.camelcase_modelname}}ForConditionalGeneration({{cookiecutte
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
+            if use_cache:
+                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(labels, self.config.pad_token_id, self.config.decoder_start_token_id)

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_{{cookiecutter.lowercase_modelname}}.py
@@ -1571,7 +1571,6 @@ class {{cookiecutter.camelcase_modelname}}ForQuestionAnswering({{cookiecutter.ca
 import math
 import copy
 import random
-import warnings
 from typing import Optional, Tuple
 
 import torch
@@ -2834,7 +2833,7 @@ class {{cookiecutter.camelcase_modelname}}ForConditionalGeneration({{cookiecutte
 
         if labels is not None:
             if use_cache:
-                warnings.warn("The `use_cache` argument is changed to `False` since `labels` is provided.")
+                logger.warning("The `use_cache` argument is changed to `False` since `labels` is provided.")
             use_cache = False
             if decoder_input_ids is None:
                 decoder_input_ids = shift_tokens_right(labels, self.config.pad_token_id, self.config.decoder_start_token_id)


### PR DESCRIPTION
# What does this PR do?

In `TFxxxForForConditionalGeneration` models, there is 

```
        if inputs["labels"] is not None:
            ...
            inputs["use_cache"] = False
```
while there is no such change in `xxxForForConditionalGeneration` models.

This would fail a more complete pt/tf equivalence test.
I understand why TF models doing this (which might be beneficial for efficiency.

We can do it in another way: add `use_cache=False` for PyTorch models if `labels` is passed. Let me know which way HF prefers.
