### PR TITLE
Remove parent/child tests in auto model tests

### DIFF
--- a/tests/auto/test_modeling_auto.py
+++ b/tests/auto/test_modeling_auto.py
@@ -74,12 +74,9 @@ if is_torch_available():
         MODEL_FOR_MASKED_LM_MAPPING,
         MODEL_FOR_PRETRAINING_MAPPING,
         MODEL_FOR_QUESTION_ANSWERING_MAPPING,
-        MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
         MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING,
-        MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING,
         MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING,
         MODEL_MAPPING,
-        MODEL_WITH_LM_HEAD_MAPPING,
     )
     from transformers.models.bert.modeling_bert import BERT_PRETRAINED_MODEL_ARCHIVE_LIST
     from transformers.models.gpt2.modeling_gpt2 import GPT2_PRETRAINED_MODEL_ARCHIVE_LIST
@@ -250,40 +247,6 @@ class AutoModelTest(unittest.TestCase):
             model.save_pretrained(tmp_dir)
             model = AutoModel.from_pretrained(tmp_dir)
             self.assertIsInstance(model, FunnelBaseModel)
-
-    def test_parents_and_children_in_mappings(self):
-        # Test that the children are placed before the parents in the mappings, as the `instanceof` will be triggered
-        # by the parents and will return the wrong configuration type when using auto models
-
-        mappings = (
-            MODEL_MAPPING,
-            MODEL_FOR_PRETRAINING_MAPPING,
-            MODEL_FOR_QUESTION_ANSWERING_MAPPING,
-            MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING,
-            MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING,
-            MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING,
-            MODEL_WITH_LM_HEAD_MAPPING,
-            MODEL_FOR_CAUSAL_LM_MAPPING,
-            MODEL_FOR_MASKED_LM_MAPPING,
-            MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
-        )
-
-        for mapping in mappings:
-            mapping = tuple(mapping.items())
-            for index, (child_config, child_model) in enumerate(mapping[1:]):
-                for parent_config, parent_model in mapping[: index + 1]:
-                    assert not issubclass(
-                        child_config, parent_config
-                    ), f"{child_config.__name__} is child of {parent_config.__name__}"
-
-                    # Tuplify child_model and parent_model since some of them could be tuples.
-                    if not isinstance(child_model, (list, tuple)):
-                        child_model = (child_model,)
-                    if not isinstance(parent_model, (list, tuple)):
-                        parent_model = (parent_model,)
-
-                    for child, parent in [(a, b) for a in child_model for b in parent_model]:
-                        assert not issubclass(child, parent), f"{child.__name__} is child of {parent.__name__}"
 
     def test_from_pretrained_dynamic_model_local(self):
         try:

--- a/tests/auto/test_modeling_tf_auto.py
+++ b/tests/auto/test_modeling_tf_auto.py
@@ -58,12 +58,9 @@ if is_tf_available():
         TF_MODEL_FOR_MASKED_LM_MAPPING,
         TF_MODEL_FOR_PRETRAINING_MAPPING,
         TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING,
-        TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
         TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING,
-        TF_MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING,
         TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING,
         TF_MODEL_MAPPING,
-        TF_MODEL_WITH_LM_HEAD_MAPPING,
     )
     from transformers.models.bert.modeling_tf_bert import TF_BERT_PRETRAINED_MODEL_ARCHIVE_LIST
     from transformers.models.gpt2.modeling_tf_gpt2 import TF_GPT2_PRETRAINED_MODEL_ARCHIVE_LIST
@@ -217,38 +214,6 @@ class TFAutoModelTest(unittest.TestCase):
             model.save_pretrained(tmp_dir)
             model = TFAutoModel.from_pretrained(tmp_dir)
             self.assertIsInstance(model, TFFunnelBaseModel)
-
-    def test_parents_and_children_in_mappings(self):
-        # Test that the children are placed before the parents in the mappings, as the `instanceof` will be triggered
-        # by the parents and will return the wrong configuration type when using auto models
-        mappings = (
-            TF_MODEL_MAPPING,
-            TF_MODEL_FOR_PRETRAINING_MAPPING,
-            TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING,
-            TF_MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING,
-            TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING,
-            TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING,
-            TF_MODEL_WITH_LM_HEAD_MAPPING,
-            TF_MODEL_FOR_CAUSAL_LM_MAPPING,
-            TF_MODEL_FOR_MASKED_LM_MAPPING,
-            TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
-        )
-
-        for mapping in mappings:
-            mapping = tuple(mapping.items())
-            for index, (child_config, child_model) in enumerate(mapping[1:]):
-                for parent_config, parent_model in mapping[: index + 1]:
-                    with self.subTest(msg=f"Testing if {child_config.__name__} is child of {parent_config.__name__}"):
-                        self.assertFalse(issubclass(child_config, parent_config))
-
-                    # Tuplify child_model and parent_model since some of them could be tuples.
-                    if not isinstance(child_model, (list, tuple)):
-                        child_model = (child_model,)
-                    if not isinstance(parent_model, (list, tuple)):
-                        parent_model = (parent_model,)
-
-                    for child, parent in [(a, b) for a in child_model for b in parent_model]:
-                        assert not issubclass(child, parent), f"{child.__name__} is child of {parent.__name__}"
 
     def test_new_model_registration(self):
         try:

--- a/tests/auto/test_tokenization_auto.py
+++ b/tests/auto/test_tokenization_auto.py
@@ -151,19 +151,6 @@ class AutoTokenizerTest(unittest.TestCase):
             ):
                 _ = tokenizer_class.from_pretrained("julien-c/herlolip-not-exists")
 
-    def test_parents_and_children_in_mappings(self):
-        # Test that the children are placed before the parents in the mappings, as the `instanceof` will be triggered
-        # by the parents and will return the wrong configuration type when using auto models
-
-        mappings = (TOKENIZER_MAPPING,)
-
-        for mapping in mappings:
-            mapping = tuple(mapping.items())
-            for index, (child_config, _) in enumerate(mapping[1:]):
-                for parent_config, _ in mapping[: index + 1]:
-                    with self.subTest(msg=f"Testing if {child_config.__name__} is child of {parent_config.__name__}"):
-                        self.assertFalse(issubclass(child_config, parent_config))
-
     def test_model_name_edge_cases_in_mappings(self):
         # tests: https://github.com/huggingface/transformers/pull/13251
         # 1. models with `-`, e.g. xlm-roberta -> xlm_roberta


### PR DESCRIPTION
# What does this PR do?

This PR removes the tests that checks whether models/configs/tokenizers are sorted in the auto mappings such that children classes are before parent classes. While it may have been necessary in the pasts for the `AutoXxx` APIs to work, this is not longer the case and this actually makes it harder on contributors to add new models.

Also, in the future we could have a script like isort that enforces all those auto-mappings are alphabetically sorted.