### PR TITLE
[M2M100, XGLM] fix positional emb resize

### DIFF
--- a/src/transformers/models/m2m_100/modeling_m2m_100.py
+++ b/src/transformers/models/m2m_100/modeling_m2m_100.py
@@ -170,7 +170,7 @@ class M2M100SinusoidalPositionalEmbedding(nn.Module):
             position_ids = self.create_position_ids_from_inputs_embeds(inputs_embeds)
 
         # expand embeddings if needed
-        max_pos = self.padding_idx + 1 + seq_len
+        max_pos = self.padding_idx + 1 + seq_len + past_key_values_length
         if max_pos > self.weights.size(0):
             self.make_weights(max_pos + self.offset, self.embedding_dim, self.padding_idx)
 

--- a/src/transformers/models/xglm/modeling_xglm.py
+++ b/src/transformers/models/xglm/modeling_xglm.py
@@ -214,7 +214,7 @@ class XGLMSinusoidalPositionalEmbedding(nn.Module):
             position_ids = self.create_position_ids_from_inputs_embeds(inputs_embeds)
 
         # expand embeddings if needed
-        max_pos = self.padding_idx + 1 + seq_len
+        max_pos = self.padding_idx + 1 + seq_len + past_key_values_length
         if max_pos > self.weights.size(0):
             self.make_weights(max_pos + self.offset, self.embedding_dim, self.padding_idx)
 


### PR DESCRIPTION
# What does this PR do?

The sinusoidal position embeddings in M2M100 and XGLM are not correctly resized as the `max_pos` is computed in-correctly. Take into account the `past_key_values_length` when computing `max_pos`.