### PR TITLE
Fix batch size in evaluation loop

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2411,7 +2411,7 @@ class Trainer:
             elif args.bf16_full_eval:
                 model = model.to(dtype=torch.bfloat16, device=args.device)
 
-        batch_size = self.args.per_device_eval_batch_size
+        batch_size = self.args.eval_batch_size
 
         logger.info(f"***** Running {description} *****")
         if has_length(dataloader):
@@ -2548,6 +2548,7 @@ class Trainer:
         # Number of losses has been rounded to a multiple of batch_size and in a distributed training, the number of
         # samplers has been rounded to a multiple of batch_size, so we truncate.
         if all_losses is not None:
+            print(all_losses)
             all_losses = all_losses[:num_samples]
         if all_preds is not None:
             all_preds = nested_truncate(all_preds, num_samples)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2548,7 +2548,6 @@ class Trainer:
         # Number of losses has been rounded to a multiple of batch_size and in a distributed training, the number of
         # samplers has been rounded to a multiple of batch_size, so we truncate.
         if all_losses is not None:
-            print(all_losses)
             all_losses = all_losses[:num_samples]
         if all_preds is not None:
             all_preds = nested_truncate(all_preds, num_samples)


### PR DESCRIPTION
# What does this PR do?

The batch size used in the evaluation loop is wrong: it's using the per device batch size, which is different from the actual batch size when using DataParallel with more than one GPU. As a result, the `test_evaluate` test is failing for 2 GPUs (see #16716).

This PR fixes that.