### PR TITLE
fix deepspeed tests

### DIFF
--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -20,6 +20,7 @@ import unittest
 from copy import deepcopy
 
 from parameterized import parameterized
+from tests.trainer.test_trainer import TrainerIntegrationCommon  # noqa
 from transformers import AutoModel, TrainingArguments, is_torch_available, logging
 from transformers.deepspeed import HfDeepSpeedConfig, is_deepspeed_available
 from transformers.file_utils import WEIGHTS_NAME
@@ -39,11 +40,13 @@ from transformers.testing_utils import (
 )
 from transformers.trainer_utils import get_last_checkpoint, set_seed
 
-from tests.trainer.test_trainer import TrainerIntegrationCommon  # noqa
-
 
 if is_torch_available():
-    from tests.trainer.test_trainer import RegressionModelConfig, RegressionPreTrainedModel, get_regression_trainer  # noqa
+    from tests.trainer.test_trainer import (  # noqa
+        RegressionModelConfig,
+        RegressionPreTrainedModel,
+        get_regression_trainer,
+    )
 
 
 set_seed(42)

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -39,11 +39,11 @@ from transformers.testing_utils import (
 )
 from transformers.trainer_utils import get_last_checkpoint, set_seed
 
-from ..trainer.test_trainer import TrainerIntegrationCommon  # noqa
+from tests.trainer.test_trainer import TrainerIntegrationCommon  # noqa
 
 
 if is_torch_available():
-    from ..trainer.test_trainer import RegressionModelConfig, RegressionPreTrainedModel, get_regression_trainer  # noqa
+    from tests.trainer.test_trainer import RegressionModelConfig, RegressionPreTrainedModel, get_regression_trainer  # noqa
 
 
 set_seed(42)

--- a/tests/deepspeed/test_model_zoo.py
+++ b/tests/deepspeed/test_model_zoo.py
@@ -18,6 +18,7 @@ import subprocess
 from os.path import dirname
 
 from parameterized import parameterized
+from tests.trainer.test_trainer import TrainerIntegrationCommon  # noqa
 from transformers import is_torch_available
 from transformers.testing_utils import (
     TestCasePlus,
@@ -29,11 +30,13 @@ from transformers.testing_utils import (
 )
 from transformers.trainer_utils import set_seed
 
-from tests.trainer.test_trainer import TrainerIntegrationCommon  # noqa
-
 
 if is_torch_available():
-    from tests.trainer.test_trainer import RegressionModelConfig, RegressionPreTrainedModel, get_regression_trainer  # noqa
+    from tests.trainer.test_trainer import (  # noqa
+        RegressionModelConfig,
+        RegressionPreTrainedModel,
+        get_regression_trainer,
+    )
 
 
 set_seed(42)

--- a/tests/deepspeed/test_model_zoo.py
+++ b/tests/deepspeed/test_model_zoo.py
@@ -100,8 +100,8 @@ def get_launcher(distributed=False):
 
 def make_task_cmds():
     data_dir_samples = f"{FIXTURE_DIRECTORY}/tests_samples"
-    data_dir_wmt = f"{FIXTURE_DIRECTORY}/wmt_en_ro"
-    data_dir_xsum = f"{FIXTURE_DIRECTORY}/xsum"
+    data_dir_wmt = f"{data_dir_samples}/wmt_en_ro"
+    data_dir_xsum = f"{data_dir_samples}/xsum"
     args_main = """
         --do_train
         --max_train_samples 4

--- a/tests/deepspeed/test_model_zoo.py
+++ b/tests/deepspeed/test_model_zoo.py
@@ -29,11 +29,11 @@ from transformers.testing_utils import (
 )
 from transformers.trainer_utils import set_seed
 
-from ..trainer.test_trainer import TrainerIntegrationCommon  # noqa
+from tests.trainer.test_trainer import TrainerIntegrationCommon  # noqa
 
 
 if is_torch_available():
-    from ..trainer.test_trainer import RegressionModelConfig, RegressionPreTrainedModel, get_regression_trainer  # noqa
+    from tests.trainer.test_trainer import RegressionModelConfig, RegressionPreTrainedModel, get_regression_trainer  # noqa
 
 
 set_seed(42)


### PR DESCRIPTION
Making deepspeed tests work again after the big tests structure reshuffle.

@LysandreJik - we can't have `tests/deepspeed/__init__.py` as then it conflicts with the actual `deepspeed` package, please see: https://github.com/huggingface/transformers/pull/15725#issuecomment-1056027398

Additionally I don't think we should turn tests into packages, as it'd cause all kinds of problems. Instead, I think we should extract any package-worthy code that is re-used by multiple tests and put it under `src/transformers` like `testing_utils.py`.

Please let me know if the failing doc builder is a false alarm. Thanks.
