### PR TITLE
TF: Add informative warning for inexistent CPU backprop ops

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -691,6 +691,14 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         """
         return "tf"
 
+    @property
+    def has_cpu_backprop_support(self) -> bool:
+        """
+        Returns:
+            `bool`: Whether the model has backpropagation support on CPU
+        """
+        return True
+
     def __init__(self, config, *inputs, **kwargs):
         super().__init__(*inputs, **kwargs)
         if not isinstance(config, PretrainedConfig):
@@ -899,8 +907,23 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         with tf.GradientTape() as tape:
             y_pred = self(x, training=True)
             loss = self.compiled_loss(y, y_pred, sample_weight, regularization_losses=self.losses)
+
         # Run backwards pass.
-        self.optimizer.minimize(loss, self.trainable_variables, tape=tape)
+        try:
+            self.optimizer.minimize(loss, self.trainable_variables, tape=tape)
+        except tf.errors.InvalidArgumentError as exc:
+            if not self.has_cpu_backprop_support:
+                # When there are no GPUs on the machine, the message can be vague, which has caused raised issues.
+                raise tf.errors.InvalidArgumentError(
+                    node_def=exc.node_def,
+                    op=exc.op,
+                    message=exc.message + (
+                        f"\n\n{self.__class__.__name__} has backpropagation operations that are NOT supported on CPU. "
+                        "Please try training/fine-tunning with other kinds of hardware devices if you are using a CPU."
+                    ),
+                )
+            raise
+
         # When y_pred is a ModelOutput and y is a tf.Tensor the metrics update
         # should be done only with the relevant ModelOutput param that is
         # considered by the loss.

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -917,7 +917,8 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                 raise tf.errors.InvalidArgumentError(
                     node_def=exc.node_def,
                     op=exc.op,
-                    message=exc.message + (
+                    message=exc.message
+                    + (
                         f"\n\n{self.__class__.__name__} has backpropagation operations that are NOT supported on CPU. "
                         "Please try training/fine-tunning with other kinds of hardware devices if you are using a CPU."
                     ),

--- a/src/transformers/models/hubert/modeling_tf_hubert.py
+++ b/src/transformers/models/hubert/modeling_tf_hubert.py
@@ -1284,16 +1284,6 @@ class TFHubertPreTrainedModel(TFPreTrainedModel):
     main_input_name = "input_values"
 
     @property
-    def has_cpu_backprop_support(self) -> bool:
-        """
-        Grouped convolutions are not supported on CPU, see https://github.com/keras-team/keras/issues/15713
-
-        Returns:
-            `bool`: Whether the model has backpropagation support on CPU
-        """
-        return False
-
-    @property
     def dummy_inputs(self) -> Dict[str, tf.Tensor]:
         pad_token = 0.0
         input_values = tf.convert_to_tensor(np.random.rand(1, 16000), tf.float32)
@@ -1302,6 +1292,13 @@ class TFHubertPreTrainedModel(TFPreTrainedModel):
             "attention_mask": tf.cast(tf.not_equal(input_values, pad_token), tf.float32),
         }
         return dummy_inputs
+
+    def __init__(self, config, *inputs, **kwargs):
+        super().__init__(config, *inputs, **kwargs)
+        logger.warning(
+            f"\n{self.__class__.__name__} has backpropagation operations that are NOT supported on CPU. If you wish "
+            "to train/fine-tine this model, you need a GPU or a TPU"
+        )
 
     @tf.function
     def serving(self, inputs):

--- a/src/transformers/models/hubert/modeling_tf_hubert.py
+++ b/src/transformers/models/hubert/modeling_tf_hubert.py
@@ -1284,6 +1284,16 @@ class TFHubertPreTrainedModel(TFPreTrainedModel):
     main_input_name = "input_values"
 
     @property
+    def has_cpu_backprop_support(self) -> bool:
+        """
+        Grouped convolutions are not supported on CPU, see https://github.com/keras-team/keras/issues/15713
+
+        Returns:
+            `bool`: Whether the model has backpropagation support on CPU
+        """
+        return False
+
+    @property
     def dummy_inputs(self) -> Dict[str, tf.Tensor]:
         pad_token = 0.0
         input_values = tf.convert_to_tensor(np.random.rand(1, 16000), tf.float32)

--- a/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py
@@ -1310,16 +1310,6 @@ class TFWav2Vec2PreTrainedModel(TFPreTrainedModel):
     main_input_name = "input_values"
 
     @property
-    def has_cpu_backprop_support(self) -> bool:
-        """
-        Grouped convolutions are not supported on CPU, see https://github.com/keras-team/keras/issues/15713
-
-        Returns:
-            `bool`: Whether the model has backpropagation support on CPU
-        """
-        return False
-
-    @property
     def dummy_inputs(self) -> Dict[str, tf.Tensor]:
         pad_token = 0.0
         input_values = tf.convert_to_tensor(np.random.rand(1, 16000), tf.float32)
@@ -1328,6 +1318,13 @@ class TFWav2Vec2PreTrainedModel(TFPreTrainedModel):
             "attention_mask": tf.cast(tf.not_equal(input_values, pad_token), tf.float32),
         }
         return dummy_inputs
+
+    def __init__(self, config, *inputs, **kwargs):
+        super().__init__(config, *inputs, **kwargs)
+        logger.warning(
+            f"\n{self.__class__.__name__} has backpropagation operations that are NOT supported on CPU. If you wish "
+            "to train/fine-tine this model, you need a GPU or a TPU"
+        )
 
     @tf.function
     def serving(self, inputs):

--- a/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py
@@ -1310,6 +1310,16 @@ class TFWav2Vec2PreTrainedModel(TFPreTrainedModel):
     main_input_name = "input_values"
 
     @property
+    def has_cpu_backprop_support(self) -> bool:
+        """
+        Grouped convolutions are not supported on CPU, see https://github.com/keras-team/keras/issues/15713
+
+        Returns:
+            `bool`: Whether the model has backpropagation support on CPU
+        """
+        return False
+
+    @property
     def dummy_inputs(self) -> Dict[str, tf.Tensor]:
         pad_token = 0.0
         input_values = tf.convert_to_tensor(np.random.rand(1, 16000), tf.float32)


### PR DESCRIPTION
# What does this PR do?

Some TF operations do not support backpropagation on CPU, namely convolutions with the `groups` argument set ([related issue on Keras](https://github.com/keras-team/keras/issues/15713)). Sadly, the exception thrown is very uninformative and makes no mention of hardware problems if there is no GPU on the system (but it does if the machine has a GPU). This PR adds an informative warning in case a user loads the affected models.

Fixes #15114
Fixes #15059
