### PR TITLE
Fix hashing for deduplication in CodeParrot

### DIFF
--- a/examples/research_projects/codeparrot/scripts/preprocessing.py
+++ b/examples/research_projects/codeparrot/scripts/preprocessing.py
@@ -1,4 +1,5 @@
 import gzip
+import hashlib
 import multiprocessing
 import os
 import shutil
@@ -13,7 +14,7 @@ from transformers import HfArgumentParser
 
 def get_hash(example):
     """Get hash of content field."""
-    return {"hash": hash(example["content"])}
+    return {"hash": hashlib.md5(example["content"].strip().encode("utf-8")).hexdigest()}
 
 
 def line_stats(example):


### PR DESCRIPTION
# What does this PR do?

Fix hashing mechanism to be process independent. Typically `hash` doesn't generate the same hash when using different process. So this makes the maximum number of occurence of a text to be `num_proc` instead of `1` when deduplicating.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@lvwerra @loubnabnl 