### PR TITLE
Fix RemBertTokenizerFast

### DIFF
--- a/src/transformers/models/rembert/tokenization_rembert_fast.py
+++ b/src/transformers/models/rembert/tokenization_rembert_fast.py
@@ -139,6 +139,7 @@ class RemBertTokenizerFast(PreTrainedTokenizerFast):
         self.remove_space = remove_space
         self.keep_accents = keep_accents
         self.vocab_file = vocab_file
+        self.can_save_slow_tokenizer = False if not self.vocab_file else True
 
     def build_inputs_with_special_tokens(
         self, token_ids_0: List[int], token_ids_1: Optional[List[int]] = None


### PR DESCRIPTION
# What does this PR do?

`RemBertTokenizer(Fast)` are similar to  `AlbertTokenizer(Fast)`, the slow versions are based on `SentencePiece`.

Unlike `AlbertTokenizerFast`, the fast tokenizer `RemBertTokenizerFast` doesn't have

```python
self.can_save_slow_tokenizer = False if not self.vocab_file else True
```

And I got error when I want to call `save_pretrained()` after doing something like
```
tokenizer_fast.train_new_from_iterator(training_ds["text"], 1024)
```

(while working on the task for creating tiny random models/processor)

### Error message without this PR

```
  File "/home/yih_dar_huggingface_co/transformers/create_dummy_models.py", line 457, in convert_processors
    p.save_pretrained(output_folder)
  File "/home/yih_dar_huggingface_co/transformers/src/transformers/tokenization_utils_base.py", line 2101, in save_pretrained
    save_files = self._save_pretrained(
  File "/home/yih_dar_huggingface_co/transformers/src/transformers/tokenization_utils_fast.py", line 591, in _save_pretrained
    vocab_files = self.save_vocabulary(save_directory, filename_prefix=filename_prefix)
  File "/home/yih_dar_huggingface_co/transformers/src/transformers/models/rembert/tokenization_rembert_fast.py", line 237, in save_vocabulary
    if os.path.abspath(self.vocab_file) != os.path.abspath(out_vocab_file):
  File "/home/yih_dar_huggingface_co/miniconda3/envs/py-3-9/lib/python3.9/posixpath.py", line 375, in abspath
    path = os.fspath(path)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```