### PR TITLE
Support modern list type hints in HfArgumentParser

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -129,7 +129,8 @@ class HfArgumentParser(ArgumentParser):
                     # This is the value that will get picked if we do --field_name (without value)
                     kwargs["const"] = True
             elif (
-                hasattr(field.type, "__origin__") and re.search(r"^(typing\.List|list)\[(.*)\]$", str(field.type)) is not None
+                hasattr(field.type, "__origin__")
+                and re.search(r"^(typing\.List|list)\[(.*)\]$", str(field.type)) is not None
             ):
                 kwargs["nargs"] = "+"
                 kwargs["type"] = field.type.__args__[0]

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -129,7 +129,7 @@ class HfArgumentParser(ArgumentParser):
                     # This is the value that will get picked if we do --field_name (without value)
                     kwargs["const"] = True
             elif (
-                hasattr(field.type, "__origin__") and re.search(r"^typing\.List\[(.*)\]$", str(field.type)) is not None
+                hasattr(field.type, "__origin__") and re.search(r"^(typing\.List|list)\[(.*)\]$", str(field.type)) is not None
             ):
                 kwargs["nargs"] = "+"
                 kwargs["type"] = field.type.__args__[0]


### PR DESCRIPTION
# What does this PR do?
Support modern list type hint syntax ([PEP 585](https://www.python.org/dev/peps/pep-0585/), introduced in Python 3.9) in the HfArgumentParser. This change keeps backwards compatibility, e.g. the old `typing.List[...]` works just as well as the newer `list[...]`.


Fixes #15950 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sgugger 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
