### PR TITLE
[Flax(Speech)EncoderDecoder] Fix bug in `decoder_module`

### DIFF
--- a/src/transformers/models/encoder_decoder/modeling_flax_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_flax_encoder_decoder.py
@@ -593,7 +593,7 @@ class FlaxEncoderDecoderModel(FlaxPreTrainedModel):
                 decoder_input_ids,
                 decoder_attention_mask,
                 decoder_position_ids,
-                encoder_hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
                 **kwargs,
             )
 

--- a/src/transformers/models/speech_encoder_decoder/modeling_flax_speech_encoder_decoder.py
+++ b/src/transformers/models/speech_encoder_decoder/modeling_flax_speech_encoder_decoder.py
@@ -627,7 +627,7 @@ class FlaxSpeechEncoderDecoderModel(FlaxPreTrainedModel):
                 decoder_input_ids,
                 decoder_attention_mask,
                 decoder_position_ids,
-                encoder_hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
                 **kwargs,
             )
 


### PR DESCRIPTION
The current use of `decoder_module` assumes that `encoder_hidden_states` is the fourth positional argument of the decoder's call method. We see that this is indeed true of the two current Flax decoder models: [`FlaxGPT2LMHeadModel`](https://github.com/huggingface/transformers/blob/da47c264f9a881f5db5f6fbb59a30c95e428571f/src/transformers/models/gpt2/modeling_flax_gpt2.py#L691) and [`FlaxBartForCausalLM`](https://github.com/huggingface/transformers/blob/da47c264f9a881f5db5f6fbb59a30c95e428571f/src/transformers/models/bart/modeling_flax_bart.py#L1911). However, for other possible decoder models, such as the work-in-progress [`FlaxBertForCausalLM`](https://github.com/huggingface/transformers/blob/9c9e49bd3aeb3f84c0d61b7f0fdca8ea853ac5a1/src/transformers/models/bert/modeling_flax_bert.py#L1545), there may be additional positional arguments (such as `token_type_ids` or `head_mask`) **prior** to `encoder_hidden_states`. To handle this more general case, we should not assume `encoder_hidden_states` is necessarily the fourth positional argument, and should instead pass it as a _key-word argument_.