### PR TITLE
Fix drop_path_rates argument passed to ConvNextStage

### DIFF
--- a/src/transformers/models/convnext/modeling_convnext.py
+++ b/src/transformers/models/convnext/modeling_convnext.py
@@ -218,7 +218,7 @@ class ConvNextEncoder(nn.Module):
                 out_channels=out_chs,
                 stride=2 if i > 0 else 1,
                 depth=config.depths[i],
-                drop_path_rates=drop_path_rates[cur],
+                drop_path_rates=drop_path_rates[cur:],
             )
             self.stages.append(stage)
             cur += config.depths[i]


### PR DESCRIPTION
# What does this PR do?

- Pass a sub-list of `drop_path_rates` to ConvNextStage  instead of a single element.
- Fix the following issue: 
Argument `drop_path_rates (List[float])` passed to `ConvNextStage` is a single float
when `drop_path_rate` is specified by the config.


Reproducer:
```
from transformers import ConvNextModel, ConvNextConfig

configuration = ConvNextConfig(drop_path_rate=0.1)
model = ConvNextModel(configuration)
```
Throws:
```
Traceback (most recent call last):
  File "repro-droprate.py", line 4, in <module>
    model = ConvNextModel(configuration)
  File "/home/alexandrec/.local/lib/python3.6/site-packages/transformers/models/convnext/modeling_convnext.py", line 311, in __init__
    self.encoder = ConvNextEncoder(config)
  File "/home/alexandrec/.local/lib/python3.6/site-packages/transformers/models/convnext/modeling_convnext.py", line 221, in __init__
    drop_path_rates=drop_path_rates[cur],
  File "/home/alexandrec/.local/lib/python3.6/site-packages/transformers/models/convnext/modeling_convnext.py", line 197, in __init__
    *[ConvNextLayer(config, dim=out_channels, drop_path=drop_path_rates[j]) for j in range(depth)]
  File "/home/alexandrec/.local/lib/python3.6/site-packages/transformers/models/convnext/modeling_convnext.py", line 197, in <listcomp>
    *[ConvNextLayer(config, dim=out_channels, drop_path=drop_path_rates[j]) for j in range(depth)]
TypeError: 'float' object is not subscriptable
```
Reproduced with Transformers 4.18.0 , Ubuntu 18.04 + Python 3.6.9

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->