### PR TITLE
Fix Funnel configuration doc

### DIFF
--- a/src/transformers/models/funnel/configuration_funnel.py
+++ b/src/transformers/models/funnel/configuration_funnel.py
@@ -77,7 +77,7 @@ class FunnelConfig(PretrainedConfig):
         type_vocab_size (`int`, *optional*, defaults to 3):
             The vocabulary size of the `token_type_ids` passed when calling [`FunnelModel`] or [`TFFunnelModel`].
         initializer_range (`float`, *optional*, defaults to 0.1):
-            The standard deviation of the *uniform initializer* for initializing all weight matrices in attention
+            The upper bound of the *uniform initializer* for initializing all weight matrices in attention
             layers.
         initializer_std (`float`, *optional*):
             The standard deviation of the *normal initializer* for initializing the embedding matrix and the weight of

--- a/tests/test_modeling_tf_funnel.py
+++ b/tests/test_modeling_tf_funnel.py
@@ -63,6 +63,7 @@ class TFFunnelModelTester:
         activation_dropout=0.0,
         max_position_embeddings=512,
         type_vocab_size=3,
+        initializer_std=0.02,  # Set to a smaller value, so we can keep the small error threshold (1e-5) in the test
         num_labels=3,
         num_choices=4,
         scope=None,
@@ -92,6 +93,7 @@ class TFFunnelModelTester:
         self.num_labels = num_labels
         self.num_choices = num_choices
         self.scope = scope
+        self.initializer_std = initializer_std
 
         # Used in the tests to check the size of the first attention layer
         self.num_attention_heads = n_head
@@ -137,6 +139,7 @@ class TFFunnelModelTester:
             activation_dropout=self.activation_dropout,
             max_position_embeddings=self.max_position_embeddings,
             type_vocab_size=self.type_vocab_size,
+            initializer_std=self.initializer_std,
         )
 
         return (


### PR DESCRIPTION
# What does this PR do?

The part `standard deviation` should be `upper bound` in

https://github.com/huggingface/transformers/blob/cdc51ffd27f8f5a3151da161ae2b5dbb410d2803/src/transformers/models/funnel/configuration_funnel.py#L79-L80

as it is used for `nn.init.uniform_`:

https://github.com/huggingface/transformers/blob/cdc51ffd27f8f5a3151da161ae2b5dbb410d2803/src/transformers/models/funnel/modeling_funnel.py#L774-L778

@sgugger 