### PR TITLE
Allow saved_model export of TFCLIPModel in save_pretrained

### DIFF
--- a/src/transformers/models/clip/modeling_tf_clip.py
+++ b/src/transformers/models/clip/modeling_tf_clip.py
@@ -555,16 +555,7 @@ class TFCLIPTextTransformer(tf.keras.layers.Layer):
         diag = tf.cast(tf.fill((seq_length,), 0.0), dtype)
 
         # set an additive 2D attention mask with all places being masked
-        to_mask = tf.cast(
-            tf.fill(
-                (
-                    seq_length,
-                    seq_length,
-                ),
-                -10000.0,
-            ),
-            dtype,
-        )
+        to_mask = tf.cast(tf.fill((seq_length, seq_length), -10000.0), dtype)
 
         # set diagonal & lower triangular parts to 0 (i.e. the places not to be masked)
         # TIP: think the 2D matrix as the space of (query_seq, key_seq)

--- a/src/transformers/models/clip/modeling_tf_clip.py
+++ b/src/transformers/models/clip/modeling_tf_clip.py
@@ -555,7 +555,16 @@ class TFCLIPTextTransformer(tf.keras.layers.Layer):
         diag = tf.cast(tf.fill((seq_length,), 0.0), dtype)
 
         # set an additive 2D attention mask with all places being masked
-        to_mask = tf.cast(tf.fill((seq_length, seq_length,), -10000.0), dtype)
+        to_mask = tf.cast(
+            tf.fill(
+                (
+                    seq_length,
+                    seq_length,
+                ),
+                -10000.0,
+            ),
+            dtype,
+        )
 
         # set diagonal & lower triangular parts to 0 (i.e. the places not to be masked)
         # TIP: think the 2D matrix as the space of (query_seq, key_seq)
@@ -1082,11 +1091,25 @@ class TFCLIPTextModel(TFCLIPPreTrainedModel):
 
         return outputs
 
-    @tf.function(input_signature=
-        [
+    @tf.function(
+        input_signature=[
             {
-                'input_ids': tf.TensorSpec((None, None,), tf.int32, name='input_ids'),
-                'attention_mask': tf.TensorSpec((None, None,), tf.int32, name='attention_mask')
+                "input_ids": tf.TensorSpec(
+                    (
+                        None,
+                        None,
+                    ),
+                    tf.int32,
+                    name="input_ids",
+                ),
+                "attention_mask": tf.TensorSpec(
+                    (
+                        None,
+                        None,
+                    ),
+                    tf.int32,
+                    name="attention_mask",
+                ),
             }
         ]
     )
@@ -1387,8 +1410,12 @@ class TFCLIPModel(TFCLIPPreTrainedModel):
         return outputs
 
     def serving_output(self, output: TFCLIPOutput) -> TFCLIPOutput:
-        text_hs = tf.convert_to_tensor(output.text_model_output.hidden_states) if self.config.output_hidden_states else None
-        text_attns = tf.convert_to_tensor(output.text_model_output.attentions) if self.config.output_attentions else None
+        text_hs = (
+            tf.convert_to_tensor(output.text_model_output.hidden_states) if self.config.output_hidden_states else None
+        )
+        text_attns = (
+            tf.convert_to_tensor(output.text_model_output.attentions) if self.config.output_attentions else None
+        )
         text_model_output = TFBaseModelOutputWithPooling(
             last_hidden_state=output.text_model_output.last_hidden_state,
             pooler_output=output.text_model_output.pooler_output,
@@ -1396,8 +1423,14 @@ class TFCLIPModel(TFCLIPPreTrainedModel):
             attentions=text_attns,
         )
 
-        vision_hs = tf.convert_to_tensor(output.vision_model_output.hidden_states) if self.config.output_hidden_states else None
-        vision_attns = tf.convert_to_tensor(output.vision_model_output.attentions) if self.config.output_attentions else None
+        vision_hs = (
+            tf.convert_to_tensor(output.vision_model_output.hidden_states)
+            if self.config.output_hidden_states
+            else None
+        )
+        vision_attns = (
+            tf.convert_to_tensor(output.vision_model_output.attentions) if self.config.output_attentions else None
+        )
         vision_model_output = TFBaseModelOutputWithPooling(
             last_hidden_state=output.vision_model_output.last_hidden_state,
             pooler_output=output.vision_model_output.pooler_output,

--- a/src/transformers/models/clip/modeling_tf_clip.py
+++ b/src/transformers/models/clip/modeling_tf_clip.py
@@ -1090,7 +1090,7 @@ class TFCLIPTextModel(TFCLIPPreTrainedModel):
             }
         ]
     )
