### PR TITLE
TF - Fix interchangeable past/past_key_values and revert output variable name in GPT2

### DIFF
--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -1703,6 +1703,8 @@ class TFGenerationMixin:
             model_kwargs["past"] = outputs.mems
         elif "past_buckets_states" in outputs:
             model_kwargs["past"] = outputs.past_buckets_states
+        elif "past" in model_kwargs:
+            model_kwargs["past"] = outputs.past
         else:
             model_kwargs["past"] = None
 

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -1703,8 +1703,6 @@ class TFGenerationMixin:
             model_kwargs["past"] = outputs.mems
         elif "past_buckets_states" in outputs:
             model_kwargs["past"] = outputs.past_buckets_states
-        elif "past" in model_kwargs:
-            model_kwargs["past"] = outputs.past
         else:
             model_kwargs["past"] = None
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -498,15 +498,10 @@ def input_processing(func, config, input_ids, **kwargs):
                 f"Data of type {type(input_ids)} is not allowed only {allowed_types} is accepted for {parameter_names_list[0]}."
             )
 
-    # Populates any unspecified argument with their default value. For the first argument, populates it with None when
-    # not passed -- some models, like T5, accept `input_ids` or `inputs_embeds` as input. In those cases, we rely on
-    # ad hoc exceptions to handle missing inputs.
+    # Populates any unspecified argument with their default value, according to the signature.
     for name in parameter_names:
         if name not in list(output.keys()) and name != "args":
-            if name == parameter_names_list[0]:
-                output[name] = None
-            else:
-                output[name] = kwargs.pop(name, signature[name].default)
+            output[name] = kwargs.pop(name, signature[name].default)
 
     # When creating a SavedModel TF calls the method with LayerCall.__call__(args, **kwargs)
     # So to respect the proper output we have to add this exception

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -404,8 +404,7 @@ def input_processing(func, config, input_ids, **kwargs):
     signature = dict(inspect.signature(func).parameters)
     signature.pop("kwargs", None)
     signature.pop("self", None)
-    parameter_names_list = list(signature.keys())
-    parameter_names = set(parameter_names_list)
+    parameter_names = list(signature.keys())
     output = {}
     allowed_types = (tf.Tensor, bool, int, ModelOutput, tuple, list, dict, np.ndarray, KerasTensor)
 
@@ -457,12 +456,12 @@ def input_processing(func, config, input_ids, **kwargs):
                 if tensor_name in parameter_names:
                     output[tensor_name] = input
                 else:
-                    output[parameter_names_list[i]] = input
+                    output[parameter_names[i]] = input
             elif isinstance(input, allowed_types) or input is None:
-                output[parameter_names_list[i]] = input
+                output[parameter_names[i]] = input
             else:
                 raise ValueError(
-                    f"Data of type {type(input)} is not allowed only {allowed_types} is accepted for {parameter_names_list[i]}."
+                    f"Data of type {type(input)} is not allowed only {allowed_types} is accepted for {parameter_names[i]}."
                 )
     elif isinstance(input_ids, (dict, BatchEncoding)):
         if "inputs" in input_ids:
@@ -492,10 +491,10 @@ def input_processing(func, config, input_ids, **kwargs):
                 raise ValueError(f"Data of type {type(v)} is not allowed only {allowed_types} is accepted for {k}.")
     else:
         if isinstance(input_ids, (tf.Tensor, KerasTensor)) or input_ids is None:
-            output[parameter_names_list[0]] = input_ids
+            output[parameter_names[0]] = input_ids
         else:
             raise ValueError(
-                f"Data of type {type(input_ids)} is not allowed only {allowed_types} is accepted for {parameter_names_list[0]}."
+                f"Data of type {type(input_ids)} is not allowed only {allowed_types} is accepted for {parameter_names[0]}."
             )
 
     # Populates any unspecified argument with their default value, according to the signature.

--- a/src/transformers/models/encoder_decoder/modeling_tf_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_tf_encoder_decoder.py
@@ -694,6 +694,9 @@ class TFEncoderDecoderModel(TFPreTrainedModel, TFCausalLanguageModelingLoss):
     ):
         decoder_inputs = self.decoder.prepare_inputs_for_generation(input_ids, past=past)
         decoder_attention_mask = decoder_inputs["attention_mask"] if "attention_mask" in decoder_inputs else None
