### PR TITLE
Fix Funnel configuration doc

### DIFF
--- a/src/transformers/models/funnel/configuration_funnel.py
+++ b/src/transformers/models/funnel/configuration_funnel.py
@@ -77,8 +77,7 @@ class FunnelConfig(PretrainedConfig):
         type_vocab_size (`int`, *optional*, defaults to 3):
             The vocabulary size of the `token_type_ids` passed when calling [`FunnelModel`] or [`TFFunnelModel`].
         initializer_range (`float`, *optional*, defaults to 0.1):
-            The upper bound of the *uniform initializer* for initializing all weight matrices in attention
-            layers.
+            The upper bound of the *uniform initializer* for initializing all weight matrices in attention layers.
         initializer_std (`float`, *optional*):
             The standard deviation of the *normal initializer* for initializing the embedding matrix and the weight of
             linear layers. Will default to 1 for the embedding matrix and the value given by Xavier initialization for

--- a/src/transformers/models/funnel/configuration_funnel.py
+++ b/src/transformers/models/funnel/configuration_funnel.py
@@ -77,7 +77,7 @@ class FunnelConfig(PretrainedConfig):
         type_vocab_size (`int`, *optional*, defaults to 3):
             The vocabulary size of the `token_type_ids` passed when calling [`FunnelModel`] or [`TFFunnelModel`].
         initializer_range (`float`, *optional*, defaults to 0.1):
-            The standard deviation of the *uniform initializer* for initializing all weight matrices in attention
+            The upper bound of the *uniform initializer* for initializing all weight matrices in attention
             layers.
         initializer_std (`float`, *optional*):
             The standard deviation of the *normal initializer* for initializing the embedding matrix and the weight of


### PR DESCRIPTION
# What does this PR do?

The part `standard deviation` should be `upper bound` in

https://github.com/huggingface/transformers/blob/cdc51ffd27f8f5a3151da161ae2b5dbb410d2803/src/transformers/models/funnel/configuration_funnel.py#L79-L80

as it is used for `nn.init.uniform_`:

https://github.com/huggingface/transformers/blob/cdc51ffd27f8f5a3151da161ae2b5dbb410d2803/src/transformers/models/funnel/modeling_funnel.py#L774-L778

@sgugger 