### PR TITLE
Fix spurious warning in TF TokenClassification models

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -219,7 +219,7 @@ class TFTokenClassificationLoss:
         # make sure only labels that are not equal to -100
         # are taken into account as loss
         if tf.math.reduce_any(labels == -1):
-            warnings.warn("Using `-1` to mask the loss for the token is deprecated. Please use `-100` instead.")
+            tf.print("Using `-1` to mask the loss for the token is deprecated. Please use `-100` instead.")
             active_loss = tf.reshape(labels, (-1,)) != -1
         else:
             active_loss = tf.reshape(labels, (-1,)) != -100


### PR DESCRIPTION
This small fix switches `warnings.warn` for `tf.print` in the loss function for TF `TokenClassification` models. When TF compiles a model which has a conditional that depends on values inside a Tensor, it traces both branches. The result of this is that when one of the branches contains a `warnings.warn` statement, that warning is fired during tracing, before the model has seen any data.

Using `tf.print` instead of `warnings.warn` has a few downsides - in particular, it will possibly fire more than once. Still, this is better than firing the warning every time the model is used even if the data is correct, which is what happens now.