### PR TITLE
CI: pip install now updates

### DIFF
--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -28,9 +28,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip!=21.3
-          pip install -U click  # Click 7 is installed in the environment by default, but we need at least version 8 for Black
           sudo apt -y update && sudo apt install -y libsndfile1-dev
-          pip install .[dev]
+          pip install .[dev] -U
 
       - name: Create model files
         run: |

--- a/.github/workflows/github-torch-hub.yml
+++ b/.github/workflows/github-torch-hub.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         pip install --upgrade pip
         # install torch-hub specific dependencies
-        pip install -e git+https://github.com/huggingface/transformers.git#egg=transformers[torchhub]
+        pip install -e git+https://github.com/huggingface/transformers.git#egg=transformers[torchhub] -U
         # no longer needed
         pip uninstall -y transformers
 

--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           pip install --upgrade pip!=21.3
           sudo apt -y update && sudo apt install -y libsndfile1-dev
-          pip install .[dev]
+          pip install .[dev] -U
       - name: Create model files
         run: |
           transformers-cli add-new-model --testing --testing_file=templates/adding_a_new_model/tests/encoder-bert-tokenizer.json --path=templates/adding_a_new_model

--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Setup environment
         run: |
-          pip install git+https://github.com/huggingface/transformers#egg=transformers[dev]
+          pip install git+https://github.com/huggingface/transformers#egg=transformers[dev] -U
 
       - name: Update metadata
         run: |


### PR DESCRIPTION
# What does this PR do?

Follow up from https://github.com/huggingface/transformers/pull/16751: `pip install` in non-remote GHA workflows now updates packages, to allow us to override pre-installed versions.