### PR TITLE
Pytorch QA examples fix & clean-up (code dedup)

### DIFF
--- a/examples/flax/question-answering/utils_qa.py
+++ b/examples/flax/question-answering/utils_qa.py
@@ -350,9 +350,12 @@ def postprocess_qa_predictions_with_beam_search(
                         start_index >= len(offset_mapping)
                         or end_index >= len(offset_mapping)
                         or offset_mapping[start_index] is None
+                        or len(offset_mapping[start_index]) < 2
                         or offset_mapping[end_index] is None
+                        or len(offset_mapping[end_index]) < 2
                     ):
                         continue
+
                     # Don't consider answers with a length negative or > max_answer_length.
                     if end_index < start_index or end_index - start_index + 1 > max_answer_length:
                         continue
@@ -381,7 +384,9 @@ def postprocess_qa_predictions_with_beam_search(
         # In the very rare edge case we have not a single non-null prediction, we create a fake prediction to avoid
         # failure.
         if len(predictions) == 0:
-            predictions.insert(0, {"text": "", "start_logit": -1e-6, "end_logit": -1e-6, "score": -2e-6})
+            # Without predictions min_null_score is going to be None and None will cause an exception later
+            min_null_score = -2e-6
+            predictions.insert(0, {"text": "", "start_logit": -1e-6, "end_logit": -1e-6, "score": min_null_score})
 
         # Compute the softmax of all scores (we do it with numpy to stay independent from torch/tf in this file, using
         # the LogSumExp trick).

--- a/examples/pytorch/question-answering/run_qa.py
+++ b/examples/pytorch/question-answering/run_qa.py
@@ -22,6 +22,7 @@ import logging
 import os
 import sys
 from dataclasses import dataclass, field
+from functools import partial
 from typing import Optional
 
 import datasets
@@ -44,7 +45,7 @@ from transformers import (
 from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
-from utils_qa import postprocess_qa_predictions
+from utils_qa_add import post_processing_function, prepare_train_features, prepare_validation_features
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
@@ -346,84 +347,6 @@ def main():
         )
     max_seq_length = min(data_args.max_seq_length, tokenizer.model_max_length)
 
-    # Training preprocessing
-    def prepare_train_features(examples):
-        # Some of the questions have lots of whitespace on the left, which is not useful and will make the
-        # truncation of the context fail (the tokenized question will take a lots of space). So we remove that
-        # left whitespace
-        examples[question_column_name] = [q.lstrip() for q in examples[question_column_name]]
-
-        # Tokenize our examples with truncation and maybe padding, but keep the overflows using a stride. This results
-        # in one example possible giving several features when a context is long, each of those features having a
-        # context that overlaps a bit the context of the previous feature.
-        tokenized_examples = tokenizer(
-            examples[question_column_name if pad_on_right else context_column_name],
-            examples[context_column_name if pad_on_right else question_column_name],
-            truncation="only_second" if pad_on_right else "only_first",
-            max_length=max_seq_length,
-            stride=data_args.doc_stride,
-            return_overflowing_tokens=True,
-            return_offsets_mapping=True,
-            padding="max_length" if data_args.pad_to_max_length else False,
-        )
-
-        # Since one example might give us several features if it has a long context, we need a map from a feature to
-        # its corresponding example. This key gives us just that.
-        sample_mapping = tokenized_examples.pop("overflow_to_sample_mapping")
-        # The offset mappings will give us a map from token to character position in the original context. This will
-        # help us compute the start_positions and end_positions.
-        offset_mapping = tokenized_examples.pop("offset_mapping")
-
-        # Let's label those examples!
-        tokenized_examples["start_positions"] = []
-        tokenized_examples["end_positions"] = []
-
-        for i, offsets in enumerate(offset_mapping):
-            # We will label impossible answers with the index of the CLS token.
-            input_ids = tokenized_examples["input_ids"][i]
-            cls_index = input_ids.index(tokenizer.cls_token_id)
-
-            # Grab the sequence corresponding to that example (to know what is the context and what is the question).
-            sequence_ids = tokenized_examples.sequence_ids(i)
-
-            # One example can give several spans, this is the index of the example containing this span of text.
-            sample_index = sample_mapping[i]
-            answers = examples[answer_column_name][sample_index]
-            # If no answers are given, set the cls_index as answer.
-            if len(answers["answer_start"]) == 0:
-                tokenized_examples["start_positions"].append(cls_index)
-                tokenized_examples["end_positions"].append(cls_index)
-            else:
-                # Start/end character index of the answer in the text.
-                start_char = answers["answer_start"][0]
-                end_char = start_char + len(answers["text"][0])
-
-                # Start token index of the current span in the text.
-                token_start_index = 0
-                while sequence_ids[token_start_index] != (1 if pad_on_right else 0):
-                    token_start_index += 1
-
-                # End token index of the current span in the text.
-                token_end_index = len(input_ids) - 1
-                while sequence_ids[token_end_index] != (1 if pad_on_right else 0):
-                    token_end_index -= 1
-
-                # Detect if the answer is out of the span (in which case this feature is labeled with the CLS index).
-                if not (offsets[token_start_index][0] <= start_char and offsets[token_end_index][1] >= end_char):
-                    tokenized_examples["start_positions"].append(cls_index)
-                    tokenized_examples["end_positions"].append(cls_index)
-                else:
-                    # Otherwise move the token_start_index and token_end_index to the two ends of the answer.
-                    # Note: we could go after the last offset if the answer is the last word (edge case).
-                    while token_start_index < len(offsets) and offsets[token_start_index][0] <= start_char:
-                        token_start_index += 1
-                    tokenized_examples["start_positions"].append(token_start_index - 1)
-                    while offsets[token_end_index][1] >= end_char:
-                        token_end_index -= 1
-                    tokenized_examples["end_positions"].append(token_end_index + 1)
-
-        return tokenized_examples
-
     if training_args.do_train:
         if "train" not in raw_datasets:
             raise ValueError("--do_train requires a train dataset")
@@ -435,7 +358,17 @@ def main():
         # Create train feature from dataset
         with training_args.main_process_first(desc="train dataset map pre-processing"):
             train_dataset = train_dataset.map(
-                prepare_train_features,
+                partial(
+                    prepare_train_features,
+                    tokenizer=tokenizer,
+                    max_seq_length=max_seq_length,
+                    doc_stride=data_args.doc_stride,
+                    pad_on_right=pad_on_right,
+                    pad_to_max_length=data_args.pad_to_max_length,
+                    question_column_name=question_column_name,
+                    answer_column_name=answer_column_name,
+                    context_column_name=context_column_name,
+                ),
                 batched=True,
                 num_proc=data_args.preprocessing_num_workers,
                 remove_columns=column_names,
@@ -446,53 +379,6 @@ def main():
             # Number of samples might increase during Feature Creation, We select only specified max samples
             max_train_samples = min(len(train_dataset), data_args.max_train_samples)
             train_dataset = train_dataset.select(range(max_train_samples))
-
-    # Validation preprocessing
-    def prepare_validation_features(examples):
-        # Some of the questions have lots of whitespace on the left, which is not useful and will make the
-        # truncation of the context fail (the tokenized question will take a lots of space). So we remove that
-        # left whitespace
-        examples[question_column_name] = [q.lstrip() for q in examples[question_column_name]]
-
-        # Tokenize our examples with truncation and maybe padding, but keep the overflows using a stride. This results
-        # in one example possible giving several features when a context is long, each of those features having a
-        # context that overlaps a bit the context of the previous feature.
-        tokenized_examples = tokenizer(
-            examples[question_column_name if pad_on_right else context_column_name],
-            examples[context_column_name if pad_on_right else question_column_name],
-            truncation="only_second" if pad_on_right else "only_first",
-            max_length=max_seq_length,
-            stride=data_args.doc_stride,
-            return_overflowing_tokens=True,
-            return_offsets_mapping=True,
-            padding="max_length" if data_args.pad_to_max_length else False,
-        )
-
-        # Since one example might give us several features if it has a long context, we need a map from a feature to
-        # its corresponding example. This key gives us just that.
-        sample_mapping = tokenized_examples.pop("overflow_to_sample_mapping")
-
-        # For evaluation, we will need to convert our predictions to substrings of the context, so we keep the
-        # corresponding example_id and we will store the offset mappings.
-        tokenized_examples["example_id"] = []
-
-        for i in range(len(tokenized_examples["input_ids"])):
-            # Grab the sequence corresponding to that example (to know what is the context and what is the question).
-            sequence_ids = tokenized_examples.sequence_ids(i)
-            context_index = 1 if pad_on_right else 0
-
-            # One example can give several spans, this is the index of the example containing this span of text.
-            sample_index = sample_mapping[i]
-            tokenized_examples["example_id"].append(examples["id"][sample_index])
-
-            # Set to None the offset_mapping that are not part of the context so it's easy to determine if a token
-            # position is part of the context or not.
-            tokenized_examples["offset_mapping"][i] = [
-                (o if sequence_ids[k] == context_index else None)
-                for k, o in enumerate(tokenized_examples["offset_mapping"][i])
-            ]
-
-        return tokenized_examples
 
     if training_args.do_eval:
         if "validation" not in raw_datasets:
@@ -505,7 +391,16 @@ def main():
         # Validation Feature Creation
         with training_args.main_process_first(desc="validation dataset map pre-processing"):
             eval_dataset = eval_examples.map(
-                prepare_validation_features,
+                partial(
+                    prepare_validation_features,
+                    tokenizer=tokenizer,
+                    max_seq_length=max_seq_length,
+                    doc_stride=data_args.doc_stride,
+                    pad_on_right=pad_on_right,
+                    pad_to_max_length=data_args.pad_to_max_length,
+                    question_column_name=question_column_name,
+                    context_column_name=context_column_name,
+                ),
                 batched=True,
                 num_proc=data_args.preprocessing_num_workers,
                 remove_columns=column_names,
@@ -548,32 +443,6 @@ def main():
         else DataCollatorWithPadding(tokenizer, pad_to_multiple_of=8 if training_args.fp16 else None)
     )
 
-    # Post-processing:
-    def post_processing_function(examples, features, predictions, stage="eval"):
-        # Post-processing: we match the start logits and end logits to answers in the original context.
-        predictions = postprocess_qa_predictions(
-            examples=examples,
-            features=features,
-            predictions=predictions,
-            version_2_with_negative=data_args.version_2_with_negative,
-            n_best_size=data_args.n_best_size,
-            max_answer_length=data_args.max_answer_length,
-            null_score_diff_threshold=data_args.null_score_diff_threshold,
-            output_dir=training_args.output_dir,
-            log_level=log_level,
-            prefix=stage,
-        )
-        # Format the result to the format the metric expects.
-        if data_args.version_2_with_negative:
-            formatted_predictions = [
-                {"id": k, "prediction_text": v, "no_answer_probability": 0.0} for k, v in predictions.items()
-            ]
-        else:
-            formatted_predictions = [{"id": k, "prediction_text": v} for k, v in predictions.items()]
-
-        references = [{"id": ex["id"], "answers": ex[answer_column_name]} for ex in examples]
-        return EvalPrediction(predictions=formatted_predictions, label_ids=references)
-
     metric = load_metric("squad_v2" if data_args.version_2_with_negative else "squad")
 
     def compute_metrics(p: EvalPrediction):
@@ -588,7 +457,16 @@ def main():
         eval_examples=eval_examples if training_args.do_eval else None,
         tokenizer=tokenizer,
         data_collator=data_collator,
-        post_process_function=post_processing_function,
+        post_process_function=partial(
+            post_processing_function,
+            answer_column_name=answer_column_name,
+            version_2_with_negative=data_args.version_2_with_negative,
+            n_best_size=data_args.n_best_size,
+            max_answer_length=data_args.max_answer_length,
+            null_score_diff_threshold=data_args.null_score_diff_threshold,
+            output_dir=training_args.output_dir,
+            log_level=log_level,
+        ),
         compute_metrics=compute_metrics,
     )
 

--- a/examples/pytorch/question-answering/run_qa_beam_search.py
+++ b/examples/pytorch/question-answering/run_qa_beam_search.py
@@ -22,6 +22,7 @@ import logging
 import os
 import sys
 from dataclasses import dataclass, field
+from functools import partial
 from typing import Optional
 
 import datasets
@@ -43,7 +44,11 @@ from transformers import (
 from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
-from utils_qa import postprocess_qa_predictions_with_beam_search
+from utils_qa_add import (
+    post_processing_function_with_beam_search,
+    prepare_train_features_with_beam_search,
+    prepare_validation_features_with_beam_search,
+)
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
@@ -334,107 +339,6 @@ def main():
         )
     max_seq_length = min(data_args.max_seq_length, tokenizer.model_max_length)
 
-    # Training preprocessing
-    def prepare_train_features(examples):
-        # Some of the questions have lots of whitespace on the left, which is not useful and will make the
-        # truncation of the context fail (the tokenized question will take a lots of space). So we remove that
-        # left whitespace
-        examples[question_column_name] = [q.lstrip() for q in examples[question_column_name]]
-
-        # Tokenize our examples with truncation and maybe padding, but keep the overflows using a stride. This results
-        # in one example possible giving several features when a context is long, each of those features having a
-        # context that overlaps a bit the context of the previous feature.
-        tokenized_examples = tokenizer(
-            examples[question_column_name if pad_on_right else context_column_name],
-            examples[context_column_name if pad_on_right else question_column_name],
-            truncation="only_second" if pad_on_right else "only_first",
-            max_length=max_seq_length,
-            stride=data_args.doc_stride,
-            return_overflowing_tokens=True,
-            return_offsets_mapping=True,
-            return_special_tokens_mask=True,
-            return_token_type_ids=True,
-            padding="max_length",
-        )
-
-        # Since one example might give us several features if it has a long context, we need a map from a feature to
-        # its corresponding example. This key gives us just that.
-        sample_mapping = tokenized_examples.pop("overflow_to_sample_mapping")
-        # The offset mappings will give us a map from token to character position in the original context. This will
-        # help us compute the start_positions and end_positions.
-        offset_mapping = tokenized_examples.pop("offset_mapping")
-        # The special tokens will help us build the p_mask (which indicates the tokens that can't be in answers).
-        special_tokens = tokenized_examples.pop("special_tokens_mask")
-
-        # Let's label those examples!
-        tokenized_examples["start_positions"] = []
-        tokenized_examples["end_positions"] = []
-        tokenized_examples["is_impossible"] = []
-        tokenized_examples["cls_index"] = []
-        tokenized_examples["p_mask"] = []
-
-        for i, offsets in enumerate(offset_mapping):
-            # We will label impossible answers with the index of the CLS token.
-            input_ids = tokenized_examples["input_ids"][i]
-            cls_index = input_ids.index(tokenizer.cls_token_id)
-            tokenized_examples["cls_index"].append(cls_index)
-
-            # Grab the sequence corresponding to that example (to know what is the context and what is the question).
-            sequence_ids = tokenized_examples["token_type_ids"][i]
-            for k, s in enumerate(special_tokens[i]):
-                if s:
-                    sequence_ids[k] = 3
-            context_idx = 1 if pad_on_right else 0
-
-            # Build the p_mask: non special tokens and context gets 0.0, the others get 1.0.
-            # The cls token gets 1.0 too (for predictions of empty answers).
-            tokenized_examples["p_mask"].append(
-                [
-                    0.0 if (not special_tokens[i][k] and s == context_idx) or k == cls_index else 1.0
-                    for k, s in enumerate(sequence_ids)
-                ]
-            )
-
-            # One example can give several spans, this is the index of the example containing this span of text.
-            sample_index = sample_mapping[i]
-            answers = examples[answer_column_name][sample_index]
-            # If no answers are given, set the cls_index as answer.
-            if len(answers["answer_start"]) == 0:
-                tokenized_examples["start_positions"].append(cls_index)
-                tokenized_examples["end_positions"].append(cls_index)
-                tokenized_examples["is_impossible"].append(1.0)
-            else:
-                # Start/end character index of the answer in the text.
-                start_char = answers["answer_start"][0]
-                end_char = start_char + len(answers["text"][0])
-
-                # Start token index of the current span in the text.
-                token_start_index = 0
-                while sequence_ids[token_start_index] != context_idx:
-                    token_start_index += 1
-
-                # End token index of the current span in the text.
-                token_end_index = len(input_ids) - 1
-                while sequence_ids[token_end_index] != context_idx:
-                    token_end_index -= 1
-                # Detect if the answer is out of the span (in which case this feature is labeled with the CLS index).
-                if not (offsets[token_start_index][0] <= start_char and offsets[token_end_index][1] >= end_char):
-                    tokenized_examples["start_positions"].append(cls_index)
-                    tokenized_examples["end_positions"].append(cls_index)
-                    tokenized_examples["is_impossible"].append(1.0)
-                else:
-                    # Otherwise move the token_start_index and token_end_index to the two ends of the answer.
-                    # Note: we could go after the last offset if the answer is the last word (edge case).
-                    while token_start_index < len(offsets) and offsets[token_start_index][0] <= start_char:
-                        token_start_index += 1
-                    tokenized_examples["start_positions"].append(token_start_index - 1)
-                    while offsets[token_end_index][1] >= end_char:
-                        token_end_index -= 1
-                    tokenized_examples["end_positions"].append(token_end_index + 1)
-                    tokenized_examples["is_impossible"].append(0.0)
-
-        return tokenized_examples
-
     if training_args.do_train:
         if "train" not in raw_datasets:
             raise ValueError("--do_train requires a train dataset")
@@ -446,7 +350,16 @@ def main():
         # Create Training Features
         with training_args.main_process_first(desc="train dataset map pre-processing"):
             train_dataset = train_dataset.map(
-                prepare_train_features,
+                partial(
+                    prepare_train_features_with_beam_search,
+                    tokenizer=tokenizer,
+                    max_seq_length=max_seq_length,
+                    doc_stride=data_args.doc_stride,
+                    pad_on_right=pad_on_right,
+                    question_column_name=question_column_name,
+                    answer_column_name=answer_column_name,
+                    context_column_name=context_column_name,
+                ),
                 batched=True,
                 num_proc=data_args.preprocessing_num_workers,
                 remove_columns=column_names,
@@ -457,72 +370,6 @@ def main():
             # Select samples from dataset again since Feature Creation might increase number of features
             max_train_samples = min(len(train_dataset), data_args.max_train_samples)
             train_dataset = train_dataset.select(range(max_train_samples))
-
-    # Validation preprocessing
-    def prepare_validation_features(examples):
-        # Tokenize our examples with truncation and maybe padding, but keep the overflows using a stride. This results
-        # in one example possible giving several features when a context is long, each of those features having a
-        # context that overlaps a bit the context of the previous feature.
-        tokenized_examples = tokenizer(
-            examples[question_column_name if pad_on_right else context_column_name],
-            examples[context_column_name if pad_on_right else question_column_name],
-            truncation="only_second" if pad_on_right else "only_first",
-            max_length=max_seq_length,
-            stride=data_args.doc_stride,
-            return_overflowing_tokens=True,
-            return_offsets_mapping=True,
-            return_special_tokens_mask=True,
-            return_token_type_ids=True,
-            padding="max_length",
-        )
-
-        # Since one example might give us several features if it has a long context, we need a map from a feature to
-        # its corresponding example. This key gives us just that.
-        sample_mapping = tokenized_examples.pop("overflow_to_sample_mapping")
-
-        # The special tokens will help us build the p_mask (which indicates the tokens that can't be in answers).
-        special_tokens = tokenized_examples.pop("special_tokens_mask")
-
-        # For evaluation, we will need to convert our predictions to substrings of the context, so we keep the
-        # corresponding example_id and we will store the offset mappings.
-        tokenized_examples["example_id"] = []
-
-        # We still provide the index of the CLS token and the p_mask to the model, but not the is_impossible label.
-        tokenized_examples["cls_index"] = []
-        tokenized_examples["p_mask"] = []
-
-        for i, input_ids in enumerate(tokenized_examples["input_ids"]):
-            # Find the CLS token in the input ids.
-            cls_index = input_ids.index(tokenizer.cls_token_id)
-            tokenized_examples["cls_index"].append(cls_index)
-
-            # Grab the sequence corresponding to that example (to know what is the context and what is the question).
-            sequence_ids = tokenized_examples["token_type_ids"][i]
-            for k, s in enumerate(special_tokens[i]):
-                if s:
-                    sequence_ids[k] = 3
-            context_idx = 1 if pad_on_right else 0
-
-            # Build the p_mask: non special tokens and context gets 0.0, the others 1.0.
-            tokenized_examples["p_mask"].append(
-                [
-                    0.0 if (not special_tokens[i][k] and s == context_idx) or k == cls_index else 1.0
-                    for k, s in enumerate(sequence_ids)
-                ]
-            )
-
-            # One example can give several spans, this is the index of the example containing this span of text.
-            sample_index = sample_mapping[i]
-            tokenized_examples["example_id"].append(examples["id"][sample_index])
-
-            # Set to None the offset_mapping that are not part of the context so it's easy to determine if a token
-            # position is part of the context or not.
-            tokenized_examples["offset_mapping"][i] = [
-                (o if sequence_ids[k] == context_idx else None)
-                for k, o in enumerate(tokenized_examples["offset_mapping"][i])
-            ]
-
-        return tokenized_examples
 
     if training_args.do_eval:
         if "validation" not in raw_datasets:
@@ -535,7 +382,15 @@ def main():
         # Create Features from Eval Dataset
         with training_args.main_process_first(desc="validation dataset map pre-processing"):
             eval_dataset = eval_examples.map(
-                prepare_validation_features,
+                partial(
+                    prepare_validation_features_with_beam_search,
+                    tokenizer=tokenizer,
+                    max_seq_length=max_seq_length,
+                    doc_stride=data_args.doc_stride,
+                    pad_on_right=pad_on_right,
+                    question_column_name=question_column_name,
+                    context_column_name=context_column_name,
+                ),
                 batched=True,
                 num_proc=data_args.preprocessing_num_workers,
                 remove_columns=column_names,
@@ -557,7 +412,15 @@ def main():
         # Test Feature Creation
         with training_args.main_process_first(desc="prediction dataset map pre-processing"):
             predict_dataset = predict_examples.map(
-                prepare_validation_features,
+                partial(
+                    prepare_validation_features_with_beam_search,
+                    tokenizer=tokenizer,
+                    max_seq_length=max_seq_length,
+                    doc_stride=data_args.doc_stride,
+                    pad_on_right=pad_on_right,
+                    question_column_name=question_column_name,
+                    context_column_name=context_column_name,
+                ),
                 batched=True,
                 num_proc=data_args.preprocessing_num_workers,
                 remove_columns=column_names,
@@ -578,34 +441,6 @@ def main():
         else DataCollatorWithPadding(tokenizer, pad_to_multiple_of=8 if training_args.fp16 else None)
     )
 
-    # Post-processing:
-    def post_processing_function(examples, features, predictions, stage="eval"):
-        # Post-processing: we match the start logits and end logits to answers in the original context.
-        predictions, scores_diff_json = postprocess_qa_predictions_with_beam_search(
-            examples=examples,
-            features=features,
-            predictions=predictions,
-            version_2_with_negative=data_args.version_2_with_negative,
-            n_best_size=data_args.n_best_size,
-            max_answer_length=data_args.max_answer_length,
-            start_n_top=model.config.start_n_top,
-            end_n_top=model.config.end_n_top,
-            output_dir=training_args.output_dir,
-            log_level=log_level,
-            prefix=stage,
-        )
-        # Format the result to the format the metric expects.
-        if data_args.version_2_with_negative:
-            formatted_predictions = [
-                {"id": k, "prediction_text": v, "no_answer_probability": scores_diff_json[k]}
-                for k, v in predictions.items()
-            ]
-        else:
-            formatted_predictions = [{"id": k, "prediction_text": v} for k, v in predictions.items()]
-
-        references = [{"id": ex["id"], "answers": ex[answer_column_name]} for ex in examples]
-        return EvalPrediction(predictions=formatted_predictions, label_ids=references)
-
     metric = load_metric("squad_v2" if data_args.version_2_with_negative else "squad")
 
     def compute_metrics(p: EvalPrediction):
@@ -620,7 +455,16 @@ def main():
         eval_examples=eval_examples if training_args.do_eval else None,
         tokenizer=tokenizer,
         data_collator=data_collator,
-        post_process_function=post_processing_function,
+        post_process_function=partial(
+            post_processing_function_with_beam_search,
+            answer_column_name=answer_column_name,
+            version_2_with_negative=data_args.version_2_with_negative,
+            n_best_size=data_args.n_best_size,
+            max_answer_length=data_args.max_answer_length,
+            start_n_top=model.config.start_n_top,
+            end_n_top=model.config.end_n_top,
+            output_dir=training_args.output_dir,
+        ),
         compute_metrics=compute_metrics,
     )
 

--- a/examples/pytorch/question-answering/run_qa_no_trainer.py
+++ b/examples/pytorch/question-answering/run_qa_no_trainer.py
@@ -24,10 +24,10 @@ import logging
 import math
 import os
 import random
+from functools import partial
 from pathlib import Path
 
 import datasets
-import numpy as np
 import torch
 from datasets import load_dataset, load_metric
 from torch.utils.data import DataLoader
@@ -45,14 +45,19 @@ from transformers import (
     AutoModelForQuestionAnswering,
     AutoTokenizer,
     DataCollatorWithPadding,
-    EvalPrediction,
     SchedulerType,
     default_data_collator,
     get_scheduler,
 )
 from transformers.utils import check_min_version, get_full_repo_name
 from transformers.utils.versions import require_version
-from utils_qa import postprocess_qa_predictions
+from utils_qa_add import (
+    create_and_fill_np_array,
+    post_processing_function,
+    prepare_train_features,
+    prepare_validation_features,
+    save_prefixed_metrics,
+)
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
@@ -194,8 +199,7 @@ def parse_args():
     )
     parser.add_argument(
         "--version_2_with_negative",
-        type=bool,
-        default=False,
+        action="store_true",
         help="If true, some of the examples do not have an answer.",
     )
     parser.add_argument(
@@ -220,7 +224,7 @@ def parse_args():
         "value if set.",
     )
     parser.add_argument(
-        "--overwrite_cache", type=bool, default=False, help="Overwrite the cached training and evaluation sets"
+        "--overwrite_cache", action="store_true", help="Overwrite the cached training and evaluation sets"
     )
     parser.add_argument(
         "--max_predict_samples",
@@ -408,84 +412,6 @@ def main():
 
     max_seq_length = min(args.max_seq_length, tokenizer.model_max_length)
 
-    # Training preprocessing
-    def prepare_train_features(examples):
-        # Some of the questions have lots of whitespace on the left, which is not useful and will make the
-        # truncation of the context fail (the tokenized question will take a lots of space). So we remove that
-        # left whitespace
-        examples[question_column_name] = [q.lstrip() for q in examples[question_column_name]]
-
-        # Tokenize our examples with truncation and maybe padding, but keep the overflows using a stride. This results
-        # in one example possible giving several features when a context is long, each of those features having a
-        # context that overlaps a bit the context of the previous feature.
-        tokenized_examples = tokenizer(
-            examples[question_column_name if pad_on_right else context_column_name],
-            examples[context_column_name if pad_on_right else question_column_name],
-            truncation="only_second" if pad_on_right else "only_first",
-            max_length=max_seq_length,
-            stride=args.doc_stride,
-            return_overflowing_tokens=True,
-            return_offsets_mapping=True,
-            padding="max_length" if args.pad_to_max_length else False,
-        )
-
-        # Since one example might give us several features if it has a long context, we need a map from a feature to
-        # its corresponding example. This key gives us just that.
-        sample_mapping = tokenized_examples.pop("overflow_to_sample_mapping")
-        # The offset mappings will give us a map from token to character position in the original context. This will
-        # help us compute the start_positions and end_positions.
-        offset_mapping = tokenized_examples.pop("offset_mapping")
-
-        # Let's label those examples!
-        tokenized_examples["start_positions"] = []
-        tokenized_examples["end_positions"] = []
-
-        for i, offsets in enumerate(offset_mapping):
-            # We will label impossible answers with the index of the CLS token.
-            input_ids = tokenized_examples["input_ids"][i]
-            cls_index = input_ids.index(tokenizer.cls_token_id)
-
-            # Grab the sequence corresponding to that example (to know what is the context and what is the question).
-            sequence_ids = tokenized_examples.sequence_ids(i)
-
-            # One example can give several spans, this is the index of the example containing this span of text.
-            sample_index = sample_mapping[i]
-            answers = examples[answer_column_name][sample_index]
-            # If no answers are given, set the cls_index as answer.
-            if len(answers["answer_start"]) == 0:
-                tokenized_examples["start_positions"].append(cls_index)
-                tokenized_examples["end_positions"].append(cls_index)
-            else:
-                # Start/end character index of the answer in the text.
-                start_char = answers["answer_start"][0]
-                end_char = start_char + len(answers["text"][0])
-
-                # Start token index of the current span in the text.
-                token_start_index = 0
-                while sequence_ids[token_start_index] != (1 if pad_on_right else 0):
-                    token_start_index += 1
-
-                # End token index of the current span in the text.
-                token_end_index = len(input_ids) - 1
-                while sequence_ids[token_end_index] != (1 if pad_on_right else 0):
-                    token_end_index -= 1
-
-                # Detect if the answer is out of the span (in which case this feature is labeled with the CLS index).
-                if not (offsets[token_start_index][0] <= start_char and offsets[token_end_index][1] >= end_char):
-                    tokenized_examples["start_positions"].append(cls_index)
-                    tokenized_examples["end_positions"].append(cls_index)
-                else:
-                    # Otherwise move the token_start_index and token_end_index to the two ends of the answer.
-                    # Note: we could go after the last offset if the answer is the last word (edge case).
-                    while token_start_index < len(offsets) and offsets[token_start_index][0] <= start_char:
-                        token_start_index += 1
-                    tokenized_examples["start_positions"].append(token_start_index - 1)
-                    while offsets[token_end_index][1] >= end_char:
-                        token_end_index -= 1
-                    tokenized_examples["end_positions"].append(token_end_index + 1)
-
-        return tokenized_examples
-
     if "train" not in raw_datasets:
         raise ValueError("--do_train requires a train dataset")
     train_dataset = raw_datasets["train"]
@@ -496,7 +422,17 @@ def main():
     # Create train feature from dataset
     with accelerator.main_process_first():
         train_dataset = train_dataset.map(
-            prepare_train_features,
+            partial(
+                prepare_train_features,
+                tokenizer=tokenizer,
+                max_seq_length=max_seq_length,
+                doc_stride=args.doc_stride,
+                pad_on_right=pad_on_right,
+                pad_to_max_length=args.pad_to_max_length,
+                question_column_name=question_column_name,
+                answer_column_name=answer_column_name,
+                context_column_name=context_column_name,
+            ),
             batched=True,
             num_proc=args.preprocessing_num_workers,
             remove_columns=column_names,
@@ -507,53 +443,6 @@ def main():
             # Number of samples might increase during Feature Creation, We select only specified max samples
             train_dataset = train_dataset.select(range(args.max_train_samples))
 
-    # Validation preprocessing
-    def prepare_validation_features(examples):
-        # Some of the questions have lots of whitespace on the left, which is not useful and will make the
-        # truncation of the context fail (the tokenized question will take a lots of space). So we remove that
-        # left whitespace
-        examples[question_column_name] = [q.lstrip() for q in examples[question_column_name]]
-
-        # Tokenize our examples with truncation and maybe padding, but keep the overflows using a stride. This results
-        # in one example possible giving several features when a context is long, each of those features having a
-        # context that overlaps a bit the context of the previous feature.
-        tokenized_examples = tokenizer(
-            examples[question_column_name if pad_on_right else context_column_name],
-            examples[context_column_name if pad_on_right else question_column_name],
-            truncation="only_second" if pad_on_right else "only_first",
-            max_length=max_seq_length,
-            stride=args.doc_stride,
-            return_overflowing_tokens=True,
-            return_offsets_mapping=True,
-            padding="max_length" if args.pad_to_max_length else False,
-        )
-
-        # Since one example might give us several features if it has a long context, we need a map from a feature to
-        # its corresponding example. This key gives us just that.
-        sample_mapping = tokenized_examples.pop("overflow_to_sample_mapping")
-
-        # For evaluation, we will need to convert our predictions to substrings of the context, so we keep the
-        # corresponding example_id and we will store the offset mappings.
-        tokenized_examples["example_id"] = []
-
-        for i in range(len(tokenized_examples["input_ids"])):
-            # Grab the sequence corresponding to that example (to know what is the context and what is the question).
-            sequence_ids = tokenized_examples.sequence_ids(i)
-            context_index = 1 if pad_on_right else 0
-
-            # One example can give several spans, this is the index of the example containing this span of text.
-            sample_index = sample_mapping[i]
-            tokenized_examples["example_id"].append(examples["id"][sample_index])
-
-            # Set to None the offset_mapping that are not part of the context so it's easy to determine if a token
-            # position is part of the context or not.
-            tokenized_examples["offset_mapping"][i] = [
-                (o if sequence_ids[k] == context_index else None)
-                for k, o in enumerate(tokenized_examples["offset_mapping"][i])
-            ]
-
-        return tokenized_examples
-
     if "validation" not in raw_datasets:
         raise ValueError("--do_eval requires a validation dataset")
     eval_examples = raw_datasets["validation"]
@@ -563,7 +452,16 @@ def main():
     # Validation Feature Creation
     with accelerator.main_process_first():
         eval_dataset = eval_examples.map(
-            prepare_validation_features,
+            partial(
+                prepare_validation_features,
+                tokenizer=tokenizer,
+                max_seq_length=max_seq_length,
+                doc_stride=args.doc_stride,
+                pad_on_right=pad_on_right,
+                pad_to_max_length=args.pad_to_max_length,
+                question_column_name=question_column_name,
+                context_column_name=context_column_name,
+            ),
             batched=True,
             num_proc=args.preprocessing_num_workers,
             remove_columns=column_names,
@@ -626,65 +524,7 @@ def main():
             predict_dataset_for_model, collate_fn=data_collator, batch_size=args.per_device_eval_batch_size
         )
 
-    # Post-processing:
-    def post_processing_function(examples, features, predictions, stage="eval"):
-        # Post-processing: we match the start logits and end logits to answers in the original context.
-        predictions = postprocess_qa_predictions(
-            examples=examples,
-            features=features,
-            predictions=predictions,
-            version_2_with_negative=args.version_2_with_negative,
-            n_best_size=args.n_best_size,
-            max_answer_length=args.max_answer_length,
-            null_score_diff_threshold=args.null_score_diff_threshold,
-            output_dir=args.output_dir,
-            prefix=stage,
-        )
-        # Format the result to the format the metric expects.
-        if args.version_2_with_negative:
-            formatted_predictions = [
-                {"id": k, "prediction_text": v, "no_answer_probability": 0.0} for k, v in predictions.items()
-            ]
-        else:
-            formatted_predictions = [{"id": k, "prediction_text": v} for k, v in predictions.items()]
-
-        references = [{"id": ex["id"], "answers": ex[answer_column_name]} for ex in examples]
-        return EvalPrediction(predictions=formatted_predictions, label_ids=references)
-
     metric = load_metric("squad_v2" if args.version_2_with_negative else "squad")
-
-    # Create and fill numpy array of size len_of_validation_data * max_length_of_output_tensor
-    def create_and_fill_np_array(start_or_end_logits, dataset, max_len):
-        """
-        Create and fill numpy array of size len_of_validation_data * max_length_of_output_tensor
-
-        Args:
-            start_or_end_logits(:obj:`tensor`):
-                This is the output predictions of the model. We can only enter either start or end logits.
-            eval_dataset: Evaluation dataset
-            max_len(:obj:`int`):
-                The maximum length of the output tensor. ( See the model.eval() part for more details )
-        """
-
-        step = 0
-        # create a numpy array and fill it with -100.
-        logits_concat = np.full((len(dataset), max_len), -100, dtype=np.float64)
-        # Now since we have create an array now we will populate it with the outputs gathered using accelerator.gather
-        for i, output_logit in enumerate(start_or_end_logits):  # populate columns
-            # We have to fill it such that we have to take the whole tensor and replace it on the newly created array
-            # And after every iteration we have to change the step
-
-            batch_size = output_logit.shape[0]
-            cols = output_logit.shape[1]
-
-            if step + batch_size < len(dataset):
-                logits_concat[step : step + batch_size, :cols] = output_logit
-            else:
-                logits_concat[step:, :cols] = output_logit[: len(dataset) - step]
-
-            step += batch_size
-
-        return logits_concat
 
     # Optimizer
     # Split weights in two groups, one with weight decay and the other not.
@@ -824,6 +664,9 @@ def main():
 
     all_start_logits = []
     all_end_logits = []
+
+    model.eval()
+
     for step, batch in enumerate(eval_dataloader):
         with torch.no_grad():
             outputs = model(**batch)
@@ -848,7 +691,18 @@ def main():
     del all_end_logits
 
     outputs_numpy = (start_logits_concat, end_logits_concat)
-    prediction = post_processing_function(eval_examples, eval_dataset, outputs_numpy)
+    prediction = post_processing_function(
+        eval_examples,
+        eval_dataset,
+        outputs_numpy,
+        answer_column_name=answer_column_name,
+        version_2_with_negative=args.version_2_with_negative,
+        n_best_size=args.n_best_size,
+        max_answer_length=args.max_answer_length,
+        null_score_diff_threshold=args.null_score_diff_threshold,
+        output_dir=args.output_dir,
+        log_level=logging.WARNING,
+    )
     eval_metric = metric.compute(predictions=prediction.predictions, references=prediction.label_ids)
     logger.info(f"Evaluation metrics: {eval_metric}")
 
@@ -860,6 +714,9 @@ def main():
 
         all_start_logits = []
         all_end_logits = []
+
+        model.eval()
+
         for step, batch in enumerate(predict_dataloader):
             with torch.no_grad():
                 outputs = model(**batch)
@@ -907,8 +764,9 @@ def main():
             tokenizer.save_pretrained(args.output_dir)
             if args.push_to_hub:
                 repo.push_to_hub(commit_message="End of training", auto_lfs_prune=True)
-        with open(os.path.join(args.output_dir, "all_results.json"), "w") as f:
-            json.dump({"eval_f1": eval_metric["f1"], "eval_exact": eval_metric["exact"]}, f)
+
+            logger.info(json.dumps(eval_metric, indent=4))
+            save_prefixed_metrics(eval_metric, args.output_dir)
 
 
 if __name__ == "__main__":

--- a/examples/pytorch/question-answering/utils_qa.py
+++ b/examples/pytorch/question-answering/utils_qa.py
@@ -350,9 +350,12 @@ def postprocess_qa_predictions_with_beam_search(
                         start_index >= len(offset_mapping)
                         or end_index >= len(offset_mapping)
                         or offset_mapping[start_index] is None
+                        or len(offset_mapping[start_index]) < 2
                         or offset_mapping[end_index] is None
+                        or len(offset_mapping[end_index]) < 2
                     ):
                         continue
+
                     # Don't consider answers with a length negative or > max_answer_length.
                     if end_index < start_index or end_index - start_index + 1 > max_answer_length:
                         continue
@@ -381,7 +384,9 @@ def postprocess_qa_predictions_with_beam_search(
         # In the very rare edge case we have not a single non-null prediction, we create a fake prediction to avoid
         # failure.
         if len(predictions) == 0:
-            predictions.insert(0, {"text": "", "start_logit": -1e-6, "end_logit": -1e-6, "score": -2e-6})
+            # Without predictions min_null_score is going to be None and None will cause an exception later
+            min_null_score = -2e-6
+            predictions.insert(0, {"text": "", "start_logit": -1e-6, "end_logit": -1e-6, "score": min_null_score})
 
         # Compute the softmax of all scores (we do it with numpy to stay independent from torch/tf in this file, using
         # the LogSumExp trick).

--- a/examples/pytorch/question-answering/utils_qa_add.py
+++ b/examples/pytorch/question-answering/utils_qa_add.py
@@ -1,0 +1,599 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Team All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Higher-level, i.e., wrappers post-processing utilities for question answering.
+"""
+import json
+import logging
+import os
+
+import numpy as np
+
+from transformers import EvalPrediction
+from utils_qa import postprocess_qa_predictions, postprocess_qa_predictions_with_beam_search
+
+
+logger = logging.getLogger(__name__)
+
+
+def save_prefixed_metrics(results, output_dir, file_name: str = "all_results.json", metric_key_prefix: str = "eval"):
+    """
+    Save results while prefixing metric names.
+
+    Args:
+        results: (:obj:`dict`):
+            A dictionary of results.
+        output_dir: (:obj:`str`):
+            An output directory.
+        file_name: (:obj:`str`, `optional`, defaults to :obj:`all_results.json`):
+            An output file name.
+        metric_key_prefix: (:obj:`str`, `optional`, defaults to :obj:`eval`):
+            A metric name prefix.
+    """
+    # Prefix all keys with metric_key_prefix + '_'
+    for key in list(results.keys()):
+        if not key.startswith(f"{metric_key_prefix}_"):
+            results[f"{metric_key_prefix}_{key}"] = results.pop(key)
+
+    with open(os.path.join(output_dir, file_name), "w") as f:
+        json.dump(results, f, indent=4)
+
+
+def post_processing_function(
+    examples,
+    features,
+    predictions,
+    answer_column_name,
+    version_2_with_negative,
+    n_best_size,
+    max_answer_length,
+    null_score_diff_threshold,
+    output_dir,
+    log_level,
+    stage="eval",
+):
+    """
+    A high-level/wrapper postprocessing function.
+
+    Args:
+        examples: The non-preprocessed dataset (see the main script for more information).
+        features: The processed dataset (see the main script for more information).
+        predictions (:obj:`Tuple[np.ndarray, np.ndarray]`):
+            The predictions of the model: two arrays containing the start logits and the end logits respectively. Its
+            first dimension must match the number of elements of :obj:`features`.
+        answer_column_name: (:obj:`str`):
+            The name of the text field/column that stores the answer.
+        version_2_with_negative (:obj:`bool`, `optional`, defaults to :obj:`False`):
+            Whether or not the underlying dataset contains examples with no answers.
+        n_best_size (:obj:`int`, `optional`, defaults to 20):
+            The total number of n-best predictions to generate when looking for an answer.
+        max_answer_length (:obj:`int`, `optional`, defaults to 30):
+            The maximum length of an answer that can be generated. This is needed because the start and end predictions
+            are not conditioned on one another.
+        null_score_diff_threshold (:obj:`float`, `optional`, defaults to 0):
+            The threshold used to select the null answer: if the best answer has a score that is less than the score of
+            the null answer minus this threshold, the null answer is selected for this example (note that the score of
+            the null answer for an example giving several features is the minimum of the scores for the null answer on
+            each feature: all features must be aligned on the fact they `want` to predict a null answer).
+
+            Only useful when :obj:`version_2_with_negative` is :obj:`True`.
+        output_dir (:obj:`str`, `optional`):
+            If provided, the dictionaries of predictions, n_best predictions (with their scores and logits) and, if
+            :obj:`version_2_with_negative=True`, the dictionary of the scores differences between best and null
+            answers, are saved in `output_dir`.
+        stage (:obj:`str`, `optional`):
+            If provided, the dictionaries mentioned above are saved with `stage` added to their names.
+        log_level (:obj:`int`, `optional`, defaults to ``logging.WARNING``):
+            ``logging`` log level (e.g., ``logging.WARNING``)
+    """
+    # Post-processing: we match the start logits and end logits to answers in the original context.
+    predictions = postprocess_qa_predictions(
+        examples=examples,
+        features=features,
+        predictions=predictions,
+        version_2_with_negative=version_2_with_negative,
+        n_best_size=n_best_size,
+        max_answer_length=max_answer_length,
+        null_score_diff_threshold=null_score_diff_threshold,
+        output_dir=output_dir,
+        log_level=log_level,
+        prefix=stage,
+    )
+    # Format the result to the format the metric expects.
+    if version_2_with_negative:
+        formatted_predictions = [
+            {"id": k, "prediction_text": v, "no_answer_probability": 0.0} for k, v in predictions.items()
+        ]
+    else:
+        formatted_predictions = [{"id": k, "prediction_text": v} for k, v in predictions.items()]
+
+    references = [{"id": ex["id"], "answers": ex[answer_column_name]} for ex in examples]
+    return EvalPrediction(predictions=formatted_predictions, label_ids=references)
+
+
+def post_processing_function_with_beam_search(
+    examples,
+    features,
+    predictions,
+    answer_column_name,
+    version_2_with_negative,
+    n_best_size,
+    start_n_top,
+    end_n_top,
+    max_answer_length,
+    output_dir,
+    stage="eval",
+):
+    """
+    A high-level/wrapper postprocessing function (for QA with the beam-search).
+
+    Args:
+        examples: The non-preprocessed dataset (see the main script for more information).
+        features: The processed dataset (see the main script for more information).
+        predictions (:obj:`Tuple[np.ndarray, np.ndarray]`):
+            The predictions of the model: two arrays containing the start logits and the end logits respectively. Its
+            first dimension must match the number of elements of :obj:`features`.
+        answer_column_name: (:obj:`str`):
+            The name of the text field/column that stores the answer.
+        version_2_with_negative (:obj:`bool`, `optional`, defaults to :obj:`False`):
+            Whether or not the underlying dataset contains examples with no answers.
+        n_best_size (:obj:`int`, `optional`, defaults to 20):
+            The total number of n-best predictions to generate when looking for an answer.
+        start_n_top (`int`):
+            Used in the SQuAD evaluation script.
+        end_n_top (`int`):
+            Used in the SQuAD evaluation script.
+        max_answer_length (:obj:`int`, `optional`, defaults to 30):
+            The maximum length of an answer that can be generated. This is needed because the start and end predictions
+            are not conditioned on one another.
+        output_dir (:obj:`str`, `optional`):
+            If provided, the dictionaries of predictions, n_best predictions (with their scores and logits) and, if
+            :obj:`version_2_with_negative=True`, the dictionary of the scores differences between best and null
+            answers, are saved in `output_dir`.
+        stage (:obj:`str`, `optional`):
+            If provided, the dictionaries mentioned above are saved with `stage` added to their names.
+    """
+    # Post-processing: we match the start logits and end logits to answers in the original context.
+    predictions, scores_diff_json = postprocess_qa_predictions_with_beam_search(
+        examples=examples,
+        features=features,
+        predictions=predictions,
+        version_2_with_negative=version_2_with_negative,
+        n_best_size=n_best_size,
+        max_answer_length=max_answer_length,
+        start_n_top=start_n_top,
+        end_n_top=end_n_top,
+        output_dir=output_dir,
+        prefix=stage,
+    )
+    # Format the result to the format the metric expects.
+    if version_2_with_negative:
+        formatted_predictions = [
+            {"id": k, "prediction_text": v, "no_answer_probability": scores_diff_json[k]}
+            for k, v in predictions.items()
+        ]
+    else:
+        formatted_predictions = [{"id": k, "prediction_text": v} for k, v in predictions.items()]
+
+    references = [{"id": ex["id"], "answers": ex[answer_column_name]} for ex in examples]
+    return EvalPrediction(predictions=formatted_predictions, label_ids=references)
+
+
+def create_and_fill_np_array(start_or_end_logits, dataset, max_len):
+    """
+    Create and fill numpy array of size len_of_validation_data * max_length_of_output_tensor
+
+    Args:
+        start_or_end_logits(:obj:`tensor`):
+            This is the output predictions of the model. We can only enter either start or end logits.
+        eval_dataset: Evaluation dataset
+        max_len(:obj:`int`):
+            The maximum length of the output tensor. ( See the model.eval() part for more details )
+    """
+
+    step = 0
+    # create a numpy array and fill it with -100.
+    logits_concat = np.full((len(dataset), max_len), -100, dtype=np.float64)
+    # Now since we have create an array now we will populate it with the outputs gathered using accelerator.gather
+    for i, output_logit in enumerate(start_or_end_logits):  # populate columns
+        # We have to fill it such that we have to take the whole tensor and replace it on the newly created array
+        # And after every iteration we have to change the step
+
+        batch_size = output_logit.shape[0]
+        cols = output_logit.shape[1]
+
+        if step + batch_size < len(dataset):
+            logits_concat[step : step + batch_size, :cols] = output_logit
+        else:
+            logits_concat[step:, :cols] = output_logit[: len(dataset) - step]
+
+        step += batch_size
+
+    return logits_concat
+
+
+def prepare_train_features(
+    examples,
+    tokenizer,
+    max_seq_length,
+    doc_stride,
+    pad_on_right,
+    pad_to_max_length,
+    question_column_name,
+    answer_column_name,
+    context_column_name,
+):
+    """
+    Feature-generation to train a question-answering model.
+
+    Args:
+        examples: The non-preprocessed dataset (see the main script for more information).
+        tokenizer: input tokenizer.
+        max_seq_length: the maximum sequence length passed to the tokenizer.
+        doc_stride: the stride passed to the tokenizer.
+        pad_on_right: true to enable padding on the right and false otherwise.
+        pad_to_max_length: true if we want the tokenizer to pad to the maximum sequence length.
+        question_column_name: the name of the text field/column that stores the question.
+        answer_column_name: the name of the text field/column that stores the answer.
+        context_column_name: the name of the text field/column that stores the answer context.
+    """
+    # Some of the questions have lots of whitespace on the left, which is not useful and will make the
+    # truncation of the context fail (the tokenized question will take a lots of space). So we remove that
+    # left whitespace
+    examples[question_column_name] = [q.lstrip() for q in examples[question_column_name]]
+
+    # Tokenize our examples with truncation and maybe padding, but keep the overflows using a stride. This results
+    # in one example possible giving several features when a context is long, each of those features having a
+    # context that overlaps a bit the context of the previous feature.
+    tokenized_examples = tokenizer(
+        examples[question_column_name if pad_on_right else context_column_name],
+        examples[context_column_name if pad_on_right else question_column_name],
+        truncation="only_second" if pad_on_right else "only_first",
+        max_length=max_seq_length,
+        stride=doc_stride,
+        return_overflowing_tokens=True,
+        return_offsets_mapping=True,
+        padding="max_length" if pad_to_max_length else False,
+    )
+
+    # Since one example might give us several features if it has a long context, we need a map from a feature to
+    # its corresponding example. This key gives us just that.
+    sample_mapping = tokenized_examples.pop("overflow_to_sample_mapping")
+    # The offset mappings will give us a map from token to character position in the original context. This will
+    # help us compute the start_positions and end_positions.
+    offset_mapping = tokenized_examples.pop("offset_mapping")
+
+    # Let's label those examples!
+    tokenized_examples["start_positions"] = []
+    tokenized_examples["end_positions"] = []
+
+    for i, offsets in enumerate(offset_mapping):
+        # We will label impossible answers with the index of the CLS token.
+        input_ids = tokenized_examples["input_ids"][i]
+        cls_index = input_ids.index(tokenizer.cls_token_id)
+
+        # Grab the sequence corresponding to that example (to know what is the context and what is the question).
+        sequence_ids = tokenized_examples.sequence_ids(i)
+
+        # One example can give several spans, this is the index of the example containing this span of text.
+        sample_index = sample_mapping[i]
+        answers = examples[answer_column_name][sample_index]
+        # If no answers are given, set the cls_index as answer.
+        if len(answers["answer_start"]) == 0:
+            tokenized_examples["start_positions"].append(cls_index)
+            tokenized_examples["end_positions"].append(cls_index)
+        else:
+            # Start/end character index of the answer in the text.
+            start_char = answers["answer_start"][0]
+            end_char = start_char + len(answers["text"][0])
+
+            # Start token index of the current span in the text.
+            token_start_index = 0
+            while sequence_ids[token_start_index] != (1 if pad_on_right else 0):
+                token_start_index += 1
+
+            # End token index of the current span in the text.
+            token_end_index = len(input_ids) - 1
+            while sequence_ids[token_end_index] != (1 if pad_on_right else 0):
+                token_end_index -= 1
+
+            # Detect if the answer is out of the span (in which case this feature is labeled with the CLS index).
+            if not (offsets[token_start_index][0] <= start_char and offsets[token_end_index][1] >= end_char):
+                tokenized_examples["start_positions"].append(cls_index)
+                tokenized_examples["end_positions"].append(cls_index)
+            else:
+                # Otherwise move the token_start_index and token_end_index to the two ends of the answer.
+                # Note: we could go after the last offset if the answer is the last word (edge case).
+                while token_start_index < len(offsets) and offsets[token_start_index][0] <= start_char:
+                    token_start_index += 1
+                tokenized_examples["start_positions"].append(token_start_index - 1)
+                while offsets[token_end_index][1] >= end_char:
+                    token_end_index -= 1
+                tokenized_examples["end_positions"].append(token_end_index + 1)
+
+    return tokenized_examples
+
+
+def prepare_validation_features(
+    examples,
+    tokenizer,
+    max_seq_length,
+    doc_stride,
+    pad_on_right,
+    pad_to_max_length,
+    question_column_name,
+    context_column_name,
+):
+    """
+    Feature-generation to validate a question-answering model.
+
+    Args:
+        examples: The non-preprocessed dataset (see the main script for more information).
+        tokenizer: input tokenizer.
+        max_seq_length: the maximum sequence length passed to the tokenizer.
+        doc_stride: the stride passed to the tokenizer.
+        pad_on_right: true to enable padding on the right and false otherwise.
+        pad_to_max_length: true if we want the tokenizer to pad to the maximum sequence length.
+        question_column_name: the name of the text field/column that stores the question.
+        context_column_name: the name of the text field/column that stores the answer context.
+    """
+    # Some of the questions have lots of whitespace on the left, which is not useful and will make the
+    # truncation of the context fail (the tokenized question will take a lots of space). So we remove that
+    # left whitespace
+    examples[question_column_name] = [q.lstrip() for q in examples[question_column_name]]
+
+    # Tokenize our examples with truncation and maybe padding, but keep the overflows using a stride. This results
+    # in one example possible giving several features when a context is long, each of those features having a
+    # context that overlaps a bit the context of the previous feature.
+    tokenized_examples = tokenizer(
+        examples[question_column_name if pad_on_right else context_column_name],
+        examples[context_column_name if pad_on_right else question_column_name],
+        truncation="only_second" if pad_on_right else "only_first",
+        max_length=max_seq_length,
+        stride=doc_stride,
+        return_overflowing_tokens=True,
+        return_offsets_mapping=True,
+        padding="max_length" if pad_to_max_length else False,
+    )
+
+    # Since one example might give us several features if it has a long context, we need a map from a feature to
+    # its corresponding example. This key gives us just that.
+    sample_mapping = tokenized_examples.pop("overflow_to_sample_mapping")
+
+    # For evaluation, we will need to convert our predictions to substrings of the context, so we keep the
+    # corresponding example_id and we will store the offset mappings.
+    tokenized_examples["example_id"] = []
+
+    for i in range(len(tokenized_examples["input_ids"])):
+        # Grab the sequence corresponding to that example (to know what is the context and what is the question).
+        sequence_ids = tokenized_examples.sequence_ids(i)
+        context_index = 1 if pad_on_right else 0
+
+        # One example can give several spans, this is the index of the example containing this span of text.
+        sample_index = sample_mapping[i]
+        tokenized_examples["example_id"].append(examples["id"][sample_index])
+
+        # Set to None the offset_mapping that are not part of the context so it's easy to determine if a token
+        # position is part of the context or not.
+        tokenized_examples["offset_mapping"][i] = [
+            (o if sequence_ids[k] == context_index else None)
+            for k, o in enumerate(tokenized_examples["offset_mapping"][i])
+        ]
+
+    return tokenized_examples
+
+
+def prepare_train_features_with_beam_search(
+    examples,
+    tokenizer,
+    max_seq_length,
+    doc_stride,
+    pad_on_right,
+    question_column_name,
+    answer_column_name,
+    context_column_name,
+):
+    """
+    Feature-generation to train a question-answering model (that additionally uses beam search).
+
+    Args:
+        examples: The non-preprocessed dataset (see the main script for more information).
+        tokenizer: input tokenizer.
+        max_seq_length: the maximum sequence length passed to the tokenizer.
+        doc_stride: the stride passed to the tokenizer.
+        pad_on_right: true to enable padding on the right and false otherwise.
+        question_column_name: the name of the text field/column that stores the question.
+        answer_column_name: the name of the text field/column that stores the answer.
+        context_column_name: the name of the text field/column that stores the answer context.
+    """
+    # Some of the questions have lots of whitespace on the left, which is not useful and will make the
+    # truncation of the context fail (the tokenized question will take a lots of space). So we remove that
+    # left whitespace
+    examples[question_column_name] = [q.lstrip() for q in examples[question_column_name]]
+
+    # Tokenize our examples with truncation and maybe padding, but keep the overflows using a stride. This results
+    # in one example possible giving several features when a context is long, each of those features having a
+    # context that overlaps a bit the context of the previous feature.
+    tokenized_examples = tokenizer(
+        examples[question_column_name if pad_on_right else context_column_name],
+        examples[context_column_name if pad_on_right else question_column_name],
+        truncation="only_second" if pad_on_right else "only_first",
+        max_length=max_seq_length,
+        stride=doc_stride,
+        return_overflowing_tokens=True,
+        return_offsets_mapping=True,
+        return_special_tokens_mask=True,
+        return_token_type_ids=True,
+        padding="max_length",
+    )
+
+    # Since one example might give us several features if it has a long context, we need a map from a feature to
+    # its corresponding example. This key gives us just that.
+    sample_mapping = tokenized_examples.pop("overflow_to_sample_mapping")
+    # The offset mappings will give us a map from token to character position in the original context. This will
+    # help us compute the start_positions and end_positions.
+    offset_mapping = tokenized_examples.pop("offset_mapping")
+    # The special tokens will help us build the p_mask (which indicates the tokens that can't be in answers).
+    special_tokens = tokenized_examples.pop("special_tokens_mask")
+
+    # Let's label those examples!
+    tokenized_examples["start_positions"] = []
+    tokenized_examples["end_positions"] = []
+    tokenized_examples["is_impossible"] = []
+    tokenized_examples["cls_index"] = []
+    tokenized_examples["p_mask"] = []
+
+    for i, offsets in enumerate(offset_mapping):
+        # We will label impossible answers with the index of the CLS token.
+        input_ids = tokenized_examples["input_ids"][i]
+        cls_index = input_ids.index(tokenizer.cls_token_id)
+        tokenized_examples["cls_index"].append(cls_index)
+
+        # Grab the sequence corresponding to that example (to know what is the context and what is the question).
+        sequence_ids = tokenized_examples["token_type_ids"][i]
+        for k, s in enumerate(special_tokens[i]):
+            if s:
+                sequence_ids[k] = 3
+        context_idx = 1 if pad_on_right else 0
+
+        # Build the p_mask: non special tokens and context gets 0.0, the others get 1.0.
+        # The cls token gets 1.0 too (for predictions of empty answers).
+        tokenized_examples["p_mask"].append(
+            [
+                0.0 if (not special_tokens[i][k] and s == context_idx) or k == cls_index else 1.0
+                for k, s in enumerate(sequence_ids)
+            ]
+        )
+
+        # One example can give several spans, this is the index of the example containing this span of text.
+        sample_index = sample_mapping[i]
+        answers = examples[answer_column_name][sample_index]
+        # If no answers are given, set the cls_index as answer.
+        if len(answers["answer_start"]) == 0:
+            tokenized_examples["start_positions"].append(cls_index)
+            tokenized_examples["end_positions"].append(cls_index)
+            tokenized_examples["is_impossible"].append(1.0)
+        else:
+            # Start/end character index of the answer in the text.
+            start_char = answers["answer_start"][0]
+            end_char = start_char + len(answers["text"][0])
+
+            # Start token index of the current span in the text.
+            token_start_index = 0
+            while sequence_ids[token_start_index] != context_idx:
+                token_start_index += 1
+
+            # End token index of the current span in the text.
+            token_end_index = len(input_ids) - 1
+            while sequence_ids[token_end_index] != context_idx:
+                token_end_index -= 1
+            # Detect if the answer is out of the span (in which case this feature is labeled with the CLS index).
+            if not (offsets[token_start_index][0] <= start_char and offsets[token_end_index][1] >= end_char):
+                tokenized_examples["start_positions"].append(cls_index)
+                tokenized_examples["end_positions"].append(cls_index)
+                tokenized_examples["is_impossible"].append(1.0)
+            else:
+                # Otherwise move the token_start_index and token_end_index to the two ends of the answer.
+                # Note: we could go after the last offset if the answer is the last word (edge case).
+                while token_start_index < len(offsets) and offsets[token_start_index][0] <= start_char:
+                    token_start_index += 1
+                tokenized_examples["start_positions"].append(token_start_index - 1)
+                while offsets[token_end_index][1] >= end_char:
+                    token_end_index -= 1
+                tokenized_examples["end_positions"].append(token_end_index + 1)
+                tokenized_examples["is_impossible"].append(0.0)
+
+    return tokenized_examples
+
+
+# Validation preprocessing
+def prepare_validation_features_with_beam_search(
+    examples, tokenizer, max_seq_length, doc_stride, pad_on_right, question_column_name, context_column_name
+):
+    """
+    Feature-generation to validate a question-answering model (that additionally uses beam search).
+
+    Args:
+        examples: The non-preprocessed dataset (see the main script for more information).
+        tokenizer: input tokenizer.
+        max_seq_length: the maximum sequence length passed to the tokenizer.
+        doc_stride: the stride passed to the tokenizer.
+        pad_on_right: true to enable padding on the right and false otherwise.
+        question_column_name: the name of the text field/column that stores the question.
+        context_column_name: the name of the text field/column that stores the answer context.
+    """
+    # Tokenize our examples with truncation and maybe padding, but keep the overflows using a stride. This results
+    # in one example possible giving several features when a context is long, each of those features having a
+    # context that overlaps a bit the context of the previous feature.
+    tokenized_examples = tokenizer(
+        examples[question_column_name if pad_on_right else context_column_name],
+        examples[context_column_name if pad_on_right else question_column_name],
+        truncation="only_second" if pad_on_right else "only_first",
+        max_length=max_seq_length,
+        stride=doc_stride,
+        return_overflowing_tokens=True,
+        return_offsets_mapping=True,
+        return_special_tokens_mask=True,
+        return_token_type_ids=True,
+        padding="max_length",
+    )
+
+    # Since one example might give us several features if it has a long context, we need a map from a feature to
+    # its corresponding example. This key gives us just that.
+    sample_mapping = tokenized_examples.pop("overflow_to_sample_mapping")
+
+    # The special tokens will help us build the p_mask (which indicates the tokens that can't be in answers).
+    special_tokens = tokenized_examples.pop("special_tokens_mask")
+
+    # For evaluation, we will need to convert our predictions to substrings of the context, so we keep the
+    # corresponding example_id and we will store the offset mappings.
+    tokenized_examples["example_id"] = []
+
+    # We still provide the index of the CLS token and the p_mask to the model, but not the is_impossible label.
+    tokenized_examples["cls_index"] = []
+    tokenized_examples["p_mask"] = []
+
+    for i, input_ids in enumerate(tokenized_examples["input_ids"]):
+        # Find the CLS token in the input ids.
+        cls_index = input_ids.index(tokenizer.cls_token_id)
+        tokenized_examples["cls_index"].append(cls_index)
+
+        # Grab the sequence corresponding to that example (to know what is the context and what is the question).
+        sequence_ids = tokenized_examples["token_type_ids"][i]
+        for k, s in enumerate(special_tokens[i]):
+            if s:
+                sequence_ids[k] = 3
+        context_idx = 1 if pad_on_right else 0
+
+        # Build the p_mask: non special tokens and context gets 0.0, the others 1.0.
+        tokenized_examples["p_mask"].append(
+            [
+                0.0 if (not special_tokens[i][k] and s == context_idx) or k == cls_index else 1.0
+                for k, s in enumerate(sequence_ids)
+            ]
+        )
+
+        # One example can give several spans, this is the index of the example containing this span of text.
+        sample_index = sample_mapping[i]
+        tokenized_examples["example_id"].append(examples["id"][sample_index])
+
+        # Set to None the offset_mapping that are not part of the context so it's easy to determine if a token
+        # position is part of the context or not.
+        tokenized_examples["offset_mapping"][i] = [
+            (o if sequence_ids[k] == context_idx else None)
+            for k, o in enumerate(tokenized_examples["offset_mapping"][i])
+        ]
+
+    return tokenized_examples

--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -200,7 +200,6 @@ class ExamplesTestsNoTrainer(TestCasePlus):
         testargs = f"""
             run_qa_no_trainer.py
             --model_name_or_path bert-base-uncased
-            --version_2_with_negative=False
             --train_file tests/fixtures/tests_samples/SQUAD/sample.json
             --validation_file tests/fixtures/tests_samples/SQUAD/sample.json
             --output_dir {tmp_dir}
@@ -217,7 +216,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
             run_squad_no_trainer.main()
             result = get_results(tmp_dir)
             self.assertGreaterEqual(result["eval_f1"], 30)
-            self.assertGreaterEqual(result["eval_exact"], 30)
+            self.assertGreaterEqual(result["eval_exact_match"], 30)
             self.assertTrue(os.path.exists(os.path.join(tmp_dir, "epoch_0")))
             self.assertTrue(os.path.exists(os.path.join(tmp_dir, "qa_no_trainer")))
 

--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -200,6 +200,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
         testargs = f"""
             run_qa_no_trainer.py
             --model_name_or_path bert-base-uncased
+            --version_2_with_negative
             --train_file tests/fixtures/tests_samples/SQUAD/sample.json
             --validation_file tests/fixtures/tests_samples/SQUAD/sample.json
             --output_dir {tmp_dir}
@@ -215,8 +216,9 @@ class ExamplesTestsNoTrainer(TestCasePlus):
         with patch.object(sys, "argv", testargs):
             run_squad_no_trainer.main()
             result = get_results(tmp_dir)
+            # Because we use --version_2_with_negative the testing script uses SQuAD v2 metrics.
             self.assertGreaterEqual(result["eval_f1"], 30)
-            self.assertGreaterEqual(result["eval_exact_match"], 30)
+            self.assertGreaterEqual(result["eval_exact"], 30)
             self.assertTrue(os.path.exists(os.path.join(tmp_dir, "epoch_0")))
             self.assertTrue(os.path.exists(os.path.join(tmp_dir, "qa_no_trainer")))
 

--- a/examples/tensorflow/question-answering/utils_qa.py
+++ b/examples/tensorflow/question-answering/utils_qa.py
@@ -350,9 +350,12 @@ def postprocess_qa_predictions_with_beam_search(
                         start_index >= len(offset_mapping)
                         or end_index >= len(offset_mapping)
                         or offset_mapping[start_index] is None
+                        or len(offset_mapping[start_index]) < 2
                         or offset_mapping[end_index] is None
+                        or len(offset_mapping[end_index]) < 2
                     ):
                         continue
+
                     # Don't consider answers with a length negative or > max_answer_length.
                     if end_index < start_index or end_index - start_index + 1 > max_answer_length:
                         continue
@@ -381,7 +384,9 @@ def postprocess_qa_predictions_with_beam_search(
         # In the very rare edge case we have not a single non-null prediction, we create a fake prediction to avoid
         # failure.
         if len(predictions) == 0:
-            predictions.insert(0, {"text": "", "start_logit": -1e-6, "end_logit": -1e-6, "score": -2e-6})
+            # Without predictions min_null_score is going to be None and None will cause an exception later
+            min_null_score = -2e-6
+            predictions.insert(0, {"text": "", "start_logit": -1e-6, "end_logit": -1e-6, "score": min_null_score})
 
         # Compute the softmax of all scores (we do it with numpy to stay independent from torch/tf in this file, using
         # the LogSumExp trick).


### PR DESCRIPTION
Thank you for the great library! I had to clean up QA examples, because of the duplicate pre- and post-processing code. However, while doing so I have encountered a number of issues that I had to fix. Please, see details below.

# What does this PR do?

1. refactoring: consolidating duplicate post-processing functions in a helper file (now shared between regular and no-trainer version)
2. Fixes evaluation errors popping up when you train/eval on squad v2 (one was newly encountered and one that was previously reported #15401 but not completely fixed).
3. Removes boolean arguments that don't use `store_true`. Please, don't use these: **ANY* non-empty string is being converted to True in this case and this clearly is not the desired behavior (and it creates a **LOT** of confusion).
4. all **no-trainer** test scripts are now saving metric values in the same way (with the right prefix ``eval_``), which is consistent with the **trainer**-based versions. 
5. Adds forgotten `model.eval()` in the **no-trainer** versions. This improved some results, but not everything (see the discussion in the end). Please, see the F1 scores and the discussion below.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] You make sure to update the documentation with your changes? **I believe examples aren't covered by the documentation** 
- [X] Did you write any new necessary tests? **I trained squad and squad v2 models and compared results (see the discussion below)**, but I am not sure if running more QA tests automatically will be feasible. Do note that the existing "unit-test" is very crude and does not permit detecting small regressions in model quality.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Perhaps, this can be of most interest for  @sgugger, @patil-suraj.

## Comparing old and new performance + some potential issues

Some remaining issues:
1. Despite the fixes & improvements, there's still a discrepancy between no-trainer and original version for SQuAD v2 or the beam-search version.
2. In particular, for SQuAD v2 and the beam-search variant **without trainer**, both old and new numbers look very wrong to me.

Please note that to be able to run SQuAD v2 tests, **I had to apply utils_qa.py fixes to the old code as well**. Otherwise, it would have just failed:

The metric is F1, the exact scores have the same pattern.

|                                   | previous | fixed |
|-----------------------------------|----------|-------|
| squad v1                          |     88.4 |  88.4 |
| squad v1 (no trainer)             |     86.7 |  88.5 |
| squad v1 (beam search)            |     92.1 |  92.1 |
| squad v1 (beam search no trainer) |     90.2 |  91.0 |
| squad v2 (beam search)            |     83.2 |  83.2 |
| squad v2 (beam search no trainer) |      4.9 |  50.1 |