### PR TITLE
Make Flax pt-flax equivalence test more aggressive

### DIFF
--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -259,8 +259,8 @@ class FlaxModelTesterMixin:
                         pt_outputs = pt_model(**pt_inputs)
                     fx_outputs = fx_model(**prepared_inputs_dict)
 
-                    fx_keys = [k for k, v in fx_outputs.items() if v is not None]
-                    pt_keys = [k for k, v in pt_outputs.items() if v is not None]
+                    fx_keys = tuple([k for k, v in fx_outputs.items() if v is not None])
+                    pt_keys = tuple([k for k, v in pt_outputs.items() if v is not None])
 
                     self.assertEqual(fx_keys, pt_keys)
                     self.check_outputs(fx_outputs.to_tuple(), pt_outputs.to_tuple(), model_class, names=fx_keys, context="load_via_memory", results=results)
@@ -271,8 +271,8 @@ class FlaxModelTesterMixin:
 
                     fx_outputs_loaded = fx_model_loaded(**prepared_inputs_dict)
 
-                    fx_keys = [k for k, v in fx_outputs_loaded.items() if v is not None]
-                    pt_keys = [k for k, v in pt_outputs.items() if v is not None]
+                    fx_keys = tuple([k for k, v in fx_outputs_loaded.items() if v is not None])
+                    pt_keys = tuple([k for k, v in pt_outputs.items() if v is not None])
 
                     self.assertEqual(fx_keys, pt_keys)
                     self.check_outputs(fx_outputs_loaded.to_tuple(), pt_outputs.to_tuple(), model_class, names=fx_keys, context="load_via_disk", results=results)
@@ -333,8 +333,8 @@ class FlaxModelTesterMixin:
                         pt_outputs = pt_model(**pt_inputs)
                     fx_outputs = fx_model(**prepared_inputs_dict)
 
-                    fx_keys = [k for k, v in fx_outputs.items() if v is not None]
-                    pt_keys = [k for k, v in pt_outputs.items() if v is not None]
+                    fx_keys = tuple([k for k, v in fx_outputs.items() if v is not None])
+                    pt_keys = tuple([k for k, v in pt_outputs.items() if v is not None])
 
                     self.assertEqual(fx_keys, pt_keys)
                     self.check_outputs(fx_outputs.to_tuple(), pt_outputs.to_tuple(), model_class, names=fx_keys, context="load_via_memory", results=results)
@@ -349,8 +349,8 @@ class FlaxModelTesterMixin:
                     with torch.no_grad():
                         pt_outputs_loaded = pt_model_loaded(**pt_inputs)
 
-                    fx_keys = [k for k, v in fx_outputs.items() if v is not None]
-                    pt_keys = [k for k, v in pt_outputs_loaded.items() if v is not None]
+                    fx_keys = tuple([k for k, v in fx_outputs.items() if v is not None])
+                    pt_keys = tuple([k for k, v in pt_outputs_loaded.items() if v is not None])
 
                     self.assertEqual(fx_keys, pt_keys)
                     self.check_outputs(fx_outputs.to_tuple(), pt_outputs_loaded.to_tuple(), model_class, names=fx_keys, context="load_via_disk", results=results)

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -190,11 +190,11 @@ class FlaxModelTesterMixin:
         elif isinstance(fxo, jnp.ndarray):
             self.assertTrue(isinstance(pto, torch.Tensor))
 
-            fxo = fxo.numpy()
+            fxo = np.asarray(fxo)
             pto = pto.numpy()
 
-            fx_nans = np.copy(np.isnan(fxo))
-            pt_nans = np.copy(np.isnan(pto))
+            fx_nans = np.isnan(fxo)
+            pt_nans = np.isnan(pto)
 
             pto[fx_nans] = 0
             fxo[fx_nans] = 0

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -198,11 +198,20 @@ class FlaxModelTesterMixin:
 
     @is_pt_flax_cross_test
     def test_equivalence_pt_to_flax(self):
-
+        # It might be better to put this inside the for loop below (because we modify the config there).
+        # But logically, it is fine.
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         for model_class in self.all_model_classes:
             with self.subTest(model_class.__name__):
+
+                # Output all for aggressive testing
+                config.output_hidden_states = True
+                # Pure convolutional models have no attention
+                # TODO: use a better and general criteria
+                if "FlaxConvNext" not in model_class.__name__:
+                    config.output_attentions = True
+
                 # prepare inputs
                 prepared_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
                 pt_inputs = {k: torch.tensor(v.tolist()) for k, v in prepared_inputs_dict.items()}
