### PR TITLE
Fix nightly CI Accelerate failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -623,6 +623,7 @@ jobs:
             - run: pip install --upgrade pip
             - run: pip install .[sklearn,torch,sentencepiece,testing,torch-speech]
             - run: pip install -r examples/pytorch/_tests_requirements.txt
+            - run: pip install git+https://github.com/huggingface/accelerate
             - save_cache:
                   key: v0.4-torch_examples-{{ checksum "setup.py" }}
                   paths:


### PR DESCRIPTION
# Fix Nightly CI Build failures for Accelerate examples

## What does this add?

Changes the `run_examples_torch_all` CircleCI workflow to also install Accelerate from git for the time being, until the next release is performed.

The CI was failing due to accelerate being tested with unreleased fixes and improvements