### PR TITLE
Fix a TF Vision Encoder Decoder test

### DIFF
--- a/tests/vision_encoder_decoder/test_modeling_tf_vision_encoder_decoder.py
+++ b/tests/vision_encoder_decoder/test_modeling_tf_vision_encoder_decoder.py
@@ -324,7 +324,7 @@ class TFVisionEncoderDecoderMixin:
         self.assertEqual(len(tf_outputs), len(pt_outputs), "Output lengths differ between TF and PyTorch")
 
         for tf_output, pt_output in zip(tf_outputs, pt_outputs):
-            self.assert_almost_equals(tf_output.numpy(), pt_output.numpy(), 1e-3)
+            self.assert_almost_equals(tf_output.numpy(), pt_output.detach().to("cpu").numpy(), 1e-3)
 
         # PT -> TF
         with tempfile.TemporaryDirectory() as encoder_tmp_dirname, tempfile.TemporaryDirectory() as decoder_tmp_dirname:

--- a/tests/vision_encoder_decoder/test_modeling_tf_vision_encoder_decoder.py
+++ b/tests/vision_encoder_decoder/test_modeling_tf_vision_encoder_decoder.py
@@ -344,7 +344,7 @@ class TFVisionEncoderDecoderMixin:
         self.assertEqual(len(tf_outputs_loaded), len(pt_outputs), "Output lengths differ between TF and PyTorch")
 
         for tf_output_loaded, pt_output in zip(tf_outputs_loaded, pt_outputs):
-            self.assert_almost_equals(tf_output_loaded.numpy(), pt_output.numpy(), 1e-3)
+            self.assert_almost_equals(tf_output_loaded.numpy(), pt_output.detach().to("cpu").numpy(), 1e-3)
 
     def check_equivalence_pt_to_tf(self, config, decoder_config, inputs_dict):
 

--- a/tests/vision_encoder_decoder/test_modeling_tf_vision_encoder_decoder.py
+++ b/tests/vision_encoder_decoder/test_modeling_tf_vision_encoder_decoder.py
@@ -311,6 +311,9 @@ class TFVisionEncoderDecoderMixin:
         if "labels" in pt_inputs:
             pt_inputs["labels"] = pt_inputs["labels"].type(torch.LongTensor)
 
+        # send pytorch inputs to the correct device
+        pt_inputs = {k: v.to(device=torch_device) if isinstance(v, torch.Tensor) else v for k, v in pt_inputs.items()}
+
         with torch.no_grad():
             pt_outputs = pt_model(**pt_inputs).to_tuple()
 


### PR DESCRIPTION
# What does this PR do?

Simple fix for the following CI failure: 

```
tests.vision_encoder_decoder.test_modeling_tf_vision_encoder_decoder.TFViT2GPT2EncoderDecoderModelTest.test_pt_tf_equivalence
```
This is due to a few PyTorch device issue (need `pt_inputs` to be on the correct device).

Tested on GCP GPU VM - it pass now.

@patrickvonplaten @sgugger 