### PR TITLE
Bump cookiecutter version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ _deps = [
     "Pillow",
     "black~=22.0",
     "codecarbon==1.2.0",
-    "cookiecutter==1.7.2",
+    "cookiecutter==1.7.3",
     "dataclasses",
     "datasets",
     "deepspeed>=0.6.0",


### PR DESCRIPTION
# What does this PR do?

Fix

```
ImportError: cannot import name 'json' from 'itsdangerous'
```
due to the flask/itsdangerous versions issue, when we run `pytest`.