### PR TITLE
Remove duplicate header in doc

### DIFF
--- a/docs/source/en/serialization.mdx
+++ b/docs/source/en/serialization.mdx
@@ -491,9 +491,6 @@ Exporting a model requires two things:
 
 These necessities imply several things developers should be careful about. These are detailed below.
 
-
-### Implications
-
 ### TorchScript flag and tied weights
 
 This flag is necessary because most of the language models in this repository have tied weights between their


### PR DESCRIPTION
# What does this PR do?

<s>`doc-builder` doesn't accept duplicated headers anymore, this PR should fix the doc build. Will merge as soon as the Build Doc PR job is green to fix the main branch :-)</s>

The change has been reverted on the `doc-builder` side, but this was a mistake worth fixing anyway.