### PR TITLE
fix: :bug: changing context of multiprocessing while decoding for Windows

### DIFF
--- a/src/transformers/models/wav2vec2_with_lm/processing_wav2vec2_with_lm.py
+++ b/src/transformers/models/wav2vec2_with_lm/processing_wav2vec2_with_lm.py
@@ -313,7 +313,7 @@ class Wav2Vec2ProcessorWithLM(ProcessorMixin):
         # create multiprocessing pool and list numpy arrays
         # filter out logits padding
         logits_list = [array[(array != -100.0).all(axis=-1)] for array in logits]
-        pool = get_context("fork").Pool(num_processes)
+        pool = get_context("spawn").Pool(num_processes)
 
         # pyctcdecode
         decoded_beams = self.decoder.decode_beams_batch(


### PR DESCRIPTION
# What does this PR do?

- This PR aim is to fix the context for the multiprocessing used in `wav2vec_with_LM batch_decode()` to change from `fork` to `spawn` so it can run with non-Linux based systems as well.

Fixes # (issue)

- multiprocessing context when `batch_decode`

## Before submitting

- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? 
   This is the [link for the GitHub issue](https://github.com/huggingface/transformers/issues/16898)


## Who can review?
@patrickvonplaten 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.


Models:

- Wav2Vec2 with LM

Library:

- benchmarks: @patrickvonplaten

Documentation: @sgugger

