### PR TITLE
use base_version to check torch version in torch_less_than_1_11

### DIFF
--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -22,7 +22,7 @@ from .utils import logging
 logger = logging.get_logger(__name__)
 
 is_torch_less_than_1_8 = version.parse(torch.__version__) < version.parse("1.8.0")
-is_torch_less_than_1_11 = version.parse(torch.__version__) < version.parse("1.11")
+is_torch_less_than_1_11 = version.parse(version.parse(torch.__version__).base_version) < version.parse("1.11")
 
 
 def torch_int_div(tensor1, tensor2):

--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -23,7 +23,7 @@ from .utils import logging
 
 logger = logging.get_logger(__name__)
 
-is_torch_less_than_1_8 = version.parse(torch.__version__) < version.parse("1.8.0")
+is_torch_less_than_1_8 = version.parse(version.parse(torch.__version__).base_version) < version.parse("1.8.0")
 is_torch_less_than_1_11 = version.parse(version.parse(torch.__version__).base_version) < version.parse("1.11")
 
 


### PR DESCRIPTION
The current check `version.parse(torch.__version__) < version.parse("1.11")` doesn't work if the version has additional stuff after it like `1.11.0a0+17540c5`.

New way: `version.parse(version.parse(torch.__version__).base_version) < version.parse("1.11")`

This change, as suggested by @whoknowsB [here](https://github.com/huggingface/transformers/pull/16043#issuecomment-1079644824),  fixes it.

Fixes https://github.com/huggingface/transformers/issues/16587 and https://github.com/huggingface/transformers/issues/14375

## Who can review?

@LysandreJik 
@sgugger 
