### PR TITLE
Update check_models_are_tested to deal with Windows path

### DIFF
--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -361,7 +361,7 @@ def check_models_are_tested(module, test_file):
     defined_models = get_models(module)
     tested_models = find_tested_models(test_file)
     if tested_models is None:
-        if test_file in TEST_FILES_WITH_NO_COMMON_TESTS:
+        if test_file.replace(os.sep, "/") in TEST_FILES_WITH_NO_COMMON_TESTS:
             return
         return [
             f"{test_file} should define `all_model_classes` to apply common tests to the models it tests. "

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -361,7 +361,7 @@ def check_models_are_tested(module, test_file):
     defined_models = get_models(module)
     tested_models = find_tested_models(test_file)
     if tested_models is None:
-        if test_file.replace(os.sep, "/") in TEST_FILES_WITH_NO_COMMON_TESTS:
+        if test_file.replace(os.path.sep, "/") in TEST_FILES_WITH_NO_COMMON_TESTS:
             return
         return [
             f"{test_file} should define `all_model_classes` to apply common tests to the models it tests. "


### PR DESCRIPTION
# What does this PR do?

`TEST_FILES_WITH_NO_COMMON_TESTS` contains forward slash like `mt5/test_modeling_flax_mt5.py`.

The condition `if test_file in TEST_FILES_WITH_NO_COMMON_TESTS:` in `check_models_are_tested` would give failures to fix on Windows, like

```
camembert\test_modeling_camembert.py should define `all_model_classes` to apply common tests
```

This PR uses  `test_file.replace(os.sep, "/")` to make it work on Windows too 😄 