### PR TITLE
use scale=1.0 in floats_tensor called in speech model testers

### DIFF
--- a/tests/data2vec/test_modeling_data2vec_audio.py
+++ b/tests/data2vec/test_modeling_data2vec_audio.py
@@ -116,7 +116,7 @@ class Data2VecAudioModelTester:
         self.adapter_output_seq_length = (self.output_seq_length - 1) // adapter_stride + 1
 
     def prepare_config_and_inputs(self):
-        input_values = floats_tensor([self.batch_size, self.seq_length], self.vocab_size)
+        input_values = floats_tensor([self.batch_size, self.seq_length], scale=1.0)
         attention_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         config = self.get_config()

--- a/tests/hubert/test_modeling_hubert.py
+++ b/tests/hubert/test_modeling_hubert.py
@@ -106,7 +106,7 @@ class HubertModelTester:
         self.encoder_seq_length = self.output_seq_length
 
     def prepare_config_and_inputs(self):
-        input_values = floats_tensor([self.batch_size, self.seq_length], self.vocab_size)
+        input_values = floats_tensor([self.batch_size, self.seq_length], scale=1.0)
         attention_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         config = self.get_config()

--- a/tests/perceiver/test_modeling_perceiver.py
+++ b/tests/perceiver/test_modeling_perceiver.py
@@ -143,7 +143,7 @@ class PerceiverModelTester:
             token_labels = ids_tensor([self.batch_size, self.seq_length], self.num_labels)
 
         if model_class is None or model_class.__name__ == "PerceiverModel":
-            inputs = floats_tensor([self.batch_size, self.seq_length, config.d_model], self.vocab_size)
+            inputs = floats_tensor([self.batch_size, self.seq_length, config.d_model], scale=1.0)
             return config, inputs, input_mask, sequence_labels, token_labels
         elif model_class.__name__ in ["PerceiverForMaskedLM", "PerceiverForSequenceClassification"]:
             inputs = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)

--- a/tests/sew/test_modeling_sew.py
+++ b/tests/sew/test_modeling_sew.py
@@ -108,7 +108,7 @@ class SEWModelTester:
         self.encoder_seq_length = self.output_seq_length // self.squeeze_factor
 
     def prepare_config_and_inputs(self):
-        input_values = floats_tensor([self.batch_size, self.seq_length], self.vocab_size)
+        input_values = floats_tensor([self.batch_size, self.seq_length], scale=1.0)
         attention_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         config = self.get_config()

--- a/tests/sew_d/test_modeling_sew_d.py
+++ b/tests/sew_d/test_modeling_sew_d.py
@@ -122,7 +122,7 @@ class SEWDModelTester:
         self.encoder_seq_length = self.output_seq_length // self.squeeze_factor
 
     def prepare_config_and_inputs(self):
-        input_values = floats_tensor([self.batch_size, self.seq_length], self.vocab_size)
+        input_values = floats_tensor([self.batch_size, self.seq_length], scale=1.0)
         attention_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         config = self.get_config()

--- a/tests/speech_encoder_decoder/test_modeling_flax_speech_encoder_decoder.py
+++ b/tests/speech_encoder_decoder/test_modeling_flax_speech_encoder_decoder.py
@@ -582,7 +582,7 @@ class FlaxWav2Vec2GPT2ModelTest(FlaxEncoderDecoderMixin, unittest.TestCase):
             "facebook/wav2vec2-large-lv60", "gpt2-medium"
         )
         batch_size = 13
-        input_values = floats_tensor([batch_size, 512], model.config.encoder.vocab_size)
+        input_values = floats_tensor([batch_size, 512], scale=1.0)
         attention_mask = random_attention_mask([batch_size, 512])
         decoder_input_ids = ids_tensor([batch_size, 4], model.config.decoder.vocab_size)
         decoder_attention_mask = random_attention_mask([batch_size, 4])
@@ -638,7 +638,7 @@ class FlaxWav2Vec2GPT2ModelTest(FlaxEncoderDecoderMixin, unittest.TestCase):
 
         # prepare inputs
         batch_size = 13
