### PR TITLE
[tests] Improve forward_signature test

### DIFF
--- a/tests/beit/test_modeling_beit.py
+++ b/tests/beit/test_modeling_beit.py
@@ -15,7 +15,6 @@
 """ Testing suite for the PyTorch BEiT model. """
 
 
-import inspect
 import unittest
 
 from datasets import load_dataset
@@ -213,18 +212,6 @@ class BeitModelTest(ModelTesterMixin, unittest.TestCase):
             self.assertIsInstance(model.get_input_embeddings(), (nn.Module))
             x = model.get_output_embeddings()
             self.assertTrue(x is None or isinstance(x, nn.Linear))
-
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.forward)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["pixel_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
 
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/beit/test_modeling_flax_beit.py
+++ b/tests/beit/test_modeling_flax_beit.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 import unittest
 
 import numpy as np
@@ -196,20 +195,7 @@ class FlaxBeitModelTest(FlaxModelTesterMixin, unittest.TestCase):
                 [self.model_tester.num_attention_heads, seq_length, seq_length],
             )
 
-    # We neeed to override this test because Beit's forward signature is different than text models.
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.__call__)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["pixel_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
-
-    # We neeed to override this test because Beit expects pixel_values instead of input_ids
+    # We need to override this test because Beit expects pixel_values instead of input_ids
     def test_jit_compilation(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/clip/test_modeling_flax_clip.py
+++ b/tests/clip/test_modeling_flax_clip.py
@@ -93,18 +93,6 @@ class FlaxCLIPVisionModelTest(FlaxModelTesterMixin, unittest.TestCase):
     def setUp(self):
         self.model_tester = FlaxCLIPVisionModelTester(self)
 
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.__call__)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["pixel_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
-
     def test_jit_compilation(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/clip/test_modeling_tf_clip.py
+++ b/tests/clip/test_modeling_tf_clip.py
@@ -15,7 +15,6 @@
 """ Testing suite for the TensorFlow CLIP model. """
 
 
-import inspect
 import os
 import tempfile
 import unittest
@@ -151,18 +150,6 @@ class TFCLIPVisionModelTest(TFModelTesterMixin, unittest.TestCase):
             self.assertIsInstance(model.get_input_embeddings(), (tf.keras.layers.Layer))
             x = model.get_output_embeddings()
             self.assertTrue(x is None or isinstance(x, tf.keras.layers.Layer))
-
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.call)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["pixel_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
 
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/convnext/test_modeling_convnext.py
+++ b/tests/convnext/test_modeling_convnext.py
@@ -15,7 +15,6 @@
 """ Testing suite for the PyTorch ConvNext model. """
 
 
-import inspect
 import unittest
 from typing import Dict, List, Tuple
 
@@ -166,18 +165,6 @@ class ConvNextModelTest(ModelTesterMixin, unittest.TestCase):
     @unittest.skip(reason="ConvNext does not support input and output embeddings")
     def test_model_common_attributes(self):
         pass
-
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.forward)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["pixel_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
 
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/deit/test_modeling_deit.py
+++ b/tests/deit/test_modeling_deit.py
@@ -15,7 +15,6 @@
 """ Testing suite for the PyTorch DeiT model. """
 
 
-import inspect
 import unittest
 import warnings
 
@@ -192,18 +191,6 @@ class DeiTModelTest(ModelTesterMixin, unittest.TestCase):
             self.assertIsInstance(model.get_input_embeddings(), (nn.Module))
             x = model.get_output_embeddings()
             self.assertTrue(x is None or isinstance(x, nn.Linear))
-
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.forward)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["pixel_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
 
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/hubert/test_modeling_hubert.py
+++ b/tests/hubert/test_modeling_hubert.py
@@ -337,10 +337,6 @@ class HubertModelTest(ModelTesterMixin, unittest.TestCase):
     def test_inputs_embeds(self):
         pass
 
-    # `input_ids` is renamed to `input_values`
-    def test_forward_signature(self):
-        pass
-
     # Hubert cannot resize token embeddings
     # since it has no tokens embeddings
     def test_resize_tokens_embeddings(self):

--- a/tests/hubert/test_modeling_tf_hubert.py
+++ b/tests/hubert/test_modeling_tf_hubert.py
@@ -15,7 +15,6 @@
 
 
 import copy
-import inspect
 import math
 import unittest
 
@@ -233,19 +232,6 @@ class TFHubertModelTest(TFModelTesterMixin, unittest.TestCase):
         self.config_tester.run_common_tests()
 
     # overwrite because input_values != input_ids
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.call)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["input_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
-
-    # overwrite because input_values != input_ids
     def test_keyword_and_dict_args(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
@@ -342,19 +328,6 @@ class TFHubertRobustModelTest(TFModelTesterMixin, unittest.TestCase):
             scope="robust",
         )
         self.config_tester = ConfigTester(self, config_class=HubertConfig, hidden_size=37)
-
-    # overwrite because input_values != input_ids
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.call)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["input_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
 
     # overwrite because input_values != input_ids
     def test_keyword_and_dict_args(self):

--- a/tests/imagegpt/test_modeling_imagegpt.py
+++ b/tests/imagegpt/test_modeling_imagegpt.py
@@ -15,7 +15,6 @@
 
 
 import copy
-import inspect
 import os
 import tempfile
 import unittest
@@ -310,18 +309,6 @@ class ImageGPTModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCa
         for model_name in IMAGEGPT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
             model = ImageGPTModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
-
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.forward)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["input_ids"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
 
     def test_resize_tokens_embeddings(self):
         (

--- a/tests/perceiver/test_modeling_perceiver.py
+++ b/tests/perceiver/test_modeling_perceiver.py
@@ -15,7 +15,6 @@
 """ Testing suite for the PyTorch Perceiver model. """
 
 import copy
-import inspect
 import math
 import tempfile
 import unittest
@@ -366,18 +365,6 @@ class PerceiverModelTest(ModelTesterMixin, unittest.TestCase):
             inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
             loss = model(**inputs).loss
             loss.backward()
-
-    def test_forward_signature(self):
-        for model_class in self.all_model_classes:
-            config, _ = self.model_tester.prepare_config_and_inputs_for_model_class(model_class)
-
-            model = model_class(config)
-            signature = inspect.signature(model.forward)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["inputs"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
 
     def test_determinism(self):
         for model_class in self.all_model_classes:

--- a/tests/poolformer/test_modeling_poolformer.py
+++ b/tests/poolformer/test_modeling_poolformer.py
@@ -15,7 +15,6 @@
 """ Testing suite for the PyTorch PoolFormer model. """
 
 
-import inspect
 import unittest
 from typing import Dict, List, Tuple
 
@@ -227,18 +226,6 @@ class PoolFormerModelTest(ModelTesterMixin, unittest.TestCase):
             tuple_inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
             dict_inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
             check_equivalence(model, tuple_inputs, dict_inputs, {"output_hidden_states": True})
-
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.forward)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["pixel_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
 
     @unittest.skip("PoolFormer does not have attention")
     def test_attention_outputs(self):

--- a/tests/segformer/test_modeling_segformer.py
+++ b/tests/segformer/test_modeling_segformer.py
@@ -15,7 +15,6 @@
 """ Testing suite for the PyTorch SegFormer model. """
 
 
-import inspect
 import unittest
 
 from transformers import is_torch_available, is_vision_available
@@ -189,18 +188,6 @@ class SegformerModelTest(ModelTesterMixin, unittest.TestCase):
     @unittest.skip("SegFormer does not have get_input_embeddings method and get_output_embeddings methods")
     def test_model_common_attributes(self):
         pass
-
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.forward)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["pixel_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
 
     def test_attention_outputs(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/sew/test_modeling_sew.py
+++ b/tests/sew/test_modeling_sew.py
@@ -332,10 +332,6 @@ class SEWModelTest(ModelTesterMixin, unittest.TestCase):
     def test_inputs_embeds(self):
         pass
 
-    # `input_ids` is renamed to `input_values`
-    def test_forward_signature(self):
-        pass
-
     # SEW cannot resize token embeddings
     # since it has no tokens embeddings
     def test_resize_tokens_embeddings(self):

--- a/tests/sew_d/test_modeling_sew_d.py
+++ b/tests/sew_d/test_modeling_sew_d.py
@@ -353,10 +353,6 @@ class SEWDModelTest(ModelTesterMixin, unittest.TestCase):
     def test_inputs_embeds(self):
         pass
 
-    # `input_ids` is renamed to `input_values`
-    def test_forward_signature(self):
-        pass
-
     # SEW cannot resize token embeddings
     # since it has no tokens embeddings
     def test_resize_tokens_embeddings(self):

--- a/tests/swin/test_modeling_swin.py
+++ b/tests/swin/test_modeling_swin.py
@@ -15,7 +15,6 @@
 """ Testing suite for the PyTorch Swin model. """
 
 import copy
-import inspect
 import unittest
 
 from transformers import SwinConfig
@@ -214,18 +213,6 @@ class SwinModelTest(ModelTesterMixin, unittest.TestCase):
             self.assertIsInstance(model.get_input_embeddings(), (nn.Module))
             x = model.get_output_embeddings()
             self.assertTrue(x is None or isinstance(x, nn.Linear))
-
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.forward)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["pixel_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
 
     def test_attention_outputs(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -128,6 +128,9 @@ class ModelTesterMixin:
     test_missing_keys = True
     test_model_parallel = False
     is_encoder_decoder = False
+    # other_arg_names is a list of expected argument names in the forward pass of all variants of a model
+    # besides model.main_input_name, like ["attention_mask"] for text models
+    other_arg_names = None
 
     def _prepare_for_class(self, inputs_dict, model_class, return_labels=False):
         inputs_dict = copy.deepcopy(inputs_dict)
@@ -414,7 +417,9 @@ class ModelTesterMixin:
                 self.assertListEqual(arg_names[: len(expected_arg_names)], expected_arg_names)
             else:
                 expected_arg_names = [model.main_input_name]
-                self.assertListEqual(arg_names[:1], expected_arg_names)
+                if self.other_arg_names is not None:
+                    expected_arg_names.extend(self.other_arg_names)
+                self.assertListEqual(arg_names[: len(expected_arg_names)], expected_arg_names)
 
     def test_training(self):
         if not self.model_tester.is_training:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -413,7 +413,7 @@ class ModelTesterMixin:
                 )
                 self.assertListEqual(arg_names[: len(expected_arg_names)], expected_arg_names)
             else:
-                expected_arg_names = ["input_ids"]
+                expected_arg_names = [model.main_input_name]
                 self.assertListEqual(arg_names[:1], expected_arg_names)
 
     def test_training(self):

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -112,6 +112,9 @@ class FlaxModelTesterMixin:
     test_mismatched_shapes = True
     is_encoder_decoder = False
     test_head_masking = False
+    # other_arg_names is a list of expected argument names in the forward pass of all variants of a model
+    # besides model.main_input_name, like ["attention_mask"] for text models
+    other_arg_names = None
 
     def _prepare_for_class(self, inputs_dict, model_class):
         inputs_dict = copy.deepcopy(inputs_dict)
@@ -451,7 +454,9 @@ class FlaxModelTesterMixin:
                 self.assertListEqual(arg_names[: len(expected_arg_names)], expected_arg_names)
             else:
                 expected_arg_names = [model.main_input_name]
-                self.assertListEqual(arg_names[:1], expected_arg_names)
+                if self.other_arg_names is not None:
+                    expected_arg_names.extend(self.other_arg_names)
+                self.assertListEqual(arg_names[: len(expected_arg_names)], expected_arg_names)
 
     def test_naming_convention(self):
         for model_class in self.all_model_classes:

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -450,8 +450,8 @@ class FlaxModelTesterMixin:
                 ]
                 self.assertListEqual(arg_names[: len(expected_arg_names)], expected_arg_names)
             else:
-                expected_arg_names = ["input_ids", "attention_mask"]
-                self.assertListEqual(arg_names[:2], expected_arg_names)
+                expected_arg_names = [model.main_input_name]
+                self.assertListEqual(arg_names[:1], expected_arg_names)
 
     def test_naming_convention(self):
         for model_class in self.all_model_classes:

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -211,7 +211,7 @@ class TFModelTesterMixin:
                 self.assertListEqual(arg_names[: len(expected_arg_names)], expected_arg_names)
 
             else:
-                expected_arg_names = ["input_ids"]
+                expected_arg_names = [model.main_input_name]
                 self.assertListEqual(arg_names[:1], expected_arg_names)
 
     def test_onnx_compliancy(self):

--- a/tests/unispeech/test_modeling_unispeech.py
+++ b/tests/unispeech/test_modeling_unispeech.py
@@ -348,10 +348,6 @@ class UniSpeechRobustModelTest(ModelTesterMixin, unittest.TestCase):
     def test_inputs_embeds(self):
         pass
 
-    # `input_ids` is renamed to `input_values`
-    def test_forward_signature(self):
-        pass
-
     # UniSpeech cannot resize token embeddings
     # since it has no tokens embeddings
     def test_resize_tokens_embeddings(self):

--- a/tests/unispeech_sat/test_modeling_unispeech_sat.py
+++ b/tests/unispeech_sat/test_modeling_unispeech_sat.py
@@ -397,10 +397,6 @@ class UniSpeechSatModelTest(ModelTesterMixin, unittest.TestCase):
     def test_inputs_embeds(self):
         pass
 
-    # `input_ids` is renamed to `input_values`
-    def test_forward_signature(self):
-        pass
-
     # UniSpeechSat cannot resize token embeddings
     # since it has no tokens embeddings
     def test_resize_tokens_embeddings(self):

--- a/tests/vit/test_modeling_flax_vit.py
+++ b/tests/vit/test_modeling_flax_vit.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 import unittest
 
 import numpy as np
@@ -165,20 +164,7 @@ class FlaxViTModelTest(FlaxModelTesterMixin, unittest.TestCase):
                 [self.model_tester.num_attention_heads, seq_length, seq_length],
             )
 
-    # We neeed to override this test because ViT's forward signature is different than text models.
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.__call__)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["pixel_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
-
-    # We neeed to override this test because ViT expects pixel_values instead of input_ids
+    # We need to override this test because ViT expects pixel_values instead of input_ids
     def test_jit_compilation(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/vit/test_modeling_tf_vit.py
+++ b/tests/vit/test_modeling_tf_vit.py
@@ -15,7 +15,6 @@
 """ Testing suite for the TensorFlow ViT model. """
 
 
-import inspect
 import os
 import tempfile
 import unittest
@@ -181,18 +180,6 @@ class TFViTModelTest(TFModelTesterMixin, unittest.TestCase):
             self.assertIsInstance(model.get_input_embeddings(), (tf.keras.layers.Layer))
             x = model.get_output_embeddings()
             self.assertTrue(x is None or isinstance(x, tf.keras.layers.Layer))
-
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.call)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["pixel_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
 
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/vit/test_modeling_vit.py
+++ b/tests/vit/test_modeling_vit.py
@@ -15,7 +15,6 @@
 """ Testing suite for the PyTorch ViT model. """
 
 
-import inspect
 import unittest
 
 from transformers import ViTConfig
@@ -181,18 +180,6 @@ class ViTModelTest(ModelTesterMixin, unittest.TestCase):
             self.assertIsInstance(model.get_input_embeddings(), (nn.Module))
             x = model.get_output_embeddings()
             self.assertTrue(x is None or isinstance(x, nn.Linear))
-
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.forward)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["pixel_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
 
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/vit_mae/test_modeling_vit_mae.py
+++ b/tests/vit_mae/test_modeling_vit_mae.py
@@ -15,7 +15,6 @@
 """ Testing suite for the PyTorch ViTMAE model. """
 
 
-import inspect
 import math
 import tempfile
 import unittest
@@ -181,18 +180,6 @@ class ViTMAEModelTest(ModelTesterMixin, unittest.TestCase):
             self.assertIsInstance(model.get_input_embeddings(), (nn.Module))
             x = model.get_output_embeddings()
             self.assertTrue(x is None or isinstance(x, nn.Linear))
-
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.forward)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["pixel_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
 
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/wav2vec2/test_modeling_flax_wav2vec2.py
+++ b/tests/wav2vec2/test_modeling_flax_wav2vec2.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 import math
 import unittest
 
@@ -190,19 +189,6 @@ class FlaxWav2Vec2ModelTest(FlaxModelTesterMixin, unittest.TestCase):
         )[0]
 
         self.assertTrue(output.shape == (batch_size, sequence_length, model.config.proj_codevector_dim))
-
-    # overwrite because of `input_values`
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.__call__)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["input_values", "attention_mask"]
-            self.assertListEqual(arg_names[:2], expected_arg_names)
 
     # overwrite because of `input_values`
     def test_jit_compilation(self):

--- a/tests/wav2vec2/test_modeling_flax_wav2vec2.py
+++ b/tests/wav2vec2/test_modeling_flax_wav2vec2.py
@@ -154,6 +154,7 @@ class FlaxWav2Vec2ModelTest(FlaxModelTesterMixin, unittest.TestCase):
     all_model_classes = (
         (FlaxWav2Vec2Model, FlaxWav2Vec2ForCTC, FlaxWav2Vec2ForPreTraining) if is_flax_available() else ()
     )
+    other_arg_names = ["attention_mask"]
 
     def setUp(self):
         self.model_tester = FlaxWav2Vec2ModelTester(self)

--- a/tests/wav2vec2/test_modeling_tf_wav2vec2.py
+++ b/tests/wav2vec2/test_modeling_tf_wav2vec2.py
@@ -16,7 +16,6 @@
 
 import copy
 import glob
-import inspect
 import math
 import unittest
 
@@ -245,19 +244,6 @@ class TFWav2Vec2ModelTest(TFModelTesterMixin, unittest.TestCase):
         self.config_tester.run_common_tests()
 
     # overwrite because input_values != input_ids
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.call)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["input_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
-
-    # overwrite because input_values != input_ids
     def test_keyword_and_dict_args(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
@@ -354,19 +340,6 @@ class TFWav2Vec2RobustModelTest(TFModelTesterMixin, unittest.TestCase):
             scope="robust",
         )
         self.config_tester = ConfigTester(self, config_class=Wav2Vec2Config, hidden_size=37)
-
-    # overwrite because input_values != input_ids
-    def test_forward_signature(self):
-        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-
-        for model_class in self.all_model_classes:
-            model = model_class(config)
-            signature = inspect.signature(model.call)
-            # signature.parameters is an OrderedDict => so arg_names order is deterministic
-            arg_names = [*signature.parameters.keys()]
-
-            expected_arg_names = ["input_values"]
-            self.assertListEqual(arg_names[:1], expected_arg_names)
 
     # overwrite because input_values != input_ids
     def test_keyword_and_dict_args(self):

--- a/tests/wav2vec2/test_modeling_wav2vec2.py
+++ b/tests/wav2vec2/test_modeling_wav2vec2.py
@@ -466,10 +466,6 @@ class Wav2Vec2ModelTest(ModelTesterMixin, unittest.TestCase):
     def test_inputs_embeds(self):
         pass
 
-    # `input_ids` is renamed to `input_values`
-    def test_forward_signature(self):
-        pass
-
     # Wav2Vec2 cannot resize token embeddings
     # since it has no tokens embeddings
     def test_resize_tokens_embeddings(self):

--- a/tests/wavlm/test_modeling_wavlm.py
+++ b/tests/wavlm/test_modeling_wavlm.py
@@ -353,10 +353,6 @@ class WavLMModelTest(ModelTesterMixin, unittest.TestCase):
     def test_inputs_embeds(self):
         pass
 
-    # `input_ids` is renamed to `input_values`
-    def test_forward_signature(self):
-        pass
-
     # WavLM cannot resize token embeddings
     # since it has no tokens embeddings
     def test_resize_tokens_embeddings(self):


### PR DESCRIPTION
# What does this PR do?

The `test_forward_signature` test is currently being overridden in 25 model test files, because these models don't expect `input_ids`, but rather `pixel_values` (for vision models) or `input_values` (for speech models).

This PR instead leverages the `main_input_name` to update the test in `test_modeling_common.py`, `test_modeling_tf_common.py` and `test_modeling_flax_common.py`.