### PR TITLE
TF generate refactor - Beam Search

### DIFF
--- a/docs/source/en/internal/generation_utils.mdx
+++ b/docs/source/en/internal/generation_utils.mdx
@@ -178,6 +178,12 @@ generation.
 [[autodoc]] TFRepetitionPenaltyLogitsProcessor
     - __call__
 
+[[autodoc]] TFForcedBOSTokenLogitsProcessor
+    - __call__
+
+[[autodoc]] TFForcedEOSTokenLogitsProcessor
+    - __call__
+
 [[autodoc]] FlaxLogitsProcessor
     - __call__
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -1699,6 +1699,8 @@ if is_tf_available():
     _import_structure["benchmark.benchmark_args_tf"] = ["TensorFlowBenchmarkArguments"]
     _import_structure["benchmark.benchmark_tf"] = ["TensorFlowBenchmark"]
     _import_structure["generation_tf_logits_process"] = [
+        "TFForcedBOSTokenLogitsProcessor",
+        "TFForcedEOSTokenLogitsProcessor",
         "TFLogitsProcessor",
         "TFLogitsProcessorList",
         "TFLogitsWarper",
@@ -3827,6 +3829,8 @@ if TYPE_CHECKING:
         # Benchmarks
         from .benchmark.benchmark_tf import TensorFlowBenchmark
         from .generation_tf_logits_process import (
+            TFForcedBOSTokenLogitsProcessor,
+            TFForcedEOSTokenLogitsProcessor,
             TFLogitsProcessor,
             TFLogitsProcessorList,
             TFLogitsWarper,

--- a/src/transformers/generation_tf_logits_process.py
+++ b/src/transformers/generation_tf_logits_process.py
@@ -414,6 +414,8 @@ class TFForcedBOSTokenLogitsProcessor(TFLogitsProcessor):
     """
 
     def __init__(self, bos_token_id: int):
+        if bos_token_id < 0:
+            raise ValueError(f"The forced bos token id  must be a non-negative integer, got {bos_token_id}")
         self.bos_token_id = bos_token_id
 
     def __call__(self, input_ids: tf.Tensor, scores: tf.Tensor, cur_len: int) -> tf.Tensor:
@@ -445,6 +447,8 @@ class TFForcedEOSTokenLogitsProcessor(TFLogitsProcessor):
 
     def __init__(self, max_length: int, eos_token_id: int):
         self.max_length = max_length
+        if eos_token_id < 0:
+            raise ValueError(f"The forced eos token id must be a non-negative integer, got {eos_token_id}")
         self.eos_token_id = eos_token_id
 
     def __call__(self, input_ids: tf.Tensor, scores: tf.Tensor, cur_len: int) -> tf.Tensor:

--- a/src/transformers/generation_tf_logits_process.py
+++ b/src/transformers/generation_tf_logits_process.py
@@ -425,7 +425,10 @@ class TFForcedBOSTokenLogitsProcessor(TFLogitsProcessor):
             if self.bos_token_id > 0:
                 scores = tf.concat((tf.broadcast_to(-float("inf"), (batch_size, self.bos_token_id)), scores), axis=-1)
             if self.bos_token_id < (num_tokens - 1):
-                scores = tf.concat((scores, tf.broadcast_to(-float("inf"), (batch_size, (num_tokens - 1) - self.bos_token_id))), axis=-1)
+                scores = tf.concat(
+                    (scores, tf.broadcast_to(-float("inf"), (batch_size, (num_tokens - 1) - self.bos_token_id))),
+                    axis=-1,
+                )
         return scores
 
 
@@ -453,5 +456,8 @@ class TFForcedEOSTokenLogitsProcessor(TFLogitsProcessor):
             if self.eos_token_id > 0:
                 scores = tf.concat((tf.broadcast_to(-float("inf"), (batch_size, self.eos_token_id)), scores), axis=-1)
             if self.eos_token_id < (num_tokens - 1):
-                scores = tf.concat((scores, tf.broadcast_to(-float("inf"), (batch_size, (num_tokens - 1) - self.eos_token_id))), axis=-1)
+                scores = tf.concat(
+                    (scores, tf.broadcast_to(-float("inf"), (batch_size, (num_tokens - 1) - self.eos_token_id))),
+                    axis=-1,
+                )
         return scores

--- a/src/transformers/generation_tf_logits_process.py
+++ b/src/transformers/generation_tf_logits_process.py
@@ -330,12 +330,12 @@ class TFNoBadWordsLogitsProcessor(TFLogitsProcessor):
 
         return banned_tokens
 
-    def __call__(self, input_ids: tf.Tensor, scores: tf.Tensor) -> tf.Tensor:
+    def __call__(self, input_ids: tf.Tensor, scores: tf.Tensor, cur_len: int) -> tf.Tensor:
 
         vocab_size = scores.shape[-1]
 
         # calculate a list of banned tokens according to bad words
-        banned_tokens = self.calc_banned_bad_words_ids(input_ids)
+        banned_tokens = self.calc_banned_bad_words_ids(input_ids[:, :cur_len])
 
         banned_tokens_indices_mask = []
         for banned_tokens_slice in banned_tokens:

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -917,7 +917,6 @@ class TFGenerationMixin:
             if self._use_cache(outputs, use_cache):
                 past = outputs[1]
 
-            breakpoint()
             # repetition penalty (from CTRL paper https://arxiv.org/abs/1909.05858)
             if repetition_penalty != 1.0:
                 next_token_logits_penalties = _create_next_token_logits_penalties(

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -1493,7 +1493,8 @@ class TFGenerationMixin:
             model_kwargs["output_hidden_states"] = output_hidden_states
         if use_cache is not None:
             model_kwargs["use_cache"] = use_cache
-        model_kwargs["attention_mask"] = attention_mask
+        if attention_mask is not None:
+            model_kwargs["attention_mask"] = attention_mask
 
         accepts_attention_mask = "attention_mask" in set(inspect.signature(self.call).parameters.keys())
         requires_attention_mask = "encoder_outputs" not in model_kwargs
@@ -2502,8 +2503,8 @@ class TFGenerationMixin:
         )
 
         use_xla = not tf.executing_eagerly()
-        # GPT2 has a slightly different cache structure, with a different batch axis
-        cache_batch_axis = 1 if "TFGPT2" in str(self) else 0
+        # GPT2 and other models has a slightly different cache structure, with a different batch axis
+        cache_batch_axis = 1 if any([model_name in str(self) for model_name in ("TFGPT2", "TFCTRL")]) else 0
 
         # 2. init `attentions`, `hidden_states`, and `scores` tuples
         scores = [] if (return_dict_in_generate and output_scores) else None

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -2580,7 +2580,7 @@ class TFGenerationMixin:
             # 3. is there still a beam that has not finished?
             still_open_beam = ~(tf.math.reduce_all(is_sent_finished) & early_stopping)
 
-            return not_max_length_yet & still_open_beam & improvement_still_possible
+            return not_max_length_yet & (still_open_beam | improvement_still_possible)
 
         def beam_search_body_fn(
             cur_len,
@@ -2703,7 +2703,7 @@ class TFGenerationMixin:
                 eos_in_next_token.shape,
             )
 
-            # non-top `num_beams` eos tokens can't be used to finish a beam, but they can't be used in the next
+            # non-top `num_beams` eos tokens can't be used to finish a beam, but the others can't be used in the next
             # running sentences either
             running_topk_log_probs = topk_log_probs + tf.cast(eos_in_next_token, tf.float32) * -1.0e9
 
@@ -3040,7 +3040,6 @@ class BeamHypotheses(object):
         If there are enough hypotheses and that none of the hypotheses being generated can become better than the worst
         one in the heap, then we are done with this sentence.
         """
-
         if len(self) < self.num_beams:
             return False
         elif self.early_stopping:

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -2747,7 +2747,6 @@ class TFGenerationMixin:
         if beam_search_cond_fn(
             cur_len, running_sequences, running_scores, sequences, scores, is_sent_finished, model_kwargs
         ):
-            # maximum_iterations = max_length - cur_len - 1
             maximum_iterations = max_length - cur_len
             cur_len, running_sequences, running_scores, sequences, scores, is_sent_finished, _ = tf.while_loop(
                 beam_search_cond_fn,

--- a/src/transformers/models/rag/modeling_tf_rag.py
+++ b/src/transformers/models/rag/modeling_tf_rag.py
@@ -1245,7 +1245,10 @@ class TFRagTokenForGeneration(TFRagPreTrainedModel, TFCausalLanguageModelingLoss
                 no_repeat_ngram_size=no_repeat_ngram_size,
                 bad_words_ids=bad_words_ids,
                 min_length=min_length,
+                max_length=max_length,
                 eos_token_id=eos_token_id,
+                forced_bos_token_id=None,
+                forced_eos_token_id=None,
             )
             model_kwargs["attention_mask"] = context_attention_mask
 

--- a/src/transformers/utils/dummy_tf_objects.py
+++ b/src/transformers/utils/dummy_tf_objects.py
@@ -17,6 +17,20 @@ class TensorFlowBenchmark(metaclass=DummyObject):
         requires_backends(self, ["tf"])
 
 
+class TFForcedBOSTokenLogitsProcessor(metaclass=DummyObject):
+    _backends = ["tf"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["tf"])
+
+
+class TFForcedEOSTokenLogitsProcessor(metaclass=DummyObject):
+    _backends = ["tf"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["tf"])
+
+
 class TFLogitsProcessor(metaclass=DummyObject):
     _backends = ["tf"]
 

--- a/tests/generation/test_generation_logits_process.py
+++ b/tests/generation/test_generation_logits_process.py
@@ -472,14 +472,14 @@ class LogitsProcessorTest(unittest.TestCase):
 
         logits_processor = ForcedEOSTokenLogitsProcessor(max_length=max_length, eos_token_id=eos_token_id)
 
-        # check that all scores are -inf except the eos_token_id when max_length is reached
+        # check that all scores are -inf except the eos_token_id when max_length-1 is reached
         input_ids = ids_tensor((batch_size, 4), vocab_size=20)
         scores = self._get_uniform_logits(batch_size, vocab_size)
         scores = logits_processor(input_ids, scores)
         self.assertTrue(torch.isneginf(scores[:, eos_token_id + 1 :]).all())
         self.assertListEqual(scores[:, eos_token_id].tolist(), 4 * [0])  # score for eos_token_id should be zero
 
-        # check that eos_token_id is not forced if max_length is not reached
+        # check that eos_token_id is not forced if max_length-1 is not reached
         input_ids = ids_tensor((batch_size, 3), vocab_size=20)
         scores = self._get_uniform_logits(batch_size, vocab_size)
         scores = logits_processor(input_ids, scores)

--- a/tests/generation/test_generation_tf_logits_process.py
+++ b/tests/generation/test_generation_tf_logits_process.py
@@ -43,7 +43,7 @@ if is_tf_available():
 @require_tf
 class TFLogitsProcessorTest(unittest.TestCase):
     def _get_uniform_logits(self, batch_size: int, length: int):
-        scores = np.ones((batch_size, length), dtype=np.float32) / length
+        scores = tf.ones((batch_size, length), dtype=tf.float32) / length
         return scores
 
     def test_min_length_dist_processor(self):
@@ -54,15 +54,17 @@ class TFLogitsProcessorTest(unittest.TestCase):
         min_dist_processor = TFMinLengthLogitsProcessor(min_length=10, eos_token_id=eos_token_id)
 
         # check that min length is applied at length 5
-        input_ids = ids_tensor((batch_size, 5), vocab_size=20)
+        cur_len = 5
+        input_ids = ids_tensor((batch_size, cur_len), vocab_size=20)
         scores = self._get_uniform_logits(batch_size, vocab_size)
-        scores_before_min_length = min_dist_processor(input_ids, scores)
+        scores_before_min_length = min_dist_processor(input_ids, scores, cur_len)
         self.assertListEqual(scores_before_min_length[:, eos_token_id].numpy().tolist(), 4 * [-float("inf")])
 
         # check that min length is not applied anymore at length 15
-        input_ids = ids_tensor((batch_size, 15), vocab_size=20)
+        cur_len = 15
+        input_ids = ids_tensor((batch_size, cur_len), vocab_size=20)
         scores = self._get_uniform_logits(batch_size, vocab_size)
-        scores_before_min_length = min_dist_processor(input_ids, scores)
+        scores_before_min_length = min_dist_processor(input_ids, scores, cur_len)
         self.assertFalse(tf.math.reduce_any(tf.math.is_inf(scores_before_min_length)).numpy())
 
     def test_temperature_dist_warper(self):
@@ -72,8 +74,10 @@ class TFLogitsProcessorTest(unittest.TestCase):
         scores = self._get_uniform_logits(batch_size=2, length=length)
 
         # tweak scores to not be uniform anymore
+        scores = scores.numpy()
         scores[1, 5] = (1 / length) + 0.1  # peak, 1st batch
         scores[1, 10] = (1 / length) - 0.4  # valley, 1st batch
+        scores = tf.convert_to_tensor(scores)
 
         # compute softmax
         probs = tf.nn.softmax(scores, axis=-1)
@@ -97,8 +101,11 @@ class TFLogitsProcessorTest(unittest.TestCase):
         self.assertLess(tf.math.reduce_min(probs[1, :]), tf.math.reduce_min(warped_prob_smooth[1, :]))
 
     def test_repetition_penalty_dist_process(self):
-        input_ids = tf.constant([[0, 1], [5, 0]], dtype=tf.int32)
         vocab_size = 10
+        cur_len = 2
+
+        input_ids = tf.constant([[0, 1], [5, 0]], dtype=tf.int32)
+        self.assertEqual(cur_len, input_ids.shape[1])
 
         scores = self._get_uniform_logits(batch_size=2, length=vocab_size)
 
@@ -109,7 +116,7 @@ class TFLogitsProcessorTest(unittest.TestCase):
 
         rep_penalty_proc = TFRepetitionPenaltyLogitsProcessor(penalty=2.0)
 
-        scores = rep_penalty_proc(input_ids, tf.identity(scores))
+        scores = rep_penalty_proc(input_ids, tf.identity(scores), cur_len)
 
         # check that values were correctly changed
         self.assertAlmostEqual(scores[0, 0].numpy(), -(1 / vocab_size) * 2)
@@ -188,15 +195,18 @@ class TFLogitsProcessorTest(unittest.TestCase):
     def test_no_repeat_ngram_dist_processor(self):
         vocab_size = 3
         batch_size = 2
+        cur_len = 4
 
         input_ids = tf.constant([[1, 1, 2, 1], [0, 1, 0, 1]], dtype=tf.int32)
+        self.assertEqual(cur_len, input_ids.shape[1])
+
         scores = self._get_uniform_logits(batch_size, vocab_size)
 
         no_repeat_proc_2_gram = TFNoRepeatNGramLogitsProcessor(2)
         no_repeat_proc_3_gram = TFNoRepeatNGramLogitsProcessor(3)
 
-        filtered_scores_2_gram = no_repeat_proc_2_gram(input_ids, tf.identity(scores))
-        filtered_scores_3_gram = no_repeat_proc_3_gram(input_ids, tf.identity(scores))
+        filtered_scores_2_gram = no_repeat_proc_2_gram(input_ids, tf.identity(scores), cur_len)
+        filtered_scores_3_gram = no_repeat_proc_3_gram(input_ids, tf.identity(scores), cur_len)
 
         # 2-gram would forbid 2nd and 3rd token (1,2) at 1st batch and 1st token (0) at 2nd batch
         self.assertListEqual(
@@ -212,14 +222,17 @@ class TFLogitsProcessorTest(unittest.TestCase):
         vocab_size = 5
         batch_size = 2
         eos_token_id = 4
+        cur_len = 4
 
         input_ids = tf.constant([[0, 1, 3, 1], [0, 1, 0, 1]], dtype=tf.int32)
+        self.assertEqual(cur_len, input_ids.shape[1])
+
         bad_word_tokens = [[1], [4], [1, 0], [0, 1, 2], [1, 3, 1, 3]]
         scores = self._get_uniform_logits(batch_size, vocab_size)
 
         no_bad_words_dist_proc = TFNoBadWordsLogitsProcessor(bad_words_ids=bad_word_tokens, eos_token_id=eos_token_id)
 
-        filtered_scores = no_bad_words_dist_proc(input_ids, tf.identity(scores))
+        filtered_scores = no_bad_words_dist_proc(input_ids, tf.identity(scores), cur_len)
 
         # batch 1: 1st, 2nd, and 4th (0, 1, 3) token are forbidden
         # batch 2: 1st, 2nd, and 3rd (0, 1, 2) token are forbidden
@@ -230,12 +243,12 @@ class TFLogitsProcessorTest(unittest.TestCase):
 
     def test_processor_list(self):
         batch_size = 4
-        sequence_length = 10
+        cur_len = 10
         vocab_size = 15
         eos_token_id = 0
 
         # dummy input_ids and scores
-        input_ids = ids_tensor((batch_size, sequence_length), vocab_size)
+        input_ids = ids_tensor((batch_size, cur_len), vocab_size)
         input_ids_comp = tf.identity(input_ids)
 
         scores = self._get_uniform_logits(batch_size, vocab_size)
@@ -251,13 +264,13 @@ class TFLogitsProcessorTest(unittest.TestCase):
         no_bad_words_dist_proc = TFNoBadWordsLogitsProcessor(bad_words_ids=[[1]], eos_token_id=eos_token_id)
 
         # no processor list
-        scores = min_dist_proc(input_ids, scores)
+        scores = min_dist_proc(input_ids, scores, cur_len)
         scores = temp_dist_warp(input_ids, scores)
-        scores = rep_penalty_proc(input_ids, scores)
+        scores = rep_penalty_proc(input_ids, scores, cur_len)
         scores = top_k_warp(input_ids, scores)
         scores = top_p_warp(input_ids, scores)
-        scores = no_repeat_proc(input_ids, scores)
-        scores = no_bad_words_dist_proc(input_ids, scores)
+        scores = no_repeat_proc(input_ids, scores, cur_len)
+        scores = no_bad_words_dist_proc(input_ids, scores, cur_len)
 
         # with processor list
         processor = TFLogitsProcessorList(
@@ -271,7 +284,7 @@ class TFLogitsProcessorTest(unittest.TestCase):
                 no_bad_words_dist_proc,
             ]
         )
-        scores_comp = processor(input_ids, scores_comp)
+        scores_comp = processor(input_ids, scores_comp, cur_len=cur_len)
 
         # remove inf
         scores = set_tensor_by_indices_to_value(scores, tf.math.is_inf(scores), -1e9)

--- a/tests/generation/test_generation_tf_logits_process.py
+++ b/tests/generation/test_generation_tf_logits_process.py
@@ -255,7 +255,9 @@ class TFLogitsProcessorTest(unittest.TestCase):
         input_ids = ids_tensor((batch_size, cur_len), vocab_size=20)
         scores = self._get_uniform_logits(batch_size, vocab_size)
         scores = logits_processor(input_ids, scores, cur_len)
-        self.assertTrue(tf.math.reduce_all(tf.math.is_inf(scores[:, bos_token_id + 1 :]) & (scores[:, bos_token_id + 1 :] < 0)))
+        self.assertTrue(
+            tf.math.reduce_all(tf.math.is_inf(scores[:, bos_token_id + 1 :]) & (scores[:, bos_token_id + 1 :] < 0))
+        )
         self.assertListEqual(scores[:, bos_token_id].numpy().tolist(), 4 * [0])  # score for bos_token_id shold be zero
 
         # check that bos_token_id is not forced if current length is greater than 1
@@ -278,8 +280,12 @@ class TFLogitsProcessorTest(unittest.TestCase):
         input_ids = ids_tensor((batch_size, cur_len), vocab_size=20)
         scores = self._get_uniform_logits(batch_size, vocab_size)
         scores = logits_processor(input_ids, scores, cur_len)
-        self.assertTrue(tf.math.reduce_all(tf.math.is_inf(scores[:, eos_token_id + 1 :]) & (scores[:, eos_token_id + 1 :] < 0)))
-        self.assertListEqual(scores[:, eos_token_id].numpy().tolist(), 4 * [0])  # score for eos_token_id should be zero
+        self.assertTrue(
+            tf.math.reduce_all(tf.math.is_inf(scores[:, eos_token_id + 1 :]) & (scores[:, eos_token_id + 1 :] < 0))
+        )
+        self.assertListEqual(
+            scores[:, eos_token_id].numpy().tolist(), 4 * [0]
+        )  # score for eos_token_id should be zero
 
         # check that eos_token_id is not forced if max_length-1 is not reached
         cur_len = 3

--- a/tests/gpt2/test_modeling_tf_gpt2.py
+++ b/tests/gpt2/test_modeling_tf_gpt2.py
@@ -536,7 +536,6 @@ class TFGPT2ModelLanguageGenerationTest(unittest.TestCase):
             "bad_words_ids": [tokenizer("is").input_ids, tokenizer("angry about").input_ids],
             "no_repeat_ngram_size": 2,
             "do_sample": False,
-            "repetition_penalty": 1.3,
             "num_beams": 2,
         }
 
@@ -544,8 +543,8 @@ class TFGPT2ModelLanguageGenerationTest(unittest.TestCase):
 
         output_strings = tokenizer.batch_decode(output_ids, skip_special_tokens=True)
         expected_output_string = [
-            "Today is a beautiful day and I hope you enjoy it.\nI am very happy to announce that",
-            "Yesterday was the first time I've ever seen a game where you can play with",
+            "Today is a beautiful day and a great day for all of us.\n\nI’m",
+            "Yesterday was the first day of the year for the second time in a row,",
         ]
         self.assertListEqual(output_strings, expected_output_string)
 

--- a/tests/gpt2/test_modeling_tf_gpt2.py
+++ b/tests/gpt2/test_modeling_tf_gpt2.py
@@ -549,37 +549,6 @@ class TFGPT2ModelLanguageGenerationTest(unittest.TestCase):
         ]
         self.assertListEqual(output_strings, expected_output_string)
 
-    # TODO (Joao): enable this in a future PR. Some generate Ops not yet compatible
-    # @slow
-    # def test_lm_generate_greedy_distilgpt2_beam_search_special_xla(self):
-    #     """This test gives the exact same results as the non-xla test above"""
-    #     model = TFGPT2LMHeadModel.from_pretrained("distilgpt2")
-    #     tokenizer = GPT2Tokenizer.from_pretrained("distilgpt2")
-
-    #     tokenizer.pad_token = tokenizer.eos_token
-    #     tokenizer.padding_side = "left"
-
-    #     sentences = ["Today is a beautiful day and", "Yesterday was"]
-    #     input_ids = tokenizer(sentences, return_tensors="tf", padding=True).input_ids
-
-    #     generation_kwargs = {
-    #         "bad_words_ids": [tokenizer("is").input_ids, tokenizer("angry about").input_ids],
-    #         "no_repeat_ngram_size": 2,
-    #         "do_sample": False,
-    #         "repetition_penalty": 1.3,
-    #         "num_beams": 2,
-    #     }
-
-    #     xla_generate = tf.function(model.generate, jit_compile=True)
-    #     output_ids = xla_generate(input_ids, **generation_kwargs)
-
-    #     output_strings = tokenizer.batch_decode(output_ids, skip_special_tokens=True)
-    #     expected_output_string = [
-    #         "Today is a beautiful day and I hope you enjoy it.\nI am very happy to announce that",
-    #         "Yesterday was the first time I've ever seen a game where you can play with",
-    #     ]
-    #     self.assertListEqual(output_strings, expected_output_string)
-
     @slow
     def test_lm_generate_gpt2(self):
         model = TFGPT2LMHeadModel.from_pretrained("gpt2")

--- a/tests/gpt2/test_modeling_tf_gpt2.py
+++ b/tests/gpt2/test_modeling_tf_gpt2.py
@@ -549,7 +549,7 @@ class TFGPT2ModelLanguageGenerationTest(unittest.TestCase):
         ]
         self.assertListEqual(output_strings, expected_output_string)
 
