### PR TITLE
Add option to resize like torchvision's Resize

### DIFF
--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -221,8 +221,7 @@ class ImageFeatureExtractionMixin:
 
         if isinstance(size, int) or len(size) == 1:
             if default_to_square:
-                if isinstance(size, int):
-                    size = (size, size)
+                size = (size, size) if isinstance(size, int) else (size[0], size[0])
             else:
                 width, height = image.size
                 # specified size only for the smallest edge

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -184,7 +184,7 @@ class ImageFeatureExtractionMixin:
         else:
             return (image - mean) / std
 
-    def resize(self, image, size, resample=PIL.Image.BILINEAR):
+    def resize(self, image, size, resample=PIL.Image.BILINEAR, torch_resize=False, max_size=None):
         """
         Resizes `image`. Note that this will trigger a conversion of `image` to a PIL Image.
 
@@ -192,18 +192,55 @@ class ImageFeatureExtractionMixin:
             image (`PIL.Image.Image` or `np.ndarray` or `torch.Tensor`):
                 The image to resize.
             size (`int` or `Tuple[int, int]`):
-                The size to use for resizing the image.
+                The size to use for resizing the image. If `size` is a sequence like (h, w), output size will be
+                matched to this.
+
+                If `size` is an int and `torch_resize` is `False`, then image will be resized to (size, size). If
+                `size` is an int and `torch_resize` is `True`, then smaller edge of the image will be matched to this
+                number. i.e, if height > width, then image will be rescaled to (size * height / width, size).
             resample (`int`, *optional*, defaults to `PIL.Image.BILINEAR`):
                 The filter to user for resampling.
+            torch_resize (`bool`, *optional*, defaults to `False`):
+                Whether or not to replicate `torchvision.transforms.Resize` with support for resizing only the smallest
+                edge and providing an optional `max_size`.
+            max_size (`int`, *optional*, defaults to `None`):
+                The maximum allowed for the longer edge of the resized image: if the longer edge of the image is
+                greater than `max_size` after being resized according to `size`, then the image is resized again so
+                that the longer edge is equal to `max_size`. As a result, `size` might be overruled, i.e the smaller
+                edge may be shorter than `size`. Only used if `torch_resize` is `True`.
         """
         self._ensure_format_supported(image)
 
-        if isinstance(size, int):
-            size = (size, size)
-        elif isinstance(size, list):
-            size = tuple(size)
         if not isinstance(image, PIL.Image.Image):
             image = self.to_pil_image(image)
+
+        if isinstance(size, list):
+            size = tuple(size)
+
+        if torch_resize:
+            w, h = image.size
+            if isinstance(size, int) or len(size) == 1:  # specified size only for the smallest edge
+                short, long = (w, h) if w <= h else (h, w)
+                requested_new_short = size if isinstance(size, int) else size[0]
+
+                if short == requested_new_short:
+                    return image
+
+                new_short, new_long = requested_new_short, int(requested_new_short * long / short)
+
+                if max_size is not None:
+                    if max_size <= requested_new_short:
+                        raise ValueError(
+                            f"max_size = {max_size} must be strictly greater than the requested "
+                            f"size for the smaller edge size = {size}"
+                        )
+                    if new_long > max_size:
+                        new_short, new_long = int(max_size * new_short / new_long), max_size
+
+                size = (new_short, new_long) if w <= h else (new_long, new_short)
+        else:
+            if isinstance(size, int):
+                size = (size, size)
 
         return image.resize(size, resample=resample)
 

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -201,7 +201,8 @@ class ImageFeatureExtractionMixin:
             resample (`int`, *optional*, defaults to `PIL.Image.BILINEAR`):
                 The filter to user for resampling.
             default_to_square (`bool`, *optional*, defaults to `True`):
-                If set to `False`, will replicate
+                How to convert `size` when it is a single int. If set to `True`, the `size` will be converted to a
+                square (`size`,`size`). If set to `False`, will replicate
                 [`torchvision.transforms.Resize`](https://pytorch.org/vision/stable/transforms.html#torchvision.transforms.Resize)
                 with support for resizing only the smallest edge and providing an optional `max_size`.
             max_size (`int`, *optional*, defaults to `None`):

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -246,18 +246,8 @@ class ImageFeatureExtractionTester(unittest.TestCase):
             (35, 29),
         ]
 
