### PR TITLE
Use argument for preprocessing workers in run_summairzation

### DIFF
--- a/examples/pytorch/summarization/run_summarization_no_trainer.py
+++ b/examples/pytorch/summarization/run_summarization_no_trainer.py
@@ -443,6 +443,7 @@ def main():
         processed_datasets = raw_datasets.map(
             preprocess_function,
             batched=True,
+            num_proc=args.preprocessing_num_workers,
             remove_columns=column_names,
             load_from_cache_file=not args.overwrite_cache,
             desc="Running tokenizer on dataset",


### PR DESCRIPTION
# What does this PR do?

The argument `preprocessing_num_workers` is defined but not used, this PR fixes that.
Fixes #15338