-    def serving(self, inputs):
+    def serving(self, inputs: Dict[str, tf.Tensor]) -> TFBaseModelOutputWithPooling:
         output = self.call(inputs)
         return self.serving_output(output)
 
@@ -1135,7 +1135,7 @@ class TFCLIPVisionModel(TFCLIPPreTrainedModel):
             }
         ]
     )
-    def serving(self, inputs):
+    def serving(self, inputs: Dict[str, tf.Tensor]) -> TFBaseModelOutputWithPooling:
         """
         Method used for serving the model.
 
@@ -1238,7 +1238,7 @@ class TFCLIPModel(TFCLIPPreTrainedModel):
             }
         ]
     )
-    def serving(self, inputs):
+    def serving(self, inputs: Dict[str, tf.Tensor]) -> TFCLIPOutput:
         """
         Method used for serving the model.
 
@@ -1415,4 +1415,4 @@ class TFCLIPModel(TFCLIPPreTrainedModel):
             vision_model_output=vision_model_output,
         )
 
-        return output.to_tuple()
+        return output

--- a/src/transformers/models/clip/modeling_tf_clip.py
+++ b/src/transformers/models/clip/modeling_tf_clip.py
@@ -1401,42 +1401,7 @@ class TFCLIPModel(TFCLIPPreTrainedModel):
         return outputs
 
     def serving_output(self, output: TFCLIPOutput) -> TFCLIPOutput:
-        text_hs = (
-            tf.convert_to_tensor(output.text_model_output.hidden_states) if self.config.output_hidden_states else None
-        )
-        text_attns = (
-            tf.convert_to_tensor(output.text_model_output.attentions) if self.config.output_attentions else None
-        )
-        text_model_output = TFBaseModelOutputWithPooling(
-            last_hidden_state=output.text_model_output.last_hidden_state,
-            pooler_output=output.text_model_output.pooler_output,
-            hidden_states=text_hs,
-            attentions=text_attns,
-        )
-
-        vision_hs = (
-            tf.convert_to_tensor(output.vision_model_output.hidden_states)
-            if self.config.output_hidden_states
-            else None
-        )
-        vision_attns = (
-            tf.convert_to_tensor(output.vision_model_output.attentions) if self.config.output_attentions else None
-        )
-        vision_model_output = TFBaseModelOutputWithPooling(
-            last_hidden_state=output.vision_model_output.last_hidden_state,
-            pooler_output=output.vision_model_output.pooler_output,
-            hidden_states=vision_hs,
-            attentions=vision_attns,
-        )
-
-        output = TFCLIPOutput(
-            loss=output.loss,
-            logits_per_image=output.logits_per_image,
-            logits_per_text=output.logits_per_text,
-            text_embeds=output.text_embeds,
-            image_embeds=output.image_embeds,
-            text_model_output=text_model_output,
-            vision_model_output=vision_model_output,
-        )
-
+        # TODO: As is this currently fails with saved_model=True, because
+        # TensorFlow cannot trace through nested dataclasses. Reference:
+        # https://github.com/huggingface/transformers/pull/16886
         return output

--- a/src/transformers/models/clip/modeling_tf_clip.py
+++ b/src/transformers/models/clip/modeling_tf_clip.py
@@ -1401,7 +1401,42 @@ class TFCLIPModel(TFCLIPPreTrainedModel):
         return outputs
 
     def serving_output(self, output: TFCLIPOutput) -> TFCLIPOutput:
