### PR TITLE
Remove redundant error logging in from_pretrained() method

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -603,7 +603,6 @@ class PretrainedConfig(PushToHubMixin):
             )
 
         except RepositoryNotFoundError as err:
-            logger.error(err)
             raise EnvironmentError(
                 f"{pretrained_model_name_or_path} is not a local folder and is not a valid model identifier listed on "
                 "'https://huggingface.co/models'\nIf this is a private repository, make sure to pass a token having "
@@ -611,19 +610,16 @@ class PretrainedConfig(PushToHubMixin):
                 "`use_auth_token=True`."
             )
         except RevisionNotFoundError as err:
-            logger.error(err)
             raise EnvironmentError(
                 f"{revision} is not a valid git identifier (branch name, tag name or commit id) that exists for this "
                 f"model name. Check the model page at 'https://huggingface.co/{pretrained_model_name_or_path}' for "
                 "available revisions."
             )
         except EntryNotFoundError as err:
-            logger.error(err)
             raise EnvironmentError(
                 f"{pretrained_model_name_or_path} does not appear to have a file named {configuration_file}."
             )
         except HTTPError as err:
-            logger.error(err)
             raise EnvironmentError(
                 "We couldn't connect to 'https://huggingface.co/' to load this model and it looks like "
                 f"{pretrained_model_name_or_path} is not the path to a directory conaining a {configuration_file} "
@@ -631,7 +627,6 @@ class PretrainedConfig(PushToHubMixin):
                 "'https://huggingface.co/docs/transformers/installation#offline-mode'."
             )
         except EnvironmentError as err:
-            logger.error(err)
             raise EnvironmentError(
                 f"Can't load config for '{pretrained_model_name_or_path}'. If you were trying to load it from "
                 "'https://huggingface.co/models', make sure you don't have a local directory with the same name. "

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -602,31 +602,31 @@ class PretrainedConfig(PushToHubMixin):
                 user_agent=user_agent,
             )
 
-        except RepositoryNotFoundError as err:
+        except RepositoryNotFoundError:
             raise EnvironmentError(
                 f"{pretrained_model_name_or_path} is not a local folder and is not a valid model identifier listed on "
                 "'https://huggingface.co/models'\nIf this is a private repository, make sure to pass a token having "
                 "permission to this repo with `use_auth_token` or log in with `huggingface-cli login` and pass "
                 "`use_auth_token=True`."
             )
-        except RevisionNotFoundError as err:
+        except RevisionNotFoundError:
             raise EnvironmentError(
                 f"{revision} is not a valid git identifier (branch name, tag name or commit id) that exists for this "
                 f"model name. Check the model page at 'https://huggingface.co/{pretrained_model_name_or_path}' for "
                 "available revisions."
             )
-        except EntryNotFoundError as err:
+        except EntryNotFoundError:
             raise EnvironmentError(
                 f"{pretrained_model_name_or_path} does not appear to have a file named {configuration_file}."
             )
-        except HTTPError as err:
+        except HTTPError:
             raise EnvironmentError(
                 "We couldn't connect to 'https://huggingface.co/' to load this model and it looks like "
                 f"{pretrained_model_name_or_path} is not the path to a directory conaining a {configuration_file} "
                 "file.\nCheckout your internet connection or see how to run the library in offline mode at "
                 "'https://huggingface.co/docs/transformers/installation#offline-mode'."
             )
-        except EnvironmentError as err:
+        except EnvironmentError:
             raise EnvironmentError(
                 f"Can't load config for '{pretrained_model_name_or_path}'. If you were trying to load it from "
                 "'https://huggingface.co/models', make sure you don't have a local directory with the same name. "

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -380,31 +380,31 @@ class FeatureExtractionMixin:
                 user_agent=user_agent,
             )
 