@@ -210,12 +219,6 @@ class FlaxModelTesterMixin:
                 # load corresponding PyTorch class
                 pt_model_class_name = model_class.__name__[4:]  # Skip the "Flax" at the beginning
                 pt_model_class = getattr(transformers, pt_model_class_name)
-
-                config.output_hidden_states = True
-                # Pure convolutional models have no attention
-                # TODO: use a better and general criteria
-                if "FlaxConvNext" not in model_class.__name__:
-                    config.output_attentions = True
 
                 pt_model = pt_model_class(config).eval()
                 # Flax models don't use the `use_cache` option and cache is not returned as a default.
@@ -254,6 +257,14 @@ class FlaxModelTesterMixin:
 
         for model_class in self.all_model_classes:
             with self.subTest(model_class.__name__):
+
+                # Output all for aggressive testing
+                config.output_hidden_states = True
+                # Pure convolutional models have no attention
+                # TODO: use a better and general criteria
+                if "FlaxConvNext" not in model_class.__name__:
+                    config.output_attentions = True
+
                 # prepare inputs
                 prepared_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
                 pt_inputs = {k: torch.tensor(v.tolist()) for k, v in prepared_inputs_dict.items()}
@@ -261,12 +272,6 @@ class FlaxModelTesterMixin:
                 # load corresponding PyTorch class
                 pt_model_class_name = model_class.__name__[4:]  # Skip the "Flax" at the beginning
                 pt_model_class = getattr(transformers, pt_model_class_name)
-
-                config.output_hidden_states = True
-                # Pure convolutional models have no attention
-                # TODO: use a better and general criteria
-                if "FlaxConvNext" not in model_class.__name__:
-                    config.output_attentions = True
 
                 pt_model = pt_model_class(config).eval()
                 # Flax models don't use the `use_cache` option and cache is not returned as a default.

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -194,7 +194,7 @@ class FlaxModelTesterMixin:
 
             # Using `np.asarray` gives `ValueError: assignment destination is read-only` at the line `fxo[fx_nans] = 0`.
             fxo = np.array(fxo)
-            pto = pto.numpy()
+            pto = pto.detach().to("cpu").numpy()
 
             fx_nans = np.isnan(fxo)
             pt_nans = np.isnan(pto)

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -181,7 +181,7 @@ class FlaxModelTesterMixin:
         if type(fxo) in [tuple, list]:
             self.assertEqual(type(fxo), type(pto))
             self.assertEqual(len(fxo), len(pto))
-            if type(names) in tuple:
+            if type(names) == tuple:
                 for fo, po, name in zip(fxo, pto, names):
                     self.check_outputs(fo, po, model_class, names=name, context=context, results=results)
             elif type(names) == str:

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -168,7 +168,7 @@ class FlaxModelTesterMixin:
             dict_inputs = self._prepare_for_class(inputs_dict, model_class)
             check_equivalence(model, tuple_inputs, dict_inputs, {"output_hidden_states": True})
 
