### PR TITLE
[HELP NEEDED] Use target tokenizer for all functionality in target side

### DIFF
--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -171,13 +171,14 @@ class Text2TextGenerationPipeline(Pipeline):
             if return_type == ReturnType.TENSORS:
                 record = {f"{self.return_name}_token_ids": model_outputs}
             elif return_type == ReturnType.TEXT:
-                record = {
-                    f"{self.return_name}_text": self.tokenizer.decode(
-                        output_ids,
-                        skip_special_tokens=True,
-                        clean_up_tokenization_spaces=clean_up_tokenization_spaces,
-                    )
-                }
+                with self.tokenizer.as_target_tokenizer():
+                    record = {
+                        f"{self.return_name}_text": self.tokenizer.decode(
+                            output_ids,
+                            skip_special_tokens=True,
+                            clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+                        )
+                    }
             records.append(record)
         return records
 


### PR DESCRIPTION
# What does this PR do?

When using the MarianTokenizer with a different source and target SPMs, it is expected to get the length of the target vocabulary when performing:
```python
with tokenizer.as_target_tokenizer():
    print(len(tokenizer))
```
Along with the expectation to be able to get the target vocabulary, and in translation time to use the target tokenizer.


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Did you write any new necessary tests?

## HELP NEEDED

Tests do not pass, as the token IDs returned change.
However, the IDs are taken directly from the SPM model and not the VOCAB file, and I do not understand why my new values are less correct compared to the ones in the test files.