### PR TITLE
Fix PyTorch RAG tests GPU OOM

### DIFF
--- a/tests/rag/test_modeling_rag.py
+++ b/tests/rag/test_modeling_rag.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+import gc
 import json
 import os
 import shutil
@@ -196,6 +197,7 @@ class RagTestMixin:
         shutil.rmtree(self.tmpdirname)
 
         # clean-up as much as possible GPU memory occupied by PyTorch
+        gc.collect()
         torch.cuda.empty_cache()
 
     def get_retriever(self, config):
@@ -683,6 +685,7 @@ class RagModelIntegrationTests(unittest.TestCase):
     def tearDown(self):
         super().tearDown()
         # clean-up as much as possible GPU memory occupied by PyTorch
+        gc.collect()
         torch.cuda.empty_cache()
 
     @cached_property
@@ -1035,6 +1038,7 @@ class RagModelSaveLoadTests(unittest.TestCase):
     def tearDown(self):
         super().tearDown()
         # clean-up as much as possible GPU memory occupied by PyTorch
+        gc.collect()
         torch.cuda.empty_cache()
 
     def get_rag_config(self):

--- a/tests/rag/test_modeling_rag.py
+++ b/tests/rag/test_modeling_rag.py
@@ -761,6 +761,8 @@ class RagModelIntegrationTests(unittest.TestCase):
         expected_loss = torch.tensor([36.7368]).to(torch_device)
         _assert_tensors_equal(expected_loss, output.loss, atol=TOLERANCE)
 
+        torch.cuda.empty_cache()
+
     @slow
     def test_rag_token_inference(self):
         rag_config = self.get_rag_config()
@@ -799,6 +801,8 @@ class RagModelIntegrationTests(unittest.TestCase):
 
         expected_loss = torch.tensor([36.3557]).to(torch_device)
         _assert_tensors_equal(expected_loss, output.loss, atol=TOLERANCE)
+
+        torch.cuda.empty_cache()
 
     @slow
     def test_rag_token_generate_beam(self):
@@ -839,6 +843,8 @@ class RagModelIntegrationTests(unittest.TestCase):
         self.assertEqual(output_text_1, EXPECTED_OUTPUT_TEXT_1)
         self.assertEqual(output_text_2, EXPECTED_OUTPUT_TEXT_2)
 
+        torch.cuda.empty_cache()
+
     @slow
     def test_rag_sequence_generate_beam(self):
         rag_config = self.get_rag_config()
@@ -877,6 +883,8 @@ class RagModelIntegrationTests(unittest.TestCase):
 
         self.assertEqual(output_text_1, EXPECTED_OUTPUT_TEXT_1)
         self.assertEqual(output_text_2, EXPECTED_OUTPUT_TEXT_2)
+
+        torch.cuda.empty_cache()
 
     @property
     def test_data_questions(self):
@@ -930,6 +938,8 @@ class RagModelIntegrationTests(unittest.TestCase):
         ]
         self.assertListEqual(outputs, EXPECTED_OUTPUTS)
 
+        torch.cuda.empty_cache()
+
     @slow
     def test_rag_sequence_generate_batch_from_context_input_ids(self):
         tokenizer = RagTokenizer.from_pretrained("facebook/rag-sequence-nq")
@@ -980,6 +990,8 @@ class RagModelIntegrationTests(unittest.TestCase):
         ]
         self.assertListEqual(outputs, EXPECTED_OUTPUTS)
 
+        torch.cuda.empty_cache()
+
     @slow
     def test_rag_token_generate_batch(self):
         tokenizer = RagTokenizer.from_pretrained("facebook/rag-token-nq")
@@ -1020,6 +1032,7 @@ class RagModelIntegrationTests(unittest.TestCase):
         ]
         self.assertListEqual(outputs, EXPECTED_OUTPUTS)
 
+        torch.cuda.empty_cache()
 
 @require_torch
 @require_retrieval
@@ -1108,6 +1121,8 @@ class RagModelSaveLoadTests(unittest.TestCase):
 
         self.assertAlmostEqual(loss_pretrained.item(), loss_init.item(), places=4)
 
+        torch.cuda.empty_cache()
+
     @slow
     def test_rag_token_from_pretrained(self):
         rag_config = self.get_rag_config()
@@ -1171,3 +1186,5 @@ class RagModelSaveLoadTests(unittest.TestCase):
         loss_init = output.loss
 
         self.assertAlmostEqual(loss_pretrained.item(), loss_init.item(), places=4)
+
+        torch.cuda.empty_cache()

--- a/tests/rag/test_modeling_rag.py
+++ b/tests/rag/test_modeling_rag.py
@@ -761,8 +761,6 @@ class RagModelIntegrationTests(unittest.TestCase):
         expected_loss = torch.tensor([36.7368]).to(torch_device)
         _assert_tensors_equal(expected_loss, output.loss, atol=TOLERANCE)
 
-        torch.cuda.empty_cache()
-
     @slow
     def test_rag_token_inference(self):
         rag_config = self.get_rag_config()
@@ -801,8 +799,6 @@ class RagModelIntegrationTests(unittest.TestCase):
 
         expected_loss = torch.tensor([36.3557]).to(torch_device)
         _assert_tensors_equal(expected_loss, output.loss, atol=TOLERANCE)
-
-        torch.cuda.empty_cache()
 
     @slow
     def test_rag_token_generate_beam(self):
