### PR TITLE
Fix TFSequenceSummary's activation

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1958,9 +1958,10 @@ class TFSequenceSummary(tf.keras.layers.Layer):
                 num_classes, kernel_initializer=get_initializer(initializer_range), name="summary"
             )
 
-        self.has_activation = hasattr(config, "summary_activation")
-        if self.has_activation:
-            activation_string = getattr(config, "summary_activation")
+        self.has_activation = False
+        activation_string = getattr(config, "summary_activation", None)
+        if activation_string is not None:
+            self.has_activation = True
             self.activation = get_tf_activation(activation_string)
 
         self.has_first_dropout = hasattr(config, "summary_first_dropout") and config.summary_first_dropout > 0

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -34,6 +34,7 @@ from tensorflow.python.keras.saving import hdf5_format
 from huggingface_hub import Repository, list_repo_files
 from requests import HTTPError
 
+from .activations_tf import get_tf_activation
 from .configuration_utils import PretrainedConfig
 from .dynamic_module_utils import custom_object_save
 from .file_utils import (
@@ -1957,9 +1958,10 @@ class TFSequenceSummary(tf.keras.layers.Layer):
                 num_classes, kernel_initializer=get_initializer(initializer_range), name="summary"
             )
 
-        self.has_activation = hasattr(config, "summary_activation") and config.summary_activation == "tanh"
+        self.has_activation = hasattr(config, "summary_activation")
         if self.has_activation:
-            self.activation = tf.keras.activations.tanh
+            activation_string = getattr(config, "summary_activation")
+            self.activation = get_tf_activation(activation_string)
 
         self.has_first_dropout = hasattr(config, "summary_first_dropout") and config.summary_first_dropout > 0
         if self.has_first_dropout:


### PR DESCRIPTION
[TFSequenceSummary](https://github.com/huggingface/transformers/blob/52d2e6f6e904ef9b75c78716ce77b98196ed837a/src/transformers/modeling_tf_utils.py#L1910) set its `activation` only when `config.summary_activation == "tanh"`.

https://github.com/huggingface/transformers/blob/52d2e6f6e904ef9b75c78716ce77b98196ed837a/src/transformers/modeling_tf_utils.py#L1960

However, [ElectraConfig](https://github.com/huggingface/transformers/blob/52d2e6f6e904ef9b75c78716ce77b98196ed837a/src/transformers/models/electra/configuration_electra.py#L137) has default value `"gelu"` for `summary_activation`, and therefore [TFElectraForMultipleChoice](https://github.com/huggingface/transformers/blob/52d2e6f6e904ef9b75c78716ce77b98196ed837a/src/transformers/models/electra/modeling_tf_electra.py#L1427) doesn't use activation at all for `self.sequence_summary`.

This is different from PyTorch version: [SequenceSummary](https://github.com/huggingface/transformers/blob/52d2e6f6e904ef9b75c78716ce77b98196ed837a/src/transformers/modeling_utils.py#L2198)
https://github.com/huggingface/transformers/blob/52d2e6f6e904ef9b75c78716ce77b98196ed837a/src/transformers/modeling_utils.py#L2242
(which has no condition on `tanh`).

This inconsistency also makes the extended pt/tf equivalence fail for `electra` model.

This PR fixes the above issue.


TF: @gante @Rocketknight1

cc @patil-suraj for his somehow related work on adding `ElectraForMultipleChoice` (#4954) with `gelu` for `summary_activation`