### PR TITLE
[Flax] Improve Robustness of Back-Prop Tests

### DIFF
--- a/tests/speech_encoder_decoder/test_modeling_flax_speech_encoder_decoder.py
+++ b/tests/speech_encoder_decoder/test_modeling_flax_speech_encoder_decoder.py
@@ -366,7 +366,9 @@ class FlaxEncoderDecoderMixin:
         grad_fn = jax.value_and_grad(compute_loss, has_aux=True)
 
         # compute the loss, logits, and gradients for the unfrozen model
-        (loss, logits), grads = grad_fn(params, inputs, attention_mask, decoder_input_ids, freeze_feature_encoder=False)
+        (loss, logits), grads = grad_fn(
+            params, inputs, attention_mask, decoder_input_ids, freeze_feature_encoder=False
+        )
 
         # compare to the loss, logits and gradients for the frozen model
         (loss_frozen, logits_frozen), grads_frozen = grad_fn(

--- a/tests/wav2vec2/test_modeling_flax_wav2vec2.py
+++ b/tests/wav2vec2/test_modeling_flax_wav2vec2.py
@@ -265,7 +265,7 @@ class FlaxWav2Vec2ModelTest(FlaxModelTesterMixin, unittest.TestCase):
         # compare to loss and gradients for frozen model
         loss_frozen, grads_frozen = grad_fn(params, input_values, attention_mask, freeze_feature_encoder=True)
 
-        self.assert_almost_equals(loss, loss_frozen, 1e-5)
+        self.assertEqual(loss, loss_frozen)
 
         grads = flatten_dict(grads)
         grads_frozen = flatten_dict(grads_frozen)
@@ -273,7 +273,7 @@ class FlaxWav2Vec2ModelTest(FlaxModelTesterMixin, unittest.TestCase):
         # ensure that the dicts of gradients contain the same keys
         self.assertEqual(grads.keys(), grads_frozen.keys())
 
-        # ensure that the gradients of the frozen layers are precisely zero and that they differ to the gradients of the unfrozen layers
+        # ensure that the gradients of the feature extractor layers are precisely zero when frozen and contain non-zero entries when unfrozen
         feature_extractor_grads = tuple(grads[k] for k in grads if "feature_extractor" in k)
         feature_extractor_grads_frozen = tuple(grads_frozen[k] for k in grads_frozen if "feature_extractor" in k)
 
@@ -281,22 +281,14 @@ class FlaxWav2Vec2ModelTest(FlaxModelTesterMixin, unittest.TestCase):
             feature_extractor_grads, feature_extractor_grads_frozen
         ):
             self.assertTrue((feature_extractor_grad_frozen == 0.0).all())
-            self.assert_difference(feature_extractor_grad, feature_extractor_grad_frozen, 1e-7)
+            self.assertTrue((feature_extractor_grad > 0.0).any())
 
         # ensure that the gradients of all unfrozen layers remain equal, i.e. all layers excluding the frozen 'feature_extractor'
         grads = tuple(grads[k] for k in grads if "feature_extractor" not in k)
         grads_frozen = tuple(grads_frozen[k] for k in grads_frozen if "feature_extractor" not in k)
 
         for grad, grad_frozen in zip(grads, grads_frozen):
-            self.assert_almost_equals(grad, grad_frozen, 1e-7)
-
-    def assert_difference(self, a, b, tol: float):
-        diff = jnp.abs((a - b)).min()
-        self.assertGreaterEqual(diff, tol, f"Difference between arrays is {diff} (<= {tol}).")
-
-    def assert_almost_equals(self, a, b, tol: float):
-        diff = jnp.abs((a - b)).max()
-        self.assertLessEqual(diff, tol, f"Difference between arrays is {diff} (>= {tol}).")
+            self.assertTrue((grad == grad_frozen).all())
 
     @slow
     def test_model_from_pretrained(self):

--- a/tests/wav2vec2/test_modeling_flax_wav2vec2.py
+++ b/tests/wav2vec2/test_modeling_flax_wav2vec2.py
@@ -263,7 +263,9 @@ class FlaxWav2Vec2ModelTest(FlaxModelTesterMixin, unittest.TestCase):
         (loss, outputs), grads = grad_fn(params, input_values, attention_mask, freeze_feature_encoder=False)
 
         # compare to loss, outputs and gradients for frozen model
-        (loss_frozen, outputs_frozen), grads_frozen = grad_fn(params, input_values, attention_mask, freeze_feature_encoder=True)
+        (loss_frozen, outputs_frozen), grads_frozen = grad_fn(
+            params, input_values, attention_mask, freeze_feature_encoder=True
+        )
 
         # ensure that the outputs and losses remain precisely equal
         for output, output_frozen in zip(outputs, outputs_frozen):


### PR DESCRIPTION
This PR makes several modifications to the `test_freeze_feature_encoder` tests for two Flax models, FlaxWav2Vec2 and FlaxSpeechEncoderDecoderModel. This test is in place to verify that feature encoder of the FlaxWav2Vec2 model is correctly frozen when the keyword argument `freeze_feature_encoder` is set to `True`. This is achieved through one dummy forward and backward pass, in which the losses and gradients are compared for the case when the feature encoder is frozen and the case when it is not.

The modifications made include:

- Implementing a check that asserts the outputs of the unfrozen and frozen feature encoder models are _precisely equal_;

- Asserting that the losses of the unfrozen and frozen models are _precisely equal_, instead of _almost equal_ as was previously;

- Asserting that the gradients of the unfrozen feature encoder layers contain at least one non-zero entry, instead of asserting that at least one entry that surpasses a specified tolerance;

- Asserting that the gradients of all unfrozen layers remain _precisely equal_, instead of _almost equal_ as was previously.

The statements that assert unfrozen and frozen gradient values are _precisely equal_ instead of _almost equal_ provides more rigour to the back-propagation test. It verifies that `jax.stop_gradient` has no impact on the forward or backward pass, other than skipping computation of the gradients of any frozen layers. **Crucially**, these changes bypass the need to set a specified tolerance (`tol`) in the `assert_almost_equal` or `assert_difference` functions. Even with seemingly appropriate values for this tolerance (`1e-5`), the tests were prone to failing a small proportion of the time (<2.5%). With this PR, the tests should now pass 100% of the time.