@@ -843,8 +839,6 @@ class RagModelIntegrationTests(unittest.TestCase):
         self.assertEqual(output_text_1, EXPECTED_OUTPUT_TEXT_1)
         self.assertEqual(output_text_2, EXPECTED_OUTPUT_TEXT_2)
 
-        torch.cuda.empty_cache()
-
     @slow
     def test_rag_sequence_generate_beam(self):
         rag_config = self.get_rag_config()
@@ -883,8 +877,6 @@ class RagModelIntegrationTests(unittest.TestCase):
 
         self.assertEqual(output_text_1, EXPECTED_OUTPUT_TEXT_1)
         self.assertEqual(output_text_2, EXPECTED_OUTPUT_TEXT_2)
-
-        torch.cuda.empty_cache()
 
     @property
     def test_data_questions(self):
@@ -938,8 +930,6 @@ class RagModelIntegrationTests(unittest.TestCase):
         ]
         self.assertListEqual(outputs, EXPECTED_OUTPUTS)
 
-        torch.cuda.empty_cache()
-
     @slow
     def test_rag_sequence_generate_batch_from_context_input_ids(self):
         tokenizer = RagTokenizer.from_pretrained("facebook/rag-sequence-nq")
@@ -990,8 +980,6 @@ class RagModelIntegrationTests(unittest.TestCase):
         ]
         self.assertListEqual(outputs, EXPECTED_OUTPUTS)
 
-        torch.cuda.empty_cache()
-
     @slow
     def test_rag_token_generate_batch(self):
         tokenizer = RagTokenizer.from_pretrained("facebook/rag-token-nq")
@@ -1031,8 +1019,6 @@ class RagModelIntegrationTests(unittest.TestCase):
             " 13",
         ]
         self.assertListEqual(outputs, EXPECTED_OUTPUTS)
-
-        torch.cuda.empty_cache()
 
 
 @require_torch
@@ -1122,8 +1108,6 @@ class RagModelSaveLoadTests(unittest.TestCase):
 
         self.assertAlmostEqual(loss_pretrained.item(), loss_init.item(), places=4)
 
-        torch.cuda.empty_cache()
-
     @slow
     def test_rag_token_from_pretrained(self):
         rag_config = self.get_rag_config()
@@ -1188,4 +1172,7 @@ class RagModelSaveLoadTests(unittest.TestCase):
 
         self.assertAlmostEqual(loss_pretrained.item(), loss_init.item(), places=4)
 
-        torch.cuda.empty_cache()
+
+def tearDownModule():
+    # clean-up as much as possible GPU memory occupied by PyTorch
+    torch.cuda.empty_cache()

--- a/tests/rag/test_modeling_rag.py
+++ b/tests/rag/test_modeling_rag.py
@@ -1034,6 +1034,7 @@ class RagModelIntegrationTests(unittest.TestCase):
 
         torch.cuda.empty_cache()
 
+
 @require_torch
 @require_retrieval
 class RagModelSaveLoadTests(unittest.TestCase):

--- a/tests/rag/test_modeling_rag.py
+++ b/tests/rag/test_modeling_rag.py
@@ -195,6 +195,9 @@ class RagTestMixin:
     def tearDown(self):
         shutil.rmtree(self.tmpdirname)
 
+        # clean-up as much as possible GPU memory occupied by PyTorch
+        torch.cuda.empty_cache()
+
     def get_retriever(self, config):
         dataset = Dataset.from_dict(
             {
@@ -677,6 +680,11 @@ class RagDPRT5Test(RagTestMixin, unittest.TestCase):
 @require_tokenizers
 @require_torch_non_multi_gpu
 class RagModelIntegrationTests(unittest.TestCase):
+    def tearDown(self):
+        super().tearDown()
+        # clean-up as much as possible GPU memory occupied by PyTorch
+        torch.cuda.empty_cache()
+
     @cached_property
     def sequence_model(self):
         return (
@@ -1024,6 +1032,11 @@ class RagModelIntegrationTests(unittest.TestCase):
 @require_torch
 @require_retrieval
 class RagModelSaveLoadTests(unittest.TestCase):
+    def tearDown(self):
+        super().tearDown()
+        # clean-up as much as possible GPU memory occupied by PyTorch
+        torch.cuda.empty_cache()
+
     def get_rag_config(self):
         question_encoder_config = AutoConfig.from_pretrained("facebook/dpr-question_encoder-single-nq-base")
         generator_config = AutoConfig.from_pretrained("facebook/bart-large-cnn")
@@ -1171,8 +1184,3 @@ class RagModelSaveLoadTests(unittest.TestCase):
         loss_init = output.loss
 
         self.assertAlmostEqual(loss_pretrained.item(), loss_init.item(), places=4)
-
-
-def tearDownModule():
-    # clean-up as much as possible GPU memory occupied by PyTorch
-    torch.cuda.empty_cache()


### PR DESCRIPTION
# What does this PR do?

Fix PyTorch RAG tests GPU OOM.

The GPU OOM 
```
E     tensorflow.python.framework.errors_impl.ResourceExhaustedError: OOM when allocating tensor with shape[32,5,16,300,64] and type float on /job:localhost/replica:0/task:0/device:GPU:0 by allocator GPU_0_bfc [Op:GatherV2]
```
could be found in https://github.com/huggingface/transformers/runs/6100697349?check_suite_focus=true

## Results

- Without this PR, after the PyTorch RAG test, torch occupies about `9.5 GB` GPU memory. There are 10 TF RAG tests failed.
- With this PR, all PT/TF RAG tests pass without GPU OOM