### PR TITLE
Update GPT2 I/O definition to be recognized by ORT optimizer.

### DIFF
--- a/src/transformers/models/gpt2/configuration_gpt2.py
+++ b/src/transformers/models/gpt2/configuration_gpt2.py
@@ -249,25 +249,25 @@ class GPT2OnnxConfig(OnnxConfigWithPast):
 
                 batch, seqlen = common_inputs["input_ids"].shape
                 # Not using the same length for past_key_values
-                past_key_values_length = seqlen + 2
+                past_key_values_length = 1
                 past_shape = (
+                    2,
                     batch,
                     self.num_attention_heads,
                     past_key_values_length,
                     self._config.hidden_size // self.num_attention_heads,
                 )
                 ordered_inputs["past_key_values"] = [
-                    (torch.zeros(past_shape), torch.zeros(past_shape)) for _ in range(self.num_layers)
+                    torch.zeros(past_shape, dtype=torch.float32) for _ in range(self.num_layers)
                 ]
 
-        ordered_inputs["attention_mask"] = common_inputs["attention_mask"]
-        if self.use_past:
-            ordered_inputs["attention_mask"] = torch.cat(
-                [ordered_inputs["attention_mask"], torch.ones(batch, past_key_values_length)], dim=1
-            )
+            if self.use_past:
+                ordered_inputs["attention_mask"] = torch.ones(batch, seqlen + past_key_values_length, dtype=torch.int64)
+        else:
+            ordered_inputs["attention_mask"] = common_inputs["attention_mask"].long()
 
         return ordered_inputs
 
     @property
     def default_onnx_opset(self) -> int:
-        return 13
+        return 11

--- a/src/transformers/models/gpt2/configuration_gpt2.py
+++ b/src/transformers/models/gpt2/configuration_gpt2.py
@@ -262,7 +262,9 @@ class GPT2OnnxConfig(OnnxConfigWithPast):
                 ]
 
             if self.use_past:
-                ordered_inputs["attention_mask"] = torch.ones(batch, seqlen + past_key_values_length, dtype=torch.int64)
+                ordered_inputs["attention_mask"] = torch.ones(
+                    batch, seqlen + past_key_values_length, dtype=torch.int64
+                )
         else:
             ordered_inputs["attention_mask"] = common_inputs["attention_mask"].long()
 

--- a/src/transformers/models/gpt2/configuration_gpt2.py
+++ b/src/transformers/models/gpt2/configuration_gpt2.py
@@ -251,7 +251,7 @@ class GPT2OnnxConfig(OnnxConfigWithPast):
                 # Not using the same length for past_key_values
                 past_key_values_length = 1
                 past_shape = (
-                    2,
+                    2,  # Key AND Values
                     batch,
                     self.num_attention_heads,
                     past_key_values_length,

--- a/src/transformers/models/gpt_neo/configuration_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/configuration_gpt_neo.py
@@ -259,7 +259,9 @@ class GPTNeoOnnxConfig(OnnxConfigWithPast):
                 ]
 
             if self.use_past:
-                ordered_inputs["attention_mask"] = torch.ones(batch, seqlen + past_key_values_length, dtype=torch.int64)
+                ordered_inputs["attention_mask"] = torch.ones(
+                    batch, seqlen + past_key_values_length, dtype=torch.int64
+                )
         else:
             ordered_inputs["attention_mask"] = common_inputs["attention_mask"].long()
 

--- a/src/transformers/models/gptj/configuration_gptj.py
+++ b/src/transformers/models/gptj/configuration_gptj.py
@@ -211,7 +211,9 @@ class GPTJOnnxConfig(OnnxConfigWithPast):
                 ]
 
             if self.use_past:
-                ordered_inputs["attention_mask"] = torch.ones(batch, seqlen + past_key_values_length, dtype=torch.int64)
+                ordered_inputs["attention_mask"] = torch.ones(
+                    batch, seqlen + past_key_values_length, dtype=torch.int64
+                )
         else:
             ordered_inputs["attention_mask"] = common_inputs["attention_mask"].long()
 

--- a/src/transformers/models/gptj/configuration_gptj.py
+++ b/src/transformers/models/gptj/configuration_gptj.py
@@ -198,24 +198,22 @@ class GPTJOnnxConfig(OnnxConfigWithPast):
 
                 batch, seqlen = common_inputs["input_ids"].shape
                 # Not using the same length for past_key_values
-                past_key_values_length = seqlen + 2
+                past_key_values_length = 1
                 past_shape = (
+                    2,  # Key AND Values
                     batch,
                     self.num_attention_heads,
                     past_key_values_length,
                     self._config.hidden_size // self.num_attention_heads,
                 )
                 ordered_inputs["past_key_values"] = [
-                    (torch.zeros(past_shape), torch.zeros(past_shape)) for _ in range(self.num_layers)
+                    torch.zeros(past_shape, dtype=torch.float32) for _ in range(self.num_layers)
                 ]
 
-        ordered_inputs["attention_mask"] = common_inputs["attention_mask"]
-        if self.use_past:
-            ordered_inputs["attention_mask"] = torch.cat(
-                [ordered_inputs["attention_mask"], torch.ones(batch, past_key_values_length)], dim=1
-            )
-
-        return ordered_inputs
+            if self.use_past:
+                ordered_inputs["attention_mask"] = torch.ones(batch, seqlen + past_key_values_length, dtype=torch.int64)
+        else:
+            ordered_inputs["attention_mask"] = common_inputs["attention_mask"].long()
 
     @property
     def default_onnx_opset(self) -> int:

--- a/src/transformers/onnx/config.py
+++ b/src/transformers/onnx/config.py
@@ -628,7 +628,7 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
         remaining_side_name = "encoder" if num_encoder_layers > num_decoder_layers else "decoder"
 
         encoder_sequence = "past_encoder_sequence"
-        decoder_sequence = "past_decoder_sequence" if direction == "inputs" else "past_sequence + sequence"
+        decoder_sequence = "past_decoder_sequence" if direction == "inputs" else "past_decoder_sequence + sequence"
 
         for i in range(min_num_layers):
             inputs_or_outputs[f"{name}.{i}.decoder.key"] = {0: "batch", 2: decoder_sequence}

--- a/src/transformers/onnx/config.py
+++ b/src/transformers/onnx/config.py
@@ -101,10 +101,7 @@ class OnnxConfig(ABC):
 
         self._patching_specs = []
         for spec in patching_specs if patching_specs is not None else []:
-            final_spec = spec
-            if spec.orig_op is None:
-                final_spec = dataclasses.replace(spec, orig_op=getattr(spec.o, spec.name))
-            self._patching_specs.append(final_spec)
+            self.install_patching_spec(spec)
 
     @classmethod
     def from_model_config(cls, config: "PretrainedConfig", task: str = "default") -> "OnnxConfig":
@@ -245,6 +242,17 @@ class OnnxConfig(ABC):
             data = np.random.rand(image_height, image_width, num_channels) * 255
             images.append(Image.fromarray(data.astype("uint8")).convert("RGB"))
         return images
+
+    def install_patching_spec(self, spec: PatchingSpec):
+        """
+        Append a patching spec after initialization of the configuration
+        :param spec:
+        :return:
+        """
+        if spec.orig_op is None:
+            spec = dataclasses.replace(spec, orig_op=getattr(spec.o, spec.name))
+
+        self._patching_specs.append(spec)
 
     def generate_dummy_inputs(
         self,

--- a/src/transformers/onnx/config.py
+++ b/src/transformers/onnx/config.py
@@ -466,7 +466,11 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
 
             if "attention_mask" in common_inputs:
                 common_inputs["attention_mask"] = torch.cat(
-                    [common_inputs["attention_mask"], torch.ones(batch, seqlen + past_key_values_length, dtype=torch.int64)], dim=1
+                    [
+                        common_inputs["attention_mask"],
+                        torch.ones(batch, seqlen + past_key_values_length, dtype=torch.int64),
+                    ],
+                    dim=1,
                 )
 
             common_inputs["past_key_values"] = []

--- a/src/transformers/onnx/convert.py
+++ b/src/transformers/onnx/convert.py
@@ -31,6 +31,7 @@ from ..utils import (
 )
 from .config import OnnxConfig, OnnxConfigWithPast
 
+
 if is_torch_available():
     from ..modeling_utils import PreTrainedModel
 
@@ -374,11 +375,14 @@ def validate_model_outputs(
     for name, value in reference_model_inputs.items():
         if isinstance(value, (list, tuple)):
             value = config.flatten_output_collection_property(name, value)
-            onnx_inputs.update({
-                tensor_name: np.stack([t.numpy() for t in pt_tensor])
-                if isinstance(pt_tensor, tuple) else pt_tensor.numpy()
-                for tensor_name, pt_tensor in value.items()
-            })
+            onnx_inputs.update(
+                {
+                    tensor_name: np.stack([t.numpy() for t in pt_tensor])
+                    if isinstance(pt_tensor, tuple)
+                    else pt_tensor.numpy()
+                    for tensor_name, pt_tensor in value.items()
+                }
+            )
         else:
             onnx_inputs[name] = value.numpy()
 

--- a/src/transformers/onnx/utils.py
+++ b/src/transformers/onnx/utils.py
@@ -87,14 +87,16 @@ if is_torch_available():
                     # Since transformers v4.*, past key and values are separated outputs.
                     # Here we concatenate them into one tensor to be compatible with Attention operator.
                     present.append(
-                        torch.cat((
-                            result["past_key_values"][i][0].unsqueeze(0),
-                            result["past_key_values"][i][1].unsqueeze(0)
-                        ), dim=0)
+                        torch.cat(
+                            (
+                                result["past_key_values"][i][0].unsqueeze(0),
+                                result["past_key_values"][i][1].unsqueeze(0),
+                            ),
+                            dim=0,
+                        )
                     )
                 return {"logits": result["logits"], "past_key_values": tuple(present)}
             else:
                 return result
 
         return compatible_forward
-


### PR DESCRIPTION
This PR aims at making the GPT2 + past more compatible with ONNX Runtime optimizer (especially attention fusion).
Past key values should be presented as a single tensor with both key and value stacked on the leading axis.

It also provide a concat mecanism to merge the resulting past key values so it's a single tensor too.

- [x] I/O shapes changes
- [x] I/O dtype changes
- [ ] Past keys wrapper
- [ ] Monkey Patching
- [ ] Unittests