+        past_key_values = decoder_inputs.get("past_key_values")
+        if past_key_values is None:
+            past_key_values = decoder_inputs.get("past")  # e.g. on TF GPT2
         input_dict = {
             "input_ids": None,  # needs to be passed to make Keras.layer.__call__ happy
             "attention_mask": attention_mask,
@@ -701,7 +704,7 @@ class TFEncoderDecoderModel(TFPreTrainedModel, TFCausalLanguageModelingLoss):
             "decoder_input_ids": decoder_inputs["input_ids"],
             # TODO (joao): the `TFBaseModelOutput` wrapper should not be needed after the generate refactor is complete
             "encoder_outputs": TFBaseModelOutput(last_hidden_state=encoder_outputs[0]),
-            "past_key_values": decoder_inputs["past_key_values"],
+            "past_key_values": past_key_values,
             "use_cache": use_cache,
         }
         return input_dict

--- a/src/transformers/models/gpt2/modeling_tf_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_tf_gpt2.py
@@ -878,7 +878,7 @@ class TFGPT2LMHeadModel(TFGPT2PreTrainedModel, TFCausalLanguageModelingLoss):
             "input_ids": inputs,
             "attention_mask": attention_mask,
             "position_ids": position_ids,
-            "past_key_values": past,
+            "past": past,
             "use_cache": use_cache,
         }
 

--- a/src/transformers/models/gpt2/modeling_tf_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_tf_gpt2.py
@@ -878,7 +878,7 @@ class TFGPT2LMHeadModel(TFGPT2PreTrainedModel, TFCausalLanguageModelingLoss):
             "input_ids": inputs,
             "attention_mask": attention_mask,
             "position_ids": position_ids,
-            "past": past,
+            "past_key_values": past,
             "use_cache": use_cache,
         }
 

--- a/src/transformers/models/vision_encoder_decoder/modeling_tf_vision_encoder_decoder.py
+++ b/src/transformers/models/vision_encoder_decoder/modeling_tf_vision_encoder_decoder.py
@@ -725,6 +725,9 @@ class TFVisionEncoderDecoderModel(TFPreTrainedModel, TFCausalLanguageModelingLos
     ):
         decoder_inputs = self.decoder.prepare_inputs_for_generation(input_ids, past=past)
         decoder_attention_mask = decoder_inputs["attention_mask"] if "attention_mask" in decoder_inputs else None
