### PR TITLE
fix image type DETR feature extraction for panoptic segmentation

### DIFF
--- a/src/transformers/models/detr/feature_extraction_detr.py
+++ b/src/transformers/models/detr/feature_extraction_detr.py
@@ -306,6 +306,9 @@ class DetrFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin):
             target["iscrowd"] = np.asarray([ann["iscrowd"] for ann in ann_info["segments_info"]], dtype=np.int64)
             target["area"] = np.asarray([ann["area"] for ann in ann_info["segments_info"]], dtype=np.float32)
 
+        if isinstance(image, Image.Image):
+            image = self.to_numpy_array(image)
+
         return image, target
 
     def _resize(self, image, size, target=None, max_size=None):


### PR DESCRIPTION
# What does this PR do?

The __call__ function of the DETR, expects an object with a `shape` when `pad_and_return_pixel_mask=True`
If try to use the extract feature with `do_resize=False` and `do_normalize=False` will crash on https://github.com/huggingface/transformers/blob/69233cf03be5fbce0492f3997e139c4d05499e27/src/transformers/models/detr/feature_extraction_detr.py#L584
because if pass the image as PIL format will need to convert this to an object with shape. And the conversion to Numpy array is done on this PR, to fix at `prepare_coco_panoptic`.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@NielsRogge 
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.