### PR TITLE
bert: properly mention deprecation of TF2 conversion script

### DIFF
--- a/src/transformers/models/bert/convert_bert_original_tf2_checkpoint_to_pytorch.py
+++ b/src/transformers/models/bert/convert_bert_original_tf2_checkpoint_to_pytorch.py
@@ -13,13 +13,16 @@
 # limitations under the License.
 
 """
-This script can be used to convert a head-less TF2.x Bert model to PyTorch, as published on the official GitHub:
-https://github.com/tensorflow/models/tree/master/official/nlp/bert
+This script can be used to convert a head-less TF2.x Bert model to PyTorch, as published on the official (now
+deprecated) GitHub: https://github.com/tensorflow/models/tree/v2.3.0/official/nlp/bert
 
 TF2.x uses different variable names from the original BERT (TF 1.4) implementation. The script re-maps the TF2.x Bert
 weight names to the original names, so the model can be imported with Huggingface/transformer.
 
 You may adapt this script to include classification/MLM/NSP/etc. heads.
+
+Note: This script is only working with an older version of the TensorFlow models repository (<= v2.3.0).
+      Models trained with never versions are not compatible with this script.
 """
 import argparse
 import os


### PR DESCRIPTION
Hi,

after training some BERT models with the TF2 implementation from the TF models repo, I just made the following observations:

The training code was deprecated a while ago, and now lives under the `legacy` namespace. I have trained models with this "legacy" implementation but the TF2 conversion script is no longer working.

I did some debugging, trained a few models and found out that the latest working version is v2.3.

For that reason, I have just updated the description in the TF2 conversion script.