-        # TODO: As is this currently fails with saved_model=True, because
-        # TensorFlow cannot trace through nested dataclasses. Reference:
-        # https://github.com/huggingface/transformers/pull/16886
+        text_hs = (
+            tf.convert_to_tensor(output.text_model_output.hidden_states) if self.config.output_hidden_states else None
+        )
+        text_attns = (
+            tf.convert_to_tensor(output.text_model_output.attentions) if self.config.output_attentions else None
+        )
+        text_model_output = TFBaseModelOutputWithPooling(
+            last_hidden_state=output.text_model_output.last_hidden_state,
+            pooler_output=output.text_model_output.pooler_output,
+            hidden_states=text_hs,
+            attentions=text_attns,
+        )
+
+        vision_hs = (
+            tf.convert_to_tensor(output.vision_model_output.hidden_states)
+            if self.config.output_hidden_states
+            else None
+        )
+        vision_attns = (
+            tf.convert_to_tensor(output.vision_model_output.attentions) if self.config.output_attentions else None
+        )
+        vision_model_output = TFBaseModelOutputWithPooling(
+            last_hidden_state=output.vision_model_output.last_hidden_state,
+            pooler_output=output.vision_model_output.pooler_output,
+            hidden_states=vision_hs,
+            attentions=vision_attns,
+        )
+
+        output = TFCLIPOutput(
+            loss=output.loss,
+            logits_per_image=output.logits_per_image,
+            logits_per_text=output.logits_per_text,
+            text_embeds=output.text_embeds,
+            image_embeds=output.image_embeds,
+            text_model_output=text_model_output,
+            vision_model_output=vision_model_output,
+        )
+
         return output

--- a/src/transformers/models/clip/modeling_tf_clip.py
+++ b/src/transformers/models/clip/modeling_tf_clip.py
@@ -156,7 +156,7 @@ class TFCLIPVisionEmbeddings(tf.keras.layers.Layer):
 
         self.class_embedding = self.add_weight(
             shape=(self.embed_dim,),
-            initializer=get_initializer(self.embed_dim ** -0.5 * factor),
+            initializer=get_initializer(self.embed_dim**-0.5 * factor),
             trainable=True,
             name="class_embedding",
         )
@@ -226,7 +226,10 @@ class TFCLIPTextEmbeddings(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def call(
-        self, input_ids: tf.Tensor = None, position_ids: tf.Tensor = None, inputs_embeds: tf.Tensor = None,
+        self,
+        input_ids: tf.Tensor = None,
+        position_ids: tf.Tensor = None,
+        inputs_embeds: tf.Tensor = None,
     ) -> tf.Tensor:
         """
         Applies embedding based on inputs tensor.
@@ -267,8 +270,8 @@ class TFCLIPAttention(tf.keras.layers.Layer):
             )
 
         factor = config.initializer_factor
-        in_proj_std = (self.embed_dim ** -0.5) * ((2 * config.num_hidden_layers) ** -0.5) * factor
-        out_proj_std = (self.embed_dim ** -0.5) * factor
+        in_proj_std = (self.embed_dim**-0.5) * ((2 * config.num_hidden_layers) ** -0.5) * factor
+        out_proj_std = (self.embed_dim**-0.5) * factor
 
         self.sqrt_att_head_size = math.sqrt(self.attention_head_size)
 
@@ -357,7 +360,7 @@ class TFCLIPMLP(tf.keras.layers.Layer):
         self.activation_fn = get_tf_activation(config.hidden_act)
 
         factor = config.initializer_factor
-        in_proj_std = (config.hidden_size ** -0.5) * ((2 * config.num_hidden_layers) ** -0.5) * factor
+        in_proj_std = (config.hidden_size**-0.5) * ((2 * config.num_hidden_layers) ** -0.5) * factor
         fc_std = (2 * config.hidden_size) ** -0.5 * factor
 
         self.fc1 = tf.keras.layers.Dense(
@@ -725,14 +728,14 @@ class TFCLIPMainLayer(tf.keras.layers.Layer):
 
         self.visual_projection = tf.keras.layers.Dense(
             units=self.projection_dim,
-            kernel_initializer=get_initializer(vision_config.hidden_size ** -0.5 * self.config.initializer_factor),
+            kernel_initializer=get_initializer(vision_config.hidden_size**-0.5 * self.config.initializer_factor),
             use_bias=False,
             name="visual_projection",
         )
 
         self.text_projection = tf.keras.layers.Dense(
             units=self.projection_dim,
-            kernel_initializer=get_initializer(text_config.hidden_size ** -0.5 * self.config.initializer_factor),
+            kernel_initializer=get_initializer(text_config.hidden_size**-0.5 * self.config.initializer_factor),
             use_bias=False,
             name="text_projection",
         )
@@ -1129,7 +1132,11 @@ class TFCLIPVisionModel(TFCLIPPreTrainedModel):
         return {"pixel_values": VISION_DUMMY_INPUTS}
 
     @tf.function(
-        input_signature=[{"pixel_values": tf.TensorSpec((None, None, None, None), tf.float32, name="pixel_values"),}]
+        input_signature=[
+            {
+                "pixel_values": tf.TensorSpec((None, None, None, None), tf.float32, name="pixel_values"),
+            }
+        ]
     )
     def serving(self, inputs: Dict[str, tf.Tensor]) -> TFBaseModelOutputWithPooling:
         """

--- a/src/transformers/models/clip/modeling_tf_clip.py
+++ b/src/transformers/models/clip/modeling_tf_clip.py
@@ -551,7 +551,10 @@ class TFCLIPTextTransformer(tf.keras.layers.Layer):
         )
 
     def _build_causal_attention_mask(self, batch_size, seq_length, dtype=tf.float32):
