### PR TITLE
Partial checkpoint support for SMP

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1362,6 +1362,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     del state_dict[ignore_key]
 
         from .utils import is_sagemaker_mp_enabled
+
         if is_sagemaker_mp_enabled():
             # Do not shard checkpoints when sagemaker model parallel is enabled
             output_model_file = os.path.join(save_directory, WEIGHTS_NAME)

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -424,11 +424,14 @@ class TrainingArguments:
             Whether or not the inputs will be passed to the `compute_metrics` function. This is intended for metrics
             that need inputs, predictions and references for scoring calculation in Metric class.
         smp_save_partial (`bool`, *optional*, defaults to `False`):
-            If True, saves checkpoints partially. `"smp_save_partial"` can only be used with Sagemaker Model Parallel library.
+            If True, saves checkpoints partially. `"smp_save_partial"` can only be used with Sagemaker Model Parallel
+            library.
         smp_load_partial (`bool`, *optional*, defaults to `False`):
-            If True, loads partial checkpoints. `"smp_load_partial"` can only be used with Sagemaker Model Parallel library.
+            If True, loads partial checkpoints. `"smp_load_partial"` can only be used with Sagemaker Model Parallel
+            library.
         smp_tensor_parallel_full_model (`bool`, *optional*, defaults to `False`):
