### PR TITLE
Make BigBird model compatiable to fp16 dtype.

### DIFF
--- a/src/transformers/models/big_bird/modeling_big_bird.py
+++ b/src/transformers/models/big_bird/modeling_big_bird.py
@@ -23,10 +23,10 @@ from typing import Optional, Tuple
 import numpy as np
 import torch
 import torch.utils.checkpoint
-from torch.utils._pytree import tree_map
 from packaging import version
 from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
+from torch.utils._pytree import tree_map
 
 from ...activations import ACT2FN
 from ...file_utils import (

--- a/src/transformers/models/big_bird/modeling_big_bird.py
+++ b/src/transformers/models/big_bird/modeling_big_bird.py
@@ -1397,6 +1397,7 @@ class BigBirdAttention(nn.Module):
                 hidden_states, band_mask, from_mask, to_mask, from_blocked_mask, to_blocked_mask, output_attentions
             )
 
+        self_outputs = tuple(map(lambda x: x.to(hidden_states.dtype), self_outputs)) # fp16 compatibility
         attention_output = self.output(self_outputs[0], hidden_states)
         outputs = (attention_output,) + self_outputs[1:]  # add attentions if we output them
         return outputs

--- a/src/transformers/models/big_bird/modeling_big_bird.py
+++ b/src/transformers/models/big_bird/modeling_big_bird.py
@@ -23,6 +23,7 @@ from typing import Optional, Tuple
 import numpy as np
 import torch
 import torch.utils.checkpoint
+from torch.utils._pytree import tree_map
 from packaging import version
 from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
@@ -1397,7 +1398,7 @@ class BigBirdAttention(nn.Module):
                 hidden_states, band_mask, from_mask, to_mask, from_blocked_mask, to_blocked_mask, output_attentions
             )
 
-        self_outputs = tuple(map(lambda x: x.to(hidden_states.dtype), self_outputs)) # fp16 compatibility
+        self_outputs = tuple(tree_map(lambda x: x.to(hidden_states.dtype) if isinstance(x, torch.Tensor) else x, self_outputs)) # fp16 compatibility
         attention_output = self.output(self_outputs[0], hidden_states)
         outputs = (attention_output,) + self_outputs[1:]  # add attentions if we output them
         return outputs

--- a/src/transformers/models/big_bird/modeling_big_bird.py
+++ b/src/transformers/models/big_bird/modeling_big_bird.py
@@ -1398,7 +1398,9 @@ class BigBirdAttention(nn.Module):
                 hidden_states, band_mask, from_mask, to_mask, from_blocked_mask, to_blocked_mask, output_attentions
             )
 
-        self_outputs = tuple(tree_map(lambda x: x.to(hidden_states.dtype) if isinstance(x, torch.Tensor) else x, self_outputs)) # fp16 compatibility
+        self_outputs = tuple(
+            tree_map(lambda x: x.to(hidden_states.dtype) if isinstance(x, torch.Tensor) else x, self_outputs)
+        )  # fp16 compatibility
         attention_output = self.output(self_outputs[0], hidden_states)
         outputs = (attention_output,) + self_outputs[1:]  # add attentions if we output them
         return outputs

--- a/src/transformers/models/big_bird/modeling_big_bird.py
+++ b/src/transformers/models/big_bird/modeling_big_bird.py
@@ -26,7 +26,6 @@ import torch.utils.checkpoint
 from packaging import version
 from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
-from torch.utils._pytree import tree_map
 
 from ...activations import ACT2FN
 from ...file_utils import (
@@ -1380,12 +1379,12 @@ class BigBirdAttention(nn.Module):
         to_blocked_mask=None,
     ):
         # fp16 compatibility
-        def convert_dtype(mask):
-            return tree_map(lambda x: x.to(hidden_states.dtype) if isinstance(x, torch.Tensor) else x, mask)
-
-        band_mask = convert_dtype(band_mask)
-        from_mask = convert_dtype(from_mask)
-        to_mask = convert_dtype(to_mask)
+        if band_mask is not None:
+            band_mask = band_mask.to(hidden_states.dtype)
+        if from_mask is not None:
+            from_mask = from_mask.to(hidden_states.dtype)
+        if to_mask is not None:
+            to_mask = to_mask.to(hidden_states.dtype)
 
         if self.attention_type == "original_full":
             self_outputs = self.self(

--- a/src/transformers/models/big_bird/modeling_big_bird.py
+++ b/src/transformers/models/big_bird/modeling_big_bird.py
@@ -1382,6 +1382,7 @@ class BigBirdAttention(nn.Module):
         # fp16 compatibility
         def convert_dtype(mask):
             return tree_map(lambda x: x.to(hidden_states.dtype) if isinstance(x, torch.Tensor) else x, mask)
+
         band_mask = convert_dtype(band_mask)
         from_mask = convert_dtype(from_mask)
         to_mask = convert_dtype(to_mask)


### PR DESCRIPTION
# What does this PR do?

Currently, the BigBird model doesn't support fp16 data type with a `.half()` call.
For example, the following code snippet:

```python
from transformers import *
import torch

if __name__ == "__main__":
  device = 'cuda'
  config = BigBirdConfig(attention_type="block_sparse",)
  model = AutoModelForMaskedLM.from_config(config).to(device)
  eval_context = torch.randint(0, config.vocab_size, (1, 4096)).to(device)
  example_inputs = {'input_ids': eval_context, }
  model = model.half()
  model(**example_inputs)
```
will fail with the following error message:

```
Traceback (most recent call last):
  File "1.py", line 11, in <module>
    model(**example_inputs)
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/transformers/models/big_bird/modeling_big_bird.py", line 2351, in forward
    outputs = self.bert(
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/transformers/models/big_bird/modeling_big_bird.py", line 2081, in forward
    encoder_outputs = self.encoder(
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/transformers/models/big_bird/modeling_big_bird.py", line 1615, in forward
    layer_outputs = layer_module(
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/transformers/models/big_bird/modeling_big_bird.py", line 1467, in forward
    self_attention_outputs = self.attention(
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/transformers/models/big_bird/modeling_big_bird.py", line 1385, in forward
    attention_output = self.output(self_outputs[0], hidden_states)
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/transformers/models/big_bird/modeling_big_bird.py", line 1300, in forward
    hidden_states = self.dense(hidden_states)
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/torch/nn/modules/linear.py", line 103, in forward
    return F.linear(input, self.weight, self.bias)
RuntimeError: expected scalar type Float but found Half
```

It runs fine after merging this PR.

Other huggingface models, such as `hf_Bert`, doesn't have this problem. For example, `hf_Bert` support fp16 with [this line](https://github.com/huggingface/transformers/blob/master/src/transformers/models/bert/modeling_bert.py#L314).

