### PR TITLE
[modeling_utils] use less cpu memory with sharded checkpoint loading

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 import json
 import os
 import re
@@ -2148,6 +2149,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     )
                 else:
                     error_msgs += _load_state_dict_into_model(model_to_load, state_dict, start_prefix)
+
+                # force memory release
+                del state_dict
+                gc.collect()
 
         if len(error_msgs) > 0:
             error_msg = "\n\t".join(error_msgs)


### PR DESCRIPTION
This PR lowers the peak cpu memory usage for sharded checkpoint loading

The following demonstration tells the full story. I'm using `/usr/bin/time -f %M` to report max rss = total cpu memory used by the process including peak memory.

This demo uses T0 which is 42GB big in fp32 https://huggingface.co/bigscience/T0/tree/main

So with the normal loading the program needs 87GB of CPU RAM (42x2 plus a few GBs for temps)

```
# full checkpoint
/usr/bin/time -f %M python -c "from transformers import AutoModelForSeq2SeqLM; \
model = AutoModelForSeq2SeqLM.from_pretrained('bigscience/T0')"
87286376

# shard it to 10GB / shard
python -c "from transformers import AutoModelForSeq2SeqLM; \
model = AutoModelForSeq2SeqLM.from_pretrained('bigscience/T0'); \
model.save_pretrained('t0-sharded')"

# before this PR
/usr/bin/time -f %M python -c "from transformers import AutoModelForSeq2SeqLM; \
model = AutoModelForSeq2SeqLM.from_pretrained('t0-sharded')"
68358000

# after this PR
/usr/bin/time -f %M python -c "from transformers import AutoModelForSeq2SeqLM; \
model = AutoModelForSeq2SeqLM.from_pretrained('t0-sharded')"
53529416
```

So after this PR the CPU memory usage is 1x model size (42GB here) + largest shard (10GB) + some temps = 53GB

Before this PR we were getting an additional 15GB (1.5x shard) of peak cpu memory.

@sgugger