### PR TITLE
don't load state_dict twice when using low_cpu_mem_usage in from_pretrained

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1823,7 +1823,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 if is_sharded:
                     loaded_state_dict_keys = sharded_metadata["all_checkpoint_keys"]
                 else:
-                    state_dict = load_state_dict(resolved_archive_file)
                     loaded_state_dict_keys = [k for k in state_dict.keys()]
                     del state_dict  # free CPU memory - will reload again later
 


### PR DESCRIPTION
# What does this PR do?

In `from_pretrained` the `state_dict` is loaded twice when `low_cpu_mem_usage` is `True`,  which is not required since the `state_dict` is already loaded before as we can here.
https://github.com/huggingface/transformers/blob/21decb7731e998d3d208ec33e5b249b0a84c0a02/src/transformers/modeling_utils.py#L1795-L1797

So, it's fine to remove it there because when is_sharded=False, the state_dict is loaded at line 1797