### PR TITLE
Do a pull in case docs were updated during build

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -97,6 +97,7 @@ jobs:
           cd doc-build &&
           if [[ `git status --porcelain` ]]; then 
             git add . &&
+            git stash && git pull && git stash apply &&
             git commit -m "Updated with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/transformers/commit/${{ github.sha }}" &&
             git push origin main
           else


### PR DESCRIPTION
# What does this PR do?

Now that the build of the documentation takes a long time, it can happen that the doc has changed when trying to update the doc-build repo in the case of a release (for instance there was a failure with the v4.17.0 release doc update since the master doc was updated during its build).
This PR stashes, pulls and pops the stash to avoid that.