### PR TITLE
Raise diff tolerance value for TFViTMAEModelTest

### DIFF
--- a/tests/vit_mae/test_modeling_tf_vit_mae.py
+++ b/tests/vit_mae/test_modeling_tf_vit_mae.py
@@ -428,7 +428,7 @@ class TFViTMAEModelTest(TFModelTesterMixin, unittest.TestCase):
 
                 max_diff = np.amax(np.abs(tf_outputs - pt_outputs))
                 # Set a higher tolerance (2e-5) here than the one in the common test (1e-5).
-                # TODO: A deeper look to decide the best tolerance for the test to be strict but not too flaky.
+                # TODO: A deeper look to decide the best (common) tolerance for the test to be strict but not too flaky.
                 self.assertLessEqual(max_diff, 2e-5)
             else:
                 raise ValueError(

--- a/tests/vit_mae/test_modeling_tf_vit_mae.py
+++ b/tests/vit_mae/test_modeling_tf_vit_mae.py
@@ -427,7 +427,9 @@ class TFViTMAEModelTest(TFModelTesterMixin, unittest.TestCase):
                 tf_outputs[pt_nans] = 0
 
                 max_diff = np.amax(np.abs(tf_outputs - pt_outputs))
-                self.assertLessEqual(max_diff, 1e-5)
+                # Set a higher tolerance (2e-5) here than the one in the common test (1e-5).
+                # TODO: A deeper look to decide the best tolerance for the test to be strict but not too flaky.
+                self.assertLessEqual(max_diff, 2e-5)
             else:
                 raise ValueError(
                     f"`tf_outputs` should be a `tuple` or an instance of `tf.Tensor`. Got {type(tf_outputs)} instead."


### PR DESCRIPTION
# What does this PR do?

For now, change the tol from `1e-5` to `2e-5` in `TFViTMAEModelTest.test_pt_tf_model_equivalence` to avoid being flaky.