### PR TITLE
skip large generations pipeline test for XGLM

### DIFF
--- a/tests/test_pipelines_text_generation.py
+++ b/tests/test_pipelines_text_generation.py
@@ -152,7 +152,8 @@ class TextGenerationPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseM
             return
         # We don't care about infinite range models.
         # They already work.
-        if tokenizer.model_max_length < 10000:
+        # Skip this test for XGLM, since it uses sinusoidal positional embeddings which are resized on-the-fly.
+        if tokenizer.model_max_length < 10000 and "XGLM" not in tokenizer.__class__.__name__:
             # Handling of large generations
             with self.assertRaises((RuntimeError, IndexError, ValueError, AssertionError)):
                 text_generator("This is a test" * 500, max_new_tokens=20)


### PR DESCRIPTION
# What does this PR do?

Skip large generations pipeline test for XGLM since it uses sinusoidal positional embeddings which are resized on the fly.