### PR TITLE
Add -e flag to some GH workflow yml files

### DIFF
--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -30,11 +30,22 @@ jobs:
           key: v2-tests_model_like-${{ hashFiles('setup.py') }}
 
       - name: Create virtual environment on cache miss
-        if: steps.cache.outputs.cache-hit != 'false'
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           python -m venv ~/venv && . ~/venv/bin/activate
           pip install --upgrade pip!=21.3
           pip install -e .[dev]
+
+      - name: Check transformers location
+        run: |
+          . ~/venv/bin/activate
+          transformer_loc=$(pip show transformers | grep "Location: " | cut -c11-)
+          transformer_repo_loc=$(pwd .)
+          if [ "$transformer_loc" != "$transformer_repo_loc/src" ]; then
+              echo "transformers is from $transformer_loc but it shoud be from $transformer_repo_loc/src."
+              echo "A fix is required. Stop testing."
+              exit 1
+          fi
 
       - name: Create model files
         run: |

--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -30,7 +30,7 @@ jobs:
           key: v2-tests_model_like-${{ hashFiles('setup.py') }}
 
       - name: Create virtual environment on cache miss
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit != 'false'
         run: |
           python -m venv ~/venv && . ~/venv/bin/activate
           pip install --upgrade pip!=21.3

--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -27,7 +27,7 @@ jobs:
         id: cache
         with:
           path: ~/venv/
-          key: v2-tests_model_like-${{ hashFiles('setup.py') }}
+          key: v3-tests_model_like-${{ hashFiles('setup.py') }}
 
       - name: Create virtual environment on cache miss
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -37,6 +37,7 @@ jobs:
           pip install -e .[dev]
 
       - name: Check transformers location
+        # make `transformers` available as package (required since we use `-e` flag) and check it indeeds from the repo.
         run: |
           . ~/venv/bin/activate
           python setup.py build install

--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Check transformers location
         run: |
           . ~/venv/bin/activate
+          python setup.py build install
           transformer_loc=$(pip show transformers | grep "Location: " | cut -c11-)
           transformer_repo_loc=$(pwd .)
           if [ "$transformer_loc" != "$transformer_repo_loc/src" ]; then

--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -37,7 +37,7 @@ jobs:
           pip install -e .[dev]
 
       - name: Check transformers location
-        # make `transformers` available as package (required since we use `-e` flag) and check it indeeds from the repo.
+        # make `transformers` available as package (required since we use `-e` flag) and check it's indeed from the repo.
         run: |
           . ~/venv/bin/activate
           python setup.py build install

--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -40,7 +40,7 @@ jobs:
         # make `transformers` available as package (required since we use `-e` flag) and check it's indeed from the repo.
         run: |
           . ~/venv/bin/activate
-          python setup.py build install
+          python setup.py develop
           transformer_loc=$(pip show transformers | grep "Location: " | cut -c11-)
           transformer_repo_loc=$(pwd .)
           if [ "$transformer_loc" != "$transformer_repo_loc/src" ]; then

--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           python -m venv ~/venv && . ~/venv/bin/activate
           pip install --upgrade pip!=21.3
-          pip install .[dev]
+          pip install -e .[dev]
 
       - name: Create model files
         run: |

--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           python -m venv ~/venv && . ~/venv/bin/activate
           pip install --upgrade pip!=21.3
-          pip install .[dev]
+          pip install -e .[dev]
 
       - name: Create model files
         run: |

--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Check transformers location
         run: |
+          . ~/venv/bin/activate
           transformer_loc=$(pip show transformers | grep "Location: " | cut -c11-)
           transformer_repo_loc=$(pwd .)
           if [ "$transformer_loc" == "$transformer_repo_loc/src" ]; then

--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -36,7 +36,7 @@ jobs:
           key: v2-tests_templates-${{ hashFiles('setup.py') }}
 
       - name: Create virtual environment on cache miss
-        if: steps.cache.outputs.cache-hit != 'false'
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           python -m venv ~/venv && . ~/venv/bin/activate
           pip install --upgrade pip!=21.3
@@ -47,7 +47,7 @@ jobs:
           . ~/venv/bin/activate
           transformer_loc=$(pip show transformers | grep "Location: " | cut -c11-)
           transformer_repo_loc=$(pwd .)
