### PR TITLE
Fix `HfArgumentParser` when passing a generator

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 import dataclasses
 import json
 import re
@@ -67,10 +66,7 @@ class HfArgumentParser(ArgumentParser):
         super().__init__(**kwargs)
         if dataclasses.is_dataclass(dataclass_types):
             dataclass_types = [dataclass_types]
-        if isinstance(dataclass_types, collections.Sequence):
-            self.dataclass_types = dataclass_types
-        else:
-            self.dataclass_types = list(dataclass_types)
+        self.dataclass_types = list(dataclass_types)
         for dtype in self.dataclass_types:
             self._add_dataclass_arguments(dtype)
 

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -66,7 +66,10 @@ class HfArgumentParser(ArgumentParser):
         super().__init__(**kwargs)
         if dataclasses.is_dataclass(dataclass_types):
             dataclass_types = [dataclass_types]
-        self.dataclass_types = dataclass_types
+        if isinstance(dataclass_types, collections.Sequence):
+            self.dataclass_types = dataclass_types
+        else:
+            self.dataclass_types = list(dataclass_types)
         for dtype in self.dataclass_types:
             self._add_dataclass_arguments(dtype)
 

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 import dataclasses
 import json
 import re


### PR DESCRIPTION
# What does this PR do?

It fixes `HfArgumentParser.__init__` when `dataclass_types` is a generator. Without this, when a generator is passed, after the init it's exhausted so then a call to `parse_args_into_dataclasses` will return a wrong result.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

I think pretty much anyone.