### PR TITLE
Warn if using a CTC+LM model with no decoder (asr pipeline)

### DIFF
--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -136,8 +136,10 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 self.type = "ctc_with_lm"
             else:
                 # this sounds like an error
-                logger.warning("This ctc model is capable of using a Language Model decoder, but none was provided: pipeline(..., decoder=None).")
                 self.type = "ctc"
+                logger.warning(
+                    "This ctc model is capable of using a Language Model decoder, but none was provided: pipeline(..., decoder=None)."
+                )
         else:
             self.type = "ctc"
 

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -130,10 +130,14 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
         elif (
             feature_extractor._processor_class
             and feature_extractor._processor_class.endswith("WithLM")
-            and kwargs.get("decoder", None) is not None
         ):
-            self.decoder = kwargs["decoder"]
-            self.type = "ctc_with_lm"
+            if kwargs.get("decoder", None) is not None:
+                self.decoder = kwargs["decoder"]
+                self.type = "ctc_with_lm"
+            else:
+                # this sounds like an error
+                logger.warning("This ctc model is capable of using a Language Model decoder, but none was provided: pipeline(..., decoder=None).")
+                self.type = "ctc"
         else:
             self.type = "ctc"
 


### PR DESCRIPTION
When feeding a model to the automatic-speech-recognition pipeline, if the decoder is forgotten, the model is used as normal ctc without language model applied. This is likely to be accidental, and might go unnoticed. To address this, I propose to add a warning.

cc @LysandreJik 