### PR TITLE
Add local and TensorFlow ONNX export examples to docs

### DIFF
--- a/docs/source/serialization.mdx
+++ b/docs/source/serialization.mdx
@@ -154,7 +154,9 @@ organization](https://huggingface.co/keras-io) as follows:
 python -m transformers.onnx --model=keras-io/transformers-qa onnx/
 ```
 
-To export a model that's stored locally, you'll need to have the model's weights and tokenizer files stored in a directory. For example, in PyTorch we can load and save a checkpoint as follows:
+To export a model that's stored locally, you'll need to have the model's weights
+and tokenizer files stored in a directory. For example, we can load and save a
+checkpoint as follows:
 
 ```python
 >>> from transformers import AutoTokenizer, AutoModelForSequenceClassification
@@ -165,17 +167,7 @@ To export a model that's stored locally, you'll need to have the model's weights
 >>> # Save to disk
 >>> tokenizer.save_pretrained("local-pt-checkpoint")
 >>> pt_model.save_pretrained("local-pt-checkpoint")
-```
-
-Once the checkpoint is saved, we can point the `--model` argument of the `transformers.onnx` package to the desired directory:
-
-```bash
-python -m transformers.onnx --model=local-pt-checkpoint onnx/
-```
-
-The process is similar for TensorFlow models, except we use the TensorFlow autoclass to load and save the weights:
-
-```python
+===PT-TF-SPLIT===
 >>> from transformers import AutoTokenizer, TFAutoModelForSequenceClassification
 
 >>> # Load tokenizer and TensorFlow weights from the Hub
@@ -186,9 +178,12 @@ The process is similar for TensorFlow models, except we use the TensorFlow autoc
 >>> tf_model.save_pretrained("local-tf-checkpoint")
 ```
 
-As we saw with the PyTorch example, we can then export the local TensorFlow model as follows:
+Once the checkpoint is saved, we can export it to ONNX by pointing the `--model`
+argument of the `transformers.onnx` package to the desired directory:
 
 ```bash
+python -m transformers.onnx --model=local-pt-checkpoint onnx/
+===PT-TF-SPLIT===
 python -m transformers.onnx --model=local-tf-checkpoint onnx/
 ```
 

--- a/docs/source/serialization.mdx
+++ b/docs/source/serialization.mdx
@@ -114,8 +114,8 @@ All good, model saved at: onnx/model.onnx
 ```
 
 This exports an ONNX graph of the checkpoint defined by the `--model` argument.
-In this example it is `distilbert-base-uncased`, but it can be any model on the
-Hugging Face Hub or one that's stored locally.
+In this example it is `distilbert-base-uncased`, but it can be any checkpoint on
+the Hugging Face Hub or one that's stored locally.
 
 The resulting `model.onnx` file can then be run on one of the [many
 accelerators](https://onnx.ai/supported-tools.html#deployModel) that support the
@@ -146,7 +146,51 @@ DistilBERT we have:
 ["last_hidden_state"]
 ```
 
-The approach is similar for TensorFlow models.
+The process is identical for TensorFlow checkpoints on the Hub. For example, we
+can export a pure TensorFlow checkpoint from the [Keras
+organization](https://huggingface.co/keras-io) as follows:
+
+```bash
+python -m transformers.onnx --model=keras-io/transformers-qa onnx/
+```
+
+To export a model that's stored locally, you'll need to have the model's weights and tokenizer files stored in a directory. For example, in PyTorch we can load and save a checkpoint as follows:
+
+```python
+>>> from transformers import AutoTokenizer, AutoModelForSequenceClassification
+
+>>> # Load tokenizer and PyTorch weights form the Hub
+>>> tokenizer = tokenizer = AutoTokenizer.from_pretrained("distilbert-base-uncased")
+>>> pt_model = AutoModelForSequenceClassification.from_pretrained("distilbert-base-uncased")
+>>> # Save to disk
+>>> tokenizer.save_pretrained("local-pt-checkpoint")
+>>> pt_model.save_pretrained("local-pt-checkpoint")
+```
+
+Once the checkpoint is saved, we can point the `--model` argument of the `transformers.onnx` package to the desired directory:
+
+```bash
+python -m transformers.onnx --model=local-pt-checkpoint onnx/
+```
+
+The process is similar for TensorFlow models, except we use the TensorFlow autoclass to load and save the weights:
+
+```python
+>>> from transformers import AutoTokenizer, TFAutoModelForSequenceClassification
+
+>>> # Load tokenizer and TensorFlow weights from the Hub
+>>> tokenizer = tokenizer = AutoTokenizer.from_pretrained("distilbert-base-uncased")
+>>> tf_model = TFAutoModelForSequenceClassification.from_pretrained("distilbert-base-uncased")
+>>> # Save to disk
+>>> tokenizer.save_pretrained("local-tf-checkpoint")
+>>> tf_model.save_pretrained("local-tf-checkpoint")
+```
+
+As we saw with the PyTorch example, we can then export the local TensorFlow model as follows:
+
+```bash
+python -m transformers.onnx --model=local-tf-checkpoint onnx/
+```
 
 ### Selecting features for different model topologies
 


### PR DESCRIPTION
# What does this PR do?

This PR builds on #13831 to show examples of:

* Exporting a local checkpoint to ONNX
* Exporting a pure TensorFlow checkpoint to ONNX
