### PR TITLE
DeBERTa/DeBERTa-v2/SEW Support for torch 1.11

### DIFF
--- a/src/transformers/models/deberta/modeling_deberta.py
+++ b/src/transformers/models/deberta/modeling_deberta.py
@@ -18,6 +18,7 @@ import math
 from collections.abc import Sequence
 
 import torch
+from packaging import version
 from torch import _softmax_backward_data, nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
@@ -36,6 +37,8 @@ from .configuration_deberta import DebertaConfig
 
 
 logger = logging.get_logger(__name__)
+
+convert_to_dtype = not version.parse(torch.__version__) < version.parse("1.11")
 
 _CONFIG_FOR_DOC = "DebertaConfig"
 _TOKENIZER_FOR_DOC = "DebertaTokenizer"
@@ -115,7 +118,7 @@ class XSoftmax(torch.autograd.Function):
     @staticmethod
     def backward(self, grad_output):
         (output,) = self.saved_tensors
-        inputGrad = _softmax_backward_data(grad_output, output, self.dim, output)
+        inputGrad = _softmax_backward_data(grad_output, output, self.dim, output.dtype if convert_to_dtype else output)
         return inputGrad, None, None
 
     @staticmethod

--- a/src/transformers/models/deberta/modeling_deberta.py
+++ b/src/transformers/models/deberta/modeling_deberta.py
@@ -18,8 +18,7 @@ import math
 from collections.abc import Sequence
 
 import torch
-from packaging import version
-from torch import _softmax_backward_data, nn
+from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
 from ...activations import ACT2FN
@@ -32,14 +31,12 @@ from ...modeling_outputs import (
     TokenClassifierOutput,
 )
 from ...modeling_utils import PreTrainedModel
+from ...pytorch_utils import softmax_backward_data
 from ...utils import logging
 from .configuration_deberta import DebertaConfig
 
 
 logger = logging.get_logger(__name__)
-
-convert_to_dtype = not version.parse(torch.__version__) < version.parse("1.11")
-
 _CONFIG_FOR_DOC = "DebertaConfig"
 _TOKENIZER_FOR_DOC = "DebertaTokenizer"
 _CHECKPOINT_FOR_DOC = "microsoft/deberta-base"
@@ -118,7 +115,7 @@ class XSoftmax(torch.autograd.Function):
     @staticmethod
     def backward(self, grad_output):
         (output,) = self.saved_tensors
-        inputGrad = _softmax_backward_data(grad_output, output, self.dim, output.dtype if convert_to_dtype else output)
+        inputGrad = softmax_backward_data(self, grad_output, output, self.dim, output)
         return inputGrad, None, None
 
     @staticmethod

--- a/src/transformers/models/deberta_v2/modeling_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_deberta_v2.py
@@ -19,6 +19,7 @@ from collections.abc import Sequence
 
 import numpy as np
 import torch
+from packaging import version
 from torch import _softmax_backward_data, nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, LayerNorm, MSELoss
 
@@ -48,6 +49,8 @@ DEBERTA_V2_PRETRAINED_MODEL_ARCHIVE_LIST = [
     "microsoft/deberta-v2-xlarge-mnli",
     "microsoft/deberta-v2-xxlarge-mnli",
 ]
+
+convert_to_dtype = not version.parse(torch.__version__) < version.parse("1.11")
 
 
 # Copied from transformers.models.deberta.modeling_deberta.ContextPooler
@@ -116,7 +119,7 @@ class XSoftmax(torch.autograd.Function):
     @staticmethod
     def backward(self, grad_output):
         (output,) = self.saved_tensors
-        inputGrad = _softmax_backward_data(grad_output, output, self.dim, output)
+        inputGrad = _softmax_backward_data(grad_output, output, self.dim, output.dtype if convert_to_dtype else output)
         return inputGrad, None, None
 
     @staticmethod

--- a/src/transformers/models/sew_d/modeling_sew_d.py
+++ b/src/transformers/models/sew_d/modeling_sew_d.py
@@ -22,8 +22,7 @@ from typing import Optional, Tuple, Union
 import numpy as np
 import torch
 import torch.utils.checkpoint
