### PR TITLE
Simplify selection of indices in FlaxCLIPTextTransformer to support JAX model conversion tooling

### DIFF
--- a/src/transformers/models/clip/modeling_flax_clip.py
+++ b/src/transformers/models/clip/modeling_flax_clip.py
@@ -517,7 +517,7 @@ class FlaxCLIPTextTransformer(nn.Module):
 
         # text_embeds.shape = [batch_size, sequence_length, transformer.width]
         # take features from the EOS embedding (eos_token_id is the highest number in each sequence)
-        pooled_output = last_hidden_state[jnp.arange(last_hidden_state.shape[0]), input_ids.argmax(axis=-1)]
+        pooled_output = last_hidden_state[:, input_ids.argmax(axis=-1)]
 
         if not return_dict:
             return (last_hidden_state, pooled_output) + encoder_outputs[1:]


### PR DESCRIPTION
# What does this PR do?
It makes a simple change so that `FlaxCLIPModel` compatible with the `jax2tf` conversion tool, which currently doesn't support certain types of gather operations. It's explained by a JAX engineer here: https://github.com/google/jax/issues/9572#issuecomment-1047162054

## Who can review?
@patil-suraj 

Note that I haven't ran any tests. Please feel free to close this if testing is required on my part, or if there simply isn't interest in making this change at this point (`jax2tf` will eventually support a larger subset of gather operations, so it's not super high-priority in that sense).
