### PR TITLE
added changes in deberta dropout

### DIFF
--- a/src/transformers/models/deberta/configuration_deberta.py
+++ b/src/transformers/models/deberta/configuration_deberta.py
@@ -83,6 +83,8 @@ class DebertaConfig(PretrainedConfig):
             `["p2c", "c2p"]`.
         layer_norm_eps (`float`, optional, defaults to 1e-12):
             The epsilon used by the layer normalization layers.
+        cls_dropout (`float`, optional, defaults to 0.1):
+            The dropout for the task layer.
     """
     model_type = "deberta"
 
@@ -107,7 +109,8 @@ class DebertaConfig(PretrainedConfig):
         pos_att_type=None,
         pooler_dropout=0,
         pooler_hidden_act="gelu",
-        **kwargs
+        cls_dropout=0.1,
+        **kwargs,
     ):
         super().__init__(**kwargs)
 
@@ -137,3 +140,4 @@ class DebertaConfig(PretrainedConfig):
         self.pooler_hidden_size = kwargs.get("pooler_hidden_size", hidden_size)
         self.pooler_dropout = pooler_dropout
         self.pooler_hidden_act = pooler_hidden_act
+        cls_dropout = cls_dropout

--- a/src/transformers/models/deberta/modeling_deberta.py
+++ b/src/transformers/models/deberta/modeling_deberta.py
@@ -1139,8 +1139,7 @@ class DebertaForSequenceClassification(DebertaPreTrainedModel):
         output_dim = self.pooler.output_dim
 
         self.classifier = nn.Linear(output_dim, num_labels)
-        drop_out = getattr(config, "cls_dropout", None)
-        drop_out = self.config.hidden_dropout_prob if drop_out is None else drop_out
+        drop_out = getattr(config, "cls_dropout", self.config.hidden_dropout_prob)
         self.dropout = StableDropout(drop_out)
 
         # Initialize weights and apply final processing
@@ -1254,7 +1253,8 @@ class DebertaForTokenClassification(DebertaPreTrainedModel):
         self.num_labels = config.num_labels
 
         self.deberta = DebertaModel(config)
-        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+        drop_out = getattr(config, "cls_dropout", self.config.hidden_dropout_prob)
+        self.dropout = StableDropout(drop_out)
         self.classifier = nn.Linear(config.hidden_size, config.num_labels)
 
         # Initialize weights and apply final processing

--- a/src/transformers/models/deberta_v2/modeling_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_deberta_v2.py
@@ -1236,8 +1236,7 @@ class DebertaV2ForSequenceClassification(DebertaV2PreTrainedModel):
         output_dim = self.pooler.output_dim
 
         self.classifier = nn.Linear(output_dim, num_labels)
-        drop_out = getattr(config, "cls_dropout", None)
-        drop_out = self.config.hidden_dropout_prob if drop_out is None else drop_out
+        drop_out = getattr(config, "cls_dropout", self.config.hidden_dropout_prob)
         self.dropout = StableDropout(drop_out)
 
         # Initialize weights and apply final processing
@@ -1352,7 +1351,8 @@ class DebertaV2ForTokenClassification(DebertaV2PreTrainedModel):
         self.num_labels = config.num_labels
 
         self.deberta = DebertaV2Model(config)
-        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+        drop_out = getattr(config, "cls_dropout", self.config.hidden_dropout_prob)
+        self.dropout = StableDropout(drop_out)
         self.classifier = nn.Linear(config.hidden_size, config.num_labels)
 
         # Initialize weights and apply final processing


### PR DESCRIPTION
# What does this PR do?

This PR does the foillowing. 
1- Add a task dropout to deberta config, that is, cls_dropout. This is similar to what Bert and others have. This is justified since in Deberta paper adjusting task dropout is very important, therefore I think it shouldn't be just be set to the hidden_dropout_prob. While the latter should, in general, not be changed, cls_dropout should be tuned to obtain best results, as stated in: https://arxiv.org/abs/2006.03654
2. Armonize the use of Dropout. In general, Deberta uses Stable Dropout, which was also used in Classification. However, I don't understand why, on Token Classification normal Dropout was used. In some experiments I carried out, StableDropout worked better than normal dropout also for token classification, and it is the type of dropout that is used in all other Deberta layers, therefore I think it is better to have the same type of dropout in all task layers. 
I also changed a little bit how the dropout is created to remove redundant lines, but as you see there are only a few changes, they're not many lines of code, but for clarity and simplicity I decided to change that also; e.g (instead of first getting cls_dropout if existing and then if it is None take hidden_dropout_prob, I do it all in one line in getattr).

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR

@BigBird01 @LysandreJik @patrickvonplaten 