### PR TITLE
Use CLIP model config to set some kwargs for components

### DIFF
--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -287,6 +287,12 @@ class CLIPConfig(PretrainedConfig):
         self.text_config = CLIPTextConfig(**text_config_dict)
         self.vision_config = CLIPVisionConfig(**vision_config_dict)
 
+        # Update components' (vision & text) configurations for some configs specified in CLIP model.
+        for k in ["output_hidden_states", "output_attentions", "return_dict"]:
+            if self[k] is not None:
+                self.text_config[k] = self[k]
+                self.vision_config[k] = self[k]
+
         self.projection_dim = projection_dim
         self.logit_scale_init_value = logit_scale_init_value
         self.initializer_factor = 1.0

--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -287,12 +287,6 @@ class CLIPConfig(PretrainedConfig):
         self.text_config = CLIPTextConfig(**text_config_dict)
         self.vision_config = CLIPVisionConfig(**vision_config_dict)
 
-        # Update components' (vision & text) configurations for some configs specified in CLIP model.
-        for k in ["output_hidden_states", "output_attentions", "return_dict"]:
-            if self[k] is not None:
-                self.text_config[k] = self[k]
-                self.vision_config[k] = self[k]
-
         self.projection_dim = projection_dim
         self.logit_scale_init_value = logit_scale_init_value
         self.initializer_factor = 1.0

--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -898,6 +898,13 @@ class CLIPModel(CLIPPreTrainedModel):
         >>> inputs = tokenizer(["a photo of a cat", "a photo of a dog"], padding=True, return_tensors="pt")
         >>> text_features = model.get_text_features(**inputs)
         ```"""
+        # Use CLIP model's config for some fields (if specified) instead of those of vision & text components.
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
         text_outputs = self.text_model(
             input_ids=input_ids,
             attention_mask=attention_mask,
@@ -942,6 +949,13 @@ class CLIPModel(CLIPPreTrainedModel):
 
         >>> image_features = model.get_image_features(**inputs)
         ```"""
+        # Use CLIP model's config for some fields (if specified) instead of those of vision & text components.
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
         vision_outputs = self.vision_model(
             pixel_values=pixel_values,
             output_attentions=output_attentions,
@@ -991,7 +1005,13 @@ class CLIPModel(CLIPPreTrainedModel):
         >>> logits_per_image = outputs.logits_per_image  # this is the image-text similarity score
         >>> probs = logits_per_image.softmax(dim=1)  # we can take the softmax to get the label probabilities
         ```"""
-        return_dict = return_dict if return_dict is not None else self.config.return_dict
+        # Use CLIP model's config for some fields (if specified) instead of those of vision & text components.
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
         vision_outputs = self.vision_model(
             pixel_values=pixel_values,
             output_attentions=output_attentions,


### PR DESCRIPTION
# What does this PR do?

In `CLIPModel`, set `output_attentions` and `output_hidden_states` using `CLIPModel.config` if these values are specified in the configuration + not specified in the arguments.

(currently, these operations are done in its vision & text components separately, and cause a WIP CLIP PT/TF equivalence test failing - #16557)

## Details

Currently, `CLIPModel` uses its 2 components' (`vision_model` and `text_model`) configurations to perform things like

(here self is `CLIPVisionTransformer` or `CLIPTextTransformer`)
```python
output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
```

If `output_attentions`/`output_hidden_states` are not passed to `CLIPModel.forward` at this line

https://github.com/huggingface/transformers/blob/9fd5e6bbe605941b707b0e1aa223a5c51c183550/src/transformers/models/clip/modeling_clip.py#L966-L967

but `CLIPModel.config` has these values set, `CLIPModel.config.output_attentions` and `CLIPModel.config.output_hidden_states` won't have any effect. This case happens here
https://github.com/huggingface/transformers/blob/9fd5e6bbe605941b707b0e1aa223a5c51c183550/tests/test_modeling_tf_common.py#L544-L547

Therefore, **CLIP PT/TF equivalence test won't returns hidden_states/attentions for the PT model.**

In TF, 

https://github.com/huggingface/transformers/blob/b33ab4eb59f3baa0108d494695bc09b4688960a7/src/transformers/modeling_tf_utils.py#L393

will use `config` to set the kwargs at the `CLIPModel` level. These kwargs are passed to the 2 components, and **CLIP PT/TF equivalence test  returns hidden_states/attentions for the TF model.**
