### PR TITLE
Fixing overriding from_pretrained with `truncation_side`.

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1460,6 +1460,14 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             "right",
             "left",
         ], f"Padding side should be selected between 'right' and 'left', current value: {self.padding_side}"
+
+        # Truncation side is right by default and overridden in subclasses. If specified in the kwargs, it is changed.
+        self.truncation_side = kwargs.pop("truncation_side", self.truncation_side)
+        assert self.truncation_side in [
+            "right",
+            "left",
+        ], f"Truncation side should be selected between 'right' and 'left', current value: {self.truncation_side}"
+
         self.model_input_names = kwargs.pop("model_input_names", self.model_input_names)
 
         self.deprecation_warnings = (

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -35,6 +35,8 @@ from transformers import (
     AutoTokenizer,
     BertTokenizer,
     BertTokenizerFast,
+    GPT2Tokenizer,
+    GPT2TokenizerFast,
     PreTrainedTokenizer,
     PreTrainedTokenizerBase,
     PreTrainedTokenizerFast,
@@ -3732,6 +3734,21 @@ class TokenizerPushToHubTester(unittest.TestCase):
         )
         # Can't make an isinstance check because the new_model.config is from the FakeConfig class of a dynamic module
         self.assertEqual(tokenizer.__class__.__name__, "FakeTokenizer")
+
+
+class FromPretrainedOverrideTest(unittest.TestCase):
+    def test_override_from_pretrained(self):
+        tokenizer = GPT2Tokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2", padding_side="left")
+        self.assertEqual(tokenizer.padding_side, "left")
+
+        tokenizer = GPT2TokenizerFast.from_pretrained("hf-internal-testing/tiny-random-gpt2", padding_side="left")
+        self.assertEqual(tokenizer.padding_side, "left")
+
+        tokenizer = GPT2Tokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2", truncation_side="left")
+        self.assertEqual(tokenizer.truncation_side, "left")
+
+        tokenizer = GPT2TokenizerFast.from_pretrained("hf-internal-testing/tiny-random-gpt2", truncation_side="left")
+        self.assertEqual(tokenizer.truncation_side, "left")
 
 
 class TrieTest(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

Make sure users can override `truncation_side` on load.

Fixes #15440

@sgugger

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->