### PR TITLE
[FlaxSpeechEncoderDecoderModel] Skip from_encoder_decoder_pretrained

### DIFF
--- a/tests/speech_encoder_decoder/test_modeling_flax_speech_encoder_decoder.py
+++ b/tests/speech_encoder_decoder/test_modeling_flax_speech_encoder_decoder.py
@@ -17,6 +17,7 @@ import tempfile
 import unittest
 
 import numpy as np
+from pytest import skip
 
 from transformers import is_flax_available, is_torch_available
 from transformers.testing_utils import is_pt_flax_cross_test, require_flax, slow, torch_device
@@ -486,6 +487,7 @@ class FlaxEncoderDecoderMixin:
         input_ids_dict = self.prepare_config_and_inputs()
         self.check_save_and_load(**input_ids_dict)
 
+    @skip("Re-enable this test once this issue is fixed: https://github.com/google/jax/issues/9941")
     def test_encoder_decoder_model_from_encoder_decoder_pretrained(self):
         input_ids_dict = self.prepare_config_and_inputs()
         self.check_encoder_decoder_model_from_encoder_decoder_pretrained(**input_ids_dict)

--- a/tests/speech_encoder_decoder/test_modeling_flax_speech_encoder_decoder.py
+++ b/tests/speech_encoder_decoder/test_modeling_flax_speech_encoder_decoder.py
@@ -17,7 +17,6 @@ import tempfile
 import unittest
 
 import numpy as np
-from pytest import skip
 
 from transformers import is_flax_available, is_torch_available
 from transformers.testing_utils import is_pt_flax_cross_test, require_flax, slow, torch_device
@@ -692,7 +691,7 @@ class FlaxWav2Vec2GPT2ModelTest(FlaxEncoderDecoderMixin, unittest.TestCase):
         self.assertEqual(len(fx_outputs), len(pt_outputs_loaded), "Output lengths differ between Flax and PyTorch")
         self.assert_almost_equals(fx_logits, pt_logits_loaded.numpy(), 4e-2)
 
-    @skip("Re-enable this test once this issue is fixed: https://github.com/google/jax/issues/9941")
+    @unittest.skip("Re-enable this test once this issue is fixed: https://github.com/google/jax/issues/9941")
     def test_encoder_decoder_model_from_encoder_decoder_pretrained(self):
         pass
 
@@ -813,6 +812,6 @@ class FlaxWav2Vec2BartModelTest(FlaxEncoderDecoderMixin, unittest.TestCase):
         self.assertEqual(len(fx_outputs), len(pt_outputs_loaded), "Output lengths differ between Flax and PyTorch")
         self.assert_almost_equals(fx_logits, pt_logits_loaded.numpy(), 4e-2)
 
-    @skip("Re-enable this test once this issue is fixed: https://github.com/google/jax/issues/9941")
+    @unittest.skip("Re-enable this test once this issue is fixed: https://github.com/google/jax/issues/9941")
     def test_encoder_decoder_model_from_encoder_decoder_pretrained(self):
         pass

--- a/tests/speech_encoder_decoder/test_modeling_flax_speech_encoder_decoder.py
+++ b/tests/speech_encoder_decoder/test_modeling_flax_speech_encoder_decoder.py
@@ -487,7 +487,6 @@ class FlaxEncoderDecoderMixin:
         input_ids_dict = self.prepare_config_and_inputs()
         self.check_save_and_load(**input_ids_dict)
 
-    @skip("Re-enable this test once this issue is fixed: https://github.com/google/jax/issues/9941")
     def test_encoder_decoder_model_from_encoder_decoder_pretrained(self):
         input_ids_dict = self.prepare_config_and_inputs()
         self.check_encoder_decoder_model_from_encoder_decoder_pretrained(**input_ids_dict)
@@ -693,6 +692,10 @@ class FlaxWav2Vec2GPT2ModelTest(FlaxEncoderDecoderMixin, unittest.TestCase):
         self.assertEqual(len(fx_outputs), len(pt_outputs_loaded), "Output lengths differ between Flax and PyTorch")
         self.assert_almost_equals(fx_logits, pt_logits_loaded.numpy(), 4e-2)
 
+    @skip("Re-enable this test once this issue is fixed: https://github.com/google/jax/issues/9941")
+    def test_encoder_decoder_model_from_encoder_decoder_pretrained(self):
+        pass
+
 
 @require_flax
 class FlaxWav2Vec2BartModelTest(FlaxEncoderDecoderMixin, unittest.TestCase):
@@ -809,3 +812,7 @@ class FlaxWav2Vec2BartModelTest(FlaxEncoderDecoderMixin, unittest.TestCase):
 
         self.assertEqual(len(fx_outputs), len(pt_outputs_loaded), "Output lengths differ between Flax and PyTorch")
         self.assert_almost_equals(fx_logits, pt_logits_loaded.numpy(), 4e-2)
+
+    @skip("Re-enable this test once this issue is fixed: https://github.com/google/jax/issues/9941")
+    def test_encoder_decoder_model_from_encoder_decoder_pretrained(self):
+        pass


### PR DESCRIPTION
# What does this PR do?

Skip `test_encoder_decoder_model_from_encoder_decoder_pretrained` until this issue is: https://github.com/google/jax/issues/9941

cc @sanchit-gandhi @patrickvonplaten 