### PR TITLE
Use tiny models for get_pretrained_model in TFEncoderDecoderModelTest

### DIFF
--- a/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
+++ b/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
@@ -509,7 +509,7 @@ class TFEncoderDecoderMixin:
         model = TFEncoderDecoderModel(encoder_decoder_config)
         model(**inputs_dict)
 
-    def test_real_model_save_load_from_pretrained(self):
+    def test_model_save_load_from_pretrained(self):
         model_2 = self.get_pretrained_model()
         input_ids = ids_tensor([13, 5], model_2.config.encoder.vocab_size)
         decoder_input_ids = ids_tensor([13, 1], model_2.config.decoder.vocab_size)

--- a/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
+++ b/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
@@ -541,7 +541,10 @@ class TFEncoderDecoderMixin:
 @require_tf
 class TFBertEncoderDecoderModelTest(TFEncoderDecoderMixin, unittest.TestCase):
     def get_pretrained_model(self):
-        return TFEncoderDecoderModel.from_encoder_decoder_pretrained("bert-base-uncased", "bert-base-uncased")
+        return TFEncoderDecoderModel.from_encoder_decoder_pretrained(
+            "hf-internal-testing/tiny-random-bert",
+            "hf-internal-testing/tiny-random-bert",
+        )
 
     def get_encoder_decoder_model(self, config, decoder_config):
         encoder_model = TFBertModel(config, name="encoder")
@@ -636,7 +639,10 @@ class TFBertEncoderDecoderModelTest(TFEncoderDecoderMixin, unittest.TestCase):
 @require_tf
 class TFGPT2EncoderDecoderModelTest(TFEncoderDecoderMixin, unittest.TestCase):
     def get_pretrained_model(self):
-        return TFEncoderDecoderModel.from_encoder_decoder_pretrained("bert-base-cased", "../gpt2")
+        return TFEncoderDecoderModel.from_encoder_decoder_pretrained(
+            "hf-internal-testing/tiny-random-bert",
+            "hf-internal-testing/tiny-random-gpt2",
+        )
 
     def get_encoder_decoder_model(self, config, decoder_config):
         encoder_model = TFBertModel(config, name="encoder")
@@ -725,7 +731,10 @@ class TFGPT2EncoderDecoderModelTest(TFEncoderDecoderMixin, unittest.TestCase):
 @require_tf
 class TFRoBertaEncoderDecoderModelTest(TFEncoderDecoderMixin, unittest.TestCase):
     def get_pretrained_model(self):
-        return TFEncoderDecoderModel.from_encoder_decoder_pretrained("roberta-base", "roberta-base")
+        return TFEncoderDecoderModel.from_encoder_decoder_pretrained(
+            "tiny-random-roberta",
+            "tiny-random-roberta",
+        )
 
     def get_encoder_decoder_model(self, config, decoder_config):
         encoder_model = TFRobertaModel(config, name="encoder")

--- a/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
+++ b/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
@@ -509,7 +509,6 @@ class TFEncoderDecoderMixin:
         model = TFEncoderDecoderModel(encoder_decoder_config)
         model(**inputs_dict)
 
-    @slow
     def test_real_model_save_load_from_pretrained(self):
         model_2 = self.get_pretrained_model()
         input_ids = ids_tensor([13, 5], model_2.config.encoder.vocab_size)
@@ -782,7 +781,10 @@ class TFRoBertaEncoderDecoderModelTest(TFEncoderDecoderMixin, unittest.TestCase)
 @require_tf
 class TFRembertEncoderDecoderModelTest(TFEncoderDecoderMixin, unittest.TestCase):
     def get_pretrained_model(self):
-        return TFEncoderDecoderModel.from_encoder_decoder_pretrained("google/rembert", "google/rembert")
+        return TFEncoderDecoderModel.from_encoder_decoder_pretrained(
+            "hf-internal-testing/tiny-random-rembert",
+            "hf-internal-testing/tiny-random-rembert",
+        )
 
     def get_encoder_decoder_model(self, config, decoder_config):
         encoder_model = TFRemBertModel(config, name="encoder")

--- a/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
+++ b/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
@@ -732,8 +732,8 @@ class TFGPT2EncoderDecoderModelTest(TFEncoderDecoderMixin, unittest.TestCase):
 class TFRoBertaEncoderDecoderModelTest(TFEncoderDecoderMixin, unittest.TestCase):
     def get_pretrained_model(self):
         return TFEncoderDecoderModel.from_encoder_decoder_pretrained(
-            "tiny-random-roberta",
-            "tiny-random-roberta",
+            "hf-internal-testing/tiny-random-roberta",
+            "hf-internal-testing/tiny-random-roberta",
         )
 
     def get_encoder_decoder_model(self, config, decoder_config):


### PR DESCRIPTION
# What does this PR do?

Use tiny models for `get_pretrained_model` in `TFEncoderDecoderModelTest`.

This is originally for avoiding **GPU OOM** for `TFRembertEncoderDecoderModelTest` on CI daily testing.
But @patrickvonplaten suggests that we should actually use the small model in the following quote:

_... think we can rename it to test_model_save_loaf_from_pretrained(...) :wink: I think this "real" name was propragated since the first encoder-decoder tests existed in PyTorch. **Since the test does no integration testing** (e.g. checking if the output corresponds to something reasonable) **it makes 0 difference whether we use dummy weights or no** dummy weights here ..._