### PR TITLE
Removed an outdated check about hdf5_version

### DIFF
--- a/tests/auto/test_modeling_tf_pytorch.py
+++ b/tests/auto/test_modeling_tf_pytorch.py
@@ -72,8 +72,6 @@ if is_torch_available():
 class TFPTAutoModelTest(unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
-        import h5py
-
         # for model_name in TF_BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
         for model_name in ["bert-base-uncased"]:
             config = AutoConfig.from_pretrained(model_name)
@@ -90,8 +88,6 @@ class TFPTAutoModelTest(unittest.TestCase):
 
     @slow
     def test_model_for_pretraining_from_pretrained(self):
-        import h5py
-
         # for model_name in TF_BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
         for model_name in ["bert-base-uncased"]:
             config = AutoConfig.from_pretrained(model_name)

--- a/tests/auto/test_modeling_tf_pytorch.py
+++ b/tests/auto/test_modeling_tf_pytorch.py
@@ -74,8 +74,6 @@ class TFPTAutoModelTest(unittest.TestCase):
     def test_model_from_pretrained(self):
         import h5py
 
-        self.assertTrue(h5py.version.hdf5_version.startswith("1.10"))
-
         # for model_name in TF_BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
         for model_name in ["bert-base-uncased"]:
             config = AutoConfig.from_pretrained(model_name)
@@ -93,8 +91,6 @@ class TFPTAutoModelTest(unittest.TestCase):
     @slow
     def test_model_for_pretraining_from_pretrained(self):
         import h5py
-
-        self.assertTrue(h5py.version.hdf5_version.startswith("1.10"))
 
         # for model_name in TF_BERT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
         for model_name in ["bert-base-uncased"]:


### PR DESCRIPTION
# What does this PR do?

Remove a check `self.assertTrue(h5py.version.hdf5_version.startswith("1.10"))` which is outdated and makes the CI daily test fail.

@LysandreJik @sgugger 