-        input_values = floats_tensor([batch_size, 512], fx_model.config.encoder.vocab_size)
+        input_values = floats_tensor([batch_size, 512], scale=1.0)
         attention_mask = random_attention_mask([batch_size, 512])
         decoder_input_ids = ids_tensor([batch_size, 4], fx_model.config.decoder.vocab_size)
         decoder_attention_mask = random_attention_mask([batch_size, 4])
@@ -699,7 +699,7 @@ class FlaxWav2Vec2BartModelTest(FlaxEncoderDecoderMixin, unittest.TestCase):
             "facebook/wav2vec2-large-lv60", "bart-large"
         )
         batch_size = 13
-        input_values = floats_tensor([batch_size, 512], model.config.encoder.vocab_size)
+        input_values = floats_tensor([batch_size, 512], scale=1.0)
         attention_mask = random_attention_mask([batch_size, 512])
         decoder_input_ids = ids_tensor([batch_size, 4], model.config.decoder.vocab_size)
         decoder_attention_mask = random_attention_mask([batch_size, 4])
@@ -755,7 +755,7 @@ class FlaxWav2Vec2BartModelTest(FlaxEncoderDecoderMixin, unittest.TestCase):
 
         # prepare inputs
         batch_size = 13
-        input_values = floats_tensor([batch_size, 512], fx_model.config.encoder.vocab_size)
+        input_values = floats_tensor([batch_size, 512], scale=1.0)
         attention_mask = random_attention_mask([batch_size, 512])
         decoder_input_ids = ids_tensor([batch_size, 4], fx_model.config.decoder.vocab_size)
         decoder_attention_mask = random_attention_mask([batch_size, 4])

--- a/tests/speech_encoder_decoder/test_modeling_speech_encoder_decoder.py
+++ b/tests/speech_encoder_decoder/test_modeling_speech_encoder_decoder.py
@@ -425,7 +425,7 @@ class Wav2Vec2BertModelTest(EncoderDecoderMixin, unittest.TestCase):
             "facebook/wav2vec2-base-960h", "bert-base-cased"
         )
         batch_size = 13
-        input_values = floats_tensor([batch_size, 512], model.encoder.config.vocab_size)
+        input_values = floats_tensor([batch_size, 512], scale=1.0)
         attention_mask = random_attention_mask([batch_size, 512])
         decoder_input_ids = ids_tensor([batch_size, 4], model.decoder.config.vocab_size)
         decoder_attention_mask = random_attention_mask([batch_size, 4])
@@ -489,7 +489,7 @@ class Speech2TextBertModelTest(EncoderDecoderMixin, unittest.TestCase):
             "facebook/s2t-small-librispeech-asr", "bert-base-cased"
         )
         batch_size = 13
-        input_features = floats_tensor([batch_size, 7, 80], model.encoder.config.vocab_size)
+        input_features = floats_tensor([batch_size, 7, 80], scale=1.0)
         attention_mask = random_attention_mask([batch_size, 7])
         decoder_input_ids = ids_tensor([batch_size, 4], model.decoder.config.vocab_size)
         decoder_attention_mask = random_attention_mask([batch_size, 4])

--- a/tests/unispeech/test_modeling_unispeech.py
+++ b/tests/unispeech/test_modeling_unispeech.py
@@ -107,7 +107,7 @@ class UniSpeechModelTester:
         self.encoder_seq_length = self.output_seq_length
 
     def prepare_config_and_inputs(self):
-        input_values = floats_tensor([self.batch_size, self.seq_length], self.vocab_size)
+        input_values = floats_tensor([self.batch_size, self.seq_length], scale=1.0)
         attention_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         config = self.get_config()

--- a/tests/unispeech_sat/test_modeling_unispeech_sat.py
+++ b/tests/unispeech_sat/test_modeling_unispeech_sat.py
@@ -121,7 +121,7 @@ class UniSpeechSatModelTester:
         self.encoder_seq_length = self.output_seq_length
 
     def prepare_config_and_inputs(self):
-        input_values = floats_tensor([self.batch_size, self.seq_length], self.vocab_size)
+        input_values = floats_tensor([self.batch_size, self.seq_length], scale=1.0)
         attention_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         config = self.get_config()
