### PR TITLE
Add initializer_std to TFFunnelModelTester with a default value 0.02

### DIFF
--- a/tests/test_modeling_tf_funnel.py
+++ b/tests/test_modeling_tf_funnel.py
@@ -63,6 +63,7 @@ class TFFunnelModelTester:
         activation_dropout=0.0,
         max_position_embeddings=512,
         type_vocab_size=3,
+        initializer_std=0.02,  # Set to a smaller value, so we can keep the small error threshold (1e-5) in the test
         num_labels=3,
         num_choices=4,
         scope=None,
@@ -92,6 +93,7 @@ class TFFunnelModelTester:
         self.num_labels = num_labels
         self.num_choices = num_choices
         self.scope = scope
+        self.initializer_std = initializer_std
 
         # Used in the tests to check the size of the first attention layer
         self.num_attention_heads = n_head
@@ -137,6 +139,7 @@ class TFFunnelModelTester:
             activation_dropout=self.activation_dropout,
             max_position_embeddings=self.max_position_embeddings,
             type_vocab_size=self.type_vocab_size,
+            initializer_std=self.initializer_std,
         )
 
         return (


### PR DESCRIPTION
# What does this PR do?

This PR sets `initializer_std=0.02` in `TFFunnelModelTester`, so we can use `1e-5` as the threshold in PT/TF equivalence test.
(so the inconsistencies are less likely to be undetected)

TF: @gante @Rocketknight1 


## Details

The `test_pt_tf_model_equivalence` in `test_modeling_tf_common.py` has:

- create Pytorch/TensorFlow models using a config (defined in each TF test script)
- load the Pytorch model to TensorFlow model
- load the TensorFlow model (already changed in the previous step) to the Pytorch model

See
https://github.com/huggingface/transformers/blob/cdc51ffd27f8f5a3151da161ae2b5dbb410d2803/tests/test_modeling_tf_common.py#L359-L366

For `Funnel` model:

- In `test_modeling_tf_funnel.py`, we don't use `initializer_std`.
- In `config_funnel.py`, we have [initializer_std=None](https://github.com/huggingface/transformers/blob/cdc51ffd27f8f5a3151da161ae2b5dbb410d2803/src/transformers/models/funnel/configuration_funnel.py#L124)
- In `modeling_funnel.py`, we have [std = 1.0 if self.config.initializer_std is None](https://github.com/huggingface/transformers/blob/cdc51ffd27f8f5a3151da161ae2b5dbb410d2803/src/transformers/models/funnel/modeling_funnel.py#L780)

Therefore, the Pytorch Funnel model created for the testing uses `std=1.0` to create `FunnelEmbeddings` (and the weights are loaded to TF model). This has the following effect for `TFFunnelForMaskedLM`:

- while all the hidden states have a PT/TF difference in the range `1e-7 ~ 2e-6`, the `logits` will have a larger difference (say `2e-5`) with a higher probability - due to the larger magnitude of embedding weights.

The (extended) PT/TF equivalence test used to search for inconsistency uses `1e-5` as threshold. So far, the equivalence tests failed with this threshold have proven to be due to some PT/TF inconsistency (i.e. not due to randomness). And after some fixes, they all have differences < `1e-5`.

In order to continue to use `1e-5` as threshold (so the inconsistencies are less likely to be undetected), this PR sets `initializer_std=0.02` in `TFFunnelModelTester`.

## Remark

The weight initialization logic for `TFFunnelModel` diverges from the `FunnelModel`, and would be good to fix it in another PR.