### PR TITLE
CI: non-remote GH Actions now use a python venv

### DIFF
--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -22,28 +22,35 @@ jobs:
         uses: actions/cache@v2
         id: cache
         with:
-          path: ~/.cache/pip
-          key: v1-tests_model_like-${{ hashFiles('setup.py') }}
+          path: ~/venv/
+          key: v2-tests_model_like-${{ hashFiles('setup.py') }}
 
       - name: Install dependencies
         run: |
-          pip install --upgrade pip!=21.3
-          pip install -U click  # Click 7 is installed in the environment by default, but we need at least version 8 for Black
           sudo apt -y update && sudo apt install -y libsndfile1-dev
+
+      - name: Create Virtual Environment on Cache Miss
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          python -m venv ~/venv && . ~/venv/bin/activate
+          pip install --upgrade pip!=21.3
           pip install .[dev]
 
       - name: Create model files
         run: |
+          . ~/venv/bin/activate
           transformers-cli add-new-model-like --config_file tests/fixtures/add_distilbert_like_config.json --path_to_repo .
           make style
           make fix-copies
 
       - name: Run all PyTorch modeling test
         run: |
+          . ~/venv/bin/activate
           python -m pytest -n 2 --dist=loadfile -s --make-reports=tests_new_models tests/bert_new/test_modeling_bert_new.py
 
       - name: Run style changes
         run: |
+          . ~/venv/bin/activate
           make style && make quality && make repo-consistency
 
       - name: Failure short reports

--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -18,18 +18,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Loading cache.
+      - name: Install dependencies
+        run: |
+          sudo apt -y update && sudo apt install -y libsndfile1-dev
+
+      - name: Load cached virtual environment
         uses: actions/cache@v2
         id: cache
         with:
           path: ~/venv/
           key: v2-tests_model_like-${{ hashFiles('setup.py') }}
 
-      - name: Install dependencies
-        run: |
-          sudo apt -y update && sudo apt install -y libsndfile1-dev
-
-      - name: Create Virtual Environment on Cache Miss
+      - name: Create virtual environment on cache miss
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           python -m venv ~/venv && . ~/venv/bin/activate

--- a/.github/workflows/github-torch-hub.yml
+++ b/.github/workflows/github-torch-hub.yml
@@ -22,15 +22,16 @@ jobs:
       with:
         python-version: 3.7
 
-    - name: Loading cache
-      uses: actions/cache@v2
-      id: cache
-      with:
-        path: ~/.cache/pip
-        key: v0-torch_hub-${{ hashFiles('setup.py') }}
+    - name: Load cached virtual environment
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: ~/venv/
+          key: v1-torch_hub-${{ hashFiles('setup.py') }}
 
     - name: Install dependencies
       run: |
+        . ~/venv/bin/activate
         pip install --upgrade pip
         # install torch-hub specific dependencies
         pip install -e git+https://github.com/huggingface/transformers.git#egg=transformers[torchhub]

--- a/.github/workflows/github-torch-hub.yml
+++ b/.github/workflows/github-torch-hub.yml
@@ -23,11 +23,11 @@ jobs:
         python-version: 3.7
 
     - name: Load cached virtual environment
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: ~/venv/
-          key: v1-torch_hub-${{ hashFiles('setup.py') }}
+      uses: actions/cache@v2
+      id: cache
+      with:
+        path: ~/venv/
+        key: v1-torch_hub-${{ hashFiles('setup.py') }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -24,20 +24,27 @@ jobs:
         with:
           python-version: 3.6
 
-      - name: Loading cache.
+      - name: Install dependencies
+        run: |
+          sudo apt -y update && sudo apt install -y libsndfile1-dev
+
+      - name: Load cached virtual environment
         uses: actions/cache@v2
         id: cache
         with:
-          path: ~/.cache/pip
-          key: v1.2-tests_templates-${{ hashFiles('setup.py') }}
+          path: ~/venv/
+          key: v2-tests_templates-${{ hashFiles('setup.py') }}
 
-      - name: Install dependencies
+      - name: Create virtual environment on cache miss
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
+          python -m venv ~/venv && . ~/venv/bin/activate
           pip install --upgrade pip!=21.3
-          sudo apt -y update && sudo apt install -y libsndfile1-dev
           pip install .[dev]
+
       - name: Create model files
         run: |
+          . ~/venv/bin/activate
           transformers-cli add-new-model --testing --testing_file=templates/adding_a_new_model/tests/encoder-bert-tokenizer.json --path=templates/adding_a_new_model
           transformers-cli add-new-model --testing --testing_file=templates/adding_a_new_model/tests/pt-encoder-bert-tokenizer.json --path=templates/adding_a_new_model
           transformers-cli add-new-model --testing --testing_file=templates/adding_a_new_model/tests/standalone.json --path=templates/adding_a_new_model
@@ -53,11 +60,13 @@ jobs:
 
       - name: Run all non-slow tests
         run: |
+          . ~/venv/bin/activate
           python -m pytest -n 2 --dist=loadfile -s --make-reports=tests_templates tests/*template*
 
       - name: Run style changes
         run: |
           git fetch origin main:main
+          . ~/venv/bin/activate
           make style && make quality && make repo-consistency
 
       - name: Failure short reports

--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -16,17 +16,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Loading cache.
+      - name: Load cached virtual environment
         uses: actions/cache@v2
         id: cache
         with:
-          path: ~/.cache/pip
-          key: v1-metadata-${{ hashFiles('setup.py') }}
+          path: ~/venv/
+          key: v2-metadata-${{ hashFiles('setup.py') }}
 
       - name: Setup environment
         run: |
+          . ~/venv/bin/activate
           pip install git+https://github.com/huggingface/transformers#egg=transformers[dev]
 
       - name: Update metadata
         run: |
+          . ~/venv/bin/activate
           python utils/update_metadata.py --token ${{ secrets.SYLVAIN_HF_TOKEN }} --commit_sha ${{ github.sha }}


### PR DESCRIPTION
# What does this PR do?
 
This PR changes the cached python environment in non-remote GH actions to fresh virtual environments, that are rebuilt whenever `setup.py` gets updated. This ensures our test environment is closer to what a new user would see in the wild, and that we don't have package constraints due to other installed libraries (that come bundled in `ubuntu-latest`).

As a side effect, because the cached venv requires no installation of python packages on a cache hit, we also got slightly faster CI: 
- \>3 mins faster in `Add new model like template tests`
- \>3 mins faster in `Model templates runner`
(total of ~7 mins per full CI run when there is a cache hit)

Examples of runs:
cache miss -> create new venv: https://github.com/huggingface/transformers/runs/6027339356?check_suite_focus=true
cache hit -> load cached venv: https://github.com/huggingface/transformers/runs/6028381114?check_suite_focus=true