### PR TITLE
Click new version

### DIFF
--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip!=21.3
+          pip install -U click  # Click 7 is installed in the environment by default, but we need at least version 8 for Black
           sudo apt -y update && sudo apt install -y libsndfile1-dev
           pip install .[dev]
 


### PR DESCRIPTION
Upgrades click version in CI, as the `ubuntu-latest` image with python 3.8 support has `click~=7` installed by default which is incompatible with `black`. The `pip` dependency resolver doesn't manage to update.