### PR TITLE
Swap inequalities

### DIFF
--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -443,7 +443,7 @@ class DefaultFlowCallback(TrainerCallback):
             control.should_log = True
 
         # Evaluate
-        if args.evaluation_strategy == IntervalStrategy.EPOCH and args.eval_delay < state.epoch:
+        if args.evaluation_strategy == IntervalStrategy.EPOCH and args.eval_delay <= state.epoch:
             control.should_evaluate = True
 
         # Save

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -419,7 +419,7 @@ class DefaultFlowCallback(TrainerCallback):
         if (
             args.evaluation_strategy == IntervalStrategy.STEPS
             and state.global_step % args.eval_steps == 0
-            and args.eval_delay > state.global_step
+            and args.eval_delay < state.global_step
         ):
             control.should_evaluate = True
 
@@ -443,7 +443,7 @@ class DefaultFlowCallback(TrainerCallback):
             control.should_log = True
 
         # Evaluate
-        if args.evaluation_strategy == IntervalStrategy.EPOCH and args.eval_delay > state.epoch:
+        if args.evaluation_strategy == IntervalStrategy.EPOCH and args.eval_delay < state.epoch:
             control.should_evaluate = True
 
         # Save

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -419,7 +419,7 @@ class DefaultFlowCallback(TrainerCallback):
         if (
             args.evaluation_strategy == IntervalStrategy.STEPS
             and state.global_step % args.eval_steps == 0
-            and args.eval_delay < state.global_step
+            and args.eval_delay <= state.global_step
         ):
             control.should_evaluate = True
 


### PR DESCRIPTION
# What does this PR do?

The eval delay is a feature that allows a user to specify the number of steps/epochs to wait before the first evaluation can take place. This fixes a bug where the opposite behavior occurs - evaluation stops after eval_delay!

Fixes #16365


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@sgugger (sorry for the repeated tagging)