-        except RepositoryNotFoundError as err:
+        except RepositoryNotFoundError:
             raise EnvironmentError(
                 f"{pretrained_model_name_or_path} is not a local folder and is not a valid model identifier listed on "
                 "'https://huggingface.co/models'\nIf this is a private repository, make sure to pass a token having "
                 "permission to this repo with `use_auth_token` or log in with `huggingface-cli login` and pass "
                 "`use_auth_token=True`."
             )
-        except RevisionNotFoundError as err:
+        except RevisionNotFoundError:
             raise EnvironmentError(
                 f"{revision} is not a valid git identifier (branch name, tag name or commit id) that exists for this "
                 f"model name. Check the model page at 'https://huggingface.co/{pretrained_model_name_or_path}' for "
                 "available revisions."
             )
-        except EntryNotFoundError as err:
+        except EntryNotFoundError:
             raise EnvironmentError(
                 f"{pretrained_model_name_or_path} does not appear to have a file named {FEATURE_EXTRACTOR_NAME}."
             )
-        except HTTPError as err:
+        except HTTPError:
             raise EnvironmentError(
                 "We couldn't connect to 'https://huggingface.co/' to load this model and it looks like "
                 f"{pretrained_model_name_or_path} is not the path to a directory conaining a "
                 f"{FEATURE_EXTRACTOR_NAME} file.\nCheckout your internet connection or see how to run the library in "
                 "offline mode at 'https://huggingface.co/docs/transformers/installation#offline-mode'."
             )
-        except EnvironmentError as err:
+        except EnvironmentError:
             raise EnvironmentError(
                 f"Can't load feature extractor for '{pretrained_model_name_or_path}'. If you were trying to load it "
                 "from 'https://huggingface.co/models', make sure you don't have a local directory with the same name. "

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -381,7 +381,6 @@ class FeatureExtractionMixin:
             )
 
         except RepositoryNotFoundError as err:
-            logger.error(err)
             raise EnvironmentError(
                 f"{pretrained_model_name_or_path} is not a local folder and is not a valid model identifier listed on "
                 "'https://huggingface.co/models'\nIf this is a private repository, make sure to pass a token having "
@@ -389,19 +388,16 @@ class FeatureExtractionMixin:
                 "`use_auth_token=True`."
             )
         except RevisionNotFoundError as err:
-            logger.error(err)
             raise EnvironmentError(
                 f"{revision} is not a valid git identifier (branch name, tag name or commit id) that exists for this "
                 f"model name. Check the model page at 'https://huggingface.co/{pretrained_model_name_or_path}' for "
                 "available revisions."
             )
         except EntryNotFoundError as err:
-            logger.error(err)
             raise EnvironmentError(
                 f"{pretrained_model_name_or_path} does not appear to have a file named {FEATURE_EXTRACTOR_NAME}."
             )
         except HTTPError as err:
-            logger.error(err)
             raise EnvironmentError(
                 "We couldn't connect to 'https://huggingface.co/' to load this model and it looks like "
                 f"{pretrained_model_name_or_path} is not the path to a directory conaining a "
@@ -409,7 +405,6 @@ class FeatureExtractionMixin:
                 "offline mode at 'https://huggingface.co/docs/transformers/installation#offline-mode'."
             )
         except EnvironmentError as err:
-            logger.error(err)
             raise EnvironmentError(
                 f"Can't load feature extractor for '{pretrained_model_name_or_path}'. If you were trying to load it "
                 "from 'https://huggingface.co/models', make sure you don't have a local directory with the same name. "

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -2301,7 +2301,6 @@ def get_file_from_repo(
         )
 
     except RepositoryNotFoundError as err:
-        logger.error(err)
         raise EnvironmentError(
             f"{path_or_repo} is not a local folder and is not a valid model identifier "
             "listed on 'https://huggingface.co/models'\nIf this is a private repository, make sure to "
@@ -2309,7 +2308,6 @@ def get_file_from_repo(
             "`huggingface-cli login` and pass `use_auth_token=True`."
         )
     except RevisionNotFoundError as err:
-        logger.error(err)
         raise EnvironmentError(
             f"{revision} is not a valid git identifier (branch name, tag name or commit id) that exists "
             "for this model name. Check the model page at "

--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -2300,14 +2300,14 @@ def get_file_from_repo(
             use_auth_token=use_auth_token,
         )
 
-    except RepositoryNotFoundError as err:
+    except RepositoryNotFoundError:
         raise EnvironmentError(
             f"{path_or_repo} is not a local folder and is not a valid model identifier "
             "listed on 'https://huggingface.co/models'\nIf this is a private repository, make sure to "
             "pass a token having permission to this repo with `use_auth_token` or log in with "
             "`huggingface-cli login` and pass `use_auth_token=True`."
         )
-    except RevisionNotFoundError as err:
+    except RevisionNotFoundError:
         raise EnvironmentError(
             f"{revision} is not a valid git identifier (branch name, tag name or commit id) that exists "
             "for this model name. Check the model page at "

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -493,7 +493,6 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
                 )
 
             except RepositoryNotFoundError as err:
-                logger.error(err)
                 raise EnvironmentError(
                     f"{pretrained_model_name_or_path} is not a local folder and is not a valid model identifier "
                     "listed on 'https://huggingface.co/models'\nIf this is a private repository, make sure to pass a "
@@ -501,14 +500,12 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
                     "login` and pass `use_auth_token=True`."
                 )
             except RevisionNotFoundError as err:
-                logger.error(err)
                 raise EnvironmentError(
                     f"{revision} is not a valid git identifier (branch name, tag name or commit id) that exists for "
                     "this model name. Check the model page at "
                     f"'https://huggingface.co/{pretrained_model_name_or_path}' for available revisions."
                 )
             except EntryNotFoundError as err:
-                logger.error(err)
                 if filename == FLAX_WEIGHTS_NAME:
                     has_file_kwargs = {"revision": revision, "proxies": proxies, "use_auth_token": use_auth_token}
                     if has_file(pretrained_model_name_or_path, WEIGHTS_NAME, **has_file_kwargs):
@@ -518,7 +515,6 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
                             "those weights."
                         )
                     else:
-                        logger.error(err)
                         raise EnvironmentError(
                             f"{pretrained_model_name_or_path} does not appear to have a file named {FLAX_WEIGHTS_NAME} "
                             f"or {WEIGHTS_NAME}."
@@ -528,7 +524,6 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
                         f"{pretrained_model_name_or_path} does not appear to have a file named {filename}."
                     )
             except HTTPError as err:
-                logger.error(err)
                 raise EnvironmentError(
                     "We couldn't connect to 'https://huggingface.co/' to load this model and it looks like "
                     f"{pretrained_model_name_or_path} is not the path to a directory conaining a a file named "
@@ -537,7 +532,6 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
                     "'https://huggingface.co/docs/transformers/installation#offline-mode'."
                 )
             except EnvironmentError as err:
-                logger.error(err)
                 raise EnvironmentError(
                     f"Can't load the model for '{pretrained_model_name_or_path}'. If you were trying to load it from "
                     "'https://huggingface.co/models', make sure you don't have a local directory with the same name. "

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -492,20 +492,20 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
                     user_agent=user_agent,
                 )
 
-            except RepositoryNotFoundError as err:
+            except RepositoryNotFoundError:
                 raise EnvironmentError(
                     f"{pretrained_model_name_or_path} is not a local folder and is not a valid model identifier "
                     "listed on 'https://huggingface.co/models'\nIf this is a private repository, make sure to pass a "
                     "token having permission to this repo with `use_auth_token` or log in with `huggingface-cli "
                     "login` and pass `use_auth_token=True`."
                 )
-            except RevisionNotFoundError as err:
+            except RevisionNotFoundError:
                 raise EnvironmentError(
                     f"{revision} is not a valid git identifier (branch name, tag name or commit id) that exists for "
                     "this model name. Check the model page at "
                     f"'https://huggingface.co/{pretrained_model_name_or_path}' for available revisions."
                 )
-            except EntryNotFoundError as err:
+            except EntryNotFoundError:
                 if filename == FLAX_WEIGHTS_NAME:
                     has_file_kwargs = {"revision": revision, "proxies": proxies, "use_auth_token": use_auth_token}
                     if has_file(pretrained_model_name_or_path, WEIGHTS_NAME, **has_file_kwargs):
@@ -523,7 +523,7 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
                     raise EnvironmentError(
                         f"{pretrained_model_name_or_path} does not appear to have a file named {filename}."
                     )
-            except HTTPError as err:
+            except HTTPError:
                 raise EnvironmentError(
                     "We couldn't connect to 'https://huggingface.co/' to load this model and it looks like "
                     f"{pretrained_model_name_or_path} is not the path to a directory conaining a a file named "
@@ -531,7 +531,7 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
                     "Checkout your internet connection or see how to run the library in offline mode at "
                     "'https://huggingface.co/docs/transformers/installation#offline-mode'."
                 )
-            except EnvironmentError as err:
+            except EnvironmentError:
                 raise EnvironmentError(
                     f"Can't load the model for '{pretrained_model_name_or_path}'. If you were trying to load it from "
                     "'https://huggingface.co/models', make sure you don't have a local directory with the same name. "

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1584,7 +1584,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                 )
 
             except RepositoryNotFoundError as err:
-                logger.error(err)
                 raise EnvironmentError(
                     f"{pretrained_model_name_or_path} is not a local folder and is not a valid model identifier "
                     "listed on 'https://huggingface.co/models'\nIf this is a private repository, make sure to pass a "
@@ -1592,14 +1591,12 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                     "login` and pass `use_auth_token=True`."
                 )
             except RevisionNotFoundError as err:
-                logger.error(err)
                 raise EnvironmentError(
                     f"{revision} is not a valid git identifier (branch name, tag name or commit id) that exists for "
                     "this model name. Check the model page at "
                     f"'https://huggingface.co/{pretrained_model_name_or_path}' for available revisions."
                 )
             except EntryNotFoundError as err:
-                logger.error(err)
                 if filename == TF2_WEIGHTS_NAME:
                     has_file_kwargs = {
                         "revision": revision,
@@ -1614,7 +1611,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                             "those weights."
                         )
                     else:
-                        logger.error(err)
                         raise EnvironmentError(
                             f"{pretrained_model_name_or_path} does not appear to have a file named {TF2_WEIGHTS_NAME} "
                             f"or {WEIGHTS_NAME}."
@@ -1624,7 +1620,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                         f"{pretrained_model_name_or_path} does not appear to have a file named {filename}."
                     )
             except HTTPError as err:
-                logger.error(err)
                 raise EnvironmentError(
                     "We couldn't connect to 'https://huggingface.co/' to load this model and it looks like "
                     f"{pretrained_model_name_or_path} is not the path to a directory conaining a a file named "
@@ -1633,7 +1628,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                     "'https://huggingface.co/docs/transformers/installation#offline-mode'."
                 )
             except EnvironmentError as err:
-                logger.error(err)
                 raise EnvironmentError(
                     f"Can't load the model for '{pretrained_model_name_or_path}'. If you were trying to load it from "
                     "'https://huggingface.co/models', make sure you don't have a local directory with the same name. "

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1583,20 +1583,20 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                     user_agent=user_agent,
                 )
 
-            except RepositoryNotFoundError as err:
+            except RepositoryNotFoundError:
                 raise EnvironmentError(
                     f"{pretrained_model_name_or_path} is not a local folder and is not a valid model identifier "
                     "listed on 'https://huggingface.co/models'\nIf this is a private repository, make sure to pass a "
                     "token having permission to this repo with `use_auth_token` or log in with `huggingface-cli "
                     "login` and pass `use_auth_token=True`."
                 )
-            except RevisionNotFoundError as err:
+            except RevisionNotFoundError:
                 raise EnvironmentError(
                     f"{revision} is not a valid git identifier (branch name, tag name or commit id) that exists for "
                     "this model name. Check the model page at "
                     f"'https://huggingface.co/{pretrained_model_name_or_path}' for available revisions."
                 )
-            except EntryNotFoundError as err:
+            except EntryNotFoundError:
                 if filename == TF2_WEIGHTS_NAME:
                     has_file_kwargs = {
                         "revision": revision,
@@ -1619,7 +1619,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                     raise EnvironmentError(
                         f"{pretrained_model_name_or_path} does not appear to have a file named {filename}."
                     )
-            except HTTPError as err:
+            except HTTPError:
                 raise EnvironmentError(
                     "We couldn't connect to 'https://huggingface.co/' to load this model and it looks like "
                     f"{pretrained_model_name_or_path} is not the path to a directory conaining a a file named "
@@ -1627,7 +1627,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                     "Checkout your internet connection or see how to run the library in offline mode at "
                     "'https://huggingface.co/docs/transformers/installation#offline-mode'."
                 )
-            except EnvironmentError as err:
+            except EnvironmentError:
                 raise EnvironmentError(
                     f"Can't load the model for '{pretrained_model_name_or_path}'. If you were trying to load it from "
                     "'https://huggingface.co/models', make sure you don't have a local directory with the same name. "

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1366,23 +1366,20 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     user_agent=user_agent,
                 )
 
-            except RepositoryNotFoundError as err:
-                logger.error(err)
+            except RepositoryNotFoundError:
                 raise EnvironmentError(
                     f"{pretrained_model_name_or_path} is not a local folder and is not a valid model identifier "
                     "listed on 'https://huggingface.co/models'\nIf this is a private repository, make sure to pass a "
                     "token having permission to this repo with `use_auth_token` or log in with `huggingface-cli "
                     "login` and pass `use_auth_token=True`."
                 )
-            except RevisionNotFoundError as err:
-                logger.error(err)
+            except RevisionNotFoundError:
                 raise EnvironmentError(
                     f"{revision} is not a valid git identifier (branch name, tag name or commit id) that exists for "
                     "this model name. Check the model page at "
                     f"'https://huggingface.co/{pretrained_model_name_or_path}' for available revisions."
                 )
-            except EntryNotFoundError as err:
-                logger.error(err)
+            except EntryNotFoundError:
                 if filename == WEIGHTS_NAME:
                     has_file_kwargs = {
                         "revision": revision,
@@ -1403,7 +1400,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                             "weights."
                         )
                     else:
-                        logger.error(err)
                         raise EnvironmentError(
                             f"{pretrained_model_name_or_path} does not appear to have a file named {WEIGHTS_NAME}, "
                             f"{TF2_WEIGHTS_NAME}, {TF_WEIGHTS_NAME} or {FLAX_WEIGHTS_NAME}."
@@ -1412,8 +1408,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     raise EnvironmentError(
                         f"{pretrained_model_name_or_path} does not appear to have a file named {filename}."
                     )
-            except HTTPError as err:
-                logger.error(err)
+            except HTTPError:
                 raise EnvironmentError(
                     "We couldn't connect to 'https://huggingface.co/' to load this model and it looks like "
                     f"{pretrained_model_name_or_path} is not the path to a directory conaining a a file named "
@@ -1421,8 +1416,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     "Checkout your internet connection or see how to run the library in offline mode at "
                     "'https://huggingface.co/docs/transformers/installation#offline-mode'."
                 )
-            except EnvironmentError as err:
-                logger.error(err)
+            except EnvironmentError:
                 raise EnvironmentError(
                     f"Can't load the model for '{pretrained_model_name_or_path}'. If you were trying to load it from "
                     "'https://huggingface.co/models', make sure you don't have a local directory with the same name. "

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1738,14 +1738,14 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                     else:
                         raise error
 
-                except RepositoryNotFoundError as err:
+                except RepositoryNotFoundError:
                     raise EnvironmentError(
                         f"{pretrained_model_name_or_path} is not a local folder and is not a valid model identifier "
                         "listed on 'https://huggingface.co/models'\nIf this is a private repository, make sure to "
                         "pass a token having permission to this repo with `use_auth_token` or log in with "
                         "`huggingface-cli login` and pass `use_auth_token=True`."
                     )
-                except RevisionNotFoundError as err:
+                except RevisionNotFoundError:
                     raise EnvironmentError(
                         f"{revision} is not a valid git identifier (branch name, tag name or commit id) that exists "
                         "for this model name. Check the model page at "

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1739,7 +1739,6 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                         raise error
 
                 except RepositoryNotFoundError as err:
-                    logger.error(err)
                     raise EnvironmentError(
                         f"{pretrained_model_name_or_path} is not a local folder and is not a valid model identifier "
                         "listed on 'https://huggingface.co/models'\nIf this is a private repository, make sure to "
@@ -1747,7 +1746,6 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                         "`huggingface-cli login` and pass `use_auth_token=True`."
                     )
                 except RevisionNotFoundError as err:
-                    logger.error(err)
                     raise EnvironmentError(
                         f"{revision} is not a valid git identifier (branch name, tag name or commit id) that exists "
                         "for this model name. Check the model page at "


### PR DESCRIPTION
# What does this PR do?

This PR removes the redundant error logging in the `from_pretrained()` method of:

* Configs
* Tokenizers
* Models
* Feature extractors

I also took the liberty of removing the redundant logging from the file utils. If a genuine error is raised, the user will still see it since the corresponding `EnvironmentError` is raised and provides a helpful message. 

## Why do this?

In PRs #15620 and #15625 we observed that the `AutoModel.from_pretrained()` method displays a 404 error in the logs when PyTorch and TensorFlow are installed in the same environment and:

* The `transformers.onnx` package is used to export a pure TensorFlow model
* The `pipeline()` function is used to load a pure TensorFlow model

Examples of specific log messages are shown below:

```bash
# Displays 404 Client Error: Entry Not Found for url: https://huggingface.co/keras-io/transformers-qa/resolve/main/pytorch_model.bin
python -m transformers.onnx --model=keras-io/transformers-qa onnx/
```

```python
from transformers import pipeline

# Displays 404 Client Error: Entry Not Found for url: https://huggingface.co/keras-io/transformers-qa/resolve
p = pipeline("question-answering", model="keras-io/transformers-qa")
```

The reason these logs appear is that both the `transformers.onnx` package and the `pipeline()` function attempt to first load the model weights in an `AutoModel` class (see [here](https://github.com/huggingface/transformers/blob/fcb0f7439754f1b830ebac2070a0c8a8f003f7c5/src/transformers/onnx/features.py#L306) and [here](https://github.com/huggingface/transformers/blob/fcb0f7439754f1b830ebac2070a0c8a8f003f7c5/src/transformers/pipelines/base.py#L305)). If the model repo only has TensorFlow weights, the error is logged, but the API resolves it by using either `from_tf=True` or instantiating a `TFAutoModel`.

These logs are potentially confusing for end-users and it's not clear we need them since we raise `EnvironmentError` for "real" errors and provide a pretty clear message on what went wrong. 

If we have to keep these logs, one alternative is to rewrite the `transformers.onnx` and `pipeline()` logic so that the error isn't raised for these edge cases (both frameworks installed, trying to load a pure TF model). I'd rather not do that, so happy to hear other suggestions!