### PR TITLE
Adding the option to return_timestamps on pure CTC ASR models.

### DIFF
--- a/src/transformers/models/hubert/configuration_hubert.py
+++ b/src/transformers/models/hubert/configuration_hubert.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 """ Hubert model configuration"""
 
-import math
+import functools
+import operator
 
 from ...configuration_utils import PretrainedConfig
 from ...utils import logging
@@ -253,4 +254,4 @@ class HubertConfig(PretrainedConfig):
 
     @property
     def inputs_to_logits_ratio(self):
-        return math.prod(self.conv_stride)
+        return functools.reduce(operator.mul, self.conv_stride, 1)

--- a/src/transformers/models/sew/configuration_sew.py
+++ b/src/transformers/models/sew/configuration_sew.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 """ SEW model configuration"""
 
-import math
+import functools
+import operator
 
 from ...configuration_utils import PretrainedConfig
 from ...utils import logging
@@ -248,4 +249,4 @@ class SEWConfig(PretrainedConfig):
 
     @property
     def inputs_to_logits_ratio(self):
-        return math.prod(self.conv_stride)
+        return functools.reduce(operator.mul, self.conv_stride, 1)

--- a/src/transformers/models/sew_d/configuration_sew_d.py
+++ b/src/transformers/models/sew_d/configuration_sew_d.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 """ SEW-D model configuration"""
 
-import math
+import functools
+import operator
 
 from ...configuration_utils import PretrainedConfig
 from ...utils import logging
@@ -284,4 +285,4 @@ class SEWDConfig(PretrainedConfig):
 
     @property
     def inputs_to_logits_ratio(self):
-        return math.prod(self.conv_stride)
+        return functools.reduce(operator.mul, self.conv_stride, 1)

--- a/src/transformers/models/unispeech/configuration_unispeech.py
+++ b/src/transformers/models/unispeech/configuration_unispeech.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 """ UniSpeech model configuration"""
 
-import math
+import functools
+import operator
 
 from ...configuration_utils import PretrainedConfig
 from ...utils import logging
@@ -294,4 +295,4 @@ class UniSpeechConfig(PretrainedConfig):
 
     @property
     def inputs_to_logits_ratio(self):
-        return math.prod(self.conv_stride)
+        return functools.reduce(operator.mul, self.conv_stride, 1)

--- a/src/transformers/models/unispeech_sat/configuration_unispeech_sat.py
+++ b/src/transformers/models/unispeech_sat/configuration_unispeech_sat.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 """ UniSpeechSat model configuration"""
 
-import math
+import functools
+import operator
 
 from ...configuration_utils import PretrainedConfig
 from ...utils import logging
@@ -311,4 +312,4 @@ class UniSpeechSatConfig(PretrainedConfig):
 
     @property
     def inputs_to_logits_ratio(self):
-        return math.prod(self.conv_stride)
+        return functools.reduce(operator.mul, self.conv_stride, 1)

--- a/src/transformers/models/wav2vec2/configuration_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/configuration_wav2vec2.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 """ Wav2Vec2 model configuration"""
 
-import math
+import functools
+import operator
 
 from ...configuration_utils import PretrainedConfig
 from ...utils import logging
@@ -334,4 +335,4 @@ class Wav2Vec2Config(PretrainedConfig):
 
     @property
     def inputs_to_logits_ratio(self):
-        return math.prod(self.conv_stride)
+        return functools.reduce(operator.mul, self.conv_stride, 1)

--- a/src/transformers/models/wavlm/configuration_wavlm.py
+++ b/src/transformers/models/wavlm/configuration_wavlm.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 """ WavLM model configuration"""
 
-import math
+import functools
+import operator
 
 from ...configuration_utils import PretrainedConfig
 from ...utils import logging
@@ -335,4 +336,4 @@ class WavLMConfig(PretrainedConfig):
 
     @property
     def inputs_to_logits_ratio(self):
-        return math.prod(self.conv_stride)
+        return functools.reduce(operator.mul, self.conv_stride, 1)

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -172,7 +172,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 after `0.5` and before `0.6` seconds. If set to `"word"`, the pipeline will return `timestamps`
                 along the text for every word in the text. For instance if could get `[{"text": "Hi ", "timestamps":
                 (0.5,0.9), {"text": "there", "timestamps": (1.0, .1.5)}]`, then it means the model assumes the word