-
+        # It is possible with an unspecified sequence length for seq_length to be
+        # a runtime value, which is unsupported by tf.constant. Per the TensorFlow
+        # docs, tf.fill can handle runtime dynamic shapes:
+        # https://www.tensorflow.org/api_docs/python/tf/fill
         diag = tf.cast(tf.fill((seq_length,), 0.0), dtype)
 
         # set an additive 2D attention mask with all places being masked
@@ -1085,22 +1088,8 @@ class TFCLIPTextModel(TFCLIPPreTrainedModel):
     @tf.function(
         input_signature=[
             {
-                "input_ids": tf.TensorSpec(
-                    (
-                        None,
-                        None,
-                    ),
-                    tf.int32,
-                    name="input_ids",
-                ),
-                "attention_mask": tf.TensorSpec(
-                    (
-                        None,
-                        None,
-                    ),
-                    tf.int32,
-                    name="attention_mask",
-                ),
+                "input_ids": tf.TensorSpec((None, None), tf.int32, name="input_ids"),
+                "attention_mask": tf.TensorSpec((None, None), tf.int32, name="attention_mask"),
             }
         ]
     )

--- a/src/transformers/models/clip/modeling_tf_clip.py
+++ b/src/transformers/models/clip/modeling_tf_clip.py
@@ -156,7 +156,7 @@ class TFCLIPVisionEmbeddings(tf.keras.layers.Layer):
 
         self.class_embedding = self.add_weight(
             shape=(self.embed_dim,),
-            initializer=get_initializer(self.embed_dim**-0.5 * factor),
+            initializer=get_initializer(self.embed_dim ** -0.5 * factor),
             trainable=True,
             name="class_embedding",
         )
