### PR TITLE
Fix #15898

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -454,6 +454,10 @@ def main():
             eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
 
         def preprocess_logits_for_metrics(logits, labels):
+            if isinstance(logits, tuple):
+                # Depending on the model and config, logits may contain extra tensors,
+                # like past_key_values, but logits always come first
+                logits = logits[0]
             return logits.argmax(dim=-1)
 
         metric = load_metric("accuracy")

--- a/examples/pytorch/language-modeling/run_mlm.py
+++ b/examples/pytorch/language-modeling/run_mlm.py
@@ -477,6 +477,10 @@ def main():
             eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
 
         def preprocess_logits_for_metrics(logits, labels):
+            if isinstance(logits, tuple):
+                # Depending on the model and config, logits may contain extra tensors,
+                # like past_key_values, but logits always come first
+                logits = logits[0]
             return logits.argmax(dim=-1)
 
         metric = load_metric("accuracy")


### PR DESCRIPTION
Fixes #15898

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sgugger


I guess it's obvious looking at the [glue example] (https://github.com/huggingface/transformers/blob/4cd7ed4b3b7360aef3a9fb16dfcc105001188717/examples/pytorch/text-classification/run_glue.py#L448) referenced in the issue, but just to be sure: is it guaranteed that the actual logits (final output of the models) are always placed in the first position?

I looked at the models of `MODEL_FOR_CAUSAL_LM_MAPPING_NAMES` and it seems a convention. I'm a bit confused because there is a `past_index` arg in `Trainer` that indexes the output of the model, which made me question if the position of the logits is guaranteed, but I guess it's never 0 or there's any other reason I don't know of. You know better than me for sure.

