### PR TITLE
[Robust Speech Challenge] Add missing LR parameter

### DIFF
--- a/examples/research_projects/robust-speech-event/run_speech_recognition_ctc_bnb.py
+++ b/examples/research_projects/robust-speech-event/run_speech_recognition_ctc_bnb.py
@@ -677,6 +677,7 @@ def main():
     ]
     optimizer = bnb.optim.Adam8bit(
         params=optimizer_grouped_parameters,
+        lr=training_args.learning_rate,
         betas=(training_args.adam_beta1, training_args.adam_beta2),
         eps=training_args.adam_epsilon,
     )


### PR DESCRIPTION
Some participants of the Robust Speech event complain about learning rate issues when training the model with the run_speech_recognition_ctc_bnb.py script. This problem is due to a missing LR parameter on the 8-bit optimizer initialization. This PR fixes this.

@patrickvonplaten