### PR TITLE
fix last element in hidden_states for XGLM

### DIFF
--- a/src/transformers/models/xglm/modeling_flax_xglm.py
+++ b/src/transformers/models/xglm/modeling_flax_xglm.py
@@ -534,13 +534,18 @@ class FlaxXGLMModule(nn.Module):
         last_hidden_states = outputs[0]
         last_hidden_states = self.layer_norm(last_hidden_states)
 
+        hidden_states = None
+        if output_hidden_states:
+            hidden_states = outputs[1]
+            hidden_states = hidden_states[:-1] + (last_hidden_states,)
+
         if not return_dict:
-            outputs = (last_hidden_states,) + outputs[1:]
+            outputs = (last_hidden_states, hidden_states) + (outputs[2:] if output_hidden_states else outputs[1:])
             return tuple(v for v in outputs if v is not None)
 
         return FlaxBaseModelOutputWithPastAndCrossAttentions(
             last_hidden_state=last_hidden_states,
-            hidden_states=outputs.hidden_states,
+            hidden_states=hidden_states,
             attentions=outputs.attentions,
             cross_attentions=outputs.cross_attentions,
         )


### PR DESCRIPTION
# What does this PR do?

Same fix as in #16167 (where the last element in `hidden_states` is different between PT/Flax version.)

This was missed in the previous PR - because XGLM model test overwrites the common (more thorough) PT/Flax equivalence test.

This fix is tested with #16280 and passed !