### PR TITLE
Fix Loading of Flax(Speech)EncoderDecoderModel kwargs from PreTrained Encoder-Decoder Checkpoints

### DIFF
--- a/src/transformers/models/encoder_decoder/modeling_flax_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_flax_encoder_decoder.py
@@ -822,7 +822,9 @@ class FlaxEncoderDecoderModel(FlaxPreTrainedModel):
                 )
 
             if "config" not in kwargs_encoder:
-                encoder_config = AutoConfig.from_pretrained(encoder_pretrained_model_name_or_path)
+                encoder_config, kwargs_encoder = AutoConfig.from_pretrained(
+                    encoder_pretrained_model_name_or_path, **kwargs_encoder, return_unused_kwargs=True
+                )
                 if encoder_config.is_decoder is True or encoder_config.add_cross_attention is True:
                     logger.info(
                         f"Initializing {encoder_pretrained_model_name_or_path} as a encoder model "
@@ -846,7 +848,9 @@ class FlaxEncoderDecoderModel(FlaxPreTrainedModel):
                 )
 
             if "config" not in kwargs_decoder:
-                decoder_config = AutoConfig.from_pretrained(decoder_pretrained_model_name_or_path)
+                decoder_config, kwargs_decoder = AutoConfig.from_pretrained(
+                    decoder_pretrained_model_name_or_path, **kwargs_decoder, return_unused_kwargs=True
+                )
                 if decoder_config.is_decoder is False or decoder_config.add_cross_attention is False:
                     logger.info(
                         f"Initializing {decoder_pretrained_model_name_or_path} as a decoder model. "

--- a/src/transformers/models/speech_encoder_decoder/modeling_flax_speech_encoder_decoder.py
+++ b/src/transformers/models/speech_encoder_decoder/modeling_flax_speech_encoder_decoder.py
@@ -835,7 +835,9 @@ class FlaxSpeechEncoderDecoderModel(FlaxPreTrainedModel):
                 )
 
             if "config" not in kwargs_encoder:
-                encoder_config = AutoConfig.from_pretrained(encoder_pretrained_model_name_or_path)
+                encoder_config, kwargs_encoder = AutoConfig.from_pretrained(
+                    encoder_pretrained_model_name_or_path, **kwargs_encoder, return_unused_kwargs=True
+                )
                 if encoder_config.is_decoder is True or encoder_config.add_cross_attention is True:
                     logger.info(
                         f"Initializing {encoder_pretrained_model_name_or_path} as a encoder model "
@@ -859,7 +861,9 @@ class FlaxSpeechEncoderDecoderModel(FlaxPreTrainedModel):
                 )
 
             if "config" not in kwargs_decoder:
-                decoder_config = AutoConfig.from_pretrained(decoder_pretrained_model_name_or_path)
+                decoder_config, kwargs_decoder = AutoConfig.from_pretrained(
+                    decoder_pretrained_model_name_or_path, **kwargs_decoder, return_unused_kwargs=True
+                )
                 if decoder_config.is_decoder is False or decoder_config.add_cross_attention is False:
                     logger.info(
                         f"Initializing {decoder_pretrained_model_name_or_path} as a decoder model. "

--- a/tests/encoder_decoder/test_modeling_flax_encoder_decoder.py
+++ b/tests/encoder_decoder/test_modeling_flax_encoder_decoder.py
@@ -188,7 +188,7 @@ class FlaxEncoderDecoderMixin:
                     decoder_use_cache=not decoder_config.use_cache,
                 )
 
-        # assert that setting opposite encoder and decoder kwargs to the configs has correctly been applied
+        # assert that setting encoder and decoder kwargs opposite to those in the configs has correctly been applied
         self.assertNotEqual(config.use_cache, enc_dec_model.config.encoder.use_cache)
         self.assertNotEqual(decoder_config.use_cache, enc_dec_model.config.decoder.use_cache)
 

--- a/tests/encoder_decoder/test_modeling_flax_encoder_decoder.py
+++ b/tests/encoder_decoder/test_modeling_flax_encoder_decoder.py
@@ -160,6 +160,51 @@ class FlaxEncoderDecoderMixin:
             max_diff = np.amax(np.abs(out_1 - out_2))
             self.assertLessEqual(max_diff, 1e-5)
 
