### PR TITLE
Wav2 vec2 phoneme ctc tokenizer optimisation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,8 +368,7 @@ For documentation strings, 🤗 Transformers follows the [google style](https://
 Check our [documentation writing guide](https://github.com/huggingface/transformers/tree/main/docs#writing-documentation---specification)
 for more information.
 
-#### This guide was heavily inspired by the awesome [scikit-learn guide to contributing](https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md)
-
+<h4> This guide was heavily inspired by the awesome <a href=https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md>scikit-learn guide to contributing</a></h4>
 
 ### Develop on Windows
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,7 +368,7 @@ For documentation strings, 🤗 Transformers follows the [google style](https://
 Check our [documentation writing guide](https://github.com/huggingface/transformers/tree/main/docs#writing-documentation---specification)
 for more information.
 
-<h4> This guide was heavily inspired by the awesome <a href=https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md>scikit-learn guide to contributing</a></h4>
+**This guide was heavily inspired by the awesome [scikit-learn guide to contributing](https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md).**
 
 ### Develop on Windows
 

--- a/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
+++ b/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
@@ -177,7 +177,7 @@ class Wav2Vec2PhonemeCTCTokenizer(PreTrainedTokenizer):
         Initializes the backend.
 
         Args:
-            phonemizer_lang (str): language to be used
+            phonemizer_lang (`str`): The language to be used.
         """
         requires_backends(self, "phonemizer")
         from phonemizer.backend import BACKENDS

--- a/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
+++ b/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
@@ -158,6 +158,9 @@ class Wav2Vec2PhonemeCTCTokenizer(PreTrainedTokenizer):
         self.phonemizer_lang = phonemizer_lang
         self.phonemizer_backend = phonemizer_backend
 
+        if do_phonemize:
+            self.init_backend(self.phonemizer_lang)
+
         with open(vocab_file, encoding="utf-8") as vocab_handle:
             self.encoder = json.load(vocab_handle)
         self.decoder = {v: k for k, v in self.encoder.items()}
@@ -168,6 +171,17 @@ class Wav2Vec2PhonemeCTCTokenizer(PreTrainedTokenizer):
 
     def get_vocab(self) -> Dict:
         return dict(self.encoder, **self.added_tokens_encoder)
+
+    def init_backend(self, phonemizer_lang: str):
+        """Initiaizes the backend 
+
+        Args:
+            phonemizer_lang (str): language to be used 
+        """
+        requires_backends(self, "phonemizer")
+        from phonemizer.backend import BACKENDS
+
+        self.backend = BACKENDS[self.phonemizer_backend](phonemizer_lang, language_switch="remove-flags")
 
     def prepare_for_tokenization(
         self,
@@ -209,6 +223,7 @@ class Wav2Vec2PhonemeCTCTokenizer(PreTrainedTokenizer):
         # set the correct phonemizer language
         if phonemizer_lang is not None:
             self.phonemizer_lang = phonemizer_lang
+            self.init_backend(phonemizer_lang)
 
         return (text, {})
 
@@ -234,23 +249,20 @@ class Wav2Vec2PhonemeCTCTokenizer(PreTrainedTokenizer):
         return tokens
 
     def phonemize(self, text: str, phonemizer_lang: Optional[str] = None) -> str:
-        requires_backends(self, "phonemizer")
-
-        from phonemizer import phonemize
         from phonemizer.separator import Separator
 
         word_delimiter = self.word_delimiter_token + " " if self.word_delimiter_token is not None else ""
-        phonemizer_lang = phonemizer_lang if phonemizer_lang is not None else self.phonemizer_lang
+        if phonemizer_lang is not None and phonemizer_lang != self.phonemizer_lang:
+            self.init_backend(phonemizer_lang)
+        else:
+            phonemizer_lang = self.phonemizer_lang
 
         separator = Separator(phone=self.phone_delimiter_token, word=word_delimiter, syllable="")
-        phonemes = phonemize(
-            text,
-            language=phonemizer_lang,
-            backend=self.phonemizer_backend,
+        phonemes = self.backend.phonemize(
+            [text],
             separator=separator,
-            language_switch="remove-flags",
         )
-        phonemes = phonemes.strip()
+        phonemes = phonemes[0].strip()
 
         return phonemes
 

--- a/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
+++ b/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
@@ -173,10 +173,10 @@ class Wav2Vec2PhonemeCTCTokenizer(PreTrainedTokenizer):
         return dict(self.encoder, **self.added_tokens_encoder)
 
     def init_backend(self, phonemizer_lang: str):
-        """Initiaizes the backend 
+        """Initiaizes the backend
 
         Args:
-            phonemizer_lang (str): language to be used 
+            phonemizer_lang (str): language to be used
         """
         requires_backends(self, "phonemizer")
         from phonemizer.backend import BACKENDS

--- a/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
+++ b/src/transformers/models/wav2vec2_phoneme/tokenization_wav2vec2_phoneme.py
@@ -173,7 +173,8 @@ class Wav2Vec2PhonemeCTCTokenizer(PreTrainedTokenizer):
         return dict(self.encoder, **self.added_tokens_encoder)
 
     def init_backend(self, phonemizer_lang: str):
-        """Initiaizes the backend
+        """
+        Initializes the backend.
 
         Args:
             phonemizer_lang (str): language to be used


### PR DESCRIPTION
# What does this PR do?

This is my FIRST PR! 
The Wav2Vec2PhonemCTCTokenizer is slow when its argument `do_phonemize` is set to True. It re-initialises the backend at each forward pass. This is adressed using a class argument. 

There was also an H4 title in the documentation which had a link which did not render( `<h4></h4>` used to replace `####`)  

Tests were passed, no additional ones were created. Runtime experiments to phonemize the entire 'tr' (turkish) subset of the common voice dataset gives a x10 boost in performances. 

Models:
- Wav2Vec2PhonemeCTCTokenizer: @patrickvonplaten, @LysandreJik 

Documentation: @sgugger

