### PR TITLE
Fx with meta

### DIFF
--- a/src/transformers/models/electra/modeling_electra.py
+++ b/src/transformers/models/electra/modeling_electra.py
@@ -850,7 +850,7 @@ class ElectraModel(ElectraPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, BaseModelOutputWithCrossAttentions]:
+    ) -> Union[Tuple[torch.Tensor], BaseModelOutputWithCrossAttentions]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -985,7 +985,7 @@ class ElectraForSequenceClassification(ElectraPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, SequenceClassifierOutput]:
+    ) -> Union[Tuple[torch.Tensor], SequenceClassifierOutput]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
             Labels for computing the sequence classification/regression loss. Indices should be in `[0, ...,
@@ -1075,7 +1075,7 @@ class ElectraForPreTraining(ElectraPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, ElectraForPreTrainingOutput]:
+    ) -> Union[Tuple[torch.Tensor], ElectraForPreTrainingOutput]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels for computing the ELECTRA loss. Input should be a sequence of tokens (see `input_ids` docstring)
@@ -1197,7 +1197,7 @@ class ElectraForMaskedLM(ElectraPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, MaskedLMOutput]:
+    ) -> Union[Tuple[torch.Tensor], MaskedLMOutput]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels for computing the masked language modeling loss. Indices should be in `[-100, 0, ...,
@@ -1283,7 +1283,7 @@ class ElectraForTokenClassification(ElectraPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, TokenClassifierOutput]:
+    ) -> Union[Tuple[torch.Tensor], TokenClassifierOutput]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels for computing the token classification loss. Indices should be in `[0, ..., config.num_labels - 1]`.
@@ -1368,7 +1368,7 @@ class ElectraForQuestionAnswering(ElectraPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, QuestionAnsweringModelOutput]:
+    ) -> Union[Tuple[torch.Tensor], QuestionAnsweringModelOutput]:
         r"""
         start_positions (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
             Labels for position (index) of the start of the labelled span for computing the token classification loss.
@@ -1469,7 +1469,7 @@ class ElectraForMultipleChoice(ElectraPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, MultipleChoiceModelOutput]:
+    ) -> Union[Tuple[torch.Tensor], MultipleChoiceModelOutput]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
             Labels for computing the multiple choice classification loss. Indices should be in `[0, ...,
@@ -1564,7 +1564,7 @@ class ElectraForCausalLM(ElectraPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, CausalLMOutputWithCrossAttentions]:
+    ) -> Union[Tuple[torch.Tensor], CausalLMOutputWithCrossAttentions]:
         r"""
         encoder_hidden_states  (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
             Sequence of hidden-states at the output of the last layer of the encoder. Used in the cross-attention if

--- a/src/transformers/models/gpt_neo/modeling_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/modeling_gpt_neo.py
@@ -508,7 +508,7 @@ class GPTNeoModel(GPTNeoPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, BaseModelOutputWithPastAndCrossAttentions]:
+    ) -> Union[Tuple[torch.Tensor], BaseModelOutputWithPastAndCrossAttentions]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -727,7 +727,7 @@ class GPTNeoForCausalLM(GPTNeoPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, CausalLMOutputWithCrossAttentions]:
+    ) -> Union[Tuple[torch.Tensor], CausalLMOutputWithCrossAttentions]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels for language modeling. Note that the labels **are shifted** inside the model, i.e. you can set
@@ -842,7 +842,7 @@ class GPTNeoForSequenceClassification(GPTNeoPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, SequenceClassifierOutputWithPast]:
+    ) -> Union[Tuple[torch.Tensor], SequenceClassifierOutputWithPast]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
             Labels for computing the sequence classification/regression loss. Indices should be in `[0, ...,

--- a/src/transformers/models/roberta/modeling_roberta.py
+++ b/src/transformers/models/roberta/modeling_roberta.py
@@ -919,7 +919,7 @@ class RobertaForCausalLM(RobertaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, CausalLMOutputWithCrossAttentions]:
+    ) -> Union[Tuple[torch.Tensor], CausalLMOutputWithCrossAttentions]:
         r"""
         encoder_hidden_states  (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
             Sequence of hidden-states at the output of the last layer of the encoder. Used in the cross-attention if
@@ -1080,7 +1080,7 @@ class RobertaForMaskedLM(RobertaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, MaskedLMOutput]:
+    ) -> Union[Tuple[torch.Tensor], MaskedLMOutput]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels for computing the masked language modeling loss. Indices should be in `[-100, 0, ...,
@@ -1193,7 +1193,7 @@ class RobertaForSequenceClassification(RobertaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, SequenceClassifierOutput]:
+    ) -> Union[Tuple[torch.Tensor], SequenceClassifierOutput]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
             Labels for computing the sequence classification/regression loss. Indices should be in `[0, ...,
@@ -1290,7 +1290,7 @@ class RobertaForMultipleChoice(RobertaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, MultipleChoiceModelOutput]:
+    ) -> Union[Tuple[torch.Tensor], MultipleChoiceModelOutput]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
             Labels for computing the multiple choice classification loss. Indices should be in `[0, ...,
@@ -1390,7 +1390,7 @@ class RobertaForTokenClassification(RobertaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, TokenClassifierOutput]:
+    ) -> Union[Tuple[torch.Tensor], TokenClassifierOutput]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels for computing the token classification loss. Indices should be in `[0, ..., config.num_labels - 1]`.
@@ -1496,7 +1496,7 @@ class RobertaForQuestionAnswering(RobertaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, QuestionAnsweringModelOutput]:
+    ) -> Union[Tuple[torch.Tensor], QuestionAnsweringModelOutput]:
         r"""
         start_positions (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
             Labels for position (index) of the start of the labelled span for computing the token classification loss.

--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -17,7 +17,6 @@ import builtins
 import functools
 import inspect
 import math
-import operator
 import random
 import warnings
 from typing import Any, Callable, Dict, Iterable, List, Optional, Type, Union

--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -143,7 +143,7 @@ def torch_nn_relu_override(self, x):
 
 
 def torch_nn_functional_relu_override(x, inplace=False):
-    assert not inplace, "dont support inplace functional.relu for metatensor analysis"
+    assert not inplace, "Don't support in-place functional.relu for MetaTensor analysis"
     return x
 
 
@@ -154,7 +154,7 @@ def torch_where_override(condition, x, y):
 
 
 def torch_abs_override(input, *, out=None):
-    assert out is None, "Dont support in-place abs for MetaTensor analysis"
+    assert out is None, "Don't support in-place abs for MetaTensor analysis"
     return input
 
 

--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -496,7 +496,6 @@ class HFTracer(Tracer):
                 elif model.config.problem_type == "multi_label_classification":
                     labels_shape = (batch_size, model.config.num_labels)
                     labels_dtype = torch.float32
-                    pass
                 else:
                     raise ValueError(
                         'Expected model.config.problem_type to be either: "regression", "single_label_classification"'

--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -166,12 +166,6 @@ def torch_arange_with_start_override(
     return torch.empty((end - start) // step, dtype=dtype, layout=layout, device="meta")
 
 
-def torch_arange_without_start_override(
-    end, *, step=1, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False
-):
-    return torch_arange_with_start_override(0, end, step=step, dtype=dtype, layout=layout)
-
-
 def torch_cat_override(tensors, dim=None, axis=None, *, out=None):
     if dim is None and axis is None:
         dim = 0
@@ -239,8 +233,6 @@ manual_meta_overrides: Dict[Callable, Callable] = {
     torch.nn.ReLU: torch_nn_relu_override,
     torch.where: torch_where_override,
     torch.abs: torch_abs_override,
-    torch.ops.aten.arange.start: torch_arange_with_start_override,
-    torch.ops.aten.arange.start_end: torch_arange_with_start_override,
     torch.ops.aten.arange: torch_arange_with_start_override,
     torch.cat: torch_cat_override,
     torch.stack: torch_stack_override,

--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -122,56 +122,6 @@ _SUPPORTED_MODELS = tuple(
 )
 
 
-# class HFProxy(Proxy):
-#     """
-# Proxy that is able to provide the proper ranks, shapes and boolean values during symbolic tracing by implementing #
-the dim, size and __bool__ methods. It can be easily extended by either adding new methods or extending the # existing
-ones. #"""
-#
-#     def __init__(self, node: Node, tracer: Optional[Tracer] = None):
-#         super().__init__(node, tracer=tracer)
-#         if hasattr(self, "tracer") and self.tracer is not None:
-#             self.device = self.tracer.root.device
-#             self.dtype = next(self.tracer.root.parameters()).dtype
-#             self.cache = None
-#
-#     @property
-#     def shape(self):
-#         return self.size()
-#
-#     def __setitem__(self, key, value):
-#         pass
-#
-#     def __contains__(self, key):
-#         return False
-#
-#     def __eq__(self, other):
-#         if self.cache is not None:
-#             return self.cache == other
-#         elif isinstance(other, HFProxy):
-#             return True
-#         else:
-#             return super().__eq__(other)
-#
-#     def __ne__(self, other):
-#         return not self == other
-#
-#     def __len__(self):
-#         if self.cache is not None:
-#             if isinstance(self.cache, int):
-#                 return self.cache
-#             elif isinstance(self.cache, (torch.Size, list, tuple)):
-#                 return len(self.cache)
-#             else:
-#                 return super().__len__(self)
-#         return super().__len__(self)
-#
-#     def __torch_function__(self, orig_method, types, args=None, kwargs=None):
-#         proxy = super().__torch_function__(orig_method, types, args=args, kwargs=kwargs)
-#         proxy.cache = self.cache
-#         return proxy
-
-
 class HFProxy(Proxy):
     """
     Proxy that uses meta data to handle data-dependent control-flow.

--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -143,7 +143,8 @@ def torch_nn_relu_override(self, x):
 
 
 def torch_nn_functional_relu_override(x, inplace=False):
-    assert not inplace, "Don't support in-place functional.relu for MetaTensor analysis"
+    if not inplace:
+        raise ValueError("Don't support in-place functional.relu for MetaTensor analysis")
     return x
 
 
@@ -154,7 +155,8 @@ def torch_where_override(condition, x, y):
 
 
 def torch_abs_override(input, *, out=None):
-    assert out is None, "Don't support in-place abs for MetaTensor analysis"
+    if out is None:
+        raise ValueError("Don't support in-place abs for MetaTensor analysis")
     return input
 
 
@@ -556,7 +558,8 @@ class HFTracer(Tracer):
                 meta_target = _MANUAL_META_OVERRIDES.get(method, method)
                 meta_out = meta_target(*args_metas, **kwargs_metas)
             elif kind == "call_module":
-                assert hasattr(self, "orig_forward")
+                if not hasattr(self, "orig_forward"):
+                    raise AttributeError(f"{self} does not have an attribute called orig_forward")
                 self._disable_module_getattr = True
                 try:
                     mod = self.root.get_submodule(target)
@@ -583,7 +586,8 @@ class HFTracer(Tracer):
             else:
                 return rv
 
-            assert isinstance(rv, Proxy), "Dont support composite output yet"
+            if not isinstance(rv, Proxy):
+                raise ValueError("Don't support composite output yet")
             rv.install_metadata(meta_out)
         except Exception as e:
             warnings.warn(f"Could not compute metadata for {kind} target {target}: {e}")

--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -214,9 +214,6 @@ def torch_add_override(input, other, *, alpha=1, out=None):
 
 
 def torch_mul_override(input, other, *, out=None):
-    import pdb
-
-    pdb.set_trace()
     return torch_add_override(input, other, out=out)
 
 
@@ -267,6 +264,16 @@ def torch_tensor_repeat_override(self, *sizes):
     return torch.empty(shape, device="meta")
 
 
+def torch_index_select(input, dim, index, *, out=None):
+    shape = list(input.shape)
+    shape[dim] = len(index)
+    return torch.empty(*shape, device="meta")
+
+
+def torch_tensor_index_select(self, dim, index):
+    return torch_tensor_index_select(self, dim, index)
+
+
 def torch_nn_mseloss(self, input, target):
     if self.reduction == "none":
         shape = target.shape
@@ -308,6 +315,9 @@ _MANUAL_META_OVERRIDES: Dict[Callable, Callable] = {
     torch.Tensor.mul: torch_tensor_mul_override,
     torch.matmul: torch_matmul_override,
     torch.Tensor.repeat: torch_tensor_repeat_override,
+    # TODO: those might not be needed.
+    # torch.index_select: torch_index_select,
+    # torch.Tensor.index_select: torch_tensor_index_select,
     torch.nn.MSELoss: torch_nn_mseloss,
     torch.nn.CrossEntropyLoss: torch_nn_crossentropyloss,
     torch.nn.BCEWithLogitsLoss: torch_nn_bcewithlogitsloss,

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -697,9 +697,9 @@ class ModelTesterMixin:
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         self._create_and_check_torch_fx_tracing(config, inputs_dict)
 
-    # def test_torch_fx_output_loss(self):
-    #     config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-    #     self._create_and_check_torch_fx_tracing(config, inputs_dict, output_loss=True)
+    def test_torch_fx_output_loss(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        self._create_and_check_torch_fx_tracing(config, inputs_dict, output_loss=True)
 
     def _create_and_check_torch_fx_tracing(self, config, inputs_dict, output_loss=False):
         if not is_torch_fx_available() or not self.fx_compatible:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -725,13 +725,8 @@ class ModelTesterMixin:
 
                     model_output = model(**filtered_inputs)
 
-                    try:
-                        traced_model = symbolic_trace(model, input_names)
-                        traced_output = traced_model(**filtered_inputs)
-                    except:
-                        import pdb
-
-                        pdb.set_trace()
+                    traced_model = symbolic_trace(model, input_names)
+                    traced_output = traced_model(**filtered_inputs)
                 else:
                     input_names = ["input_ids", "attention_mask", "token_type_ids"]
                     input_ids = inputs["input_ids"]
@@ -757,13 +752,8 @@ class ModelTesterMixin:
                             f"symbolic_trace automatic parameters inference not implemented for input of rank {rank}."
                         )
 
-                    try:
-                        traced_model = symbolic_trace(model, input_names)
-                        traced_output = traced_model(**filtered_inputs)
-                    except:
-                        import pdb
-
-                        pdb.set_trace()
+                    traced_model = symbolic_trace(model, input_names)
+                    traced_output = traced_model(**filtered_inputs)
 
             except RuntimeError:
                 self.fail("Couldn't trace module.")

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -697,9 +697,9 @@ class ModelTesterMixin:
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         self._create_and_check_torch_fx_tracing(config, inputs_dict)
 
-    def test_torch_fx_output_loss(self):
-        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        self._create_and_check_torch_fx_tracing(config, inputs_dict, output_loss=True)
+    # def test_torch_fx_output_loss(self):
+    #     config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+    #     self._create_and_check_torch_fx_tracing(config, inputs_dict, output_loss=True)
 
     def _create_and_check_torch_fx_tracing(self, config, inputs_dict, output_loss=False):
         if not is_torch_fx_available() or not self.fx_compatible:
@@ -725,8 +725,13 @@ class ModelTesterMixin:
 
                     model_output = model(**filtered_inputs)
 
-                    traced_model = symbolic_trace(model, input_names)
-                    traced_output = traced_model(**filtered_inputs)
+                    try:
+                        traced_model = symbolic_trace(model, input_names)
+                        traced_output = traced_model(**filtered_inputs)
+                    except:
+                        import pdb
+
+                        pdb.set_trace()
                 else:
                     input_names = ["input_ids", "attention_mask", "token_type_ids"]
                     input_ids = inputs["input_ids"]
@@ -752,8 +757,13 @@ class ModelTesterMixin:
                             f"symbolic_trace automatic parameters inference not implemented for input of rank {rank}."
                         )
 
-                    traced_model = symbolic_trace(model, input_names)
-                    traced_output = traced_model(**filtered_inputs)
+                    try:
+                        traced_model = symbolic_trace(model, input_names)
+                        traced_output = traced_model(**filtered_inputs)
+                    except:
+                        import pdb
+
+                        pdb.set_trace()
 
             except RuntimeError:
                 self.fail("Couldn't trace module.")


### PR DESCRIPTION
# What does this PR do?

This PR simplies and improves the way tracing works with torch.fx.

Instead of recording concrete values via a forward pass on the original model, metadata is attached to the proxies, either tensors on the `meta` device (which saves us from making actual computations, only shape inference is performed) or any other type such as `torch.Size` and builtin types. On top of allowing to trace very big models, this gives much more flexibility and should allow to support many new architectures.

A big thanks to @jamesr66a as he was the one who provided the basis for tracing with meta tensors, and I simply extended what was already done to our purposes.

@jamesr66a @pbelevich I would love your review and feedbacks!
