### PR TITLE
[WIP] Flax Speech Recognition Seq2Seq

### DIFF
--- a/docs/source/en/model_doc/auto.mdx
+++ b/docs/source/en/model_doc/auto.mdx
@@ -238,6 +238,10 @@ Likewise, if your `NewModel` is a subclass of [`PreTrainedModel`], make sure its
 
 [[autodoc]] FlaxAutoModelForSequenceClassification
 
+## FlaxAutoModelForSpeechSeq2Seq
+
+[[autodoc]] FlaxAutoModelForSpeechSeq2Seq
+
 ## FlaxAutoModelForQuestionAnswering
 
 [[autodoc]] FlaxAutoModelForQuestionAnswering

--- a/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
+++ b/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
@@ -957,8 +957,8 @@ def main():
     logger.info(f"  Num examples = {len(vectorized_datasets['train'])}")
     logger.info(f"  Num Epochs = {num_epochs}")
     logger.info(f"  Instantaneous batch size per device = {training_args.per_device_train_batch_size}")
-    logger.info(f"  Total train batch size (w. parallel & distributed) = {train_batch_size}")
     logger.info(f"  Num gradient accumulation steps = {gradient_accumulation_steps}")
+    logger.info(f"  Total train batch size (w. parallel & distributed) = {batch_size_per_update}")
     logger.info(f"  Total optimization steps = {total_train_steps}")
 
     train_time = 0
@@ -996,7 +996,6 @@ def main():
                     f"Step... ({cur_step} | Loss: {train_metric['loss']}, Learning Rate: {train_metric['learning_rate']}, Gradient Norm: {train_metric['grad_norm']})"
                 )
 
-        continue
         # ======================== Evaluating ==============================
         eval_metrics = []
         eval_preds = []

--- a/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
+++ b/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
@@ -685,7 +685,7 @@ def main():
 
     # Augment adam optimizer to facilitate gradient accumulation
     if gradient_accumulation_steps > 1:
-        optim = optax.MultiSteps(optim, gradient_accumulation_steps, use_grad_mean=False)
+        optim = optax.chain(optim, optax.apply_every(gradient_accumulation_steps), use_grad_mean=False)
 
     # Setup train state
     state = TrainState.create(apply_fn=model.__call__, params=model.params, tx=optim, dropout_rng=dropout_rng)
@@ -838,7 +838,6 @@ def main():
 
                 train_metrics = []
 
-        wandb.log()
         # ======================== Evaluating ==============================
         eval_metrics = []
         eval_preds = []