-                "Hi" was pronounces and the `0.5s and 0.9s` of the input audio
+                "hi" was pronounces before 0.5 and after 0.9 seconds.
 
         Return:
             `Dict`: A dictionary with the following keys:

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -178,7 +178,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             `Dict`: A dictionary with the following keys:
                 - **text** (`str` ) -- The recognized text.
                 - **chunks** (*optional(, `List[Dict]`)
-                        When using `return_timestamps`, the `chunks` will become a list of containing all the various
+                        When using `return_timestamps`, the `chunks` will become a list containing all the various
                         text chunks identified by the model, *e.g.* `[{"text": "hi ", "timestamps": (0.5,0.9), {"text":
                         "there", "timestamps": (1.0, 1.5)}]`. The original full text can roughly be recovered by doing
                         `"".join(chunk["text"] for chunk in output["chunks"])`.

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -171,7 +171,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 {"text": "i", "timestamps": (0.7, .9)}]`, then it means the model predicts that the letter "h" was pronounced
                 after `0.5` and before `0.6` seconds. If set to `"word"`, the pipeline will return `timestamps`
                 along the text for every word in the text. For instance if could get `[{"text": "Hi ", "timestamps":
-                (0.5,0.9), {"text": "there", "timestamps": (1.0, .1.5)}]`, then it means the model assumes the word
+                (0.5,0.9), {"text": "there", "timestamps": (1.0, .1.5)}]`, then it means the model predicts that the word
                 "hi" was pronounces before 0.5 and after 0.9 seconds.
 
         Return:

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -170,7 +170,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 text for every character in the text. For instance if you get `[{"text": "h", "timestamps": (0.5,0.6),
                 {"text": "i", "timestamps": (0.7, .9)}]`, then it means the model predicts that the letter "h" was pronounced
                 after `0.5` and before `0.6` seconds. If set to `"word"`, the pipeline will return `timestamps`
-                along the text for every word in the text. For instance if could get `[{"text": "Hi ", "timestamps":
+                along the text for every word in the text. For instance if you get `[{"text": "hi ", "timestamps":
                 (0.5,0.9), {"text": "there", "timestamps": (1.0, .1.5)}]`, then it means the model predicts that the word
                 "hi" was pronounces before 0.5 and after 0.9 seconds.
 

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -180,7 +180,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 - **chunks** (*optional(, `List[Dict]`)
                         When using `return_timestamps`, the `chunks` will become a list of containing all the various
                         text chunks identified by the model, *e.g.* `[{"text": "hi ", "timestamps": (0.5,0.9), {"text":
-                        "there", "timestamps": (1.0, .1.5)}]` The original full text can roughly be recovered by doing
+                        "there", "timestamps": (1.0, 1.5)}]`. The original full text can roughly be recovered by doing
                         `"".join(chunk["text"] for chunk in output["chunks"])`.
         """
         return super().__call__(inputs, **kwargs)

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -167,7 +167,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                       inference to provide more context to the model). Only use `stride` with CTC models.
             return_timestamps (*optional*, `str`):
                 Only available for pure CTC models. If set to `"char"`, the pipeline will return `timestamps` along the
-                text for every character in the text. For instance if you get `[{"text": "H", "timestamps": (0.5,0.6),
+                text for every character in the text. For instance if you get `[{"text": "h", "timestamps": (0.5,0.6),
                 {"text": "i", "timestamps": (0.7, .9)}]`, then it means the model predicts that the letter "h" was pronounced
                 and the `0.5s and 0.6s` of the input audio If set to `"word"`, the pipeline will return `timestamps`
                 along the text for every word in the text. For instance if could get `[{"text": "Hi ", "timestamps":

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -166,20 +166,22 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                       treat the first `left` samples and last `right` samples to be ignored in decoding (but used at
                       inference to provide more context to the model). Only use `stride` with CTC models.
             return_timestamps (*optional*, `str`):
-                Only available for pure CTC models.
-                If set to `"char"`, the pipeline will return `timestamps` along the
-                text for every character in the text. For instance if you get `[{"text": "H", "timestamps": (0.5,0.6), {"text": "i", "timestamps": (0.7, .9)}]`, then it means the
-                model assumes the letter "H" was pronounces and the `0.5s and 0.6s` of the input audio
-                If set to `"word"`, the pipeline will return `timestamps` along the
-                text for every word in the text. For instance if could get `[{"text": "Hi ", "timestamps": (0.5,0.9), {"text": "there", "timestamps": (1.0, .1.5)}]`, then it means the
-                model assumes the word "Hi" was pronounces and the `0.5s and 0.9s` of the input audio
+                Only available for pure CTC models. If set to `"char"`, the pipeline will return `timestamps` along the
+                text for every character in the text. For instance if you get `[{"text": "H", "timestamps": (0.5,0.6),
+                {"text": "i", "timestamps": (0.7, .9)}]`, then it means the model assumes the letter "H" was pronounces
+                and the `0.5s and 0.6s` of the input audio If set to `"word"`, the pipeline will return `timestamps`
+                along the text for every word in the text. For instance if could get `[{"text": "Hi ", "timestamps":
+                (0.5,0.9), {"text": "there", "timestamps": (1.0, .1.5)}]`, then it means the model assumes the word
+                "Hi" was pronounces and the `0.5s and 0.9s` of the input audio
 
         Return:
             `Dict`: A dictionary with the following keys:
                 - **text** (`str` ) -- The recognized text.
                 - **chunks** (*optional(, `List[Dict]`)
-                        When using `return_timestamps`, the `chunks` will become a list of containing all the various text chunks identified by the model `[{"text": "Hi ", "timestamps": (0.5,0.9), {"text": "there", "timestamps": (1.0, .1.5)}]`
-                        The original full text can roughly be recovered by doing `"".join(chunk["text"] for chunk in output["chunks"])`.
+                        When using `return_timestamps`, the `chunks` will become a list of containing all the various
+                        text chunks identified by the model `[{"text": "Hi ", "timestamps": (0.5,0.9), {"text":
+                        "there", "timestamps": (1.0, .1.5)}]` The original full text can roughly be recovered by doing
+                        `"".join(chunk["text"] for chunk in output["chunks"])`.
         """
         return super().__call__(inputs, **kwargs)
 

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -169,7 +169,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 Only available for pure CTC models. If set to `"char"`, the pipeline will return `timestamps` along the
                 text for every character in the text. For instance if you get `[{"text": "h", "timestamps": (0.5,0.6),
                 {"text": "i", "timestamps": (0.7, .9)}]`, then it means the model predicts that the letter "h" was pronounced
-                and the `0.5s and 0.6s` of the input audio If set to `"word"`, the pipeline will return `timestamps`
+                after `0.5` and before `0.6` seconds. If set to `"word"`, the pipeline will return `timestamps`
                 along the text for every word in the text. For instance if could get `[{"text": "Hi ", "timestamps":
                 (0.5,0.9), {"text": "there", "timestamps": (1.0, .1.5)}]`, then it means the model assumes the word
                 "Hi" was pronounces and the `0.5s and 0.9s` of the input audio

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -168,18 +168,18 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             return_timestamps (*optional*, `str`):
                 Only available for pure CTC models. If set to `"char"`, the pipeline will return `timestamps` along the
                 text for every character in the text. For instance if you get `[{"text": "h", "timestamps": (0.5,0.6),
-                {"text": "i", "timestamps": (0.7, .9)}]`, then it means the model predicts that the letter "h" was pronounced
-                after `0.5` and before `0.6` seconds. If set to `"word"`, the pipeline will return `timestamps`
-                along the text for every word in the text. For instance if you get `[{"text": "hi ", "timestamps":
-                (0.5,0.9), {"text": "there", "timestamps": (1.0, .1.5)}]`, then it means the model predicts that the word
-                "hi" was pronounces before 0.5 and after 0.9 seconds.
+                {"text": "i", "timestamps": (0.7, .9)}]`, then it means the model predicts that the letter "h" was
+                pronounced after `0.5` and before `0.6` seconds. If set to `"word"`, the pipeline will return
+                `timestamps` along the text for every word in the text. For instance if you get `[{"text": "hi ",
+                "timestamps": (0.5,0.9), {"text": "there", "timestamps": (1.0, .1.5)}]`, then it means the model
+                predicts that the word "hi" was pronounces before 0.5 and after 0.9 seconds.
 
         Return:
             `Dict`: A dictionary with the following keys:
                 - **text** (`str` ) -- The recognized text.
                 - **chunks** (*optional(, `List[Dict]`)
-                        When using `return_timestamps`, the `chunks` will become a list containing all the various
-                        text chunks identified by the model, *e.g.* `[{"text": "hi ", "timestamps": (0.5,0.9), {"text":
+                        When using `return_timestamps`, the `chunks` will become a list containing all the various text
+                        chunks identified by the model, *e.g.* `[{"text": "hi ", "timestamps": (0.5,0.9), {"text":
                         "there", "timestamps": (1.0, 1.5)}]`. The original full text can roughly be recovered by doing
                         `"".join(chunk["text"] for chunk in output["chunks"])`.
         """

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -179,7 +179,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 - **text** (`str` ) -- The recognized text.
                 - **chunks** (*optional(, `List[Dict]`)
                         When using `return_timestamps`, the `chunks` will become a list of containing all the various
-                        text chunks identified by the model `[{"text": "Hi ", "timestamps": (0.5,0.9), {"text":
+                        text chunks identified by the model, *e.g.* `[{"text": "hi ", "timestamps": (0.5,0.9), {"text":
                         "there", "timestamps": (1.0, .1.5)}]` The original full text can roughly be recovered by doing
                         `"".join(chunk["text"] for chunk in output["chunks"])`.
         """

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -165,10 +165,17 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                       np.array}` with optionally a `"stride": (left: int, right: int)` than can ask the pipeline to
                       treat the first `left` samples and last `right` samples to be ignored in decoding (but used at
                       inference to provide more context to the model). Only use `stride` with CTC models.
+            return_timestamps (`bool`, defaults to `False`):
+                Only available for pure CTC models. If set to `True`, the pipeline will return `timestamps` along the
+                text. For instance if you get `{"text": "Hi", "timestamps": [(0.5,0.6), (0.7, .9)]}`, then it means the
+                model assumes the letter "H" was pronounces and the 0.5s mark in the incoming audio and lasted for
+                0.1s.
 
         Return:
             `Dict`: A dictionary with the following keys:
                 - **text** (`str`) -- The recognized text.
+                - **timestamps** (`List[Tuple[float, float]]`) -- Optionally returned, when the pipeline is called with
+                  `return_timestamps` argument. Only available for pure CTC models at the moment.
         """
         return super().__call__(inputs, **kwargs)
 
@@ -183,6 +190,8 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
         postprocess_params = {}
         if "decoder_kwargs" in kwargs:
             postprocess_params["decoder_kwargs"] = kwargs["decoder_kwargs"]
+        if "return_timestamps" in kwargs:
+            postprocess_params["return_timestamps"] = kwargs["return_timestamps"]
 
         return preprocess_params, {}, postprocess_params
 
@@ -323,7 +332,13 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
         extra = model_inputs
         return {"is_last": is_last, **out, **extra}
 
-    def postprocess(self, model_outputs, decoder_kwargs: Optional[Dict] = None):
+    def postprocess(self, model_outputs, decoder_kwargs: Optional[Dict] = None, return_timestamps=False):
+        # Optional return types
+        optional = {}
+
+        if return_timestamps and self.type != "ctc":
+            raise ValueError("We cannot return_timestamps yet on non-ctc models !")
+
         if self.type == "ctc_with_lm":
             final_logits = []
             for outputs in model_outputs:
@@ -347,7 +362,30 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             skip_special_tokens = self.type != "ctc"
             tokens = np.concatenate([outputs["tokens"].numpy() for outputs in model_outputs], axis=-1)
             tokens = tokens.squeeze(0)
-            text = self.tokenizer.decode(tokens, skip_special_tokens=skip_special_tokens)
+
+            if return_timestamps:
+                decoded = self.tokenizer.decode(
+                    tokens, skip_special_tokens=skip_special_tokens, output_char_offsets=True
+                )
+                text = ""
+                timestamps = []
+                for item in decoded.char_offsets:
+                    text += item["char"]
+                    start = (
+                        item["start_offset"]
+                        * self.model.config.inputs_to_logits_ratio
+                        / self.feature_extractor.sampling_rate
+                    )
+                    stop = (
+                        item["end_offset"]
+                        * self.model.config.inputs_to_logits_ratio
+                        / self.feature_extractor.sampling_rate
+                    )
+                    timestamps.append((start, stop))
+                optional["timestamps"] = timestamps
+
+            else:
+                text = self.tokenizer.decode(tokens, skip_special_tokens=skip_special_tokens)
 
         extra = defaultdict(list)
         for output in model_outputs:
@@ -357,4 +395,4 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 if k == "is_last":
                     continue
                 extra[k].append(v)
-        return {"text": text, **extra}
+        return {"text": text, **optional, **extra}

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -168,7 +168,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             return_timestamps (*optional*, `str`):
                 Only available for pure CTC models. If set to `"char"`, the pipeline will return `timestamps` along the
                 text for every character in the text. For instance if you get `[{"text": "H", "timestamps": (0.5,0.6),
-                {"text": "i", "timestamps": (0.7, .9)}]`, then it means the model assumes the letter "H" was pronounces
+                {"text": "i", "timestamps": (0.7, .9)}]`, then it means the model predicts that the letter "h" was pronounced
                 and the `0.5s and 0.6s` of the input audio If set to `"word"`, the pipeline will return `timestamps`
                 along the text for every word in the text. For instance if could get `[{"text": "Hi ", "timestamps":
                 (0.5,0.9), {"text": "there", "timestamps": (1.0, .1.5)}]`, then it means the model assumes the word

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -99,7 +99,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase, metaclass=Pipel
         if speech_recognizer.type == "ctc":
             outputs = speech_recognizer(audio, return_timestamps=True)
             n = len(outputs["text"])
-            self.assertEqual(outputs, {"text": ANY(str), "timestamps": [(ANY(int), ANY(int)) for i in range(n)]})
+            self.assertEqual(outputs, {"text": ANY(str), "timestamps": [(ANY(float), ANY(float)) for i in range(n)]})
         else:
             # Non CTC models cannot use return_timestamps
             with self.assertRaises(ValueError):

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -92,18 +92,35 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase, metaclass=Pipel
             # Non CTC models cannot use striding.
             with self.assertRaises(ValueError):
                 outputs = speech_recognizer(audio)
-            outputs = speech_recognizer(audio, return_timestamps=True)
 
         # Timestamps
         audio = np.zeros((34000,))
         if speech_recognizer.type == "ctc":
-            outputs = speech_recognizer(audio, return_timestamps=True)
-            n = len(outputs["text"])
-            self.assertEqual(outputs, {"text": ANY(str), "timestamps": [(ANY(float), ANY(float)) for i in range(n)]})
+            outputs = speech_recognizer(audio, return_timestamps="char")
+            self.assertIsInstance(outputs["chunks"], list)
+            n = len(outputs["chunks"])
+            self.assertEqual(
+                outputs,
+                {
+                    "text": ANY(str),
+                    "chunks": [{"text": ANY(str), "timestamp": (ANY(float), ANY(float))} for i in range(n)],
+                },
+            )
+
+            outputs = speech_recognizer(audio, return_timestamps="word")
+            self.assertIsInstance(outputs["chunks"], list)
+            n = len(outputs["chunks"])
+            self.assertEqual(
+                outputs,
+                {
+                    "text": ANY(str),
+                    "chunks": [{"text": ANY(str), "timestamp": (ANY(float), ANY(float))} for i in range(n)],
+                },
+            )
         else:
             # Non CTC models cannot use return_timestamps
             with self.assertRaises(ValueError):
-                outputs = speech_recognizer(audio, return_timestamps=True)
+                outputs = speech_recognizer(audio, return_timestamps="char")
 
     @require_torch
     @slow
@@ -346,12 +363,38 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase, metaclass=Pipel
 
         ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation").sort("id")
         # Take short audio to keep the test readable
-        audio = ds[40]["audio"]["array"][:500]
+        audio = ds[40]["audio"]["array"][:800]
 
-        output = speech_recognizer(audio, return_timestamps=True)
+        output = speech_recognizer(audio, return_timestamps="char")
         self.assertEqual(
             output,
-            {"text": " Z T", "timestamps": [(0.0, 0.012), (0.012, 0.016), (0.016, 0.02), (0.02, 0.024)]},
+            {
+                "text": "ZBT ZX G",
+                "chunks": [
+                    {"text": " ", "timestamp": (0.0, 0.012)},
+                    {"text": "Z", "timestamp": (0.012, 0.016)},
+                    {"text": "B", "timestamp": (0.016, 0.02)},
+                    {"text": "T", "timestamp": (0.02, 0.024)},
+                    {"text": " ", "timestamp": (0.024, 0.028)},
+                    {"text": "Z", "timestamp": (0.028, 0.032)},
+                    {"text": "X", "timestamp": (0.032, 0.036)},
+                    {"text": " ", "timestamp": (0.036, 0.04)},
+                    {"text": "G", "timestamp": (0.04, 0.044)},
+                ],
+            },
+        )
+
+        output = speech_recognizer(audio, return_timestamps="word")
+        self.assertEqual(
+            output,
+            {
+                "text": "ZBT ZX G",
+                "chunks": [
+                    {"text": "ZBT", "timestamp": (0.012, 0.024)},
+                    {"text": "ZX", "timestamp": (0.028, 0.036)},
+                    {"text": "G", "timestamp": (0.04, 0.044)},
+                ],
+            },
         )
 
     @require_torch
@@ -431,7 +474,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase, metaclass=Pipel
 
     @require_torch
     @slow
-    def test_chunking(self):
+    def test_chunking_and_timestamps(self):
         model = Wav2Vec2ForCTC.from_pretrained("facebook/wav2vec2-base-960h")
         tokenizer = AutoTokenizer.from_pretrained("facebook/wav2vec2-base-960h")
         feature_extractor = AutoFeatureExtractor.from_pretrained("facebook/wav2vec2-base-960h")
@@ -452,54 +495,72 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase, metaclass=Pipel
         output = speech_recognizer([audio_tiled], batch_size=2)
         self.assertEqual(output, [{"text": ("A MAN SAID TO THE UNIVERSE SIR I EXIST " * n_repeats).strip()}])
 
-        output = speech_recognizer(audio, return_timestamps=True)
+        output = speech_recognizer(audio, return_timestamps="char")
         self.assertEqual(audio.shape, (74_400,))
         self.assertEqual(speech_recognizer.feature_extractor.sampling_rate, 16_000)
         # The audio is 74_400 / 16_000 = 4.65s long.
         self.assertEqual(
             output,
             {
-                "text": "A MAN SAID TO THE UNIVERSE SIR I EXIST ",
-                "timestamps": [
-                    (0.6, 0.62),
-                    (0.62, 0.66),
-                    (0.68, 0.7),
-                    (0.78, 0.8),
-                    (0.84, 0.86),
-                    (0.92, 0.98),
-                    (1.06, 1.08),
-                    (1.14, 1.16),
-                    (1.16, 1.18),
-                    (1.2, 1.24),
-                    (1.24, 1.28),
-                    (1.28, 1.32),
-                    (1.34, 1.36),
-                    (1.38, 1.42),
-                    (1.42, 1.44),
-                    (1.44, 1.46),
-                    (1.46, 1.5),
-                    (1.5, 1.56),
-                    (1.58, 1.62),
-                    (1.64, 1.68),
-                    (1.7, 1.72),
-                    (1.76, 1.78),
-                    (1.84, 1.86),
-                    (1.86, 1.9),
-                    (1.96, 1.98),
-                    (1.98, 2.02),
-                    (2.02, 2.06),
-                    (2.82, 2.86),
-                    (2.94, 2.96),
-                    (2.98, 3.02),
-                    (3.06, 3.12),
-                    (3.5, 3.52),
-                    (3.58, 3.6),
-                    (3.66, 3.68),
-                    (3.68, 3.7),
-                    (3.9, 3.92),
-                    (3.94, 3.96),
-                    (4.0, 4.02),
-                    (4.06, 4.1),
+                "text": "A MAN SAID TO THE UNIVERSE SIR I EXIST",
+                "chunks": [
+                    {"text": "A", "timestamp": (0.6, 0.62)},
+                    {"text": " ", "timestamp": (0.62, 0.66)},
+                    {"text": "M", "timestamp": (0.68, 0.7)},
+                    {"text": "A", "timestamp": (0.78, 0.8)},
+                    {"text": "N", "timestamp": (0.84, 0.86)},
+                    {"text": " ", "timestamp": (0.92, 0.98)},
+                    {"text": "S", "timestamp": (1.06, 1.08)},
+                    {"text": "A", "timestamp": (1.14, 1.16)},
+                    {"text": "I", "timestamp": (1.16, 1.18)},
+                    {"text": "D", "timestamp": (1.2, 1.24)},
+                    {"text": " ", "timestamp": (1.24, 1.28)},
+                    {"text": "T", "timestamp": (1.28, 1.32)},
+                    {"text": "O", "timestamp": (1.34, 1.36)},
+                    {"text": " ", "timestamp": (1.38, 1.42)},
+                    {"text": "T", "timestamp": (1.42, 1.44)},
+                    {"text": "H", "timestamp": (1.44, 1.46)},
+                    {"text": "E", "timestamp": (1.46, 1.5)},
+                    {"text": " ", "timestamp": (1.5, 1.56)},
+                    {"text": "U", "timestamp": (1.58, 1.62)},
+                    {"text": "N", "timestamp": (1.64, 1.68)},
+                    {"text": "I", "timestamp": (1.7, 1.72)},
+                    {"text": "V", "timestamp": (1.76, 1.78)},
+                    {"text": "E", "timestamp": (1.84, 1.86)},
+                    {"text": "R", "timestamp": (1.86, 1.9)},
+                    {"text": "S", "timestamp": (1.96, 1.98)},
+                    {"text": "E", "timestamp": (1.98, 2.02)},
+                    {"text": " ", "timestamp": (2.02, 2.06)},
+                    {"text": "S", "timestamp": (2.82, 2.86)},
+                    {"text": "I", "timestamp": (2.94, 2.96)},
+                    {"text": "R", "timestamp": (2.98, 3.02)},
+                    {"text": " ", "timestamp": (3.06, 3.12)},
+                    {"text": "I", "timestamp": (3.5, 3.52)},
+                    {"text": " ", "timestamp": (3.58, 3.6)},
+                    {"text": "E", "timestamp": (3.66, 3.68)},
+                    {"text": "X", "timestamp": (3.68, 3.7)},
+                    {"text": "I", "timestamp": (3.9, 3.92)},
+                    {"text": "S", "timestamp": (3.94, 3.96)},
+                    {"text": "T", "timestamp": (4.0, 4.02)},
+                    {"text": " ", "timestamp": (4.06, 4.1)},
+                ],
+            },
+        )
+        output = speech_recognizer(audio, return_timestamps="word")
+        self.assertEqual(
+            output,
+            {
+                "text": "A MAN SAID TO THE UNIVERSE SIR I EXIST",
+                "chunks": [
+                    {"text": "A", "timestamp": (0.6, 0.62)},
+                    {"text": "MAN", "timestamp": (0.68, 0.86)},
+                    {"text": "SAID", "timestamp": (1.06, 1.24)},
+                    {"text": "TO", "timestamp": (1.28, 1.36)},
+                    {"text": "THE", "timestamp": (1.42, 1.5)},
+                    {"text": "UNIVERSE", "timestamp": (1.58, 2.02)},
+                    {"text": "SIR", "timestamp": (2.82, 3.02)},
+                    {"text": "I", "timestamp": (3.5, 3.52)},
+                    {"text": "EXIST", "timestamp": (3.66, 4.02)},
                 ],
             },
         )

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -89,7 +89,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase, metaclass=Pipel
             self.assertEqual(outputs, {"text": ANY(str)})
 
         else:
-            # Non CTC models cannot use stridin
+            # Non CTC models cannot use striding.
             with self.assertRaises(ValueError):
                 outputs = speech_recognizer(audio)
             outputs = speech_recognizer(audio, return_timestamps=True)
@@ -101,7 +101,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase, metaclass=Pipel
             n = len(outputs["text"])
             self.assertEqual(outputs, {"text": ANY(str), "timestamps": [(ANY(int), ANY(int)) for i in range(n)]})
         else:
-            # Non CTC models cannot use stridin
+            # Non CTC models cannot use return_timestamps
             with self.assertRaises(ValueError):
                 outputs = speech_recognizer(audio, return_timestamps=True)
 


### PR DESCRIPTION
# What does this PR do?

Adding the option to return_timestamps on pure CTC ASR models.

This works by using the `output_char_offsets` during the decoding and
simply recovering the actual offset in seconds instead of number of tokens.

Works only on pure CTC right now.

Thanks @patrickvonplaten  for the earlier PR, made this one a breeze.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->