### PR TITLE
Update ArrowWriter path in examples

### DIFF
--- a/examples/research_projects/lxmert/extracting_data.py
+++ b/examples/research_projects/lxmert/extracting_data.py
@@ -98,7 +98,7 @@ class Extract:
     def __call__(self):
         # make writer
         if not TEST:
-            writer = datasets.ArrowWriter(features=self.schema, path=self.outputfile)
+            writer = datasets.arrow_writer.ArrowWriter(features=self.schema, path=self.outputfile)
         # do file generator
         for i, (img_ids, filepaths) in enumerate(self.file_generator):
             images, sizes, scales_yx = self.preprocess(filepaths)

--- a/examples/research_projects/visual_bert/extracting_data.py
+++ b/examples/research_projects/visual_bert/extracting_data.py
@@ -98,7 +98,7 @@ class Extract:
     def __call__(self):
         # make writer
         if not TEST:
-            writer = datasets.ArrowWriter(features=self.schema, path=self.outputfile)
+            writer = datasets.arrow_writer.ArrowWriter(features=self.schema, path=self.outputfile)
         # do file generator
         for i, (img_ids, filepaths) in enumerate(self.file_generator):
             images, sizes, scales_yx = self.preprocess(filepaths)


### PR DESCRIPTION
`ArrowWriter` is no longer in the top-level namespace in `datasets` v2.0 (see https://github.com/huggingface/datasets/pull/3875#discussion_r822924405), so I'm replacing the`datasets.ArrowWriter` occurances with `datasets.arrow_writer.ArrowWriter`.