### PR TITLE
Skip equivalence test for TransfoXL

### DIFF
--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -476,7 +476,7 @@ class TFModelTesterMixin:
                         "TFFunnelForPreTraining",
                         "TFElectraForPreTraining",
                         "TFXLMWithLMHeadModel",
-                    ]:
+                    ] + ["TFTransfoXLLMHeadModel"]:
                         self.assertEqual(tf_loss is None, pt_loss is None)
 
                 tf_keys = tuple([k for k, v in tf_outputs.items() if v is not None])

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -476,7 +476,8 @@ class TFModelTesterMixin:
                         "TFFunnelForPreTraining",
                         "TFElectraForPreTraining",
                         "TFXLMWithLMHeadModel",
-                    ] + ["TFTransfoXLLMHeadModel"]:
+                        "TFTransfoXLLMHeadModel",
+                    ]:
                         self.assertEqual(tf_loss is None, pt_loss is None)
 
                 tf_keys = tuple([k for k, v in tf_outputs.items() if v is not None])
@@ -490,7 +491,8 @@ class TFModelTesterMixin:
                         "TFFunnelForPreTraining",
                         "TFElectraForPreTraining",
                         "TFXLMWithLMHeadModel",
-                    ] + ["TFTransfoXLLMHeadModel"]:
+                        "TFTransfoXLLMHeadModel",
+                    ]:
                         self.assertEqual(tf_keys, pt_keys)
 
                 # Since we deliberately make some tests pass above (regarding the `loss`), let's still try to test


### PR DESCRIPTION
Skips the equivalence test for TransfoXL as it does not have the `loss` or `losses` returned.