### PR TITLE
Fix CI: test_inference_for_pretraining in ViTMAEModelTest

### DIFF
--- a/tests/vit_mae/test_modeling_vit_mae.py
+++ b/tests/vit_mae/test_modeling_vit_mae.py
@@ -561,7 +561,7 @@ class ViTMAEModelIntegrationTest(unittest.TestCase):
 
         # forward pass
         with torch.no_grad():
-            outputs = model(**inputs, noise=torch.from_numpy(noise))
+            outputs = model(**inputs, noise=torch.from_numpy(noise).to(device=torch_device))
 
         # verify the logits
         expected_shape = torch.Size((1, 196, 768))


### PR DESCRIPTION
# What does this PR do?

Fix CI (scheduled): `test_inference_for_pretraining` in `ViTMAEModelTest`: incorrect device

https://github.com/huggingface/transformers/runs/5809883645?check_suite_focus=true