### PR TITLE
Fix TFBert `past_key_values`

### DIFF
--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -740,6 +740,12 @@ class TFBertMainLayer(tf.keras.layers.Layer):
         **kwargs,
     ) -> Union[TFBaseModelOutputWithPoolingAndCrossAttentions, Tuple[tf.Tensor]]:
 
+        # The received `past_key_values` is a tuple of 2 elements.
+        # The 1st element is `encoder_hidden_states`. The 2nd element is a tuple of `n_layers` elements,
+        # each element is a tuple of 4 tensors of shape (batch_size, n_heads, seq_len - 1, embed_size_per_head)
+        if past_key_values is not None:
+            past_key_values = past_key_values[1]
+
         if not self.config.is_decoder:
             use_cache = False
 

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -743,7 +743,7 @@ class TFBertMainLayer(tf.keras.layers.Layer):
         # The received `past_key_values` is a tuple of 2 elements.
         # The 1st element is `encoder_hidden_states`. The 2nd element is a tuple of `n_layers` elements,
         # each element is a tuple of 4 tensors of shape (batch_size, n_heads, seq_len - 1, embed_size_per_head)
-        if past_key_values is not None:
+        if type(past_key_values) == tuple and len(past_key_values) == 2 and type(past_key_values[1]) == tuple:
             past_key_values = past_key_values[1]
 
         if not self.config.is_decoder:


### PR DESCRIPTION
# What does this PR do?

Current `TFBertEncoderDecoderModelTest.test_bert2bert_summarization` on `master` will fail because `past_key_values` received by TF Bert is a tuple of 2 elements:
  - 1st element: it is just `encoder_hidden_states`
  - 2nd element: this is the same as the `past_key_values` in Pytorch version

The remaining code in TF Bert expects `past_key_values` not containing the 1st element.

Prior to #15944  , the `past_key_values` is only the 2nd element in the current version.

This PR fixes the test, but it looks like we should prepare the correct inputs rather than this hacking fix.

I would like to have your (in particular @gante ) confirmation before going further, thanks.