### PR TITLE
Build the doc in a seperate folder then move it

### DIFF
--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -96,19 +96,18 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=6656
         run: |
-          cd doc-build-dev && git pull
-          cd ../doc-builder
-          doc-builder build transformers ../transformers/docs/source --build_dir ../doc-build-dev --notebook_dir ../notebooks/transformers_doc --clean --version pr_$PR_NUMBER --html
+          doc-builder build transformers transformers/docs/source --build_dir build_dir --clean --version pr_$PR_NUMBER --html
 
       - name: Push to repositories
         run: |
           cd doc-build-dev
-          ls
+          git pull
+          rm -rf transformers/pr_$PR_NUMBER
+          mv ../build_dir/transformers/pr_$PR_NUMBER transformers/pr_$PR_NUMBER
           git status
 
           if [[ `git status --porcelain` ]]; then
             git add .
-            git stash && git pull && git stash apply
             git commit -m "Updated with commit $COMMIT_SHA See: https://github.com/huggingface/transformers/commit/$COMMIT_SHA"
             git push origin main
           else

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -89,12 +89,12 @@ jobs:
         run: |
           cd doc-build &&
           git pull &&
-          mv ../builder_dir/transformers . &&
+          cp -r ../builder_dir/transformers . &&
           git status &&
           cd .. &&
 
           cd notebooks &&
           git pull &&
-          mv ../notebooks_dir transformers_doc &&
+          cp -r ../notebooks_dir/. transformers_doc &&
           git status &&
           cd ..

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Make documentation
         run: |
           cd doc-builder &&
-          doc-builder build transformers ../transformers/docs/source --build_dir ../build_dir --notebook_dir notebooks_dir --clean --html &&
+          doc-builder build transformers ../transformers/docs/source --build_dir ../build_dir --notebook_dir ../notebooks_dir --clean --html &&
           cd ..
         env:
           NODE_OPTIONS: --max-old-space-size=6656
@@ -90,27 +90,11 @@ jobs:
           cd doc-build &&
           git pull &&
           mv ../builder_dir/transformers . &&
-          git status
-
-#          if [[ `git status --porcelain` ]]; then 
-#            git add . &&
-#            git stash && git pull && git stash apply &&
-#            git commit -m "Updated with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/transformers/commit/${{ github.sha }}" &&
-#            git push origin main
-#          else
-#            echo "No diff in the documentation."
-#          fi &&
+          git status &&
           cd .. &&
 
           cd notebooks &&
           git pull &&
           mv ../notebooks_dir transformers_doc &&
-          git status
-#          if [[ `git status --porcelain` ]]; then
-#            git add transformers_doc &&
-#            git commit -m "Updated Transformer doc notebooks with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/transformers/commit/${{ github.sha }}" &&
-#            git push origin master
-#          else
-#            echo "No diff in the notebooks."
-#          fi &&
+          git status &&
           cd ..

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -88,7 +88,7 @@ jobs:
           
       - name: Make documentation
         run: |
-          doc-builder build transformers transformers/docs/source --build_dir build_dir --notebook_dir notebooks_dir --clean --html &&
+          doc-builder build transformers transformers/docs/source --build_dir build_dir --notebook_dir notebooks_dir --clean --html
         env:
           NODE_OPTIONS: --max-old-space-size=6656
 

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -89,9 +89,9 @@ jobs:
         run: |
           cd doc-build &&
           git pull &&
-          VERSION = $(ls ../builder_dir/transformers) &&
+          VERSION = $(ls ../build_dir/transformers) &&
           rm -rf transformers/$VERSION &&
-          mv ../builder_dir/transformers/$VERSION transformers/$VERSION &&
+          mv ../build_dir/transformers/$VERSION transformers/$VERSION &&
           git status &&
           cd .. &&
 

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -76,12 +76,18 @@ jobs:
         run: |
           git config --global user.name "Hugging Face Doc Builder"
           git config --global user.email docs@huggingface.co
