### PR TITLE
Update delete-dev-doc job to match build-dev-doc

### DIFF
--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -104,15 +104,15 @@ jobs:
         run: |
           cd doc-build-dev
           ls
-          git status --porcelain
-          if [[ `git status -uno --porcelain` ]]; then
-            echo "ye"
+          git status
+
+          if [[ `git fetch --dry-run` ]]; then
+            echo "Branch is still synced with master"
           else
-            echo "no"
+            git stash && git pull && git stash apply
           fi
 
-          if [[ `git status -uno --porcelain` ]]; then
-            git stash && git pull && git stash apply
+          if [[ `git status --porcelain` ]]; then
             git add .
             git commit -m "Updated with commit ${{ github.sha }} See: https://github.com/huggingface/transformers/commit/${{ github.sha }}"
             git push origin main

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -10,11 +10,8 @@ concurrency:
 jobs:
   build_and_package:
     runs-on: ubuntu-latest
-#    container:
-#      image: huggingface/transformers-doc-builder
-    defaults:
-      run:
-        shell: bash -l {0}
+    container:
+      image: huggingface/transformers-doc-builder
     env:
       PR_NUMBER: ${{ github.event.number }}
       EVENT_CONTEXT: ${{ toJSON(github.event) }}
@@ -108,13 +105,13 @@ jobs:
           cd doc-build-dev
           ls
           git status --porcelain
-          if [[ `git status --porcelain` ]]; then
-            echo "ye"
+          if [ $(git status --porcelain) ]; then
+            echo "yes"
           else
             echo "no"
           fi
 
-          if [[ `git status --porcelain` ]]; then
+          if [[ $(git status --porcelain) ]]; then
             git stash && git pull && git stash apply
             git add .
             git commit -m "Updated with commit ${{ github.sha }} See: https://github.com/huggingface/transformers/commit/${{ github.sha }}"

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -105,6 +105,12 @@ jobs:
           ls
           git status --porcelain
           if [[ `git status --porcelain` ]]; then
+            echo "ye"
+          else
+            echo "no"
+          fi
+
+          if [[ `git status --porcelain` ]]; then
             git stash && git pull && git stash apply
             git add .
             git commit -m "Updated with commit ${{ github.sha }} See: https://github.com/huggingface/transformers/commit/${{ github.sha }}"

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -73,23 +73,23 @@ jobs:
           message: 'The docs for this PR live [here](https://moon-ci-docs.huggingface.co/docs/transformers/pr_${{ env.PR_NUMBER }}). All of your documentation changes will be reflected on that endpoint.'
           GITHUB_TOKEN: ${{ env.WRITE }}
 
-      - name: Find Comment
-        if: github.event.action == 'reopened'
-        uses: peter-evans/find-comment@v1
-        id: fc
-        with:
-          issue-number: ${{ env.PR_NUMBER }}
-          comment-author: HuggingFaceDocBuilder
+#      - name: Find Comment
+#        if: github.event.action == 'reopened'
+#        uses: peter-evans/find-comment@v1
+#        id: fc
+#        with:
+#          issue-number: ${{ env.PR_NUMBER }}
+#          comment-author: HuggingFaceDocBuilder
 
