### PR TITLE
use python 3.7 for flax self-push tests

### DIFF
--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -82,6 +82,11 @@ jobs:
       image: tensorflow/tensorflow:2.4.1-gpu
       options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
       - name: Install dependencies
         run: |
           apt -y update && apt install -y software-properties-common && apt -y update && add-apt-repository -y ppa:git-core/ppa && apt -y update && apt install -y git espeak-ng

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -94,7 +94,7 @@ jobs:
           pip install --upgrade pip
           pip install .[sklearn,testing,sentencepiece,flax,flax-speech,vision]
           pip install Cython
-          git clone https://github.com/kpu/kenlm/ && cd kenlm/python && cython -3 --cplus kenlm.pyx && pip install -e .
+          git clone https://github.com/kpu/kenlm/ && cd kenlm/python && cython -3 --cplus kenlm.pyx && cd .. && pip install -e .
 
       - name: Launcher docker
         uses: actions/checkout@v2

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt -y update && apt install -y software-properties-common && apt -y update && add-apt-repository -y ppa:git-core/ppa && apt -y update && apt install -y git espeak-ng && apt install -y python-dev
+          apt -y update && apt install -y software-properties-common && apt -y update && add-apt-repository -y ppa:git-core/ppa && apt -y update && apt install -y git espeak-ng && apt install -y python3-dev
           pip install --upgrade "jax[cuda111]" -f https://storage.googleapis.com/jax-releases/jax_releases.html
           pip install --upgrade pip
           pip install .[sklearn,testing,sentencepiece,flax,flax-speech,vision]

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -93,8 +93,6 @@ jobs:
           pip install --upgrade "jax[cuda111]" -f https://storage.googleapis.com/jax-releases/jax_releases.html
           pip install --upgrade pip
           pip install .[sklearn,testing,sentencepiece,flax,flax-speech,vision]
-          pip install Cython
-          git clone https://github.com/kpu/kenlm KenLM && cd KenLM/python && cython -3 --cplus kenlm.pyx && cd .. && pip install -e .
 
       - name: Launcher docker
         uses: actions/checkout@v2

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -94,7 +94,7 @@ jobs:
           pip install --upgrade pip
           pip install .[sklearn,testing,sentencepiece,flax,flax-speech,vision]
           pip install Cython
-          git clone https://github.com/kpu/kenlm/ && cd kenlm/python && cython -3 --cplus kenlm.pyx && cd .. && pip install -e .
+          git clone https://github.com/kpu/kenlm KenLM && cd KenLM/python && cython -3 --cplus kenlm.pyx && cd .. && pip install -e .
 
       - name: Launcher docker
         uses: actions/checkout@v2

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -93,6 +93,7 @@ jobs:
           pip install --upgrade "jax[cuda111]" -f https://storage.googleapis.com/jax-releases/jax_releases.html
           pip install --upgrade pip
           pip install .[sklearn,testing,sentencepiece,flax,flax-speech,vision]
+          pip install Cython
           git clone https://github.com/kpu/kenlm/ && cd kenlm/python && cython -3 --cplus kenlm.pyx && pip install -e .
 
       - name: Launcher docker

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt -y update && apt install -y software-properties-common && apt -y update && add-apt-repository -y ppa:git-core/ppa && apt -y update && apt install -y git espeak-ng
+          apt -y update && apt install -y software-properties-common && apt -y update && add-apt-repository -y ppa:git-core/ppa && apt -y update && apt install -y git espeak-ng && apt install python-dev
           pip install --upgrade "jax[cuda111]" -f https://storage.googleapis.com/jax-releases/jax_releases.html
           pip install --upgrade pip
           pip install .[sklearn,testing,sentencepiece,flax,flax-speech,vision]

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -93,7 +93,7 @@ jobs:
           pip install --upgrade "jax[cuda111]" -f https://storage.googleapis.com/jax-releases/jax_releases.html
           pip install --upgrade pip
           pip install .[sklearn,testing,sentencepiece,flax,flax-speech,vision]
-          pip install https://github.com/kpu/kenlm/archive/master.zip
+          git clone https://github.com/kpu/kenlm/ && cd kenlm/python && cython -3 --cplus kenlm.pyx && pip install -e .
 
       - name: Launcher docker
         uses: actions/checkout@v2

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -83,7 +83,7 @@ jobs:
       options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.7
 

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt -y update && apt install -y software-properties-common && apt -y update && add-apt-repository -y ppa:git-core/ppa && apt -y update && apt install -y git espeak-ng && apt install python-dev
+          apt -y update && apt install -y software-properties-common && apt -y update && add-apt-repository -y ppa:git-core/ppa && apt -y update && apt install -y git espeak-ng && apt install -y python-dev
           pip install --upgrade "jax[cuda111]" -f https://storage.googleapis.com/jax-releases/jax_releases.html
           pip install --upgrade pip
           pip install .[sklearn,testing,sentencepiece,flax,flax-speech,vision]

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt -y update && apt install -y software-properties-common && apt -y update && add-apt-repository -y ppa:git-core/ppa && apt -y update && apt install -y git espeak-ng && apt install -y python3-dev
+          apt -y update && apt install -y software-properties-common && apt -y update && add-apt-repository -y ppa:git-core/ppa && apt -y update && apt install -y git espeak-ng
           pip install --upgrade "jax[cuda111]" -f https://storage.googleapis.com/jax-releases/jax_releases.html
           pip install --upgrade pip
           pip install .[sklearn,testing,sentencepiece,flax,flax-speech,vision]

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -114,7 +114,6 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
 
         # randomly initialized parameters
         random_params = self.init_weights(self.key, input_shape)
-        self.foo = "foo"
 
         # save required_params as set
         self._required_params = set(flatten_dict(unfreeze(random_params)).keys())

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -114,6 +114,7 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
 
         # randomly initialized parameters
         random_params = self.init_weights(self.key, input_shape)
+        self.foo = "foo"
 
         # save required_params as set
         self._required_params = set(flatten_dict(unfreeze(random_params)).keys())


### PR DESCRIPTION
# What does this PR do?

Use python 3.7 for flax self-push tests. This PR also removes`kenlm` installation since it was  causing some issues and is actually not required for flax tests.