### PR TITLE
fix TFMarianMTModel output

### DIFF
--- a/src/transformers/models/marian/modeling_tf_marian.py
+++ b/src/transformers/models/marian/modeling_tf_marian.py
@@ -1450,7 +1450,7 @@ class TFMarianMTModel(TFMarianPreTrainedModel, TFCausalLanguageModelingLoss):
             decoder_hidden_states=outputs.decoder_hidden_states,  # index 2 of d outputs
             decoder_attentions=outputs.decoder_attentions,  # index 3 of d outputs
             cross_attentions=outputs.cross_attentions,  # index 4 of d outputs
-            encoder_last_hidden_state=outputs.last_hidden_state,  # index 0 of encoder outputs
+            encoder_last_hidden_state=outputs.encoder_last_hidden_state,  # index 0 of encoder outputs
             encoder_hidden_states=outputs.encoder_hidden_states,  # 1 of e out
             encoder_attentions=outputs.encoder_attentions,  # 2 of e out
         )


### PR DESCRIPTION
# What does this PR do?

One line change:

Current `TFMarianMTModel` returns `decoder`'s `last_hidden_state` as `encoder_last_hidden_state`. This PR fixes it.

```
encoder_last_hidden_state=outputs.last_hidden_state,  # index 0 of encoder outputs
```