### PR TITLE
Fix build_documentation CI

### DIFF
--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -110,8 +110,8 @@ jobs:
 
       - name: Make documentation
         run: |
-          cd doc-builder
-          doc-builder build transformers ../transformers/docs/source --build_dir ../doc-build-dev --notebook_dir notebooks/transformers_doc --clean --version pr_$PR_NUMBER --html
+          cd doc-builder &&
+          doc-builder build transformers ../transformers/docs/source --build_dir ../doc-build-dev --notebook_dir notebooks/transformers_doc --clean --version pr_$PR_NUMBER --html &&
           cd ..
 
       - name: Push to repositories

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -116,8 +116,8 @@ jobs:
 
       - name: Push to repositories
         run: |
-          cd doc-build-dev
-          ls
-          git add .
-          git commit -m "Updated with commit ${{ github.sha }} See: https://github.com/huggingface/transformers/commit/${{ github.sha }}"
+          cd doc-build-dev &&
+          ls &&
+          git add . &&
+          git commit -m "Updated with commit ${{ github.sha }} See: https://github.com/huggingface/transformers/commit/${{ github.sha }}" &&
           git push origin main

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: '14'
 
-       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -87,29 +87,29 @@ jobs:
       - name: Make documentation
         run: |
           cd doc-builder &&
-          doc-builder build transformers ../transformers/docs/source --build_dir ../doc-build --notebook_dir notebooks/transformers_doc --clean --version master --html &&
+          doc-builder build transformers ../transformers/docs/source --build_dir ../doc-build --notebook_dir notebooks/transformers_doc --clean --html &&
           cd ..
         env:
           NODE_OPTIONS: --max-old-space-size=6656
 
       - name: Push to repositories
         run: |
-          cd doc-build
-          if [[ `git status --porcelain` ]]; then
-            git add .
-            git commit -m "Updated with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/transformers/commit/${{ github.sha }}"
+          cd doc-build &&
+          if [[ `git status --porcelain` ]]; then 
+            git add . &&
+            git commit -m "Updated with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/transformers/commit/${{ github.sha }}" &&
             git push origin main
           else
             echo "No diff in the documentation."
-          fi
-          cd ..
+          fi &&
+          cd .. &&
 
-          cd notebooks
+          cd notebooks &&
           if [[ `git status --porcelain` ]]; then
-            git add transformers_doc
-            git commit -m "Updated Transformer doc notebooks with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/transformers/commit/${{ github.sha }}"
+            git add transformers_doc &&
+            git commit -m "Updated Transformer doc notebooks with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/transformers/commit/${{ github.sha }}" &&
             git push origin master
           else
             echo "No diff in the notebooks."
-          fi
+          fi &&
           cd ..

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev
 
-          pip install git+https://github.com/huggingface/doc-builder -U
+          pip install git+https://github.com/huggingface/doc-builder
           cd transformers
           pip install .[dev]
           cd ..
@@ -89,6 +89,8 @@ jobs:
           cd doc-builder
           doc-builder build transformers ../transformers/docs/source --build_dir ../doc-build --notebook_dir notebooks/transformers_doc --clean --html
           cd ..
+        env:
+          NODE_OPTIONS: --max-old-space-size=6656
 
       - name: Push to repositories
         run: |

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: '14'
 
-      - uses: actions/checkout@v2
+       - uses: actions/checkout@v2
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
@@ -55,7 +55,7 @@ jobs:
         run: |
           sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev
 
-          pip install git+https://github.com/huggingface/doc-builder
+          pip install git+https://github.com/huggingface/doc-builder -U
           cd transformers
           pip install .[dev]
           cd ..

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -86,8 +86,8 @@ jobs:
 
       - name: Make documentation
         run: |
-          cd doc-builder
-          doc-builder build transformers ../transformers/docs/source --build_dir ../doc-build --notebook_dir notebooks/transformers_doc --clean --html
+          cd doc-builder &&
+          doc-builder build transformers ../transformers/docs/source --build_dir ../doc-build --notebook_dir notebooks/transformers_doc --clean --version master --html &&
           cd ..
         env:
           NODE_OPTIONS: --max-old-space-size=6656


### PR DESCRIPTION
# What does this PR do?

We add more memory to the html build step with `NODE_OPTIONS: --max-old-space-size=6656` in the env.

We also mark the CI as failure if the html generation fails, or the git push fails afterwards.

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