@@ -226,10 +226,7 @@ class TFCLIPTextEmbeddings(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def call(
-        self,
-        input_ids: tf.Tensor = None,
-        position_ids: tf.Tensor = None,
-        inputs_embeds: tf.Tensor = None,
+        self, input_ids: tf.Tensor = None, position_ids: tf.Tensor = None, inputs_embeds: tf.Tensor = None,
     ) -> tf.Tensor:
         """
         Applies embedding based on inputs tensor.
@@ -270,8 +267,8 @@ class TFCLIPAttention(tf.keras.layers.Layer):
             )
 
         factor = config.initializer_factor
-        in_proj_std = (self.embed_dim**-0.5) * ((2 * config.num_hidden_layers) ** -0.5) * factor
-        out_proj_std = (self.embed_dim**-0.5) * factor
+        in_proj_std = (self.embed_dim ** -0.5) * ((2 * config.num_hidden_layers) ** -0.5) * factor
+        out_proj_std = (self.embed_dim ** -0.5) * factor
 
         self.sqrt_att_head_size = math.sqrt(self.attention_head_size)
 
@@ -360,7 +357,7 @@ class TFCLIPMLP(tf.keras.layers.Layer):
         self.activation_fn = get_tf_activation(config.hidden_act)
 
         factor = config.initializer_factor
-        in_proj_std = (config.hidden_size**-0.5) * ((2 * config.num_hidden_layers) ** -0.5) * factor
+        in_proj_std = (config.hidden_size ** -0.5) * ((2 * config.num_hidden_layers) ** -0.5) * factor
         fc_std = (2 * config.hidden_size) ** -0.5 * factor
 
         self.fc1 = tf.keras.layers.Dense(
@@ -728,14 +725,14 @@ class TFCLIPMainLayer(tf.keras.layers.Layer):
 
         self.visual_projection = tf.keras.layers.Dense(
             units=self.projection_dim,
-            kernel_initializer=get_initializer(vision_config.hidden_size**-0.5 * self.config.initializer_factor),
+            kernel_initializer=get_initializer(vision_config.hidden_size ** -0.5 * self.config.initializer_factor),
             use_bias=False,
             name="visual_projection",
         )
 
         self.text_projection = tf.keras.layers.Dense(
             units=self.projection_dim,
-            kernel_initializer=get_initializer(text_config.hidden_size**-0.5 * self.config.initializer_factor),
+            kernel_initializer=get_initializer(text_config.hidden_size ** -0.5 * self.config.initializer_factor),
             use_bias=False,
             name="text_projection",
         )
@@ -1132,11 +1129,7 @@ class TFCLIPVisionModel(TFCLIPPreTrainedModel):
         return {"pixel_values": VISION_DUMMY_INPUTS}
 
     @tf.function(
-        input_signature=[
-            {
-                "pixel_values": tf.TensorSpec((None, None, None, None), tf.float32, name="pixel_values"),
-            }
-        ]
+        input_signature=[{"pixel_values": tf.TensorSpec((None, None, None, None), tf.float32, name="pixel_values"),}]
     )
     def serving(self, inputs: Dict[str, tf.Tensor]) -> TFBaseModelOutputWithPooling:
         """

--- a/tests/models/clip/test_modeling_tf_clip.py
+++ b/tests/models/clip/test_modeling_tf_clip.py
@@ -276,21 +276,11 @@ class TFCLIPVisionModelTest(TFModelTesterMixin, unittest.TestCase):
                 model = tf.keras.models.load_model(saved_model_dir)
                 outputs = model(class_inputs_dict)
 
-                if self.is_encoder_decoder:
-                    output_hidden_states = outputs["encoder_hidden_states"]
-                    output_attentions = outputs["encoder_attentions"]
-                else:
-                    output_hidden_states = outputs["hidden_states"]
-                    output_attentions = outputs["attentions"]
-
                 self.assertEqual(len(outputs), num_out)
 
                 expected_num_layers = getattr(
                     self.model_tester, "expected_num_hidden_layers", self.model_tester.num_hidden_layers + 1
                 )
-
-                self.assertEqual(len(output_hidden_states), expected_num_layers)
-                self.assertEqual(len(output_attentions), self.model_tester.num_hidden_layers)
 
 
 class TFCLIPTextModelTester:

--- a/tests/models/clip/test_modeling_tf_clip.py
+++ b/tests/models/clip/test_modeling_tf_clip.py
@@ -210,7 +210,8 @@ class TFCLIPVisionModelTest(TFModelTesterMixin, unittest.TestCase):
             self.assertEqual(len(self_attentions), self.model_tester.num_hidden_layers)
 
             self.assertListEqual(
-                list(self_attentions[0].shape[-3:]), [self.model_tester.num_attention_heads, seq_len, seq_len],
+                list(self_attentions[0].shape[-3:]),
+                [self.model_tester.num_attention_heads, seq_len, seq_len],
             )
 
     def test_hidden_states_output(self):
@@ -233,7 +234,8 @@ class TFCLIPVisionModelTest(TFModelTesterMixin, unittest.TestCase):
             seq_length = num_patches + 1
 
             self.assertListEqual(
-                list(hidden_states[0].shape[-2:]), [seq_length, self.model_tester.hidden_size],
+                list(hidden_states[0].shape[-2:]),
+                [seq_length, self.model_tester.hidden_size],
             )
 
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
@@ -300,12 +302,14 @@ class TFCLIPVisionModelTest(TFModelTesterMixin, unittest.TestCase):
                 seq_len = num_patches + 1
 
                 self.assertListEqual(
-                    list(output_attentions[0].shape[-3:]), [self.model_tester.num_attention_heads, seq_len, seq_len],
+                    list(output_attentions[0].shape[-3:]),
+                    [self.model_tester.num_attention_heads, seq_len, seq_len],
                 )
 
                 # Check hidden states
                 self.assertListEqual(
-                    list(output_hidden_states[0].shape[-2:]), [seq_len, self.model_tester.hidden_size],
+                    list(output_hidden_states[0].shape[-2:]),
+                    [seq_len, self.model_tester.hidden_size],
                 )
 
 
@@ -633,10 +637,12 @@ class TFCLIPModelIntegrationTest(unittest.TestCase):
 
         # verify the logits
         self.assertEqual(
-            outputs.logits_per_image.shape, tf.TensorShape((inputs.pixel_values.shape[0], inputs.input_ids.shape[0])),
+            outputs.logits_per_image.shape,
+            tf.TensorShape((inputs.pixel_values.shape[0], inputs.input_ids.shape[0])),
         )
         self.assertEqual(
-            outputs.logits_per_text.shape, tf.TensorShape((inputs.input_ids.shape[0], inputs.pixel_values.shape[0])),
+            outputs.logits_per_text.shape,
+            tf.TensorShape((inputs.input_ids.shape[0], inputs.pixel_values.shape[0])),
         )
 
         expected_logits = tf.constant([[24.5701, 19.3049]])

--- a/tests/models/clip/test_modeling_tf_clip.py
+++ b/tests/models/clip/test_modeling_tf_clip.py
@@ -282,6 +282,9 @@ class TFCLIPVisionModelTest(TFModelTesterMixin, unittest.TestCase):
                     self.model_tester, "expected_num_hidden_layers", self.model_tester.num_hidden_layers + 1
                 )
 
