### PR TITLE
Fix Bug in FlaxWav2Vec2 Slow Test

### DIFF
--- a/tests/wav2vec2/test_modeling_flax_wav2vec2.py
+++ b/tests/wav2vec2/test_modeling_flax_wav2vec2.py
@@ -384,7 +384,7 @@ class FlaxWav2Vec2ModelIntegrationTest(unittest.TestCase):
 
         input_speech = self._load_datasamples(4)
 
-        inputs = processor(input_speech, return_tensors="pt", padding=True, truncation=True)
+        inputs = processor(input_speech, return_tensors="np", padding=True)
 
         input_values = inputs.input_values
         attention_mask = inputs.attention_mask


### PR DESCRIPTION
This PR fixes a small bug the `test_inference_ctc_robust_batched` FlaxWav2Vec2 slow test. Currently, the input processor is run with `return_tensors="pt"` and `trunctation=True`:
https://github.com/huggingface/transformers/blob/05c237ea94e08786abbac6c6185cfdfa262a8c53/tests/wav2vec2/test_modeling_flax_wav2vec2.py#L387
However, as outlined in `feature_extraction_sequence_utils.py`, when setting `trunctation=True`, one must **also** specify the `max_len`:
https://github.com/huggingface/transformers/blob/6e57a56987ff201747f5f01bbce3ed2c0fda1910/src/transformers/feature_extraction_sequence_utils.py#L326-L327
The modifications make the change to `return_tensors="np"` and remove the `truncation` flag. The first change returns the native tensor type for Flax (`np` as opposed to `pt`), and the second change aligns the test with its PyTorch counterpart:
https://github.com/huggingface/transformers/blob/6e57a56987ff201747f5f01bbce3ed2c0fda1910/tests/wav2vec2/test_modeling_wav2vec2.py#L1170


 