### PR TITLE
TF text classification examples

### DIFF
--- a/docs/source/main_classes/processors.mdx
+++ b/docs/source/main_classes/processors.mdx
@@ -65,12 +65,7 @@ Those processors are:
 Additionally, the following method can be used to load values from a data file and convert them to a list of
 [`~data.processors.utils.InputExample`].
 
-automethod,transformers.data.processors.glue.glue_convert_examples_to_features
-
-
-### Example usage
-
-An example using these processors is given in the [run_glue.py](https://github.com/huggingface/transformers/tree/master/examples/legacy/text-classification/run_glue.py) script.
+[[autodoc]] data.processors.glue.glue_convert_examples_to_features
 
 
 ## XNLI
@@ -114,7 +109,7 @@ They both inherit from the abstract class [`~data.processors.utils.SquadProcesso
 Additionally, the following method can be used to convert SQuAD examples into
 [`~data.processors.utils.SquadFeatures`] that can be used as model inputs.
 
-automethod,transformers.data.processors.squad.squad_convert_examples_to_features
+[[autodoc]] data.processors.squad.squad_convert_examples_to_features
 
 
 These processors as well as the aforementionned method can be used with files containing the data as well as with the

--- a/examples/pytorch/text-classification/run_glue.py
+++ b/examples/pytorch/text-classification/run_glue.py
@@ -457,7 +457,8 @@ def main():
         else:
             return {"accuracy": (preds == p.label_ids).astype(np.float32).mean().item()}
 
-    # Data collator will default to DataCollatorWithPadding, so we change it if we already did the padding.
+    # Data collator will default to DataCollatorWithPadding when the tokenizer is passed to Trainer, so we change it if
+    # we already did the padding.
     if data_args.pad_to_max_length:
         data_collator = default_data_collator
     elif training_args.fp16:

--- a/examples/tensorflow/text-classification/run_glue.py
+++ b/examples/tensorflow/text-classification/run_glue.py
@@ -20,6 +20,7 @@ import logging
 import os
 import sys
 from dataclasses import dataclass, field
+from functools import partial
 from typing import Optional
 
 import numpy as np
@@ -30,10 +31,12 @@ import transformers
 from transformers import (
     AutoConfig,
     AutoTokenizer,
+    DataCollatorWithPadding,
     HfArgumentParser,
     PretrainedConfig,
     TFAutoModelForSequenceClassification,
     TFTrainingArguments,
+    default_data_collator,
     set_seed,
 )
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
@@ -41,48 +44,6 @@ from transformers.utils import check_min_version
 
 
 # region Helper functions
-
-
-def convert_dataset_for_tensorflow(
-    dataset, non_label_column_names, batch_size, dataset_mode="variable_batch", shuffle=True, drop_remainder=True
-):
-    """Converts a Hugging Face dataset to a Tensorflow Dataset. The dataset_mode controls whether we pad all batches
-    to the maximum sequence length, or whether we only pad to the maximum length within that batch. The former
-    is most useful when training on TPU, as a new graph compilation is required for each sequence length.
-    """
-
-    def densify_ragged_batch(features, label=None):
-        features = {
-            feature: ragged_tensor.to_tensor(shape=batch_shape[feature]) for feature, ragged_tensor in features.items()
-        }
-        if label is None:
-            return features
-        else:
-            return features, label
-
-    feature_keys = list(set(dataset.features.keys()) - set(non_label_column_names + ["label"]))
-    if dataset_mode == "variable_batch":
-        batch_shape = {key: None for key in feature_keys}
-        data = {key: tf.ragged.constant(dataset[key]) for key in feature_keys}
-    elif dataset_mode == "constant_batch":
-        data = {key: tf.ragged.constant(dataset[key]) for key in feature_keys}
-        batch_shape = {
-            key: tf.concat(([batch_size], ragged_tensor.bounding_shape()[1:]), axis=0)
-            for key, ragged_tensor in data.items()
-        }
-    else:
-        raise ValueError("Unknown dataset mode!")
-
-    if "label" in dataset.features:
-        labels = tf.convert_to_tensor(np.array(dataset["label"]))
-        tf_dataset = tf.data.Dataset.from_tensor_slices((data, labels))
-    else:
-        tf_dataset = tf.data.Dataset.from_tensor_slices(data)
-    if shuffle:
-        tf_dataset = tf_dataset.shuffle(buffer_size=len(dataset))
-    tf_dataset = tf_dataset.batch(batch_size=batch_size, drop_remainder=drop_remainder).map(densify_ragged_batch)
-    return tf_dataset
-
 
 class SavePretrainedCallback(tf.keras.callbacks.Callback):
     # Hugging Face models have a save_pretrained() method that saves both the weights and the necessary
@@ -146,7 +107,7 @@ class DataTrainingArguments:
         default=False, metadata={"help": "Overwrite the cached preprocessed datasets or not."}
     )
     pad_to_max_length: bool = field(
-        default=False,
+        default=True,
         metadata={
             "help": "Whether to pad all samples to `max_seq_length`. "
             "If False, will pad the samples dynamically when batching to the maximum length in the batch."
@@ -377,6 +338,11 @@ def main():
 
     datasets = datasets.map(preprocess_function, batched=True, load_from_cache_file=not data_args.overwrite_cache)
 
+    if data_args.pad_to_max_length:
+        data_collator = partial(default_data_collator, return_tensors="tf")
+    else:
+        data_collator = DataCollatorWithPadding(tokenizer, return_tensors="tf")
+
     # endregion
 
     # region Metric function
@@ -426,11 +392,6 @@ def main():
 
         # region Convert data to a tf.data.Dataset
         tf_data = dict()
-        if isinstance(training_args.strategy, tf.distribute.TPUStrategy) or data_args.pad_to_max_length:
-            logger.info("Padding all batches to max length because argument was set or we're on TPU.")
-            dataset_mode = "constant_batch"
-        else:
-            dataset_mode = "variable_batch"
         max_samples = {
             "train": data_args.max_train_samples,
             "validation": data_args.max_eval_samples,
@@ -456,13 +417,12 @@ def main():
             dataset = datasets[key]
             if samples_limit is not None:
                 dataset = dataset.select(range(samples_limit))
-            data = convert_dataset_for_tensorflow(
-                dataset,
-                non_label_column_names,
-                batch_size=batch_size,
-                dataset_mode=dataset_mode,
-                drop_remainder=drop_remainder,
+            data = dataset.to_tf_dataset(
+                columns=list(set(dataset.column_names) - set(non_label_column_names)),
                 shuffle=shuffle,
+                batch_size=batch_size,
+                collate_fn=data_collator,
+                drop_remainder=drop_remainder,
             )
             tf_data[key] = data
         # endregion

--- a/examples/tensorflow/text-classification/run_glue.py
+++ b/examples/tensorflow/text-classification/run_glue.py
@@ -418,11 +418,12 @@ def main():
             if samples_limit is not None:
                 dataset = dataset.select(range(samples_limit))
             data = dataset.to_tf_dataset(
-                columns=list(set(dataset.column_names) - set(non_label_column_names)),
+                columns=[col for col in dataset.column_names if col not in set(non_label_column_names + ["label"])],
                 shuffle=shuffle,
                 batch_size=batch_size,
                 collate_fn=data_collator,
                 drop_remainder=drop_remainder,
+                label_cols="label" if "label" in dataset.column_names else None,
             )
             tf_data[key] = data
         # endregion

--- a/examples/tensorflow/text-classification/run_glue.py
+++ b/examples/tensorflow/text-classification/run_glue.py
@@ -107,7 +107,7 @@ class DataTrainingArguments:
         default=False, metadata={"help": "Overwrite the cached preprocessed datasets or not."}
     )
     pad_to_max_length: bool = field(
-        default=True,
+        default=False,
         metadata={
             "help": "Whether to pad all samples to `max_seq_length`. "
             "If False, will pad the samples dynamically when batching to the maximum length in the batch."
@@ -342,7 +342,6 @@ def main():
         data_collator = partial(default_data_collator, return_tensors="tf")
     else:
         data_collator = DataCollatorWithPadding(tokenizer, return_tensors="tf")
-
     # endregion
 
     # region Metric function

--- a/examples/tensorflow/text-classification/run_glue.py
+++ b/examples/tensorflow/text-classification/run_glue.py
@@ -45,6 +45,7 @@ from transformers.utils import check_min_version
 
 # region Helper functions
 
+
 class SavePretrainedCallback(tf.keras.callbacks.Callback):
     # Hugging Face models have a save_pretrained() method that saves both the weights and the necessary
     # metadata to allow them to be loaded as a pretrained model in future. This is a simple Keras callback

--- a/examples/tensorflow/text-classification/run_glue.py
+++ b/examples/tensorflow/text-classification/run_glue.py
@@ -20,7 +20,6 @@ import logging
 import os
 import sys
 from dataclasses import dataclass, field
-from functools import partial
 from typing import Optional
 
 import numpy as np
@@ -32,11 +31,11 @@ from transformers import (
     AutoConfig,
     AutoTokenizer,
     DataCollatorWithPadding,
+    DefaultDataCollator,
     HfArgumentParser,
     PretrainedConfig,
     TFAutoModelForSequenceClassification,
     TFTrainingArguments,
-    default_data_collator,
     set_seed,
 )
 from transformers.trainer_utils import get_last_checkpoint, is_main_process
@@ -340,7 +339,7 @@ def main():
     datasets = datasets.map(preprocess_function, batched=True, load_from_cache_file=not data_args.overwrite_cache)
 
     if data_args.pad_to_max_length:
-        data_collator = partial(default_data_collator, return_tensors="tf")
+        data_collator = DefaultDataCollator(return_tensors="tf")
     else:
         data_collator = DataCollatorWithPadding(tokenizer, return_tensors="tf")
     # endregion

--- a/examples/tensorflow/text-classification/run_glue.py
+++ b/examples/tensorflow/text-classification/run_glue.py
@@ -422,6 +422,7 @@ def main():
                 batch_size=batch_size,
                 collate_fn=data_collator,
                 drop_remainder=drop_remainder,
+                # `label_cols` is needed for user-defined losses, such as in this example
                 label_cols="label" if "label" in dataset.column_names else None,
             )
             tf_data[key] = data

--- a/examples/tensorflow/text-classification/run_text_classification.py
+++ b/examples/tensorflow/text-classification/run_text_classification.py
@@ -60,6 +60,7 @@ class SavePretrainedCallback(tf.keras.callbacks.Callback):
     def on_epoch_end(self, epoch, logs=None):
         self.model.save_pretrained(self.output_dir)
 
+
 # endregion
 
 

--- a/examples/tensorflow/text-classification/run_text_classification.py
+++ b/examples/tensorflow/text-classification/run_text_classification.py
@@ -20,7 +20,6 @@ import logging
 import os
 import sys
 from dataclasses import dataclass, field
-from functools import partial
 from pathlib import Path
 from typing import Optional
 
@@ -31,11 +30,11 @@ from transformers import (
     AutoConfig,
     AutoTokenizer,
     DataCollatorWithPadding,
+    DefaultDataCollator,
     HfArgumentParser,
     PretrainedConfig,
     TFAutoModelForSequenceClassification,
     TFTrainingArguments,
-    default_data_collator,
     set_seed,
 )
 from transformers.file_utils import CONFIG_NAME, TF2_WEIGHTS_NAME
@@ -363,7 +362,7 @@ def main():
     datasets = datasets.map(preprocess_function, batched=True, load_from_cache_file=not data_args.overwrite_cache)
 
     if data_args.pad_to_max_length:
-        data_collator = partial(default_data_collator, return_tensors="tf")
+        data_collator = DefaultDataCollator(return_tensors="tf")
     else:
         data_collator = DataCollatorWithPadding(tokenizer, return_tensors="tf")
     # endregion

--- a/examples/tensorflow/text-classification/run_text_classification.py
+++ b/examples/tensorflow/text-classification/run_text_classification.py
@@ -20,6 +20,7 @@ import logging
 import os
 import sys
 from dataclasses import dataclass, field
+from functools import partial
 from pathlib import Path
 from typing import Optional
 
@@ -29,10 +30,12 @@ from datasets import load_dataset
 from transformers import (
     AutoConfig,
     AutoTokenizer,
+    DataCollatorWithPadding,
     HfArgumentParser,
     PretrainedConfig,
     TFAutoModelForSequenceClassification,
     TFTrainingArguments,
+    default_data_collator,
     set_seed,
 )
 from transformers.file_utils import CONFIG_NAME, TF2_WEIGHTS_NAME
@@ -56,48 +59,6 @@ class SavePretrainedCallback(tf.keras.callbacks.Callback):
 
     def on_epoch_end(self, epoch, logs=None):
         self.model.save_pretrained(self.output_dir)
-
-
-def convert_dataset_for_tensorflow(
-    dataset, non_label_column_names, batch_size, dataset_mode="variable_batch", shuffle=True, drop_remainder=True
-):
-    """Converts a Hugging Face dataset to a Tensorflow Dataset. The dataset_mode controls whether we pad all batches
-    to the maximum sequence length, or whether we only pad to the maximum length within that batch. The former
-    is most useful when training on TPU, as a new graph compilation is required for each sequence length.
-    """
-
-    def densify_ragged_batch(features, label=None):
-        features = {
-            feature: ragged_tensor.to_tensor(shape=batch_shape[feature]) for feature, ragged_tensor in features.items()
-        }
-        if label is None:
-            return features
-        else:
-            return features, label
-
-    feature_keys = list(set(dataset.features.keys()) - set(non_label_column_names + ["label"]))
-    if dataset_mode == "variable_batch":
-        batch_shape = {key: None for key in feature_keys}
-        data = {key: tf.ragged.constant(dataset[key]) for key in feature_keys}
-    elif dataset_mode == "constant_batch":
-        data = {key: tf.ragged.constant(dataset[key]) for key in feature_keys}
-        batch_shape = {
-            key: tf.concat(([batch_size], ragged_tensor.bounding_shape()[1:]), axis=0)
-            for key, ragged_tensor in data.items()
-        }
-    else:
-        raise ValueError("Unknown dataset mode!")
-
-    if "label" in dataset.features:
-        labels = tf.convert_to_tensor(np.array(dataset["label"]))
-        tf_dataset = tf.data.Dataset.from_tensor_slices((data, labels))
-    else:
-        tf_dataset = tf.data.Dataset.from_tensor_slices(data)
-    if shuffle:
-        tf_dataset = tf_dataset.shuffle(buffer_size=len(dataset))
-    tf_dataset = tf_dataset.batch(batch_size=batch_size, drop_remainder=drop_remainder).map(densify_ragged_batch)
-    return tf_dataset
-
 
 # endregion
 
@@ -399,6 +360,11 @@ def main():
         return result
 
     datasets = datasets.map(preprocess_function, batched=True, load_from_cache_file=not data_args.overwrite_cache)
+
+    if data_args.pad_to_max_length:
+        data_collator = partial(default_data_collator, return_tensors="tf")
+    else:
+        data_collator = DataCollatorWithPadding(tokenizer, return_tensors="tf")
     # endregion
 
     with training_args.strategy.scope():
@@ -464,18 +430,13 @@ def main():
             dataset = datasets[key]
             if samples_limit is not None:
                 dataset = dataset.select(range(samples_limit))
-            if isinstance(training_args.strategy, tf.distribute.TPUStrategy) or data_args.pad_to_max_length:
-                logger.info("Padding all batches to max length because argument was set or we're on TPU.")
-                dataset_mode = "constant_batch"
-            else:
-                dataset_mode = "variable_batch"
-            data = convert_dataset_for_tensorflow(
-                dataset,
-                non_label_column_names,
-                batch_size=batch_size,
-                dataset_mode=dataset_mode,
-                drop_remainder=drop_remainder,
+            data = dataset.to_tf_dataset(
+                columns=[col for col in dataset.column_names if col not in set(non_label_column_names + ["label"])],
                 shuffle=shuffle,
+                batch_size=batch_size,
+                collate_fn=data_collator,
+                drop_remainder=drop_remainder,
+                label_cols="label" if "label" in dataset.column_names else None,
             )
             tf_data[key] = data
         # endregion

--- a/examples/tensorflow/text-classification/run_text_classification.py
+++ b/examples/tensorflow/text-classification/run_text_classification.py
@@ -436,6 +436,7 @@ def main():
                 batch_size=batch_size,
                 collate_fn=data_collator,
                 drop_remainder=drop_remainder,
+                # `label_cols` is needed for user-defined losses, such as in this example
                 label_cols="label" if "label" in dataset.column_names else None,
             )
             tf_data[key] = data

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -882,15 +882,15 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
 
     def train_step(self, data):
         """
-        A modification of Keras's default `train_step` that cleans up the printed metrics when we use a dummy loss. If
-        a user specifies a loss at model compile time, this function behaves as the original Keras `train_step`. In
-        this case, it expects the same `data` as the original function (i.e. `(inputs, labels)`). However, when the
-        model is compiled without specifying the loss AND the expected label columns are passed as part of the input
-        dictionary, the loss is computed internally (inside the model class) and is used in the backwards pass. In this
-        case, `data` is a singleton tuple containing `(inputs,)`. This is possible under the aforementioned
-        circumstances because our overriden compile function can set an additional loss function that reduces a `loss`
-        output, and the model will output `loss` component (notice the name matching) containing the loss that was used
-        to train the pre-trained model.
+        A modification of Keras's default `train_step` that cleans up the printed metrics when we use a dummy loss. If a
+        user specifies a loss at model compile time, this function behaves as the original Keras `train_step`. In this
+        case, it expects the same `data` as the original function (i.e. `(inputs, labels)`). However, when the model is
+        compiled without specifying the loss AND the expected label columns are passed as part of the input dictionary,
+        the loss is computed internally (inside the model class) and is used in the backwards pass. In this case, `data`
+        is a singleton tuple containing `(inputs,)`. This is possible under the aforementioned circumstances because our
+        overriden compile function can set an additional loss function that reduces a `loss` output, and the model will
+        output a `loss` component (notice the name matching) containing the loss that was used to train the pre-trained
+        model.
         """
         # These are the only transformations `Model.fit` applies to user-input
         # data when a `tf.data.Dataset` is provided.

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -882,7 +882,15 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
 
     def train_step(self, data):
         """
-        A modification of Keras's default train_step that cleans up the printed metrics when we use a dummy loss.
+        A modification of Keras's default `train_step` that cleans up the printed metrics when we use a dummy loss. If
+        a user specifies a loss at model compile time, this function behaves as the original Keras `train_step`. In
+        this case, it expects the same `data` as the original function (i.e. `(inputs, labels)`). However, when the
+        model is compiled without specifying the loss AND the expected label columns are passed as part of the input
+        dictionary, the loss is computed internally (inside the model class) and is used in the backwards pass. In this
+        case, `data` is a singleton tuple containing `(inputs,)`. This is possible under the aforementioned
+        circumstances because our overriden compile function can set an additional loss function that reduces a `loss`
+        output, and the model will output `loss` component (notice the name matching) containing the loss that was used
+        to train the pre-trained model.
         """
         # These are the only transformations `Model.fit` applies to user-input
         # data when a `tf.data.Dataset` is provided.

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -882,15 +882,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
 
     def train_step(self, data):
         """
-        A modification of Keras's default `train_step` that cleans up the printed metrics when we use a dummy loss. If a
-        user specifies a loss at model compile time, this function behaves as the original Keras `train_step`. In this
-        case, it expects the same `data` as the original function (i.e. `(inputs, labels)`). However, when the model is
-        compiled without specifying the loss AND the expected label columns are passed as part of the input dictionary,
-        the loss is computed internally (inside the model class) and is used in the backwards pass. In this case, `data`
-        is a singleton tuple containing `(inputs,)`. This is possible under the aforementioned circumstances because our
-        overriden compile function can set an additional loss function that reduces a `loss` output, and the model will
-        output a `loss` component (notice the name matching) containing the loss that was used to train the pre-trained
-        model.
+        A modification of Keras's default `train_step` that cleans up the printed metrics when we use a dummy loss.
         """
         # These are the only transformations `Model.fit` applies to user-input
         # data when a `tf.data.Dataset` is provided.


### PR DESCRIPTION
# What does this PR do?

This PR updates the text classification examples to use the more modern `to_tf_dataset()` method, as opposed to a custom function. A few minor fixes were added as I navigated related files.

Example of running command: `python run_glue.py --model_name_or_path distilbert-base-cased --task_name mnli --do_train --do_eval --output_dir $HOME/test_model`