### PR TITLE
Improve Swin for VisionEncoderDecoder

### DIFF
--- a/src/transformers/models/swin/configuration_swin.py
+++ b/src/transformers/models/swin/configuration_swin.py
@@ -94,6 +94,7 @@ class SwinConfig(PretrainedConfig):
 
     attribute_map = {
         "num_attention_heads": "num_heads",
+        "num_hidden_layers": "num_layers",
     }
 
     def __init__(
@@ -141,4 +142,4 @@ class SwinConfig(PretrainedConfig):
         self.encoder_stride = encoder_stride
         # we set the hidden_size attribute in order to make Swin work with VisionEncoderDecoderModel
         # this indicates the channel dimension after the last stage of the model
-        self.hidden_size = embed_dim * 8
+        self.hidden_size = int(embed_dim * 2 ** (len(depths) - 1))

--- a/tests/swin/test_modeling_swin.py
+++ b/tests/swin/test_modeling_swin.py
@@ -52,7 +52,7 @@ class SwinModelTester:
         self,
         parent,
         batch_size=13,
-        image_size=128,
+        image_size=32,
         patch_size=2,
         num_channels=3,
         embed_dim=16,
@@ -73,7 +73,7 @@ class SwinModelTester:
         scope=None,
         use_labels=True,
         type_sequence_label_size=10,
-        encoder_stride=2,
+        encoder_stride=8,
     ):
         self.parent = parent
         self.batch_size = batch_size

--- a/tests/swin/test_modeling_swin.py
+++ b/tests/swin/test_modeling_swin.py
@@ -52,12 +52,12 @@ class SwinModelTester:
         self,
         parent,
         batch_size=13,
-        image_size=32,
+        image_size=128,
         patch_size=2,
         num_channels=3,
         embed_dim=16,
-        depths=[1],
-        num_heads=[2],
+        depths=[1, 2, 1],
+        num_heads=[2, 2, 4],
         window_size=2,
         mlp_ratio=2.0,
         qkv_bias=True,
@@ -139,8 +139,7 @@ class SwinModelTester:
         model.eval()
         result = model(pixel_values)
 
-        # since the model we're testing only consists of a single layer, expected_seq_len = number of patches
-        expected_seq_len = (config.image_size // config.patch_size) ** 2
+        expected_seq_len = ((config.image_size // config.patch_size) ** 2) // (4 ** (len(config.depths) - 1))
         expected_dim = int(config.embed_dim * 2 ** (len(config.depths) - 1))
 
         self.parent.assertEqual(result.last_hidden_state.shape, (self.batch_size, expected_seq_len, expected_dim))


### PR DESCRIPTION
# What does this PR do?

This PR improves support for the Swin Transformer with the `VisionEncoderDecoderModel` framework.

Thanks to @FrancescoSaverioZuppichini we now have general formulas to compute the sequence length and hidden size of the last hidden state of Swin Transformer.