+      
+      - name: Create build directory
+          cd doc-build
+          git pull
+          cd ..
+          mkdir build_dir
+          mkdir build_dir/transformers
+          cp doc-build/transformers/_versions.yml build_dir/transformers
           
       - name: Make documentation
         run: |
-          cd doc-builder &&
-          doc-builder build transformers ../transformers/docs/source --build_dir ../build_dir --notebook_dir ../notebooks_dir --clean --html &&
-          cd ..
+          doc-builder build transformers transformers/docs/source --build_dir build_dir --notebook_dir notebooks_dir --clean --html &&
         env:
           NODE_OPTIONS: --max-old-space-size=6656
 
@@ -89,6 +95,7 @@ jobs:
         run: |
           cd doc-build
           git pull
+          mv ../build_dir/transformers/_versions.yml transformers/
           rm -rf transformers/$(ls ../build_dir/transformers)
           mv ../build_dir/transformers/$(ls ../build_dir/transformers) transformers/$(ls ../build_dir/transformers)
           git status
@@ -96,6 +103,6 @@ jobs:
 
           cd notebooks
           git pull
-          cp -r ../notebooks_dir/. transformers_doc
+          cp -r ../notebook_dir/. transformers_doc/
           git status
           cd ..

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -88,7 +88,9 @@ jobs:
           
       - name: Make documentation
         run: |
-          doc-builder build transformers transformers/docs/source --build_dir build_dir --notebook_dir notebooks_dir --clean --html
+          cd doc-builder &&
+          doc-builder build transformers ../transformers/docs/source --build_dir ../build_dir --notebook_dir ../notebooks_dir --clean --html &&
+          cd ..
         env:
           NODE_OPTIONS: --max-old-space-size=6656
 

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -89,7 +89,9 @@ jobs:
         run: |
           cd doc-build &&
           git pull &&
-          cp -r ../builder_dir/transformers . &&
+          VERSION = $(ls ../builder_dir/transformers) &&
+          rm -rf transformers/$VERSION &&
+          mv ../builder_dir/transformers/$VERSION transformers/$VERSION &&
           git status &&
           cd .. &&
 

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -99,10 +99,28 @@ jobs:
           rm -rf transformers/$(ls ../build_dir/transformers)
           mv ../build_dir/transformers/$(ls ../build_dir/transformers) transformers/$(ls ../build_dir/transformers)
           git status
+
+          if [[ `git status --porcelain` ]]; then 
+            git add .
+            git commit -m "Updated with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/transformers/commit/${{ github.sha }}"
+            git push origin main
+          else
+            echo "No diff in the documentation."
+          fi
+
           cd ..
 
           cd notebooks
           git pull
           cp -r ../notebook_dir/. transformers_doc/
           git status
+
+          if [[ `git status --porcelain` ]]; then
+            git add transformers_doc
+            git commit -m "Updated Transformer doc notebooks with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/transformers/commit/${{ github.sha }}" &&
+            git push origin master
+          else
+            echo "No diff in the notebooks."
+          fi
+
           cd ..

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -87,16 +87,15 @@ jobs:
 
       - name: Push to repositories
         run: |
-          cd doc-build &&
-          git pull &&
-          VERSION = $(ls ../build_dir/transformers) &&
-          rm -rf transformers/$VERSION &&
-          mv ../build_dir/transformers/$VERSION transformers/$VERSION &&
-          git status &&
-          cd .. &&
+          cd doc-build
+          git pull
+          rm -rf transformers/$(ls ../build_dir/transformers)
+          mv ../build_dir/transformers/$(ls ../build_dir/transformers) transformers/$(ls ../build_dir/transformers)
+          git status
+          cd ..
 
