### PR TITLE
Make `pos` optional in `PerceiverAudioPreprocessor` to avoid crashing `PerceiverModel` operation

### DIFF
--- a/src/transformers/models/perceiver/modeling_perceiver.py
+++ b/src/transformers/models/perceiver/modeling_perceiver.py
@@ -3264,7 +3264,7 @@ class PerceiverAudioPreprocessor(AbstractPreprocessor):
 
         return inputs_with_pos, inputs
 
-    def forward(self, inputs, pos, network_input_is_1d: bool = True):
+    def forward(self, inputs: torch.Tensor, pos: Optional[torch.Tensor] = None, network_input_is_1d: bool = True):
         inputs = torch.reshape(inputs, [inputs.shape[0], -1, self.samples_per_patch])
 
         inputs, inputs_without_pos = self._build_network_inputs(inputs, pos)


### PR DESCRIPTION
Updates `PerceiverAudioPreprocessor` `forward()` implementation to match most other preprocessors / postprocessors.

Fixes #15971.
