### PR TITLE
Fix (deprecated) ONNX exporter to account for new tf2onnx API

### DIFF
--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -327,8 +327,9 @@ def convert_tensorflow(nlp: Pipeline, opset: int, output: Path):
     try:
         import tensorflow as tf
 
+        # from tf2onnx import convert_keras, save_model
+        import tf2onnx
         from tf2onnx import __version__ as t2ov
-        from tf2onnx import convert_keras, save_model
 
         print(f"Using framework TensorFlow: {tf.version.VERSION}, tf2onnx: {t2ov}")
 
@@ -337,11 +338,18 @@ def convert_tensorflow(nlp: Pipeline, opset: int, output: Path):
 
         # Forward
         nlp.model.predict(tokens.data)
-        onnx_model = convert_keras(nlp.model, nlp.model.name, target_opset=opset)
-        save_model(onnx_model, output.as_posix())
+        # onnx_model = convert_keras(nlp.model, nlp.model.name, target_opset=opset)
+        print(tokens)
+        input_signature = [tf.TensorSpec.from_tensor(tensor, name=key) for key, tensor in tokens.items()]
+        model_proto, _ = tf2onnx.convert.from_keras(
+            nlp.model, input_signature, opset=opset, output_path=output.as_posix()
+        )
+        # save_model(onnx_model, output.as_posix())
 
     except ImportError as e:
-        raise Exception(f"Cannot import {e.name} required to convert TF model to ONNX. Please install {e.name} first.")
+        raise Exception(
+            f"Cannot import {e.name} required to convert TF model to ONNX. Please install {e.name} first. {e}"
+        )
 
 
 def convert(

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -327,7 +327,6 @@ def convert_tensorflow(nlp: Pipeline, opset: int, output: Path):
     try:
         import tensorflow as tf
 
-        # from tf2onnx import convert_keras, save_model
         import tf2onnx
         from tf2onnx import __version__ as t2ov
 
@@ -338,13 +337,10 @@ def convert_tensorflow(nlp: Pipeline, opset: int, output: Path):
 
         # Forward
         nlp.model.predict(tokens.data)
-        # onnx_model = convert_keras(nlp.model, nlp.model.name, target_opset=opset)
-        print(tokens)
         input_signature = [tf.TensorSpec.from_tensor(tensor, name=key) for key, tensor in tokens.items()]
         model_proto, _ = tf2onnx.convert.from_keras(
             nlp.model, input_signature, opset=opset, output_path=output.as_posix()
         )
-        # save_model(onnx_model, output.as_posix())
 
     except ImportError as e:
         raise Exception(


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue with the deprecated `convert_graph_to_onnx` module, where exporting TensorFlow models to ONNX failed due to changes in the `tf2onnx` API. In particular, the failing tests in question were:

* `test_onnx.py::OnnxExportTestCase::test_export_tensorflow`
* `test_onnx.py::OnnxExportTestCase::test_quantize_tf`

With this fix, the whole `test_onnx.py` test suite now passes when I run:

```
RUN_SLOW=1 pytest tests/onnx/test_onnx.py
```