### PR TITLE
Fix TFEncDecModelTest - Pytorch device

### DIFF
--- a/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
+++ b/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
@@ -319,7 +319,7 @@ class TFEncoderDecoderMixin:
 
         # prepare inputs
         tf_inputs = inputs_dict
-        pt_inputs = {k: torch.tensor(v.numpy()) for k, v in tf_inputs.items()}
+        pt_inputs = {k: torch.tensor(v.numpy()).to(device=torch_device) for k, v in tf_inputs.items()}
         if "labels" in pt_inputs:
             pt_inputs["labels"] = pt_inputs["labels"].type(torch.LongTensor)
 

--- a/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
+++ b/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
@@ -321,7 +321,7 @@ class TFEncoderDecoderMixin:
         tf_inputs = inputs_dict
         pt_inputs = {k: torch.tensor(v.numpy()).to(device=torch_device) for k, v in tf_inputs.items()}
         if "labels" in pt_inputs:
-            pt_inputs["labels"] = pt_inputs["labels"].type(torch.LongTensor)
+            pt_inputs["labels"] = pt_inputs["labels"].type(torch.long)
 
         with torch.no_grad():
             pt_outputs = pt_model(**pt_inputs).to_tuple()

--- a/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
+++ b/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
@@ -333,7 +333,7 @@ class TFEncoderDecoderMixin:
         self.assertEqual(len(tf_outputs), len(pt_outputs), "Output lengths differ between TF and PyTorch")
 
         for tf_output, pt_output in zip(tf_outputs, pt_outputs):
-            self.assert_almost_equals(tf_output.numpy(), pt_output.numpy(), 1e-3)
+            self.assert_almost_equals(tf_output.numpy(), pt_output.detach().to("cpu").numpy(), 1e-3)
 
         # PT -> TF
         with tempfile.TemporaryDirectory() as encoder_tmp_dirname, tempfile.TemporaryDirectory() as decoder_tmp_dirname:
@@ -353,7 +353,7 @@ class TFEncoderDecoderMixin:
         self.assertEqual(len(tf_outputs_loaded), len(pt_outputs), "Output lengths differ between TF and PyTorch")
 
         for tf_output_loaded, pt_output in zip(tf_outputs_loaded, pt_outputs):
-            self.assert_almost_equals(tf_output_loaded.numpy(), pt_output.numpy(), 1e-3)
+            self.assert_almost_equals(tf_output_loaded.numpy(), pt_output.detach().to("cpu").numpy(), 1e-3)
 
     def check_equivalence_pt_to_tf(self, config, decoder_config, inputs_dict):
 

--- a/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
+++ b/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
@@ -319,9 +319,12 @@ class TFEncoderDecoderMixin:
 
         # prepare inputs
         tf_inputs = inputs_dict
-        pt_inputs = {k: torch.tensor(v.numpy()).to(device=torch_device) for k, v in tf_inputs.items()}
+        pt_inputs = {k: torch.tensor(v.numpy()) for k, v in tf_inputs.items()}
         if "labels" in pt_inputs:
-            pt_inputs["labels"] = pt_inputs["labels"].type(torch.long)
+            pt_inputs["labels"] = pt_inputs["labels"]
+
+        # send pytorch inputs to the correct device
+        pt_inputs = {k: v.to(device=torch_device) if isinstance(v, torch.Tensor) else v for k, v in pt_inputs.items()}
 
         with torch.no_grad():
             pt_outputs = pt_model(**pt_inputs).to_tuple()

--- a/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
+++ b/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
@@ -321,7 +321,7 @@ class TFEncoderDecoderMixin:
         tf_inputs = inputs_dict
         pt_inputs = {k: torch.tensor(v.numpy()) for k, v in tf_inputs.items()}
         if "labels" in pt_inputs:
-            pt_inputs["labels"] = pt_inputs["labels"]
+            pt_inputs["labels"] = pt_inputs["labels"].type(torch.LongTensor)
 
         # send pytorch inputs to the correct device
         pt_inputs = {k: v.to(device=torch_device) if isinstance(v, torch.Tensor) else v for k, v in pt_inputs.items()}


### PR DESCRIPTION
# What does this PR do?

Fix pytorch device issue for `test_pt_tf_equivalence` in `TFEncoderDecoderMixin`.

@patrickvonplaten @sgugger 

## Remark:

There are other issues to fix for TFEncoderDecoder test pass:
  1. use small models for `test_real_model_save_load_from_pretrained`
  2. `test_bert2bert_summarization` test fails after #15562
 
Think these should be addressed in separate PRs (especially for 2.)