### PR TITLE
Fix doctest list

### DIFF
--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -2,7 +2,7 @@ docs/source/en/quicktour.mdx
 docs/source/en/task_summary.mdx
 docs/source/en/model_doc/speech_to_text.mdx
 docs/source/en/model_doc/t5.mdx
-docs/source/en/model_doc/t5v1_1.mdx
+docs/source/en/model_doc/t5v1.1.mdx
 docs/source/en/model_doc/byt5.mdx
 docs/source/en/model_doc/tapex.mdx
 src/transformers/generation_utils.py


### PR DESCRIPTION
# What does this PR do?

We have `docs/source/en/model_doc/t5v1_1.mdx` in `documentation_tests.txt`, but the file is actually `docs/source/en/model_doc/t5v1.1.mdx`.

This cause doctest fail.

```
ERROR: file or directory not found: docs/source/en/model_doc/t5v1_1.mdx
```
(https://github.com/huggingface/transformers/runs/6104280137?check_suite_focus=true)