### PR TITLE
fixed crash when deleting older checkpoint and files with name f"{checkpoint_prefix}-*" exist

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2200,7 +2200,7 @@ class Trainer:
     ) -> List[str]:
         ordering_and_checkpoint_path = []
 
-        glob_checkpoints = [str(x) for x in Path(output_dir).glob(f"{checkpoint_prefix}-*")]
+        glob_checkpoints = [str(x) for x in Path(output_dir).glob(f"{checkpoint_prefix}-*") if os.path.isdir(x)]
 
         for path in glob_checkpoints:
             if use_mtime:


### PR DESCRIPTION
What does this PR do?


I create an archive of older checkpoints during training the checkpoint has a  name with `f"{checkpoint_prefix}-*.zip/.tar ` 
previously `glob(f"{checkpoint_prefix}-*")` takes all files/folders starting with the name checkpoint, and later `shutil.rmtree(checkpoint)` takes a folder name; since at some point it my get a zip file; it crashes training; adding this `if os.path.isdir(x)` allows only folders on `glob_checkpoints`. 

let's say output folder structure is like: (with `save_limit=5`)
```
checkpoint-36000
checkpoint-35000
checkpoint-34000
checkpoint-33000
checkpoint-33000.zip
```
then code attempts to remove oldest checkpoint 
since  we have a file (checkpoint-33000.zip) and pass the file to `shutil.rmtree(checkpoint)` to delete it will fail.

by avoiding storing files on `glob_checkpoints` this will get fixed! ( checking everything is folder as checkpoints are folders not single files.) 

**Before submitting:**

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x]  Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

Who can review?

@sgugger 


