### PR TITLE
Reduce Funnel PT/TF diff

### DIFF
--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -84,7 +84,7 @@ class TFFunnelEmbeddings(tf.keras.layers.Layer):
 
         self.vocab_size = config.vocab_size
         self.hidden_size = config.hidden_size
-        self.initializer_std = 1.0 if self.config.initializer_std is None else self.config.initializer_std
+        self.initializer_std = 1.0 if config.initializer_std is None else config.initializer_std
 
         self.LayerNorm = tf.keras.layers.LayerNormalization(epsilon=config.layer_norm_eps, name="layer_norm")
         self.dropout = tf.keras.layers.Dropout(rate=config.hidden_dropout)

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -84,7 +84,7 @@ class TFFunnelEmbeddings(tf.keras.layers.Layer):
 
         self.vocab_size = config.vocab_size
         self.hidden_size = config.hidden_size
-        self.initializer_range = config.initializer_range
+        self.initializer_std = 1.0 if self.config.initializer_std is None else self.config.initializer_std
 
         self.LayerNorm = tf.keras.layers.LayerNormalization(epsilon=config.layer_norm_eps, name="layer_norm")
         self.dropout = tf.keras.layers.Dropout(rate=config.hidden_dropout)
@@ -94,7 +94,7 @@ class TFFunnelEmbeddings(tf.keras.layers.Layer):
             self.weight = self.add_weight(
                 name="weight",
                 shape=[self.vocab_size, self.hidden_size],
-                initializer=get_initializer(initializer_range=self.initializer_range),
+                initializer=get_initializer(initializer_range=self.initializer_std),
             )
 
         super().build(input_shape)

--- a/tests/funnel/test_modeling_funnel.py
+++ b/tests/funnel/test_modeling_funnel.py
@@ -65,6 +65,7 @@ class FunnelModelTester:
         activation_dropout=0.0,
         max_position_embeddings=512,
         type_vocab_size=3,
+        initializer_std=0.02,  # Set to a smaller value, so we can keep the small error threshold (1e-5) in the test
         num_labels=3,
         num_choices=4,
         scope=None,
@@ -94,6 +95,7 @@ class FunnelModelTester:
         self.num_labels = num_labels
         self.num_choices = num_choices
         self.scope = scope
+        self.initializer_std = initializer_std
 
         # Used in the tests to check the size of the first attention layer
         self.num_attention_heads = n_head
@@ -154,6 +156,7 @@ class FunnelModelTester:
             activation_dropout=self.activation_dropout,
             max_position_embeddings=self.max_position_embeddings,
             type_vocab_size=self.type_vocab_size,
+            initializer_std=self.initializer_std,
         )
 
     def create_and_check_model(


### PR DESCRIPTION
# What does this PR do?

Same as #15684, but on PT test side.

As mentioned in #15684, this is not a real bug in model. Just a setting in the test configuration.

## Comment

The change in `modeling_tf_funnel.py` is to address **a real issue** regarding **weight initialization**, see

https://github.com/huggingface/transformers/blob/15de7a010ddcdec0532b30d1eb6c28e7b314a6a9/src/transformers/models/funnel/configuration_funnel.py#L79-L84
and
https://github.com/huggingface/transformers/blob/15de7a010ddcdec0532b30d1eb6c28e7b314a6a9/src/transformers/models/funnel/modeling_funnel.py#L812-L814

**(But, this issue is not the cause of the large diff between PT/TF)**