### PR TITLE
[TAPEX] Update drop_rows_to_fit

### DIFF
--- a/src/transformers/models/tapex/tokenization_tapex.py
+++ b/src/transformers/models/tapex/tokenization_tapex.py
@@ -258,9 +258,9 @@ class TapexTokenizer(PreTrainedTokenizer):
             Maximum number of characters per cell when linearizing a table. If this number is exceeded, truncation
             takes place.
         drop_rows_to_fit (`bool`, *optional*, defaults to `False`):
-            Whether to truncate the table to a maximum length specified with the argument `max_length` or to the
-            maximum acceptable input length for the model if that argument is not provided. This will randomly drop
-            unrelated rows based on the `answer` provided.
+            Whether to truncate the table to a maximum length specified with the argument `max_length` in the
+            `__call__` method of the tokenizer or to the maximum acceptable input length for the model if that argument
+            is not provided. This will randomly drop unrelated rows based on the `answer` provided.
     """
 
     vocab_files_names = VOCAB_FILES_NAMES


### PR DESCRIPTION
# What does this PR do?

This PR makes `drop_rows_to_fit` an attribute of `TapexTokenizer`, rather than a standalone `TruncationStrategy`.

The truncation strategies that can be used are the same as those of BART (as TAPEX is a BART model), meaning `truncation=True` will truncate to the maximum length. However, one can still randomly drop rows based on answers using this attribute.