### PR TITLE
[Fix doc example] FlaxMarianPreTrainedModel

### DIFF
--- a/src/transformers/models/marian/modeling_flax_marian.py
+++ b/src/transformers/models/marian/modeling_flax_marian.py
@@ -986,7 +986,7 @@ class FlaxMarianPreTrainedModel(FlaxPreTrainedModel):
         ```python
         >>> from transformers import MarianTokenizer, FlaxMarianMTModel
 
-        >>> tokenizer = MarianTokenizer.from_pretrained("facebook/marian-large-cnn")
+        >>> tokenizer = MarianTokenizer.from_pretrained("Helsinki-NLP/opus-mt-en-de")
         >>> model = FlaxMarianMTModel.from_pretrained("Helsinki-NLP/opus-mt-en-de")
 
         >>> text = "My friends are cool but they eat too many carbs."
@@ -1053,7 +1053,7 @@ class FlaxMarianPreTrainedModel(FlaxPreTrainedModel):
         ```python
         >>> from transformers import MarianTokenizer, FlaxMarianMTModel
 
-        >>> tokenizer = MarianTokenizer.from_pretrained("facebook/marian-large-cnn")
+        >>> tokenizer = MarianTokenizer.from_pretrained("Helsinki-NLP/opus-mt-en-de")
         >>> model = FlaxMarianMTModel.from_pretrained("Helsinki-NLP/opus-mt-en-de")
 
         >>> text = "My friends are cool but they eat too many carbs."


### PR DESCRIPTION
# What does this PR do?

Tiny fix:

change
```
>>> tokenizer = MarianTokenizer.from_pretrained("facebook/marian-large-cnn")
```
to 
```
>>> tokenizer = MarianTokenizer.from_pretrained("Helsinki-NLP/opus-mt-en-de")
```

BTW, `Helsinki-NLP/opus-mt-en-de` has no Flax model checkpoint. The next line

```
 >>> model = FlaxMarianMTModel.from_pretrained("Helsinki-NLP/opus-mt-en-de")
```
will fail I think.
