### PR TITLE
Fix Respect output device in the Pipeline base impl.

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -942,7 +942,7 @@ class Pipeline(_ScikitCompat):
                 with inference_context():
                     model_inputs = self._ensure_tensor_on_device(model_inputs, device=self.device)
                     model_outputs = self._forward(model_inputs, **forward_params)
-                    model_outputs = self._ensure_tensor_on_device(model_outputs, device=torch.device("cpu"))
+                    model_outputs = self._ensure_tensor_on_device(model_outputs, device=self.device)
             else:
                 raise ValueError(f"Framework {self.framework} is not supported")
         return model_outputs


### PR DESCRIPTION
changes hardcoded `"cpu"` device in return in the forward method to `self.device`

# What does this PR do?
The base class in pipeline surprisingly returns a tensor on the right device, and this is then moved to the "cpu" for some reason. This PR makes sure that the input and the output to the `forward(..)` method remain on the same device. 

Fixes #16315 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)?  https://github.com/huggingface/transformers/issues/16315
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@LysandreJik