-            If True, apply tensor paralellism for the full model. `"smp_tensor_parallel_full_model"` can only be used with Sagemaker Model Parallel library.
+            If True, apply tensor paralellism for the full model. `"smp_tensor_parallel_full_model"` can only be used
+            with Sagemaker Model Parallel library.
     """
 
     output_dir: str = field(
@@ -758,7 +761,9 @@ class TrainingArguments:
     )
     smp_save_partial: bool = field(default=False, metadata={"help": "Save checkpoints partially for SMP."})
     smp_load_partial: bool = field(default=False, metadata={"help": "Load partial checkpoints for SMP."})
-    smp_tensor_parallel_full_model: bool = field(default=False, metadata={"help": "Enables tensor parallelism for full model in SMP."})
+    smp_tensor_parallel_full_model: bool = field(
+        default=False, metadata={"help": "Enables tensor parallelism for full model in SMP."}
+    )
 
     # Deprecated arguments
     fp16_backend: str = field(
@@ -996,16 +1001,20 @@ class TrainingArguments:
             )
 
         if (self.smp_save_partial or self.smp_load_partial) and not is_sagemaker_mp_enabled():
-            raise ValueError(f"smp_save_partial and smp_load_partial can only be used with Sagemaker Model Parallel library.")
+            raise ValueError(
+                f"smp_save_partial and smp_load_partial can only be used with Sagemaker Model Parallel library."
+            )
 
-        if (is_sagemaker_mp_enabled() and not self.smp_save_partial and smp.state.cfg.shard_optimizer_state ):
-            warnings.warn("Optimizer sharding can only be used with partial checkpointing. Switching to partial checkpointing.")
+        if is_sagemaker_mp_enabled() and not self.smp_save_partial and smp.state.cfg.shard_optimizer_state:
+            warnings.warn(
+                "Optimizer sharding can only be used with partial checkpointing. Switching to partial checkpointing."
+            )
             self.smp_save_partial = True
 
-        if (is_sagemaker_mp_enabled() and self.smp_save_partial and self.load_best_model_at_end ):
+        if is_sagemaker_mp_enabled() and self.smp_save_partial and self.load_best_model_at_end:
             self.smp_load_partial = True
 
-        if (is_sagemaker_mp_enabled() and (not self.smp_save_partial) and (self.save_strategy != IntervalStrategy.NO)):
+        if is_sagemaker_mp_enabled() and (not self.smp_save_partial) and (self.save_strategy != IntervalStrategy.NO):
             warnings.warn("Saving weights but not the optimizer state.")
 
     def __str__(self):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -423,6 +423,12 @@ class TrainingArguments:
         include_inputs_for_metrics (`bool`, *optional*, defaults to `False`):
             Whether or not the inputs will be passed to the `compute_metrics` function. This is intended for metrics
             that need inputs, predictions and references for scoring calculation in Metric class.
+        smp_save_partial (`bool`, *optional*, defaults to `False`):
+            If True, saves checkpoints partially. `"smp_save_partial"` can only be used with Sagemaker Model Parallel library.
+        smp_load_partial (`bool`, *optional*, defaults to `False`):
+            If True, loads partial checkpoints. `"smp_load_partial"` can only be used with Sagemaker Model Parallel library.
+        smp_tensor_parallel_full_model (`bool`, *optional*, defaults to `False`):
+            If True, apply tensor paralellism for the full model. `"smp_tensor_parallel_full_model"` can only be used with Sagemaker Model Parallel library.
     """
 
     output_dir: str = field(
@@ -750,6 +756,10 @@ class TrainingArguments:
     include_inputs_for_metrics: bool = field(
         default=False, metadata={"help": "Whether or not the inputs will be passed to the `compute_metrics` function."}
     )
+    smp_save_partial: bool = field(default=False, metadata={"help": "Save checkpoints partially for SMP."})
+    smp_load_partial: bool = field(default=False, metadata={"help": "Load partial checkpoints for SMP."})
+    smp_tensor_parallel_full_model: bool = field(default=False, metadata={"help": "Enables tensor parallelism for full model in SMP."})
+
     # Deprecated arguments
     fp16_backend: str = field(
         default="auto",
@@ -985,6 +995,19 @@ class TrainingArguments:
                 FutureWarning,
             )
 
+        if (self.smp_save_partial or self.smp_load_partial) and not is_sagemaker_mp_enabled():
+            raise ValueError(f"smp_save_partial and smp_load_partial can only be used with Sagemaker Model Parallel library.")
+
+        if (is_sagemaker_mp_enabled() and not self.smp_save_partial and smp.state.cfg.shard_optimizer_state ):
+            warnings.warn("Optimizer sharding can only be used with partial checkpointing. Switching to partial checkpointing.")
+            self.smp_save_partial = True
+
+        if (is_sagemaker_mp_enabled() and self.smp_save_partial and self.load_best_model_at_end ):
+            self.smp_load_partial = True
+
+        if (is_sagemaker_mp_enabled() and (not self.smp_save_partial) and (self.save_strategy != IntervalStrategy.NO)):
+            warnings.warn("Saving weights but not the optimizer state.")
+
     def __str__(self):
         self_as_dict = asdict(self)
 
@@ -1218,7 +1241,10 @@ class TrainingArguments:
             return self.local_process_index == 0
         else:
             if is_sagemaker_mp_enabled():
-                return smp.rank() == 0
+                if self.smp_save_partial:
+                    return smp.rdp_rank() == 0
+                else:
+                    return smp.rank() == 0
             else:
                 return self.process_index == 0
 


### PR DESCRIPTION
# What does this PR do?

- Adds 3 new training args(`smp_save_partial` and `smp_load_partial`) to support partial checkpointing with SMP. `smp_tensor_parallel_full_model` to apply tensor parallelism to whole model. 
- Uses the right ranks for partial checkpoint saving in should_save.
- Uses `local_state_dict()` with partial checkpoint saving.
- Uses `smp.save` instead of `torch.save` when partial checkpoint saving is enabled. 
- Uses `smp.load` instead of `torch.load` when partial checkpoint loading is enabled.  Reorders partial checkpoint loading to happen after wrapping of model, since `smp.load` can only load to a smp model.
- Updated checks for the existence of checkpoint files since smp partial checkpoints contain postfixes in addition to filename(example: filename_0_0 or filename_0_0_0).
- Skip checkpoint sharding when smp is enabled. 
- `smp_gather` is causing increased memory usage on GPU0 when tensor parallelism is enabled. Switches to `distributed_concat` for ddp. 
- adds `load_best_model_at_end` support for SMP.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/master/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
