### PR TITLE
[Fix doc example] Fix checkpoint name in docstring example

### DIFF
--- a/src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
+++ b/src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
@@ -870,7 +870,7 @@ class Speech2Text2ForCausalLM(Speech2Text2PreTrainedModel):
         >>> from datasets import load_dataset
 
         >>> feature_extractor = Wav2Vec2FeatureExtractor()
-        >>> tokenizer = Speech2Text2Tokenizer.from_pretrained(_CHECKPOINT_FOR_DOC)
+        >>> tokenizer = Speech2Text2Tokenizer.from_pretrained("facebook/s2t-wav2vec2-large-en-de")
 
         >>> encoder = Wav2Vec2Model(Wav2Vec2Config())
         >>> decoder = Speech2Text2ForCausalLM(Speech2Text2Config())

--- a/src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
+++ b/src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
@@ -787,7 +787,7 @@ class Speech2Text2ForCausalLM(Speech2Text2PreTrainedModel):
         output_hidden_states=None,
         return_dict=None,
     ):
-        f"""
+        r"""
         Args:
             input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
                 Indices of input sequence tokens in the vocabulary. Padding will be ignored by default should you
@@ -870,7 +870,7 @@ class Speech2Text2ForCausalLM(Speech2Text2PreTrainedModel):
         >>> from datasets import load_dataset
 
         >>> feature_extractor = Wav2Vec2FeatureExtractor()
-        >>> tokenizer = Speech2Text2Tokenizer.from_pretrained({_CHECKPOINT_FOR_DOC})
+        >>> tokenizer = Speech2Text2Tokenizer.from_pretrained("facebook/s2t-wav2vec2-large-en-de")
 
         >>> encoder = Wav2Vec2Model(Wav2Vec2Config())
         >>> decoder = Speech2Text2ForCausalLM(Speech2Text2Config())

--- a/src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
+++ b/src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
@@ -787,7 +787,7 @@ class Speech2Text2ForCausalLM(Speech2Text2PreTrainedModel):
         output_hidden_states=None,
         return_dict=None,
     ):
-        rf"""
+        f"""
         Args:
             input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
                 Indices of input sequence tokens in the vocabulary. Padding will be ignored by default should you

--- a/src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
+++ b/src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
@@ -787,7 +787,7 @@ class Speech2Text2ForCausalLM(Speech2Text2PreTrainedModel):
         output_hidden_states=None,
         return_dict=None,
     ):
-        r"""
+        rf"""
         Args:
             input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
                 Indices of input sequence tokens in the vocabulary. Padding will be ignored by default should you

--- a/src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
+++ b/src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
@@ -870,7 +870,7 @@ class Speech2Text2ForCausalLM(Speech2Text2PreTrainedModel):
         >>> from datasets import load_dataset
 
         >>> feature_extractor = Wav2Vec2FeatureExtractor()
-        >>> tokenizer = Speech2Text2Tokenizer.from_pretrained("facebook/s2t-wav2vec2-large-en-de")
+        >>> tokenizer = Speech2Text2Tokenizer.from_pretrained({_CHECKPOINT_FOR_DOC})
 
         >>> encoder = Wav2Vec2Model(Wav2Vec2Config())
         >>> decoder = Speech2Text2ForCausalLM(Speech2Text2Config())


### PR DESCRIPTION
# What does this PR do?

Use real name instead of `_CHECKPOINT_FOR_DOC` in docstring example.

## More context

This line in `modeling_speech_to_text_2.py`
```python
>>> tokenizer = Speech2Text2Tokenizer.from_pretrained(_CHECKPOINT_FOR_DOC)
```

gives the following error:
```python
Traceback (most recent call last):
  File "/tmp/tmpgv1pik63/-789619136090462200.py", line 13, in <module>
    tokenizer = Speech2Text2Tokenizer.from_pretrained(_CHECKPOINT_FOR_DOC)
NameError: name '_CHECKPOINT_FOR_DOC' is not defined
```

because `_CHECKPOINT_FOR_DOC` is not defined if a user copies the code example and try to run it.