### PR TITLE
CI: Create empty venv on cache miss

### DIFF
--- a/.github/workflows/github-torch-hub.yml
+++ b/.github/workflows/github-torch-hub.yml
@@ -29,10 +29,15 @@ jobs:
         path: ~/venv/
         key: v1-torch_hub-${{ hashFiles('setup.py') }}
 
+    - name: Create virtual environment on cache miss
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          python -m venv ~/venv && . ~/venv/bin/activate
+          pip install --upgrade pip
+
     - name: Install dependencies
       run: |
         . ~/venv/bin/activate
-        pip install --upgrade pip
         # install torch-hub specific dependencies
         pip install -e git+https://github.com/huggingface/transformers.git#egg=transformers[torchhub]
         # no longer needed

--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -23,6 +23,12 @@ jobs:
           path: ~/venv/
           key: v2-metadata-${{ hashFiles('setup.py') }}
 
+      - name: Create virtual environment on cache miss
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          python -m venv ~/venv && . ~/venv/bin/activate
+          pip install --upgrade pip
+
       - name: Setup environment
         run: |
           . ~/venv/bin/activate


### PR DESCRIPTION
# What does this PR do?

Fixes a CI error introduced by https://github.com/huggingface/transformers/pull/16789 -- when there was a cache miss, it attempted to initialize a virtual environment that didn't exist, in two CI workflows.

This PR fixes that by creating empty venvs on a cache miss.

(I wonder why the original CI run inside the PR didn't fail, the new cache names should have triggered the same error 🤔 )