### PR TITLE
TF MT5 embeddings resize

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1135,6 +1135,11 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         return model_embeds
 
     def _get_word_embedding_weight(model, embedding_layer):
+        # If the variable holds the weights themselves, return them
+        if isinstance(embedding_layer, tf.Tensor):
+            return embedding_layer
+        # Otherwise, try to get them from the layer's attributes
+
         embeds = getattr(embedding_layer, "weight", None)
         if embeds is not None:
             return embeds

--- a/tests/test_modeling_tf_mt5.py
+++ b/tests/test_modeling_tf_mt5.py
@@ -22,16 +22,16 @@ from transformers.testing_utils import require_sentencepiece, require_tf, requir
 if is_tf_available():
     import tensorflow as tf
 
-    from transformers import AutoTokenizer, TFAutoModelForSeq2SeqLM, T5Tokenizer, TFMT5ForConditionalGeneration
+    from transformers import AutoTokenizer, T5Tokenizer, TFAutoModelForSeq2SeqLM, TFMT5ForConditionalGeneration
 
 
 @require_tf
-class TFMT5ModelTest(unittest.TestCase):  # no mixin -> most cases are already covered in the TF T5 tests
+class TFMT5ModelTest(unittest.TestCase):  # no mixin with common tests -> most cases are already covered in the TF T5
     @slow
     def test_resize_embeddings(self):
         model = TFMT5ForConditionalGeneration.from_pretrained("google/mt5-small")
         tokenizer = T5Tokenizer.from_pretrained("google/mt5-small")
-        tokenizer.add_special_tokens({'bos_token': '', 'eos_token': ''})
+        tokenizer.add_special_tokens({"bos_token": "", "eos_token": ""})
         model._resize_token_embeddings(len(tokenizer))
 
 

--- a/tests/test_modeling_tf_mt5.py
+++ b/tests/test_modeling_tf_mt5.py
@@ -30,9 +30,16 @@ class TFMT5ModelTest(unittest.TestCase):  # no mixin with common tests -> most c
     @slow
     def test_resize_embeddings(self):
         model = TFMT5ForConditionalGeneration.from_pretrained("google/mt5-small")
+        original_vocab_size = model.get_input_embeddings().weight.shape[0]
+        # the vocab size is defined in the model config
+        self.assertEqual(original_vocab_size, model.config.vocab_size)
+
         tokenizer = T5Tokenizer.from_pretrained("google/mt5-small")
         tokenizer.add_special_tokens({"bos_token": "", "eos_token": ""})
         model._resize_token_embeddings(len(tokenizer))
+        # the vocab size is now resized to the length of the tokenizer, which is different from the original size
+        self.assertEqual(model.get_input_embeddings().weight.shape[0], len(tokenizer))
+        self.assertNotEqual(model.get_input_embeddings().weight.shape[0], original_vocab_size)
 
 
 @require_tf

--- a/tests/test_modeling_tf_mt5.py
+++ b/tests/test_modeling_tf_mt5.py
@@ -22,7 +22,17 @@ from transformers.testing_utils import require_sentencepiece, require_tf, requir
 if is_tf_available():
     import tensorflow as tf
 
-    from transformers import AutoTokenizer, TFAutoModelForSeq2SeqLM
+    from transformers import AutoTokenizer, TFAutoModelForSeq2SeqLM, T5Tokenizer, TFMT5ForConditionalGeneration
+
+
+@require_tf
+class TFMT5ModelTest(unittest.TestCase):  # no mixin -> most cases are already covered in the TF T5 tests
+    @slow
+    def test_resize_embeddings(self):
+        model = TFMT5ForConditionalGeneration.from_pretrained("google/mt5-small")
+        tokenizer = T5Tokenizer.from_pretrained("google/mt5-small")
+        tokenizer.add_special_tokens({'bos_token': '', 'eos_token': ''})
+        model._resize_token_embeddings(len(tokenizer))
 
 
 @require_tf

--- a/tests/test_modeling_tf_t5.py
+++ b/tests/test_modeling_tf_t5.py
@@ -314,6 +314,13 @@ class TFT5ModelTest(TFModelTesterMixin, unittest.TestCase):
         # TODO: Fix head-masking according to PyTorch T5 model
         pass
 
+    @slow
+    def test_resize_embeddings(self):
+        model = TFT5ForConditionalGeneration.from_pretrained("t5-small")
+        tokenizer = T5Tokenizer.from_pretrained("t5-small")
+        tokenizer.add_special_tokens({'bos_token': '', 'eos_token': ''})
+        model._resize_token_embeddings(len(tokenizer))
+
 
 class TFT5EncoderOnlyModelTester:
     def __init__(

--- a/tests/test_modeling_tf_t5.py
+++ b/tests/test_modeling_tf_t5.py
@@ -318,7 +318,7 @@ class TFT5ModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_resize_embeddings(self):
         model = TFT5ForConditionalGeneration.from_pretrained("t5-small")
         tokenizer = T5Tokenizer.from_pretrained("t5-small")
-        tokenizer.add_special_tokens({'bos_token': '', 'eos_token': ''})
+        tokenizer.add_special_tokens({"bos_token": "", "eos_token": ""})
         model._resize_token_embeddings(len(tokenizer))
 
 

--- a/tests/test_modeling_tf_t5.py
+++ b/tests/test_modeling_tf_t5.py
@@ -317,9 +317,16 @@ class TFT5ModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_resize_embeddings(self):
         model = TFT5ForConditionalGeneration.from_pretrained("t5-small")
+        original_vocab_size = model.get_input_embeddings().weight.shape[0]
+        # the vocab size is defined in the model config
+        self.assertEqual(original_vocab_size, model.config.vocab_size)
+
         tokenizer = T5Tokenizer.from_pretrained("t5-small")
         tokenizer.add_special_tokens({"bos_token": "", "eos_token": ""})
         model._resize_token_embeddings(len(tokenizer))
+        # the vocab size is now resized to the length of the tokenizer, which is different from the original size
+        self.assertEqual(model.get_input_embeddings().weight.shape[0], len(tokenizer))
+        self.assertNotEqual(model.get_input_embeddings().weight.shape[0], original_vocab_size)
 
 
 class TFT5EncoderOnlyModelTester:


### PR DESCRIPTION
# What does this PR do?

Fixes #13839 

In MT5, the `get_output_embeddings()` method does not return a layer, returns a `tf.Tensor` with the weights. As such, `self._get_word_embedding_weight(self.get_output_embeddings())` was failing, as it expected a layer. Since the point of `_get_word_embedding_weight` is to get the weights, added a return for the case where we already have the weights. Also added tests to ensure we don't regress.