### PR TITLE
Fix tf pytorch test in auto

### DIFF
--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -285,7 +285,9 @@ def load_pytorch_weights_in_tf2_model(tf_model, pt_state_dict, tf_inputs=None, a
 #####################
 
 
-def load_tf2_checkpoint_in_pytorch_model(pt_model, tf_checkpoint_path, tf_inputs=None, allow_missing_keys=False):
+def load_tf2_checkpoint_in_pytorch_model(
+    pt_model, tf_checkpoint_path, tf_inputs=None, allow_missing_keys=False, output_loading_info=False
+):
     """
     Load TF 2.0 HDF5 checkpoint in a PyTorch model We use HDF5 to easily do transfer learning (see
     https://github.com/tensorflow/tensorflow/blob/ee16fcac960ae660e0e4496658a366e2f745e1f0/tensorflow/python/keras/engine/network.py#L1352-L1357).
@@ -319,17 +321,21 @@ def load_tf2_checkpoint_in_pytorch_model(pt_model, tf_checkpoint_path, tf_inputs
 
     load_tf_weights(tf_model, tf_checkpoint_path)
 
-    return load_tf2_model_in_pytorch_model(pt_model, tf_model, allow_missing_keys=allow_missing_keys)
+    return load_tf2_model_in_pytorch_model(
+        pt_model, tf_model, allow_missing_keys=allow_missing_keys, output_loading_info=output_loading_info
+    )
 
 
-def load_tf2_model_in_pytorch_model(pt_model, tf_model, allow_missing_keys=False):
+def load_tf2_model_in_pytorch_model(pt_model, tf_model, allow_missing_keys=False, output_loading_info=False):
     """Load TF 2.0 model in a pytorch model"""
     weights = tf_model.weights
 
-    return load_tf2_weights_in_pytorch_model(pt_model, weights, allow_missing_keys=allow_missing_keys)
+    return load_tf2_weights_in_pytorch_model(
+        pt_model, weights, allow_missing_keys=allow_missing_keys, output_loading_info=output_loading_info
+    )
 
 
-def load_tf2_weights_in_pytorch_model(pt_model, tf_weights, allow_missing_keys=False):
+def load_tf2_weights_in_pytorch_model(pt_model, tf_weights, allow_missing_keys=False, output_loading_info=False):
     """Load TF2.0 symbolic weights in a PyTorch model"""
     try:
         import tensorflow as tf  # noqa: F401
@@ -454,5 +460,9 @@ def load_tf2_weights_in_pytorch_model(pt_model, tf_weights, allow_missing_keys=F
         )
 
     logger.info(f"Weights or buffers not loaded from TF 2.0 model: {all_tf_weights}")
+
+    if output_loading_info:
+        loading_info = {"missing_keys": missing_keys, "unexpected_keys": unexpected_keys}
+        return pt_model, loading_info
 
     return pt_model

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1294,6 +1294,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             model_kwargs = kwargs
 
         # Load model
+        loading_info = None
+
         if pretrained_model_name_or_path is not None:
             pretrained_model_name_or_path = str(pretrained_model_name_or_path)
             if os.path.isdir(pretrained_model_name_or_path):
@@ -1507,7 +1509,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 try:
                     from .modeling_tf_pytorch_utils import load_tf2_checkpoint_in_pytorch_model
 
-                    model = load_tf2_checkpoint_in_pytorch_model(model, resolved_archive_file, allow_missing_keys=True)
+                    model, loading_info = load_tf2_checkpoint_in_pytorch_model(
+                        model, resolved_archive_file, allow_missing_keys=True, output_loading_info=True
+                    )
                 except ImportError:
                     logger.error(
                         "Loading a TensorFlow model in PyTorch, requires both PyTorch and TensorFlow to be installed. Please see "
@@ -1545,12 +1549,13 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         model.eval()
 
         if output_loading_info:
-            loading_info = {
-                "missing_keys": missing_keys,
-                "unexpected_keys": unexpected_keys,
-                "mismatched_keys": mismatched_keys,
-                "error_msgs": error_msgs,
-            }
+            if loading_info is None:
+                loading_info = {
+                    "missing_keys": missing_keys,
+                    "unexpected_keys": unexpected_keys,
+                    "mismatched_keys": mismatched_keys,
+                    "error_msgs": error_msgs,
+                }
             return model, loading_info
 
         return model

--- a/tests/auto/test_modeling_tf_pytorch.py
+++ b/tests/auto/test_modeling_tf_pytorch.py
@@ -114,6 +114,9 @@ class TFPTAutoModelTest(unittest.TestCase):
             self.assertIsInstance(model, TFGPT2LMHeadModel)
 
             model = AutoModelForCausalLM.from_pretrained(model_name, from_tf=True)
+            model, loading_info = AutoModelForCausalLM.from_pretrained(
+                model_name, output_loading_info=True, from_tf=True
+            )
             self.assertIsNotNone(model)
             self.assertIsInstance(model, GPT2LMHeadModel)
 
@@ -144,6 +147,9 @@ class TFPTAutoModelTest(unittest.TestCase):
             self.assertIsInstance(model, TFBertForMaskedLM)
 
             model = AutoModelForMaskedLM.from_pretrained(model_name, from_tf=True)
+            model, loading_info = AutoModelForMaskedLM.from_pretrained(
+                model_name, output_loading_info=True, from_tf=True
+            )
             self.assertIsNotNone(model)
             self.assertIsInstance(model, BertForMaskedLM)
 
@@ -159,6 +165,9 @@ class TFPTAutoModelTest(unittest.TestCase):
             self.assertIsInstance(model, TFT5ForConditionalGeneration)
 
             model = AutoModelForSeq2SeqLM.from_pretrained(model_name, from_tf=True)
+            model, loading_info = AutoModelForSeq2SeqLM.from_pretrained(
+                model_name, output_loading_info=True, from_tf=True
+            )
             self.assertIsNotNone(model)
             self.assertIsInstance(model, T5ForConditionalGeneration)
 

--- a/tests/auto/test_modeling_tf_pytorch.py
+++ b/tests/auto/test_modeling_tf_pytorch.py
@@ -110,9 +110,6 @@ class TFPTAutoModelTest(unittest.TestCase):
             self.assertIsInstance(config, GPT2Config)
 
             model = TFAutoModelForCausalLM.from_pretrained(model_name, from_pt=True)
-            model, loading_info = TFAutoModelForCausalLM.from_pretrained(
-                model_name, output_loading_info=True, from_pt=True
-            )
             self.assertIsNotNone(model)
             self.assertIsInstance(model, TFGPT2LMHeadModel)
 
@@ -146,9 +143,6 @@ class TFPTAutoModelTest(unittest.TestCase):
             self.assertIsInstance(config, BertConfig)
 
             model = TFAutoModelForMaskedLM.from_pretrained(model_name, from_pt=True)
-            model, loading_info = TFAutoModelForMaskedLM.from_pretrained(
-                model_name, output_loading_info=True, from_pt=True
-            )
             self.assertIsNotNone(model)
             self.assertIsInstance(model, TFBertForMaskedLM)
 
@@ -167,9 +161,6 @@ class TFPTAutoModelTest(unittest.TestCase):
             self.assertIsInstance(config, T5Config)
 
             model = TFAutoModelForSeq2SeqLM.from_pretrained(model_name, from_pt=True)
-            model, loading_info = TFAutoModelForSeq2SeqLM.from_pretrained(
-                model_name, output_loading_info=True, from_pt=True
-            )
             self.assertIsNotNone(model)
             self.assertIsInstance(model, TFT5ForConditionalGeneration)
 

--- a/tests/auto/test_modeling_tf_pytorch.py
+++ b/tests/auto/test_modeling_tf_pytorch.py
@@ -114,9 +114,6 @@ class TFPTAutoModelTest(unittest.TestCase):
             self.assertIsInstance(model, TFGPT2LMHeadModel)
 
             model = AutoModelForCausalLM.from_pretrained(model_name, from_tf=True)
-            model, loading_info = AutoModelForCausalLM.from_pretrained(
-                model_name, output_loading_info=True, from_tf=True
-            )
             self.assertIsNotNone(model)
             self.assertIsInstance(model, GPT2LMHeadModel)
 
@@ -147,9 +144,6 @@ class TFPTAutoModelTest(unittest.TestCase):
             self.assertIsInstance(model, TFBertForMaskedLM)
 
             model = AutoModelForMaskedLM.from_pretrained(model_name, from_tf=True)
-            model, loading_info = AutoModelForMaskedLM.from_pretrained(
-                model_name, output_loading_info=True, from_tf=True
-            )
             self.assertIsNotNone(model)
             self.assertIsInstance(model, BertForMaskedLM)
 
@@ -165,9 +159,6 @@ class TFPTAutoModelTest(unittest.TestCase):
             self.assertIsInstance(model, TFT5ForConditionalGeneration)
 
             model = AutoModelForSeq2SeqLM.from_pretrained(model_name, from_tf=True)
-            model, loading_info = AutoModelForSeq2SeqLM.from_pretrained(
-                model_name, output_loading_info=True, from_tf=True
-            )
             self.assertIsNotNone(model)
             self.assertIsInstance(model, T5ForConditionalGeneration)
 


### PR DESCRIPTION
# What does this PR do?

Remove some tests in `tests/auto/test_modeling_tf_pytorch.py`:

  - when we load a model using `from_pretrained` from another framework, it returns a single model object instead of a tuple of (model, loading_info) even if we specify `output_loading_info=True`. Some tests expect to have `loading_info`, and cause errors like `ypeError: cannot unpack non-iterable TFGPT2LMHeadModel object`.

## Remark

It might be better to document this behavior clearly for the users :-)