### PR TITLE
Fix prepare_for_model error inconsistency

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2953,6 +2953,13 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         len_ids = len(ids)
         len_pair_ids = len(pair_ids) if pair else 0
 
+        # Load from model defaults
+        if return_token_type_ids is None:
+            return_token_type_ids = "token_type_ids" in self.model_input_names
+        if return_attention_mask is None:
+            return_attention_mask = "attention_mask" in self.model_input_names
+        
+        # Parameter sanity check
         if return_token_type_ids and not add_special_tokens:
             raise ValueError(
                 "Asking to return token_type_ids while setting add_special_tokens to False "
@@ -2970,12 +2977,6 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 "`longest_first`. Please select another truncation strategy than `longest_first`, "
                 "for instance `only_second` or `only_first`."
             )
-
-        # Load from model defaults
-        if return_token_type_ids is None:
-            return_token_type_ids = "token_type_ids" in self.model_input_names
-        if return_attention_mask is None:
-            return_attention_mask = "attention_mask" in self.model_input_names
 
         encoded_inputs = {}
 


### PR DESCRIPTION
# What does this PR do?
The model default parameters in the `tokenization_utils_base.prepare_for_model` function are fetched after the parameter sanity check. This causes the sanity check to not recognize wrong parameter combinations when using model defaults.
This PR swaps those two.

Fixes #15679

- tokenizers: @n1t0, @LysandreJik

## Code to test:
Prepare:
```
from transformers import AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained('bert-base-uncased')
sentences = ['Sentence number one.',
             'Sentence number two is longer to trigger padding.']

token_ids = tokenizer.batch_encode_plus(
    sentences,
    add_special_tokens=True,
    truncation=False,
    padding=False)
token_ids = token_ids['input_ids']
```

Test:
```
try:
	  tokenizer.prepare_for_model(
	      token_ids,
	      add_special_tokens=False,
	      padding='longest',
	      truncation=False,
	      return_token_type_ids=None) # Uses the model default
except Exception as e:
	e1 = e	

try: 
	  tokenizer.prepare_for_model(
	      token_ids,
	      add_special_tokens=False,
	      padding='longest',
	      truncation=False,
	      return_token_type_ids=True) # Explicitly set to true
except Exception as e:
	e2 = e

assert type(e1) is type(e2) and e1.args == e2.args
```

The error code of Test_01 and Test_02 should be the same.