+                self.assertEqual(len(output_hidden_states), expected_num_layers)
+                self.assertEqual(len(output_attentions), self.model_tester.num_hidden_layers)
+
 
 class TFCLIPTextModelTester:
     def __init__(

--- a/tests/models/clip/test_modeling_tf_clip.py
+++ b/tests/models/clip/test_modeling_tf_clip.py
@@ -292,6 +292,7 @@ class TFCLIPVisionModelTest(TFModelTesterMixin, unittest.TestCase):
                 self.assertEqual(len(output_hidden_states), expected_num_layers)
                 self.assertEqual(len(output_attentions), self.model_tester.num_hidden_layers)
 
+
 class TFCLIPTextModelTester:
     def __init__(
         self,
@@ -443,6 +444,7 @@ class TFCLIPTextModelTest(TFModelTesterMixin, unittest.TestCase):
 
                 self.assertEqual(len(output_attentions), self.model_tester.num_hidden_layers)
 
+
 class TFCLIPModelTester:
     def __init__(self, parent, is_training=True):
         self.parent = parent
@@ -577,7 +579,6 @@ class TFCLIPModelTest(TFModelTesterMixin, unittest.TestCase):
             model = TFCLIPModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
-
     @slow
     def test_saved_model_creation_extended(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
@@ -618,6 +619,7 @@ class TFCLIPModelTest(TFModelTesterMixin, unittest.TestCase):
                 )
 
                 self.assertEqual(len(output_attentions), self.model_tester.num_hidden_layers)
+
 
 # We will verify our results on an image of cute cats
 def prepare_img():

--- a/tests/models/clip/test_modeling_tf_clip.py
+++ b/tests/models/clip/test_modeling_tf_clip.py
@@ -463,7 +463,7 @@ class TFCLIPTextModelTest(TFModelTesterMixin, unittest.TestCase):
                 # Check attention outputs
                 self.assertEqual(len(output_attentions), self.model_tester.num_hidden_layers)
 
-                seq_length = getattr(self.model_tester, "seq_length", self.model_tester.seq_length)
+                seq_length = self.model_tester.seq_length
                 key_length = getattr(self.model_tester, "key_length", seq_length)
 
                 self.assertListEqual(


### PR DESCRIPTION
# What does this PR do?

I apologize if this is out of scope. There were a few bugs in TFCLIPModel which prevented the model from being exported using the TensorFlow SavedModel format:

1) `_build_causal_attention_mask` makes use of `tf.constant` with a runtime dynamic value. It seems `shape_list` makes use of `tf.shape` which returns a symbolic tensor (inside autograph), which prevents the graph from being fully traced. `tf.constant` does not allow runtime dynamic values, but `tf.fill` does, so I replaced `tf.constant` with a ` tf.cast` and `tf.fill` combo. I don't even think `TFCLIPModel` would run inside a `tf.function` without this change because the autograph trace fails.

2) `TFCLIPTextModel` needs to override the `serving` default implementation. The default implementation expects `token_type_ids` which is not a valid input here.

3) `serving_output` for TFCLIPModel has some issue with tracing through nested dataclasses, which I can't seem to get right just quite yet. Ideally it should be as easy as calling `serving_output` on `text_model_output` and `vision_model_output` (since  there is some `convert_to_tensor` stuff going on in each output). I was having problems with TensorFlow saying `TFBaseModelOutputWithPooling` not being a tensor, so I figured the tuple conversion would work, but it doesn't seem to be the fix.

I added tests for exporting each of `TFCLIPModel`, `TFTextModel` and `TFVisionModel` as saved models to verify individual components work and that it's the integration of both that's failing

cc @LysandreJik for TensorFlow changes
