### PR TITLE
Adding DocTest to TrOCR

### DIFF
--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -901,6 +901,7 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         ... )
         >>> import requests
         >>> from PIL import Image
+
         >>> # TrOCR is a decoder model and should be used within a VisionEncoderDecoderModel
         >>> # init vision2text model with random weights
         >>> encoder = ViTModel(ViTConfig())

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -909,10 +909,19 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         >>> # load image from the IAM dataset
         >>> url = "https://fki.tic.heia-fr.ch/static/img/a01-122-02.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw).convert("RGB")
-
         >>> pixel_values = processor(image, return_tensors="pt").pixel_values
-        >>> generated_ids = model.generate(pixel_values)
 
+        >>> # training
+        >>> model.config.decoder_start_token_id = processor.tokenizer.cls_token_id
+        >>> model.config.pad_token_id = processor.tokenizer.pad_token_id
+        >>> model.config.vocab_size = model.config.decoder.vocab_size
+        >>> text = "hello world"
+        >>> labels = processor.tokenizer(text, return_tensors="pt").input_ids
+        >>> outputs = model(pixel_values, labels=labels)
+        >>> loss = outputs.loss
+
+        >>> # inference
+        >>> generated_ids = model.generate(pixel_values)
         >>> generated_text = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
         >>> generated_text
         'industry, " Mr. Brown commented icily. " Let us have a'

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -891,33 +891,32 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         Example:
 
         ```python
-        >>> from transformers import VisionEncoderDecoderModel, TrOCRForCausalLM, ViTModel, TrOCRConfig, ViTConfig, TrOCRProcessor
-
-        >>> import numpy
+        >>> from transformers import TrOCRProcessor, VisionEncoderDecoderModel
+        >>> from transformers import VisionEncoderDecoderModel, TrOCRForCausalLM, ViTModel, TrOCRConfig, ViTConfig
+        >>> import requests
         >>> from PIL import Image
 
+        >>> processor = TrOCRProcessor.from_pretrained("microsoft/trocr-base-handwritten")
+
+        >>> # TrOCR is a decoder model and should be used within a VisionEncoderDecoderModel
         >>> encoder = ViTModel(ViTConfig())
         >>> decoder = TrOCRForCausalLM(TrOCRConfig())
-        # init vision2text model
-
         >>> model = VisionEncoderDecoderModel(encoder=encoder, decoder=decoder)
+
+        >>> # If you want to start from the pretrained model, load it from a VisionEncoderDecoderModel
+        >>> model = VisionEncoderDecoderModel.from_pretrained("microsoft/trocr-base-handwritten")
 
         >>> # load image from the IAM dataset
         >>> url = "https://fki.tic.heia-fr.ch/static/img/a01-122-02.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw).convert("RGB")
 
-        >>> # training
-        >>> model.config.decoder_start_token_id = processor.tokenizer.cls_token_id
-        >>> model.config.pad_token_id = processor.tokenizer.pad_token_id
-        >>> model.config.vocab_size = model.config.decoder.vocab_size
-
         >>> pixel_values = processor(image, return_tensors="pt").pixel_values
-        >>> text = "hello world"
-        >>> labels = processor.tokenizer(text, return_tensors="pt").input_ids
-        >>> outputs = model(pixel_values=pixel_values, labels=labels)
-        >>> loss = outputs.loss
+        >>> generated_ids = model.generate(pixel_values)
 
-        >>> model(pixel_values)
+        >>> generated_text = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
+        >>> generated_text
+        'industry, " Mr. Brown commented icily. " Let us have a'
+
         ```"""
 
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -891,13 +891,33 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         Example:
 
         ```python
-        >>> from transformers import VisionEncoderDecoderModel, TrOCRForCausalLM, ViTModel, TrOCRConfig, ViTConfig
+        >>> from transformers import VisionEncoderDecoderModel, TrOCRForCausalLM, ViTModel, TrOCRConfig, ViTConfig, TrOCRProcessor
+
+        >>> import numpy
+        >>> from PIL import Image
 
         >>> encoder = ViTModel(ViTConfig())
         >>> decoder = TrOCRForCausalLM(TrOCRConfig())
         # init vision2text model
 
         >>> model = VisionEncoderDecoderModel(encoder=encoder, decoder=decoder)
+
+        >>> # load image from the IAM dataset
+        >>> url = "https://fki.tic.heia-fr.ch/static/img/a01-122-02.jpg"
+        >>> image = Image.open(requests.get(url, stream=True).raw).convert("RGB")
+
+        >>> # training
+        >>> model.config.decoder_start_token_id = processor.tokenizer.cls_token_id
+        >>> model.config.pad_token_id = processor.tokenizer.pad_token_id
+        >>> model.config.vocab_size = model.config.decoder.vocab_size
+
+        >>> pixel_values = processor(image, return_tensors="pt").pixel_values
+        >>> text = "hello world"
+        >>> labels = processor.tokenizer(text, return_tensors="pt").input_ids
+        >>> outputs = model(pixel_values=pixel_values, labels=labels)
+        >>> loss = outputs.loss
+
+        >>> model(pixel_values)
         ```"""
 
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -892,12 +892,12 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
 
         ```python
         >>> from transformers import (
-        ...     TrOCRProcessor,
-        ...     VisionEncoderDecoderModel,
-        ...     TrOCRForCausalLM,
-        ...     ViTModel,
         ...     TrOCRConfig,
+        ...     TrOCRProcessor,
+        ...     TrOCRForCausalLM,
         ...     ViTConfig,
+        ...     ViTModel,
+        ...     VisionEncoderDecoderModel,
         ... )
         >>> import requests
         >>> from PIL import Image
@@ -908,15 +908,15 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         >>> decoder = TrOCRForCausalLM(TrOCRConfig())
         >>> model = VisionEncoderDecoderModel(encoder=encoder, decoder=decoder)
 
-        >>> # If you want to start from the pretrained model, load it from a VisionEncoderDecoderModel
+        >>> # If you want to start from the pretrained model, load the checkpoint with `VisionEncoderDecoderModel`
         >>> processor = TrOCRProcessor.from_pretrained("microsoft/trocr-base-handwritten")
         >>> model = VisionEncoderDecoderModel.from_pretrained("microsoft/trocr-base-handwritten")
 
         >>> # load image from the IAM dataset
         >>> url = "https://fki.tic.heia-fr.ch/static/img/a01-122-02.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw).convert("RGB")
-        >>> text = "hello world"
         >>> pixel_values = processor(image, return_tensors="pt").pixel_values
+        >>> text = "hello world"
 
         >>> # training
         >>> model.config.decoder_start_token_id = processor.tokenizer.cls_token_id
@@ -926,6 +926,8 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         >>> labels = processor.tokenizer(text, return_tensors="pt").input_ids
         >>> outputs = model(pixel_values, labels=labels)
         >>> loss = outputs.loss
+        >>> loss.item()
+        22.05887222290039
 
         >>> # inference
         >>> generated_ids = model.generate(pixel_values)

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -891,31 +891,30 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         Example:
 
         ```python
