### PR TITLE
Update for doc-builder -> hf-doc-utils

### DIFF
--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          repository: 'huggingface/doc-builder'
-          path: doc-builder
+          repository: 'huggingface/hf-doc-utils'
+          path: hf-doc-utils
 
       - uses: actions/checkout@v2
         with:
@@ -46,8 +46,8 @@ jobs:
           rm -rf doc-build-dev
           git clone --depth 1 https://HuggingFaceDocBuilderDev:${{ env.WRITE }}@github.com/huggingface/doc-build-dev
           
-          pip uninstall -y doc-builder
-          cd doc-builder
+          pip uninstall -y hf-doc-utils
+          cd hf-doc-utils
           git pull origin main
           pip install -e .
           cd ..
@@ -97,8 +97,8 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=6656
         run: |
           cd doc-build-dev && git pull
-          cd ../doc-builder
-          doc-builder build transformers ../transformers/docs/source --build_dir ../doc-build-dev --notebook_dir ../notebooks/transformers_doc --clean --version pr_$PR_NUMBER --html
+          cd ../hf-doc-utils
+          hf-doc-utils build transformers ../transformers/docs/source --build_dir ../doc-build-dev --notebook_dir ../notebooks/transformers_doc --clean --version pr_$PR_NUMBER --html
 
       - name: Push to repositories
         run: |

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -21,8 +21,8 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          repository: 'huggingface/doc-builder'
-          path: doc-builder
+          repository: 'huggingface/hf-doc-utils'
+          path: hf-doc-utils
 
       - uses: actions/checkout@v2
         with:
@@ -55,7 +55,7 @@ jobs:
         run: |
           sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev
 
-          pip install git+https://github.com/huggingface/doc-builder
+          pip install git+https://github.com/huggingface/hf-doc-utils
           cd transformers
           pip install .[dev]
           cd ..
@@ -86,8 +86,8 @@ jobs:
 
       - name: Make documentation
         run: |
-          cd doc-builder &&
-          doc-builder build transformers ../transformers/docs/source --build_dir ../doc-build --notebook_dir notebooks/transformers_doc --clean --html &&
+          cd hf-doc-utils &&
+          hf-doc-utils build transformers ../transformers/docs/source --build_dir ../doc-build --notebook_dir notebooks/transformers_doc --clean --html &&
           cd ..
         env:
           NODE_OPTIONS: --max-old-space-size=6656

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ pip install -e ".[docs]"
 Then you need to install our special tool that builds the documentation:
 
 ```bash
-pip install git+https://github.com/huggingface/doc-builder
+pip install git+https://github.com/huggingface/hf-doc-utils
 ```
 
 ---
@@ -39,11 +39,11 @@ check how they look like before committing for instance). You don't have to comm
 
 ## Building the documentation
 
-Once you have setup the `doc-builder` and additional packages, you can generate the documentation by 
+Once you have setup the `hf-doc-utilsr` and additional packages, you can generate the documentation by 
 typing the following command:
 
 ```bash
-doc-builder build transformers docs/source/ --build_dir ~/tmp/test-build
+hf-doc-utils build transformers docs/source/ --build_dir ~/tmp/test-build
 ```
 
 You can adapt the `--build_dir` to set any temporary folder that you prefer. This command will create it and generate


### PR DESCRIPTION
# What does this PR do?

This PR deals with the upcoming rename of `doc-builder` to `hf-doc-utils`. Should be merged at the same time as the rename happens.