### PR TITLE
update vilt model: remove index param in torch.meshgrid

### DIFF
--- a/src/transformers/models/vilt/modeling_vilt.py
+++ b/src/transformers/models/vilt/modeling_vilt.py
@@ -142,7 +142,7 @@ class ViltEmbeddings(nn.Module):
         pos_embed = pos_embed.flatten(2).transpose(1, 2)
         x = x.flatten(2).transpose(1, 2)
         patch_index = torch.stack(
-            torch.meshgrid(torch.arange(x_mask.shape[-2]), torch.arange(x_mask.shape[-1]), indexing="ij"), dim=-1
+            torch.meshgrid(torch.arange(x_mask.shape[-2]), torch.arange(x_mask.shape[-1])), dim=-1
         )
         patch_index = patch_index[None, None, :, :, :]
         patch_index = patch_index.expand(x_mask.shape[0], x_mask.shape[1], -1, -1, -1)


### PR DESCRIPTION
# What does this PR do?

remove index argument in torch.meshgrid in ViLT model which would lead to 
`Exception has occurred: TypeError
meshgrid() got an unexpected keyword argument 'indexing'`




