### PR TITLE
Use random_attention_mask for TF tests

### DIFF
--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/test_modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/test_modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -21,7 +21,7 @@ from transformers import is_tf_available, {{cookiecutter.camelcase_modelname}}Co
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, floats_tensor, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, floats_tensor, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -92,7 +92,7 @@ class TF{{cookiecutter.camelcase_modelname}}ModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/albert/test_modeling_tf_albert.py
+++ b/tests/albert/test_modeling_tf_albert.py
@@ -21,7 +21,7 @@ from transformers.models.auto import get_values
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -96,7 +96,7 @@ class TFAlbertModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/bert/test_modeling_tf_bert.py
+++ b/tests/bert/test_modeling_tf_bert.py
@@ -21,7 +21,7 @@ from transformers.models.auto import get_values
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, floats_tensor, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, floats_tensor, ids_tensor, random_attention_mask
 from ..utils.test_modeling_tf_core import TFCoreModelTesterMixin
 
 
@@ -96,7 +96,7 @@ class TFBertModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/clip/test_modeling_tf_clip.py
+++ b/tests/clip/test_modeling_tf_clip.py
@@ -301,6 +301,10 @@ class TFCLIPTextModelTester:
         input_mask = None
         if self.use_input_mask:
             input_mask = random_attention_mask([self.batch_size, self.seq_length])
+            # make sure the first token has attention mask `1` to ensure that, after combining the causal mask, there
+            # is still at least one token being attended to for each batch.
+            # TODO: Change `random_attention_mask` in PT/TF/Flax common test file, after a discussion with the team.
+            input_mask = tf.concat([tf.ones_like(input_mask[:, :1], dtype=input_mask.dtype), input_mask[:, 1:]], axis=-1)
 
         config = self.get_config()
 

--- a/tests/clip/test_modeling_tf_clip.py
+++ b/tests/clip/test_modeling_tf_clip.py
@@ -304,7 +304,9 @@ class TFCLIPTextModelTester:
             # make sure the first token has attention mask `1` to ensure that, after combining the causal mask, there
             # is still at least one token being attended to for each batch.
             # TODO: Change `random_attention_mask` in PT/TF/Flax common test file, after a discussion with the team.
-            input_mask = tf.concat([tf.ones_like(input_mask[:, :1], dtype=input_mask.dtype), input_mask[:, 1:]], axis=-1)
+            input_mask = tf.concat(
+                [tf.ones_like(input_mask[:, :1], dtype=input_mask.dtype), input_mask[:, 1:]], axis=-1
+            )
 
         config = self.get_config()
 

--- a/tests/convbert/test_modeling_tf_convbert.py
+++ b/tests/convbert/test_modeling_tf_convbert.py
@@ -20,7 +20,7 @@ from transformers import ConvBertConfig, is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -94,7 +94,7 @@ class TFConvBertModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/ctrl/test_modeling_tf_ctrl.py
+++ b/tests/ctrl/test_modeling_tf_ctrl.py
@@ -20,7 +20,7 @@ from transformers import CTRLConfig, is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -69,7 +69,7 @@ class TFCTRLModelTester(object):
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/deberta/test_modeling_tf_deberta.py
+++ b/tests/deberta/test_modeling_tf_deberta.py
@@ -20,7 +20,7 @@ from transformers import DebertaConfig, is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -92,7 +92,7 @@ class TFDebertaModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/deberta_v2/test_modeling_tf_deberta_v2.py
+++ b/tests/deberta_v2/test_modeling_tf_deberta_v2.py
@@ -20,7 +20,7 @@ from transformers import DebertaV2Config, is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -95,7 +95,7 @@ class TFDebertaV2ModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/distilbert/test_modeling_tf_distilbert.py
+++ b/tests/distilbert/test_modeling_tf_distilbert.py
@@ -20,7 +20,7 @@ from transformers import DistilBertConfig, is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -70,7 +70,7 @@ class TFDistilBertModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         sequence_labels = None
         token_labels = None

--- a/tests/dpr/test_modeling_tf_dpr.py
+++ b/tests/dpr/test_modeling_tf_dpr.py
@@ -19,7 +19,7 @@ from transformers import is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -94,9 +94,8 @@ class TFDPRModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor(
-                [self.batch_size, self.seq_length], vocab_size=2
-            )  # follow test_modeling_tf_ctrl.py
+            # follow test_modeling_tf_ctrl.py
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/electra/test_modeling_tf_electra.py
+++ b/tests/electra/test_modeling_tf_electra.py
@@ -20,7 +20,7 @@ from transformers import ElectraConfig, is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, floats_tensor, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, floats_tensor, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -71,7 +71,7 @@ class TFElectraModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/flaubert/test_modeling_tf_flaubert.py
+++ b/tests/flaubert/test_modeling_tf_flaubert.py
@@ -19,7 +19,7 @@ from transformers import is_tf_available
 from transformers.testing_utils import require_sentencepiece, require_tf, require_tokenizers, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -75,7 +75,7 @@ class TFFlaubertModelTester:
 
     def prepare_config_and_inputs(self):
         input_ids = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
