### PR TITLE
Remove disclaimer from Longformer docs

### DIFF
--- a/docs/source/model_doc/longformer.mdx
+++ b/docs/source/model_doc/longformer.mdx
@@ -12,8 +12,6 @@ specific language governing permissions and limitations under the License.
 
 # Longformer
 
-**DISCLAIMER:** This model is still a work in progress, if you see something strange, file a [Github Issue](https://github.com/huggingface/transformers/issues/new?assignees=&labels=&template=bug-report.md&title).
-
 ## Overview
 
 The Longformer model was presented in [Longformer: The Long-Document Transformer](https://arxiv.org/pdf/2004.05150.pdf) by Iz Beltagy, Matthew E. Peters, Arman Cohan.


### PR DESCRIPTION
# What does this PR do?
This PR removes disclaimer from the Longformer docs. Checked with @patil-suraj.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?
Documentation: @sgugger
CC: @patil-suraj 