-    def check_outputs(self, fxo, pto, model_class, names):
+    def check_outputs(self, fxo, pto, model_class, names, context, results):
         """
         Args:
             model_class: The class of the model that is currently testing. For example, ..., etc.
@@ -183,10 +183,10 @@ class FlaxModelTesterMixin:
             self.assertEqual(len(fxo), len(pto))
             if type(names) in tuple:
                 for fo, po, name in zip(fxo, pto, names):
-                    self.check_outputs(fo, po, model_class, names=name)
+                    self.check_outputs(fo, po, model_class, names=name, context=context, results=results)
             elif type(names) == str:
                 for idx, (fo, po) in enumerate(zip(fxo, pto)):
-                    self.check_outputs(fo, po, model_class, names=f"{names}_{idx}")
+                    self.check_outputs(fo, po, model_class, names=f"{names}_{idx}", context=context, results=results)
             else:
                 raise ValueError(f"`names` should be a `tuple` or a string. Got {type(names)} instead.")
         elif isinstance(fxo, jnp.ndarray):
@@ -206,6 +206,12 @@ class FlaxModelTesterMixin:
 
             max_diff = np.amax(np.abs(fxo - pto))
             self.assertLessEqual(max_diff, 1e-5)
+
+            if context not in results[model_class.__name__]:
+                results[model_class.__name__][context] = {}
+            if names not in results[model_class.__name__][context]:
+                results[model_class.__name__][context][names] = []
+            results[model_class.__name__][context][names].append(float(max_diff))
         else:
             raise ValueError(
                 f"`fxo` should be a `tuple` or an instance of `jnp.ndarray`. Got {type(fxo)} instead."
@@ -217,112 +223,150 @@ class FlaxModelTesterMixin:
         # But logically, it is fine.
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
+        results = {}
+
         for model_class in self.all_model_classes:
             with self.subTest(model_class.__name__):
 
-                # Output all for aggressive testing
-                config.output_hidden_states = True
+                results[model_class.__name__] = {}
 
-                # prepare inputs
-                prepared_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
-                pt_inputs = {k: torch.tensor(v.tolist(), device=torch_device) for k, v in prepared_inputs_dict.items()}
+                for _ in range(3):
 
-                # load corresponding PyTorch class
-                pt_model_class_name = model_class.__name__[4:]  # Skip the "Flax" at the beginning
-                pt_model_class = getattr(transformers, pt_model_class_name)
+                    # Output all for aggressive testing
+                    config.output_hidden_states = True
 
-                pt_model = pt_model_class(config).eval()
-                # Flax models don't use the `use_cache` option and cache is not returned as a default.
-                # So we disable `use_cache` here for PyTorch model.
-                pt_model.config.use_cache = False
-                fx_model = model_class(config, dtype=jnp.float32)
+                    # prepare inputs
+                    prepared_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
+                    pt_inputs = {k: torch.tensor(v.tolist(), device=torch_device) for k, v in prepared_inputs_dict.items()}
 
-                fx_state = convert_pytorch_state_dict_to_flax(pt_model.state_dict(), fx_model)
-                fx_model.params = fx_state
+                    # load corresponding PyTorch class
+                    pt_model_class_name = model_class.__name__[4:]  # Skip the "Flax" at the beginning
+                    pt_model_class = getattr(transformers, pt_model_class_name)
 
-                # send pytorch model to the correct device
-                pt_model.to(torch_device)
+                    pt_model = pt_model_class(config).eval()
+                    # Flax models don't use the `use_cache` option and cache is not returned as a default.
+                    # So we disable `use_cache` here for PyTorch model.
+                    pt_model.config.use_cache = False
+                    fx_model = model_class(config, dtype=jnp.float32)
 
-                with torch.no_grad():
-                    pt_outputs = pt_model(**pt_inputs)
-                fx_outputs = fx_model(**prepared_inputs_dict)
+                    fx_state = convert_pytorch_state_dict_to_flax(pt_model.state_dict(), fx_model)
+                    fx_model.params = fx_state
 
-                fx_keys = [k for k, v in fx_outputs.items() if v is not None]
-                pt_keys = [k for k, v in pt_outputs.items() if v is not None]
+                    # send pytorch model to the correct device
+                    pt_model.to(torch_device)
 
-                self.assertEqual(fx_keys, pt_keys)
-                self.check_outputs(fx_outputs.to_tuple(), pt_outputs.to_tuple(), model_class, names=fx_keys)
+                    with torch.no_grad():
+                        pt_outputs = pt_model(**pt_inputs)
+                    fx_outputs = fx_model(**prepared_inputs_dict)
 
-                with tempfile.TemporaryDirectory() as tmpdirname:
-                    pt_model.save_pretrained(tmpdirname)
-                    fx_model_loaded = model_class.from_pretrained(tmpdirname, from_pt=True)
+                    fx_keys = [k for k, v in fx_outputs.items() if v is not None]
+                    pt_keys = [k for k, v in pt_outputs.items() if v is not None]
 
-                fx_outputs_loaded = fx_model_loaded(**prepared_inputs_dict)
+                    self.assertEqual(fx_keys, pt_keys)
+                    self.check_outputs(fx_outputs.to_tuple(), pt_outputs.to_tuple(), model_class, names=fx_keys, context="load_via_memory", results=results)
 
-                fx_keys = [k for k, v in fx_outputs_loaded.items() if v is not None]
-                pt_keys = [k for k, v in pt_outputs.items() if v is not None]
+                    with tempfile.TemporaryDirectory() as tmpdirname:
+                        pt_model.save_pretrained(tmpdirname)
+                        fx_model_loaded = model_class.from_pretrained(tmpdirname, from_pt=True)
 
-                self.assertEqual(fx_keys, pt_keys)
-                self.check_outputs(fx_outputs_loaded.to_tuple(), pt_outputs.to_tuple(), model_class, names=fx_keys)
+                    fx_outputs_loaded = fx_model_loaded(**prepared_inputs_dict)
+
+                    fx_keys = [k for k, v in fx_outputs_loaded.items() if v is not None]
+                    pt_keys = [k for k, v in pt_outputs.items() if v is not None]
+
+                    self.assertEqual(fx_keys, pt_keys)
+                    self.check_outputs(fx_outputs_loaded.to_tuple(), pt_outputs.to_tuple(), model_class, names=fx_keys, context="load_via_disk", results=results)
+
+        if len(self.all_model_classes) > 0:
+
+            for model_class_name in results:
+
+                for context in results[model_class_name]:
+                    for names in results[model_class_name][context]:
+                        results[model_class_name][context][names] = float(
+                            np.amax(np.array(results[model_class_name][context][names])))
+
+            import json
+            with open(f"pt_to_flax_test_results_{type(self).__name__}.json", "w", encoding="UTF-8") as fp:
+                json.dump(results, fp, ensure_ascii=False, indent=4)
 
     @is_pt_flax_cross_test
     def test_equivalence_flax_to_pt(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
+        results = {}
+
         for model_class in self.all_model_classes:
             with self.subTest(model_class.__name__):
 
-                # Output all for aggressive testing
-                config.output_hidden_states = True
-                # Pure convolutional models have no attention
+                results[model_class.__name__] = {}
 
-                # prepare inputs
-                prepared_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
-                pt_inputs = {k: torch.tensor(v.tolist(), device=torch_device) for k, v in prepared_inputs_dict.items()}
+                for _ in range(3):
 
-                # load corresponding PyTorch class
-                pt_model_class_name = model_class.__name__[4:]  # Skip the "Flax" at the beginning
-                pt_model_class = getattr(transformers, pt_model_class_name)
+                    # Output all for aggressive testing
+                    config.output_hidden_states = True
+                    # Pure convolutional models have no attention
 
-                pt_model = pt_model_class(config).eval()
-                # Flax models don't use the `use_cache` option and cache is not returned as a default.
-                # So we disable `use_cache` here for PyTorch model.
-                pt_model.config.use_cache = False
-                fx_model = model_class(config, dtype=jnp.float32)
+                    # prepare inputs
+                    prepared_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
+                    pt_inputs = {k: torch.tensor(v.tolist(), device=torch_device) for k, v in prepared_inputs_dict.items()}
 
-                pt_model = load_flax_weights_in_pytorch_model(pt_model, fx_model.params)
+                    # load corresponding PyTorch class
+                    pt_model_class_name = model_class.__name__[4:]  # Skip the "Flax" at the beginning
+                    pt_model_class = getattr(transformers, pt_model_class_name)
 
-                # make sure weights are tied in PyTorch
-                pt_model.tie_weights()
+                    pt_model = pt_model_class(config).eval()
+                    # Flax models don't use the `use_cache` option and cache is not returned as a default.
+                    # So we disable `use_cache` here for PyTorch model.
+                    pt_model.config.use_cache = False
+                    fx_model = model_class(config, dtype=jnp.float32)
 
-                # send pytorch model to the correct device
-                pt_model.to(torch_device)
+                    pt_model = load_flax_weights_in_pytorch_model(pt_model, fx_model.params)
 
-                with torch.no_grad():
-                    pt_outputs = pt_model(**pt_inputs)
-                fx_outputs = fx_model(**prepared_inputs_dict)
+                    # make sure weights are tied in PyTorch
+                    pt_model.tie_weights()
 
-                fx_keys = [k for k, v in fx_outputs.items() if v is not None]
-                pt_keys = [k for k, v in pt_outputs.items() if v is not None]
+                    # send pytorch model to the correct device
+                    pt_model.to(torch_device)
 
-                self.assertEqual(fx_keys, pt_keys)
-                self.check_outputs(fx_outputs.to_tuple(), pt_outputs.to_tuple(), model_class, names=fx_keys)
+                    with torch.no_grad():
+                        pt_outputs = pt_model(**pt_inputs)
+                    fx_outputs = fx_model(**prepared_inputs_dict)
 
-                with tempfile.TemporaryDirectory() as tmpdirname:
-                    fx_model.save_pretrained(tmpdirname)
-                    pt_model_loaded = pt_model_class.from_pretrained(tmpdirname, from_flax=True)
+                    fx_keys = [k for k, v in fx_outputs.items() if v is not None]
+                    pt_keys = [k for k, v in pt_outputs.items() if v is not None]
 
-                # send pytorch model to the correct device
-                pt_model_loaded.to(torch_device)
+                    self.assertEqual(fx_keys, pt_keys)
+                    self.check_outputs(fx_outputs.to_tuple(), pt_outputs.to_tuple(), model_class, names=fx_keys, context="load_via_memory", results=results)
 
-                with torch.no_grad():
-                    pt_outputs_loaded = pt_model_loaded(**pt_inputs)
+                    with tempfile.TemporaryDirectory() as tmpdirname:
+                        fx_model.save_pretrained(tmpdirname)
+                        pt_model_loaded = pt_model_class.from_pretrained(tmpdirname, from_flax=True)
 
-                fx_keys = [k for k, v in fx_outputs.items() if v is not None]
-                pt_keys = [k for k, v in pt_outputs_loaded.items() if v is not None]
+                    # send pytorch model to the correct device
+                    pt_model_loaded.to(torch_device)
 
-                self.assertEqual(fx_keys, pt_keys)
-                self.check_outputs(fx_outputs.to_tuple(), pt_outputs_loaded.to_tuple(), model_class, names=fx_keys)
+                    with torch.no_grad():
+                        pt_outputs_loaded = pt_model_loaded(**pt_inputs)
+
+                    fx_keys = [k for k, v in fx_outputs.items() if v is not None]
+                    pt_keys = [k for k, v in pt_outputs_loaded.items() if v is not None]
+
+                    self.assertEqual(fx_keys, pt_keys)
+                    self.check_outputs(fx_outputs.to_tuple(), pt_outputs_loaded.to_tuple(), model_class, names=fx_keys, context="load_via_disk", results=results)
+
+        if len(self.all_model_classes) > 0:
+
+            for model_class_name in results:
+
+                for context in results[model_class_name]:
+                    for names in results[model_class_name][context]:
+                        results[model_class_name][context][names] = float(
+                            np.amax(np.array(results[model_class_name][context][names])))
+
+            import json
+            with open(f"flax_to_pt_test_results_{type(self).__name__}.json", "w", encoding="UTF-8") as fp:
+                json.dump(results, fp, ensure_ascii=False, indent=4)
 
     def test_from_pretrained_save_pretrained(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -178,15 +178,17 @@ class FlaxModelTesterMixin:
                 Currently unused, but in the future, we could use this information to make the error message clearer
                 by giving the name(s) of the output tensor(s) with large difference(s) between PT and Flax.
         """
