### PR TITLE
Adding new train_step logic to make things less confusing for users

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -21,7 +21,6 @@ import os
 import pickle
 import re
 import warnings
-from collections import OrderedDict
 from typing import Dict, List, Optional, Union
 
 import h5py

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -57,6 +57,7 @@ from .utils import (
     is_offline_mode,
     is_remote_url,
     logging,
+    find_labels,
 )
 
 
@@ -963,14 +964,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         loss that just reads the loss output head of the model. When using this dummy loss, inputs can be passed either
         as keys in the input dictionary, or as normal Keras labels.
         """
-        possible_label_cols = {
-            "labels",
-            "label",
-            "label_ids",
-            "start_positions",
-            "end_positions",
-            "next_sentence_label",
-        }
+
         # These are the only transformations `Model.fit` applies to user-input
         # data when a `tf.data.Dataset` is provided.
         if not self._using_dummy_loss:
@@ -981,7 +975,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         # if those keys are not already present in the input dict
         if self._using_dummy_loss and y is not None:
             arg_names = list(dict(inspect.signature(self.call).parameters).keys())
-            label_kwargs = possible_label_cols.intersection(arg_names)
+            label_kwargs = find_labels(self.__class__)
             # If y is a tensor and the model only has one label-like input, map y to that input
             if len(label_kwargs) == 1 and isinstance(y, tf.Tensor):
                 if isinstance(x, tf.Tensor):
@@ -1035,14 +1029,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         loss that just reads the loss output head of the model. When using this dummy loss, inputs can be passed either
         as keys in the input dictionary, or as normal Keras labels.
         """
-        possible_label_cols = {
-            "labels",
-            "label",
-            "label_ids",
-            "start_positions",
-            "end_positions",
-            "next_sentence_label",
-        }
         # These are the only transformations `Model.fit` applies to user-input
         # data when a `tf.data.Dataset` is provided.
         if not self._using_dummy_loss:
@@ -1053,7 +1039,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         # if those keys are not already present in the input dict
         if self._using_dummy_loss and y is not None:
             arg_names = list(dict(inspect.signature(self.call).parameters).keys())
