### PR TITLE
Make `add-new-model-like` work in an env without all frameworks

### DIFF
--- a/src/transformers/commands/add_new_model_like.py
+++ b/src/transformers/commands/add_new_model_like.py
@@ -610,6 +610,7 @@ def get_default_frameworks():
         frameworks.append("tf")
     if is_flax_available():
         frameworks.append("flax")
+    return frameworks
 
 
 _re_model_mapping = re.compile("MODEL_([A-Z_]*)MAPPING_NAMES")
@@ -699,9 +700,9 @@ def retrieve_info_for_model(model_type, frameworks: Optional[List[str]] = None):
             available_frameworks.append("pt")
 
     if frameworks is None:
-        frameworks = available_frameworks.copy()
-    else:
-        frameworks = [f for f in frameworks if f in available_frameworks]
+        frameworks = get_default_frameworks()
+
+    frameworks = [f for f in frameworks if f in available_frameworks]
 
     model_classes = retrieve_model_classes(model_type, frameworks=frameworks)
 

--- a/src/transformers/commands/add_new_model_like.py
+++ b/src/transformers/commands/add_new_model_like.py
@@ -502,7 +502,7 @@ def filter_framework_files(
         `List[Union[str, os.PathLike]]`: The list of filtered files.
     """
     if frameworks is None:
-        return files
+        frameworks = get_default_frameworks()
 
     framework_to_file = {}
     others = []


### PR DESCRIPTION
# What does this PR do?

This PR removes the need for a full dev installed when a user wants to run `add-new-model-like`.