--- a/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
+++ b/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
@@ -1,0 +1,741 @@
+#!/usr/bin/env python
+# coding=utf-8
+# Copyright 2022 The HuggingFace Team All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Fine-tuning the Flax library models for sequence to sequence speech recognition.
+"""
+# You can also adapt this script on your own sequence to sequence task. Pointers for this are left as comments.
+
+import json
+import logging
+import os
+import random
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from functools import partial
+from itertools import chain
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Union, List, Tuple
+
+import datasets
+import numpy as np
+from datasets import Dataset, DatasetDict, load_dataset, load_metric
+from tqdm import tqdm
+
+import jax
+import jax.numpy as jnp
+import optax
+import transformers
+from flax import jax_utils, traverse_util
+from flax.jax_utils import replicate, unreplicate
+from flax.training import train_state
+from flax.training.common_utils import get_metrics, onehot, shard, shard_prng_key
+from huggingface_hub import Repository
+from transformers import (
+    CONFIG_MAPPING,
+    AutoConfig,
+    AutoFeatureExtractor,
+    FlaxAutoModelForSpeechSeq2Seq,
+    AutoProcessor,
+    AutoTokenizer,
+    HfArgumentParser,
+    Seq2SeqTrainer,
+    Seq2SeqTrainingArguments,
+    set_seed,
+    is_tensorboard_available,
+)
+from transformers.trainer_utils import get_last_checkpoint, is_main_process
+from transformers.file_utils import get_full_repo_name
+from transformers.utils import check_min_version
+from transformers.utils.versions import require_version
+
+# Will error if the minimal version of Transformers is not installed. Remove at your own risks.
+check_min_version("4.17.0.dev0")
+
+require_version("datasets>=1.18.0", "To fix: pip install -r examples/pytorch/speech-recognition/requirements.txt")
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ModelArguments:
+    """
+    Arguments pertaining to which model/config/tokenizer we are going to fine-tune from.
+    """
+
+    model_name_or_path: str = field(
+        metadata={"help": "Path to pretrained model or model identifier from huggingface.co/models"}
+    )
+    config_name: Optional[str] = field(
+        default=None, metadata={"help": "Pretrained config name or path if not the same as model_name"}
+    )
+    tokenizer_name: Optional[str] = field(
+        default=None, metadata={"help": "Pretrained tokenizer name or path if not the same as model_name"}
+    )
+    feature_extractor_name: Optional[str] = field(
+        default=None, metadata={"help": "feature extractor name or path if not the same as model_name"}
+    )
+    cache_dir: Optional[str] = field(
+        default=None,
+        metadata={"help": "Where to store the pretrained models downloaded from huggingface.co"},
+    )
+    use_fast_tokenizer: bool = field(
+        default=True,
+        metadata={"help": "Whether to use one of the fast tokenizer (backed by the tokenizers library) or not."},
+    )
+    model_revision: str = field(
+        default="main",
+        metadata={"help": "The specific model version to use (can be a branch name, tag name or commit id)."},
+    )
+    use_auth_token: bool = field(
+        default=False,
+        metadata={
+            "help": "Will use the token generated when running `transformers-cli login` (necessary to use this script "
+            "with private models)."
+        },
+    )
+    freeze_feature_encoder: bool = field(
+        default=True, metadata={"help": "Whether to freeze the feature encoder layers of the model."}
+    )
+
+@dataclass
+class DataTrainingArguments:
+    """
+    Arguments pertaining to what data we are going to input our model for training and eval.
+    """
+
+    dataset_name: str = field(
+        default=None, metadata={"help": "The name of the dataset to use (via the datasets library)."}
+    )
+    dataset_config_name: Optional[str] = field(
+        default=None, metadata={"help": "The configuration name of the dataset to use (via the datasets library)."}
+    )
+    text_column: Optional[str] = field(
+        default=None,
+        metadata={"help": "The name of the column in the datasets containing the full texts (for summarization)."},
+    )
+    overwrite_cache: bool = field(
+        default=False, metadata={"help": "Overwrite the cached training and evaluation sets"}
+    )
+    preprocessing_num_workers: Optional[int] = field(
+        default=None,
+        metadata={"help": "The number of processes to use for the preprocessing."},
+    )
+    max_train_samples: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": "For debugging purposes or quicker training, truncate the number of training examples to this "
+            "value if set."
+        },
+    )
+    max_eval_samples: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": "For debugging purposes or quicker training, truncate the number of evaluation examples to this "
+            "value if set."
+        },
+    )
+    audio_column_name: str = field(
+        default="audio",
+        metadata={"help": "The name of the dataset column containing the audio data. Defaults to 'audio'"},
+    )
+    text_column_name: str = field(
+        default="text",
+        metadata={"help": "The name of the dataset column containing the text data. Defaults to 'text'"},
+    )
+    max_duration_in_seconds: float = field(
+        default=20.0,
+        metadata={
+            "help": "Truncate audio files that are longer than `max_duration_in_seconds` seconds to 'max_duration_in_seconds`"
+        },
+    )
+    min_duration_in_seconds: float = field(
+        default=0.0, metadata={"help": "Filter audio files that are shorter than `min_duration_in_seconds` seconds"}
+    )
+    preprocessing_only: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to only do data preprocessing and skip training. "
+            "This is especially useful when data preprocessing errors out in distributed training due to timeout. "
+            "In this case, one should run the preprocessing in a non-distributed setup with `preprocessing_only=True` "
+            "so that the cached datasets can consequently be loaded in distributed training"
+        },
+    )
+    train_split_name: str = field(
+        default="train",
+        metadata={
+            "help": "The name of the training data set split to use (via the datasets library). Defaults to 'train'"
+        },
+    )
+    eval_split_name: str = field(
+        default="test",
+        metadata={
+            "help": "The name of the training data set split to use (via the datasets library). Defaults to 'train'"
+        },
+    )
+    do_lower_case: bool = field(
+        default=True,
+        metadata={"help": "Whether the target text should be lower cased."},
+    )
+
+"""
+Following needed? Review later.
+"""
+@dataclass
+class DataCollatorSpeechSeq2SeqWithPadding:
+    """
+    Data collator that will dynamically pad the inputs received.
+    Args:
+        processor ([`Wav2Vec2Processor`])
+            The processor used for proccessing the data.
+        decoder_start_token_id (`int`)
+            The begin-of-sentence of the decoder.
+    """
+
+    processor: Any
+    decoder_start_token_id: int
+
+    def __call__(self, features: List[Dict[str, Union[List[int], jnp.array]]]) -> Dict[str, jnp.array]:
+        # split inputs and labels since they have to be of different lengths and need
+        # different padding methods
+        input_features = [{"input_values": feature["input_values"]} for feature in features]
+        label_features = [{"input_ids": feature["labels"]} for feature in features]
+
+        batch = self.processor.feature_extractor.pad(input_features, return_tensors="np")
+
+        labels_batch = self.processor.tokenizer.pad(label_features, return_tensors="np")
+
+        # replace padding with -100 to ignore loss correctly
+        labels = labels_batch["input_ids"].masked_fill(labels_batch.attention_mask.ne(1), -100)
+
+        # if bos token is appended in previous tokenization step,
+        # cut bos token here as it's append later
+        if (labels[:, 0] == self.decoder_start_token_id).all().item():
+            labels = labels[:, 1:]
+
+        batch["labels"] = labels
+
+        return batch
+
+class TrainState(train_state.TrainState):
+    dropout_rng: jnp.ndarray
+
+    def replicate(self):
+        return jax_utils.replicate(self).replace(dropout_rng=shard_prng_key(self.dropout_rng))
+
+def data_loader(rng: jax.random.PRNGKey, dataset: Dataset, batch_size: int, shuffle: bool = False):
+    """
+    Returns batches of size `batch_size` from truncated `dataset`, sharded over all local devices.
+    Shuffle batches if `shuffle` is `True`.
+    """
+    steps_per_epoch = len(dataset) // batch_size
+
+    if shuffle:
+        batch_idx = jax.random.permutation(rng, len(dataset))
+    else:
+        batch_idx = jnp.arange(len(dataset))
+
+    batch_idx = batch_idx[: steps_per_epoch * batch_size]  # Skip incomplete batch.
+    batch_idx = batch_idx.reshape((steps_per_epoch, batch_size))
+
+    for idx in batch_idx:
+        batch = dataset[idx]
+        batch = {k: jnp.array(v) for k, v in batch.items()}
+
+        batch = shard(batch)
+
+        yield batch
+
+
+def write_metric(summary_writer, train_metrics, eval_metrics, train_time, step):
+    summary_writer.scalar("train_time", train_time, step)
+
+    train_metrics = get_metrics(train_metrics)
+    for key, vals in train_metrics.items():
+        tag = f"train_{key}"
+        for i, val in enumerate(vals):
+            summary_writer.scalar(tag, val, step - len(vals) + i + 1)
+
+    for metric_name, value in eval_metrics.items():
+        summary_writer.scalar(f"eval_{metric_name}", value, step)
+
+
+def create_learning_rate_fn(
+    train_ds_size: int, train_batch_size: int, num_train_epochs: int, num_warmup_steps: int, learning_rate: float
+) -> Callable[[int], jnp.array]:
+    """Returns a linear warmup, linear_decay learning rate function."""
+    steps_per_epoch = train_ds_size // train_batch_size
+    num_train_steps = steps_per_epoch * num_train_epochs
+    warmup_fn = optax.linear_schedule(init_value=0.0, end_value=learning_rate, transition_steps=num_warmup_steps)
+    decay_fn = optax.linear_schedule(
+        init_value=learning_rate, end_value=0, transition_steps=num_train_steps - num_warmup_steps
+    )
+    schedule_fn = optax.join_schedules(schedules=[warmup_fn, decay_fn], boundaries=[num_warmup_steps])
+    return schedule_fn
+
+def main():
+    # 1. Parse input arguments
+    # See all possible arguments in src/transformers/training_args.py
+    # or by passing the --help flag to this script.
+    # We now keep distinct sets of args, for a cleaner separation of concerns.
+    parser = HfArgumentParser((ModelArguments, DataTrainingArguments, Seq2SeqTrainingArguments))
+
+    if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
+        # If we pass only one argument to the script and it's the path to a json file,
+        # let's parse it to get our arguments.
+        model_args, data_args, training_args = parser.parse_json_file(json_file=os.path.abspath(sys.argv[1]))
+    else:
+        model_args, data_args, training_args = parser.parse_args_into_dataclasses()
+
+    # 2. Setup logging
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+        datefmt="%m/%d/%Y %H:%M:%S",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+    # We only want one process per machine to log things on the screen.
+    logger.setLevel(logging.INFO if jax.process_index() == 0 else logging.ERROR)
+    if jax.process_index() == 0:
+        datasets.utils.logging.set_verbosity_warning()
+        transformers.utils.logging.set_verbosity_info()
+    else:
+        datasets.utils.logging.set_verbosity_error()
+        transformers.utils.logging.set_verbosity_error()
+
+    # Log on each process the small summary:
+    logger.warning(
+        f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
+        f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
+    )
+
+    # Set the verbosity to info of the Transformers logger (on main process only):
+    if is_main_process(training_args.local_rank):
+        transformers.utils.logging.set_verbosity_info()
+    logger.info("Training/evaluation parameters %s", training_args)
+
+    # 3. Handle the repository creation
+    if training_args.push_to_hub:
+        if training_args.hub_model_id is None:
+            repo_name = get_full_repo_name(
+                Path(training_args.output_dir).absolute().name, token=training_args.hub_token
+            )
+        else:
+            repo_name = training_args.hub_model_id
+        repo = Repository(training_args.output_dir, clone_from=repo_name)
+
+    # 3. CHANGE NUMBERS ONWARDS Detecting last checkpoint and eventually continue from last checkpoint
+    last_checkpoint = None
+    if os.path.isdir(training_args.output_dir) and training_args.do_train and not training_args.overwrite_output_dir:
+        last_checkpoint = get_last_checkpoint(training_args.output_dir)
+        if last_checkpoint is None and len(os.listdir(training_args.output_dir)) > 0:
+            raise ValueError(
+                f"Output directory ({training_args.output_dir}) already exists and is not empty. "
+                "Use --overwrite_output_dir to overcome."
+            )
+        elif last_checkpoint is not None and training_args.resume_from_checkpoint is None:
+            logger.info(
+                f"Checkpoint detected, resuming training at {last_checkpoint}. To avoid this behavior, change "
+                "the `--output_dir` or add `--overwrite_output_dir` to train from scratch."
+            )
+
+    # 4. Load dataset
+    raw_datasets = DatasetDict()
+
+    if training_args.do_train:
+        raw_datasets["train"] = load_dataset(
+            data_args.dataset_name, data_args.dataset_config_name, split=data_args.train_split_name
+        )
+
+    if training_args.do_eval:
+        raw_datasets["eval"] = load_dataset(
+            data_args.dataset_name, data_args.dataset_config_name, split=data_args.eval_split_name
+        )
+
+    if data_args.audio_column_name not in next(iter(raw_datasets.values())).column_names:
+        raise ValueError(
+            f"--audio_column_name '{data_args.audio_column_name}' not found in dataset '{data_args.dataset_name}'. "
+            "Make sure to set `--audio_column_name` to the correct audio column - one of "
+            f"{', '.join(next(iter(raw_datasets.values())).column_names)}."
+        )
+
+    if data_args.text_column_name not in next(iter(raw_datasets.values())).column_names:
+        raise ValueError(
+            f"--text_column_name {data_args.text_column_name} not found in dataset '{data_args.dataset_name}'. "
+            "Make sure to set `--text_column_name` to the correct text column - one of "
+            f"{', '.join(next(iter(raw_datasets.values())).column_names)}."
+        )
+    # 5. Load pretrained model, tokenizer, and feature extractor
+    #
+    # Distributed training:
+    # The .from_pretrained methods guarantee that only one local process can concurrently
+    config = AutoConfig.from_pretrained(
+        model_args.config_name if model_args.config_name else model_args.model_name_or_path,
+        cache_dir=model_args.cache_dir,
+        revision=model_args.model_revision,
+        use_auth_token=True if model_args.use_auth_token else None,
+    )
+
+    feature_extractor = AutoFeatureExtractor.from_pretrained(
+        model_args.feature_extractor_name if model_args.feature_extractor_name else model_args.model_name_or_path,
+        cache_dir=model_args.cache_dir,
+        revision=model_args.model_revision,
+        use_auth_token=True if model_args.use_auth_token else None,
+    )
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_args.tokenizer_name if model_args.tokenizer_name else model_args.model_name_or_path,
+        cache_dir=model_args.cache_dir,
+        use_fast=model_args.use_fast_tokenizer,
+        revision=model_args.model_revision,
+        use_auth_token=True if model_args.use_auth_token else None,
+    )
+    model = FlaxAutoModelForSpeechSeq2Seq.from_pretrained(
+        model_args.model_name_or_path,
+        config=config,
+        cache_dir=model_args.cache_dir,
+        revision=model_args.model_revision,
+        use_auth_token=True if model_args.use_auth_token else None,
+    )
+
+    if model.config.decoder_start_token_id is None:
+        raise ValueError("Make sure that `config.decoder_start_token_id` is correctly defined")
+
+    #TODO: freeze feature encoder
+    if model_args.freeze_feature_encoder:
+        model.freeze_feature_encoder()
+
+# 6. Resample speech dataset if necessary
+    dataset_sampling_rate = next(iter(raw_datasets.values())).features[data_args.audio_column_name].sampling_rate
+    if dataset_sampling_rate != feature_extractor.sampling_rate:
+        raw_datasets = raw_datasets.cast_column(
+            data_args.audio_column_name, datasets.features.Audio(sampling_rate=feature_extractor.sampling_rate)
+        )
+
+    # 7. Preprocessing the datasets.
+    # We need to read the audio files as arrays and tokenize the targets.
+    max_input_length = data_args.max_duration_in_seconds * feature_extractor.sampling_rate
+    min_input_length = data_args.min_duration_in_seconds * feature_extractor.sampling_rate
+    audio_column_name = data_args.audio_column_name
+    num_workers = data_args.preprocessing_num_workers
+    text_column_name = data_args.text_column_name
+    model_input_name = feature_extractor.model_input_names[0]
+    do_lower_case = data_args.do_lower_case
+
+    if data_args.max_train_samples is not None:
+        raw_datasets["train"] = raw_datasets["train"].select(range(data_args.max_train_samples))
+
+    if data_args.max_eval_samples is not None:
+        raw_datasets["eval"] = raw_datasets["eval"].select(range(data_args.max_eval_samples))
+
+    def prepare_dataset(batch):
+        # process audio
+        sample = batch[audio_column_name]
+        inputs = feature_extractor(sample["array"], sampling_rate=sample["sampling_rate"])
+        # process audio length
+        batch[model_input_name] = inputs.input_values[0]
+        batch["input_length"] = len(batch["input_values"])
+
+        # process targets
+        input_str = batch[text_column_name].lower() if do_lower_case else batch[text_column_name]
+        batch["labels"] = tokenizer(input_str).input_ids
+        return batch
+
+    with training_args.main_process_first(desc="dataset map pre-processing"):
+        vectorized_datasets = raw_datasets.map(
+            prepare_dataset,
+            remove_columns=next(iter(raw_datasets.values())).column_names,
+            num_proc=data_args.preprocessing_num_workers,
+            desc="preprocess train dataset",
+        )
+
+    # filter data that is shorter than min_input_length or longer than
+    # max_input_length
+    def is_audio_in_length_range(length):
+        return length > min_input_length and length < max_input_length
+
+    vectorized_datasets = vectorized_datasets.filter(
+        is_audio_in_length_range,
+        num_proc=num_workers,
+        input_columns=["input_length"],
+    )
+
+    # for large datasets it is advised to run the preprocessing on a
+    # single machine first with `args.preprocessing_only` since there will mostly likely
+    # be a timeout when running the script in distributed mode.
+    # In a second step `args.preprocessing_only` can then be set to `False` to load the
+    # cached dataset
+    if data_args.preprocessing_only:
+        cache = {k: v.cache_files for k, v in vectorized_datasets.items()}
+        logger.info(f"Data preprocessing finished. Files cached at {cache}.")
+        return
+
+    # 8. Load Metric
+    metric = load_metric("wer")
+
+    def compute_metrics(pred_ids, label_ids):
+        label_ids[label_ids == -100] = tokenizer.pad_token_id
+
+        pred_str = tokenizer.batch_decode(pred_ids, skip_special_tokens=True)
+        # we do not want to group tokens when computing the metrics
+        label_str = tokenizer.batch_decode(label_ids, skip_special_tokens=True)
+
+        wer = metric.compute(predictions=pred_str, references=label_str)
+
+        return {"wer": wer}
+
+    # 9. Create a single speech processor
+    if is_main_process(training_args.local_rank):
+        # save feature extractor, tokenizer and config
+        feature_extractor.save_pretrained(training_args.output_dir)
+        tokenizer.save_pretrained(training_args.output_dir)
+        config.save_pretrained(training_args.output_dir)
+
+    processor = AutoProcessor.from_pretrained(training_args.output_dir)
+
+    # Enable tensorboard only on the master node
+    has_tensorboard = is_tensorboard_available()
+    if has_tensorboard and jax.process_index() == 0:
+        try:
+            from flax.metrics.tensorboard import SummaryWriter
+
+            summary_writer = SummaryWriter(log_dir=Path(training_args.output_dir))
+        except ImportError as ie:
+            has_tensorboard = False
+            logger.warning(
+                f"Unable to display metrics through TensorBoard because some package are not installed: {ie}"
+            )
+    else:
+        logger.warning(
+            "Unable to display metrics through TensorBoard because the package is not installed: "
+            "Please run `pip install tensorboard` to enable."
+        )
+
+    # 10. Define data collator NO NO NO
+    data_collator = DataCollatorSpeechSeq2SeqWithPadding(
+        processor=processor, decoder_start_token_id=model.config.decoder_start_token_id
+    )
+
+    # Initialize our training
+    rng = jax.random.PRNGKey(training_args.seed)
+    rng, dropout_rng = jax.random.split(rng)
+
+    # Store some constant
+    num_epochs = int(training_args.num_train_epochs)
+    train_batch_size = int(training_args.per_device_train_batch_size) * jax.device_count()
+    eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.device_count()
+    steps_per_epoch = len(vectorized_datasets["train"]) // train_batch_size
+    total_train_steps = steps_per_epoch * num_epochs
+
+    # Create learning rate schedule
+    linear_decay_lr_schedule_fn = create_learning_rate_fn(
+        len(vectorized_datasets["train"]),
+        train_batch_size,
+        training_args.num_train_epochs,
+        training_args.warmup_steps,
+        training_args.learning_rate,
+    )
+
+    # We use Optax's "masking" functionality to not apply weight decay
+    # to bias and LayerNorm scale parameters. decay_mask_fn returns a
+    # mask boolean with the same structure as the parameters.
+    # The mask is True for parameters that should be decayed.
+    # Note that this mask is specifically adapted for FlaxBart.
+    # For FlaxT5, one should correct the layer norm parameter naming
+    # accordingly - see `run_t5_mlm_flax.py` e.g.
+    def decay_mask_fn(params):
+        flat_params = traverse_util.flatten_dict(params)
+        layer_norm_params = [
+            (name, "scale") for name in ["self_attn_layer_norm", "layernorm_embedding", "final_layer_norm"]
+        ]
+        flat_mask = {path: (path[-1] != "bias" and path[-2:] not in layer_norm_params) for path in flat_params}
+        return traverse_util.unflatten_dict(flat_mask)
+
+    # create adam optimizer
+    adamw = optax.adamw(
+        learning_rate=linear_decay_lr_schedule_fn,
+        b1=training_args.adam_beta1,
+        b2=training_args.adam_beta2,
+        eps=training_args.adam_epsilon,
+        weight_decay=training_args.weight_decay,
+        mask=decay_mask_fn,
+    )
+
+    # Setup train state
+    state = TrainState.create(apply_fn=model.__call__, params=model.params, tx=adamw, dropout_rng=dropout_rng)
+
+    # label smoothed cross entropy
+    def loss_fn(logits, labels, padding_mask, label_smoothing_factor=0.0):
+        """
+        The label smoothing implementation is adapted from Flax's official example:
+        https://github.com/google/flax/blob/87a211135c6a377c8f29048a1cac3840e38b9da4/examples/wmt/train.py#L104
+        """
+        vocab_size = logits.shape[-1]
+        confidence = 1.0 - label_smoothing_factor
+        low_confidence = (1.0 - confidence) / (vocab_size - 1)
+        normalizing_constant = -(
+            confidence * jnp.log(confidence) + (vocab_size - 1) * low_confidence * jnp.log(low_confidence + 1e-20)
+        )
+        soft_labels = onehot(labels, vocab_size, on_value=confidence, off_value=low_confidence)
+
+        loss = optax.softmax_cross_entropy(logits, soft_labels)
+        loss = loss - normalizing_constant
+
+        # ignore padded tokens from loss
+        loss = loss * padding_mask
+        loss = loss.sum() / padding_mask.sum()
+        return loss
+
+    # Define gradient update step fn
+    def train_step(state, batch, label_smoothing_factor=0.0):
+        dropout_rng, new_dropout_rng = jax.random.split(state.dropout_rng)
+
+        def compute_loss(params):
+            labels = batch.pop("labels")
+            logits = state.apply_fn(**batch, params=params, dropout_rng=dropout_rng, train=True)[0]
+            loss = loss_fn(logits, labels, batch["decoder_attention_mask"], label_smoothing_factor)
+            return loss
+
+        grad_fn = jax.value_and_grad(compute_loss)
+        loss, grad = grad_fn(state.params)
+        grad = jax.lax.pmean(grad, "batch")
+
+        new_state = state.apply_gradients(grads=grad, dropout_rng=new_dropout_rng)
+
+        metrics = {"loss": loss, "learning_rate": linear_decay_lr_schedule_fn(state.step)}
+        metrics = jax.lax.pmean(metrics, axis_name="batch")
+
+        return new_state, metrics
+
+    # Define eval fn
+    def eval_step(params, batch, label_smoothing_factor=0.0):
+        labels = batch.pop("labels")
+        logits = model(**batch, params=params, train=False)[0]
+        loss = loss_fn(logits, labels, batch["decoder_attention_mask"], label_smoothing_factor)
+
+        # summarize metrics
+        metrics = {"loss": loss}
+        metrics = jax.lax.pmean(metrics, axis_name="batch")
+        return metrics
+
+    # Define generation function
+    max_length = (
+        data_args.val_max_target_length if data_args.val_max_target_length is not None else model.config.max_length
+    )
+    num_beams = data_args.num_beams if data_args.num_beams is not None else model.config.num_beams
+    gen_kwargs = {"max_length": max_length, "num_beams": num_beams}
+
+    def generate_step(params, batch):
+        model.params = params
+        output_ids = model.generate(batch["input_ids"], attention_mask=batch["attention_mask"], **gen_kwargs)
+        return output_ids.sequences
+
+    # Create parallel version of the train and eval step
+    p_train_step = jax.pmap(
+        partial(train_step, label_smoothing_factor=training_args.label_smoothing_factor), "batch", donate_argnums=(0,)
+    )
+    p_eval_step = jax.pmap(partial(eval_step, label_smoothing_factor=training_args.label_smoothing_factor), "batch")
+    p_generate_step = jax.pmap(generate_step, "batch")
+
+    # Replicate the train state on each device
+    state = state.replicate()
+
+    logger.info("***** Running training *****")
+    logger.info(f"  Num examples = {len(vectorized_datasets['train'])}")
+    logger.info(f"  Num Epochs = {num_epochs}")
+    logger.info(f"  Instantaneous batch size per device = {training_args.per_device_train_batch_size}")
+    logger.info(f"  Total train batch size (w. parallel & distributed) = {train_batch_size}")
+    logger.info(f"  Total optimization steps = {total_train_steps}")
+
+    train_time = 0
+    epochs = tqdm(range(num_epochs), desc=f"Epoch ... (1/{num_epochs})", position=0)
+    for epoch in epochs:
+        # ======================== Training ================================
+        train_start = time.time()
+
+        # Create sampling rng
+        rng, input_rng = jax.random.split(rng)
+        train_metrics = []
+
+        # Generate an epoch by shuffling sampling indices from the train dataset
+        train_loader = data_loader(input_rng, vectorized_datasets["train"], train_batch_size, shuffle=True)
+        steps_per_epoch = len(vectorized_datasets["train"]) // train_batch_size
+        # train
+        for _ in tqdm(range(steps_per_epoch), desc="Training...", position=1, leave=False):
+            batch = next(train_loader)
+            state, train_metric = p_train_step(state, batch)
+            train_metrics.append(train_metric)
+
+        train_time += time.time() - train_start
+
+        train_metric = unreplicate(train_metric)
+
+        epochs.write(
+            f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {train_metric['loss']}, Learning Rate: {train_metric['learning_rate']})"
+        )
+
+        # ======================== Evaluating ==============================
+        eval_metrics = []
+        eval_preds = []
+        eval_labels = []
+
+        eval_loader = data_loader(input_rng, vectorized_datasets["eval"], eval_batch_size)
+        eval_steps = len(vectorized_datasets["eval"]) // eval_batch_size
+        for _ in tqdm(range(eval_steps), desc="Evaluating...", position=2, leave=False):
+            # Model forward
+            batch = next(eval_loader)
+            labels = batch["labels"]
+
+            metrics = p_eval_step(state.params, batch)
+            eval_metrics.append(metrics)
+
+            # generation
+            if data_args.predict_with_generate:
+                generated_ids = p_generate_step(state.params, batch)
+                eval_preds.extend(jax.device_get(generated_ids.reshape(-1, gen_kwargs["max_length"])))
+                eval_labels.extend(jax.device_get(labels.reshape(-1, labels.shape[-1])))
+
+        # normalize eval metrics
+        eval_metrics = get_metrics(eval_metrics)
+        eval_metrics = jax.tree_map(jnp.mean, eval_metrics)
+
+        # compute WER metric
+        wer_desc = ""
+        if data_args.predict_with_generate:
+            wer_metric = compute_metrics(eval_preds, eval_labels)
+            eval_metrics.update(wer_metric)
+            wer_desc = " ".join([f"Eval {key}: {value} |" for key, value in wer_metric.items()])
+
+        # Print metrics and update progress bar
+        desc = f"Epoch... ({epoch + 1}/{num_epochs} | Eval Loss: {eval_metrics['loss']} | {wer_desc})"
+        epochs.write(desc)
+        epochs.desc = desc
+
+        # Save metrics
+        if has_tensorboard and jax.process_index() == 0:
+            cur_step = epoch * (len(vectorized_datasets["train"]) // train_batch_size)
+            write_metric(summary_writer, train_metrics, eval_metrics, train_time, cur_step)
+
+        # save checkpoint after each epoch and push checkpoint to the hub
+        if jax.process_index() == 0:
+            params = jax.device_get(jax.tree_map(lambda x: x[0], state.params))
+            model.save_pretrained(training_args.output_dir, params=params)
+            tokenizer.save_pretrained(training_args.output_dir)
+            if training_args.push_to_hub:
+                repo.push_to_hub(commit_message=f"Saving weights and logs of epoch {epoch}", blocking=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
+++ b/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
@@ -527,12 +527,6 @@ def main():
         datasets.utils.logging.set_verbosity_error()
         transformers.utils.logging.set_verbosity_error()
 
-    logger.info("Training/evaluation parameters %s", training_args)
-
-    # Set the default TPU matmul precision and display the number of devices
-    jax.config.update("jax_default_matmul_precision", training_args.matmul_precision)
-    logger.info(f"JAX devices: {jax.device_count()}, matmul precision: {training_args.matmul_precision}")
-
     # Set up wandb run
     if jax.process_index() == 0:
         wandb.init(project=data_args.wandb_project, job_type=data_args.wandb_job_type)
@@ -545,6 +539,12 @@ def main():
             "dtype": training_args.dtype,
             "matmul_precision": training_args.matmul_precision,
         }
+
+    logger.info("Training/evaluation parameters %s", training_args)
+
+    # Set the default TPU matmul precision and display the number of devices
+    jax.config.update("jax_default_matmul_precision", training_args.matmul_precision)
+    logger.info(f"JAX devices: {jax.device_count()}, matmul precision: {training_args.matmul_precision}")
 
     # TODO: 3. Detecting last checkpoint and eventually continue from last checkpoint
     last_checkpoint = None
@@ -1039,7 +1039,6 @@ def main():
         epochs.desc = desc
 
         # Save metrics
-        cur_step = epoch * (len(vectorized_datasets["train"]) // train_batch_size)
         write_wandb_log(eval_metrics, cur_step, prefix="eval")
         write_wandb_pred(pred_str, label_str, epoch)
         # if has_tensorboard and jax.process_index() == 0:

--- a/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
+++ b/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
@@ -105,7 +105,9 @@ class ModelArguments:
     freeze_feature_encoder: bool = field(
         default=True, metadata={"help": "Whether to freeze the feature encoder layers of the model."}
     )
-
+    hidden_dropout: float = field(
+        default=0.1, metadata={"help": "The dropout probability for all fully connected layers in the embeddings, encoder, and pooler."}
+    )
 
 @flax.struct.dataclass
 class DataTrainingArguments:
@@ -704,6 +706,10 @@ def main():
         revision=model_args.model_revision,
         use_auth_token=True if model_args.use_auth_token else None,
     )
+
+    # Set regularisation according to model args
+    model.config.encoder.hidden_dropout = model_args.hidden_dropout
+    model.config.decoder.dropout = model_args.hidden_dropout
 
     if model.config.decoder_start_token_id is None:
         raise ValueError("Make sure that `config.decoder_start_token_id` is correctly defined")

--- a/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
+++ b/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
@@ -329,6 +329,8 @@ def main():
         transformers.utils.logging.set_verbosity_info()
     logger.info("Training/evaluation parameters %s", training_args)
 
+    logger.info(f"JAX devices: {jax.device_count()}")
+
     # 3. Detecting last checkpoint and eventually continue from last checkpoint
     last_checkpoint = None
     if os.path.isdir(training_args.output_dir) and training_args.do_train and not training_args.overwrite_output_dir:
@@ -623,9 +625,6 @@ def main():
             # normalize loss over gradient accumulation steps
             loss = loss / gradient_accumulation_steps
             return loss
-
-        if training_args.gradient_checkpointing:
-            compute_loss = jax.checkpoint(compute_loss)
 
         grad_fn = jax.value_and_grad(compute_loss)
         loss, grad = grad_fn(state.params)

--- a/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
+++ b/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
@@ -316,12 +316,14 @@ class FlaxDataCollatorSpeechSeq2SeqWithPadding:
         batch["inputs"] = batch.pop("input_values")
         batch["labels"] = labels
         batch["decoder_input_ids"] = decoder_input_ids
-        batch["decoder_attention_mask"] = labels_batch.attention_mask
+        # decoder_attention_mask known to give issues with nan's
+        # remove decoder_attention_mask as an arg for the time being - handled by the causal mask in XXXForCausalLM
+        # batch["decoder_attention_mask"] = labels_batch.attention_mask
 
         return batch
 
 
-def write_metric(summary_writer, train_metrics, eval_metrics, train_time, step):
+def write_train_metric(summary_writer, train_metrics, train_time, step):
     summary_writer.scalar("train_time", train_time, step)
 
     train_metrics = get_metrics(train_metrics)
@@ -330,6 +332,8 @@ def write_metric(summary_writer, train_metrics, eval_metrics, train_time, step):
         for i, val in enumerate(vals):
             summary_writer.scalar(tag, val, step - len(vals) + i + 1)
 
+
+def write_eval_metric(summary_writer, eval_metrics, step):
     for metric_name, value in eval_metrics.items():
         summary_writer.scalar(f"eval_{metric_name}", value, step)
 
@@ -649,6 +653,7 @@ def main():
     # Note that this mask is specifically adapted for FlaxBart.
     # For FlaxT5, one should correct the layer norm parameter naming
     # accordingly - see `run_t5_mlm_flax.py` e.g.
+    # TODO: check param dictionary of encoder and decoder match the layer_norm_params list
     def decay_mask_fn(params):
         flat_params = traverse_util.flatten_dict(params)
         layer_norm_params = [
@@ -702,25 +707,56 @@ def main():
 
         def compute_loss(params):
             labels = batch.pop("labels")
-            logits = state.apply_fn(
+            outputs = state.apply_fn(
                 **batch,
                 params=params,
                 dropout_rng=dropout_rng,
                 freeze_feature_encoder=model_args.freeze_feature_encoder,
+                return_dict=True,
+                output_attentions=True,
+                output_hidden_states=True,
                 train=True,
-            )[0]
+            )
+            encoder_hidden_states = jnp.asarray(outputs.encoder_hidden_states)
+            encoder_outputs = outputs.encoder_last_hidden_state
+            decoder_hidden_states = jnp.asarray(outputs.decoder_hidden_states)
+            logits = outputs.logits
+
+            # check for nan in inputs by taking l2-norm over inputs
+            # a single nan in the inputs will return a nan when normed
+            logs = {"inputs": jnp.linalg.norm(batch["inputs"])}
+
+            # check for nan in encoder_hidden_states, encoder_outputs
+            logs["encoder_hidden_states"] = jnp.linalg.norm(
+                encoder_hidden_states.reshape(-1, encoder_hidden_states.shape[0]), axis=0
+            )
+            logs["encoder_outputs"] = jnp.linalg.norm(encoder_outputs)
+
+            # check for nan in decoder_hidden_states, decoder_outputs (logits)
+            logs["decoder_hidden_states"] = jnp.linalg.norm(
+                decoder_hidden_states.reshape(-1, decoder_hidden_states.shape[0]), axis=0
+            )
+            logs["logits"] = jnp.linalg.norm(logits)
+
             loss = loss_fn(logits, labels, label_smoothing_factor)
             # normalize loss over gradient accumulation steps (ignore for now)
             # loss = loss / gradient_accumulation_steps
-            return loss
+            return loss, logs
 
-        grad_fn = jax.value_and_grad(compute_loss)
-        loss, grad = grad_fn(state.params)
+        grad_fn = jax.value_and_grad(compute_loss, has_aux=True)
+        (loss, logs), grad = grad_fn(state.params)
+        # TODO: compute loss correctly over pmapped axis
         grad = jax.lax.pmean(grad, "batch")
+
+        # compute gradient norm for monitoring
+        # (re-introduce when no nan's on forward pass, currently meaningless)
+        # grad_norm = jnp.linalg.norm(jax.tree_util.tree_leaves(jax.tree_map(jnp.linalg.norm, grad)))
 
         new_state = state.apply_gradients(grads=grad, dropout_rng=new_dropout_rng)
 
-        metrics = {"loss": loss, "learning_rate": linear_decay_lr_schedule_fn(state.step)}
+        # don't log learning-rate and grad-norm until forward pass returns real-valued numbers
+        metrics = {"loss": loss}
+        metrics.update(logs)
         metrics = jax.lax.pmean(metrics, axis_name="batch")
 
         return new_state, metrics
@@ -773,7 +809,7 @@ def main():
 
         # Generate an epoch by shuffling sampling indices from the train dataset
         num_train_samples = len(vectorized_datasets["train"])
-        train_samples_idx = jax.random.permutation(input_rng, jnp.arange(num_train_samples))
+        train_samples_idx = np.random.permutation(np.arange(num_train_samples))
         train_batch_idx = generate_batch_splits(train_samples_idx, train_batch_size)
 
         # Gather the indexes for creating the batch and do a training step
@@ -784,13 +820,24 @@ def main():
             state, train_metric = p_train_step(state, batch)
             train_metrics.append(train_metric)
 
-        train_time += time.time() - train_start
+            cur_step = epoch * (num_train_samples // train_batch_size) + step
 
-        train_metric = unreplicate(train_metric)
+            if cur_step % training_args.logging_steps == 0 and cur_step > 0:
+                # Save metrics
+                train_metric = jax_utils.unreplicate(train_metric)
+                train_time += time.time() - train_start
+                # if has_tensorboard and jax.process_index() == 0:
+                #    write_train_metric(summary_writer, train_metrics, train_time, cur_step)
 
-        epochs.write(
-            f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {train_metric['loss']}, Learning Rate: {train_metric['learning_rate']})"
-        )
+                # Log everything
+                metric_desc = " ".join([f"{key}: {value} |" for key, value in train_metric.items()])
+                epochs.write(f"Step... ({cur_step}) | {metric_desc}")
+
+                train_metrics = []
+
+        # epochs.write(
+        #    f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {train_metric['loss']}, Learning Rate: {train_metric['learning_rate']})"
+        # )
 
         continue
         # ======================== Evaluating ==============================
@@ -835,7 +882,7 @@ def main():
         # Save metrics
         if has_tensorboard and jax.process_index() == 0:
             cur_step = epoch * (len(vectorized_datasets["train"]) // train_batch_size)
-            write_metric(summary_writer, train_metrics, eval_metrics, train_time, cur_step)
+            write_eval_metric(summary_writer, eval_metrics, cur_step)
 
         # save checkpoint after each epoch and push checkpoint to the hub
         if jax.process_index() == 0:

--- a/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
+++ b/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
@@ -328,6 +328,7 @@ class FlaxDataCollatorSpeechSeq2SeqWithPadding:
         # different padding methods
         input_features = [{"input_values": feature["input_values"]} for feature in features]
         label_features = [{"input_ids": feature["labels"]} for feature in features]
+        labels_length = [feature["labels_length"] for feature in features]
 
         # reformat list to dict and set to pytorch format
         batch = self.processor.feature_extractor.pad(
@@ -362,6 +363,7 @@ class FlaxDataCollatorSpeechSeq2SeqWithPadding:
         batch["inputs"] = batch.pop("input_values")
         batch["labels"] = labels
         batch["decoder_input_ids"] = decoder_input_ids
+        batch["labels_length"] = np.array(labels_length)
 
         return batch
 
@@ -846,6 +848,7 @@ def main():
 
         def compute_loss(params, minibatch):
             labels = minibatch.pop("labels")
+            labels_size = minibatch.pop("labels_length").sum()
             logits = state.apply_fn(
                 **minibatch,
                 params=params,
@@ -854,12 +857,12 @@ def main():
                 train=True,
             )[0]
             loss = loss_fn(logits, labels)
-            return loss
+            return loss, labels_size
 
-        grad_fn = jax.value_and_grad(compute_loss)
+        grad_fn = jax.value_and_grad(compute_loss, has_aux=True)
 
         if gradient_accumulation_steps == 1:
-            loss, grad = grad_fn(state.params, batch)
+            (loss, labels_size), grad = grad_fn(state.params, batch)
 
         # Custom gradient accumulation
         else:
@@ -868,31 +871,32 @@ def main():
                 lambda x: x.reshape(gradient_accumulation_steps, training_args.per_device_train_batch_size, -1), batch
             )
 
-            def accum_minibatch_step(grad_idx, accum_loss_grad):
-                accum_loss, accum_grad = accum_loss_grad
+            def accum_minibatch_step(grad_idx, accum_loss_labels_grad):
+                accum_loss, accum_labels_size, accum_grad = accum_loss_labels_grad
                 # get a minibatch (one gradient accumulation slice)
                 minibatch = jax.tree_map(
                     lambda x: jax.lax.dynamic_index_in_dim(x, grad_idx, keepdims=False),
                     batch,
                 )
-                # compute loss and grad over minibatch and accumulate
-                loss, grad = grad_fn(state.params, minibatch)
-                return jax.tree_map(jnp.add, (accum_loss, accum_grad), (loss, grad))
+                # compute the loss, labels size and grad over the minibatch and accumulate
+                (loss, labels_size), grad = grad_fn(state.params, minibatch)
+                return jax.tree_map(jnp.add, (accum_loss, accum_labels_size, accum_grad), (loss, labels_size, grad))
 
             # create an initial state for accumulating losses and gradients
-            init_loss_grad = (0, jax.tree_map(jnp.zeros_like, state.params))
+            init_loss_labels_grad = (0, 0, jax.tree_map(jnp.zeros_like, state.params))
             # loop accum minibatch step over the number of gradient accumulation steps
-            loss, grad = jax.lax.fori_loop(
+            loss, labels_size, grad = jax.lax.fori_loop(
                 0,
                 gradient_accumulation_steps,
                 accum_minibatch_step,
-                init_loss_grad,
+                init_loss_labels_grad,
             )
             # normalise losses and gradients over the number of gradient accumulation steps
-            loss, grad = jax.tree_map(lambda x: x / gradient_accumulation_steps, (loss, grad))
+            loss, labels_size, grad = jax.tree_map(lambda x: x / gradient_accumulation_steps, (loss, labels_size, grad))
 
-        # straight mean over pmapped axis, we'll modify this to a weighted sum later...
-        grad = jax.lax.pmean(grad, "batch")
+        # weighted sum over pmapped axis
+        grad = jax.lax.psum(grad, "batch")
+        grad = jax.tree_map(lambda g: g / labels_size, grad)
 
         # update state
         new_state = state.apply_gradients(grads=grad, dropout_rng=new_dropout_rng)

--- a/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
+++ b/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
@@ -621,6 +621,9 @@ def main():
             loss = loss / gradient_accumulation_steps
             return loss
 
+        if training_args.gradient_checkpointing:
+            compute_loss = jax.checkpoint(compute_loss)
+
         grad_fn = jax.value_and_grad(compute_loss)
         loss, grad = grad_fn(state.params)
         grad = jax.lax.pmean(grad, "batch")

--- a/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
+++ b/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
@@ -698,11 +698,11 @@ def main():
         eval_preds = []
         eval_labels = []
 
-        num_eval_samples = len(vectorized_datasets["validation"])
+        num_eval_samples = len(vectorized_datasets["eval"])
         eval_samples_idx = jnp.arange(num_eval_samples)
         eval_batch_idx = generate_batch_splits(eval_samples_idx, eval_batch_size)
         for i, batch_idx in enumerate(tqdm(eval_batch_idx, desc="Evaluating ...", position=2)):
-            samples = [vectorized_datasets["validation"][int(idx)] for idx in batch_idx]
+            samples = [vectorized_datasets["eval"][int(idx)] for idx in batch_idx]
             batch = data_collator(samples)
             batch = shard(batch.data)
             labels = batch["labels"]

--- a/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
+++ b/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
@@ -29,6 +29,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import datasets
 import numpy as np
 from datasets import DatasetDict, load_dataset, load_metric
+from optax._src import linear_algebra
 from tqdm import tqdm
 
 import flax
@@ -300,6 +301,7 @@ class MixedPrecisionTrainState(struct.PyTreeNode):
     tx: optax.GradientTransformation = struct.field(pytree_node=False)
     opt_state: optax.OptState
     dropout_rng: jnp.ndarray
+    max_grad_norm: Optional[float] = 1.0
 
     def apply_gradients(self, *, grads, to_dtype, **kwargs):
         """Updates `step`, `params`, `opt_state` and `**kwargs` in return value.
