### PR TITLE
Fix BigBirdModelTester

### DIFF
--- a/tests/big_bird/test_modeling_big_bird.py
+++ b/tests/big_bird/test_modeling_big_bird.py
@@ -581,7 +581,7 @@ class BigBirdModelTest(ModelTesterMixin, unittest.TestCase):
             self.assertTrue(
                 torch.allclose(
                     hidden_states[0, 0, :5],
-                    torch.tensor([1.4943, 0.0928, 0.8254, -0.2816, -0.9788], device=torch_device),
+                    torch.tensor([1.4825, 0.0774, 0.8226, -0.2962, -0.9593], device=torch_device),
                     atol=1e-3,
                 )
             )

--- a/tests/big_bird/test_modeling_big_bird.py
+++ b/tests/big_bird/test_modeling_big_bird.py
@@ -70,7 +70,7 @@ class BigBirdModelTester:
         attention_type="block_sparse",
         use_bias=True,
         rescale_embeddings=False,
-        block_size=16,
+        block_size=8,
         num_rand_blocks=3,
         position_embedding_type="absolute",
         scope=None,


### PR DESCRIPTION
# What does this PR do?

Current `BigBirdModelTester` with `block_size=16` will cause the model to change `attention_type` from `block_sparse` to `original_full`.

https://github.com/huggingface/transformers/blob/9fef668338b15e508bac99598dd139546fece00b/src/transformers/models/big_bird/modeling_big_bird.py#L2059-L2070

In the PT/Flax equivalence test (from `ModelTesterMixin`), the `FlaxBigBird` model will still use `block_sparse`. This causes the test failed with `1e-5`.

I couldn't find any word `not possible` or `impossible` in `modeling_flax_big_bird.py`.

Currently, I change  `block_size=16` to  `block_size=8` in order to make both models run with `block_sparse` and pass the test.
However, it would be good at some point to check if we should have the same `self.set_attention_type("original_full")` for `FlaxBigBirdModel`.

Question: is `block_size=16` chosen intentionally to test `self.set_attention_type` in PT's BigBird?