-    # TODO (Joao): enable this in a future PR.
+    # TODO (Joao): enable this in a future PR. Some generate Ops not yet compatible
     # @slow
     # def test_lm_generate_greedy_distilgpt2_beam_search_special_xla(self):
     #     """This test gives the exact same results as the non-xla test above"""

--- a/tests/gpt2/test_modeling_tf_gpt2.py
+++ b/tests/gpt2/test_modeling_tf_gpt2.py
@@ -549,6 +549,37 @@ class TFGPT2ModelLanguageGenerationTest(unittest.TestCase):
         ]
         self.assertListEqual(output_strings, expected_output_string)
 
+    # TODO (Joao): enable this in a future PR.
+    # @slow
+    # def test_lm_generate_greedy_distilgpt2_beam_search_special_xla(self):
+    #     """This test gives the exact same results as the non-xla test above"""
+    #     model = TFGPT2LMHeadModel.from_pretrained("distilgpt2")
+    #     tokenizer = GPT2Tokenizer.from_pretrained("distilgpt2")
+
+    #     tokenizer.pad_token = tokenizer.eos_token
+    #     tokenizer.padding_side = "left"
+
+    #     sentences = ["Today is a beautiful day and", "Yesterday was"]
+    #     input_ids = tokenizer(sentences, return_tensors="tf", padding=True).input_ids
+
+    #     generation_kwargs = {
+    #         "bad_words_ids": [tokenizer("is").input_ids, tokenizer("angry about").input_ids],
+    #         "no_repeat_ngram_size": 2,
+    #         "do_sample": False,
+    #         "repetition_penalty": 1.3,
+    #         "num_beams": 2,
+    #     }
+
+    #     xla_generate = tf.function(model.generate, jit_compile=True)
+    #     output_ids = xla_generate(input_ids, **generation_kwargs)
+
+    #     output_strings = tokenizer.batch_decode(output_ids, skip_special_tokens=True)
+    #     expected_output_string = [
+    #         "Today is a beautiful day and I hope you enjoy it.\nI am very happy to announce that",
+    #         "Yesterday was the first time I've ever seen a game where you can play with",
+    #     ]
+    #     self.assertListEqual(output_strings, expected_output_string)
+
     @slow
     def test_lm_generate_gpt2(self):
         model = TFGPT2LMHeadModel.from_pretrained("gpt2")

