### PR TITLE
Enable ONNX export when PyTorch and TensorFlow installed in the same env

### DIFF
--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -303,8 +303,16 @@ class FeaturesManager:
             The instance of the model.
 
         """
+        # If PyTorch and TensorFlow are installed in the same environment, we
+        # load an AutoModel class by default
         model_class = FeaturesManager.get_model_class_for_feature(feature)
-        return model_class.from_pretrained(model)
+        try:
+            model = model_class.from_pretrained(model)
+        # Load TensorFlow weights in an AutoModel instance if PyTorch and
+        # TensorFlow are installed in the same environment
+        except OSError:
+            model = model_class.from_pretrained(model, from_tf=True)
+        return model
 
     @staticmethod
     def check_supported_model_or_raise(


### PR DESCRIPTION
# What does this PR do?

This PR implements one of the proposals discussed in #15620 to enable the ONNX export of pure TensorFlow models (i.e. model repos without PyTorch weights) when TensorFlow and PyTorch are installed in the same environment.

When both frameworks are installed, we default to using an `AutoModel` class (instead of `TFAutoModel`), and then use the `from_tf=True` argument of the `from_pretrained()` method to load the TensorFlow weights.

With this PR, it is now possible to export models like the following without error:

```bash
python -m transformers.onnx --model=keras-io/transformers-qa onnx/
```

The user will see a 404 error in the logs from the `from_pretrained()` method:

```
404 Client Error: Entry Not Found for url: https://huggingface.co/keras-io/transformers-qa/resolve/main/pytorch_model.bin
```

but we can handle this in a separate PR if users report confusion.

Closes #15620 