### PR TITLE
`cached_download ∘ hf_hub_url` is `hf_hub_download`

### DIFF
--- a/src/transformers/models/beit/convert_beit_unilm_to_pytorch.py
+++ b/src/transformers/models/beit/convert_beit_unilm_to_pytorch.py
@@ -24,7 +24,7 @@ from datasets import load_dataset
 from PIL import Image
 
 import requests
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from transformers import (
     BeitConfig,
     BeitFeatureExtractor,
@@ -188,7 +188,7 @@ def convert_beit_checkpoint(checkpoint_url, pytorch_dump_folder_path):
         config.use_relative_position_bias = True
         config.num_labels = 21841
         filename = "imagenet-22k-id2label.json"
-        id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+        id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
         id2label = {int(k): v for k, v in id2label.items()}
         # this dataset contains 21843 labels but the model only has 21841
         # we delete the classes as mentioned in https://github.com/google-research/big_transfer/issues/18
@@ -201,7 +201,7 @@ def convert_beit_checkpoint(checkpoint_url, pytorch_dump_folder_path):
         config.use_relative_position_bias = True
         config.num_labels = 1000
         filename = "imagenet-1k-id2label.json"
-        id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+        id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
         id2label = {int(k): v for k, v in id2label.items()}
         config.id2label = id2label
         config.label2id = {v: k for k, v in id2label.items()}
@@ -214,7 +214,7 @@ def convert_beit_checkpoint(checkpoint_url, pytorch_dump_folder_path):
         config.use_relative_position_bias = True
         config.num_labels = 150
         filename = "ade20k-id2label.json"
-        id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+        id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
         id2label = {int(k): v for k, v in id2label.items()}
         config.id2label = id2label
         config.label2id = {v: k for k, v in id2label.items()}

--- a/src/transformers/models/convnext/convert_convnext_to_pytorch.py
+++ b/src/transformers/models/convnext/convert_convnext_to_pytorch.py
@@ -25,7 +25,7 @@ import torch
 from PIL import Image
 
 import requests
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from transformers import ConvNextConfig, ConvNextFeatureExtractor, ConvNextForImageClassification
 from transformers.utils import logging
 
@@ -64,7 +64,7 @@ def get_convnext_config(checkpoint_url):
 
     repo_id = "datasets/huggingface/label-files"
     config.num_labels = num_labels
-    id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+    id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
     id2label = {int(k): v for k, v in id2label.items()}
     if "1k" not in checkpoint_url:
         # this dataset contains 21843 labels but the model only has 21841

--- a/src/transformers/models/deit/convert_deit_timm_to_pytorch.py
+++ b/src/transformers/models/deit/convert_deit_timm_to_pytorch.py
@@ -24,7 +24,7 @@ from PIL import Image
 
 import requests
 import timm
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from transformers import DeiTConfig, DeiTFeatureExtractor, DeiTForImageClassificationWithTeacher
 from transformers.utils import logging
 
@@ -142,7 +142,7 @@ def convert_deit_checkpoint(deit_name, pytorch_dump_folder_path):
     config.num_labels = 1000
     repo_id = "datasets/huggingface/label-files"
     filename = "imagenet-1k-id2label.json"
-    id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+    id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
     id2label = {int(k): v for k, v in id2label.items()}
     config.id2label = id2label
     config.label2id = {v: k for k, v in id2label.items()}

--- a/src/transformers/models/detr/convert_detr_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/detr/convert_detr_original_pytorch_checkpoint_to_pytorch.py
@@ -24,7 +24,7 @@ import torch
 from PIL import Image
 
 import requests
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from transformers import DetrConfig, DetrFeatureExtractor, DetrForObjectDetection, DetrForSegmentation
 from transformers.utils import logging
 
@@ -196,7 +196,7 @@ def convert_detr_checkpoint(model_name, pytorch_dump_folder_path):
         config.num_labels = 91
         repo_id = "datasets/huggingface/label-files"
         filename = "coco-detection-id2label.json"
-        id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+        id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
         id2label = {int(k): v for k, v in id2label.items()}
         config.id2label = id2label
         config.label2id = {v: k for k, v in id2label.items()}

--- a/src/transformers/models/dit/convert_dit_unilm_to_pytorch.py
+++ b/src/transformers/models/dit/convert_dit_unilm_to_pytorch.py
@@ -23,7 +23,7 @@ import torch
 from PIL import Image
 
 import requests
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from transformers import BeitConfig, BeitFeatureExtractor, BeitForImageClassification, BeitForMaskedImageModeling
 from transformers.utils import logging
 
@@ -151,7 +151,7 @@ def convert_dit_checkpoint(checkpoint_url, pytorch_dump_folder_path, push_to_hub
         config.num_labels = 16
         repo_id = "datasets/huggingface/label-files"
         filename = "rvlcdip-id2label.json"
-        id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+        id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
         id2label = {int(k): v for k, v in id2label.items()}
         config.id2label = id2label
         config.label2id = {v: k for k, v in id2label.items()}

--- a/src/transformers/models/perceiver/convert_perceiver_haiku_to_pytorch.py
+++ b/src/transformers/models/perceiver/convert_perceiver_haiku_to_pytorch.py
@@ -26,7 +26,7 @@ from PIL import Image
 
 import haiku as hk
 import requests
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from transformers import (
     PerceiverConfig,
     PerceiverFeatureExtractor,
@@ -318,7 +318,7 @@ def convert_perceiver_checkpoint(pickle_file, pytorch_dump_folder_path, architec
         # set labels
         config.num_labels = 1000
         filename = "imagenet-1k-id2label.json"
-        id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+        id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
         id2label = {int(k): v for k, v in id2label.items()}
         config.id2label = id2label
         config.label2id = {v: k for k, v in id2label.items()}
@@ -367,7 +367,7 @@ def convert_perceiver_checkpoint(pickle_file, pytorch_dump_folder_path, architec
         model = PerceiverForMultimodalAutoencoding(config)
         # set labels
         filename = "kinetics700-id2label.json"
-        id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+        id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
         id2label = {int(k): v for k, v in id2label.items()}
         config.id2label = id2label
         config.label2id = {v: k for k, v in id2label.items()}

--- a/src/transformers/models/poolformer/convert_poolformer_original_to_pytorch.py
+++ b/src/transformers/models/poolformer/convert_poolformer_original_to_pytorch.py
@@ -23,7 +23,7 @@ import torch
 from PIL import Image
 
 import requests
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from transformers import PoolFormerConfig, PoolFormerFeatureExtractor, PoolFormerForImageClassification
 from transformers.utils import logging
 
@@ -106,7 +106,7 @@ def convert_poolformer_checkpoint(model_name, checkpoint_path, pytorch_dump_fold
     expected_shape = (1, 1000)
 
     # set config attributes
-    id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+    id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
     id2label = {int(k): v for k, v in id2label.items()}
     config.id2label = id2label
     config.label2id = {v: k for k, v in id2label.items()}

--- a/src/transformers/models/resnet/convert_resnet_to_pytorch.py
+++ b/src/transformers/models/resnet/convert_resnet_to_pytorch.py
@@ -27,7 +27,7 @@ import torch.nn as nn
 from torch import Tensor
 
 import timm
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from transformers import AutoFeatureExtractor, ResNetConfig, ResNetForImageClassification
 from transformers.utils import logging
 
@@ -129,7 +129,7 @@ def convert_weights_and_push(save_directory: Path, model_name: str = None, push_
 
     repo_id = "datasets/huggingface/label-files"
     num_labels = num_labels
-    id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+    id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
     id2label = {int(k): v for k, v in id2label.items()}
 
     id2label = id2label

--- a/src/transformers/models/segformer/convert_segformer_original_to_pytorch.py
+++ b/src/transformers/models/segformer/convert_segformer_original_to_pytorch.py
@@ -24,7 +24,7 @@ import torch
 from PIL import Image
 
 import requests
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from transformers import (
     SegformerConfig,
     SegformerFeatureExtractor,
@@ -151,7 +151,7 @@ def convert_segformer_checkpoint(model_name, checkpoint_path, pytorch_dump_folde
         raise ValueError(f"Model {model_name} not supported")
 
     # set config attributes
-    id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+    id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
     id2label = {int(k): v for k, v in id2label.items()}
     config.id2label = id2label
     config.label2id = {v: k for k, v in id2label.items()}

--- a/src/transformers/models/swin/convert_swin_timm_to_pytorch.py
+++ b/src/transformers/models/swin/convert_swin_timm_to_pytorch.py
@@ -6,7 +6,7 @@ from PIL import Image
 
 import requests
 import timm
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from transformers import AutoFeatureExtractor, SwinConfig, SwinForImageClassification
 
 
@@ -41,7 +41,7 @@ def get_swin_config(swin_name):
         num_classes = 1000
         repo_id = "datasets/huggingface/label-files"
         filename = "imagenet-1k-id2label.json"
-        id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+        id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
         id2label = {int(k): v for k, v in id2label.items()}
         config.id2label = id2label
         config.label2id = {v: k for k, v in id2label.items()}

--- a/src/transformers/models/van/convert_van_to_pytorch.py
+++ b/src/transformers/models/van/convert_van_to_pytorch.py
@@ -29,7 +29,7 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import cached_download, hf_hub_download
 from transformers import AutoFeatureExtractor, VanConfig, VanForImageClassification
 from transformers.models.van.modeling_van import VanLayerScaling
 from transformers.utils import logging
@@ -168,7 +168,7 @@ def convert_weights_and_push(save_directory: Path, model_name: str = None, push_
 
     repo_id = "datasets/huggingface/label-files"
     num_labels = num_labels
-    id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+    id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
     id2label = {int(k): v for k, v in id2label.items()}
 
     id2label = id2label

--- a/src/transformers/models/vilt/convert_vilt_original_to_pytorch.py
+++ b/src/transformers/models/vilt/convert_vilt_original_to_pytorch.py
@@ -23,7 +23,7 @@ import torch
 from PIL import Image
 
 import requests
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from transformers import (
     BertTokenizer,
     ViltConfig,
@@ -182,7 +182,7 @@ def convert_vilt_checkpoint(checkpoint_url, pytorch_dump_folder_path):
         config.num_labels = 3129
         repo_id = "datasets/huggingface/label-files"
         filename = "vqa2-id2label.json"
-        id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+        id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
         id2label = {int(k): v for k, v in id2label.items()}
         config.id2label = id2label
         config.label2id = {v: k for k, v in id2label.items()}

--- a/src/transformers/models/vit/convert_dino_to_pytorch.py
+++ b/src/transformers/models/vit/convert_dino_to_pytorch.py
@@ -23,7 +23,7 @@ import torch
 from PIL import Image
 
 import requests
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from transformers import ViTConfig, ViTFeatureExtractor, ViTForImageClassification, ViTModel
 from transformers.utils import logging
 
@@ -144,7 +144,7 @@ def convert_vit_checkpoint(model_name, pytorch_dump_folder_path, base_model=True
         config.num_labels = 1000
         repo_id = "datasets/huggingface/label-files"
         filename = "imagenet-1k-id2label.json"
-        id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+        id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
         id2label = {int(k): v for k, v in id2label.items()}
         config.id2label = id2label
         config.label2id = {v: k for k, v in id2label.items()}

--- a/src/transformers/models/vit/convert_vit_timm_to_pytorch.py
+++ b/src/transformers/models/vit/convert_vit_timm_to_pytorch.py
@@ -24,7 +24,7 @@ from PIL import Image
 
 import requests
 import timm
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from transformers import DeiTFeatureExtractor, ViTConfig, ViTFeatureExtractor, ViTForImageClassification, ViTModel
 from transformers.utils import logging
 
@@ -149,7 +149,7 @@ def convert_vit_checkpoint(vit_name, pytorch_dump_folder_path):
         config.num_labels = 1000
         repo_id = "datasets/huggingface/label-files"
         filename = "imagenet-1k-id2label.json"
-        id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename)), "r"))
+        id2label = json.load(open(hf_hub_download(repo_id, filename), "r"))
         id2label = {int(k): v for k, v in id2label.items()}
         config.id2label = id2label
         config.label2id = {v: k for k, v in id2label.items()}


### PR DESCRIPTION
For a few versions already, `huggingface_hub` has added the `hf_hub_download` method which encompasses both `cached_download` and `hf_hub_url`.