### PR TITLE
Avoid accessing .dataset of a DataLoader in Trainer

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1235,7 +1235,9 @@ class Trainer:
             num_examples = total_train_batch_size * args.max_steps
             num_train_samples = args.max_steps * total_train_batch_size
         else:
-            raise ValueError(f"args.max_steps must be set if dataloader does not have a length")
+            raise ValueError(
+                f"args.max_steps must be set to a positive value if dataloader does not have a length, was {args.max_steps}"
+            )
 
         if DebugOption.UNDERFLOW_OVERFLOW in self.args.debug:
             if self.args.n_gpu > 1:
@@ -2410,7 +2412,7 @@ class Trainer:
             elif args.bf16_full_eval:
                 model = model.to(dtype=torch.bfloat16, device=args.device)
 
-        batch_size = dataloader.batch_size
+        batch_size = self.args.per_device_eval_batch_size
 
         logger.info(f"***** Running {description} *****")
         if has_length(dataloader):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1237,7 +1237,6 @@ class Trainer:
                 num_train_epochs = math.ceil(args.num_train_epochs)
                 num_train_samples = self.num_examples(train_dataloader) * args.num_train_epochs
 
-
         if DebugOption.UNDERFLOW_OVERFLOW in self.args.debug:
             if self.args.n_gpu > 1:
                 # nn.DataParallel(model) replicates the model, creating new variables and module

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -937,8 +937,8 @@ class Trainer:
 
     def num_examples(self, dataloader: DataLoader) -> int:
         """
-        Helper to get number of samples in a [`~torch.utils.data.DataLoader`] by accessing its dataset.
-        When dataloader.dataset does not exist or has no length, estimates as best it can
+        Helper to get number of samples in a [`~torch.utils.data.DataLoader`] by accessing its dataset. When
+        dataloader.dataset does not exist or has no length, estimates as best it can
         """
         try:
             return len(dataloader.dataset)
@@ -1205,8 +1205,6 @@ class Trainer:
 
         # Keeping track whether we can can len() on the dataset or not
 
-
-
         # Setting up training control variables:
         # number of training epochs: num_train_epochs
         # number of training steps per epoch: num_update_steps_per_epoch
@@ -1238,7 +1236,6 @@ class Trainer:
                 max_steps = math.ceil(args.num_train_epochs * num_update_steps_per_epoch)
                 num_train_epochs = math.ceil(args.num_train_epochs)
                 num_train_samples = self.num_examples(train_dataloader) * args.num_train_epochs
-
 
         if DebugOption.UNDERFLOW_OVERFLOW in self.args.debug:
             if self.args.n_gpu > 1:
@@ -1388,7 +1385,9 @@ class Trainer:
                 self._past = None
 
             steps_in_epoch = (
-                len(epoch_iterator) if len_dataloader is not None else args.max_steps * args.gradient_accumulation_steps
+                len(epoch_iterator)
+                if len_dataloader is not None
+                else args.max_steps * args.gradient_accumulation_steps
             )
             self.control = self.callback_handler.on_epoch_begin(args, self.state, self.control)
 
@@ -2508,7 +2507,7 @@ class Trainer:
             all_labels = labels if all_labels is None else nested_concat(all_labels, labels, padding_index=-100)
 
         # Number of samples