+        past_key_values = decoder_inputs.get("past_key_values")
+        if past_key_values is None:
+            past_key_values = decoder_inputs.get("past")  # e.g. on TF GPT2
         input_dict = {
             "pixel_values": None,  # needs to be passed to make Keras.layer.__call__ happy
             "attention_mask": attention_mask,
@@ -732,7 +735,7 @@ class TFVisionEncoderDecoderModel(TFPreTrainedModel, TFCausalLanguageModelingLos
             "decoder_input_ids": decoder_inputs["input_ids"],
             # TODO (joao): the `TFBaseModelOutput` wrapper should not be needed after the generate refactor is complete
             "encoder_outputs": TFBaseModelOutput(last_hidden_state=encoder_outputs[0]),
-            "past_key_values": decoder_inputs["past_key_values"],
+            "past_key_values": past_key_values,
             "use_cache": use_cache,
         }
         return input_dict

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1563,14 +1563,21 @@ class UtilsFunctionsTest(unittest.TestCase):
                 self.config = PretrainedConfig(**config_kwargs)
 
             @unpack_inputs
-            def call(self, input_ids, past, output_attentions=None, output_hidden_states=None, return_dict=None):
-                return input_ids, past, output_attentions, output_hidden_states, return_dict
+            def call(self, input_ids, past=None, inputs_embeds=None, output_attentions=None, output_hidden_states=None, return_dict=None):
+                if input_ids is not None and inputs_embeds is not None:
+                    raise ValueError("there should be exacly one input")
+                elif input_ids is not None:
+                    output_data = input_ids
+                else:
+                    output_data = inputs_embeds
+                return output_data, past, output_attentions, output_hidden_states, return_dict
 
         dummy_model = DummyModel()
         input_ids = tf.constant([0, 1, 2, 3])
-        past = tf.constant([4, 5, 6, 7])
+        inputs_embeds = tf.constant([4, 5, 6, 7])
+        past = tf.constant([0, 0, 0, 0])
 
-        # test case 1: Pass inputs as keyword arguments; Booleans are inherited from the config
+        # test case 1: Pass inputs as keyword arguments; Booleans are inherited from the config.
         output = dummy_model.call(input_ids=input_ids, past=past)
         tf.debugging.assert_equal(output[0], input_ids)
         tf.debugging.assert_equal(output[1], past)
@@ -1578,7 +1585,7 @@ class UtilsFunctionsTest(unittest.TestCase):
         self.assertFalse(output[3])
         self.assertFalse(output[4])
 
-        # test case 2: Same as above, but with positional arguments
+        # test case 2: Same as above, but with positional arguments.
         output = dummy_model.call(input_ids, past)
         tf.debugging.assert_equal(output[0], input_ids)
         tf.debugging.assert_equal(output[1], past)
@@ -1586,7 +1593,7 @@ class UtilsFunctionsTest(unittest.TestCase):
         self.assertFalse(output[3])
         self.assertFalse(output[4])
 
-        # test case 3: We can also pack everything in the first input
+        # test case 3: We can also pack everything in the first input.
         output = dummy_model.call(input_ids={"input_ids": input_ids, "past": past})
         tf.debugging.assert_equal(output[0], input_ids)
         tf.debugging.assert_equal(output[1], past)
@@ -1594,7 +1601,7 @@ class UtilsFunctionsTest(unittest.TestCase):
         self.assertFalse(output[3])
         self.assertFalse(output[4])
 
-        # test case 4: Explicit boolean arguments should override the config
+        # test case 4: Explicit boolean arguments should override the config.
         output = dummy_model.call(input_ids=input_ids, past=past, output_attentions=False, return_dict=True)
         tf.debugging.assert_equal(output[0], input_ids)
         tf.debugging.assert_equal(output[1], past)
@@ -1602,18 +1609,37 @@ class UtilsFunctionsTest(unittest.TestCase):
         self.assertFalse(output[3])
         self.assertTrue(output[4])
 
-        # test case 5: Unexpected arguments should raise an exception
+        # test case 5: Unexpected arguments should raise an exception.
         with self.assertRaises(ValueError):
             output = dummy_model.call(input_ids=input_ids, past=past, foo="bar")
 
         # test case 6: Despite the above, `past_key_values` should be interchangeable with `past`
-        # (the decorator moves it to `past`, or vice-versa, depending on the signature)
+        # (the decorator moves it to `past`, or vice-versa, depending on the signature).
         output = dummy_model.call(input_ids=input_ids, past_key_values=past)
         tf.debugging.assert_equal(output[0], input_ids)
         tf.debugging.assert_equal(output[1], past)
         self.assertFalse(output[2])
         self.assertFalse(output[3])
         self.assertFalse(output[4])
+
+        # (tests relying in model internal logic, common patterns)
+        # test case 7: Models that can accept multiple data inputs gracefully populate the first data input with
+        # `None`, despite being a positional argument (Keras doesn't accept keyword arguments as the first input to a
+        # layer, so we have to define it as positional argument).
+        output = dummy_model.call(past=past, inputs_embeds=inputs_embeds)
+        tf.debugging.assert_equal(output[0], inputs_embeds)
+        tf.debugging.assert_equal(output[1], past)
+        self.assertFalse(output[2])
+        self.assertFalse(output[3])
+        self.assertFalse(output[4])
+
+        # test case 8: Passing two data inputs should expose the model internal error.
+        with self.assertRaises(ValueError):
+            output = dummy_model.call(input_ids=input_ids, inputs_embeds=inputs_embeds)
+
+        # test case 9: In this dummy model, there are no safegards for when there are no data inputs, so it should work
+        # fine without them. In the wild, they will fail when the Keras block is called.
+        output = dummy_model.call()
 
 
 @require_tf

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -28,7 +28,6 @@ from huggingface_hub import delete_repo, login
 from requests.exceptions import HTTPError
 from transformers import is_tf_available
 from transformers.configuration_utils import PretrainedConfig
-from transformers.modeling_tf_utils import unpack_inputs
 from transformers.models.auto import get_values
 from transformers.testing_utils import tooslow  # noqa: F401
 from transformers.testing_utils import (
@@ -82,6 +81,7 @@ if is_tf_available():
         TFSampleDecoderOnlyOutput,
         TFSampleEncoderDecoderOutput,
     )
+    from transformers.modeling_tf_utils import unpack_inputs
 
     if _tf_gpu_memory_limit is not None:
         gpus = tf.config.list_physical_devices("GPU")

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -27,6 +27,8 @@ from typing import List, Tuple
 from huggingface_hub import delete_repo, login
 from requests.exceptions import HTTPError
 from transformers import is_tf_available
+from transformers.configuration_utils import PretrainedConfig
+from transformers.modeling_tf_utils import unpack_inputs
 from transformers.models.auto import get_values
 from transformers.testing_utils import tooslow  # noqa: F401
 from transformers.testing_utils import (
@@ -1552,6 +1554,63 @@ class UtilsFunctionsTest(unittest.TestCase):
 
         tf.debugging.assert_near(non_inf_output, non_inf_expected_output, rtol=1e-12)
         tf.debugging.assert_equal(non_inf_idx, non_inf_expected_idx)
+
+    # tests whether the unpack_inputs function behaves as expected
+    def test_unpack_inputs(self):
+        # sets up a dummy config (accessed through `self`)
+        config_kwargs = {"output_attentions": False, "output_hidden_states": False, "return_dict": False}
+        self.config = PretrainedConfig(**config_kwargs)
+        input_ids = tf.constant([0, 1, 2, 3])
+        past = tf.constant([4, 5, 6, 7])
+
+        # test case 1: Pass inputs as keyword arguments; Booleans are inherited from the config
+        output = self.dummy_call_fn(input_ids=input_ids, past=past)
+        tf.debugging.assert_equal(output[0], input_ids)
+        tf.debugging.assert_equal(output[1], past)
+        self.assertFalse(output[2])
+        self.assertFalse(output[3])
+        self.assertFalse(output[4])
+
+        # test case 2: Same as above, but with positional arguments
+        output = self.dummy_call_fn(input_ids, past)
+        tf.debugging.assert_equal(output[0], input_ids)
+        tf.debugging.assert_equal(output[1], past)
+        self.assertFalse(output[2])
+        self.assertFalse(output[3])
+        self.assertFalse(output[4])
+
+        # test case 3: We can also pack everything in the first input
+        output = self.dummy_call_fn(input_ids={"input_ids": input_ids, "past": past})
+        tf.debugging.assert_equal(output[0], input_ids)
+        tf.debugging.assert_equal(output[1], past)
+        self.assertFalse(output[2])
+        self.assertFalse(output[3])
+        self.assertFalse(output[4])
+
+        # test case 4: Explicit boolean arguments should override the config
+        output = self.dummy_call_fn(input_ids=input_ids, past=past, output_attentions=False, return_dict=True)
+        tf.debugging.assert_equal(output[0], input_ids)
+        tf.debugging.assert_equal(output[1], past)
+        self.assertFalse(output[2])
+        self.assertFalse(output[3])
+        self.assertTrue(output[4])
+
+        # test case 5: Unexpected arguments should raise an exception
+        with self.assertRaises(ValueError):
+            output = self.dummy_call_fn(input_ids=input_ids, past=past, foo="bar")
+
+        # test case 6: Despite the above, `past_key_values` should be interchangeable with `past`
+        # (the decorator moves it to `past`, or vice-versa, depending on the signature)
+        output = self.dummy_call_fn(input_ids=input_ids, past_key_values=past)
+        tf.debugging.assert_equal(output[0], input_ids)
+        tf.debugging.assert_equal(output[1], past)
+        self.assertFalse(output[2])
+        self.assertFalse(output[3])
+        self.assertFalse(output[4])
+
+    @unpack_inputs
+    def dummy_call_fn(self, input_ids, past, output_attentions=None, output_hidden_states=None, return_dict=None):
+        return input_ids, past, output_attentions, output_hidden_states, return_dict
 
 
 @require_tf


### PR DESCRIPTION
# Context

From the discussion in https://github.com/huggingface/transformers/pull/16311 (PR that applies `@unpack_inputs` to TF `gpt2`): In the generate refactor, TF `gpt2` got an updated `prepare_inputs_for_generation()`, where its output `past` got renamed into `past_key_values` (i.e. as in FLAX/PT). Patrick suggested reverting it since this prepared input could be used externally.

# What did I find while working on this PR?

Reverting as suggested above makes TF `gpt2` fail tests related to `encoder_decoder`, which got an updated `prepare_inputs_for_generation()` in the same PR that expects a `past_key_values` (and not a `past`). 

Meanwhile, I've also noticed a related bug in the new `@unpack_inputs` decorator, where it was not preserving a previous behavior -- when the model received a `past_key_values` but expected a `past` input (and vice-versa), it automatically swapped the keyword. This feature was the key enabler behind `encoder_decoder`+`gpt2`, as `encoder_decoder` was throwing out `past_key_values` prepared inputs that were caught by `gpt2`'s `past` argument.

# So, what's in this PR?

This PR fixes the two issues above, which are needed for proper behavior in all combinations of inputs to TF `gpt2`, after the introduction of the decorator:
1. corrects the bug in the `@unpack_inputs` decorator and adds tests to ensure we don't regress on some key properties of our TF input handling. After this PR, `gpt2` preserves its ability to receive `past` (and `past_key_values`, if through `encoder_decoder`-like), with and without the decorator. 
2. It also reverts `past_key_values` into `past` whenever the change was introduced in https://github.com/huggingface/transformers/pull/15944, and makes the necessary changes in `encoder_decoder`-like models.