@@ -306,7 +306,7 @@ class UniSpeechSatModelTester:
         model.freeze_base_model()
 
         # use a longer sequence length to account for TDNN temporal downsampling
-        input_values = floats_tensor([self.batch_size, self.seq_length * 2], self.vocab_size)
+        input_values = floats_tensor([self.batch_size, self.seq_length * 2], scale=1.0)
 
         input_lengths = [input_values.shape[-1] // i for i in [4, 2, 1]]
         labels = ids_tensor((input_values.shape[0], 1), len(model.config.id2label))

--- a/tests/wav2vec2/test_modeling_flax_wav2vec2.py
+++ b/tests/wav2vec2/test_modeling_flax_wav2vec2.py
@@ -117,7 +117,7 @@ class FlaxWav2Vec2ModelTester:
         self.encoder_seq_length = self.output_seq_length
 
     def prepare_config_and_inputs(self):
-        input_values = floats_tensor([self.batch_size, self.seq_length], self.vocab_size)
+        input_values = floats_tensor([self.batch_size, self.seq_length], scale=1.0)
         attention_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         config = Wav2Vec2Config(

--- a/tests/wav2vec2/test_modeling_wav2vec2.py
+++ b/tests/wav2vec2/test_modeling_wav2vec2.py
@@ -150,7 +150,7 @@ class Wav2Vec2ModelTester:
         self.adapter_output_seq_length = (self.output_seq_length - 1) // adapter_stride + 1
 
     def prepare_config_and_inputs(self):
-        input_values = floats_tensor([self.batch_size, self.seq_length], self.vocab_size)
+        input_values = floats_tensor([self.batch_size, self.seq_length], scale=1.0)
         attention_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         config = self.get_config()

--- a/tests/wavlm/test_modeling_wavlm.py
+++ b/tests/wavlm/test_modeling_wavlm.py
@@ -114,7 +114,7 @@ class WavLMModelTester:
         self.encoder_seq_length = self.output_seq_length
 
     def prepare_config_and_inputs(self):
-        input_values = floats_tensor([self.batch_size, self.seq_length], self.vocab_size)
+        input_values = floats_tensor([self.batch_size, self.seq_length], scale=1.0)
         attention_mask = random_attention_mask([self.batch_size, self.seq_length])
 
         config = self.get_config()


### PR DESCRIPTION
# What does this PR do?

Fix the failure of `Speech2TextModelTest.test_pt_tf_model_equivalence`. This is caused by 

https://github.com/huggingface/transformers/blob/e6f00a11d7fa34215184e3c797e19e6c7debe0fe/tests/speech_to_text/test_modeling_speech_to_text.py#L134-L136

where the `input_features` get a large magnitude of `1e2` (from `self.vocab_size=99`).

(probably this happens because we just copied the `input_ids = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)` from NLP models?)

I changed it to `scale=1.0`, but need @patrickvonplaten's expertise **to make sure there was no particular reason to use `self.vocab_size`.**

### Details
Current speech model testers have

```
def prepare_config_and_inputs(self):
    input_values = floats_tensor([self.batch_size, self.seq_length], self.vocab_size)
```

The ` self.vocab_size` argument is the `scale`, so the generated dummy `input_values` has the magnitude of  `self.vocab_size`.
For `Speech2TextModelTester`, we have `vocab_size=99`.

Furthermore, `Speech2TextEncoder` has

https://github.com/huggingface/transformers/blob/e6f00a11d7fa34215184e3c797e19e6c7debe0fe/src/transformers/models/speech_to_text/modeling_speech_to_text.py#L705

and from the tester's `hidden_size=16,` we get `embed_scale=4`.

The `input_features` goes through the conv layer(s) and being scaled:
https://github.com/huggingface/transformers/blob/e6f00a11d7fa34215184e3c797e19e6c7debe0fe/src/transformers/models/speech_to_text/modeling_speech_to_text.py#L767-L768

On `CPU` however, the conv layers of PT/TF gives diff. with a magnitude of `1e-7` for input values with 1s. So with the above 2 scalings, this error becomes `4e-5`, and the PT/TF equiv. test fails.