### PR TITLE
Make FeaturesManager.get_model_from_feature a static method

### DIFF
--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -334,6 +334,7 @@ class FeaturesManager:
             )
         return task_to_automodel[task]
 
+    @staticmethod
     def get_model_from_feature(
         feature: str, model: str, framework: str = "pt", cache_dir: str = None
     ) -> Union[PreTrainedModel, TFPreTrainedModel]:


### PR DESCRIPTION
# What does this PR do?

This makes `FeaturesManager.get_model_from_feature` a static method. It was already implied but there was a missing `@staticmethod` decorator.

Fixes #16347

