### PR TITLE
Add TFCamembertForCausalLM and ONNX integration test

### DIFF
--- a/docs/source/model_doc/camembert.mdx
+++ b/docs/source/model_doc/camembert.mdx
@@ -85,6 +85,10 @@ This model was contributed by [camembert](https://huggingface.co/camembert). The
 
 [[autodoc]] TFCamembertModel
 
+## TFCamembertForCasualLM
+
+[[autodoc]] TFCamembertForCausalLM
+
 ## TFCamembertForMaskedLM
 
 [[autodoc]] TFCamembertForMaskedLM

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -1744,6 +1744,7 @@ if is_tf_available():
     _import_structure["models.camembert"].extend(
         [
             "TF_CAMEMBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+            "TFCamembertForCausalLM",
             "TFCamembertForMaskedLM",
             "TFCamembertForMultipleChoice",
             "TFCamembertForQuestionAnswering",
@@ -3812,6 +3813,7 @@ if TYPE_CHECKING:
         )
         from .models.camembert import (
             TF_CAMEMBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFCamembertForCausalLM,
             TFCamembertForMaskedLM,
             TFCamembertForMultipleChoice,
             TFCamembertForQuestionAnswering,

--- a/src/transformers/models/auto/modeling_tf_auto.py
+++ b/src/transformers/models/auto/modeling_tf_auto.py
@@ -149,6 +149,7 @@ TF_MODEL_FOR_CAUSAL_LM_MAPPING_NAMES = OrderedDict(
         ("xlnet", "TFXLNetLMHeadModel"),
         ("xlm", "TFXLMWithLMHeadModel"),
         ("ctrl", "TFCTRLLMHeadModel"),
+        ("camembert", "TFCamembertForCausalLM"),
     ]
 )
 

--- a/src/transformers/models/auto/modeling_tf_auto.py
+++ b/src/transformers/models/auto/modeling_tf_auto.py
@@ -139,6 +139,7 @@ TF_MODEL_WITH_LM_HEAD_MAPPING_NAMES = OrderedDict(
 TF_MODEL_FOR_CAUSAL_LM_MAPPING_NAMES = OrderedDict(
     [
         # Model for Causal LM mapping
+        ("camembert", "TFCamembertForCausalLM"),
         ("rembert", "TFRemBertForCausalLM"),
         ("roformer", "TFRoFormerForCausalLM"),
         ("roberta", "TFRobertaForCausalLM"),
@@ -149,7 +150,6 @@ TF_MODEL_FOR_CAUSAL_LM_MAPPING_NAMES = OrderedDict(
         ("xlnet", "TFXLNetLMHeadModel"),
         ("xlm", "TFXLMWithLMHeadModel"),
         ("ctrl", "TFCTRLLMHeadModel"),
-        ("camembert", "TFCamembertForCausalLM"),
     ]
 )
 

--- a/src/transformers/models/camembert/__init__.py
+++ b/src/transformers/models/camembert/__init__.py
@@ -52,6 +52,7 @@ if is_torch_available():
 if is_tf_available():
     _import_structure["modeling_tf_camembert"] = [
         "TF_CAMEMBERT_PRETRAINED_MODEL_ARCHIVE_LIST",
+        "TFCamembertForCausalLM",
         "TFCamembertForMaskedLM",
         "TFCamembertForMultipleChoice",
         "TFCamembertForQuestionAnswering",
@@ -85,6 +86,7 @@ if TYPE_CHECKING:
     if is_tf_available():
         from .modeling_tf_camembert import (
             TF_CAMEMBERT_PRETRAINED_MODEL_ARCHIVE_LIST,
+            TFCamembertForCausalLM,
             TFCamembertForMaskedLM,
             TFCamembertForMultipleChoice,
             TFCamembertForQuestionAnswering,

--- a/src/transformers/models/camembert/modeling_tf_camembert.py
+++ b/src/transformers/models/camembert/modeling_tf_camembert.py
@@ -18,6 +18,7 @@
 from ...file_utils import add_start_docstrings
 from ...utils import logging
 from ..roberta.modeling_tf_roberta import (
+    TFRobertaForCausalLM,
     TFRobertaForMaskedLM,
     TFRobertaForMultipleChoice,
     TFRobertaForQuestionAnswering,
@@ -158,6 +159,18 @@ class TFCamembertForQuestionAnswering(TFRobertaForQuestionAnswering):
     """
     This class overrides [`TFRobertaForQuestionAnswering`]. Please check the superclass for the appropriate
     documentation alongside usage examples.
+    """
+
+    config_class = CamembertConfig
+
+
+@add_start_docstrings(
+    """CamemBERT Model with a `language modeling` head on top for CLM fine-tuning.""", CAMEMBERT_START_DOCSTRING
+)
+class TFCamembertForCausalLM(TFRobertaForCausalLM):
+    """
+    This class overrides [`TFRobertaForCausalLM`]. Please check the superclass for the appropriate documentation
+    alongside usage examples.
     """
 
     config_class = CamembertConfig

--- a/src/transformers/utils/dummy_tf_objects.py
+++ b/src/transformers/utils/dummy_tf_objects.py
@@ -537,6 +537,13 @@ class TFBlenderbotSmallPreTrainedModel(metaclass=DummyObject):
 TF_CAMEMBERT_PRETRAINED_MODEL_ARCHIVE_LIST = None
 
 
+class TFCamembertForCausalLM(metaclass=DummyObject):
+    _backends = ["tf"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["tf"])
+
+
 class TFCamembertForMaskedLM(metaclass=DummyObject):
     _backends = ["tf"]
 

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -200,6 +200,7 @@ PYTORCH_EXPORT_SEQ2SEQ_WITH_PAST_MODELS = {
 TENSORFLOW_EXPORT_DEFAULT_MODELS = {
     ("albert", "hf-internal-testing/tiny-albert"),
     ("bert", "bert-base-cased"),
+    ("camembert", "camembert-base"),
     ("distilbert", "distilbert-base-cased"),
     ("roberta", "roberta-base"),
 }


### PR DESCRIPTION
# What does this PR do?

This PR adds a missing causal language modelling head for the TensorFlow implementation of Camembert. 

With this, we can also test the ONNX export of TensorFlow Camembert models, so I've included the checkpoint in the integration tests as well

This is my first TensorFlow contribution to `transformers`, so please be nice :)