### PR TITLE
Remove Python and use v2 action

### DIFF
--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -17,12 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
-
-      - name: Install Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.6
+        uses: actions/checkout@v2
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
# What does this PR do?

Fix the model templates GitHub job which was broken with the Python 3.6 removal.