### PR TITLE
revert temporary addition to test next version of CLIPTokenizerFast

### DIFF
--- a/tests/test_tokenization_clip.py
+++ b/tests/test_tokenization_clip.py
@@ -36,8 +36,6 @@ class CLIPTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        # temporary addition: to test the new slow to fast converter
-        self.tokenizers_list = [(CLIPTokenizerFast, "SaulLu/clip-vit-base-patch32", {})]
 
         # fmt: off
         vocab = ["l", "o", "w", "e", "r", "s", "t", "i", "d", "n", "lo", "l</w>", "w</w>", "r</w>", "t</w>", "low</w>", "er</w>", "lowest</w>", "newer</w>", "wider", "<unk>", "<|startoftext|>", "<|endoftext|>"]


### PR DESCRIPTION
# What does this PR do?

This PR aims to change the repository used to test `CLIPTokenizerFast`.

As part of the `CLIPTokenizerFast` bug fix in this PR #15067, instead of testing the tokenizer of the repo [openai/clip-vit-base-patch32](https://huggingface.co/openai/clip-vit-base-patch32) we had made a temporary change to test the one in [SaulLu/clip-vit-base-patch32](https://huggingface.co/SaulLu/clip-vit-base-patch32) that had the new version of the `tokenizer.json` file. 

As discussed, the `tokenizer.json` file should be transferred from the [SaulLu/clip-vit-base-patch32](https://huggingface.co/SaulLu/clip-vit-base-patch32) repo to the [openai/clip-vit-base-patch32](https://huggingface.co/openai/clip-vit-base-patch32) repo. Once this is done the testing of this PR should pass.

For the record, it was discussed to introduce file versioning and therefore to add a versioned file `tokenizer_vxxx.json` in the [openai/clip-vit-base-patch32](https://huggingface.co/openai/clip-vit-base-patch32)  repo. Following the last exchanges this solution has been put aside because 1) the fast version of the tokenizer is not used in `CLIPFeatureExtractor` and 2) it is a bug fix.

**Edit:** the new `ŧokenizer.json` have been added to [openai/clip-vit-base-patch32](https://huggingface.co/openai/clip-vit-base-patch32)  and now all the tests pass! 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
