### PR TITLE
Fix wrong image conditional checking

### DIFF
--- a/src/transformers/models/clip/feature_extraction_clip.py
+++ b/src/transformers/models/clip/feature_extraction_clip.py
@@ -124,7 +124,7 @@ class CLIPFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin):
         if isinstance(images, (Image.Image, np.ndarray)) or is_torch_tensor(images):
             valid_images = True
         elif isinstance(images, (list, tuple)):
-            if len(images) == 0 or isinstance(images[0], (Image.Image, np.ndarray)) or is_torch_tensor(images[0]):
+            if isinstance(images[0], (Image.Image, np.ndarray)) or is_torch_tensor(images[0]):
                 valid_images = True
 
         if not valid_images:

--- a/src/transformers/models/clip/feature_extraction_clip.py
+++ b/src/transformers/models/clip/feature_extraction_clip.py
@@ -124,7 +124,7 @@ class CLIPFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin):
         if isinstance(images, (Image.Image, np.ndarray)) or is_torch_tensor(images):
             valid_images = True
         elif isinstance(images, (list, tuple)):
-            if isinstance(images[0], (Image.Image, np.ndarray)) or is_torch_tensor(images[0]):
+            if (len(images) > 0) and (isinstance(images[0], (Image.Image, np.ndarray)) or is_torch_tensor(images[0])):
                 valid_images = True
 
         if not valid_images:


### PR DESCRIPTION
Apparently, If an empty batch comes in, it is considered valid. However, then line 138 brakes since it tries to access element 0 of an empty batch.
