### PR TITLE
Fix some Flax models' `hidden_states`

### DIFF
--- a/src/transformers/models/blenderbot/modeling_flax_blenderbot.py
+++ b/src/transformers/models/blenderbot/modeling_flax_blenderbot.py
@@ -718,10 +718,8 @@ class FlaxBlenderbotEncoder(nn.Module):
             hidden_states = hidden_states[:-1] + (last_hidden_states,)
 
         if not return_dict:
-            if not output_hidden_states:
-                return (last_hidden_states,) + outputs[1:]
-            else:
-                return (last_hidden_states, hidden_states) + outputs[2:]
+            outputs = (last_hidden_states, hidden_states) + (outputs[2:] if output_hidden_states else outputs[1:])
+            return tuple(v for v in outputs if v is not None)
 
         return FlaxBaseModelOutput(
             last_hidden_state=last_hidden_states,

--- a/src/transformers/models/blenderbot/modeling_flax_blenderbot.py
+++ b/src/transformers/models/blenderbot/modeling_flax_blenderbot.py
@@ -711,12 +711,20 @@ class FlaxBlenderbotEncoder(nn.Module):
         last_hidden_states = outputs[0]
         last_hidden_states = self.layer_norm(last_hidden_states)
 
+        # update the last element in `hidden_states` after applying `layernorm` above
+        hidden_states = outputs.hidden_states
+        if output_hidden_states:
+            hidden_states = hidden_states[:-1] + (last_hidden_states,)
+
         if not return_dict:
-            return (last_hidden_states,) + outputs[1:]
+            if not output_hidden_states:
+                return (last_hidden_states,) + outputs[1:]
+            else:
+                return (last_hidden_states, hidden_states) + outputs[2:]
 
         return FlaxBaseModelOutput(
             last_hidden_state=last_hidden_states,
-            hidden_states=outputs.hidden_states,
+            hidden_states=hidden_states,
             attentions=outputs.attentions,
         )
 
@@ -782,8 +790,16 @@ class FlaxBlenderbotDecoder(nn.Module):
         last_hidden_states = outputs[0]
         last_hidden_states = self.layer_norm(last_hidden_states)
 
+        # update the last element in `hidden_states` after applying `layernorm` above
+        hidden_states = outputs.hidden_states
+        if output_hidden_states:
+            hidden_states = hidden_states[:-1] + (last_hidden_states,)
+
         if not return_dict:
-            return (last_hidden_states,) + outputs[1:]
+            if not output_hidden_states:
+                return (last_hidden_states,) + outputs[1:]
+            else:
+                return (last_hidden_states, hidden_states) + outputs[2:]
 
         return FlaxBaseModelOutputWithPastAndCrossAttentions(
             last_hidden_state=last_hidden_states,

--- a/src/transformers/models/blenderbot/modeling_flax_blenderbot.py
+++ b/src/transformers/models/blenderbot/modeling_flax_blenderbot.py
@@ -712,8 +712,9 @@ class FlaxBlenderbotEncoder(nn.Module):
         last_hidden_states = self.layer_norm(last_hidden_states)
 
         # update the last element in `hidden_states` after applying `layernorm` above
-        hidden_states = outputs.hidden_states
+        hidden_states = None
         if output_hidden_states:
+            hidden_states = outputs[1]
             hidden_states = hidden_states[:-1] + (last_hidden_states,)
 
         if not return_dict:
@@ -791,8 +792,9 @@ class FlaxBlenderbotDecoder(nn.Module):
         last_hidden_states = self.layer_norm(last_hidden_states)
 
         # update the last element in `hidden_states` after applying `layernorm` above
-        hidden_states = outputs.hidden_states
+        hidden_states = None
         if output_hidden_states:
+            hidden_states = outputs[1]
             hidden_states = hidden_states[:-1] + (last_hidden_states,)
 
         if not return_dict:

--- a/src/transformers/models/blenderbot/modeling_flax_blenderbot.py
+++ b/src/transformers/models/blenderbot/modeling_flax_blenderbot.py
@@ -803,7 +803,7 @@ class FlaxBlenderbotDecoder(nn.Module):
 
         return FlaxBaseModelOutputWithPastAndCrossAttentions(
             last_hidden_state=last_hidden_states,
-            hidden_states=outputs.hidden_states,
+            hidden_states=hidden_states,
             attentions=outputs.attentions,
             cross_attentions=outputs.cross_attentions,
         )

--- a/src/transformers/models/blenderbot/modeling_flax_blenderbot.py
+++ b/src/transformers/models/blenderbot/modeling_flax_blenderbot.py
@@ -796,10 +796,8 @@ class FlaxBlenderbotDecoder(nn.Module):
             hidden_states = hidden_states[:-1] + (last_hidden_states,)
 
         if not return_dict:
-            if not output_hidden_states:
-                return (last_hidden_states,) + outputs[1:]
-            else:
-                return (last_hidden_states, hidden_states) + outputs[2:]
+            outputs = (last_hidden_states, hidden_states) + (outputs[2:] if output_hidden_states else outputs[1:])
+            return tuple(v for v in outputs if v is not None)
 
         return FlaxBaseModelOutputWithPastAndCrossAttentions(
             last_hidden_state=last_hidden_states,

--- a/src/transformers/models/mbart/modeling_flax_mbart.py
+++ b/src/transformers/models/mbart/modeling_flax_mbart.py
@@ -768,12 +768,20 @@ class FlaxMBartEncoder(nn.Module):
         last_hidden_states = outputs[0]
         last_hidden_states = self.layer_norm(last_hidden_states)
 
+        # update the last element in `hidden_states` after applying `layernorm` above
+        hidden_states = outputs.hidden_states
+        if output_hidden_states:
+            hidden_states = hidden_states[:-1] + (last_hidden_states,)
+
         if not return_dict:
-            return (last_hidden_states,) + outputs[1:]
+            if not output_hidden_states:
+                return (last_hidden_states,) + outputs[1:]
+            else:
+                return (last_hidden_states, hidden_states) + outputs[2:]
 
         return FlaxBaseModelOutput(
             last_hidden_state=last_hidden_states,
-            hidden_states=outputs.hidden_states,
+            hidden_states=hidden_states,
             attentions=outputs.attentions,
         )
 
@@ -845,12 +853,20 @@ class FlaxMBartDecoder(nn.Module):
         last_hidden_states = outputs[0]
         last_hidden_states = self.layer_norm(last_hidden_states)
 
+        # update the last element in `hidden_states` after applying `layernorm` above
+        hidden_states = outputs.hidden_states
+        if output_hidden_states:
+            hidden_states = hidden_states[:-1] + (last_hidden_states,)
+
         if not return_dict:
-            return (last_hidden_states,) + outputs[1:]
+            if not output_hidden_states:
+                return (last_hidden_states,) + outputs[1:]
+            else:
+                return (last_hidden_states, hidden_states) + outputs[2:]
 
         return FlaxBaseModelOutputWithPastAndCrossAttentions(
             last_hidden_state=last_hidden_states,
-            hidden_states=outputs.hidden_states,
+            hidden_states=hidden_states,
             attentions=outputs.attentions,
             cross_attentions=outputs.cross_attentions,
         )

--- a/src/transformers/models/mbart/modeling_flax_mbart.py
+++ b/src/transformers/models/mbart/modeling_flax_mbart.py
@@ -769,8 +769,9 @@ class FlaxMBartEncoder(nn.Module):
         last_hidden_states = self.layer_norm(last_hidden_states)
 
         # update the last element in `hidden_states` after applying `layernorm` above
-        hidden_states = outputs.hidden_states
+        hidden_states = None
         if output_hidden_states:
+            hidden_states = outputs[1]
             hidden_states = hidden_states[:-1] + (last_hidden_states,)
 
         if not return_dict:
@@ -854,8 +855,9 @@ class FlaxMBartDecoder(nn.Module):
         last_hidden_states = self.layer_norm(last_hidden_states)
 
         # update the last element in `hidden_states` after applying `layernorm` above
-        hidden_states = outputs.hidden_states
+        hidden_states = None
         if output_hidden_states:
+            hidden_states = outputs[1]
             hidden_states = hidden_states[:-1] + (last_hidden_states,)
 
         if not return_dict:

--- a/src/transformers/models/mbart/modeling_flax_mbart.py
+++ b/src/transformers/models/mbart/modeling_flax_mbart.py
@@ -775,10 +775,8 @@ class FlaxMBartEncoder(nn.Module):
             hidden_states = hidden_states[:-1] + (last_hidden_states,)
 
         if not return_dict:
-            if not output_hidden_states:
-                return (last_hidden_states,) + outputs[1:]
-            else:
-                return (last_hidden_states, hidden_states) + outputs[2:]
+            outputs = (last_hidden_states, hidden_states) + (outputs[2:] if output_hidden_states else outputs[1:])
+            return tuple(v for v in outputs if v is not None)
 
         return FlaxBaseModelOutput(
             last_hidden_state=last_hidden_states,
@@ -861,10 +859,8 @@ class FlaxMBartDecoder(nn.Module):
             hidden_states = hidden_states[:-1] + (last_hidden_states,)
 
         if not return_dict:
-            if not output_hidden_states:
-                return (last_hidden_states,) + outputs[1:]
-            else:
-                return (last_hidden_states, hidden_states) + outputs[2:]
+            outputs = (last_hidden_states, hidden_states) + (outputs[2:] if output_hidden_states else outputs[1:])
+            return tuple(v for v in outputs if v is not None)
 
         return FlaxBaseModelOutputWithPastAndCrossAttentions(
             last_hidden_state=last_hidden_states,

--- a/src/transformers/models/pegasus/modeling_flax_pegasus.py
+++ b/src/transformers/models/pegasus/modeling_flax_pegasus.py
@@ -728,8 +728,9 @@ class FlaxPegasusEncoder(nn.Module):
         last_hidden_state = self.layer_norm(last_hidden_state)
 
         # update the last element in `hidden_states` after applying `layernorm` above
-        hidden_states = outputs.hidden_states
+        hidden_states = None
         if output_hidden_states:
+            hidden_states = outputs[1]
             hidden_states = hidden_states[:-1] + (last_hidden_state,)
 
         if not return_dict:
@@ -805,8 +806,9 @@ class FlaxPegasusDecoder(nn.Module):
         last_hidden_state = self.layer_norm(last_hidden_state)
 
         # update the last element in `hidden_states` after applying `layernorm` above
-        hidden_states = outputs.hidden_states
+        hidden_states = None
         if output_hidden_states:
+            hidden_states = outputs[1]
             hidden_states = hidden_states[:-1] + (last_hidden_state,)
 
         if not return_dict:

--- a/src/transformers/models/pegasus/modeling_flax_pegasus.py
+++ b/src/transformers/models/pegasus/modeling_flax_pegasus.py
@@ -734,10 +734,8 @@ class FlaxPegasusEncoder(nn.Module):
             hidden_states = hidden_states[:-1] + (last_hidden_state,)
 
         if not return_dict:
-            if not output_hidden_states:
-                return (last_hidden_state,) + outputs[1:]
-            else:
-                return (last_hidden_state, hidden_states) + outputs[2:]
+            outputs = (last_hidden_state, hidden_states) + (outputs[2:] if output_hidden_states else outputs[1:])
+            return tuple(v for v in outputs if v is not None)
 
         return FlaxBaseModelOutput(
             last_hidden_state=last_hidden_state,
@@ -812,10 +810,8 @@ class FlaxPegasusDecoder(nn.Module):
             hidden_states = hidden_states[:-1] + (last_hidden_state,)
 
         if not return_dict:
-            if not output_hidden_states:
-                return (last_hidden_state,) + outputs[1:]
-            else:
-                return (last_hidden_state, hidden_states) + outputs[2:]
+            outputs = (last_hidden_state, hidden_states) + (outputs[2:] if output_hidden_states else outputs[1:])
+            return tuple(v for v in outputs if v is not None)
 
         return FlaxBaseModelOutputWithPastAndCrossAttentions(
             last_hidden_state=last_hidden_state,

--- a/src/transformers/models/pegasus/modeling_flax_pegasus.py
+++ b/src/transformers/models/pegasus/modeling_flax_pegasus.py
@@ -727,12 +727,20 @@ class FlaxPegasusEncoder(nn.Module):
         last_hidden_state = outputs[0]
         last_hidden_state = self.layer_norm(last_hidden_state)
 
+        # update the last element in `hidden_states` after applying `layernorm` above
+        hidden_states = outputs.hidden_states
+        if output_hidden_states:
+            hidden_states = hidden_states[:-1] + (last_hidden_state,)
+
         if not return_dict:
-            return (last_hidden_state,) + outputs[1:]
+            if not output_hidden_states:
+                return (last_hidden_state,) + outputs[1:]
+            else:
+                return (last_hidden_state, hidden_states) + outputs[2:]
 
         return FlaxBaseModelOutput(
             last_hidden_state=last_hidden_state,
-            hidden_states=outputs.hidden_states,
+            hidden_states=hidden_states,
             attentions=outputs.attentions,
         )
 
@@ -796,12 +804,20 @@ class FlaxPegasusDecoder(nn.Module):
         last_hidden_state = outputs[0]
         last_hidden_state = self.layer_norm(last_hidden_state)
 
+        # update the last element in `hidden_states` after applying `layernorm` above
+        hidden_states = outputs.hidden_states
+        if output_hidden_states:
+            hidden_states = hidden_states[:-1] + (last_hidden_state,)
+
         if not return_dict:
-            return (last_hidden_state,) + outputs[1:]
+            if not output_hidden_states:
+                return (last_hidden_state,) + outputs[1:]
+            else:
+                return (last_hidden_state, hidden_states) + outputs[2:]
 
         return FlaxBaseModelOutputWithPastAndCrossAttentions(
             last_hidden_state=last_hidden_state,
-            hidden_states=outputs.hidden_states,
+            hidden_states=hidden_states,
             attentions=outputs.attentions,
             cross_attentions=outputs.cross_attentions,
         )

--- a/src/transformers/models/wav2vec2/modeling_flax_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_flax_wav2vec2.py
@@ -689,10 +689,8 @@ class FlaxWav2Vec2StableLayerNormEncoder(nn.Module):
             hidden_states = hidden_states[:-1] + (last_hidden_state,)
 
         if not return_dict:
-            if not output_hidden_states:
-                return (last_hidden_state,) + outputs[1:]
-            else:
-                return (last_hidden_state, hidden_states) + outputs[2:]
+            outputs = (last_hidden_state, hidden_states) + (outputs[2:] if output_hidden_states else outputs[1:])
+            return tuple(v for v in outputs if v is not None)
 
         return FlaxBaseModelOutput(
             last_hidden_state=last_hidden_state, hidden_states=hidden_states, attentions=outputs.attentions

--- a/src/transformers/models/wav2vec2/modeling_flax_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_flax_wav2vec2.py
@@ -631,7 +631,7 @@ class FlaxWav2Vec2EncoderLayerStableLayerNormCollection(nn.Module):
         if output_hidden_states:
             all_hidden_states += (hidden_states,)
 
-        outputs = (hidden_states,)
+        outputs = (hidden_states, all_hidden_states, all_attentions)
 
         if not return_dict:
             return tuple(v for v in outputs if v is not None)

--- a/src/transformers/models/wav2vec2/modeling_flax_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_flax_wav2vec2.py
@@ -680,13 +680,21 @@ class FlaxWav2Vec2StableLayerNormEncoder(nn.Module):
             return_dict=return_dict,
         )
 
-        hidden_states = self.layer_norm(outputs[0])
+        last_hidden_state = self.layer_norm(outputs[0])
+
+        # update the last element in `hidden_states` after applying `layernorm` above
+        hidden_states = outputs.hidden_states
+        if output_hidden_states:
+            hidden_states = hidden_states[:-1] + (last_hidden_state,)
 
         if not return_dict:
-            return (hidden_states,) + outputs[1:]
+            if not output_hidden_states:
+                return (last_hidden_state,) + outputs[1:]
+            else:
+                return (last_hidden_state, hidden_states) + outputs[2:]
 
         return FlaxBaseModelOutput(
-            last_hidden_state=hidden_states, hidden_states=outputs.hidden_states, attentions=outputs.attentions
+            last_hidden_state=last_hidden_state, hidden_states=hidden_states, attentions=outputs.attentions
         )
 
 

--- a/src/transformers/models/wav2vec2/modeling_flax_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_flax_wav2vec2.py
@@ -683,8 +683,9 @@ class FlaxWav2Vec2StableLayerNormEncoder(nn.Module):
         last_hidden_state = self.layer_norm(outputs[0])
 
         # update the last element in `hidden_states` after applying `layernorm` above
-        hidden_states = outputs.hidden_states
+        hidden_states = None
         if output_hidden_states:
+            hidden_states = outputs[1]
             hidden_states = hidden_states[:-1] + (last_hidden_state,)
 
         if not return_dict:


### PR DESCRIPTION
# What does this PR do?

Fix some Flax models where the last element in `hidden_states` is different between PT/Flax version.

## More context

Some models have 

```
last_hidden_state = self.layer_norm(last_hidden_state)
```

In Pytorch version, the returned `hidden_states` have this `last_hidden_state` (after layer norm) as the last element.
In Flax version, the last element of the returned `hidden_states` is the one before the layer norm.

This PR fixes this inconsistency (by using the PyTorch logic).

