### PR TITLE
Set scale_embedding to False in some TF tests

### DIFF
--- a/tests/speech_to_text/test_modeling_tf_speech_to_text.py
+++ b/tests/speech_to_text/test_modeling_tf_speech_to_text.py
@@ -116,7 +116,7 @@ class TFSpeech2TextModelTester:
         self.eos_token_id = eos_token_id
         self.pad_token_id = pad_token_id
         self.bos_token_id = bos_token_id
-        self.scale_embedding = False
+        self.scale_embedding = scale_embedding
 
     def prepare_config_and_inputs(self):
         input_features = floats_tensor(

--- a/tests/speech_to_text/test_modeling_tf_speech_to_text.py
+++ b/tests/speech_to_text/test_modeling_tf_speech_to_text.py
@@ -90,6 +90,7 @@ class TFSpeech2TextModelTester:
         eos_token_id=2,
         pad_token_id=1,
         bos_token_id=0,
+        scale_embedding=False,
     ):
         self.parent = parent
         self.batch_size = batch_size
@@ -115,6 +116,7 @@ class TFSpeech2TextModelTester:
         self.eos_token_id = eos_token_id
         self.pad_token_id = pad_token_id
         self.bos_token_id = bos_token_id
+        self.scale_embedding = False
 
     def prepare_config_and_inputs(self):
         input_features = floats_tensor(
@@ -155,6 +157,7 @@ class TFSpeech2TextModelTester:
             eos_token_id=self.eos_token_id,
             bos_token_id=self.bos_token_id,
             pad_token_id=self.pad_token_id,
+            scale_embedding=self.scale_embedding,
         )
 
     def prepare_config_and_inputs_for_common(self):


### PR DESCRIPTION
# What does this PR do?

This PR set `scale_embedding=False` in `TFSpeech2TextModelTester` to avoid `inputs_embeds` and the PT/TF difference being scaled by 4 - the objective is to keep a low tolerance `1e-5` in the PT/TF test, as we see several times this is a strong safe guard!

(This is not a real bug. It's also similar to #15684, where we got larger differences between PT/TF simply because the model weights are initialized with larger values).

TF: @gante @Rocketknight1 
Speech: @patrickvonplaten 

## More context

Set `scale_embedding` to `False` in some TF tests.

Current `Speech2TextConfig` has default [scale_embedding=True](https://github.com/huggingface/transformers/blob/9932ee4b4bca9045d941af6687ef69eedcf68483/src/transformers/models/speech_to_text/configuration_speech_to_text.py#L137). Therefore we have

- [self.embed_scale = tf.math.sqrt(float(embed_dim))](https://github.com/huggingface/transformers/blob/9932ee4b4bca9045d941af6687ef69eedcf68483/src/transformers/models/speech_to_text/modeling_tf_speech_to_text.py#L742).
- The tests for `speech_to_text` has [hidden_size=16](https://github.com/huggingface/transformers/blob/9932ee4b4bca9045d941af6687ef69eedcf68483/tests/speech_to_text/test_modeling_tf_speech_to_text.py#L75), and therefore `inputs_embeds` will be scaled by 4.

https://github.com/huggingface/transformers/blob/9932ee4b4bca9045d941af6687ef69eedcf68483/src/transformers/models/speech_to_text/modeling_tf_speech_to_text.py#L843-L844

Since `inputs_embeds` here is obtained by some (conv.) layer instead of via look-up table, it contains some tiny difference between PT/TF. This difference is scaled by 4 through `self.embed_scale`.

This makes `TFSpeech2TextModel` **the only one** model that will fail the aggressive PT/TF test introduced in #15839 (with low tolerance `1e-5`). More precisely, the output tensors failed are `encoder_hidden_states_0` and `encoder_hidden_states_1`.

## Results

**With this PR, the tolerance `1e-5` works for all TF models' `test_pt_tf_model_equivalence` (in #15839), both on GPU / CPU, tested 100 times per model.**