### PR TITLE
fix bug in PT speech-encoder-decoder

### DIFF
--- a/src/transformers/models/speech_encoder_decoder/modeling_speech_encoder_decoder.py
+++ b/src/transformers/models/speech_encoder_decoder/modeling_speech_encoder_decoder.py
@@ -490,15 +490,16 @@ class SpeechEncoderDecoderModel(PreTrainedModel):
             argument[len("decoder_") :]: value for argument, value in kwargs.items() if argument.startswith("decoder_")
         }
 
-        if encoder_outputs is None and inputs is None:
-            if input_values is not None and input_features is not None:
-                raise ValueError("You cannot specify both input_values and input_features at the same time")
-            elif input_values is not None:
-                inputs = input_values
-            elif input_features is not None:
-                inputs = input_features
-            else:
-                raise ValueError("You have to specify either input_values or input_features")
+        if encoder_outputs is None:
+            if inputs is None:
+                if input_values is not None and input_features is not None:
+                    raise ValueError("You cannot specify both input_values and input_features at the same time")
+                elif input_values is not None:
+                    inputs = input_values
+                elif input_features is not None:
+                    inputs = input_features
+                else:
+                    raise ValueError("You have to specify either input_values or input_features")
 
             encoder_outputs = self.encoder(
                 inputs,

--- a/tests/test_modeling_speech_encoder_decoder.py
+++ b/tests/test_modeling_speech_encoder_decoder.py
@@ -113,6 +113,20 @@ class EncoderDecoderMixin:
         self.assertEqual(
             outputs_encoder_decoder["logits"].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,))
         )
+
+        # specify `inputs` to model only, omitting `input_values` and `input_features`
+        inputs = input_values if input_features is None else input_features
+        outputs_encoder_decoder = enc_dec_model(
+            inputs=inputs,
+            decoder_input_ids=decoder_input_ids,
+            attention_mask=attention_mask,
+            decoder_attention_mask=decoder_attention_mask,
+            output_hidden_states=True,
+        )
+        self.assertEqual(
+            outputs_encoder_decoder["logits"].shape, (decoder_input_ids.shape - (decoder_config.vocab_size,))
+        )
+
         encoder_outputs = BaseModelOutput(last_hidden_state=outputs_encoder_decoder.encoder_hidden_states[-1])
         outputs_encoder_decoder = enc_dec_model(
             encoder_outputs=encoder_outputs,

--- a/tests/test_modeling_speech_encoder_decoder.py
+++ b/tests/test_modeling_speech_encoder_decoder.py
@@ -161,6 +161,7 @@ class EncoderDecoderMixin:
         self.assertEqual(
             outputs_encoder_decoder_kwarg["logits"].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,))
         )
+
     def check_encoder_decoder_model_from_pretrained(
         self,
         config,

--- a/tests/test_modeling_speech_encoder_decoder.py
+++ b/tests/test_modeling_speech_encoder_decoder.py
@@ -151,7 +151,16 @@ class EncoderDecoderMixin:
         self.assertEqual(
             outputs_encoder_decoder["logits"].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,))
         )
-
+        outputs_encoder_decoder_kwarg = enc_dec_model(
+            inputs=inputs,
+            decoder_input_ids=decoder_input_ids,
+            attention_mask=attention_mask,
+            decoder_attention_mask=decoder_attention_mask,
+            output_hidden_states=True,
+        )
+        self.assertEqual(
+            outputs_encoder_decoder_kwarg["logits"].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,))
+        )
     def check_encoder_decoder_model_from_pretrained(
         self,
         config,

--- a/tests/test_modeling_speech_encoder_decoder.py
+++ b/tests/test_modeling_speech_encoder_decoder.py
@@ -124,7 +124,7 @@ class EncoderDecoderMixin:
             output_hidden_states=True,
         )
         self.assertEqual(
-            outputs_encoder_decoder["logits"].shape, (decoder_input_ids.shape - (decoder_config.vocab_size,))
+            outputs_encoder_decoder["logits"].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,))
         )
 
         encoder_outputs = BaseModelOutput(last_hidden_state=outputs_encoder_decoder.encoder_hidden_states[-1])


### PR DESCRIPTION
# What does this PR do?

Currently in the PT speech-encoder-decoder model, if:

- `encoder_outputs is None` and
- `inputs is not None`

then the encoder is _not_ run in the forward pass, and the `encoder_outputs` remain set to `None`. This throws a `TypeError` when taking the `encoder_hidden_states` - this variable is defined by indexing `encoder_outputs`, which is a `NoneType`.

This PR amends the model to handle this case by running the encoder in a forward pass to yield the `encoder_outputs`. The `encoder_outputs` can then be indexed to give the `encoder_hidden_states`.