+    def check_encoder_decoder_model_from_encoder_decoder_pretrained(
+        self,
+        config,
+        input_ids,
+        attention_mask,
+        encoder_hidden_states,
+        decoder_config,
+        decoder_input_ids,
+        decoder_attention_mask,
+        **kwargs
+    ):
+        encoder_model, decoder_model = self.get_encoder_decoder_model(config, decoder_config)
+        # assert that model attributes match those of configs
+        self.assertEqual(config.use_cache, encoder_model.config.use_cache)
+        self.assertEqual(decoder_config.use_cache, decoder_model.config.use_cache)
+
+        with tempfile.TemporaryDirectory() as enc_tmpdir:
+            with tempfile.TemporaryDirectory() as dec_tmpdir:
+                encoder_model.save_pretrained(enc_tmpdir)
+                decoder_model.save_pretrained(dec_tmpdir)
+                # load a model from pretrained encoder and decoder checkpoints, setting one encoder and one decoder kwarg opposite to that specified in their respective configs
+                enc_dec_model = FlaxEncoderDecoderModel.from_encoder_decoder_pretrained(
+                    encoder_pretrained_model_name_or_path=enc_tmpdir,
+                    decoder_pretrained_model_name_or_path=dec_tmpdir,
+                    encoder_use_cache=not config.use_cache,
+                    decoder_use_cache=not decoder_config.use_cache,
+                )
+
+        # assert that setting opposite encoder and decoder kwargs to the configs has correctly been applied
+        self.assertNotEqual(config.use_cache, enc_dec_model.config.encoder.use_cache)
+        self.assertNotEqual(decoder_config.use_cache, enc_dec_model.config.decoder.use_cache)
+
+        outputs_encoder_decoder = enc_dec_model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            decoder_input_ids=decoder_input_ids,
+            decoder_attention_mask=decoder_attention_mask,
+            output_hidden_states=True,
+            return_dict=True,
+        )
+
+        self.assertEqual(
+            outputs_encoder_decoder["logits"].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,))
+        )
+
     def check_encoder_decoder_model_output_attentions(
         self,
         config,
@@ -325,6 +370,10 @@ class FlaxEncoderDecoderMixin:
     def test_save_and_load_from_pretrained(self):
         input_ids_dict = self.prepare_config_and_inputs()
         self.check_save_and_load(**input_ids_dict)
+
+    def test_encoder_decoder_model_from_encoder_decoder_pretrained(self):
+        input_ids_dict = self.prepare_config_and_inputs()
+        self.check_encoder_decoder_model_from_encoder_decoder_pretrained(**input_ids_dict)
 
     def test_encoder_decoder_model_output_attentions(self):
         input_ids_dict = self.prepare_config_and_inputs()

--- a/tests/speech_encoder_decoder/test_modeling_flax_speech_encoder_decoder.py
+++ b/tests/speech_encoder_decoder/test_modeling_flax_speech_encoder_decoder.py
@@ -224,7 +224,7 @@ class FlaxEncoderDecoderMixin:
                     decoder_use_cache=not decoder_config.use_cache,
                 )
 
-        # assert that setting opposite encoder and decoder kwargs to the configs has correctly been applied
+        # assert that setting encoder and decoder kwargs opposite to those in the configs has correctly been applied
         self.assertNotEqual(config.add_adapter, enc_dec_model.config.encoder.add_adapter)
         self.assertNotEqual(decoder_config.use_cache, enc_dec_model.config.decoder.use_cache)
 

--- a/tests/speech_encoder_decoder/test_modeling_flax_speech_encoder_decoder.py
+++ b/tests/speech_encoder_decoder/test_modeling_flax_speech_encoder_decoder.py
@@ -196,6 +196,51 @@ class FlaxEncoderDecoderMixin:
             max_diff = np.amax(np.abs(out_1 - out_2))
             self.assertLessEqual(max_diff, 4e-2)
 
