### PR TITLE
Update Makefile Phonies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deps_table_update modified_only_fixup extra_quality_checks quality style fixup fix-copies test test-examples docs
+.PHONY: deps_table_update modified_only_fixup extra_style_checks quality style fixup fix-copies test test-examples
 
 # make sure to test the local checkout in scripts and not the pre-installed one (don't use quotes!)
 export PYTHONPATH = src


### PR DESCRIPTION
# What does this PR do?
This PR fixes vestiges of previously existing targets in the Makefile, and potentially adds missing entries as well.

Please let me know if any other recipes are to be added? My understanding is that we want to force the invokation of the recipe even if the file with same name exists, based on [this](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html#:~:text=A%20phony%20target%20is%20one,name%2C%20and%20to%20improve%20performance). Please correct me if I'm wrong.

## Who can review?
@sgugger 