### PR TITLE
Returning outputs only when asked for for MaskFormer.

### DIFF
--- a/src/transformers/models/maskformer/configuration_maskformer.py
+++ b/src/transformers/models/maskformer/configuration_maskformer.py
@@ -69,6 +69,8 @@ class MaskFormerConfig(PretrainedConfig):
             The weight for the cross entropy loss.
         mask_weight (`float`, *optional*, defaults to 20.0):
             The weight for the mask loss.
+        output_auxiliary_logits (`bool`, *optional*):
+            Should the model output its `auxiliary_logits` or not.
 
     Raises:
         `ValueError`:
@@ -109,6 +111,7 @@ class MaskFormerConfig(PretrainedConfig):
         dice_weight: float = 1.0,
         cross_entropy_weight: float = 1.0,
         mask_weight: float = 20.0,
+        output_auxiliary_logits: Optional[bool] = None,
         **kwargs,
     ):
         if backbone_config is None:
@@ -156,6 +159,7 @@ class MaskFormerConfig(PretrainedConfig):
         self.mask_weight = mask_weight
         self.use_auxiliary_loss = use_auxiliary_loss
         self.no_object_weight = no_object_weight
+        self.output_auxiliary_logits = output_auxiliary_logits
 
         self.num_attention_heads = self.decoder_config.encoder_attention_heads
         self.num_hidden_layers = self.decoder_config.num_hidden_layers

--- a/src/transformers/models/maskformer/modeling_maskformer.py
+++ b/src/transformers/models/maskformer/modeling_maskformer.py
@@ -2313,9 +2313,16 @@ class MaskFormerModel(MaskFormerPreTrainedModel):
         )
         queries = transformer_module_output.last_hidden_state
 
-        encoder_hidden_states = pixel_level_module_output.encoder_hidden_states if output_hidden_states else ()
-        pixel_decoder_hidden_states = pixel_level_module_output.decoder_hidden_states if output_hidden_states else ()
-        transformer_decoder_hidden_states = transformer_module_output.hidden_states if output_hidden_states else ()
+        if output_hidden_states:
+            encoder_hidden_states = pixel_level_module_output.encoder_hidden_states
+            pixel_decoder_hidden_states = pixel_level_module_output.decoder_hidden_states
+            transformer_decoder_hidden_states = transformer_module_output.hidden_states
+            hidden_states = encoder_hidden_states + pixel_decoder_hidden_states + transformer_decoder_hidden_states
+        else:
+            encoder_hidden_states = None
+            pixel_decoder_hidden_states = None
+            transformer_decoder_hidden_states = None
+            hidden_states = None
 
         output = MaskFormerModelOutput(
             encoder_last_hidden_state=image_features,
@@ -2324,7 +2331,7 @@ class MaskFormerModel(MaskFormerPreTrainedModel):
             encoder_hidden_states=encoder_hidden_states,
             pixel_decoder_hidden_states=pixel_decoder_hidden_states,
             transformer_decoder_hidden_states=transformer_decoder_hidden_states,
-            hidden_states=encoder_hidden_states + pixel_decoder_hidden_states + transformer_decoder_hidden_states,
+            hidden_states=hidden_states,
             attentions=transformer_module_output.attentions,
         )
 
@@ -2421,6 +2428,7 @@ class MaskFormerForInstanceSegmentation(MaskFormerPreTrainedModel):
         mask_labels: Optional[Tensor] = None,
         class_labels: Optional[Tensor] = None,
         pixel_mask: Optional[Tensor] = None,
+        output_auxiliary_logits: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
         return_dict: Optional[bool] = None,
@@ -2483,6 +2491,9 @@ class MaskFormerForInstanceSegmentation(MaskFormerPreTrainedModel):
                 masks_queries_logits, class_queries_logits, mask_labels, class_labels, auxiliary_logits
             )
             loss = self.get_loss(loss_dict)
+
+        if not output_auxiliary_logits:
+            auxiliary_logits = None
 
         output = MaskFormerForInstanceSegmentationOutput(
             loss=loss,

--- a/src/transformers/models/maskformer/modeling_maskformer.py
+++ b/src/transformers/models/maskformer/modeling_maskformer.py
@@ -2492,6 +2492,9 @@ class MaskFormerForInstanceSegmentation(MaskFormerPreTrainedModel):
             )
             loss = self.get_loss(loss_dict)
 
+        output_auxiliary_logits = (
+            self.config.output_auxiliary_logits if output_auxiliary_logits is None else output_auxiliary_logits
+        )
         if not output_auxiliary_logits:
             auxiliary_logits = None
 


### PR DESCRIPTION
# What does this PR do?

Change the return output from `()` to `None` which seems more aligned with
the rest of the library.

Also `auxiliary_logits` seem optional and don't seem to be used by the feature
extractor, so this PR makes them optional too.

Note: I couldn't test the modeling tests, there seem to be no fast tests, and the slow tests are failing for reasons seemingly unrelated to this PR.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->