### PR TITLE
Fix example logs repeating themselves

### DIFF
--- a/examples/flax/test_flax_examples.py
+++ b/examples/flax/test_flax_examples.py
@@ -21,7 +21,7 @@ import os
 import sys
 from unittest.mock import patch
 
-from transformers.testing_utils import HandlerTestCasePlus, get_gpu_count, slow
+from transformers.testing_utils import TestCasePlus, get_gpu_count, slow
 
 
 SRC_DIRS = [
@@ -70,16 +70,11 @@ def get_results(output_dir, split="eval"):
     return results
 
 
-class ExamplesTests(HandlerTestCasePlus):
-    def setUp(self):
-        super().setUp()
-        stream_handler = logging.StreamHandler(sys.stdout)
-        self.add_handler(stream_handler, logger)
-    
-    def tearDown(self):
-        super().tearDown()
-        self.remove_handlers(logger)
+stream_handler = logging.StreamHandler(sys.stdout)
+logger.addHandler(stream_handler)
 
+
+class ExamplesTests(TestCasePlus):
     def test_run_glue(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""

--- a/examples/flax/test_flax_examples.py
+++ b/examples/flax/test_flax_examples.py
@@ -21,7 +21,7 @@ import os
 import sys
 from unittest.mock import patch
 
-from transformers.testing_utils import TestCasePlus, get_gpu_count, slow
+from transformers.testing_utils import HandlerTestCasePlus, get_gpu_count, slow
 
 
 SRC_DIRS = [
@@ -70,11 +70,17 @@ def get_results(output_dir, split="eval"):
     return results
 
 
-class ExamplesTests(TestCasePlus):
-    def test_run_glue(self):
+class ExamplesTests(HandlerTestCasePlus):
+    def setUp(self):
+        super().setUp()
         stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
+        self.add_handler(stream_handler, logger)
+    
+    def tearDown(self):
+        super().tearDown()
+        self.remove_handlers(logger)
 
+    def test_run_glue(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_glue.py
@@ -98,9 +104,6 @@ class ExamplesTests(TestCasePlus):
 
     @slow
     def test_run_clm(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_clm_flax.py
@@ -125,9 +128,6 @@ class ExamplesTests(TestCasePlus):
 
     @slow
     def test_run_summarization(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_summarization.py
@@ -158,9 +158,6 @@ class ExamplesTests(TestCasePlus):
 
     @slow
     def test_run_mlm(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_mlm.py
@@ -185,9 +182,6 @@ class ExamplesTests(TestCasePlus):
 
     @slow
     def test_run_t5_mlm(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_t5_mlm_flax.py
@@ -212,9 +206,6 @@ class ExamplesTests(TestCasePlus):
 
     @slow
     def test_run_ner(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         # with so little data distributed training needs more epochs to get the score on par with 0/1 gpu
         epochs = 7 if get_gpu_count() > 1 else 2
 
@@ -245,9 +236,6 @@ class ExamplesTests(TestCasePlus):
 
     @slow
     def test_run_qa(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_qa.py

--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -23,7 +23,7 @@ from unittest.mock import patch
 
 import torch
 
-from transformers.testing_utils import HandlerTestCasePlus, get_gpu_count, slow, torch_device
+from transformers.testing_utils import TestCasePlus, get_gpu_count, slow, torch_device
 from transformers.utils import is_apex_available
 
 
@@ -85,17 +85,10 @@ def is_cuda_and_apex_available():
     is_using_cuda = torch.cuda.is_available() and torch_device == "cuda"
     return is_using_cuda and is_apex_available()
 
+stream_handler = logging.StreamHandler(sys.stdout)
+logger.addHandler(stream_handler)
 
-class ExamplesTestsNoTrainer(HandlerTestCasePlus):
-    def setUp(self):
-        super().setUp()
-        stream_handler = logging.StreamHandler(sys.stdout)
-        self.add_handler(stream_handler, logger)
-    
-    def tearDown(self):
-        super().tearDown()
-        self.remove_handlers(logger)
-
+class ExamplesTestsNoTrainer(TestCasePlus):
     def test_run_glue_no_trainer(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""

--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -23,7 +23,7 @@ from unittest.mock import patch
 
 import torch
 
-from transformers.testing_utils import TestCasePlus, get_gpu_count, slow, torch_device
+from transformers.testing_utils import HandlerTestCasePlus, get_gpu_count, slow, torch_device
 from transformers.utils import is_apex_available
 
 
@@ -86,11 +86,17 @@ def is_cuda_and_apex_available():
     return is_using_cuda and is_apex_available()
 
 
-class ExamplesTestsNoTrainer(TestCasePlus):
-    def test_run_glue_no_trainer(self):
+class ExamplesTestsNoTrainer(HandlerTestCasePlus):
+    def setUp(self):
+        super().setUp()
         stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
+        self.add_handler(stream_handler, logger)
+    
+    def tearDown(self):
+        super().tearDown()
+        self.remove_handlers(logger)
 
+    def test_run_glue_no_trainer(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_glue_no_trainer.py
@@ -115,9 +121,6 @@ class ExamplesTestsNoTrainer(TestCasePlus):
             self.assertTrue(os.path.exists(os.path.join(tmp_dir, "epoch_0")))
 
     def test_run_clm_no_trainer(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_clm_no_trainer.py
@@ -143,9 +146,6 @@ class ExamplesTestsNoTrainer(TestCasePlus):
             self.assertTrue(os.path.exists(os.path.join(tmp_dir, "epoch_0")))
 
     def test_run_mlm_no_trainer(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_mlm_no_trainer.py
@@ -164,9 +164,6 @@ class ExamplesTestsNoTrainer(TestCasePlus):
             self.assertTrue(os.path.exists(os.path.join(tmp_dir, "epoch_0")))
 
     def test_run_ner_no_trainer(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         # with so little data distributed training needs more epochs to get the score on par with 0/1 gpu
         epochs = 7 if get_gpu_count() > 1 else 2
 
@@ -193,9 +190,6 @@ class ExamplesTestsNoTrainer(TestCasePlus):
             self.assertTrue(os.path.exists(os.path.join(tmp_dir, "epoch_0")))
 
     def test_run_squad_no_trainer(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_qa_no_trainer.py
@@ -220,9 +214,6 @@ class ExamplesTestsNoTrainer(TestCasePlus):
             self.assertTrue(os.path.exists(os.path.join(tmp_dir, "epoch_0")))
 
     def test_run_swag_no_trainer(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_swag_no_trainer.py
@@ -244,9 +235,6 @@ class ExamplesTestsNoTrainer(TestCasePlus):
 
     @slow
     def test_run_summarization_no_trainer(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_summarization_no_trainer.py
@@ -273,9 +261,6 @@ class ExamplesTestsNoTrainer(TestCasePlus):
 
     @slow
     def test_run_translation_no_trainer(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_translation_no_trainer.py

--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -85,8 +85,10 @@ def is_cuda_and_apex_available():
     is_using_cuda = torch.cuda.is_available() and torch_device == "cuda"
     return is_using_cuda and is_apex_available()
 
+
 stream_handler = logging.StreamHandler(sys.stdout)
 logger.addHandler(stream_handler)
+
 
 class ExamplesTestsNoTrainer(TestCasePlus):
     def test_run_glue_no_trainer(self):

--- a/examples/pytorch/test_pytorch_examples.py
+++ b/examples/pytorch/test_pytorch_examples.py
@@ -25,7 +25,7 @@ from unittest.mock import patch
 import torch
 
 from transformers import ViTMAEForPreTraining, Wav2Vec2ForPreTraining
-from transformers.testing_utils import CaptureLogger, HandlerTestCasePlus, get_gpu_count, slow, torch_device
+from transformers.testing_utils import CaptureLogger, TestCasePlus, get_gpu_count, slow, torch_device
 from transformers.utils import is_apex_available
 
 
@@ -96,17 +96,10 @@ def is_cuda_and_apex_available():
     is_using_cuda = torch.cuda.is_available() and torch_device == "cuda"
     return is_using_cuda and is_apex_available()
 
+stream_handler = logging.StreamHandler(sys.stdout)
+logger.addHandler(stream_handler)
 
-class ExamplesTests(HandlerTestCasePlus):
-    def setUp(self):
-        super().setUp()
-        stream_handler = logging.StreamHandler(sys.stdout)
-        self.add_handler(stream_handler, logger)
-
-    def tearDown(self):
-        super().tearDown()
-        self.remove_handlers(logger)
-
+class ExamplesTests(TestCasePlus):
     def test_run_glue(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""

--- a/examples/pytorch/test_pytorch_examples.py
+++ b/examples/pytorch/test_pytorch_examples.py
@@ -96,8 +96,10 @@ def is_cuda_and_apex_available():
     is_using_cuda = torch.cuda.is_available() and torch_device == "cuda"
     return is_using_cuda and is_apex_available()
 
+
 stream_handler = logging.StreamHandler(sys.stdout)
 logger.addHandler(stream_handler)
+
 
 class ExamplesTests(TestCasePlus):
     def test_run_glue(self):

--- a/examples/pytorch/test_pytorch_examples.py
+++ b/examples/pytorch/test_pytorch_examples.py
@@ -25,7 +25,7 @@ from unittest.mock import patch
 import torch
 
 from transformers import ViTMAEForPreTraining, Wav2Vec2ForPreTraining
-from transformers.testing_utils import CaptureLogger, TestCasePlus, get_gpu_count, slow, torch_device
+from transformers.testing_utils import CaptureLogger, HandlerTestCasePlus, get_gpu_count, slow, torch_device
 from transformers.utils import is_apex_available
 
 
@@ -97,11 +97,17 @@ def is_cuda_and_apex_available():
     return is_using_cuda and is_apex_available()
 
 
-class ExamplesTests(TestCasePlus):
-    def test_run_glue(self):
+class ExamplesTests(HandlerTestCasePlus):
+    def setUp(self):
+        super().setUp()
         stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
+        self.add_handler(stream_handler, logger)
 
+    def tearDown(self):
+        super().tearDown()
+        self.remove_handlers(logger)
+
+    def test_run_glue(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_glue.py
@@ -130,9 +136,6 @@ class ExamplesTests(TestCasePlus):
             self.assertGreaterEqual(result["eval_accuracy"], 0.75)
 
     def test_run_clm(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_clm.py
@@ -187,9 +190,6 @@ class ExamplesTests(TestCasePlus):
         self.assertIn('"n_head": 2', cl.out)
 
     def test_run_mlm(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_mlm.py
@@ -213,9 +213,6 @@ class ExamplesTests(TestCasePlus):
             self.assertLess(result["perplexity"], 42)
 
     def test_run_ner(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         # with so little data distributed training needs more epochs to get the score on par with 0/1 gpu
         epochs = 7 if get_gpu_count() > 1 else 2
 
@@ -247,9 +244,6 @@ class ExamplesTests(TestCasePlus):
             self.assertLess(result["eval_loss"], 0.5)
 
     def test_run_squad(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_qa.py
@@ -275,9 +269,6 @@ class ExamplesTests(TestCasePlus):
             self.assertGreaterEqual(result["eval_exact"], 30)
 
     def test_run_squad_seq2seq(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_seq2seq_qa.py
@@ -307,9 +298,6 @@ class ExamplesTests(TestCasePlus):
             self.assertGreaterEqual(result["eval_exact"], 30)
 
     def test_run_swag(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_swag.py
@@ -333,9 +321,6 @@ class ExamplesTests(TestCasePlus):
             self.assertGreaterEqual(result["eval_accuracy"], 0.8)
 
     def test_generation(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         testargs = ["run_generation.py", "--prompt=Hello", "--length=10", "--seed=42"]
 
         if is_cuda_and_apex_available():
@@ -351,9 +336,6 @@ class ExamplesTests(TestCasePlus):
 
     @slow
     def test_run_summarization(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_summarization.py
@@ -382,9 +364,6 @@ class ExamplesTests(TestCasePlus):
 
     @slow
     def test_run_translation(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_translation.py
@@ -414,9 +393,6 @@ class ExamplesTests(TestCasePlus):
 
     @unittest.skip("This is currently broken.")
     def test_run_image_classification(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_image_classification.py
@@ -446,9 +422,6 @@ class ExamplesTests(TestCasePlus):
             self.assertGreaterEqual(result["eval_accuracy"], 0.8)
 
     def test_run_speech_recognition_ctc(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_speech_recognition_ctc.py
@@ -479,9 +452,6 @@ class ExamplesTests(TestCasePlus):
             self.assertLess(result["eval_loss"], result["train_loss"])
 
     def test_run_speech_recognition_seq2seq(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_speech_recognition_seq2seq.py
@@ -512,9 +482,6 @@ class ExamplesTests(TestCasePlus):
             self.assertLess(result["eval_loss"], result["train_loss"])
 
     def test_run_audio_classification(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_audio_classification.py
@@ -547,9 +514,6 @@ class ExamplesTests(TestCasePlus):
             self.assertLess(result["eval_loss"], result["train_loss"])
 
     def test_run_wav2vec2_pretraining(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_wav2vec2_pretraining_no_trainer.py
@@ -577,9 +541,6 @@ class ExamplesTests(TestCasePlus):
 
     @unittest.skip("This is currently broken.")
     def test_run_vit_mae_pretraining(self):
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             run_mae.py

--- a/examples/pytorch/test_xla_examples.py
+++ b/examples/pytorch/test_xla_examples.py
@@ -21,7 +21,7 @@ import sys
 from time import time
 from unittest.mock import patch
 
-from transformers.testing_utils import HandlerTestCasePlus, require_torch_tpu
+from transformers.testing_utils import TestCasePlus, require_torch_tpu
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -39,18 +39,11 @@ def get_results(output_dir):
         raise ValueError(f"can't find {path}")
     return results
 
+stream_handler = logging.StreamHandler(sys.stdout)
+logger.addHandler(stream_handler)
 
 @require_torch_tpu
-class TorchXLAExamplesTests(HandlerTestCasePlus):
-    def setUp(self):
-        super().setUp()
-        stream_handler = logging.StreamHandler(sys.stdout)
-        self.add_handler(stream_handler, logger)
-    
-    def tearDown(self):
-        super().tearDown()
-        self.remove_handlers(logger)
-
+class TorchXLAExamplesTests(TestCasePlus):
     def test_run_glue(self):
         import xla_spawn
         tmp_dir = self.get_auto_remove_tmp_dir()

--- a/examples/pytorch/test_xla_examples.py
+++ b/examples/pytorch/test_xla_examples.py
@@ -21,7 +21,7 @@ import sys
 from time import time
 from unittest.mock import patch
 
-from transformers.testing_utils import TestCasePlus, require_torch_tpu
+from transformers.testing_utils import HandlerTestCasePlus, require_torch_tpu
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -41,13 +41,18 @@ def get_results(output_dir):
 
 
 @require_torch_tpu
-class TorchXLAExamplesTests(TestCasePlus):
+class TorchXLAExamplesTests(HandlerTestCasePlus):
+    def setUp(self):
+        super().setUp()
+        stream_handler = logging.StreamHandler(sys.stdout)
+        self.add_handler(stream_handler, logger)
+    
+    def tearDown(self):
+        super().tearDown()
+        self.remove_handlers(logger)
+
     def test_run_glue(self):
         import xla_spawn
-
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
-
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             ./examples/pytorch/text-classification/run_glue.py

--- a/examples/pytorch/test_xla_examples.py
+++ b/examples/pytorch/test_xla_examples.py
@@ -39,13 +39,16 @@ def get_results(output_dir):
         raise ValueError(f"can't find {path}")
     return results
 
+
 stream_handler = logging.StreamHandler(sys.stdout)
 logger.addHandler(stream_handler)
+
 
 @require_torch_tpu
 class TorchXLAExamplesTests(TestCasePlus):
     def test_run_glue(self):
         import xla_spawn
+
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             ./examples/pytorch/text-classification/run_glue.py

--- a/examples/research_projects/rag/_test_finetune_rag.py
+++ b/examples/research_projects/rag/_test_finetune_rag.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import finetune_rag
 from transformers.file_utils import is_apex_available
 from transformers.testing_utils import (
-    HandlerTestCasePlus,
+    TestCasePlus,
     execute_subprocess_async,
     require_ray,
     require_torch_gpu,
@@ -18,17 +18,11 @@ from transformers.testing_utils import (
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
 
+stream_handler = logging.StreamHandler(sys.stdout)
+logger.addHandler(stream_handler)
 
-class RagFinetuneExampleTests(HandlerTestCasePlus):
-    def setUp(self):
-        super().setUp()
-        stream_handler = logging.StreamHandler(sys.stdout)
-        self.add_handler(stream_handler, logger)
-    
-    def tearDown(self):
-        super().tearDown()
-        self.remove_handlers(logger)
 
+class RagFinetuneExampleTests(TestCasePlus):
     def _create_dummy_data(self, data_dir):
         os.makedirs(data_dir, exist_ok=True)
         contents = {"source": "What is love ?", "target": "life"}

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1185,28 +1185,6 @@ class TestCasePlus(unittest.TestCase):
             shutil.rmtree(path, ignore_errors=True)
         self.teardown_tmp_dirs = []
 
-
-class HandlerTestCasePlus(TestCasePlus):
-    """
-    This class extends *TestCasePlus* to reduce the overload of Logging Handlers.
-    """
-    _handlers = []
-    def add_handler(self, handler:logging.Handler, logger:logging.Logger):
-        """
-        Adds `handler` to the current `logger` and stores it in `self._handlers`.
-        Should be called during `setUp`.
-        """
-        logger.addHandler(handler)
-        self._handlers.append(handler)
-
-    def remove_handlers(self, logger):
-        """
-        Removes all logging handlers that have been added from `add_handler`.
-        Should be called during `tearDown`
-        """
-        for handler in self._handlers:
-            logger.removeHandler(handler)
-
 def mockenv(**kwargs):
     """
     this is a convenience wrapper, that allows this ::

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1186,6 +1186,27 @@ class TestCasePlus(unittest.TestCase):
         self.teardown_tmp_dirs = []
 
 
+class HandlerTestCasePlus(TestCasePlus):
+    """
+    This class extends *TestCasePlus* to reduce the overload of Logging Handlers.
+    """
+    _handlers = []
+    def add_handler(self, handler:logging.Handler, logger:logging.Logger):
+        """
+        Adds `handler` to the current `logger` and stores it in `self._handlers`.
+        Should be called during `setUp`.
+        """
+        logger.addHandler(handler)
+        self._handlers.append(handler)
+
+    def remove_handlers(self, logger):
+        """
+        Removes all logging handlers that have been added from `add_handler`.
+        Should be called during `tearDown`
+        """
+        for handler in self._handlers:
+            logger.removeHandler(handler)
+
 def mockenv(**kwargs):
     """
     this is a convenience wrapper, that allows this ::

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1185,6 +1185,7 @@ class TestCasePlus(unittest.TestCase):
             shutil.rmtree(path, ignore_errors=True)
         self.teardown_tmp_dirs = []
 
+
 def mockenv(**kwargs):
     """
     this is a convenience wrapper, that allows this ::


### PR DESCRIPTION
# Fix Loggers repeating themselves during the Examples tests

## What does this add?

This PR refactores slighly how the `stream_handler` is made and passed to `logger` during all of the examples tests

## Why is it needed?

When running the `no_trainer` tests, I was noticing that after each test was called the data would repeat itself. So after test 1 it was only logged once, test 2 twice, etc. 

For example something like the following was printed:
```
***** Running training *****
***** Running training *****
***** Running training *****
  Num examples = 10
  Num examples = 10
  Num examples = 10
```
After further investigation, I found that this was due to the `stream_handler` being added at the start of each test. As discussed in this [SO post I found](https://stackoverflow.com/questions/6729268/log-messages-appearing-twice-with-python-logging), since the loggers are global we keep adding more handlers without actually removing them. 

As a result we kept getting multitudes of sys.stdout loggers being added, leading to these multiple print statements each time. 

The fix is before each test case is written, add in our handler (e.g.):
```python
stream_handler = logging.StreamHandler(sys.stdout)
logger.addHandler(stream_handler)

class SomeTestCase(TestCasePlus):
  ...
```

Also unsure why this didn't quite happen during CircleCI, but this was what occurred locally for me