### PR TITLE
Fix Seq2SeqTrainer for VisionEncoderDecoderModel

### DIFF
--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -161,6 +161,9 @@ class Seq2SeqTrainer(Trainer):
             "synced_gpus": True if is_deepspeed_zero3_enabled() else False,
         }
 
+        if "attention_mask" in inputs:
+            gen_kwargs["attention_mask"] = inputs.get("attention_mask", None)
+
         # prepare generation inputs
         # some encoder-decoder models can have varying encder's and thus
         # varying model input names
@@ -171,7 +174,6 @@ class Seq2SeqTrainer(Trainer):
 
         generated_tokens = self.model.generate(
             generation_inputs,
-            attention_mask=inputs.get("attention_mask", None),
             **gen_kwargs,
         )
         # in case the batch is shorter than max length, the output should be padded


### PR DESCRIPTION
# What does this PR do?

Fixes #15526 

The Seq2SeqTrainer always passes `attention_mask` to the `generate` method in its `prediction_step`. However, this results in an error for instances of `VisionEncoderDecoderModel`, which don't accept `attention_mask` in their forward method:

```
[/usr/local/lib/python3.7/dist-packages/transformers/trainer_seq2seq.py](https://localhost:8080/#) in prediction_step(self, model, inputs, prediction_loss_only, ignore_keys)
    173             generation_inputs,
    174             attention_mask=inputs.get("attention_mask", None),
--> 175             **gen_kwargs,
    176         )
    177         # in case the batch is shorter than max length, the output should be padded

[/usr/local/lib/python3.7/dist-packages/torch/autograd/grad_mode.py](https://localhost:8080/#) in decorate_context(*args, **kwargs)
     26         def decorate_context(*args, **kwargs):
     27             with self.__class__():
---> 28                 return func(*args, **kwargs)
     29         return cast(F, decorate_context)
     30 

[/usr/local/lib/python3.7/dist-packages/transformers/generation_utils.py](https://localhost:8080/#) in generate(self, inputs, max_length, min_length, do_sample, early_stopping, num_beams, temperature, top_k, top_p, repetition_penalty, bad_words_ids, bos_token_id, pad_token_id, eos_token_id, length_penalty, no_repeat_ngram_size, encoder_no_repeat_ngram_size, num_return_sequences, max_time, max_new_tokens, decoder_start_token_id, use_cache, num_beam_groups, diversity_penalty, prefix_allowed_tokens_fn, logits_processor, stopping_criteria, output_attentions, output_hidden_states, output_scores, return_dict_in_generate, forced_bos_token_id, forced_eos_token_id, remove_invalid_values, synced_gpus, **model_kwargs)
   1087             # and added to `model_kwargs`
   1088             model_kwargs = self._prepare_encoder_decoder_kwargs_for_generation(
-> 1089                 inputs_tensor, model_kwargs, model_input_name
   1090             )
   1091 

[/usr/local/lib/python3.7/dist-packages/transformers/generation_utils.py](https://localhost:8080/#) in _prepare_encoder_decoder_kwargs_for_generation(self, inputs_tensor, model_kwargs, model_input_name)
    505         encoder_kwargs["return_dict"] = True
    506         encoder_kwargs[model_input_name] = inputs_tensor
--> 507         model_kwargs["encoder_outputs"]: ModelOutput = encoder(**encoder_kwargs)
    508 
    509         return model_kwargs

[/usr/local/lib/python3.7/dist-packages/torch/nn/modules/module.py](https://localhost:8080/#) in _call_impl(self, *input, **kwargs)
   1100         if not (self._backward_hooks or self._forward_hooks or self._forward_pre_hooks or _global_backward_hooks
   1101                 or _global_forward_hooks or _global_forward_pre_hooks):
-> 1102             return forward_call(*input, **kwargs)
   1103         # Do not call functions when jit is used
   1104         full_backward_hooks, non_full_backward_hooks = [], []

TypeError: forward() got an unexpected keyword argument 'attention_mask'
```

This PR fixes that by adding "attention_mask" to `gen_kwargs` if they are in the inputs.