### PR TITLE
[Research] Speed up evaluation for XTREME-S

### DIFF
--- a/examples/research_projects/xtreme-s/run_xtreme_s.py
+++ b/examples/research_projects/xtreme-s/run_xtreme_s.py
@@ -456,13 +456,9 @@ def main():
         )
     if data_args.language_group is not None:
         if data_args.task != "fleurs-asr":
-            raise ValueError(
-                "--language_group should only be used with --task=fleurs-asr"
-            )
+            raise ValueError("--language_group should only be used with --task=fleurs-asr")
         if data_args.language != "all":
-            raise ValueError(
-                "--language_group should only be used with --language=all"
-            )
+            raise ValueError("--language_group should only be used with --language=all")
 
     if data_args.target_column_name is None:
         target_column_name = TASK_TO_TARGET_COLUMN_NAME[task_name]

--- a/examples/research_projects/xtreme-s/run_xtreme_s.py
+++ b/examples/research_projects/xtreme-s/run_xtreme_s.py
@@ -170,6 +170,15 @@ class DataTrainingArguments:
         default="all",
         metadata={"help": "The language id as defined in the datasets config name or `all` for all languages."},
     )
+    language_group: str = field(
+        default=None,
+        metadata={
+            "help": "The language group to select a subset of languages to train on. "
+            "This option is only used the 'fleurs-asr' task. Should be one of: "
+            "'western_european_we', 'eastern_european_ee', 'central_asia_middle_north_african_cmn', "
+            "'sub_saharan_african_ssa', 'south_asian_sa', 'south_east_asian_sea', 'chinese_japanase_korean_cjk'."
+        },
+    )
     train_split_name: str = field(
         default="train",
         metadata={
@@ -445,6 +454,15 @@ def main():
             "config to be used (e.g. 'pl', 'en.tr', 'fr-FR') or 'all'"
             " for multi-lingual fine-tuning."
         )
+    if data_args.language_group is not None:
+        if data_args.task != "fleurs-asr":
+            raise ValueError(
+                "--language_group should only be used with --task=fleurs-asr"
+            )
+        if data_args.language != "all":
+            raise ValueError(
+                "--language_group should only be used with --language=all"
+            )
 
     if data_args.target_column_name is None:
         target_column_name = TASK_TO_TARGET_COLUMN_NAME[task_name]
@@ -510,6 +528,18 @@ def main():
     if not is_text_target:
         label_list = next(iter(raw_datasets.values())).features[target_column_name].names
         num_labels = len(label_list)
+
+    num_workers = data_args.preprocessing_num_workers
+
+    lang_group = data_args.language_group
+    if lang_group is not None:
+        with training_args.main_process_first(desc="language group filter"):
+            lang_group_id = next(iter(raw_datasets.values())).features["lang_group_id"].str2int(lang_group)
+            raw_datasets = raw_datasets.filter(
+                lambda lang_group: lang_group == lang_group_id,
+                num_proc=num_workers,
+                input_columns=["lang_group_id"],
+            )
 
     # 2. We remove some special characters from the datasets
     # that make training complicated and do not help in transcribing the speech
@@ -680,7 +710,6 @@ def main():
     max_input_length = data_args.max_duration_in_seconds * feature_extractor.sampling_rate
     min_input_length = data_args.min_duration_in_seconds * feature_extractor.sampling_rate
     audio_column_name = data_args.audio_column_name
-    num_workers = data_args.preprocessing_num_workers
 
     # `phoneme_language` is only relevant if the model is fine-tuned on phoneme classification
     phoneme_language = data_args.phoneme_language
@@ -745,13 +774,13 @@ def main():
         logger.info(f"Data preprocessing finished. Files cached at {vectorized_datasets.cache_files}")
         return
 
-    def compute_asr_metric(pred):
-        pred_logits = pred.predictions
-        pred_ids = np.argmax(pred_logits, axis=-1)
+    def asr_logits_argmax(logits, labels):
+        return logits.argmax(dim=-1)
 
+    def compute_asr_metric(pred):
         pred.label_ids[pred.label_ids == -100] = tokenizer.pad_token_id
 
-        pred_str = tokenizer.batch_decode(pred_ids)
+        pred_str = tokenizer.batch_decode(pred.predictions)
         # we do not want to group tokens when computing the metrics
         label_str = tokenizer.batch_decode(pred.label_ids, group_tokens=False)
 
@@ -788,6 +817,7 @@ def main():
             model=model,
             data_collator=data_collator,
             args=training_args,
+            preprocess_logits_for_metrics=asr_logits_argmax if training_args.predict_with_generate else None,
             compute_metrics=compute_asr_metric if training_args.predict_with_generate else None,
             train_dataset=vectorized_datasets["train"] if training_args.do_train else None,
             eval_dataset=vectorized_datasets["eval"] if training_args.do_eval else None,
@@ -798,6 +828,7 @@ def main():
             model=model,
             data_collator=data_collator,
             args=training_args,
+            preprocess_logits_for_metrics=asr_logits_argmax if is_text_target else None,
             compute_metrics=compute_asr_metric if is_text_target else compute_classification_metric,
             train_dataset=vectorized_datasets["train"] if training_args.do_train else None,
             eval_dataset=vectorized_datasets["eval"] if training_args.do_eval else None,


### PR DESCRIPTION
# What does this PR do?

This adds a couple of improvements to the evaluation parts of the XTREME-S script:
* fix the bug where filtering by language happened multiple times for parallel workers (redundantly)
* use `preprocess_logits_for_metrics` to transform the logits into pred_ids before concatenating them to avoid OOMs
* add the `--language_group` parameter to train on the FLEURS dataset in batches of languages (west/eastern european languages, south asian languages etc.)

Misc:
* add `--ctc_zero_infinity` to handle the noisy FLEURS transcriptions