### PR TITLE
Fix and document Zero Shot Image Classification

### DIFF
--- a/docs/source/main_classes/pipelines.mdx
+++ b/docs/source/main_classes/pipelines.mdx
@@ -39,6 +39,7 @@ There are two categories of pipeline abstractions to be aware about:
   - [`TokenClassificationPipeline`]
   - [`TranslationPipeline`]
   - [`ZeroShotClassificationPipeline`]
+  - [`ZeroShotImageClassificationPipeline`]
 
 ## The pipeline abstraction
 

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -245,7 +245,7 @@ SUPPORTED_TASKS = {
         "impl": ZeroShotImageClassificationPipeline,
         "tf": (TFAutoModel,) if is_tf_available() else (),
         "pt": (AutoModel,) if is_torch_available() else (),
-        "default": {"pt": "openai/clip-vit-base-patch32", "tf": "openai/clip-vit-base-patch32"},
+        "default": {"model": {"pt": "openai/clip-vit-base-patch32", "tf": "openai/clip-vit-base-patch32"}},
         "type": "multimodal",
     },
     "conversational": {
@@ -346,6 +346,7 @@ def check_task(task: str) -> Tuple[Dict, Any]:
             - `"translation_xx_to_yy"`
             - `"summarization"`
             - `"zero-shot-classification"`
+            - `"zero-shot-image-classification"`
 
     Returns:
         (task_defaults`dict`, task_options: (`tuple`, None)) The actual dictionary required to initialize the pipeline

--- a/src/transformers/pipelines/zero_shot_image_classification.py
+++ b/src/transformers/pipelines/zero_shot_image_classification.py
@@ -35,7 +35,7 @@ class ZeroShotImageClassificationPipeline(ChunkPipeline):
     `"zero-shot-image-classification"`.
 
     See the list of available models on
-    [huggingface.co/models](https://huggingface.co/models?filter=zer-shot-image-classification).
+    [huggingface.co/models](https://huggingface.co/models?filter=zero-shot-image-classification).
     """
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
# What does this PR do?

This PR fixes 3 issues with `zero-shot-image-classification`

* It does not pick a default model, although there is one. This leads to weird error message

```python
pipe = pipeline("zero-shot-image-classification")
>> ValueError: The task defaults can't be correctly selected. You probably meant "translation_XX_to_YY"
```

* The pipeline is not in the list at top of https://huggingface.co/docs/transformers/main_classes/pipelines
* The filter for available models has a typo, although right now this still leads to no models (ok just one).

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@Narsil @sgugger 