-        >>> from transformers import TrOCRProcessor, VisionEncoderDecoderModel
-        >>> from transformers import VisionEncoderDecoderModel, TrOCRForCausalLM, ViTModel, TrOCRConfig, ViTConfig
+        >>> from transformers import TrOCRProcessor, VisionEncoderDecoderModel, TrOCRForCausalLM, ViTModel, TrOCRConfig, ViTConfig
         >>> import requests
         >>> from PIL import Image
 
-        >>> processor = TrOCRProcessor.from_pretrained("microsoft/trocr-base-handwritten")
-
         >>> # TrOCR is a decoder model and should be used within a VisionEncoderDecoderModel
+        >>> # init vision2text model with random weights
         >>> encoder = ViTModel(ViTConfig())
         >>> decoder = TrOCRForCausalLM(TrOCRConfig())
         >>> model = VisionEncoderDecoderModel(encoder=encoder, decoder=decoder)
 
         >>> # If you want to start from the pretrained model, load it from a VisionEncoderDecoderModel
+        >>> processor = TrOCRProcessor.from_pretrained("microsoft/trocr-base-handwritten")
         >>> model = VisionEncoderDecoderModel.from_pretrained("microsoft/trocr-base-handwritten")
 
         >>> # load image from the IAM dataset
         >>> url = "https://fki.tic.heia-fr.ch/static/img/a01-122-02.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw).convert("RGB")
+        >>> text = "hello world"
         >>> pixel_values = processor(image, return_tensors="pt").pixel_values
 
         >>> # training
         >>> model.config.decoder_start_token_id = processor.tokenizer.cls_token_id
         >>> model.config.pad_token_id = processor.tokenizer.pad_token_id
         >>> model.config.vocab_size = model.config.decoder.vocab_size
-        >>> text = "hello world"
         >>> labels = processor.tokenizer(text, return_tensors="pt").input_ids
         >>> outputs = model(pixel_values, labels=labels)
         >>> loss = outputs.loss

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -931,7 +931,6 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         >>> generated_text = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
         >>> generated_text
         'industry, " Mr. Brown commented icily. " Let us have a'
