### PR TITLE
Remove loss from some flax models docs & examples

### DIFF
--- a/src/transformers/models/clip/modeling_flax_clip.py
+++ b/src/transformers/models/clip/modeling_flax_clip.py
@@ -144,8 +144,6 @@ CLIP_INPUTS_DOCSTRING = r"""
         pixel_values (`numpy.ndarray` of shape `(batch_size, num_channels, height, width)`):
             Pixel values. Padding will be ignored by default should you provide it. Pixel values can be obtained using
             [`CLIPFeatureExtractor`]. See [`CLIPFeatureExtractor.__call__`] for details.
-        return_loss (`bool`, *optional*):
-            Whether or not to return the contrastive loss.
         output_attentions (`bool`, *optional*):
             Whether or not to return the attentions tensors of all attention layers. See `attentions` under returned
             tensors for more detail.

--- a/src/transformers/models/vision_text_dual_encoder/modeling_flax_vision_text_dual_encoder.py
+++ b/src/transformers/models/vision_text_dual_encoder/modeling_flax_vision_text_dual_encoder.py
@@ -562,7 +562,7 @@ VISION_TEXT_DUAL_ENCODER_MODEL_DOCSTRING = r"""
     ...     attention_mask=inputs.attention_mask,
     ...     pixel_values=inputs.pixel_values,
     ... )
-    >>> logits_per_image = outputs.loss, outputs.logits_per_imag  # this is the image-text similarity score
+    >>> logits_per_image = outputs.logits_per_imag  # this is the image-text similarity score
 
     >>> # save and load from pretrained
     >>> model.save_pretrained("vit-bert")

--- a/src/transformers/models/vision_text_dual_encoder/modeling_flax_vision_text_dual_encoder.py
+++ b/src/transformers/models/vision_text_dual_encoder/modeling_flax_vision_text_dual_encoder.py
@@ -561,9 +561,8 @@ VISION_TEXT_DUAL_ENCODER_MODEL_DOCSTRING = r"""
     ...     input_ids=inputs.input_ids,
     ...     attention_mask=inputs.attention_mask,
     ...     pixel_values=inputs.pixel_values,
-    ...     return_loss=True,
     ... )
-    >>> loss, logits_per_image = outputs.loss, outputs.logits_per_imag  # this is the image-text similarity score
+    >>> logits_per_image = outputs.loss, outputs.logits_per_imag  # this is the image-text similarity score
 
     >>> # save and load from pretrained
     >>> model.save_pretrained("vit-bert")

--- a/src/transformers/models/vision_text_dual_encoder/modeling_flax_vision_text_dual_encoder.py
+++ b/src/transformers/models/vision_text_dual_encoder/modeling_flax_vision_text_dual_encoder.py
@@ -562,7 +562,7 @@ VISION_TEXT_DUAL_ENCODER_MODEL_DOCSTRING = r"""
     ...     attention_mask=inputs.attention_mask,
     ...     pixel_values=inputs.pixel_values,
     ... )
-    >>> logits_per_image = outputs.logits_per_imag  # this is the image-text similarity score
+    >>> logits_per_image = outputs.logits_per_image  # this is the image-text similarity score
 
     >>> # save and load from pretrained
     >>> model.save_pretrained("vit-bert")


### PR DESCRIPTION
# What does this PR do?

Tiny change: remove `loss` & `return_loss` in flax docs & examples.

@patil-suraj 