-        input_mask = ids_tensor([self.batch_size, self.seq_length], 2, dtype=tf.float32)
+        input_mask = random_attention_mask([self.batch_size, self.seq_length], dtype=tf.float32)
 
         input_lengths = None
         if self.use_input_lengths:

--- a/tests/funnel/test_modeling_tf_funnel.py
+++ b/tests/funnel/test_modeling_tf_funnel.py
@@ -20,7 +20,7 @@ from transformers import FunnelConfig, is_tf_available
 from transformers.testing_utils import require_tf
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -111,7 +111,7 @@ class TFFunnelModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/gpt2/test_modeling_tf_gpt2.py
+++ b/tests/gpt2/test_modeling_tf_gpt2.py
@@ -19,7 +19,7 @@ from transformers import GPT2Config, is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, floats_tensor, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, floats_tensor, ids_tensor, random_attention_mask
 from ..utils.test_modeling_tf_core import TFCoreModelTesterMixin
 
 
@@ -74,7 +74,7 @@ class TFGPT2ModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/gptj/test_modeling_tf_gptj.py
+++ b/tests/gptj/test_modeling_tf_gptj.py
@@ -20,7 +20,7 @@ from transformers import AutoTokenizer, GPTJConfig, is_tf_available
 from transformers.testing_utils import require_tf, slow, tooslow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 from ..utils.test_modeling_tf_core import TFCoreModelTesterMixin
 
 
@@ -70,7 +70,7 @@ class TFGPTJModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/layoutlm/test_modeling_tf_layoutlm.py
+++ b/tests/layoutlm/test_modeling_tf_layoutlm.py
@@ -21,7 +21,7 @@ from transformers import LayoutLMConfig, is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -107,7 +107,7 @@ class TFLayoutLMModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/longformer/test_modeling_tf_longformer.py
+++ b/tests/longformer/test_modeling_tf_longformer.py
@@ -20,7 +20,7 @@ from transformers import is_tf_available
 from transformers.testing_utils import require_sentencepiece, require_tf, require_tokenizers, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -79,7 +79,7 @@ class TFLongformerModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/lxmert/test_modeling_tf_lxmert.py
+++ b/tests/lxmert/test_modeling_tf_lxmert.py
@@ -23,7 +23,7 @@ from transformers import LxmertConfig, is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -124,7 +124,7 @@ class TFLxmertModelTester(object):
 
         input_mask = None
         if self.use_lang_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
         token_type_ids = None
         if self.use_token_type_ids:
             token_type_ids = ids_tensor([self.batch_size, self.seq_length], self.type_vocab_size)

--- a/tests/mobilebert/test_modeling_tf_mobilebert.py
+++ b/tests/mobilebert/test_modeling_tf_mobilebert.py
@@ -20,7 +20,7 @@ from transformers import MobileBertConfig, is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -114,7 +114,7 @@ class TFMobileBertModelTest(TFModelTesterMixin, unittest.TestCase):
 
             input_mask = None
             if self.use_input_mask:
-                input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+                input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
             token_type_ids = None
             if self.use_token_type_ids:

--- a/tests/mpnet/test_modeling_tf_mpnet.py
+++ b/tests/mpnet/test_modeling_tf_mpnet.py
@@ -20,7 +20,7 @@ from transformers import MPNetConfig, is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -90,7 +90,7 @@ class TFMPNetModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         sequence_labels = None
         token_labels = None

--- a/tests/openai/test_modeling_tf_openai.py
+++ b/tests/openai/test_modeling_tf_openai.py
@@ -20,7 +20,7 @@ from transformers import OpenAIGPTConfig, is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -70,7 +70,7 @@ class TFOpenAIGPTModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/rembert/test_modeling_tf_rembert.py
+++ b/tests/rembert/test_modeling_tf_rembert.py
@@ -20,7 +20,7 @@ from transformers import RemBertConfig, is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, floats_tensor, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, floats_tensor, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -95,7 +95,7 @@ class TFRemBertModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/roberta/test_modeling_tf_roberta.py
+++ b/tests/roberta/test_modeling_tf_roberta.py
@@ -20,7 +20,7 @@ from transformers import RobertaConfig, is_tf_available
 from transformers.testing_utils import require_sentencepiece, require_tf, require_tokenizers, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, floats_tensor, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, floats_tensor, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -72,7 +72,7 @@ class TFRobertaModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/roformer/test_modeling_tf_roformer.py
