### PR TITLE
[Flax `.from_pretrained`] Raise a warning if model weights are not in float32

### DIFF
--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -666,16 +666,16 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
         # raise a warning if any of the parameters are not in jnp.float32
         if len(fp16_params) > 0:
             logger.warning(
-                f"Some of the weights of {model.__class__.__name__} were initialized from the model checkpoint at {pretrained_model_name_or_path} "
-                f"in float16 precision:\n{fp16_params}\n"
+                f"Some of the weights of {model.__class__.__name__} were initialized in float16 precision from "
+                f"the model checkpoint at {pretrained_model_name_or_path}:\n{fp16_params}\n"
                 "You should probably UPCAST the model weights to float32 if this was not intended. "
                 "See [`~FlaxPreTrainedModel.to_fp32`] for further information on how to do this."
             )
 
         if len(bf16_params) > 0:
             logger.warning(
-                f"Some of the weights of {model.__class__.__name__} were initialized from the model checkpoint at {pretrained_model_name_or_path} "
-                f"in bfloat16 precision:\n{bf16_params}\n"
+                f"Some of the weights of {model.__class__.__name__} were initialized in bfloat16 precision from "
+                f"the model checkpoint at {pretrained_model_name_or_path}:\n{bf16_params}\n"
                 "You should probably UPCAST the model weights to float32 if this was not intended. "
                 "See [`~FlaxPreTrainedModel.to_fp32`] for further information on how to do this."
             )


### PR DESCRIPTION
The Flax `.from_pretrained` method respects the dtype of the model weights from which it is loaded. For model weights stored in bfloat16/float16, Flax models are instantiated with parameter weights in bfloat16/float16 respectively (see #16736). The general assumption is that all Flax model weights are in float32. Loading and storing model weights in a lower precision (bfloat16/float16) is likely to lead to undesirable behaviour and model instabilities. This PR adds a warning to the `.from_pretrained` method should any of the model weights not be in float32, and advices the user to upcast the weights to float32 prior to use.