### PR TITLE
Remove MBart subclass of XLMRoberta in tokenzier docs

### DIFF
--- a/src/transformers/models/mbart/tokenization_mbart_fast.py
+++ b/src/transformers/models/mbart/tokenization_mbart_fast.py
@@ -62,9 +62,9 @@ class MBartTokenizerFast(PreTrainedTokenizerFast):
     Construct a "fast" MBART tokenizer (backed by HuggingFace's *tokenizers* library). Based on
     [BPE](https://huggingface.co/docs/tokenizers/python/latest/components.html?highlight=BPE#models).
 
-    [`MBartTokenizerFast`] is a subclass of ['PreTrainedTokenizerFast'] and is adapted from [`XLMRobertaTokenizerFast`]. Refer to superclass
-    [`PreTrainedTokenizerFast`] for usage examples and documentation concerning the initialization parameters and other
-    methods.
+    [`MBartTokenizerFast`] is a subclass of ['PreTrainedTokenizerFast'] and is adapted from
+    [`XLMRobertaTokenizerFast`]. Refer to superclass [`PreTrainedTokenizerFast`] for usage examples and documentation
+    concerning the initialization parameters and other methods.
 
     The tokenization method is `<tokens> <eos> <language code>` for source language documents, and ``<language code>
     <tokens> <eos>``` for target language documents.

--- a/src/transformers/models/mbart/tokenization_mbart_fast.py
+++ b/src/transformers/models/mbart/tokenization_mbart_fast.py
@@ -62,9 +62,8 @@ class MBartTokenizerFast(PreTrainedTokenizerFast):
     Construct a "fast" MBART tokenizer (backed by HuggingFace's *tokenizers* library). Based on
     [BPE](https://huggingface.co/docs/tokenizers/python/latest/components.html?highlight=BPE#models).
 
-    [`MBartTokenizerFast`] is a subclass of ['PreTrainedTokenizerFast'] and is adapted from
-    [`XLMRobertaTokenizerFast`]. Refer to superclass [`PreTrainedTokenizerFast`] for usage examples and documentation
-    concerning the initialization parameters and other methods.
+    This tokenizer inherits from [`PreTrainedTokenizerFast`] which contains most of the main methods. Users should
+    refer to this superclass for more information regarding those methods.
 
     The tokenization method is `<tokens> <eos> <language code>` for source language documents, and ``<language code>
     <tokens> <eos>``` for target language documents.

--- a/src/transformers/models/mbart/tokenization_mbart_fast.py
+++ b/src/transformers/models/mbart/tokenization_mbart_fast.py
@@ -62,8 +62,8 @@ class MBartTokenizerFast(PreTrainedTokenizerFast):
     Construct a "fast" MBART tokenizer (backed by HuggingFace's *tokenizers* library). Based on
     [BPE](https://huggingface.co/docs/tokenizers/python/latest/components.html?highlight=BPE#models).
 
-    [`MBartTokenizerFast`] is a subclass of [`XLMRobertaTokenizerFast`]. Refer to superclass
-    [`XLMRobertaTokenizerFast`] for usage examples and documentation concerning the initialization parameters and other
+    [`MBartTokenizerFast`] is a subclass of ['PreTrainedTokenizerFast'] and is adapted from [`XLMRobertaTokenizerFast`]. Refer to superclass
+    [`PreTrainedTokenizerFast`] for usage examples and documentation concerning the initialization parameters and other
     methods.
 
     The tokenization method is `<tokens> <eos> <language code>` for source language documents, and ``<language code>


### PR DESCRIPTION
# What does this PR do?
This PR removes the line mentioning MBartTokenizer is a subclass of XLMRobertaTokenizer in the fast tokenizer.
@sgugger @patil-suraj 