### PR TITLE
set eos_token_id to None to generate until max length

### DIFF
--- a/tests/encoder_decoder/test_modeling_encoder_decoder.py
+++ b/tests/encoder_decoder/test_modeling_encoder_decoder.py
@@ -413,7 +413,10 @@ class EncoderDecoderMixin:
         enc_dec_model = EncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
 
         # Generate until max length
-        enc_dec_model.config.decoder.eos_token_id = None
+        if hasattr(enc_dec_model.config, "eos_token_id"):
+            enc_dec_model.config.eos_token_id = None
+        if hasattr(enc_dec_model.config, "decoder") and hasattr(enc_dec_model.config.decoder, "eos_token_id"):
+            enc_dec_model.config.decoder.eos_token_id = None
         enc_dec_model.to(torch_device)
 
         # Bert does not have a bos token id, so use pad_token_id instead

--- a/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
+++ b/tests/encoder_decoder/test_modeling_tf_encoder_decoder.py
@@ -314,6 +314,12 @@ class TFEncoderDecoderMixin:
         encoder_model, decoder_model = self.get_encoder_decoder_model(config, decoder_config)
         enc_dec_model = TFEncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
 
+        # Generate until max length
+        if hasattr(enc_dec_model.config, "eos_token_id"):
+            enc_dec_model.config.eos_token_id = None
+        if hasattr(enc_dec_model.config, "decoder") and hasattr(enc_dec_model.config.decoder, "eos_token_id"):
+            enc_dec_model.config.decoder.eos_token_id = None
+
         # Bert does not have a bos token id, so use pad_token_id instead
         generated_output = enc_dec_model.generate(
             input_ids, decoder_start_token_id=enc_dec_model.config.decoder.pad_token_id

--- a/tests/speech_encoder_decoder/test_modeling_speech_encoder_decoder.py
+++ b/tests/speech_encoder_decoder/test_modeling_speech_encoder_decoder.py
@@ -347,7 +347,8 @@ class EncoderDecoderMixin:
         enc_dec_model.to(torch_device)
 
         # make sure EOS token is set to None to prevent early stopping of generation
-        enc_dec_model.config.eos_token_id = None
+        if hasattr(enc_dec_model.config, "eos_token_id"):
+            enc_dec_model.config.eos_token_id = None
         if hasattr(enc_dec_model.config, "decoder") and hasattr(enc_dec_model.config.decoder, "eos_token_id"):
             enc_dec_model.config.decoder.eos_token_id = None
 

--- a/tests/vision_encoder_decoder/test_modeling_tf_vision_encoder_decoder.py
+++ b/tests/vision_encoder_decoder/test_modeling_tf_vision_encoder_decoder.py
@@ -300,6 +300,12 @@ class TFVisionEncoderDecoderMixin:
         encoder_model, decoder_model = self.get_encoder_decoder_model(config, decoder_config)
         enc_dec_model = TFVisionEncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
 
+        # Generate until max length
+        if hasattr(enc_dec_model.config, "eos_token_id"):
+            enc_dec_model.config.eos_token_id = None
+        if hasattr(enc_dec_model.config, "decoder") and hasattr(enc_dec_model.config.decoder, "eos_token_id"):
+            enc_dec_model.config.decoder.eos_token_id = None
+
         # Bert does not have a bos token id, so use pad_token_id instead
         generated_output = enc_dec_model.generate(
             pixel_values, decoder_start_token_id=enc_dec_model.config.decoder.pad_token_id

--- a/tests/vision_encoder_decoder/test_modeling_vision_encoder_decoder.py
+++ b/tests/vision_encoder_decoder/test_modeling_vision_encoder_decoder.py
@@ -269,6 +269,12 @@ class EncoderDecoderMixin:
     def check_encoder_decoder_model_generate(self, config, decoder_config, pixel_values=None, **kwargs):
         encoder_model, decoder_model = self.get_encoder_decoder_model(config, decoder_config)
         enc_dec_model = VisionEncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
+
+        # Generate until max length
+        if hasattr(enc_dec_model.config, "eos_token_id"):
+            enc_dec_model.config.eos_token_id = None
+        if hasattr(enc_dec_model.config, "decoder") and hasattr(enc_dec_model.config.decoder, "eos_token_id"):
+            enc_dec_model.config.decoder.eos_token_id = None
         enc_dec_model.to(torch_device)
 
         inputs = pixel_values


### PR DESCRIPTION
# What does this PR do?

Update `check_encoder_decoder_model_generate` to generate until max length.
Otherwise, this check

```python
self.assertEqual(generated_output.shape, (input_ids.shape[0],) + (decoder_config.max_length,))
```

might fail.

### Remark

In `generate()`, we have

https://github.com/huggingface/transformers/blob/dced262409177586bb510b6b724c762fb89da0e8/src/transformers/generation_utils.py#L1129-L1133

So I think the (original) logic about `Generate until max length` in `check_encoder_decoder_model_generate` should be updated too. The case won't really happen in the tests, but in general, `config` might still have `eos_token_id`.

I also leave the corresponding flax tests untouched for now.

This PR will fix

```
FAILED tests/models/vision_encoder_decoder/test_modeling_vision_encoder_decoder.py::Swin2BartModelTest::test_encoder_decoder_model_generate

tests/vision_encoder_decoder/test_modeling_vision_encoder_decoder.py:280: in check_encoder_decoder_model_generate
self.assertEqual(generated_output.shape, (inputs.shape[0],) + (decoder_config.max_length,))
AssertionError: torch.Size([13, 2]) != (13, 20)
```
