### PR TITLE
Gelu10

### DIFF
--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -88,7 +88,7 @@ class ClippedGELUActivation(nn.Module):
     """
 
     def __init__(self, min: float, max: float):
-        if min < max:
+        if min > max:
             raise ValueError(f"min should be < max (got min: {min}, max: {max})")
 
         super().__init__()

--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -78,12 +78,13 @@ class ClippedGELUActivation(nn.Module):
     """
     Clip the range of possible GeLU outputs between [-10, 10]. This is especially useful for quantization purpose, as
     it allows mapping 2 negatives values in the GeLU spectrum. For more information on this trick, please refer to
-    https://arxiv.org/abs/2004.09602
+    https://arxiv.org/abs/2004.09602.
 
     Gaussian Error Linear Unit. Original Implementation of the gelu activation function in Google Bert repo when
-    initially created. For information: OpenAI GPT's gelu is slightly different (and gives slightly different results):
-    0.5 * x * (1 + torch.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * torch.pow(x, 3)))) Also see
-    https://arxiv.org/abs/1606.08415 :param x: :return:
+    initially created.
+
+    For information: OpenAI GPT's gelu is slightly different (and gives slightly different results): 0.5 * x * (1 +
+    torch.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * torch.pow(x, 3)))). See https://arxiv.org/abs/1606.08415
     """
 
     def __init__(self, min: float, max: float):

--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -74,6 +74,29 @@ class QuickGELUActivation(nn.Module):
         return input * torch.sigmoid(1.702 * input)
 
 
+class ClippedGELUActivation(nn.Module):
+    """
+    Clip the range of possible GeLU outputs between [-10, 10].
+    This is especially useful for quantization purpose, as it allows mapping 2 negatives values in the GeLU spectrum.
+    For more information on this trick, please refer to https://arxiv.org/abs/2004.09602
+
+    Gaussian Error Linear Unit. Original Implementation of the gelu activation function in Google Bert repo when
+    initially created. For information: OpenAI GPT's gelu is slightly different (and gives slightly different results):
+    0.5 * x * (1 + torch.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * torch.pow(x, 3)))) Also see
+    https://arxiv.org/abs/1606.08415
+    :param x:
+    :return:
+    """
+    def __init__(self, min: float, max: float):
+        assert min < max, f"min should be < max (got min: {min}, max: {max})"
+        super().__init__()
+        self.min = min
+        self.max = max
+
+    def forward(self, x: Tensor) -> Tensor:
+        return torch.clip(gelu(x), -10, 10)
+
+
 class SiLUActivation(nn.Module):
     """
     See Gaussian Error Linear Units (Hendrycks et al., https://arxiv.org/abs/1606.08415) where the SiLU (Sigmoid Linear
@@ -136,6 +159,7 @@ ACT2FN = {
     "gelu_new": NewGELUActivation(),
     "gelu_fast": FastGELUActivation(),
     "quick_gelu": QuickGELUActivation(),
+    "gelu_10": ClippedGELUActivation(-10, 10),
     "mish": MishActivation(),
     "linear": LinearActivation(),
     "sigmoid": nn.Sigmoid(),

--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -76,8 +76,8 @@ class QuickGELUActivation(nn.Module):
 
 class ClippedGELUActivation(nn.Module):
     """
-    Clip the range of possible GeLU outputs between [-10, 10]. This is especially useful for quantization purpose, as
-    it allows mapping 2 negatives values in the GeLU spectrum. For more information on this trick, please refer to
+    Clip the range of possible GeLU outputs between [min, max]. This is especially useful for quantization purpose, as
+    it allows mapping negatives values in the GeLU spectrum. For more information on this trick, please refer to
     https://arxiv.org/abs/2004.09602.
 
     Gaussian Error Linear Unit. Original Implementation of the gelu activation function in Google Bert repo when
@@ -88,13 +88,15 @@ class ClippedGELUActivation(nn.Module):
     """
 
     def __init__(self, min: float, max: float):
-        assert min < max, f"min should be < max (got min: {min}, max: {max})"
+        if min < max:
+            raise ValueError(f"min should be < max (got min: {min}, max: {max})")
+
         super().__init__()
         self.min = min
         self.max = max
 
     def forward(self, x: Tensor) -> Tensor:
-        return torch.clip(gelu(x), -10, 10)
+        return torch.clip(gelu(x), self.min, self.max)
 
 
 class SiLUActivation(nn.Module):

--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -76,17 +76,16 @@ class QuickGELUActivation(nn.Module):
 
 class ClippedGELUActivation(nn.Module):
     """
-    Clip the range of possible GeLU outputs between [-10, 10].
-    This is especially useful for quantization purpose, as it allows mapping 2 negatives values in the GeLU spectrum.
-    For more information on this trick, please refer to https://arxiv.org/abs/2004.09602
+    Clip the range of possible GeLU outputs between [-10, 10]. This is especially useful for quantization purpose, as
+    it allows mapping 2 negatives values in the GeLU spectrum. For more information on this trick, please refer to
+    https://arxiv.org/abs/2004.09602
 
     Gaussian Error Linear Unit. Original Implementation of the gelu activation function in Google Bert repo when
     initially created. For information: OpenAI GPT's gelu is slightly different (and gives slightly different results):
     0.5 * x * (1 + torch.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * torch.pow(x, 3)))) Also see
-    https://arxiv.org/abs/1606.08415
-    :param x:
-    :return:
+    https://arxiv.org/abs/1606.08415 :param x: :return:
     """
+
     def __init__(self, min: float, max: float):
         assert min < max, f"min should be < max (got min: {min}, max: {max})"
         super().__init__()

--- a/src/transformers/activations_tf.py
+++ b/src/transformers/activations_tf.py
@@ -69,6 +69,22 @@ def quick_gelu(x):
     return x * tf.math.sigmoid(coeff * x)
 
 
+def gelu_10(x):
+    """
+    Clip the range of possible GeLU outputs between [-10, 10].
+    This is especially useful for quantization purpose, as it allows mapping 2 negatives values in the GeLU spectrum.
+    For more information on this trick, please refer to https://arxiv.org/abs/2004.09602
+
+    Gaussian Error Linear Unit. Original Implementation of the gelu activation function in Google Bert repo when
+    initially created. For information: OpenAI GPT's gelu is slightly different (and gives slightly different results):
+    0.5 * x * (1 + torch.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * torch.pow(x, 3)))) Also see
+    https://arxiv.org/abs/1606.08415
+    :param x:
+    :return:
+    """
+    return tf.clip_by_value(_gelu(x), -10, 10)
+
+
 def glu(x, axis=-1):
     """
     Gated Linear Unit. Implementation as defined in the original paper (see https://arxiv.org/abs/1612.08083), where
@@ -107,6 +123,7 @@ ACT2FN = {
     "tanh": tf.keras.activations.tanh,
     "gelu_fast": gelu_fast,
     "quick_gelu": quick_gelu,
+    "gelu_10": gelu_10,
     "glu": glu,
 }
 

--- a/src/transformers/activations_tf.py
+++ b/src/transformers/activations_tf.py
@@ -71,16 +71,14 @@ def quick_gelu(x):
 
 def gelu_10(x):
     """
-    Clip the range of possible GeLU outputs between [-10, 10].
-    This is especially useful for quantization purpose, as it allows mapping 2 negatives values in the GeLU spectrum.
-    For more information on this trick, please refer to https://arxiv.org/abs/2004.09602
+    Clip the range of possible GeLU outputs between [-10, 10]. This is especially useful for quantization purpose, as
+    it allows mapping 2 negatives values in the GeLU spectrum. For more information on this trick, please refer to
+    https://arxiv.org/abs/2004.09602
 
     Gaussian Error Linear Unit. Original Implementation of the gelu activation function in Google Bert repo when
     initially created. For information: OpenAI GPT's gelu is slightly different (and gives slightly different results):
     0.5 * x * (1 + torch.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * torch.pow(x, 3)))) Also see
