### PR TITLE
Add class re-weighting mechanism for classification tasks

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -192,6 +192,9 @@ class PretrainedConfig(PushToHubMixin):
         label2id (`Dict[str, int]`, *optional*): A map from label to index for the model.
         num_labels (`int`, *optional*):
             Number of labels to use in the last layer added to the model, typically for a classification task.
+        class_weights (`List[float]`, *optional*):
+            Class weights for labels used in the last layer of the model, typically in a classification task. It has to
+            be the same size than the number of labels.
         task_specific_params (`Dict[str, Any]`, *optional*):
             Additional keyword arguments to store for the current task.
         problem_type (`str`, *optional*):
@@ -304,6 +307,11 @@ class PretrainedConfig(PushToHubMixin):
             # Keys are always strings in JSON so convert ids to int here.
         else:
             self.num_labels = kwargs.pop("num_labels", 2)
+        self.class_weights = kwargs.pop("class_weights", None)
+
+        if self.class_weights:
+            if len(self.class_weights) != self.num_labels:
+                raise ValueError(f"Class weights length {self.class_weights} and num labels {self.num_labels} mismatched")
 
         if self.torch_dtype is not None and isinstance(self.torch_dtype, str):
             # we will start using self.torch_dtype in v5, but to be consistent with

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -79,7 +79,7 @@ config_common_kwargs = {
 }
 
 
-class ConfigTester(object):
+class ConfigTester(unittest.TestCase):
     def __init__(self, parent, config_class=None, has_text_modality=True, **kwargs):
         self.parent = parent
         self.config_class = config_class
@@ -156,6 +156,20 @@ class ConfigTester(object):
         self.parent.assertEqual(len(config.id2label), 3)
         self.parent.assertEqual(len(config.label2id), 3)
 
+    # TODO This test can be merged with the previous one
+    def create_and_test_config_with_class_weights(self):
+        # Check mismatch between class_weights size and num labels
+        class_weights_5_classes = [1.,1.,1.,1.,1.]
+        config = self.config_class(**self.inputs_dict, num_labels=5, class_weights=class_weights_5_classes)
+        self.parent.assertEqual(len(config.id2label), 5)
+        self.parent.assertEqual(len(config.label2id), 5)
+        self.parent.assertEqual(len(config.class_weights), 5)
+        # Check mismatch between class_weights size and num labels
+        class_weights_3_classes = [1.,1.,1.]
+        with self.assertRaises(ValueError) as context:
+            self.config_class(**self.inputs_dict, num_labels=5, class_weights=class_weights_3_classes)
+        self.assertTrue('mismatched' in str(context.exception))
+
     def check_config_can_be_init_without_params(self):
         if self.config_class.is_composition:
             return
@@ -190,6 +204,10 @@ class ConfigTester(object):
         self.create_and_test_config_with_num_labels()
         self.check_config_can_be_init_without_params()
         self.check_config_arguments_init()
+
+    # TODO This test can be merged with the previous one
+    def run_tests_with_class_weights(self):
+        self.create_and_test_config_with_class_weights()
 
 
 class FakeConfig(PretrainedConfig):

--- a/tests/test_modeling_bert.py
+++ b/tests/test_modeling_bert.py
@@ -467,6 +467,7 @@ class BertModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
 
     def test_config(self):
         self.config_tester.run_common_tests()
+        self.config_tester.run_tests_with_class_weights()
 
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
@@ -545,6 +546,13 @@ class BertModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
     def test_for_sequence_classification(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_for_sequence_classification(*config_and_inputs)
+        config_and_inputs[0].class_weights = [1., 1., 1. ]
+        self.model_tester.create_and_check_for_sequence_classification(*config_and_inputs)
+        # We expect an exception when the class_weights do not match the number of classes
+        config_and_inputs[0].class_weights = [1., 1.]
+        with self.assertRaises(ValueError) as context:
+            self.model_tester.create_and_check_for_sequence_classification(*config_and_inputs)
+        self.assertTrue('mismatched' in str(context.exception))
 
     def test_for_token_classification(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()


### PR DESCRIPTION
In supervised ML classification problems, specially multiclass/multilabel, the classes in the datasets used to train a model may have very different distribution of discrete values, which is usually called class imbalance. The class imbalance may cause biases in the training of the models. DL frameworks like PyTorch or TF, allow in their loss functions (e.g. CrossEntropyLoss, BCEWithLogitsLoss...) certain parameters to adjust the possible imbalance of data in the classes. Currently, the HF framework does not allow to take advantage of these parameters, so it would be nice to have support of a class re-weighting mechanism at the HF level to improve the possible biases in the models when doing fine-tunings.

# What does this PR do?

Tentative implementation for a class re-weighting mechanism for classification tasks. WIP
