### PR TITLE
TF PushToHubCallback fixes and updates

### DIFF
--- a/src/transformers/keras_callbacks.py
+++ b/src/transformers/keras_callbacks.py
@@ -370,7 +370,7 @@ class PushToHubCallback(Callback):
 
     def on_train_end(self, logs=None):
         if self.last_job is not None and not self.last_job.is_done:
-            logger.info("Waiting for existing upload to finish...")
+            self.last_job._process.terminate()  # Gotta go fast
             while not self.last_job.is_done:
                 sleep(1)
         self.model.save_pretrained(self.output_dir)


### PR DESCRIPTION
We had a couple of reports of slowdown and hanging with the `PushToHubCallback`. In particular, when training finished, there was a very long wait for the last training checkpoint to be pushed before the end-of-training commit could start, which sometimes seemed like it had hung completely. As a workaround, the end-of-training push now cancels any previous pushes with `terminate()` (thanks @LysandreJik!) before it starts, to save time and avoid this problem. This works well in testing.

However, there is a secondary problem - when we do an end-of-training push, we probably don't want to save a whole checkpoint with things like optimizer state, as they can be very large. Right now the `PushToHubCallback` does not delete checkpoint data in the output dir when it pushes at the end of training, and also does not squash commits (so if it cancels a checkpoint push and then starts the end-of-training push, it has to push the commit that includes the checkpoint data even if it's been deleted in the end-of-training commit).

I think we should definitely delete the checkpoint data in the final push, and possibly also squash commits to make the upload a lot faster (and reduce the size of the target repo). I can make these changes in this PR - WDYT?

CC: @merveenoyan 