### PR TITLE
[WIP] Avoid BERT `attention_mask` from promoting dtype in self-attention `forward()`

### DIFF
--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -340,7 +340,7 @@ class BertSelfAttention(nn.Module):
         attention_scores = attention_scores / math.sqrt(self.attention_head_size)
         if attention_mask is not None:
             # Apply the attention mask is (precomputed for all layers in BertModel forward() function)
-            attention_scores = attention_scores + attention_mask
+            attention_scores = attention_scores + attention_mask.to(attention_scores.dtype)
 
         # Normalize the attention scores to probabilities.
         attention_probs = nn.functional.softmax(attention_scores, dim=-1)


### PR DESCRIPTION
### Overview

~The `attention_mask` passed into `BertSelfAttention.forward()` is taken from the BERT model's first parameter dtype at **construction time**.~
<details>
  <summary>Code Pointers</summary>

  https://github.com/huggingface/transformers/blob/22fc93c4d9608fa9cd171b4f3044f8c756f86773/src/transformers/models/bert/modeling_bert.py#L985
https://github.com/huggingface/transformers/blob/22fc93c4d9608fa9cd171b4f3044f8c756f86773/src/transformers/modeling_utils.py#L655
https://github.com/huggingface/transformers/blob/22fc93c4d9608fa9cd171b4f3044f8c756f86773/src/transformers/modeling_utils.py#L556-L561
https://github.com/huggingface/transformers/blob/22fc93c4d9608fa9cd171b4f3044f8c756f86773/src/transformers/modeling_utils.py#L123-L125
</details>

However, if a user only casts down the input or parameter dtype(s) (e.g. to `torch.float16`) **after** construction time and before running `forward()`, the `extended_attention_mask` will still have dtype `torch.float32` rather than the reduced precision dtype.

Due to PyTorch [type promotion semantics](https://pytorch.org/docs/stable/tensor_attributes.html#type-promotion-doc), `attention_scores = attention_scores + attention_mask` will promote `attention_scores` to `torch.float32` and propagate through the remainder of the forward pass, defeating the intention of the reduced precision.
https://github.com/huggingface/transformers/blob/22fc93c4d9608fa9cd171b4f3044f8c756f86773/src/transformers/models/bert/modeling_bert.py#L343

In order to avoid this behavior, the model parameters must be cast to the reduced precision at construction time, which is restrictive. This PR ensures that the addition does not change the dtype.

**Before**
`attention_scores`: FP16
`attention_mask`: FP32
==> FP32
`attention_scores`: FP32
`attention_mask`: FP16
==> FP32

**After**
`attention_scores`: FP16
`attention_mask`: FP32 -> FP16
==> FP16
`attention_scores`: FP32
`attention_mask`: FP16 -> FP32
==> FP32

(Hence, we see that the reverse setting has no change in behavior, while for the desired setting, we prevent the unwanted type promotion.)

### Test Plan
I ran `tests/bert/test_modeling_bert.py` locally with 4 GPUs and 68 passed and 11 skipped. Since this is a small change, direct inspection may be more valuable.
