### PR TITLE
Remove duplicate mLuke

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -254,8 +254,6 @@
       title: MegatronBERT
     - local: model_doc/megatron_gpt2
       title: MegatronGPT2
-    - local: model_doc/mluke
-      title: MLUKE
     - local: model_doc/mobilebert
       title: MobileBERT
     - local: model_doc/mluke

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -254,10 +254,10 @@
       title: MegatronBERT
     - local: model_doc/megatron_gpt2
       title: MegatronGPT2
-    - local: model_doc/mobilebert
-      title: MobileBERT
     - local: model_doc/mluke
       title: mLUKE
+    - local: model_doc/mobilebert
+      title: MobileBERT
     - local: model_doc/mpnet
       title: MPNet
     - local: model_doc/mt5


### PR DESCRIPTION
This PR removes a duplicate [mLuke](https://huggingface.co/docs/transformers/main/en/model_doc/mluke) from the model API docs.