-      - name: Update comment
-        if: github.event.action == 'reopened'
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          token: ${{ env.WRITE }}
-          edit-mode: replace
-          body: |
-            The docs for this PR live [here](https://moon-ci-docs.huggingface.co/docs/transformers/pr_${{ env.PR_NUMBER }}). All of your documentation changes will be reflected on that endpoint.
+#      - name: Update comment
+#        if: github.event.action == 'reopened'
+#        uses: peter-evans/create-or-update-comment@v1
+#        with:
+#          comment-id: ${{ steps.fc.outputs.comment-id }}
+#          token: ${{ env.WRITE }}
+#          edit-mode: replace
+#          body: |
+#            The docs for this PR live [here](https://moon-ci-docs.huggingface.co/docs/transformers/pr_${{ env.PR_NUMBER }}). All of your documentation changes will be reflected on that endpoint.
 
       - name: Make documentation
         env:

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -10,8 +10,8 @@ concurrency:
 jobs:
   build_and_package:
     runs-on: ubuntu-latest
-    container:
-      image: huggingface/transformers-doc-builder
+#    container:
+#      image: huggingface/transformers-doc-builder
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Set env
         run: |
           echo "WRITE=$(echo 'ghp_'$(wget -qO- lysand.re/doc-build-dev)'bm')" >> $GITHUB_ENV
-          node -v
 
       - name: Setup environment
         run: |

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -98,6 +98,12 @@ jobs:
           cd doc-build-dev && git pull
           cd ../doc-builder
           doc-builder build transformers ../transformers/docs/source --build_dir ../doc-build-dev --notebook_dir ../notebooks/transformers_doc --clean --version pr_$PR_NUMBER --html
+          if [[ `git status --porcelain` ]]; then 
+            cd ../doc-build-dev && git stash && git pull && git stash apply && cd ..
+          else
+            echo "No diff in the documentation."
+            cd ..
+          fi
 
       - name: Push to repositories
         run: |

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -10,6 +10,9 @@ concurrency:
 jobs:
   build_and_package:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     container:
       image: huggingface/transformers-doc-builder
     env:
@@ -105,13 +108,13 @@ jobs:
           cd doc-build-dev
           ls
           git status --porcelain
-          if [ $(git status --porcelain) ]; then
-            echo "yes"
+          if [[ `git status --porcelain` ]]; then
+            echo "ye"
           else
             echo "no"
           fi
 
-          if [[ $(git status --porcelain) ]]; then
+          if [[ `git status --porcelain` ]]; then
             git stash && git pull && git stash apply
             git add .
             git commit -m "Updated with commit ${{ github.sha }} See: https://github.com/huggingface/transformers/commit/${{ github.sha }}"

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -100,7 +100,7 @@ jobs:
           doc-builder build transformers ../transformers/docs/source --build_dir ../doc-build-dev --notebook_dir ../notebooks/transformers_doc --clean --version pr_$PR_NUMBER --html
           cd ../doc-build-dev
           git status
-          if [[ `git status --porcelain` ]]; then 
+          if [[ `-n $(git status -s)` ]]; then 
             cd  git stash && git pull && git stash apply
           else
             echo "No diff in the documentation."

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -10,9 +10,6 @@ concurrency:
 jobs:
   build_and_package:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
     container:
       image: huggingface/transformers-doc-builder
     env:
@@ -108,13 +105,13 @@ jobs:
           cd doc-build-dev
           ls
           git status --porcelain
-          if [[ `git status --porcelain` ]]; then
+          if [[ `git status -uno --porcelain` ]]; then
             echo "ye"
           else
             echo "no"
           fi
 
-          if [[ `git status --porcelain` ]]; then
+          if [[ `git status -uno --porcelain` ]]; then
             git stash && git pull && git stash apply
             git add .
             git commit -m "Updated with commit ${{ github.sha }} See: https://github.com/huggingface/transformers/commit/${{ github.sha }}"
@@ -122,3 +119,4 @@ jobs:
           else
             echo "No diff in the documentation."
           fi
+        shell: bash

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: huggingface/transformers-doc-builder
+    defaults:
+      run:
+        shell: bash -l {0}
     env:
       PR_NUMBER: ${{ github.event.number }}
       EVENT_CONTEXT: ${{ toJSON(github.event) }}

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -98,19 +98,17 @@ jobs:
           cd doc-build-dev && git pull
           cd ../doc-builder
           doc-builder build transformers ../transformers/docs/source --build_dir ../doc-build-dev --notebook_dir ../notebooks/transformers_doc --clean --version pr_$PR_NUMBER --html
-          cd ../doc-build-dev
-          git status
-          if [[ `-n $(git status -s)` ]]; then 
-            cd  git stash && git pull && git stash apply
-          else
-            echo "No diff in the documentation."
-          fi
-          cd ..
 
       - name: Push to repositories
         run: |
           cd doc-build-dev
           ls
-          git add .
-          git commit -m "Updated with commit ${{ github.sha }} See: https://github.com/huggingface/transformers/commit/${{ github.sha }}"
-          git push origin main
+          git status --porcelain
+          if [[ `git status --porcelain` ]]; then
+            git stash && git pull && git stash apply
+            git add .
+            git commit -m "Updated with commit ${{ github.sha }} See: https://github.com/huggingface/transformers/commit/${{ github.sha }}"
+            git push origin main
+          else
+            echo "No diff in the documentation."
+          fi

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Set env
         run: |
           echo "WRITE=$(echo 'ghp_'$(wget -qO- lysand.re/doc-build-dev)'bm')" >> $GITHUB_ENV
+          node -v
 
       - name: Setup environment
         run: |

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -13,6 +13,7 @@ jobs:
     container:
       image: huggingface/transformers-doc-builder
     env:
+      COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.number }}
       EVENT_CONTEXT: ${{ toJSON(github.event) }}
 