-            label_kwargs = possible_label_cols.intersection(arg_names)
+            label_kwargs = find_labels(self.__class__)
             # If y is a tensor and the model only has one label-like input, map y to that input
             if len(label_kwargs) == 1 and isinstance(y, tf.Tensor):
                 if isinstance(x, tf.Tensor):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -899,11 +899,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         This is a thin wrapper that sets the model's loss output head as the loss if the user does not specify a loss
         function themselves.
         """
-        # TODO:
-        #     1: Try training all the different classes of BERT model with this + metrics and seeing how it does
-        #     2: After the type annotation sprint is done, scan all model classes and check that none have
-        #        double output types.
-        #     3: Check the possible_label_names is reliable.
         if loss == "passthrough":
             logger.warning(
                 "No loss specified in compile() - the model's internal loss computation will be used as the "
@@ -915,34 +910,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             self._using_dummy_loss = True
             if metrics is not None and isinstance(metrics, dict):
                 raise ValueError("When using the internal loss, passing metrics as a dict is not supported!")
-            # if metrics is not None and not isinstance(metrics, dict):
-            #     type_hints = get_type_hints(self.call)
-            #     if "return" not in type_hints:
-            #         output_types = []
-            #     else:
-            #         return_types = get_type_hints(self.call)["return"].__args__
-            #         output_types = [return_type for return_type in return_types if is_dataclass(return_type)]
-            #     if len(output_types) == 0:
-            #         raise TypeError(
-            #             f"Code analysis failed to identify the output types of model {type(self)}! "
-            #             "This is most likely because that model class does not have type annotations. "
-            #             "Please pass a `dict` of metrics instead of a tuple/list, specifying the output "
-            #             "heads of the model for each metric."
-            #         )
-            #     if len(output_types) > 1:
-            #         raise TypeError(
-            #             "This model has an unusual output structure, and we could not automatically "
-            #             "determine output heads for metrics. Please pass a `dict` of metrics instead "
-            #             "of a list/tuple, specifying the output heads of the model for each metric."
-            #         )
-            #     output_type = output_types[0]
-            #     # Optional fields that allow NoneType (this includes loss) are not the main model outputs
-            #     outputs = [
-            #         field.name
-            #         for field in fields(output_type)
-            #         if type(None) not in getattr(field.type, "__args__", [])
-            #     ]
-            #     metrics = {output: metrics for output in outputs}
         else:
             self._using_dummy_loss = False
         super().compile(

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -902,7 +902,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             if metrics is not None:
                 raise ValueError(
                     "Passing metrics as a dict is not supported when using the internal loss! "
-                    "Please either specify a loss, or remove the metrics argument."
+                    "Please either compile the model with a loss, or remove the metrics argument. "
+                    "Note that advanced metrics using the KerasMetricCallback can still be used with the internal "
+                    "loss."
                 )
             logger.warning(
                 "No loss specified in compile() - the model's internal loss computation will be used as the "
@@ -958,7 +960,8 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         }
         # These are the only transformations `Model.fit` applies to user-input
         # data when a `tf.data.Dataset` is provided.
-        data = data_adapter.expand_1d(data)
+        if not self._using_dummy_loss:
+            data = data_adapter.expand_1d(data)
         x, y, sample_weight = data_adapter.unpack_x_y_sample_weight(data)
 
         # When using a dummy loss, we ensure that separate labels are copied to the correct model arguments,
@@ -1029,7 +1032,8 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         }
         # These are the only transformations `Model.fit` applies to user-input
         # data when a `tf.data.Dataset` is provided.
-        data = data_adapter.expand_1d(data)
+        if not self._using_dummy_loss:
+            data = data_adapter.expand_1d(data)
         x, y, sample_weight = data_adapter.unpack_x_y_sample_weight(data)
 
         # When using a dummy loss, we ensure that separate labels are copied to the correct model arguments,

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -38,7 +38,6 @@ from .activations_tf import get_tf_activation
 from .configuration_utils import PretrainedConfig
 from .dynamic_module_utils import custom_object_save
 from .generation_tf_utils import TFGenerationMixin
-from .modeling_tf_outputs import TFSeq2SeqLMOutput
 from .tf_utils import shape_list
 from .tokenization_utils_base import BatchEncoding
 from .utils import (
@@ -1060,12 +1059,11 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                         x[key] = val
 
         # Run forward pass.
-        with tf.GradientTape() as tape:
-            y_pred = self(x, training=True)
-            if self._using_dummy_loss:
-                loss = self.compiled_loss(y_pred.loss, y_pred.loss, sample_weight, regularization_losses=self.losses)
-            else:
-                loss = self.compiled_loss(y, y_pred, sample_weight, regularization_losses=self.losses)
+        y_pred = self(x, training=False)
+        if self._using_dummy_loss:
+            self.compiled_loss(y_pred.loss, y_pred.loss, sample_weight, regularization_losses=self.losses)
+        else:
+            self.compiled_loss(y, y_pred, sample_weight, regularization_losses=self.losses)
 
         # When using the dummy_loss we match up structures before passing to metrics, so it doesn't get confused
         if self._using_dummy_loss:

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -910,7 +910,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                 "No loss specified in compile() - the model's internal loss computation will be used as the "
                 "loss. Don't panic - this is a common way to train TensorFlow models in Transformers! "
                 "To disable this behaviour, please pass a loss argument, or explicitly pass "
-                "loss=None if you do not want your model to compute a loss."
+                "`loss=None` if you do not want your model to compute a loss."
             )
             loss = dummy_loss
             self._using_dummy_loss = True

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -925,11 +925,15 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             loss = {"loss": dummy_loss}
             self._using_dummy_loss = True
             if metrics is not None and not isinstance(metrics, dict):
-                return_types = get_type_hints(self.call)["return"].__args__
-                output_types = [return_type for return_type in return_types if is_dataclass(return_type)]
+                type_hints = get_type_hints(self.call)
+                if "return" not in type_hints:
+                    output_types = []
+                else:
+                    return_types = get_type_hints(self.call)["return"].__args__
+                    output_types = [return_type for return_type in return_types if is_dataclass(return_type)]
                 if len(output_types) == 0:
                     raise TypeError(
-                        f"Code analysis failed to identify the output types of model f{type(self)}! "
+                        f"Code analysis failed to identify the output types of model {type(self)}! "
                         "This is most likely because that model class does not have type annotations. "
                         "Please pass a `dict` of metrics instead of a tuple/list, specifying the output "
                         "heads of the model for each metric."

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1959,7 +1959,7 @@ class TFSharedEmbeddings(tf.keras.layers.Layer):
         super().__init__(**kwargs)
         self.vocab_size = vocab_size
         self.hidden_size = hidden_size
-        self.initializer_range = hidden_size ** -0.5 if initializer_range is None else initializer_range
+        self.initializer_range = hidden_size**-0.5 if initializer_range is None else initializer_range
 
     def build(self, input_shape):
         """

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -901,8 +901,10 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         """
         if loss == "passthrough":
             if metrics is not None:
-                raise ValueError("Passing metrics as a dict is not supported when using the internal loss! "
-                                 "Please either specify a loss, or remove the metrics argument.")
+                raise ValueError(
+                    "Passing metrics as a dict is not supported when using the internal loss! "
+                    "Please either specify a loss, or remove the metrics argument."
+                )
             logger.warning(
                 "No loss specified in compile() - the model's internal loss computation will be used as the "
                 "loss. Don't panic - this is a common way to train TensorFlow models in Transformers! "
@@ -950,7 +952,14 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         When using this "dummy loss", inputs can be passed either as keys in the input dictionary, or as normal Keras
         labels.
         """
