### PR TITLE
[XGLMTokenizer] correct positional emb size

### DIFF
--- a/src/transformers/models/xglm/tokenization_xglm.py
+++ b/src/transformers/models/xglm/tokenization_xglm.py
@@ -36,7 +36,7 @@ PRETRAINED_VOCAB_FILES_MAP = {
 }
 
 PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES = {
-    "facebook/xglm-564M": 1024,
+    "facebook/xglm-564M": 2048,
 }
 
 

--- a/src/transformers/models/xglm/tokenization_xglm_fast.py
+++ b/src/transformers/models/xglm/tokenization_xglm_fast.py
@@ -43,7 +43,7 @@ PRETRAINED_VOCAB_FILES_MAP = {
 }
 
 PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES = {
-    "facebook/xglm-564M": 1024,
+    "facebook/xglm-564M": 2048,
 }
 
 


### PR DESCRIPTION
# What does this PR do?

Correct the `PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES`, 1024 => 2048