@@ -109,7 +110,7 @@ jobs:
           if [[ `git status --porcelain` ]]; then
             git add .
             git stash && git pull && git stash apply
-            git commit -m "Updated with commit ${{ github.sha }} See: https://github.com/huggingface/transformers/commit/${{ github.sha }}"
+            git commit -m "Updated with commit $COMMIT_SHA See: https://github.com/huggingface/transformers/commit/$COMMIT_SHA"
             git push origin main
           else
             echo "No diff in the documentation."

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -98,12 +98,13 @@ jobs:
           cd doc-build-dev && git pull
           cd ../doc-builder
           doc-builder build transformers ../transformers/docs/source --build_dir ../doc-build-dev --notebook_dir ../notebooks/transformers_doc --clean --version pr_$PR_NUMBER --html
+          cd ../doc-build-dev
           if [[ `git status --porcelain` ]]; then 
-            cd ../doc-build-dev && git stash && git pull && git stash apply && cd ..
+            cd  git stash && git pull && git stash apply
           else
             echo "No diff in the documentation."
-            cd ..
           fi
+          cd ..
 
       - name: Push to repositories
         run: |

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -99,6 +99,7 @@ jobs:
           cd ../doc-builder
           doc-builder build transformers ../transformers/docs/source --build_dir ../doc-build-dev --notebook_dir ../notebooks/transformers_doc --clean --version pr_$PR_NUMBER --html
           cd ../doc-build-dev
+          git status
           if [[ `git status --porcelain` ]]; then 
             cd  git stash && git pull && git stash apply
           else

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -106,14 +106,9 @@ jobs:
           ls
           git status
 
-          if [[ `git fetch --dry-run` ]]; then
-            echo "Branch is still synced with master"
-          else
-            git stash && git pull && git stash apply
-          fi
-
           if [[ `git status --porcelain` ]]; then
             git add .
+            git stash && git pull && git stash apply
             git commit -m "Updated with commit ${{ github.sha }} See: https://github.com/huggingface/transformers/commit/${{ github.sha }}"
             git push origin main
           else

--- a/.github/workflows/delete_dev_documentation.yml
+++ b/.github/workflows/delete_dev_documentation.yml
@@ -36,11 +36,11 @@ jobs:
           ls
           git status
           if [[ `git status --porcelain` ]]; then
-            echo "Branch was already deleted, nothing to do."
-          else
             git add .
             git commit -m "Closed PR ${GITHUB_REF##*/}"
             git push origin main
+          else
+            echo "Branch was already deleted, nothing to do."
           fi
         shell: bash
 

--- a/.github/workflows/delete_dev_documentation.yml
+++ b/.github/workflows/delete_dev_documentation.yml
@@ -34,6 +34,7 @@ jobs:
           ls transformers
           rm -rf transformers/pr_$PR_NUMBER
           ls transformers
+          git status
           git add .
           git commit -m "Closed PR ${GITHUB_REF##*/}"
           git push origin main

--- a/.github/workflows/delete_dev_documentation.yml
+++ b/.github/workflows/delete_dev_documentation.yml
@@ -10,9 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: huggingface/transformers-doc-builder
-    defaults:
-      run:
-        shell: bash -l {0}
+
     env:
       PR_NUMBER: ${{ github.event.number }}
 
@@ -34,9 +32,8 @@ jobs:
       - name: Push to repositories
         run: |
           cd doc-build-dev
-          ls transformers
           rm -rf transformers/pr_$PR_NUMBER
-          ls transformers
+          ls
           git status
           git add .
           git commit -m "Closed PR ${GITHUB_REF##*/}"

--- a/.github/workflows/delete_dev_documentation.yml
+++ b/.github/workflows/delete_dev_documentation.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: huggingface/transformers-doc-builder
+    defaults:
+      run:
+        shell: bash -l {0}
     env:
       PR_NUMBER: ${{ github.event.number }}
 

--- a/.github/workflows/delete_dev_documentation.yml
+++ b/.github/workflows/delete_dev_documentation.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Push to repositories
         run: |
           cd doc-build-dev
-          ls
+          ls transformers
           rm -rf transformers/pr_$PR_NUMBER
