### PR TITLE
Fix TFTransfoXLLMHeadModel outputs

### DIFF
--- a/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
+++ b/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
@@ -998,12 +998,13 @@ class TFTransfoXLLMHeadModel(TFTransfoXLPreTrainedModel):
         pred_hid = last_hidden[:, -tgt_len:]
 
         softmax_output = self.crit(pred_hid, labels, training=training)
+        prediction_scores = softmax_output if labels is None else ()
 
         if not return_dict:
-            return (softmax_output,) + transformer_outputs[1:]
+            return (prediction_scores,) + transformer_outputs[1:]
 
         return TFTransfoXLLMHeadModelOutput(
-            prediction_scores=softmax_output,
+            prediction_scores=prediction_scores,
             mems=transformer_outputs.mems,
             hidden_states=transformer_outputs.hidden_states,
             attentions=transformer_outputs.attentions,


### PR DESCRIPTION
# What does this PR do?

Fix the outputs of `TFTransfoXLLMHeadModel` (in the case without `labels`) - current TF returns `softmax_output` while PT returns `prediction_scores`:

- Current PT

    https://github.com/huggingface/transformers/blob/6f9d8dc1567889b073b91059c9b19e9a6813abfa/src/transformers/models/transfo_xl/modeling_transfo_xl.py#L1119
    and

    https://github.com/huggingface/transformers/blob/6f9d8dc1567889b073b91059c9b19e9a6813abfa/src/transformers/models/transfo_xl/modeling_transfo_xl.py#L1138-L1140

- Current TF

    https://github.com/huggingface/transformers/blob/6f9d8dc1567889b073b91059c9b19e9a6813abfa/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py#L1005-L1006


## Remarks:

  - The case with `labels` is much more complicated - to be addressed in the future.
  - The current PT/TF equivalence test has a bit flaw and doesn't detect this issue. A WIP PR #16557 is on its way (with other enhancements)!