### PR TITLE
Fix TFElectraForMultipleChoice

### DIFF
--- a/src/transformers/models/electra/modeling_tf_electra.py
+++ b/src/transformers/models/electra/modeling_tf_electra.py
@@ -1508,14 +1508,14 @@ class TFElectraForMultipleChoice(TFElectraPreTrainedModel, TFMultipleChoiceLoss)
             else None
         )
         outputs = self.electra(
-            flat_input_ids,
-            flat_attention_mask,
-            flat_token_type_ids,
-            flat_position_ids,
-            inputs["head_mask"],
-            flat_inputs_embeds,
-            inputs["output_attentions"],
-            inputs["output_hidden_states"],
+            input_ids=flat_input_ids,
+            attention_mask=flat_attention_mask,
+            token_type_ids=flat_token_type_ids,
+            position_ids=flat_position_ids,
+            head_mask=inputs["head_mask"],
+            inputs_embeds=flat_inputs_embeds,
+            output_attentions=inputs["output_attentions"],
+            output_hidden_states=inputs["output_hidden_states"],
             return_dict=inputs["return_dict"],
             training=inputs["training"],
         )


### PR DESCRIPTION
# What does this PR do?

Current `TFElectraForMultipleChoice` calls `TFElectraMainLayer` using positional arguments, and it doesn't have

```
        encoder_hidden_states,
        encoder_attention_mask
        past_key_values
        use_cache
```
so `inputs["output_attentions"]` is received as `encoder_hidden_states` by the main layer, etc.

This PR fixes it (using kwargs).

@Rocketknight1 @gante 

