### PR TITLE
MarianTokenizer: get vocab length in `as_target_tokenizer` mode

### DIFF
--- a/src/transformers/models/marian/tokenization_marian.py
+++ b/src/transformers/models/marian/tokenization_marian.py
@@ -277,7 +277,7 @@ class MarianTokenizer(PreTrainedTokenizer):
 
     @property
     def vocab_size(self) -> int:
-        return len(self.encoder)
+        return len(self.current_spm) + self.num_special_tokens_to_add()
 
     def save_vocabulary(self, save_directory: str, filename_prefix: Optional[str] = None) -> Tuple[str]:
         if not os.path.isdir(save_directory):


### PR DESCRIPTION
# What does this PR do?

When using the MarianTokenizer with a different source and target SPMs, it is expected to get the length of the target vocabulary when performing:
```python
with tokenizer.as_target_tokenizer():
    print(len(tokenizer))
```

This PR introduces a minimal change to get the correct size depending on the selected SPM.


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Did you write any new necessary tests?