-
         ```"""
 
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -900,7 +900,6 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         ...     VisionEncoderDecoderModel,
         ... )
         >>> import requests
-        >>> import torch
         >>> from PIL import Image
         >>> # TrOCR is a decoder model and should be used within a VisionEncoderDecoderModel
         >>> # init vision2text model with random weights

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -924,6 +924,7 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         >>> generated_text = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
         >>> generated_text
         'industry, " Mr. Brown commented icily. " Let us have a'
+
         ```"""
 
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -925,7 +925,6 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         >>> generated_text = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
         >>> generated_text
         'industry, " Mr. Brown commented icily. " Let us have a'
-
         ```"""
 
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -597,8 +597,8 @@ class TrOCRDecoder(TrOCRPreTrainedModel):
 
                 If `past_key_values` are used, the user can optionally input only the last `decoder_input_ids` (those
                 that don't have their past key value states given to this model) of shape `(batch_size, 1)` instead of
-                all ``decoder_input_ids``` of shape `(batch_size, sequence_length)`. inputs_embeds (`torch.FloatTensor`
-                of shape `(batch_size, sequence_length, hidden_size)`, *optional*): Optionally, instead of passing
+                all `decoder_input_ids` of shape `(batch_size, sequence_length)`. inputs_embeds (`torch.FloatTensor` of
+                shape `(batch_size, sequence_length, hidden_size)`, *optional*): Optionally, instead of passing
                 `input_ids` you can choose to directly pass an embedded representation. This is useful if you want more
                 control over how to convert `input_ids` indices into associated vectors than the model's internal
                 embedding lookup matrix.

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -929,8 +929,8 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         >>> labels = processor.tokenizer(text, return_tensors="pt").input_ids
         >>> outputs = model(pixel_values, labels=labels)
         >>> loss = outputs.loss
-        >>> round(loss.item(), 3)
-        5.303
+        >>> round(loss.item(), 2)
+        5.30
 
         >>> # inference
         >>> generated_ids = model.generate(pixel_values)

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -900,7 +900,10 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         ...     VisionEncoderDecoderModel,
         ... )
         >>> import requests
+        >>> import torch
         >>> from PIL import Image
+
+        >>> torch.manual_seed(0) # doctest: +IGNORE_RESULT
 
         >>> # TrOCR is a decoder model and should be used within a VisionEncoderDecoderModel
         >>> # init vision2text model with random weights
@@ -916,7 +919,7 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         >>> url = "https://fki.tic.heia-fr.ch/static/img/a01-122-02.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw).convert("RGB")
         >>> pixel_values = processor(image, return_tensors="pt").pixel_values
-        >>> text = "hello world"
+        >>> text = "industry, ' Mr. Brown commented icily. ' Let us have a"
 
         >>> # training
         >>> model.config.decoder_start_token_id = processor.tokenizer.cls_token_id
@@ -926,8 +929,8 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         >>> labels = processor.tokenizer(text, return_tensors="pt").input_ids
         >>> outputs = model(pixel_values, labels=labels)
         >>> loss = outputs.loss
-        >>> loss.item()
-        22.05887222290039
+        >>> round(loss.item(), 3)
+        5.303
 
         >>> # inference
         >>> generated_ids = model.generate(pixel_values)

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -891,7 +891,14 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         Example:
 
         ```python
-        >>> from transformers import TrOCRProcessor, VisionEncoderDecoderModel, TrOCRForCausalLM, ViTModel, TrOCRConfig, ViTConfig
+        >>> from transformers import (
+        ...     TrOCRProcessor,
+        ...     VisionEncoderDecoderModel,
+        ...     TrOCRForCausalLM,
+        ...     ViTModel,
+        ...     TrOCRConfig,
+        ...     ViTConfig,
+        ... )
         >>> import requests
         >>> from PIL import Image
 

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -903,7 +903,7 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         >>> import torch
         >>> from PIL import Image
 
-        >>> torch.manual_seed(0) # doctest: +IGNORE_RESULT
+        >>> torch.manual_seed(0)  # doctest: +IGNORE_RESULT
 
         >>> # TrOCR is a decoder model and should be used within a VisionEncoderDecoderModel
         >>> # init vision2text model with random weights

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -922,6 +922,7 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         >>> model.config.decoder_start_token_id = processor.tokenizer.cls_token_id
         >>> model.config.pad_token_id = processor.tokenizer.pad_token_id
         >>> model.config.vocab_size = model.config.decoder.vocab_size
+
         >>> labels = processor.tokenizer(text, return_tensors="pt").input_ids
         >>> outputs = model(pixel_values, labels=labels)
         >>> loss = outputs.loss

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -902,9 +902,6 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
         >>> import requests
         >>> import torch
         >>> from PIL import Image
-
-        >>> torch.manual_seed(0)  # doctest: +IGNORE_RESULT
-
         >>> # TrOCR is a decoder model and should be used within a VisionEncoderDecoderModel
         >>> # init vision2text model with random weights
         >>> encoder = ViTModel(ViTConfig())

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -39,6 +39,7 @@ src/transformers/models/speech_encoder_decoder/modeling_speech_encoder_decoder.p
 src/transformers/models/speech_to_text/modeling_speech_to_text.py
 src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
 src/transformers/models/swin/modeling_swin.py
+src/transformers/models/trocr/modeling_trocr.py
 src/transformers/models/unispeech/modeling_unispeech.py
 src/transformers/models/unispeech_sat/modeling_unispeech_sat.py
 src/transformers/models/van/modeling_van.py


### PR DESCRIPTION
# Adding TrOCR to DocTests

For this model, there was actually a single docstring in the entire file (for the forward method).

A couple of comments:
- As far as I'm aware, there is no TF version of this model
- TrOCR is an edge case because it's meant to be used as the decoder for a VisionEncoderDecoder. So the forward function of the TrOCR is not meant to be called directly. As a result, I gave some example code to run a forward pass with TrOCR within a VisionEncoderDecoder 

Let me know if the docstring is relevant to the problem. I can also revert adapt it to actually just showcase the forward for the `TrOCRForCausalLM` outside of a VisionEncoderDecoder

@patrickvonplaten @ydshieh @patil-suraj 