--- a/tests/speech_to_text/test_modeling_tf_speech_to_text.py
+++ b/tests/speech_to_text/test_modeling_tf_speech_to_text.py
@@ -508,7 +508,7 @@ class TFSpeech2TextModelTest(TFModelTesterMixin, unittest.TestCase):
                 # if bos token id is not defined model needs input_ids, num_return_sequences = 1
                 self._check_generated_ids(model.generate(input_features, do_sample=True, num_beams=2))
 
-            with self.assertRaises(AssertionError):
+            with self.assertRaises(ValueError):
                 # generating more sequences than having beams leads is not possible
                 model.generate(input_features, do_sample=False, num_return_sequences=3, num_beams=2)
 

--- a/tests/t5/test_modeling_tf_t5.py
+++ b/tests/t5/test_modeling_tf_t5.py
@@ -553,6 +553,28 @@ class TFT5GenerationIntegrationTests(unittest.TestCase):
 
         self.assertListEqual(expected_output_string, output_strings)
 
+    # TODO (Joao): enable this in a future PR. T5 itself needs a few changes to become XLA-compatible with beam search.
+    # @slow
+    # def test_beam_search_xla_generate_simple(self):
+    #     model = TFT5ForConditionalGeneration.from_pretrained("t5-small")
+    #     tokenizer = T5Tokenizer.from_pretrained("t5-small")
+
+    #     sentence = "Translate English to German: Today is a beautiful day."
+    #     input_ids = tokenizer(sentence, return_tensors="tf", padding=True).input_ids
+
+    #     xla_generate = tf.function(model.generate, jit_compile=True)
+
+    #     output_ids = model.generate(input_ids, num_beams=4)
+    #     output_ids_xla = xla_generate(input_ids, num_beams=4)
+
+    #     output_strings = tokenizer.batch_decode(output_ids, skip_special_tokens=True)
+    #     output_strings_xla = tokenizer.batch_decode(output_ids_xla, skip_special_tokens=True)
+
+    #     expected_output_string = ["Heute ist ein schöner Tag."]
+
+    #     self.assertListEqual(expected_output_string, output_strings)
+    #     self.assertListEqual(expected_output_string, output_strings_xla)
+
     @slow
     def test_beam_search_generate(self):
         model = TFT5ForConditionalGeneration.from_pretrained("t5-small")