@@ -316,6 +318,13 @@ class MixedPrecisionTrainState(struct.PyTreeNode):
           and `opt_state` updated by applying `grads`, and additional attributes
           replaced as specified by `kwargs`.
         """
+
+        # clip gradients by global l2 norm
+        casted_max_grad_norm = to_dtype(self.max_grad_norm)
+        g_norm = linear_algebra.global_norm(grads)
+        g_norm = jnp.maximum(casted_max_grad_norm, g_norm)
+        grads = jax.tree_map(lambda t: (t / g_norm) * casted_max_grad_norm, grads)
+
         # downcast params to bf16 to match dtype of grads and optimizer state if mixed-precision training
         updates, new_opt_state = self.tx.update(grads, self.opt_state, to_dtype(self.params))
 
@@ -613,10 +622,10 @@ def main():
         wandb.config = {
             "learning_rate": training_args.learning_rate,
             "warmup_steps": training_args.warmup_steps,
-            "batch_size": training_args.per_device_train_batch_size,
+            "per_device_batch_size": training_args.per_device_train_batch_size,
             "gradient_accumulation_steps": training_args.gradient_accumulation_steps,
             "num_epochs": training_args.num_train_epochs,
-            "dtype": "bfloat16" if training_args.mixed_precision else "float32",
+            "mixed_precision": training_args.mixed_precision,
             "matmul_precision": training_args.matmul_precision,
         }
 
@@ -865,14 +874,14 @@ def main():
     batch_size_per_update = train_batch_size * gradient_accumulation_steps
     eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.device_count()
     num_train_samples = len(vectorized_datasets["train"])
-    steps_per_epoch = num_train_samples // train_batch_size
+    steps_per_epoch = num_train_samples // batch_size_per_update
     total_train_steps = steps_per_epoch * num_epochs
     to_dtype = to_bf16 if training_args.mixed_precision else to_fp32
 
     # Create learning rate schedule
     linear_decay_lr_schedule_fn = create_learning_rate_fn(
         len(vectorized_datasets["train"]),
-        train_batch_size,
+        batch_size_per_update,
         training_args.num_train_epochs,
         training_args.warmup_steps,
         training_args.learning_rate,
@@ -895,7 +904,7 @@ def main():
         return traverse_util.unflatten_dict(flat_mask)
 
     # Create adam optimizer
-    adamw = optax.adamw(
+    optim = optax.adamw(
         learning_rate=linear_decay_lr_schedule_fn,
         b1=training_args.adam_beta1,
         b2=training_args.adam_beta2,
@@ -904,10 +913,7 @@ def main():
         mask=decay_mask_fn,
     )
 
-    # Augment the optimizer to facilitate gradient clipping by global norm
-    optim = optax.chain(optax.clip_by_global_norm(training_args.max_grad_norm), adamw)
-
-    # Optax MultiSteps for gradient accumulation. For the time being, we'll only call this optimizer transformation if gradient accumulation is required (i.e. gradient accumulation steps > 1)
+    # Optax MultiSteps for gradient accumulation. We'll only call this optimizer transformation if gradient accumulation is required (i.e. gradient accumulation steps > 1)
     if training_args.multisteps and gradient_accumulation_steps > 1:
         optim = optax.MultiSteps(optim, gradient_accumulation_steps, use_grad_mean=False)
 
@@ -918,6 +924,7 @@ def main():
         tx=optim,
         to_dtype=to_dtype,
         dropout_rng=dropout_rng,
+        max_grad_norm=training_args.max_grad_norm,
     )
 
     # Cross entropy loss
@@ -974,7 +981,7 @@ def main():
                 return jax.tree_map(jnp.add, (accum_loss, accum_labels, accum_grad), (loss, num_labels, grad))
 
             # create an initial state for accumulating losses, num labels and gradients
-            init_loss_labels_grad = (0, 0, jax.tree_map(jnp.zeros_like, state.params))
+            init_loss_labels_grad = (0, 0, jax.tree_map(jnp.zeros_like, to_dtype(state.params)))
             # loop accum minibatch step over the number of gradient accumulation steps
             loss, num_labels, grad = jax.lax.fori_loop(
                 0,
@@ -1078,7 +1085,7 @@ def main():
             batch = shard(batch.data)
             state, train_metric = p_train_step(state, batch)
 
-            cur_step = epoch * (num_train_samples // train_batch_size) + step
+            cur_step = epoch * (num_train_samples // batch_size_per_update) + step
 
             if cur_step % training_args.logging_steps == 0 and cur_step > 0:
                 # Save metrics

--- a/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
+++ b/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
@@ -244,9 +244,9 @@ class FlaxSeq2SeqTrainingArguments(Seq2SeqTrainingArguments):
         default=None,
         metadata={
             "help": "Floating-point format in which to store the model parameters. Can be used on TPU to explicitly "
-                    "convert the model parameters to bfloat16 precision to do full half-precision training "
-                    "or to save weights in bfloat16 for inference in order to save memory and improve speed. "
-                    "One of `[to_fp32, to_fp16, to_bf16]`"
+            "convert the model parameters to bfloat16 precision to do full half-precision training "
+            "or to save weights in bfloat16 for inference in order to save memory and improve speed. "
+            "One of `[to_fp32, to_fp16, to_bf16]`"
         },
     )
     matmul_precision: str = field(
@@ -892,7 +892,9 @@ def main():
                 init_loss_labels_grad,
             )
             # normalise losses and gradients over the number of gradient accumulation steps
-            loss, labels_size, grad = jax.tree_map(lambda x: x / gradient_accumulation_steps, (loss, labels_size, grad))
+            loss, labels_size, grad = jax.tree_map(
+                lambda x: x / gradient_accumulation_steps, (loss, labels_size, grad)
+            )
 
         # weighted sum over pmapped axis
         grad = jax.lax.psum(grad, "batch")

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -2248,6 +2248,7 @@ if is_flax_available():
             "FlaxAutoModelForQuestionAnswering",
             "FlaxAutoModelForSeq2SeqLM",
             "FlaxAutoModelForSequenceClassification",
+            "FlaxAutoModelForSpeechSeq2Seq",
             "FlaxAutoModelForTokenClassification",
             "FlaxAutoModelForVision2Seq",
         ]
@@ -4274,6 +4275,7 @@ if TYPE_CHECKING:
             FlaxAutoModelForQuestionAnswering,
             FlaxAutoModelForSeq2SeqLM,
             FlaxAutoModelForSequenceClassification,
+            FlaxAutoModelForSpeechSeq2Seq,
             FlaxAutoModelForTokenClassification,
             FlaxAutoModelForVision2Seq,
         )

--- a/src/transformers/models/auto/__init__.py
+++ b/src/transformers/models/auto/__init__.py
@@ -138,6 +138,7 @@ if is_flax_available():
         "FlaxAutoModelForQuestionAnswering",
         "FlaxAutoModelForSeq2SeqLM",
         "FlaxAutoModelForSequenceClassification",
+        "FlaxAutoModelForSpeechSeq2Seq",
         "FlaxAutoModelForTokenClassification",
         "FlaxAutoModelForVision2Seq",
     ]
@@ -259,6 +260,7 @@ if TYPE_CHECKING:
             FlaxAutoModelForQuestionAnswering,
             FlaxAutoModelForSeq2SeqLM,
             FlaxAutoModelForSequenceClassification,
+            FlaxAutoModelForSpeechSeq2Seq,
             FlaxAutoModelForTokenClassification,
             FlaxAutoModelForVision2Seq,
         )

--- a/src/transformers/utils/dummy_flax_objects.py
+++ b/src/transformers/utils/dummy_flax_objects.py
@@ -228,6 +228,13 @@ class FlaxAutoModelForSeq2SeqLM(metaclass=DummyObject):
         requires_backends(self, ["flax"])
 
 
+class FlaxAutoModelForSpeechSeq2Seq(metaclass=DummyObject):
+    _backends = ["flax"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["flax"])
+
+
 class FlaxAutoModelForSequenceClassification(metaclass=DummyObject):
     _backends = ["flax"]
 

--- a/src/transformers/utils/dummy_flax_objects.py
+++ b/src/transformers/utils/dummy_flax_objects.py
@@ -228,14 +228,14 @@ class FlaxAutoModelForSeq2SeqLM(metaclass=DummyObject):
         requires_backends(self, ["flax"])
 
 
-class FlaxAutoModelForSpeechSeq2Seq(metaclass=DummyObject):
+class FlaxAutoModelForSequenceClassification(metaclass=DummyObject):
     _backends = ["flax"]
 
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["flax"])
 
 
-class FlaxAutoModelForSequenceClassification(metaclass=DummyObject):
+class FlaxAutoModelForSpeechSeq2Seq(metaclass=DummyObject):
     _backends = ["flax"]
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This PR adds the example script `run_flax_speech_recognition_seq2seq.py`, which can be used to fine-tune any [`Speech Sequence-to-Sequence Model`](https://huggingface.co/docs/transformers/master/en/model_doc/auto#transformers.AutoModelForSpeechSeq2Seq) for automatic speech recognition **in Flax** on one of the [official speech recognition datasets](https://huggingface.co/datasets?task_ids=task_ids:automatic-speech-recognition) or a custom dataset.

What remains TODO:
- [x] Add an adapter layer when loading a pre-trained Wav2Vec2 encoder checkpoint through a keyword argument. See: https://github.com/huggingface/transformers/pull/16056
- [x] Flax length grouped sampler: group training data into mega batches sorted by input length in order to minimise the amount of padding required. Place the batch of `batch_size` containing the element of maximum length placed first, so that an OOM happens sooner rather than later. See: https://github.com/huggingface/transformers/pull/16058/commits/d66c59de31ce3d8c61127b63b9198b69a0930ccd
- [x] Fix compilation issues with the Flax DataCollator: once the training data is grouped by input length, pad the input sequences using `pad_to_multiple_of`. Independently pad the target labels using `max_length`. See: https://github.com/huggingface/transformers/pull/16058/commits/d5a5fbdfeca67275e75c55498af0a3282c1c0741
- [ ] Verify the script works and that it yields equivalent results to PyTorch. Fine-tune Wav2Vec2-2-Bart-large-cnn on `librispeech-asr` in order to reproduce the PyTorch training results at https://huggingface.co/sanchit-gandhi/wav2vec2-2-bart-large-cnn/tensorboard.
- [ ] Save the feature encoder outputs during/before the first epoch and use these as the model inputs for subsequent epochs.
- [x] Gradient accumulation using the Optax optimiser library functions (`apply_every` or `MultiSteps`). Huge memory overhead. Switch to a custom implementations (see below).
- [x] Custom gradient accumulation. See: https://github.com/huggingface/transformers/pull/16058/commits/3ef71d141fb9b643959326c123026c454c4efa13
- [x] Gradient Checkpointing (aborted) - requires an `nn.remat` module in every Flax model layer, and shown not to give huge improvements in the Dalle-mini project.
- [ ] (Load and Continue from Last Checkpoint)