### PR TITLE
Kill async pushes when calling push_to_hub with blocking=True

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2904,6 +2904,11 @@ class Trainer:
         if not self.is_world_process_zero():
             return
 
+        # Cancel any async push in progress if blocking=True. The commits will all be pushed together.
+        if blocking and self.push_in_progress is not None and not self.push_in_progress.is_done:
+            self.push_in_progress._process.kill()
+            self.push_in_progress = None
+
         git_head_commit_url = self.repo.push_to_hub(
             commit_message=commit_message, blocking=blocking, auto_lfs_prune=True
         )


### PR DESCRIPTION
# What does this PR do?

This PR fixes a bug that sometimes appear in the `Trainer` when `push_to_hub=True`: if one of the async pushes finishes after a regular non-async push, the history gets messed up and we end up with an error like this:

```
The push command with PID 1468 failed.
remote: error: cannot lock ref 'refs/heads/main': is at 07c85fd69cd46a7daee6323c5a5eefc3e6a886da but expected 1fd7f122ef725f8e340a14bc97d537812de44076      
```

To fix this, when the `Trainer` (or the user) calls `push_to_hub` with `blocking=True`, we interrupt any push in progress. The commit history will still be good since the commit don't take time.

cc @philschmid who had the error.