-        if type(fxo) == tuple:
-            self.assertEqual(type(pto), tuple)
+        if type(fxo) in [tuple, list]:
+            self.assertEqual(type(fxo), type(pto))
             self.assertEqual(len(fxo), len(pto))
-            if type(names) in [tuple, list]:
+            if type(names) in tuple:
                 for fo, po, name in zip(fxo, pto, names):
                     self.check_outputs(fo, po, model_class, names=name)
             elif type(names) == str:
                 for idx, (fo, po) in enumerate(zip(fxo, pto)):
                     self.check_outputs(fo, po, model_class, names=f"{names}_{idx}")
+            else:
+                raise ValueError(f"`names` should be a `tuple` or a string. Got {type(names)} instead.")
         elif isinstance(fxo, jnp.ndarray):
             self.assertTrue(isinstance(pto, torch.Tensor))
 
@@ -204,6 +206,10 @@ class FlaxModelTesterMixin:
 
             max_diff = np.amax(np.abs(fxo - pto))
             self.assertLessEqual(max_diff, 1e-5)
+        else:
+            raise ValueError(
+                f"`fxo` should be a `tuple` or an instance of `jnp.ndarray`. Got {type(fxo)} instead."
+            )
 
     @is_pt_flax_cross_test
     def test_equivalence_pt_to_flax(self):

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -190,7 +190,8 @@ class FlaxModelTesterMixin:
         elif isinstance(fxo, jnp.ndarray):
             self.assertTrue(isinstance(pto, torch.Tensor))
 
-            fxo = np.asarray(fxo)
+            # Using `np.asarray` gives `ValueError: assignment destination is read-only` at the line `fxo[fx_nans] = 0`.
+            fxo = np.array(fxo)
             pto = pto.numpy()
 
             fx_nans = np.isnan(fxo)


### PR DESCRIPTION
# What does this PR do?

Make Flax pt-flax equivalence test more aggressive. (Similar to #15839 for PT/TF).

It uses `output_hidden_states=True` and `output_attentions=True` to test all output tensors (in a recursive way).

Also, it lowers the tolerance from `4e-2` to `1e-5`. (From the experience I gained in PT/TF test, if an error > `1e-5`, I always found a bug to fix).           

(A bit) surprisingly, but very good news: unlike PT/TF, there is no PT/Flax inconsistency found by this more aggressive test! (@patil-suraj  must have done a great job on flax models :-) )

Flax: @patil-suraj @patrickvonplaten 
