### PR TITLE
Replace deprecated logger.warn with warning

### DIFF
--- a/examples/research_projects/quantization-qdqbert/quant_trainer.py
+++ b/examples/research_projects/quantization-qdqbert/quant_trainer.py
@@ -269,7 +269,7 @@ def set_quantizer(name, mod, quantizer, k, v):
         assert hasattr(quantizer_mod, k)
         setattr(quantizer_mod, k, v)
     else:
-        logger.warn(f"{name} has no {quantizer}")
+        logger.warning(f"{name} has no {quantizer}")
 
 
 def set_quantizers(name, mod, which="both", **kwargs):

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -306,7 +306,7 @@ class PretrainedConfig(PushToHubMixin):
         if self.id2label is not None:
             num_labels = kwargs.pop("num_labels", None)
             if num_labels is not None and len(self.id2label) != num_labels:
-                logger.warn(
+                logger.warning(
                     f"You passed along `num_labels={num_labels}` with an incompatible id to label map: "
                     f"{self.id2label}. The number of labels wil be overwritten to {self.num_labels}."
                 )

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -641,7 +641,7 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
         unexpected_keys = set(state.keys()) - model.required_params
 
         if missing_keys and not _do_init:
-            logger.warn(
+            logger.warning(
                 f"The checkpoint {pretrained_model_name_or_path} is missing required keys: {missing_keys}. "
                 f"Make sure to call model.init_weights to initialize the missing weights."
             )


### PR DESCRIPTION
From [Python docs](https://docs.python.org/3/library/logging.html#logging.Logger.warning):
_There is an obsolete method `warn` which is functionally identical to `warning`. As `warn` is deprecated, please do not use it - use `warning` instead._
