### PR TITLE
Fix typos BigBird ONNX conversion

### DIFF
--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -159,7 +159,7 @@ class FeaturesManager:
             "question-answering",
             onnx_config_cls=BertOnnxConfig,
         ),
-        "bigbird": supported_features_mapping(
+        "big-bird": supported_features_mapping(
             "default",
             "masked-lm",
             "causal-lm",

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -172,7 +172,7 @@ class OnnxConfigWithPastTestCaseV2(TestCase):
 PYTORCH_EXPORT_MODELS = {
     ("albert", "hf-internal-testing/tiny-albert"),
     ("bert", "bert-base-cased"),
-    ("bigbird", "google/bigbird-roberta-base"),
+    ("big-bird", "google/bigbird-roberta-base"),
     ("ibert", "kssteven/ibert-roberta-base"),
     ("camembert", "camembert-base"),
     ("convbert", "YituTech/conv-bert-base"),


### PR DESCRIPTION
# What does this PR do?

I tried to convert one `BigBird` model to ONNX with the recent PR merged #16427

But it seems that there is a typo in the `src/transformers/onnx/features.py` file.
I also fixed the typo in the test_v2 file.

Here is the error I get while trying to convert `google/bigbird-roberta-base`.

```bash
$ python -m transformers.onnx --model=google/bigbird-roberta-base onnx/

> KeyError: "big-bird is not supported yet. 
> Only ['albert', 'bart', 'mbart', 'bert', 'bigbird', 
> 'ibert', 'camembert', 'distilbert', 'flaubert', 'marian', 'm2m-100', 'roberta', 't5', 
> 'xlm-roberta', 'gpt2', 'gptj', 'gpt-neo', 'layoutlm', 'electra', 'vit', 'beit', 'blenderbot', 
> 'blenderbot-small', 'data2vec-text'] are supported. 
> If you want to support big-bird please propose a PR or open up an issue."
```

As you can see in the error `bigbird` should be `big-bird`.

ping @lewtun @LysandreJik 
