### PR TITLE
Fix tests hub failure

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1552,10 +1552,10 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             _ = Repository(tmp_dir, clone_from=f"{USER}/test-trainer-epoch", use_auth_token=self._token)
             commits = self.get_commit_history(tmp_dir)
-            print(commits)
-            #expected_commits = [f"Training in progress, epoch {i}" for i in range(3, 0, -1)]
-            #expected_commits.append("initial commit")
-            #self.assertListEqual(commits, expected_commits)
+            self.assertIn("initial commit", commits)
+            # We can't test that epoch 2 and 3 are in the commits without being flaky as those might be skipped if
+            # the push for epoch 1 wasn't finished at the time.
+            self.assertIn("Training in progress, epoch 1", commits)
 
     def test_push_to_hub_with_saves_each_n_steps(self):
         num_gpus = max(1, get_gpu_count())
@@ -1579,11 +1579,10 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             _ = Repository(tmp_dir, clone_from=f"{USER}/test-trainer-step", use_auth_token=self._token)
             commits = self.get_commit_history(tmp_dir)
-            print(commits)
-            #total_steps = 20 // num_gpus
-            #expected_commits = [f"Training in progress, step {i}" for i in range(total_steps, 0, -5)]
-            #expected_commits.append("initial commit")
-            #self.assertListEqual(commits, expected_commits)
+            self.assertIn("initial commit", commits)
+            # We can't test that epoch 2 and 3 are in the commits without being flaky as those might be skipped if
+            # the push for epoch 1 wasn't finished at the time.
+            self.assertIn("Training in progress, step 5", commits)
 
 
 @require_torch

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -21,6 +21,7 @@ import random
 import re
 import subprocess
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -1544,12 +1545,17 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
             )
             trainer.train()
 
+            # Wait for the async pushes to be finished
+            while trainer.push_in_progress is not None and not trainer.push_in_progress.is_done:
+                time.sleep(0.5)
+
         with tempfile.TemporaryDirectory() as tmp_dir:
             _ = Repository(tmp_dir, clone_from=f"{USER}/test-trainer-epoch", use_auth_token=self._token)
             commits = self.get_commit_history(tmp_dir)
-            expected_commits = [f"Training in progress, epoch {i}" for i in range(3, 0, -1)]
-            expected_commits.append("initial commit")
-            self.assertListEqual(commits, expected_commits)
+            print(commits)
+            #expected_commits = [f"Training in progress, epoch {i}" for i in range(3, 0, -1)]
+            #expected_commits.append("initial commit")
+            #self.assertListEqual(commits, expected_commits)
 
     def test_push_to_hub_with_saves_each_n_steps(self):
         num_gpus = max(1, get_gpu_count())
@@ -1566,13 +1572,18 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
             )
             trainer.train()
 
+            # Wait for the async pushes to be finished
+            while trainer.push_in_progress is not None and not trainer.push_in_progress.is_done:
+                time.sleep(0.5)
+
         with tempfile.TemporaryDirectory() as tmp_dir:
             _ = Repository(tmp_dir, clone_from=f"{USER}/test-trainer-step", use_auth_token=self._token)
             commits = self.get_commit_history(tmp_dir)
-            total_steps = 20 // num_gpus
-            expected_commits = [f"Training in progress, step {i}" for i in range(total_steps, 0, -5)]
-            expected_commits.append("initial commit")
-            self.assertListEqual(commits, expected_commits)
+            print(commits)
+            #total_steps = 20 // num_gpus
+            #expected_commits = [f"Training in progress, step {i}" for i in range(total_steps, 0, -5)]
+            #expected_commits.append("initial commit")
+            #self.assertListEqual(commits, expected_commits)
 
 
 @require_torch


### PR DESCRIPTION
# What does this PR do?

This PR fixes the flaky tests in the test_hub job. 

TL;DR: the two tests changed push to the Hub with async commits which is the source of two flaky errors and one at-exit error:
- 1st flaky error: the pushes may not be finished before we try to access the repo, so we wait for the push in progress to be finished
- 2nd flaky error: the pushes may not all be done, since a commit is skipped when the push in progress is not finished

At-exit error: when exiting the test, `huggingface_hub` accesses the `is_done` property of some of the commands (even if they are finished), which calls another time the `post_method` of those command (`lfs_prune`) on a repo that does not exist anymore. This is fixed on the `huggingface_hub` side by the PR mentioned above.