### PR TITLE
[SegFormer, BEiT] Clean up tests

### DIFF
--- a/tests/beit/test_modeling_beit.py
+++ b/tests/beit/test_modeling_beit.py
@@ -246,13 +246,7 @@ class BeitModelTest(ModelTesterMixin, unittest.TestCase):
             # we don't test BeitForMaskedImageModeling
             if model_class in [*get_values(MODEL_MAPPING), BeitForMaskedImageModeling]:
                 continue
-            # TODO: remove the following 3 lines once we have a MODEL_FOR_SEMANTIC_SEGMENTATION_MAPPING
-            # this can then be incorporated into _prepare_for_class in test_modeling_common.py
-            elif model_class.__name__ == "BeitForSemanticSegmentation":
-                batch_size, num_channels, height, width = inputs_dict["pixel_values"].shape
-                inputs_dict["labels"] = torch.zeros(
-                    [self.model_tester.batch_size, height, width], device=torch_device
-                ).long()
+
             model = model_class(config)
             model.to(torch_device)
             model.train()

--- a/tests/segformer/test_modeling_segformer.py
+++ b/tests/segformer/test_modeling_segformer.py
@@ -316,13 +316,7 @@ class SegformerModelTest(ModelTesterMixin, unittest.TestCase):
         for model_class in self.all_model_classes:
             if model_class in get_values(MODEL_MAPPING):
                 continue
-            # TODO: remove the following 3 lines once we have a MODEL_FOR_SEMANTIC_SEGMENTATION_MAPPING
-            # this can then be incorporated into _prepare_for_class in test_modeling_common.py
-            if model_class.__name__ == "SegformerForSemanticSegmentation":
-                batch_size, num_channels, height, width = inputs_dict["pixel_values"].shape
-                inputs_dict["labels"] = torch.zeros(
-                    [self.model_tester.batch_size, height, width], device=torch_device
-                ).long()
+
             model = model_class(config)
             model.to(torch_device)
             model.train()


### PR DESCRIPTION
# What does this PR do?

BEiT and SegFormer still had some code that I had to remove, as semantic segmentation models are now created in the `_prepare_for_class` method in `test_modeling_common.py` (which was added in #15991).