### PR TITLE
Do not change the output from tuple to list - to match PT's version

### DIFF
--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -1012,12 +1012,6 @@ class TFBartDecoder(tf.keras.layers.Layer):
         if inputs["output_hidden_states"]:
             all_hidden_states += (hidden_states,)
 
-        if inputs["output_attentions"]:
-            all_self_attns = list(all_self_attns)
-
-            if inputs["encoder_hidden_states"] is not None:
-                all_cross_attns = list(all_cross_attns)
-
         if inputs["use_cache"]:
             present_key_values = (inputs["encoder_hidden_states"], present_key_values)
 

--- a/src/transformers/models/blenderbot/modeling_tf_blenderbot.py
+++ b/src/transformers/models/blenderbot/modeling_tf_blenderbot.py
@@ -1011,12 +1011,6 @@ class TFBlenderbotDecoder(tf.keras.layers.Layer):
         if inputs["output_hidden_states"]:
             all_hidden_states += (hidden_states,)
 
-        if inputs["output_attentions"]:
-            all_self_attns = list(all_self_attns)
-
-            if inputs["encoder_hidden_states"] is not None:
-                all_cross_attns = list(all_cross_attns)
-
         if inputs["use_cache"]:
             present_key_values = (inputs["encoder_hidden_states"], present_key_values)
 

--- a/src/transformers/models/blenderbot_small/modeling_tf_blenderbot_small.py
+++ b/src/transformers/models/blenderbot_small/modeling_tf_blenderbot_small.py
@@ -1010,12 +1010,6 @@ class TFBlenderbotSmallDecoder(tf.keras.layers.Layer):
         if inputs["output_hidden_states"]:
             all_hidden_states += (hidden_states,)
 
-        if inputs["output_attentions"]:
-            all_self_attns = list(all_self_attns)
-
-            if inputs["encoder_hidden_states"] is not None:
-                all_cross_attns = list(all_cross_attns)
-
         if inputs["use_cache"]:
             present_key_values = (inputs["encoder_hidden_states"], present_key_values)
 

--- a/src/transformers/models/marian/modeling_tf_marian.py
+++ b/src/transformers/models/marian/modeling_tf_marian.py
@@ -1050,12 +1050,6 @@ class TFMarianDecoder(tf.keras.layers.Layer):
         if inputs["output_hidden_states"]:
             all_hidden_states += (hidden_states,)
 
-        if inputs["output_attentions"]:
-            all_self_attns = list(all_self_attns)
-
-            if inputs["encoder_hidden_states"] is not None:
-                all_cross_attns = list(all_cross_attns)
-
         if inputs["use_cache"]:
             present_key_values = (inputs["encoder_hidden_states"], present_key_values)
 

--- a/src/transformers/models/mbart/modeling_tf_mbart.py
+++ b/src/transformers/models/mbart/modeling_tf_mbart.py
@@ -1034,12 +1034,6 @@ class TFMBartDecoder(tf.keras.layers.Layer):
         if inputs["output_hidden_states"]:
             all_hidden_states += (hidden_states,)
 
-        if inputs["output_attentions"]:
-            all_self_attns = list(all_self_attns)
-
-            if inputs["encoder_hidden_states"] is not None:
-                all_cross_attns = list(all_cross_attns)
-
         if inputs["use_cache"]:
             present_key_values = (inputs["encoder_hidden_states"], present_key_values)
 

--- a/src/transformers/models/pegasus/modeling_tf_pegasus.py
+++ b/src/transformers/models/pegasus/modeling_tf_pegasus.py
@@ -1058,12 +1058,6 @@ class TFPegasusDecoder(tf.keras.layers.Layer):
         if inputs["output_hidden_states"]:
             all_hidden_states += (hidden_states,)
 
-        if inputs["output_attentions"]:
-            all_self_attns = list(all_self_attns)
-
-            if inputs["encoder_hidden_states"] is not None:
-                all_cross_attns = list(all_cross_attns)
-
         if inputs["use_cache"]:
             present_key_values = (inputs["encoder_hidden_states"], present_key_values)
 

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -2736,12 +2736,6 @@ class TF{{cookiecutter.camelcase_modelname}}Decoder(tf.keras.layers.Layer):
         if inputs["output_hidden_states"]:
             all_hidden_states += (hidden_states,)
 
-        if inputs["output_attentions"]:
-            all_self_attns = list(all_self_attns)
-
-            if inputs["encoder_hidden_states"] is not None:
-                all_cross_attns = list(all_cross_attns)
-
         if inputs["use_cache"]:
             present_key_values = (inputs["encoder_hidden_states"], present_key_values)
 


### PR DESCRIPTION
# What does this PR do?

Current `TFPegasusDecoder` change `all_self_attns` and `all_cross_attns` from `tuple` to `list` before return the outputs:

https://github.com/huggingface/transformers/blob/3c4fbc616f74120c3900d07c772b7d2d9c7a53dd/src/transformers/models/pegasus/modeling_tf_pegasus.py#L1061-L1065

Pytorch `PegasusDecoder` returns them as tuple (i.e. not extra step to change them to `list`). This causes (WIP) PT-TF-equivalence test failed. 

This PR fixes this, as well as for 5 other models (+ template) with the same issue:

-  [x] bart
-  [x] blenderbot
-  [x] blenderbot_small
-  [x] marian
-  [x] mbart

Think change `list` to `tuple` is acceptable (i.e. not a [too] breaking change)? cc @sgugger for this aspect.

TF: @gante @Rocketknight1 
Bart, Pegasus: @patrickvonplaten



