### PR TITLE
fixed typo from enable to disable in disable_progress_bar function

### DIFF
--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -339,6 +339,6 @@ def enable_progress_bar():
 
 
 def disable_progress_bar():
-    """Enable tqdm progress bar."""
+    """Disable tqdm progress bar."""
     global _tqdm_active
     _tqdm_active = False


### PR DESCRIPTION
# What does this PR do?

This PR fixes the typo from `Enable progress bar` to `Disable progress bar` in `disable_progress_bar()` function's documentation.

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).