### PR TITLE
Fix check_all_models_are_tested

### DIFF
--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -393,9 +393,9 @@ def check_all_models_are_tested():
             failures.append(f"{module.__name__} has several test files: {test_file}.")
         else:
             test_file = test_file[0]
-        new_failures = check_models_are_tested(module, test_file)
-        if new_failures is not None:
-            failures += new_failures
+            new_failures = check_models_are_tested(module, test_file)
+            if new_failures is not None:
+                failures += new_failures
     if len(failures) > 0:
         raise Exception(f"There were {len(failures)} failures:\n" + "\n".join(failures))
 


### PR DESCRIPTION
# What does this PR do?

The block from L396 to L398 should be in the `else` block if I understand correctly. 

https://github.com/huggingface/transformers/blob/8d3f952adb8c98cec2ea1f59bb7acfbc08232381/utils/check_repo.py#L394-L398

Otherwise, when a model has no test file, I get errors like below, and the program stops immediately.
(with `test_file = []` passed to `check_models_are_tested`)

```python
  File "/home/yih_dar_huggingface_co/transformers/utils/check_repo.py", line 362, in check_models_are_tested
    tested_models = find_tested_models(test_file)
  File "/home/yih_dar_huggingface_co/transformers/utils/check_repo.py", line 343, in find_tested_models
    with open(os.path.join(PATH_TO_TESTS, test_file), "r", encoding="utf-8", newline="\n") as f:
  File "/usr/lib/python3.9/posixpath.py", line 90, in join
    genericpath._check_arg_types('join', a, *p)
  File "/usr/lib/python3.9/genericpath.py", line 152, in _check_arg_types
    raise TypeError(f'{funcname}() argument must be str, bytes, or '
TypeError: join() argument must be str, bytes, or os.PathLike object, not 'list'
```