### PR TITLE
Fix savedir for by epoch in translation example

### DIFF
--- a/examples/pytorch/translation/run_translation_no_trainer.py
+++ b/examples/pytorch/translation/run_translation_no_trainer.py
@@ -678,7 +678,7 @@ def main():
                 )
 
         if args.checkpointing_steps == "epoch":
-            output_dir = f"step_{completed_steps}"
+            output_dir = f"epoch_{epoch}"
             if args.output_dir is not None:
                 output_dir = os.path.join(args.output_dir, output_dir)
             accelerator.save_state(output_dir)


### PR DESCRIPTION
# What does this PR do?

Fixes up the `no_trainer` translation example to properly save the `by_epoch` to the right directory (before it saved to step, causing a slow test failure)