### PR TITLE
Deprecate model templates

### DIFF
--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -4,13 +4,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    paths:
-      - "src/**"
-      - "tests/**"
-      - ".github/**"
-      - "templates/**"
-    types: [assigned, opened, synchronize, reopened]
+  repository_dispatch:
+  schedule:
+    - cron: "0 2 * * *"
 
 jobs:
   run_tests_templates:

--- a/.github/workflows/model-templates.yml
+++ b/.github/workflows/model-templates.yml
@@ -1,9 +1,6 @@
 name: Model templates runner
 
 on:
-  push:
-    branches:
-      - main
   repository_dispatch:
   schedule:
     - cron: "0 2 * * *"

--- a/src/transformers/commands/add_new_model.py
+++ b/src/transformers/commands/add_new_model.py
@@ -15,6 +15,7 @@
 import json
 import os
 import shutil
+import warnings
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from typing import List
@@ -54,6 +55,11 @@ class AddNewModelCommand(BaseTransformersCLICommand):
         self._path = path
 
     def run(self):
+        warnings.warn(
+            "The command `transformers-cli add-new-model` is deprecated and will be removed in v5 of Transformers. "
+            "It is not actively maintained anymore, so might give a result that won't pass all tests and quality "
+            "checks, you should use `transformers-cli add-new-model-like` instead."
+        )
         if not _has_cookiecutter:
             raise ImportError(
                 "Model creation dependencies are required to use the `add_new_model` command. Install them by running "


### PR DESCRIPTION
# What does this PR do?

This PR officially deprecates the model templates and moves their test to a daily scheduled job.