### PR TITLE
CI: setup-dependent pip cache

### DIFF
--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -24,9 +24,6 @@ jobs:
         with:
           path: ~/.cache/pip
           key: v1-tests_model_like-${{ hashFiles('setup.py') }}
-          restore-keys: |
-            v1-tests_model_like-${{ hashFiles('setup.py') }}
-            v1-tests_model_like
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -23,7 +23,7 @@ jobs:
         id: cache
         with:
           path: ~/.cache/pip
-          key: v1-tests_model_like
+          key: v1-tests_model_like-${{ hashFiles('setup.py') }}
           restore-keys: |
             v1-tests_model_like-${{ hashFiles('setup.py') }}
             v1-tests_model_like

--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -29,10 +29,7 @@ jobs:
         id: cache
         with:
           path: ~/.cache/pip
-          key: v1.2-tests_templates
-          restore-keys: |
-            v1.2-tests_templates-${{ hashFiles('setup.py') }}
-            v1.2-tests_templates
+          key: v1.2-tests_templates-${{ hashFiles('setup.py') }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -15,16 +15,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Loading cache.
         uses: actions/cache@v2
         id: cache
         with:
           path: ~/.cache/pip
-          key: v1-metadata
-          restore-keys: |
-            v1-metadata-${{ hashFiles('setup.py') }}
-            v1-metadata
+          key: v1-metadata-${{ hashFiles('setup.py') }}
 
       - name: Setup environment
         run: |
@@ -33,4 +30,3 @@ jobs:
       - name: Update metadata
         run: |
           python utils/update_metadata.py --token ${{ secrets.SYLVAIN_HF_TOKEN }} --commit_sha ${{ github.sha }}
-


### PR DESCRIPTION
# What does this PR do?

This PR makes two changes to the way we cache our pip dependencies in the `add-model-like.yml` GH actions workflow:
1. The name of the cache depends on the hash of `setup.py`;
2. We do not restore the cache from partial name matches.

(this pattern exists in one of our CI files, `github-torch-hub.yml` , [here](https://github.com/huggingface/transformers/blob/main/.github/workflows/github-torch-hub.yml#L30))

Together, these changes will make us start from a fresh environment whenever we change `setup.py`. Having a stale cache was causing us to have dependency problems (e.g. [old, incompatible protobuf version](https://github.com/huggingface/transformers/runs/6007067240?check_suite_focus=true)), and potentially miss dependency issues from fresh installs.

If you agree, I will also port these changes to `model-templates.yml` and `update_metdata.yml`, which have the same pattern/issue. EDIT: ported.