### PR TITLE
[FlaxGPTJ] Fix bug in rotary embeddings

### DIFF
--- a/src/transformers/models/gptj/modeling_flax_gptj.py
+++ b/src/transformers/models/gptj/modeling_flax_gptj.py
@@ -122,7 +122,7 @@ def create_sinusoidal_positions(num_pos, dim):
 
 
 def rotate_every_two(tensor):
-    rotate_half_tensor = jnp.stack((tensor[:, :, :, 1::2], tensor[:, :, :, ::2]), axis=-1)
+    rotate_half_tensor = jnp.stack((-tensor[:, :, :, 1::2], tensor[:, :, :, ::2]), axis=-1)
     rotate_half_tensor = rotate_half_tensor.reshape(rotate_half_tensor.shape[:-2] + (-1,))
     return rotate_half_tensor
 


### PR DESCRIPTION
# What does this PR do?

The rotary embeddings in `FlaxGPTJ` are computed in-correctly and they don't match with the PT version. This PR fixes  `rotate_every_two` function to match with PT version.

Thanks a lot @ydshieh for finding this issue!

Fixes #16288