### PR TITLE
Fix missing output_attentions in PT/Flax equivalence test

### DIFF
--- a/tests/big_bird/test_modeling_flax_big_bird.py
+++ b/tests/big_bird/test_modeling_flax_big_bird.py
@@ -190,3 +190,12 @@ class FlaxBigBirdModelTest(FlaxModelTesterMixin, unittest.TestCase):
                 for jitted_output, output in zip(jitted_outputs, outputs):
 
                     self.assertEqual(jitted_output.shape, output.shape)
+
+    # overwrite from common in order to skip the check on `attentions`
+    def check_outputs(self, fx_outputs, pt_outputs, model_class, names):
+        # `bigbird_block_sparse_attention` in `FlaxBigBird` returns `attention_probs = None`, while in PyTorch version,
+        # an effort was done to return `attention_probs` (yet to be verified).
+        if type(names) == str and names.startswith("attentions"):
+            return
+        else:
+            super().check_outputs(fx_outputs, pt_outputs, model_class, names)

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -179,7 +179,8 @@ class FlaxModelTesterMixin:
                 Currently unused, but in the future, we could use this information to make the error message clearer
                 by giving the name(s) of the output tensor(s) with large difference(s) between PT and Flax.
         """
-
+        # `bigbird_block_sparse_attention` in `FlaxBigBird` returns `attention_probs = None`, while in PyTorch version,
+        # an effort was done to return `attention_probs` (yet to be verified).
         if type(names) == str and names.startswith("attentions"):
             if model_class.__name__.startswith("FlaxBigBird"):
                 return

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -179,12 +179,6 @@ class FlaxModelTesterMixin:
                 Currently unused, but in the future, we could use this information to make the error message clearer
                 by giving the name(s) of the output tensor(s) with large difference(s) between PT and Flax.
         """
-        # `bigbird_block_sparse_attention` in `FlaxBigBird` returns `attention_probs = None`, while in PyTorch version,
-        # an effort was done to return `attention_probs` (yet to be verified).
-        if type(names) == str and names.startswith("attentions"):
-            if model_class.__name__.startswith("FlaxBigBird"):
-                return
-
         if type(fx_outputs) in [tuple, list]:
             self.assertEqual(type(fx_outputs), type(pt_outputs))
             self.assertEqual(len(fx_outputs), len(pt_outputs))

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -120,6 +120,7 @@ class FlaxModelTesterMixin:
     test_mismatched_shapes = True
     is_encoder_decoder = False
     test_head_masking = False
+    has_attentions = True
 
     def _prepare_for_class(self, inputs_dict, model_class):
         inputs_dict = copy.deepcopy(inputs_dict)
@@ -178,6 +179,11 @@ class FlaxModelTesterMixin:
                 Currently unused, but in the future, we could use this information to make the error message clearer
                 by giving the name(s) of the output tensor(s) with large difference(s) between PT and Flax.
         """
+
+        if type(names) == str and names.startswith("attentions"):
+            if model_class.__name__.startswith("FlaxBigBird"):
+                return
+
         if type(fx_outputs) in [tuple, list]:
             self.assertEqual(type(fx_outputs), type(pt_outputs))
             self.assertEqual(len(fx_outputs), len(pt_outputs))
@@ -222,6 +228,8 @@ class FlaxModelTesterMixin:
 
                 # Output all for aggressive testing
                 config.output_hidden_states = True
+                if self.has_attentions:
+                    config.output_attentions = True
 
                 # prepare inputs
                 prepared_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
@@ -274,7 +282,8 @@ class FlaxModelTesterMixin:
 
                 # Output all for aggressive testing
                 config.output_hidden_states = True
-                # Pure convolutional models have no attention
+                if self.has_attentions:
+                    config.output_attentions = True
 
                 # prepare inputs
                 prepared_inputs_dict = self._prepare_for_class(inputs_dict, model_class)

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -169,6 +169,7 @@ class FlaxModelTesterMixin:
             dict_inputs = self._prepare_for_class(inputs_dict, model_class)
             check_equivalence(model, tuple_inputs, dict_inputs, {"output_hidden_states": True})
 
+    # (Copied from tests.test_modeling_common.ModelTesterMixin.check_outputs)
     def check_outputs(self, fx_outputs, pt_outputs, model_class, names):
         """
         Args:

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -228,8 +228,7 @@ class FlaxModelTesterMixin:
 
                 # Output all for aggressive testing
                 config.output_hidden_states = True
-                if self.has_attentions:
-                    config.output_attentions = True
+                config.output_attentions = self.has_attentions
 
                 # prepare inputs
                 prepared_inputs_dict = self._prepare_for_class(inputs_dict, model_class)

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -281,8 +281,7 @@ class FlaxModelTesterMixin:
 
                 # Output all for aggressive testing
                 config.output_hidden_states = True
-                if self.has_attentions:
-                    config.output_attentions = True
+                config.output_attentions = self.has_attentions
 
                 # prepare inputs
                 prepared_inputs_dict = self._prepare_for_class(inputs_dict, model_class)

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -323,7 +323,7 @@ class FlaxModelTesterMixin:
 
                 # send pytorch model to the correct device
                 pt_model_loaded.to(torch_device)
-                pt_model_loaded.eval()
+                pt_model_loaded = pt_model_loaded.eval()
 
                 with torch.no_grad():
                     pt_outputs_loaded = pt_model_loaded(**pt_inputs)

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -323,6 +323,7 @@ class FlaxModelTesterMixin:
 
                 # send pytorch model to the correct device
                 pt_model_loaded.to(torch_device)
+                pt_model_loaded.eval()
 
                 with torch.no_grad():
                     pt_outputs_loaded = pt_model_loaded(**pt_inputs)

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -323,7 +323,7 @@ class FlaxModelTesterMixin:
 
                 # send pytorch model to the correct device
                 pt_model_loaded.to(torch_device)
-                pt_model_loaded = pt_model_loaded.eval()
+                pt_model_loaded.eval()
 
                 with torch.no_grad():
                     pt_outputs_loaded = pt_model_loaded(**pt_inputs)

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -210,8 +210,7 @@ class FlaxModelTesterMixin:
             pt_outputs[pt_nans] = 0
             fx_outputs[pt_nans] = 0
 
-            max_diff = np.amax(np.abs(fx_outputs - pt_outputs))
-            self.assertLessEqual(max_diff, 1e-5)
+            self.assert_almost_equals(fx_outputs, pt_outputs, 1e-5)
         else:
             raise ValueError(
                 f"`fx_outputs` should be a `tuple` or an instance of `jnp.ndarray`. Got {type(fx_outputs)} instead."


### PR DESCRIPTION
# What does this PR do?

In a previous PR #15841, `output_attentions` was not set (I accidentally removed the whole block containing it).
This PR sets  `output_attentions` to make the test more thorough.

The test still runs successfully with `1e-5` on both CPU/GPU. However, see the 2nd points in the remarks below.

It also adds `has_attentions` attribute to `FlaxModelTesterMixin` (as done in PyTorch's `ModelTesterMixin`).

# Remarks:
- In a follow up PR, we might use `has_attentions` in some existing methods (to make sure the attentions are only tested if `has_attentions` is `True`), see #15909
- There are 4 Flax model testers overwrite the Flax common `test_equivalence_pt_to_flax` and `test_equivalence_flax_to_pt`.
  - I will update them in a next PR.
  - These include `FlaxGPTJ` and `FlaxXGLM`, which will fail with `1e-5`. I need to debug them.