+    def check_encoder_decoder_model_from_encoder_decoder_pretrained(
+        self,
+        config,
+        inputs,
+        attention_mask,
+        encoder_hidden_states,
+        decoder_config,
+        decoder_input_ids,
+        decoder_attention_mask,
+        **kwargs
+    ):
+        encoder_model, decoder_model = self.get_encoder_decoder_model(config, decoder_config)
+        # assert that loading encoder and decoder models from configs has been correctly executed
+        self.assertEqual(config.add_adapter, encoder_model.config.add_adapter)
+        self.assertEqual(decoder_config.use_cache, decoder_model.config.use_cache)
+
+        with tempfile.TemporaryDirectory() as enc_tmpdir:
+            with tempfile.TemporaryDirectory() as dec_tmpdir:
+                encoder_model.save_pretrained(enc_tmpdir)
+                decoder_model.save_pretrained(dec_tmpdir)
+                # load a model from pretrained encoder and decoder checkpoints, setting one encoder and one decoder kwarg opposite to that specified in their respective configs
+                enc_dec_model = FlaxSpeechEncoderDecoderModel.from_encoder_decoder_pretrained(
+                    encoder_pretrained_model_name_or_path=enc_tmpdir,
+                    decoder_pretrained_model_name_or_path=dec_tmpdir,
+                    encoder_add_adapter=not config.add_adapter,
+                    decoder_use_cache=not decoder_config.use_cache,
+                )
+
+        # assert that setting opposite encoder and decoder kwargs to the configs has correctly been applied
+        self.assertNotEqual(config.add_adapter, enc_dec_model.config.encoder.add_adapter)
+        self.assertNotEqual(decoder_config.use_cache, enc_dec_model.config.decoder.use_cache)
+
+        outputs_encoder_decoder = enc_dec_model(
+            inputs=inputs,
+            attention_mask=attention_mask,
+            decoder_input_ids=decoder_input_ids,
+            decoder_attention_mask=decoder_attention_mask,
+            output_hidden_states=True,
+            return_dict=True,
+        )
+
+        self.assertEqual(
+            outputs_encoder_decoder["logits"].shape, (decoder_input_ids.shape + (decoder_config.vocab_size,))
+        )
+
     def check_encoder_decoder_model_output_attentions(
         self,
         config,
@@ -440,6 +485,10 @@ class FlaxEncoderDecoderMixin:
     def test_save_and_load_from_pretrained(self):
         input_ids_dict = self.prepare_config_and_inputs()
         self.check_save_and_load(**input_ids_dict)
+
+    def test_encoder_decoder_model_from_encoder_decoder_pretrained(self):
+        input_ids_dict = self.prepare_config_and_inputs()
+        self.check_encoder_decoder_model_from_encoder_decoder_pretrained(**input_ids_dict)
 
     def test_encoder_decoder_model_output_attentions(self):
         input_ids_dict = self.prepare_config_and_inputs()


### PR DESCRIPTION
This PR modifies the `from_encoder_decoder_pretrained` class methods in the Flax(Speech)EncoderDecoderModels to correctly instantiate an encoder and a decoder from specified pre-trained model names or paths **given** a set of keyword arguments (kwargs). We should be able to pass encoder/decoder specific kwargs into the `from_encoder_decoder_pretrained` method to override the config of the pre-trained checkpoints. The following code snippet provides a short PyTorch script to demonstrate this desired behaviour using the encoder kwarg `add_adapter`:
```python
from transformers import SpeechEncoderDecoderModel
encoder_id = "hf-internal-testing/tiny-random-wav2vec2"
decoder_id = "hf-internal-testing/tiny-random-bart"
model = SpeechEncoderDecoderModel.from_encoder_decoder_pretrained(encoder_id, decoder_id, encoder_add_adapter=True)
print(model.config.encoder.add_adapter)
model = SpeechEncoderDecoderModel.from_encoder_decoder_pretrained(encoder_id, decoder_id, encoder_add_adapter=False)
print(model.config.encoder.add_adapter)
```
Output:
```python
True
False
```
Reproducing the same script using the equivalent Flax model yields an error, the model not being able to be correctly instantiated:
```python
from transformers import FlaxSpeechEncoderDecoderModel
encoder_id = "hf-internal-testing/tiny-random-wav2vec2"
decoder_id = "hf-internal-testing/tiny-random-bart"
model = FlaxSpeechEncoderDecoderModel.from_encoder_decoder_pretrained(encoder_id, decoder_id, encoder_add_adapter=True, encoder_from_pt=True, decoder_from_pt=True)
```
Output:
```python
File ~/transformers/src/transformers/models/wav2vec2/modeling_flax_wav2vec2.py:857, in FlaxWav2Vec2PreTrainedModel.__init__(self, config, input_shape, seed, dtype, **kwargs)
    849 def __init__(
    850     self,
    851     config: Wav2Vec2Config,
   (...)
    855     **kwargs,
    856 ):
--> 857     module = self.module_class(config=config, dtype=dtype, **kwargs)
    858     super().__init__(config, module, input_shape=input_shape, seed=seed, dtype=dtype)

TypeError: __init__() got an unexpected keyword argument 'add_adapter'
```
The encoder and decoder kwargs are incorrectly passed to the `__init__` method of the respective module. This raises a TypeError when loading from pre-trained checkpoints, the kwargs being unexpected arguments.

This PR amends the loading of the encoder and decoder models to handle such kwargs correctly. It's implementation is verified through a new rigorous test: `test_encoder_decoder_model_from_encoder_decoder_pretrained`. An encoder-decoder model is loaded with two kwargs set opposite to that specified in the standalone encoder and decoder configs. It asserts that the corresponding attributes in the _new_ encoder-decoder model config are in-fact set opposite to those in the standalone encoder and decoder configs.

Following these changes, the Flax script yields the desired output:
```python
from transformers import FlaxSpeechEncoderDecoderModel
encoder_id = "hf-internal-testing/tiny-random-wav2vec2"
decoder_id = "hf-internal-testing/tiny-random-bart"
model = FlaxSpeechEncoderDecoderModel.from_encoder_decoder_pretrained(encoder_id, decoder_id, encoder_add_adapter=True, encoder_from_pt=True, decoder_from_pt=True)
print(model.config.encoder.add_adapter)
model = FlaxSpeechEncoderDecoderModel.from_encoder_decoder_pretrained(encoder_id, decoder_id, encoder_add_adapter=False, encoder_from_pt=True, decoder_from_pt=True)
print(model.config.encoder.add_adapter)
```
Output:
```python
True
False
```