### PR TITLE
Change no_trainer scripts to force an output_dir if tracking is enabled

### DIFF
--- a/examples/pytorch/language-modeling/run_clm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_clm_no_trainer.py
@@ -218,7 +218,10 @@ def parse_args():
 
     if args.push_to_hub:
         assert args.output_dir is not None, "Need an `output_dir` to create a repo when `--push_to_hub` is passed."
-
+    if args.with_tracking:
+        assert (
+            args.output_dir is not None
+        ), "Need an `output_dir` to create a folder for supported Trackers when `--with_tracking` is passed."
     return args
 
 

--- a/examples/pytorch/language-modeling/run_mlm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_mlm_no_trainer.py
@@ -229,7 +229,10 @@ def parse_args():
 
     if args.push_to_hub:
         assert args.output_dir is not None, "Need an `output_dir` to create a repo when `--push_to_hub` is passed."
-
+    if args.with_tracking:
+        assert (
+            args.output_dir is not None
+        ), "Need an `output_dir` to create a folder for supported Trackers when `--with_tracking` is passed."
     return args
 
 

--- a/examples/pytorch/multiple-choice/run_swag_no_trainer.py
+++ b/examples/pytorch/multiple-choice/run_swag_no_trainer.py
@@ -199,7 +199,10 @@ def parse_args():
 
     if args.push_to_hub:
         assert args.output_dir is not None, "Need an `output_dir` to create a repo when `--push_to_hub` is passed."
-
+    if args.with_tracking:
+        assert (
+            args.output_dir is not None
+        ), "Need an `output_dir` to create a folder for supported Trackers when `--with_tracking` is passed."
     return args
 
 

--- a/examples/pytorch/question-answering/run_qa_beam_search_no_trainer.py
+++ b/examples/pytorch/question-answering/run_qa_beam_search_no_trainer.py
@@ -250,7 +250,10 @@ def parse_args():
 
     if args.push_to_hub:
         assert args.output_dir is not None, "Need an `output_dir` to create a repo when `--push_to_hub` is passed."
-
+    if args.with_tracking:
+        assert (
+            args.output_dir is not None
+        ), "Need an `output_dir` to create a folder for supported Trackers when `--with_tracking` is passed."
     return args
 
 

--- a/examples/pytorch/question-answering/run_qa_no_trainer.py
+++ b/examples/pytorch/question-answering/run_qa_no_trainer.py
@@ -280,7 +280,10 @@ def parse_args():
 
     if args.push_to_hub:
         assert args.output_dir is not None, "Need an `output_dir` to create a repo when `--push_to_hub` is passed."
-
+    if args.with_tracking:
+        assert (
+            args.output_dir is not None
+        ), "Need an `output_dir` to create a folder for supported Trackers when `--with_tracking` is passed."
     return args
 
 

--- a/examples/pytorch/summarization/run_summarization_no_trainer.py
+++ b/examples/pytorch/summarization/run_summarization_no_trainer.py
@@ -295,7 +295,10 @@ def parse_args():
 
     if args.push_to_hub:
         assert args.output_dir is not None, "Need an `output_dir` to create a repo when `--push_to_hub` is passed."
-
+    if args.with_tracking:
+        assert (
+            args.output_dir is not None
+        ), "Need an `output_dir` to create a folder for supported Trackers when `--with_tracking` is passed."
     return args
 
 

--- a/examples/pytorch/text-classification/run_glue_no_trainer.py
+++ b/examples/pytorch/text-classification/run_glue_no_trainer.py
@@ -183,7 +183,10 @@ def parse_args():
 
     if args.push_to_hub:
         assert args.output_dir is not None, "Need an `output_dir` to create a repo when `--push_to_hub` is passed."
-
+    if args.with_tracking:
+        assert (
+            args.output_dir is not None
+        ), "Need an `output_dir` to create a folder for supported Trackers when `--with_tracking` is passed."
     return args
 
 

--- a/examples/pytorch/token-classification/run_ner_no_trainer.py
+++ b/examples/pytorch/token-classification/run_ner_no_trainer.py
@@ -237,7 +237,10 @@ def parse_args():
 
     if args.push_to_hub:
         assert args.output_dir is not None, "Need an `output_dir` to create a repo when `--push_to_hub` is passed."
-
+    if args.with_tracking:
+        assert (
+            args.output_dir is not None
+        ), "Need an `output_dir` to create a folder for supported Trackers when `--with_tracking` is passed."
     return args
 
 

--- a/examples/pytorch/translation/run_translation_no_trainer.py
+++ b/examples/pytorch/translation/run_translation_no_trainer.py
@@ -277,7 +277,10 @@ def parse_args():
 
     if args.push_to_hub:
         assert args.output_dir is not None, "Need an `output_dir` to create a repo when `--push_to_hub` is passed."
-
+    if args.with_tracking:
+        assert (
+            args.output_dir is not None
+        ), "Need an `output_dir` to create a folder for supported Trackers when `--with_tracking` is passed."
     return args
 
 


### PR DESCRIPTION
`TensorBoard` requires an output directory that isn't `None`, so this PR forces an `output_dir` if tracking is used in all the `no_trainer` scripts. 