### PR TITLE
use mean instead of elementwise_mean in XLMPredLayer

### DIFF
--- a/src/transformers/models/xlm/modeling_xlm.py
+++ b/src/transformers/models/xlm/modeling_xlm.py
@@ -659,9 +659,7 @@ class XLMPredLayer(nn.Module):
             scores = self.proj(x)
             outputs = (scores,) + outputs
             if y is not None:
-                loss = nn.functional.cross_entropy(
-                    scores.view(-1, self.n_words), y.view(-1), reduction="mean"
-                )
+                loss = nn.functional.cross_entropy(scores.view(-1, self.n_words), y.view(-1), reduction="mean")
                 outputs = (loss,) + outputs
         else:
             scores = self.proj.log_prob(x)

--- a/src/transformers/models/xlm/modeling_xlm.py
+++ b/src/transformers/models/xlm/modeling_xlm.py
@@ -660,7 +660,7 @@ class XLMPredLayer(nn.Module):
             outputs = (scores,) + outputs
             if y is not None:
                 loss = nn.functional.cross_entropy(
-                    scores.view(-1, self.n_words), y.view(-1), reduction="elementwise_mean"
+                    scores.view(-1, self.n_words), y.view(-1), reduction="mean"
                 )
                 outputs = (loss,) + outputs
         else:


### PR DESCRIPTION
# What does this PR do?

Super tiny change:

`XLMPredLayer` currently uses

```
                loss = nn.functional.cross_entropy(
                    scores.view(-1, self.n_words), y.view(-1), reduction="elementwise_mean"
                )
```
I believe `elementwise_mean` is deprecated:

https://github.com/pytorch/pytorch/pull/13419

https://pytorch.org/docs/stable/generated/torch.nn.functional.cross_entropy.html
