### PR TITLE
Rename the method test_torchscript 

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -582,7 +582,7 @@ class ModelTesterMixin:
                     )
 
     @slow
-    def test_torchscript(self):
+    def test_torchscript_simple(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         self._create_and_check_torchscript(config, inputs_dict)
 


### PR DESCRIPTION
# What does this PR do?

`class ModelTesterMixin` has attribute `test_torchscript` as well as method named `def test_torchscript`.

In a few model specific test files, we have `test_torchscript = True` defined, for example, 

`T5ModelTest`:
https://github.com/huggingface/transformers/blob/7c5d79912a21880ce13d77881940458e90d98917/tests/t5/test_modeling_t5.py#L515

`DistilBertModelTest`:
https://github.com/huggingface/transformers/blob/7c5d79912a21880ce13d77881940458e90d98917/tests/distilbert/test_modeling_distilbert.py#L214

This actually makes the `test_torchscript` **being a boolean value** instead of a method, therefore `test_torchscript` is **not run** for these places. See the last section for a dummy example.

## Fix

Although this could be fixed just by removing `test_torchscript = True`, it would be a better idea to rename the method `def test_torchscript` to something else like `def test_torchscript_simple`.

## Dummy example (to reproduce the issue)

```python
class DummyCommonTest:

    test_me = True

    def test_me(self):
        a = 3
        print(a)

class DummyModelTest1(DummyCommonTest):

    pass

class DummyModelTest2(DummyCommonTest):

    test_me = True

dummy_test = DummyCommonTest()
print(dummy_test.test_me)
dummy_test.test_me()

dummy_model_test_1 = DummyModelTest1()
# A method
print(dummy_model_test_1.test_me)
# can be called
dummy_model_test_1.test_me()

dummy_model_test_2 = DummyModelTest2()
# A boolean
print(dummy_model_test_2.test_me)
# can't be called: (TypeError: 'bool' object is not callable)
dummy_model_test_2.test_me()
```

