### PR TITLE
Fix `HubertRobustTest` PT/TF equivalence test on GPU

### DIFF
--- a/tests/hubert/test_modeling_hubert.py
+++ b/tests/hubert/test_modeling_hubert.py
@@ -133,6 +133,7 @@ class HubertModelTester:
             hidden_act=self.hidden_act,
             initializer_range=self.initializer_range,
             vocab_size=self.vocab_size,
+            do_stable_layer_norm=self.do_stable_layer_norm,
         )
 
     def create_and_check_model(self, config, input_values, attention_mask):


### PR DESCRIPTION
# What does this PR do?

Fix `HubertRobustTest` PT/TF equivalence test on GPU.

Note that `HubertRobustModelTest` has

```python
    def setUp(self):
        self.model_tester = HubertModelTester(
            self, conv_stride=(3, 3, 3), feat_extract_norm="layer", do_stable_layer_norm=True
        )
```

but `get_config()` had no ` do_stable_layer_norm=self.do_stable_layer_norm`

## To investigate further

- Why no issue on CPU even without this PR
- Why using `conv_stride=(4, 4, 4)` (the default value) has no issue on GPU, even without this PR

(Does this suggest we have PT/TF Hubert behave differently with `do_stable_layer_norm=False` on GPU when `conv_stride=(3, 3, 3)` etc?)

@patrickvonplaten You might have some idea about these points ..?