-        possible_label_cols = {"labels", "label", "label_ids", "start_positions", "end_positions", "next_sentence_label"}
+        possible_label_cols = {
+            "labels",
+            "label",
+            "label_ids",
+            "start_positions",
+            "end_positions",
+            "next_sentence_label",
+        }
         # These are the only transformations `Model.fit` applies to user-input
         # data when a `tf.data.Dataset` is provided.
         data = data_adapter.expand_1d(data)
@@ -1017,7 +1026,14 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         When using this "dummy loss", inputs can be passed either as keys in the input dictionary, or as normal Keras
         labels.
         """
-        possible_label_cols = {"labels", "label", "label_ids", "start_positions", "end_positions", "next_sentence_label"}
+        possible_label_cols = {
+            "labels",
+            "label",
+            "label_ids",
+            "start_positions",
+            "end_positions",
+            "next_sentence_label",
+        }
         # These are the only transformations `Model.fit` applies to user-input
         # data when a `tf.data.Dataset` is provided.
         data = data_adapter.expand_1d(data)

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1048,14 +1048,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         # Run backwards pass.
         self.optimizer.minimize(loss, self.trainable_variables, tape=tape)
         # When using dummy_loss, reorder things so the loss key isn't in position[0]
-        if isinstance(y_pred, ModelOutput) and self._using_dummy_loss:
+        if isinstance(y_pred, ModelOutput) and not isinstance(y, dict):
             output_keys = list(y_pred.keys())
-            if output_keys[0] == "loss" and y_pred.loss is not None:
-                reordered_keys = output_keys[1:] + output_keys[:1]
-                reordered_output = IndexableOrderedDict()
-                for key in reordered_keys:
-                    reordered_output[key] = y_pred[key]
-                y_pred = reordered_output
+
 
         self.compiled_metrics.update_state(y, y_pred, sample_weight)
         # Collect metrics to return

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -22,8 +22,7 @@ import pickle
 import re
 import warnings
 from collections import OrderedDict
-from dataclasses import fields, is_dataclass
-from typing import Dict, List, Optional, Union, get_type_hints
+from typing import Dict, List, Optional, Union
 
 import h5py
 import numpy as np

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -81,16 +81,6 @@ TFModelInputType = Union[
 def dummy_loss(y_true, y_pred):
     return tf.reduce_mean(y_pred)
 
-
-class IndexableOrderedDict(OrderedDict):
-    def __getitem__(self, item):
-        if isinstance(item, int):
-            key = list(self.keys())[item]
-            return super().__getitem__(key)
-        else:
-            return super().__getitem__(item)
-
-
 class TFModelUtilsMixin:
     """
     A few utilities for `tf.keras.Model`, to be used as a mixin.

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -81,6 +81,7 @@ TFModelInputType = Union[
 def dummy_loss(y_true, y_pred):
     return tf.reduce_mean(y_pred)
 
+
 class TFModelUtilsMixin:
     """
     A few utilities for `tf.keras.Model`, to be used as a mixin.

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -916,16 +916,29 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             self._using_dummy_loss = True
         else:
             self._using_dummy_loss = False
-        super().compile(
-            optimizer=optimizer,
-            loss=loss,
-            metrics=metrics,
-            loss_weights=loss_weights,
-            weighted_metrics=weighted_metrics,
-            run_eagerly=run_eagerly,
-            steps_per_execution=steps_per_execution,
-            **kwargs,
-        )
+        parent_args = list(inspect.signature(tf.keras.Model.compile).parameters.keys())
+        if "steps_per_execution" in parent_args:
+            super().compile(
+                optimizer=optimizer,
+                loss=loss,
+                metrics=metrics,
+                loss_weights=loss_weights,
+                weighted_metrics=weighted_metrics,
+                run_eagerly=run_eagerly,
+                steps_per_execution=steps_per_execution,
+                **kwargs,
+            )
+        else:
+            super().compile(
+                optimizer=optimizer,
+                loss=loss,
+                metrics=metrics,
+                loss_weights=loss_weights,
+                weighted_metrics=weighted_metrics,
+                run_eagerly=run_eagerly,
+                experimental_steps_per_execution=steps_per_execution,
+                **kwargs,
+            )
 
     def compute_loss(self, *args, **kwargs):
         if hasattr(tf.keras.Model, "compute_loss"):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -944,9 +944,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         A modification of Keras's default `train_step` that cleans up the printed metrics when we use a dummy loss. If
         a user specifies a loss at model compile time, this function behaves as the original Keras `train_step`.
 
-        When the model is compiled without specifying the loss, our overridden compile function can set a simple
-        dummy loss that just reads the loss output head of the model. When using this dummy loss, inputs can be
-        passed either as keys in the input dictionary, or as normal Keras labels.
+        When the model is compiled without specifying the loss, our overridden compile function can set a simple dummy
+        loss that just reads the loss output head of the model. When using this dummy loss, inputs can be passed either
+        as keys in the input dictionary, or as normal Keras labels.
         """
         possible_label_cols = {
             "labels",
@@ -1015,9 +1015,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         A modification of Keras's default `test_step` that cleans up the printed metrics when we use a dummy loss. If a
         user specifies a loss at model compile time, this function behaves as the original Keras `test_step`.
 
-        When the model is compiled without specifying the loss, our overridden compile function can set a simple
-        dummy loss that just reads the loss output head of the model. When using this dummy loss, inputs can be
-        passed either as keys in the input dictionary, or as normal Keras labels.
+        When the model is compiled without specifying the loss, our overridden compile function can set a simple dummy
+        loss that just reads the loss output head of the model. When using this dummy loss, inputs can be passed either
+        as keys in the input dictionary, or as normal Keras labels.
         """
         possible_label_cols = {
             "labels",

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -52,12 +52,12 @@ from .utils import (
     RevisionNotFoundError,
     cached_path,
     copy_func,
+    find_labels,
     has_file,
     hf_bucket_url,
     is_offline_mode,
     is_remote_url,
     logging,
-    find_labels,
 )
 
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -944,12 +944,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         A modification of Keras's default `train_step` that cleans up the printed metrics when we use a dummy loss. If
         a user specifies a loss at model compile time, this function behaves as the original Keras `train_step`.
 
-        When the model is compiled without specifying the loss, our overridden compile function can set an additional
-        loss function that reduces a `loss` output, and the model will output a `loss` component (notice the name
-        matching) containing the loss that was used to train the pre-trained model.
-
-        When using this "dummy loss", inputs can be passed either as keys in the input dictionary, or as normal Keras
-        labels.
+        When the model is compiled without specifying the loss, our overridden compile function can set a simple
+        dummy loss that just reads the loss output head of the model. When using this dummy loss, inputs can be
+        passed either as keys in the input dictionary, or as normal Keras labels.
         """
         possible_label_cols = {
             "labels",
@@ -994,7 +991,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         # Run backwards pass.
         self.optimizer.minimize(loss, self.trainable_variables, tape=tape)
 
-        # When using the dummy_loss we match up structures before passing to metrics, so it doesn't get confused
+        # When using the dummy_loss we know metrics are not present, so we can skip a lot of this
         if self._using_dummy_loss:
             self.compiled_metrics.update_state(y_pred.loss, y_pred.loss, sample_weight)
         else:
@@ -1018,12 +1015,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         A modification of Keras's default `test_step` that cleans up the printed metrics when we use a dummy loss. If a
         user specifies a loss at model compile time, this function behaves as the original Keras `test_step`.
 
-        When the model is compiled without specifying the loss, our overridden compile function can set an additional
-        loss function that reduces a `loss` output, and the model will output a `loss` component (notice the name
-        matching) containing the loss that was used to train the pre-trained model.
-
-        When using this "dummy loss", inputs can be passed either as keys in the input dictionary, or as normal Keras
-        labels.
+        When the model is compiled without specifying the loss, our overridden compile function can set a simple
+        dummy loss that just reads the loss output head of the model. When using this dummy loss, inputs can be
+        passed either as keys in the input dictionary, or as normal Keras labels.
         """
         possible_label_cols = {
             "labels",
@@ -1065,7 +1059,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         else:
             self.compiled_loss(y, y_pred, sample_weight, regularization_losses=self.losses)
 
-        # When using the dummy_loss we match up structures before passing to metrics, so it doesn't get confused
+        # When using the dummy_loss we know metrics are not present, so we can skip a lot of this
         if self._using_dummy_loss:
             self.compiled_metrics.update_state(y_pred.loss, y_pred.loss, sample_weight)
         else:

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -903,7 +903,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                 raise ValueError(
                     "Passing metrics as a dict is not supported when using the internal loss! "
                     "Please either compile the model with a loss, or remove the metrics argument. "
-                    "Note that advanced metrics using the KerasMetricCallback can still be used with the internal "
+                    "Note that advanced metrics using the `KerasMetricCallback` can still be used with the internal "
                     "loss."
                 )
             logger.warning(

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1959,7 +1959,7 @@ class TFSharedEmbeddings(tf.keras.layers.Layer):
         super().__init__(**kwargs)
         self.vocab_size = vocab_size
         self.hidden_size = hidden_size
-        self.initializer_range = hidden_size**-0.5 if initializer_range is None else initializer_range
+        self.initializer_range = hidden_size ** -0.5 if initializer_range is None else initializer_range
 
     def build(self, input_shape):
         """

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/test_modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/test_modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -952,6 +952,10 @@ class TF{{cookiecutter.camelcase_modelname}}ModelTest(TFModelTesterMixin, unitte
                                 models_equal = False
                     self.assertTrue(models_equal)
 
+    @unittest.skip(reason="Template classes interact badly with this test.")
+    def test_keras_fit(self):
+        pass
+
 
 def _assert_tensors_equal(a, b, atol=1e-12, prefix=""):
     """If tensors not close, or a and b arent both tensors, raise a nice Assertion error."""

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/test_modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/test_modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -259,6 +259,7 @@ class TF{{cookiecutter.camelcase_modelname}}ModelTester:
             list(prediction_scores.numpy().shape), [self.batch_size, self.seq_length, self.vocab_size]
         )
 
+
     def create_and_check_causal_lm_model_past(
         self,
         config,
@@ -596,6 +597,10 @@ class TF{{cookiecutter.camelcase_modelname}}ModelTest(TFModelTesterMixin, unitte
         """Test the base model"""
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
+
+    @unittest.skip(reason="Template classes interact badly with this test.")
+    def test_keras_fit(self):
+        pass
 
     def test_causal_lm_base_model(self):
         """Test the base model of the causal LM model

--- a/tests/convnext/test_modeling_tf_convnext.py
+++ b/tests/convnext/test_modeling_tf_convnext.py
@@ -143,7 +143,7 @@ class TFConvNextModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_inputs_embeds(self):
         pass
 
-    @unittest.skipIf(
+    @unittest.skipIf(not is_tf_available() or
         len(tf.config.list_physical_devices("GPU")) == 0,
         reason="TF (<=2.8) does not support backprop for grouped convolutions on CPU.",
     )

--- a/tests/convnext/test_modeling_tf_convnext.py
+++ b/tests/convnext/test_modeling_tf_convnext.py
@@ -143,6 +143,10 @@ class TFConvNextModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_inputs_embeds(self):
         pass
 
+    @unittest.skip(reason="TF (<=2.8) does not support backprop for grouped convolutions on CPU.")
+    def test_keras_fit(self):
+        pass
+
     @unittest.skip(reason="ConvNext does not support input and output embeddings")
     def test_model_common_attributes(self):
         pass

--- a/tests/convnext/test_modeling_tf_convnext.py
+++ b/tests/convnext/test_modeling_tf_convnext.py
@@ -143,8 +143,8 @@ class TFConvNextModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_inputs_embeds(self):
         pass
 
-    @unittest.skipIf(not is_tf_available() or
-        len(tf.config.list_physical_devices("GPU")) == 0,
+    @unittest.skipIf(
+        not is_tf_available() or len(tf.config.list_physical_devices("GPU")) == 0,
         reason="TF (<=2.8) does not support backprop for grouped convolutions on CPU.",
     )
     def test_keras_fit(self):

--- a/tests/convnext/test_modeling_tf_convnext.py
+++ b/tests/convnext/test_modeling_tf_convnext.py
@@ -143,7 +143,10 @@ class TFConvNextModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_inputs_embeds(self):
         pass
 
-    @unittest.skip(reason="TF (<=2.8) does not support backprop for grouped convolutions on CPU.")
+    @unittest.skipIf(
+        len(tf.config.list_physical_devices("GPU")) == 0,
+        reason="TF (<=2.8) does not support backprop for grouped convolutions on CPU.",
+    )
     def test_keras_fit(self):
         pass
 

--- a/tests/t5/test_modeling_tf_t5.py
+++ b/tests/t5/test_modeling_tf_t5.py
@@ -820,7 +820,7 @@ class TFT5ModelIntegrationTests(unittest.TestCase):
                 super().__init__(_accuracy, name=name, **kwargs)
 
         model = self.model
-        model.compile("adam", loss='sparse_categorical_crossentropy', metrics=FirstTokenAccuracy())
+        model.compile("adam", loss="sparse_categorical_crossentropy", metrics=FirstTokenAccuracy())
         tokenizer = T5Tokenizer.from_pretrained("t5-small")
 
         examples = [

--- a/tests/t5/test_modeling_tf_t5.py
+++ b/tests/t5/test_modeling_tf_t5.py
@@ -820,7 +820,7 @@ class TFT5ModelIntegrationTests(unittest.TestCase):
                 super().__init__(_accuracy, name=name, **kwargs)
 
         model = self.model
-        model.compile("adam", metrics={"logits": FirstTokenAccuracy()})
+        model.compile("adam", metrics=FirstTokenAccuracy())
         tokenizer = T5Tokenizer.from_pretrained("t5-small")
 
         examples = [

--- a/tests/t5/test_modeling_tf_t5.py
+++ b/tests/t5/test_modeling_tf_t5.py
@@ -820,7 +820,7 @@ class TFT5ModelIntegrationTests(unittest.TestCase):
                 super().__init__(_accuracy, name=name, **kwargs)
 
         model = self.model
-        model.compile("adam", metrics=FirstTokenAccuracy())
+        model.compile("adam", loss='sparse_categorical_crossentropy', metrics=FirstTokenAccuracy())
         tokenizer = T5Tokenizer.from_pretrained("t5-small")
 
         examples = [

--- a/tests/t5/test_modeling_tf_t5.py
+++ b/tests/t5/test_modeling_tf_t5.py
@@ -804,33 +804,3 @@ class TFT5ModelIntegrationTests(unittest.TestCase):
         translation = tok.decode(output[0], skip_special_tokens=True, clean_up_tokenization_spaces=False)
 
         self.assertEqual(translation, expected_translation)
-
-    def test_finetune_keras_trainer(self):
-        """Ensure that the model can be fine-tuned via the keras API and
-        that metrics work as expected.
-        """
-
-        # This metric expects to be called with the logits output
-        def _accuracy(y_true, y_pred):
-            return tf.keras.metrics.sparse_categorical_crossentropy(y_true[:, 0], y_pred[:, 0])
-
-        # measure the accuracy of the first token
-        class FirstTokenAccuracy(tf.keras.metrics.MeanMetricWrapper):
-            def __init__(self, name="accuracy", **kwargs):
-                super().__init__(_accuracy, name=name, **kwargs)
-
-        model = self.model
-        model.compile("adam", loss="sparse_categorical_crossentropy", metrics=FirstTokenAccuracy())
-        tokenizer = T5Tokenizer.from_pretrained("t5-small")
-
-        examples = [
-            ("sentiment: Everything is awesome!", "positive"),
-            ("sentiment: Tensorflow datasets are hard to use", "negative"),
-        ]
-
-        inputs = dict(tokenizer([x[0] for x in examples], padding=True, return_tensors="tf"))
-        inputs["labels"] = tokenizer([x[1] for x in examples], return_tensors="tf").input_ids
-
-        model.fit(inputs)
-        m = model.evaluate(inputs)
-        self.assertEqual(len(m), 2)

--- a/tests/t5/test_modeling_tf_t5.py
+++ b/tests/t5/test_modeling_tf_t5.py
@@ -820,7 +820,7 @@ class TFT5ModelIntegrationTests(unittest.TestCase):
                 super().__init__(_accuracy, name=name, **kwargs)
 
         model = self.model
-        model.compile("adam", metrics=FirstTokenAccuracy())
+        model.compile("adam", metrics={"logits": FirstTokenAccuracy()})
         tokenizer = T5Tokenizer.from_pretrained("t5-small")
 
         examples = [

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1323,12 +1323,19 @@ class TFModelTesterMixin:
                 self.assertGreater(len(label_names), 0, msg="No matching label names found!")
                 labels = {key: val for key, val in prepared_for_class.items() if key in label_names}
                 inputs_minus_labels = {key: val for key, val in prepared_for_class.items() if key not in label_names}
-                model.compile(optimizer='sgd')
+                model.compile(optimizer="sgd")
                 # Make sure the model fits without crashing regardless of where we pass the labels
-                model.fit(prepared_for_class, validation_data=prepared_for_class, steps_per_epoch=1, validation_steps=1)
+                model.fit(
+                    prepared_for_class, validation_data=prepared_for_class, steps_per_epoch=1, validation_steps=1
+                )
 
-                model.fit(inputs_minus_labels, labels, validation_data=(inputs_minus_labels, labels),
-                          steps_per_epoch=1, validation_steps=1)
+                model.fit(
+                    inputs_minus_labels,
+                    labels,
+                    validation_data=(inputs_minus_labels, labels),
+                    steps_per_epoch=1,
+                    validation_steps=1,
+                )
 
     def test_generate_with_headmasking(self):
         attention_names = ["encoder_attentions", "decoder_attentions", "cross_attentions"]

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1324,23 +1324,26 @@ class TFModelTesterMixin:
                 labels = {key: val for key, val in prepared_for_class.items() if key in label_names}
                 inputs_minus_labels = {key: val for key, val in prepared_for_class.items() if key not in label_names}
                 self.assertGreater(len(inputs_minus_labels), 0)
-                model.compile(optimizer=tf.keras.optimizers.SGD(0.), run_eagerly=True)
+                model.compile(optimizer=tf.keras.optimizers.SGD(0.0), run_eagerly=True)
                 # Make sure the model fits without crashing regardless of where we pass the labels
                 history1 = model.fit(
-                    prepared_for_class, validation_data=prepared_for_class, steps_per_epoch=1, validation_steps=1,
-                    shuffle=False
+                    prepared_for_class,
+                    validation_data=prepared_for_class,
+                    steps_per_epoch=1,
+                    validation_steps=1,
+                    shuffle=False,
                 )
-                val_loss1 = history1.history['val_loss'][0]
+                val_loss1 = history1.history["val_loss"][0]
                 history2 = model.fit(
                     inputs_minus_labels,
                     labels,
                     validation_data=(inputs_minus_labels, labels),
                     steps_per_epoch=1,
                     validation_steps=1,
-                    shuffle=False
+                    shuffle=False,
                 )
-                val_loss2 = history2.history['val_loss'][0]
-                self.AssertTrue(np.allclose(val_loss1, val_loss2, atol=1e-4, rtol=1e-3))
+                val_loss2 = history2.history["val_loss"][0]
+                self.assertTrue(np.allclose(val_loss1, val_loss2, atol=1e-2, rtol=1e-3))
 
     def test_generate_with_headmasking(self):
         attention_names = ["encoder_attentions", "decoder_attentions", "cross_attentions"]

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1302,6 +1302,34 @@ class TFModelTesterMixin:
 
                 self.assertEqual(loss.shape, [loss_size])
 
+    def test_keras_api(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            if getattr(model, "hf_compute_loss", None):
+                # Test that model correctly compute the loss with kwargs
+                prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
+                possible_label_cols = {
+                    "labels",
+                    "label",
+                    "label_ids",
+                    "start_positions",
+                    "start_position",
+                    "end_positions",
+                    "end_position",
+                    "next_sentence_label",
+                }
+                label_names = possible_label_cols.intersection(set(prepared_for_class))
+                self.assertGreater(len(label_names), 0, msg="No matching label names found!")
+                labels = {key: val for key, val in prepared_for_class.items() if key in label_names}
+                inputs_minus_labels = {key: val for key, val in prepared_for_class.items() if key not in label_names}
+                model.compile(optimizer='sgd')
+                # Make sure the model fits without crashing regardless of where we pass the labels
+                model.fit(prepared_for_class, validation_data=prepared_for_class, steps_per_epoch=1, validation_steps=1)
+
+                model.fit(inputs_minus_labels, labels, validation_data=(inputs_minus_labels, labels),
+                          steps_per_epoch=1, validation_steps=1)
+
     def test_generate_with_headmasking(self):
         attention_names = ["encoder_attentions", "decoder_attentions", "cross_attentions"]
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1309,6 +1309,12 @@ class TFModelTesterMixin:
             if getattr(model, "hf_compute_loss", None):
                 # Test that model correctly compute the loss with kwargs
                 prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
+                prepared_for_class = {
+                    key: val
+                    for key, val in prepared_for_class.items()
+                    if key not in ("head_mask", "decoder_head_mask", "cross_attn_head_mask", "decoder_input_ids")
+                }
+
                 possible_label_cols = {
                     "labels",
                     "label",

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1309,6 +1309,7 @@ class TFModelTesterMixin:
             if getattr(model, "hf_compute_loss", None):
                 # Test that model correctly compute the loss with kwargs
                 prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
+                # Is there a better way to remove these decoder inputs?
                 prepared_for_class = {
                     key: val
                     for key, val in prepared_for_class.items()


### PR DESCRIPTION
Change to `train_step` I discussed earlier with @gante, making the new TF approaches less confusing for users.

This PR is **extremely** experimental right now, and since it touches `train_step` it could break the entire TF side of the library, so please don't merge it until I'm done!