### PR TITLE
Fix FlaxDataCollatorForT5MLM for texts with "<pad>"

### DIFF
--- a/examples/flax/language-modeling/run_t5_mlm_flax.py
+++ b/examples/flax/language-modeling/run_t5_mlm_flax.py
@@ -368,7 +368,7 @@ class FlaxDataCollatorForT5MLM:
         batch_size = input_ids.shape[0]
 
         input_ids_full = np.where(sentinel_ids != 0, sentinel_ids, input_ids)
-        input_ids = input_ids_full[input_ids_full > 0].reshape((batch_size, -1))
+        input_ids = input_ids_full[input_ids_full >= 0].reshape((batch_size, -1))
         input_ids = np.concatenate(
             [input_ids, np.full((batch_size, 1), self.tokenizer.eos_token_id, dtype=np.int32)], axis=-1
         )


### PR DESCRIPTION
If the input text contains `"<pad>"` (true for C4/en dataset) T5 tokenizer assigns it index 0.
Collator code (line 371) assumes that only tokens with `id > 0` are the text tokens and the rest are sentinel ids (`-1`), which turns out not to be true for this particular case.
This causes the line to throw an error similar to

```
input_ids = input_ids_full[input_ids_full > 0].reshape((batch_size, -1))
*** ValueError: cannot reshape array of size 1040383 into shape (8192,newaxis)
```

This modification should also allow to use padding in T5 pre-training.

@patil-suraj (note edited by @stas00 to tag the correct maintainer for flax)