### PR TITLE
Update TAPAS script to convert TAPAS-NQ weights (re-attempt #11907)

### DIFF
--- a/src/transformers/models/tapas/convert_tapas_original_tf_checkpoint_to_pytorch.py
+++ b/src/transformers/models/tapas/convert_tapas_original_tf_checkpoint_to_pytorch.py
@@ -149,9 +149,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--pytorch_dump_path", default=None, type=str, required=True, help="Path to the output PyTorch model."
     )
-    parser.add_argument(
-        "--vocab_file", default=None, type=str, required=True, help="Path to the vocabulary file."
-    )
+    parser.add_argument("--vocab_file", default=None, type=str, required=True, help="Path to the vocabulary file.")
     args = parser.parse_args()
     convert_tf_checkpoint_to_pytorch(
         args.task,
@@ -159,5 +157,5 @@ if __name__ == "__main__":
         args.tf_checkpoint_path,
         args.tapas_config_file,
         args.pytorch_dump_path,
-        args.vocab_file
+        args.vocab_file,
     )

--- a/src/transformers/models/tapas/modeling_tapas.py
+++ b/src/transformers/models/tapas/modeling_tapas.py
@@ -2367,7 +2367,7 @@ def _calculate_expected_result(
 # PyTorch does not currently support Huber loss with custom delta so we define it ourself
 def huber_loss(input, target, delta: float = 1.0):
     errors = torch.abs(input - target)  # shape (batch_size,)
-    return torch.where(errors < delta, 0.5 * errors ** 2, errors * delta - (0.5 * delta ** 2))
+    return torch.where(errors < delta, 0.5 * errors**2, errors * delta - (0.5 * delta**2))
 
 
 def _calculate_regression_loss(

--- a/src/transformers/models/tapas/modeling_tapas.py
+++ b/src/transformers/models/tapas/modeling_tapas.py
@@ -132,7 +132,7 @@ class TableQuestionAnsweringOutput(ModelOutput):
     attentions: Optional[Tuple[torch.FloatTensor]] = None
 
 
-def load_tf_weights_in_tapas(model, config, tf_checkpoint_path):
+def load_tf_weights_in_tapas(model, config, tf_checkpoint_path, model_prefix=None):
     """
     Load tf checkpoints in a PyTorch model. This is an adaptation from load_tf_weights_in_bert
 
@@ -154,6 +154,8 @@ def load_tf_weights_in_tapas(model, config, tf_checkpoint_path):
     logger.info(f"Converting TensorFlow checkpoint from {tf_path}")
     # Load weights from TF model
     init_vars = tf.train.list_variables(tf_path)
+    if model_prefix:
+        init_vars = [var for var in init_vars if var[0].split("/")[0] == model_prefix]
     names = []
     arrays = []
     for name, shape in init_vars:
@@ -198,7 +200,7 @@ def load_tf_weights_in_tapas(model, config, tf_checkpoint_path):
                 logger.info(f"Skipping {'/'.join(name)}")
                 continue
         # if first scope name starts with "bert", change it to "tapas"
-        if name[0] == "bert":
+        if name[0] == "bert" or name[0] == "bert_1":
             name[0] = "tapas"
         pointer = model
         for m_name in name:

--- a/src/transformers/models/tapas/modeling_tapas.py
+++ b/src/transformers/models/tapas/modeling_tapas.py
@@ -2367,7 +2367,7 @@ def _calculate_expected_result(
 # PyTorch does not currently support Huber loss with custom delta so we define it ourself
 def huber_loss(input, target, delta: float = 1.0):
     errors = torch.abs(input - target)  # shape (batch_size,)
-    return torch.where(errors < delta, 0.5 * errors**2, errors * delta - (0.5 * delta**2))
+    return torch.where(errors < delta, 0.5 * errors ** 2, errors * delta - (0.5 * delta ** 2))
 
 
 def _calculate_regression_loss(


### PR DESCRIPTION
Closes https://github.com/huggingface/transformers/issues/14494

This is a reattempt of #11907, as it became stall and was closed. I had to use the latest version and copy the code over.

Instructions:
* Clone fork
* go to `transformers/`
* `pip install torch pandas tensorflow`
* `pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+102.html` (or whatever your cu version is, just do `pip show torch` to find out)
* Download the retriever medium or large weights with HN from the official source: https://github.com/google-research/tapas/blob/master/DENSE_TABLE_RETRIEVER.md
* Run this:
```
# Medium model
python src/transformers/models/tapas/convert_tapas_original_tf_checkpoint_to_pytorch.py --task RETRIEVAL --tf_checkpoint_path tapas_nq_hn_retriever_medium/model.ckpt --tapas_config_file tapas_nq_hn_retriever_medium/bert_config.json --pytorch_dump_path tapas_od/ --vocab_file tapas_nq_hn_retriever_medium/vocab.txt 

# lareg model
python src/transformers/models/tapas/convert_tapas_original_tf_checkpoint_to_pytorch.py --task RETRIEVAL --tf_checkpoint_path tapas_nq_hn_retriever_large/model.ckpt --tapas_config_file tapas_nq_hn_retriever_large/bert_config.json --pytorch_dump_path tapas_nq_large/ --vocab_file tapas_nq_hn_retriever_large/vocab.txt 
```

## Results

https://huggingface.co/xhlu/tapas-nq-hn-retriever-medium-1
https://huggingface.co/xhlu/tapas-nq-hn-retriever-medium-0


https://huggingface.co/xhlu/tapas-nq-hn-retriever-large-1
https://huggingface.co/xhlu/tapas-nq-hn-retriever-large-0