### PR TITLE
[MNLI example] Prevent overwriting matched with mismatched metrics

### DIFF
--- a/examples/pytorch/text-classification/run_glue.py
+++ b/examples/pytorch/text-classification/run_glue.py
@@ -513,9 +513,7 @@ def main():
             metrics = trainer.evaluate(eval_dataset=eval_dataset)
 
             max_eval_samples = (
-                data_args.max_eval_samples
-                if data_args.max_eval_samples is not None
-                else len(eval_dataset)
+                data_args.max_eval_samples if data_args.max_eval_samples is not None else len(eval_dataset)
             )
             metrics["eval_samples"] = min(max_eval_samples, len(eval_dataset))
 


### PR DESCRIPTION
# What does this PR do?
Fixes https://github.com/huggingface/transformers/issues/16474.

The fix appends `_mm` to the metrics for `mnli-mm` evaluation dataset to prevent overwriting eval metrics from the `mnli` dataset, and writes them together in `eval_results.json` and `all_results.json`. The MNLI-metrics look like this:

```json
{
    "eval_accuracy": 0.36067244014263883,
    "eval_accuracy_mm": 0.35506509357200977,
    "eval_loss": 1.158889889717102,
    "eval_loss_mm": 1.1670204401016235,
    "eval_runtime": 16.4691,
    "eval_runtime_mm": 15.9496,
    "eval_samples": 9815,
    "eval_samples_mm": 9832,
    "eval_samples_per_second": 595.964,
    "eval_samples_per_second_mm": 616.44,
    "eval_steps_per_second": 18.641,
    "eval_steps_per_second_mm": 19.311
}
```

@sgugger, @patil-suraj