-        sizes = [
-            # single integer
-            22,
-            27,
-            28,
-            36,
-            # single integer in tuple/list
-            [
-                22,
-            ],
-            (27,),
-        ]
+        # single integer or single integer in tuple/list
+        sizes = [22, 27, 28, 36, [22], (27,)]
 
         for (height, width), size in zip(heights_widths, sizes):
             for max_size in (None, 37, 1000):

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -230,7 +230,7 @@ class ImageFeatureExtractionTester(unittest.TestCase):
         self.assertEqual(resized_image3.size, (8, 16))
         self.assertTrue(np.array_equal(np.array(resized_image1), np.array(resized_image3)))
 
-    def test_resize_image_and_array_torchvision(self):
+    def test_resize_image_and_array_non_default_to_square(self):
         feature_extractor = ImageFeatureExtractionMixin()
 
         heights_widths = [
@@ -246,7 +246,7 @@ class ImageFeatureExtractionTester(unittest.TestCase):
             (35, 29),
         ]
 
-        osize = [
+        sizes = [
             # single integer
             22,
             27,
@@ -259,34 +259,34 @@ class ImageFeatureExtractionTester(unittest.TestCase):
             (27,),
         ]
 
-        for (height, width), osize in zip(heights_widths, osize):
+        for (height, width), size in zip(heights_widths, sizes):
             for max_size in (None, 37, 1000):
                 image = get_random_image(height, width)
                 array = np.array(image)
 
-                osize = osize[0] if isinstance(osize, (list, tuple)) else osize
+                size = size[0] if isinstance(size, (list, tuple)) else size
                 # Size can be an int or a tuple of ints.
                 # If size is an int, smaller edge of the image will be matched to this number.
                 # i.e, if height > width, then image will be rescaled to (size * height / width, size).
                 if height < width:
-                    exp_w, exp_h = (int(osize * width / height), osize)  # (w, h)
+                    exp_w, exp_h = (int(size * width / height), size)
                     if max_size is not None and max_size < exp_w:
                         exp_w, exp_h = max_size, int(max_size * exp_h / exp_w)
                 elif width < height:
-                    exp_w, exp_h = (osize, int(osize * height / width))  # (w, h)
+                    exp_w, exp_h = (size, int(size * height / width))
                     if max_size is not None and max_size < exp_h:
                         exp_w, exp_h = int(max_size * exp_w / exp_h), max_size
                 else:
-                    exp_w, exp_h = (osize, osize)  # (w, h)
-                    if max_size is not None and max_size < osize:
+                    exp_w, exp_h = (size, size)
+                    if max_size is not None and max_size < size:
                         exp_w, exp_h = max_size, max_size
 
-                resized_image = feature_extractor.resize(image, size=osize, torch_resize=True, max_size=max_size)
+                resized_image = feature_extractor.resize(image, size=size, default_to_square=False, max_size=max_size)
                 self.assertTrue(isinstance(resized_image, PIL.Image.Image))
                 self.assertEqual(resized_image.size, (exp_w, exp_h))
 
                 # Passing an array converts it to a PIL Image.
-                resized_image2 = feature_extractor.resize(array, size=osize, torch_resize=True, max_size=max_size)
+                resized_image2 = feature_extractor.resize(array, size=size, default_to_square=False, max_size=max_size)
                 self.assertTrue(isinstance(resized_image2, PIL.Image.Image))
                 self.assertEqual(resized_image2.size, (exp_w, exp_h))
                 self.assertTrue(np.array_equal(np.array(resized_image), np.array(resized_image2)))


### PR DESCRIPTION
# What does this PR do?

A lot of research papers (like ConvNeXT, PoolFormer, etc.) use [`torchvision.transforms.Resize`](https://pytorch.org/vision/stable/transforms.html#torchvision.transforms.Resize) when preparing images for the model. This class supports providing an integer size, which will only resize the smaller edge of the image.

The `resize` method defined in `image_utils.py` currently resizes to (size, size) in case size is an integer. This PR adds the possibility to resize images similar to torchvision's resize by adding an argument `torch_resize` (which is set to `False` by default). One can then also provide an optional `max_size` argument.

This is replicated using Pillow.