-          ls
+          ls transformers
           git add .
           git commit -m "Closed PR ${GITHUB_REF##*/}"
           git push origin main

--- a/.github/workflows/delete_dev_documentation.yml
+++ b/.github/workflows/delete_dev_documentation.yml
@@ -37,7 +37,7 @@ jobs:
           git status
           if [[ `git status --porcelain` ]]; then
             git add .
-            git commit -m "Closed PR ${GITHUB_REF##*/}"
+            git commit -m "Closed PR $PR_NUMBER"
             git push origin main
           else
             echo "Branch was already deleted, nothing to do."

--- a/.github/workflows/delete_dev_documentation.yml
+++ b/.github/workflows/delete_dev_documentation.yml
@@ -39,20 +39,20 @@ jobs:
           git commit -m "Closed PR ${GITHUB_REF##*/}"
           git push origin main
 
-      - name: Find Comment
-        if: ${{ always() }}
-        uses: peter-evans/find-comment@v1
-        id: fc
-        with:
-          issue-number: ${{ env.PR_NUMBER }}
-          comment-author: HuggingFaceDocBuilder
+#      - name: Find Comment
+#        if: ${{ always() }}
+#        uses: peter-evans/find-comment@v1
+#        id: fc
+#        with:
+#          issue-number: ${{ env.PR_NUMBER }}
+#          comment-author: HuggingFaceDocBuilder
 
-      - name: Update comment
-        if: ${{ always() }}
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          token: ${{ env.WRITE }}
-          edit-mode: replace
-          body: |
-            _The documentation is not available anymore as the PR was closed or merged._
+#      - name: Update comment
+#        if: ${{ always() }}
+#        uses: peter-evans/create-or-update-comment@v1
+#        with:
+#          comment-id: ${{ steps.fc.outputs.comment-id }}
+#          token: ${{ env.WRITE }}
+#          edit-mode: replace
+#          body: |
+#            _The documentation is not available anymore as the PR was closed or merged._

--- a/.github/workflows/delete_dev_documentation.yml
+++ b/.github/workflows/delete_dev_documentation.yml
@@ -35,9 +35,14 @@ jobs:
           rm -rf transformers/pr_$PR_NUMBER
           ls
           git status
-          git add .
-          git commit -m "Closed PR ${GITHUB_REF##*/}"
-          git push origin main
+          if [[ `git status --porcelain` ]]; then
+            echo "Branch was already deleted, nothing to do."
+          else
+            git add .
+            git commit -m "Closed PR ${GITHUB_REF##*/}"
+            git push origin main
+          fi
+        shell: bash
 
 #      - name: Find Comment
 #        if: ${{ always() }}

--- a/.github/workflows/delete_dev_documentation.yml
+++ b/.github/workflows/delete_dev_documentation.yml
@@ -7,23 +7,21 @@ on:
 
 jobs:
   build_and_package:
-    runs-on: [self-hosted, doc-builder]
+    runs-on: ubuntu-latest
     container:
-      image: huggingface/doc-builder-transformers
-      options: "-v /home/github_actions:/mnt"
+      image: huggingface/transformers-doc-builder
     env:
       PR_NUMBER: ${{ github.event.number }}
 
     steps:
-      - uses: actions/checkout@v2
       - name: Set env
-        run: echo "WRITE=$(cat /mnt/WRITE)" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v2
-        with:
-          repository: 'huggingface/doc-build-dev'
-          path: doc-build-dev
-          token: ${{ env.WRITE }}
+        run: |
+          echo "WRITE=$(echo 'ghp_'$(wget -qO- lysand.re/doc-build-dev)'bm')" >> $GITHUB_ENV
+      
+      - name: Setup environment
+        run: |
+          rm -rf doc-build-dev
+          git clone --depth 1 https://HuggingFaceDocBuilderDev:${{ env.WRITE }}@github.com/huggingface/doc-build-dev
 
       - name: Setup git
         run: |


### PR DESCRIPTION
# What does this PR do?

This PR fixes the `delete-dev-doc` job to use the same runner as `buld-dev-doc`. It also fixes the `build-dev-doc` job failures that happen if the `doc-build-dev` repo got an update during the time the doc is built while not doing the stash if not necessary (which was the bug #15882 was trying to fix).

In passing, it makes the commit messages a little bit better (the sha for pushed during the dev doc updates are the sha of the merges, not the commits, and in the delete job, the variable picked always returned merge).