+++ b/tests/roformer/test_modeling_tf_roformer.py
@@ -20,7 +20,7 @@ from transformers import RoFormerConfig, is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -95,7 +95,7 @@ class TFRoFormerModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = None
         if self.use_token_type_ids:

--- a/tests/t5/test_modeling_tf_t5.py
+++ b/tests/t5/test_modeling_tf_t5.py
@@ -20,7 +20,7 @@ from transformers.testing_utils import require_sentencepiece, require_tf, requir
 from transformers.utils import cached_property
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -58,7 +58,7 @@ class TFT5ModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_labels = None
         if self.use_labels:

--- a/tests/tapas/test_modeling_tf_tapas.py
+++ b/tests/tapas/test_modeling_tf_tapas.py
@@ -38,7 +38,7 @@ from transformers.testing_utils import require_tensorflow_probability, require_t
 from transformers.utils import cached_property
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -158,7 +158,7 @@ class TFTapasModelTester:
 
         input_mask = None
         if self.use_input_mask:
-            input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
+            input_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         token_type_ids = []
         for type_vocab_size in self.type_vocab_sizes:

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1440,7 +1440,7 @@ def ids_tensor(shape, vocab_size, rng=None, name=None, dtype=None):
 def random_attention_mask(shape, rng=None, name=None, dtype=None):
     attn_mask = ids_tensor(shape, vocab_size=2, rng=None, name=None, dtype=dtype)
     # make sure that at least one token is attended to for each batch
-    attn_mask = tf.concat([tf.constant(value=1, shape=(shape[0], 1), dtype=dtype), attn_mask[:, 1:]], axis=1)
+    attn_mask = tf.concat([attn_mask[:, :-1], tf.ones_like(attn_mask[:, -1:], dtype=dtype)], axis=-1)
     return attn_mask
 
 

--- a/tests/xlm/test_modeling_tf_xlm.py
+++ b/tests/xlm/test_modeling_tf_xlm.py
@@ -20,7 +20,7 @@ from transformers import is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -75,7 +75,7 @@ class TFXLMModelTester:
 
     def prepare_config_and_inputs(self):
         input_ids = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
-        input_mask = ids_tensor([self.batch_size, self.seq_length], 2, dtype=tf.float32)
+        input_mask = random_attention_mask([self.batch_size, self.seq_length], dtype=tf.float32)
 
         input_lengths = None
         if self.use_input_lengths:

--- a/tests/xlnet/test_modeling_tf_xlnet.py
+++ b/tests/xlnet/test_modeling_tf_xlnet.py
@@ -22,7 +22,7 @@ from transformers import XLNetConfig, is_tf_available
 from transformers.testing_utils import require_tf, slow
 
 from ..test_configuration_common import ConfigTester
-from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor
+from ..test_modeling_tf_common import TFModelTesterMixin, ids_tensor, random_attention_mask
 
 
 if is_tf_available():
@@ -75,7 +75,7 @@ class TFXLNetModelTester:
         input_ids_1 = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
         input_ids_2 = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
         segment_ids = ids_tensor([self.batch_size, self.seq_length], self.type_vocab_size)
-        input_mask = ids_tensor([self.batch_size, self.seq_length], 2, dtype=tf.float32)
+        input_mask = random_attention_mask([self.batch_size, self.seq_length], dtype=tf.float32)
 
         input_ids_q = ids_tensor([self.batch_size, self.seq_length + 1], self.vocab_size)
         perm_mask = tf.zeros((self.batch_size, self.seq_length + 1, self.seq_length), dtype=tf.float32)


### PR DESCRIPTION
# What does this PR do?

- Change TF's `random_attention_mask` to match its PT/Flax equivalence.
- Use `random_attention_mask` defined in `test_modeling_tf_common.py` to generate attention mask in TF tests.

  - so TF code has the same logic as in PT/Flax tests (regarding this attention mask part in tests)
  - avoid large difference between PT/TF outputs. (In particular, `TFGPT2EncoderDecoderModelTest` in [here](https://github.com/huggingface/transformers/issues/16497))
    - In the case of ``TFBERTEncoderDecoderModelTest`` or `TFGPT2EncoderDecoderModelTest`, it is caused by some sequence in a batch which gets all 0s as attention mask (generated by `ids_tensor`) - may happens on both encoder and decoder (especially after combining with the causal mask).

## More context

Currently, most of TF tests still uses
```python
input_mask = ids_tensor([self.batch_size, self.seq_length], vocab_size=2)
```
while in PT/Flax tests, they call
```
input_mask = random_attention_mask([self.batch_size, self.seq_length])
```
(defined in the comment test file).

In particular, `random_attention_mask` has
```
    # make sure that at least one token is attended to for each batch
    attn_mask[:, -1] = 1
```