-    https://arxiv.org/abs/1606.08415
-    :param x:
-    :return:
+    https://arxiv.org/abs/1606.08415 :param x: :return:
     """
     return tf.clip_by_value(_gelu(x), -10, 10)
 

--- a/tests/test_activations.py
+++ b/tests/test_activations.py
@@ -32,6 +32,19 @@ class TestActivations(unittest.TestCase):
         self.assertTrue(torch.allclose(gelu_python(x), torch_builtin(x)))
         self.assertFalse(torch.allclose(gelu_python(x), gelu_new(x)))
 
+    def test_gelu_10(self):
+        x = torch.tensor([-100, -1, -0.1, 0, 0.1, 1.0, 100])
+        torch_builtin = get_activation("gelu")
+        gelu10 = get_activation("gelu_10")
+
+        y_gelu = torch_builtin(x)
+        y_gelu_10 = gelu10(x)
+
+        clipped_mask = torch.where(y_gelu_10 < 10.0, 1, 0)
+
+        self.assertTrue(torch.max(y_gelu_10).item() == 10.0)
+        self.assertTrue(torch.allclose(y_gelu * clipped_mask, y_gelu_10 * clipped_mask))
+
     def test_get_activation(self):
         get_activation("swish")
         get_activation("silu")
@@ -40,6 +53,7 @@ class TestActivations(unittest.TestCase):
         get_activation("gelu_new")
         get_activation("gelu_fast")
         get_activation("gelu_python")
+        get_activation("gelu_10")
         get_activation("quick_gelu")
         get_activation("mish")
         get_activation("linear")

--- a/tests/test_activations_tf.py
+++ b/tests/test_activations_tf.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import unittest
+
+import numpy as np
 
 from transformers import is_tf_available
 from transformers.testing_utils import require_tf
@@ -21,6 +22,7 @@ from transformers.testing_utils import require_tf
 
 if is_tf_available():
     import tensorflow as tf
+
     from transformers.activations_tf import get_tf_activation
 
 

--- a/tests/test_activations_tf.py
+++ b/tests/test_activations_tf.py
@@ -39,7 +39,7 @@ class TestTFActivations(unittest.TestCase):
 
         clipped_mask = tf.where(y_gelu_10 < 10.0, 1, 0)
 
-        self.assertTrue(tf.max(y_gelu_10).numpy().item() == 10.0)
+        self.assertEqual(tf.math.max(y_gelu_10).numpy().item(), 10.0)
         self.assertTrue(np.allclose(y_gelu * clipped_mask, y_gelu_10 * clipped_mask))
 
     def test_get_activation(self):

--- a/tests/test_activations_tf.py
+++ b/tests/test_activations_tf.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import unittest
 
-import numpy as np
 from transformers import is_tf_available
 from transformers.testing_utils import require_tf
 
@@ -28,7 +28,7 @@ if is_tf_available():
 class TestTFActivations(unittest.TestCase):
 
     def test_gelu_10(self):
-        x = tf.tensor([-100, -1, -0.1, 0, 0.1, 1.0, 100])
+        x = tf.constant([-100, -1, -0.1, 0, 0.1, 1.0, 100])
         gelu = get_tf_activation("gelu")
         gelu10 = get_tf_activation("gelu_10")
 

--- a/tests/test_activations_tf.py
+++ b/tests/test_activations_tf.py
@@ -14,13 +14,13 @@
 
 import unittest
 
-import tensorflow as tf
 import numpy as np
 from transformers import is_tf_available
 from transformers.testing_utils import require_tf
 
 
 if is_tf_available():
+    import tensorflow as tf
     from transformers.activations_tf import get_tf_activation
 
 

--- a/tests/test_activations_tf.py
+++ b/tests/test_activations_tf.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import tensorflow as tf
+import numpy as np
 from transformers import is_tf_available
 from transformers.testing_utils import require_tf
 
@@ -24,6 +26,20 @@ if is_tf_available():
 
 @require_tf
 class TestTFActivations(unittest.TestCase):
+
+    def test_gelu_10(self):
+        x = tf.tensor([-100, -1, -0.1, 0, 0.1, 1.0, 100])
+        gelu = get_tf_activation("gelu")
+        gelu10 = get_tf_activation("gelu_10")
+
+        y_gelu = gelu(x)
+        y_gelu_10 = gelu10(x)
+
+        clipped_mask = tf.where(y_gelu_10 < 10.0, 1, 0)
+
+        self.assertTrue(tf.max(y_gelu_10).numpy().item() == 10.0)
+        self.assertTrue(np.allclose(y_gelu * clipped_mask, y_gelu_10 * clipped_mask))
+
     def test_get_activation(self):
         get_tf_activation("swish")
         get_tf_activation("silu")
@@ -32,6 +48,7 @@ class TestTFActivations(unittest.TestCase):
         get_tf_activation("tanh")
         get_tf_activation("gelu_new")
         get_tf_activation("gelu_fast")
+        get_tf_activation("gelu_10")
         get_tf_activation("mish")
         get_tf_activation("quick_gelu")
         get_tf_activation("glu")

--- a/tests/test_activations_tf.py
+++ b/tests/test_activations_tf.py
@@ -30,16 +30,16 @@ if is_tf_available():
 class TestTFActivations(unittest.TestCase):
 
     def test_gelu_10(self):
-        x = tf.constant([-100, -1, -0.1, 0, 0.1, 1.0, 100])
+        x = tf.constant([-100, -1., -0.1, 0, 0.1, 1.0, 100.])
         gelu = get_tf_activation("gelu")
         gelu10 = get_tf_activation("gelu_10")
 
         y_gelu = gelu(x)
         y_gelu_10 = gelu10(x)
 
-        clipped_mask = tf.where(y_gelu_10 < 10.0, 1, 0)
+        clipped_mask = tf.where(y_gelu_10 < 10.0, 1., 0.)
 
-        self.assertEqual(tf.math.max(y_gelu_10).numpy().item(), 10.0)
+        self.assertEqual(tf.math.reduce_max(y_gelu_10).numpy().item(), 10.0)
         self.assertTrue(np.allclose(y_gelu * clipped_mask, y_gelu_10 * clipped_mask))
 
     def test_get_activation(self):

--- a/tests/test_activations_tf.py
+++ b/tests/test_activations_tf.py
@@ -28,16 +28,15 @@ if is_tf_available():
 
 @require_tf
 class TestTFActivations(unittest.TestCase):
-
     def test_gelu_10(self):
-        x = tf.constant([-100, -1., -0.1, 0, 0.1, 1.0, 100.])
+        x = tf.constant([-100, -1.0, -0.1, 0, 0.1, 1.0, 100.0])
         gelu = get_tf_activation("gelu")
         gelu10 = get_tf_activation("gelu_10")
 
         y_gelu = gelu(x)
         y_gelu_10 = gelu10(x)
 
-        clipped_mask = tf.where(y_gelu_10 < 10.0, 1., 0.)
+        clipped_mask = tf.where(y_gelu_10 < 10.0, 1.0, 0.0)
 
         self.assertEqual(tf.math.reduce_max(y_gelu_10).numpy().item(), 10.0)
         self.assertTrue(np.allclose(y_gelu * clipped_mask, y_gelu_10 * clipped_mask))


### PR DESCRIPTION
Introduce `GeLU10(x)` activation which behaves exactly like a raw GeLU but keeps output values within [-10, 10] range.

This is especially useful when quantizing neural network using GeLU activations, because it allows to map 2 negatives values within the GeLU spectrum.

Please see https://arxiv.org/abs/2004.09602 (Appendices D  "Novel activation functions"): 
> GELU has an output range of [−0.1700, ∞]. This
poses a challenge for uniform quantization as it should represent both small negative values and large positive values [...] However, if we restrict the range to [-10,10] then two negative values can be represented.

![image](https://user-images.githubusercontent.com/2241520/154236552-9ea2aaa7-d14b-4b14-924c-2bd4218c6243.png)
