### PR TITLE
Fix Typo in Argument of FlaxWav2Vec2ForPreTrainingModule

### DIFF
--- a/src/transformers/models/wav2vec2/modeling_flax_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_flax_wav2vec2.py
@@ -1235,7 +1235,7 @@ class FlaxWav2Vec2ForPreTrainingModule(nn.Module):
         deterministic: bool = True,
         output_attentions=None,
         output_hidden_states=None,
-        freeze_feature_enocder=False,
+        freeze_feature_encoder=False,
         return_dict=None,
     ):
         r"""
@@ -1256,7 +1256,7 @@ class FlaxWav2Vec2ForPreTrainingModule(nn.Module):
             output_hidden_states=output_hidden_states,
             mask_time_indices=mask_time_indices,
             deterministic=deterministic,
-            freeze_feature_encoder=freeze_feature_enocder,
+            freeze_feature_encoder=freeze_feature_encoder,
             return_dict=return_dict,
         )
 


### PR DESCRIPTION
This PR amends a typo in the `freeze_feature_encoder` argument to the `call` function in FlaxWav2Vec2ForPreTrainingModule and it's subsequent use in the Wav2Vec2 module.