-        eval_dataset = getattr(dataloader, 'dataset',None)
+        eval_dataset = getattr(dataloader, "dataset", None)
 
         # The instance check is weird and does not actually check for the type, but whether the dataset has the right
         # methods. Therefore we need to make sure it also has the attribute.

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -666,12 +666,11 @@ class Trainer:
 
         Subclass and override this method if you want to inject some custom behavior.
         """
-
         if self.train_dataset is None:
             raise ValueError("Trainer: training requires a train_dataset.")
 
         train_dataset = self.train_dataset
-        if is_datasets_available() and isinstance(self.train_dataset, datasets.Dataset):
+        if is_datasets_available() and isinstance(train_dataset, datasets.Dataset):
             train_dataset = self._remove_unused_columns(train_dataset, description="training")
 
         if isinstance(train_dataset, torch.utils.data.IterableDataset):

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -473,7 +473,7 @@ class ProgressCallback(TrainerCallback):
             self.current_step = state.global_step
 
     def on_prediction_step(self, args, state, control, eval_dataloader=None, **kwargs):
-        if state.is_local_process_zero and has_length(eval_dataloader.dataset):
+        if state.is_local_process_zero and has_length(eval_dataloader):
             if self.prediction_bar is None:
                 self.prediction_bar = tqdm(total=len(eval_dataloader), leave=self.training_bar is None)
             self.prediction_bar.update(1)

--- a/src/transformers/utils/notebook.py
+++ b/src/transformers/utils/notebook.py
@@ -294,13 +294,15 @@ class NotebookProgressCallback(TrainerCallback):
         self._force_next_update = False
 
     def on_prediction_step(self, args, state, control, eval_dataloader=None, **kwargs):
-        if not isinstance(eval_dataloader.dataset, collections.abc.Sized):
+        try:
+            len_dataloader = len(eval_dataloader)
+        except (NameError, TypeError, AttributeError):
             return
         if self.prediction_bar is None:
             if self.training_tracker is not None:
-                self.prediction_bar = self.training_tracker.add_child(len(eval_dataloader))
+                self.prediction_bar = self.training_tracker.add_child(len_dataloader)
             else:
-                self.prediction_bar = NotebookProgressBar(len(eval_dataloader))
+                self.prediction_bar = NotebookProgressBar(len_dataloader)
             self.prediction_bar.update(1)
         else:
             self.prediction_bar.update(self.prediction_bar.value + 1)

--- a/src/transformers/utils/notebook.py
+++ b/src/transformers/utils/notebook.py
@@ -20,7 +20,7 @@ from typing import Optional
 import IPython.display as disp
 
 from ..trainer_callback import TrainerCallback
-from ..trainer_utils import IntervalStrategy
+from ..trainer_utils import IntervalStrategy, has_length
 
 
 def format_time(t):
@@ -293,15 +293,13 @@ class NotebookProgressCallback(TrainerCallback):
         self._force_next_update = False
 
     def on_prediction_step(self, args, state, control, eval_dataloader=None, **kwargs):
-        try:
-            len_dataloader = len(eval_dataloader)
-        except (NameError, TypeError, AttributeError):
+        if not has_length(eval_dataloader):
             return
         if self.prediction_bar is None:
             if self.training_tracker is not None:
-                self.prediction_bar = self.training_tracker.add_child(len_dataloader)
+                self.prediction_bar = self.training_tracker.add_child(len(eval_dataloader))
             else:
-                self.prediction_bar = NotebookProgressBar(len_dataloader)
+                self.prediction_bar = NotebookProgressBar(len(eval_dataloader))
             self.prediction_bar.update(1)
         else:
             self.prediction_bar.update(self.prediction_bar.value + 1)

--- a/src/transformers/utils/notebook.py
+++ b/src/transformers/utils/notebook.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 import re
 import time
 from typing import Optional

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -169,28 +169,6 @@ class RegressionModelConfig(PretrainedConfig):
         self.hidden_size = 1
 
 
-class MultiLoader:
-    def __init__(self, loaders):
-        self.loaders = loaders
-
-    def __len__(self):
-        return sum(len(loader) for loader in self.loaders)
-
-    def __iter__(self):
-        for loader in self.loaders:
-            yield from loader
-
-
-class CustomDataloaderTrainer(Trainer):
-    def get_train_dataloader(self):
-        dataloaders = [super(CustomDataloaderTrainer, self).get_train_dataloader() for _ in range(2)]
-        return MultiLoader(dataloaders)
-
-    def get_eval_dataloader(self, eval_dataset):
-        dataloaders = [super(CustomDataloaderTrainer, self).get_eval_dataloader(eval_dataset) for _ in range(2)]
-        return MultiLoader(dataloaders)
-
-
 if is_torch_available():
 
     class SampleIterableDataset(IterableDataset):
@@ -210,6 +188,28 @@ if is_torch_available():
             while self.current_sample < len(self.dataset):
                 yield self.dataset[self.current_sample]
                 self.current_sample += 1
+
+
+    class MultiLoader:
+        def __init__(self, loaders):
+            self.loaders = loaders
+
+        def __len__(self):
+            return sum(len(loader) for loader in self.loaders)
+
+        def __iter__(self):
+            for loader in self.loaders:
+                yield from loader
+
+
+    class CustomDataloaderTrainer(Trainer):
+        def get_train_dataloader(self):
+            dataloaders = [super(CustomDataloaderTrainer, self).get_train_dataloader() for _ in range(2)]
+            return MultiLoader(dataloaders)
+
+        def get_eval_dataloader(self, eval_dataset):
+            dataloaders = [super(CustomDataloaderTrainer, self).get_eval_dataloader(eval_dataset) for _ in range(2)]
+            return MultiLoader(dataloaders)
 
     class RegressionModel(nn.Module):
         def __init__(self, a=0, b=0, double_output=False):

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -189,7 +189,6 @@ if is_torch_available():
                 yield self.dataset[self.current_sample]
                 self.current_sample += 1
 
-
     class MultiLoader:
         def __init__(self, loaders):
             self.loaders = loaders
@@ -200,7 +199,6 @@ if is_torch_available():
         def __iter__(self):
             for loader in self.loaders:
                 yield from loader
-
 
     class CustomDataloaderTrainer(Trainer):
         def get_train_dataloader(self):

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -202,11 +202,11 @@ if is_torch_available():
 
     class CustomDataloaderTrainer(Trainer):
         def get_train_dataloader(self):
-            dataloaders = [super(CustomDataloaderTrainer, self).get_train_dataloader() for _ in range(2)]
+            dataloaders = [super().get_train_dataloader(), super().get_train_dataloader()]
             return MultiLoader(dataloaders)
 
         def get_eval_dataloader(self, eval_dataset):
-            dataloaders = [super(CustomDataloaderTrainer, self).get_eval_dataloader(eval_dataset) for _ in range(2)]
+            dataloaders = [super().get_eval_dataloader(eval_dataset), super().get_eval_dataloader(eval_dataset)]
             return MultiLoader(dataloaders)
 
     class RegressionModel(nn.Module):

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -669,7 +669,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
         new_eval_dataset = RegressionDataset(length=128)
         self.assertEqual(len(trainer.get_eval_dataloader(new_eval_dataset)), 128 // (32 * n_gpu))
 
-    # tests that we do not require dataloader to have a .dataset
+    # tests that we do not require dataloader to have a .dataset attribute
     def test_dataloader_without_dataset(self):
         train_dataset = RegressionDataset(length=128)
         trainer = CustomDataloaderTrainer(


### PR DESCRIPTION
# What does this PR do?

* Respects get_train_dataloader and such, rather than going back and looking at .train_dataset or requiring attributes in the dataloader to be accessible directly.
   * This allows for overriding it by any object which implements the methods required by a DataLoader (`__len__` and `__iter__`) without additional requirements.
   * The original motivation was to train on a multi-task dataloader which defers to multiple dataloaders. 


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. 
     - Discussed in #16388
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