-from packaging import version
-from torch import _softmax_backward_data, nn
+from torch import nn
 from torch.nn import CrossEntropyLoss, LayerNorm
 
 from transformers.deepspeed import is_deepspeed_zero3_enabled
@@ -32,13 +31,12 @@ from ...activations import ACT2FN
 from ...file_utils import add_code_sample_docstrings, add_start_docstrings, add_start_docstrings_to_model_forward
 from ...modeling_outputs import BaseModelOutput, CausalLMOutput, SequenceClassifierOutput
 from ...modeling_utils import PreTrainedModel
-from ...pytorch_utils import torch_int_div
+from ...pytorch_utils import softmax_backward_data, torch_int_div
 from ...utils import logging
 from .configuration_sew_d import SEWDConfig
 
 
 logger = logging.get_logger(__name__)
-convert_to_dtype = not version.parse(torch.__version__) < version.parse("1.11")
 
 _HIDDEN_STATES_START_POSITION = 1
 
@@ -546,7 +544,7 @@ class XSoftmax(torch.autograd.Function):
     @staticmethod
     def backward(self, grad_output):
         (output,) = self.saved_tensors
-        inputGrad = _softmax_backward_data(grad_output, output, self.dim, output.dtype if convert_to_dtype else output)
+        inputGrad = softmax_backward_data(self, grad_output, output, self.dim, output)
         return inputGrad, None, None
 
     @staticmethod

--- a/src/transformers/models/sew_d/modeling_sew_d.py
+++ b/src/transformers/models/sew_d/modeling_sew_d.py
@@ -22,6 +22,7 @@ from typing import Optional, Tuple, Union
 import numpy as np
 import torch
 import torch.utils.checkpoint
+from packaging import version
 from torch import _softmax_backward_data, nn
 from torch.nn import CrossEntropyLoss, LayerNorm
 
@@ -37,7 +38,7 @@ from .configuration_sew_d import SEWDConfig
 
 
 logger = logging.get_logger(__name__)
-
+convert_to_dtype = not version.parse(torch.__version__) < version.parse("1.11")
 
 _HIDDEN_STATES_START_POSITION = 1
 
@@ -545,7 +546,7 @@ class XSoftmax(torch.autograd.Function):
     @staticmethod
     def backward(self, grad_output):
         (output,) = self.saved_tensors
-        inputGrad = _softmax_backward_data(grad_output, output, self.dim, output)
+        inputGrad = _softmax_backward_data(grad_output, output, self.dim, output.dtype if convert_to_dtype else output)
         return inputGrad, None, None
 
     @staticmethod

--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -14,18 +14,34 @@
 
 import torch
 from packaging import version
+from torch import _softmax_backward_data
 
 from .utils import logging
 
 
 logger = logging.get_logger(__name__)
 
+is_torch_less_than_1_8 = version.parse(torch.__version__) < version.parse("1.8.0")
+is_torch_less_than_1_11 = version.parse(torch.__version__) < version.parse("1.11")
+
 
 def torch_int_div(tensor1, tensor2):
     """
     A function that performs integer division across different versions of PyTorch.
     """
-    if version.parse(torch.__version__) < version.parse("1.8.0"):
+    if is_torch_less_than_1_8:
         return tensor1 // tensor2
     else:
         return torch.div(tensor1, tensor2, rounding_mode="floor")
+
+
+def softmax_backward_data(parent, grad_output, output, dim, self):
+    """
+    A function that calls the internal `_softmax_backward_data` PyTorch method and that adjusts the arguments according
+    to the torch version detected.
+    """
+
+    if is_torch_less_than_1_11:
+        return _softmax_backward_data(grad_output, output, parent.dim, self)
+    else:
+        return _softmax_backward_data(grad_output, output, parent.dim, self.dtype)


### PR DESCRIPTION
The internal `torch` method `_softmax_backward_data` changed API between 1.10 and 1.11, from requiring a tensor as its last output to requiring a size.

This PR updates the concerned models so that they are correctly supported.

Torch 1.11: https://github.com/pytorch/pytorch/blame/e47a5a64bbf4d388b70397e3237f9d5710ee4c9c/tools/autograd/derivatives.yaml#L1861
Before: https://github.com/pytorch/pytorch/blame/768cfaa8f86bf7c7b0af441d1536f060274c27a0/tools/autograd/derivatives.yaml#L1704