-          if [ "$transformer_loc" == "$transformer_repo_loc/src" ]; then
+          if [ "$transformer_loc" != "$transformer_repo_loc/src" ]; then
               echo "transformers is from $transformer_loc but it shoud be from $transformer_repo_loc/src."
               echo "A fix is required. Stop testing."
               exit 1

--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Check transformers location
         run: |
           . ~/venv/bin/activate
+          python setup.py build install
           transformer_loc=$(pip show transformers | grep "Location: " | cut -c11-)
           transformer_repo_loc=$(pwd .)
           if [ "$transformer_loc" != "$transformer_repo_loc/src" ]; then

--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -43,7 +43,7 @@ jobs:
           pip install -e .[dev]
 
       - name: Check transformers location
-        # make `transformers` available as package (required since we use `-e` flag) and check it indeeds from the repo.
+        # make `transformers` available as package (required since we use `-e` flag) and check it's indeed from the repo.
         run: |
           . ~/venv/bin/activate
           python setup.py build install

--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -33,7 +33,7 @@ jobs:
         id: cache
         with:
           path: ~/venv/
-          key: v2-tests_templates-${{ hashFiles('setup.py') }}
+          key: v3-tests_templates-${{ hashFiles('setup.py') }}
 
       - name: Create virtual environment on cache miss
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -43,6 +43,7 @@ jobs:
           pip install -e .[dev]
 
       - name: Check transformers location
+        # make `transformers` available as package (required since we use `-e` flag) and check it indeeds from the repo.
         run: |
           . ~/venv/bin/activate
           python setup.py build install

--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -46,7 +46,7 @@ jobs:
         # make `transformers` available as package (required since we use `-e` flag) and check it's indeed from the repo.
         run: |
           . ~/venv/bin/activate
-          python setup.py build install
+          python setup.py develop
           transformer_loc=$(pip show transformers | grep "Location: " | cut -c11-)
           transformer_repo_loc=$(pwd .)
           if [ "$transformer_loc" != "$transformer_repo_loc/src" ]; then

--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -42,6 +42,16 @@ jobs:
           pip install --upgrade pip!=21.3
           pip install -e .[dev]
 
+      - name: Check transformers location
+        run: |
+          transformer_loc=$(pip show transformers | grep "Location: " | cut -c11-)
+          transformer_repo_loc=$(pwd .)
+          if [ "$transformer_loc" == "$transformer_repo_loc/src" ]; then
+              echo "transformers is from $transformer_loc but it shoud be from $transformer_repo_loc/src."
+              echo "A fix is required. Stop testing."
+              exit 1
+          fi
+
       - name: Create model files
         run: |
           . ~/venv/bin/activate

--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -36,7 +36,7 @@ jobs:
           key: v2-tests_templates-${{ hashFiles('setup.py') }}
 
       - name: Create virtual environment on cache miss
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit != 'false'
         run: |
           python -m venv ~/venv && . ~/venv/bin/activate
           pip install --upgrade pip!=21.3

--- a/src/transformers/commands/add_new_model.py
+++ b/src/transformers/commands/add_new_model.py
@@ -251,3 +251,5 @@ class AddNewModelCommand(BaseTransformersCLICommand):
 
         replace_in_files(f"{directory}/to_replace_{lowercase_model_name}.py")
         os.rmdir(directory)
+
+        print("well done!")

--- a/src/transformers/commands/add_new_model.py
+++ b/src/transformers/commands/add_new_model.py
@@ -251,5 +251,3 @@ class AddNewModelCommand(BaseTransformersCLICommand):
 
         replace_in_files(f"{directory}/to_replace_{lowercase_model_name}.py")
         os.rmdir(directory)
-
-        print("well done!")


### PR DESCRIPTION
# What does this PR do?

Current 2 GitHub actions workflow yml use `pip install [.dev]`. This installs `transformers` in `/home/runner/venv/lib/python3.6/site-packages`, and this is cached. In future job runs, the cache is restored, and that `transformers` version is used - instead of the latest commit, i.e. we want to use `/home/runner/work/transformers/transformers/src`.

Without this PR, I have trouble after updating `add_new_model.py` (to change test model folders from `tests/` to `tests/models/`) because the `add_new_model.py` from `/home/runner/venv/lib/python3.6/site-packages` would be used, which would put the test template models under `tests/`

This PR makes sure the latest `transformers` is used by using `pip install -e [.dev]`, and builds a new cache with it.

- Add -e flag to some GH workflow yml files
- change cache key in order to make the change effective
- add a check on `transformers` location