### PR TITLE
FIX: updating doc/example for fine-tune for downstream Token Classification

### DIFF
--- a/docs/source/tasks/token_classification.mdx
+++ b/docs/source/tasks/token_classification.mdx
@@ -151,7 +151,7 @@ Load DistilBERT with [`AutoModelForTokenClassification`] along with the number o
 ```py
 >>> from transformers import AutoModelForTokenClassification, TrainingArguments, Trainer
 
->>> model = AutoModelForTokenClassification.from_pretrained("distilbert-base-uncased", num_labels=2)
+>>> model = AutoModelForTokenClassification.from_pretrained("distilbert-base-uncased", num_labels=14)
 ```
 
 <Tip>


### PR DESCRIPTION
# What does this PR do?

The documentation for fine tuning for downstream tasks, specifically for, Token Classification has an error, in the command AutoModelForTokenClassification command 

`model = AutoModelForTokenClassification.from_pretrained(model_checkpoint, num_labels=2)`

it should be instead 14

`model = AutoModelForTokenClassification.from_pretrained(model_checkpoint, num_labels=14)`

check the following command:

`len({x for x in sample for sample in tokenized_wnut["train"]['labels']})`

14 labels:
- The `WNUT’17 Emerging and Rare Entities task` dataset has 13 labels 
- `-100` to the special tokens `[CLS]` and `[SEP]`


@sgugger I think you are the one reviewing this types of PR, i.e. doc related.