### PR TITLE
Fix add-new-model-like when model doesn't support all frameworks

### DIFF
--- a/src/transformers/commands/add_new_model_like.py
+++ b/src/transformers/commands/add_new_model_like.py
@@ -517,7 +517,7 @@ def filter_framework_files(
         else:
             framework_to_file["pt"] = f
 
-    return [framework_to_file[f] for f in frameworks] + others
+    return [framework_to_file[f] for f in frameworks if f in framework_to_file] + others
 
 
 def get_model_files(model_type: str, frameworks: Optional[List[str]] = None) -> Dict[str, Union[Path, List[Path]]]:


### PR DESCRIPTION
# What does this PR do?

This fixes the `transformers-cli add-new-model-like` command when the model used as a model is not implemented in all frameworks.