### PR TITLE
Fix reproducibility in Training for PyTorch 1.11

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1354,9 +1354,18 @@ class Trainer:
         # Skip the first epochs_trained epochs to get the random state of the dataloader at the right point.
         if not args.ignore_data_skip:
             for epoch in range(epochs_trained):
-                # We just need to begin an iteration to create the randomization of the sampler.
-                for _ in train_dataloader:
-                    break
+                is_random_sampler = hasattr(train_dataloader, "sampler") and isinstance(
+                    train_dataloader.sampler, RandomSampler
+                )
+                if version.parse(torch.__version__) < version.parse("1.11") or not is_random_sampler:
+                    # We just need to begin an iteration to create the randomization of the sampler.
+                    # That was before PyTorch 1.11 however...
+                    for _ in train_dataloader:
+                        break
+                else:
+                    # Otherwise we need to call the whooooole sampler cause there is some random operation added
+                    # AT THE VERY END!
+                    _ = list(train_dataloader.sampler)
 
         for epoch in range(epochs_trained, num_train_epochs):
             if isinstance(train_dataloader, DataLoader) and isinstance(train_dataloader.sampler, DistributedSampler):


### PR DESCRIPTION
# What does this PR do?

It used to be that PyTorch called just one random operation in the `RandomSampler` code, so to ensure reproducibility, we only had to get the first batch of a dataloader to have its generator RNG be in the same state as if we had done the whole epoch.

Well not anymore... Introducing PyTorch 1.11, where the `RandomSampler` now does two random operations, one being at the very end. So we need to iterate through the whole sampler to guarantee reproducibility. This PR deals with that.