### PR TITLE
[FlaxGenerate] Fix bug in `decoder_start_token_id`

### DIFF
--- a/src/transformers/generation_flax_utils.py
+++ b/src/transformers/generation_flax_utils.py
@@ -264,7 +264,7 @@ class FlaxGenerationMixin:
         pad_token_id = pad_token_id if pad_token_id is not None else self.config.pad_token_id
         eos_token_id = eos_token_id if eos_token_id is not None else self.config.eos_token_id
         decoder_start_token_id = (
-            decoder_start_token_id if decoder_start_token_id else self.config.decoder_start_token_id
+            decoder_start_token_id if decoder_start_token_id is not None else self.config.decoder_start_token_id
         )
         prng_key = prng_key if prng_key is not None else jax.random.PRNGKey(0)
 


### PR DESCRIPTION
In Python, `bool` is a subclass of `int`, and `False` has the value `0`. We observe this by calling the `__bool__` method of `0`:
```python
print((0).__bool__())
print((1).__bool__())
```
```
False
True
```
https://github.com/huggingface/transformers/blob/da47c264f9a881f5db5f6fbb59a30c95e428571f/src/transformers/generation_flax_utils.py#L266-L268
In the preceding lines of code, if `decoder_start_token_id` has the value `0` (valid): 

- `if decoder_start_token_id` will be `False`
- `decoder_start_token_id` will be set to `self.config.decoder_start_token_id`

The correct behaviour should be that if `decoder_start_token_id` has the value `0`, it remains set to `0`, and not changed to `self.config.decoder_start_token_id`.