### PR TITLE
Make sure telemetry arguments are not returned as unused kwargs

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -676,6 +676,10 @@ class PretrainedConfig(PushToHubMixin):
             [`PretrainedConfig`]: The configuration object instantiated from those parameters.
         """
         return_unused_kwargs = kwargs.pop("return_unused_kwargs", False)
+        # Those arguments may be passed along for our internal telemetry.
+        # We remove them so they don't appear in `return_unused_kwargs`.
+        kwargs.pop("_from_auto", None)
+        kwargs.pop("_from_pipeline", None)
 
         config = cls(**config_dict)
 

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -356,7 +356,7 @@ class ConfigurationVersioningTest(unittest.TestCase):
         )
         self.assertEqual(new_configuration.hidden_size, 2)
         # This checks `_configuration_file` ia not kept in the kwargs by mistake.
-        self.assertDictEqual(kwargs, {"_from_auto": True})
+        self.assertDictEqual(kwargs, {})
 
         # Testing an older version by monkey-patching the version in the module it's used.
         import transformers as old_transformers


### PR DESCRIPTION
# What does this PR do?

As pointed out in #17056, the telemetry arguments are sometimes returned as unused kwargs. This is because `AutoConfig.from_pretrained` ends up using the `from_dict` method and not the `from_pretrained` method in most cases, and that `from_dict` method does not treat those kwargs.

Fixes #17056