--- a/tests/t5/test_modeling_tf_t5.py
+++ b/tests/t5/test_modeling_tf_t5.py
@@ -553,28 +553,6 @@ class TFT5GenerationIntegrationTests(unittest.TestCase):
 
         self.assertListEqual(expected_output_string, output_strings)
 
-    # TODO (Joao): enable this in a future PR. T5 itself needs a few changes to become XLA-compatible with beam search.
-    # @slow
-    # def test_beam_search_xla_generate_simple(self):
-    #     model = TFT5ForConditionalGeneration.from_pretrained("t5-small")
-    #     tokenizer = T5Tokenizer.from_pretrained("t5-small")
-
-    #     sentence = "Translate English to German: Today is a beautiful day."
-    #     input_ids = tokenizer(sentence, return_tensors="tf", padding=True).input_ids
-
-    #     xla_generate = tf.function(model.generate, jit_compile=True)
-
-    #     output_ids = model.generate(input_ids, num_beams=4)
-    #     output_ids_xla = xla_generate(input_ids, num_beams=4)
-
-    #     output_strings = tokenizer.batch_decode(output_ids, skip_special_tokens=True)
-    #     output_strings_xla = tokenizer.batch_decode(output_ids_xla, skip_special_tokens=True)
-
-    #     expected_output_string = ["Heute ist ein schöner Tag."]
-
-    #     self.assertListEqual(expected_output_string, output_strings)
-    #     self.assertListEqual(expected_output_string, output_strings_xla)
-
     @slow
     def test_beam_search_generate(self):
         model = TFT5ForConditionalGeneration.from_pretrained("t5-small")

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1179,7 +1179,7 @@ class TFModelTesterMixin:
                 # num_return_sequences = 1
                 self._check_generated_ids(model.generate(do_sample=True, max_length=5, num_beams=2))
 
-            with self.assertRaises(AssertionError):
+            with self.assertRaises(ValueError):
                 # generating more sequences than having beams leads is not possible
                 model.generate(input_ids, do_sample=False, num_return_sequences=3, num_beams=2)
 


### PR DESCRIPTION
# What does this PR do?

As discussed in the original TF generate refactor plan (https://github.com/huggingface/transformers/pull/15562), adds `beam_search`. 

This Beam Search implementation was inspired by our FLAX implementation, which is XLA-friendly. However, this PR is not yet XLA-ready (😭). To pass existing tests, a few tweaks were added on top of the FLAX adaptation -- I added some comments in the PR to explain the differences (and why they were needed), hopefully making the review process easier. 

Tests ran (and passing):
- [x] GPT-2
- [x] T5
- [x] BART
- [x] Vision Encoder Decoder
- [x] Encoder Decoder
- [x] Speech to Text
- [x] RAG