-          cd notebooks &&
-          git pull &&
-          cp -r ../notebooks_dir/. transformers_doc &&
-          git status &&
+          cd notebooks
+          git pull
+          cp -r ../notebooks_dir/. transformers_doc
+          git status
           cd ..

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -115,7 +115,7 @@ jobs:
 
           cd notebooks
           git pull
-          cp -r ../notebook_dir/. transformers_doc/
+          cp -r ../notebooks_dir/. transformers_doc/
           git status
 
           if [[ `git status --porcelain` ]]; then

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -78,6 +78,7 @@ jobs:
           git config --global user.email docs@huggingface.co
       
       - name: Create build directory
+        run: |
           cd doc-build
           git pull
           cd ..

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -90,7 +90,7 @@ jobs:
           cd doc-build &&
           git pull &&
           mv ../builder_dir/transformers . &&
-          git status &&
+          git status
 
 #          if [[ `git status --porcelain` ]]; then 
 #            git add . &&
@@ -105,7 +105,7 @@ jobs:
           cd notebooks &&
           git pull &&
           mv ../notebooks_dir transformers_doc &&
-          git status &&
+          git status
 #          if [[ `git status --porcelain` ]]; then
 #            git add transformers_doc &&
 #            git commit -m "Updated Transformer doc notebooks with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/transformers/commit/${{ github.sha }}" &&

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - doc_builder*
       - doc-builder*
       - v*-release
 

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -76,18 +76,10 @@ jobs:
           git config --global user.name "Hugging Face Doc Builder"
           git config --global user.email docs@huggingface.co
           
-          cd doc-build
-          git pull origin main
-          cd ..
-
-          cd notebooks
-          git pull origin master
-          cd ..
-
       - name: Make documentation
         run: |
           cd doc-builder &&
-          doc-builder build transformers ../transformers/docs/source --build_dir ../doc-build --notebook_dir notebooks/transformers_doc --clean --html &&
+          doc-builder build transformers ../transformers/docs/source --build_dir ../build_dir --notebook_dir notebooks_dir --clean --html &&
           cd ..
         env:
           NODE_OPTIONS: --max-old-space-size=6656
@@ -95,22 +87,29 @@ jobs:
       - name: Push to repositories
         run: |
           cd doc-build &&
-          if [[ `git status --porcelain` ]]; then 
-            git add . &&
-            git stash && git pull && git stash apply &&
-            git commit -m "Updated with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/transformers/commit/${{ github.sha }}" &&
-            git push origin main
-          else
-            echo "No diff in the documentation."
-          fi &&
+          git pull &&
+          mv ../builder_dir/transformers . &&
+          git status &&
+
+#          if [[ `git status --porcelain` ]]; then 
+#            git add . &&
+#            git stash && git pull && git stash apply &&
+#            git commit -m "Updated with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/transformers/commit/${{ github.sha }}" &&
+#            git push origin main
+#          else
+#            echo "No diff in the documentation."
+#          fi &&
           cd .. &&
 
           cd notebooks &&
-          if [[ `git status --porcelain` ]]; then
-            git add transformers_doc &&
-            git commit -m "Updated Transformer doc notebooks with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/transformers/commit/${{ github.sha }}" &&
-            git push origin master
-          else
-            echo "No diff in the notebooks."
-          fi &&
+          git pull &&
+          mv ../notebooks_dir transformers_doc &&
+          git status &&
+#          if [[ `git status --porcelain` ]]; then
+#            git add transformers_doc &&
+#            git commit -m "Updated Transformer doc notebooks with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/transformers/commit/${{ github.sha }}" &&
+#            git push origin master
+#          else
+#            echo "No diff in the notebooks."
+#          fi &&
           cd ..


### PR DESCRIPTION
# What does this PR do?

To fix the issue pointed out in #16019 this removes the need for stashing by:
- building the doc in a folder outside any repos
- pull the distant repos once the doc build is finished
- then move other the built doc to those repos and push

TODO: the dev job as well once the main job has been tested