### PR TITLE
LayoutLMv2Processor: ensure 1-to-1 mapping between images and samples in case of overflowing tokens

### DIFF
--- a/src/transformers/models/layoutlmv2/processing_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/processing_layoutlmv2.py
@@ -86,8 +86,7 @@ class LayoutLMv2Processor(ProcessorMixin):
 
         if self.feature_extractor.apply_ocr and (word_labels is not None):
             raise ValueError(
-                "You cannot provide word labels "
-                "if you initialized the feature extractor with apply_ocr set to True."
+                "You cannot provide word labels if you initialized the feature extractor with apply_ocr set to True."
             )
 
         if return_overflowing_tokens is True and return_offsets_mapping is False:
@@ -140,7 +139,8 @@ class LayoutLMv2Processor(ProcessorMixin):
 
         if len(images_with_overflow) != len(overflow_to_sample_mapping):
             raise ValueError(
-                f"Expected length of images to be the same as the length of `overflow_to_sample_mapping`, but got {len(images_with_overflow)} and {len(overflow_to_sample_mapping)}"
+                "Expected length of images to be the same as the length of `overflow_to_sample_mapping`, but got"
+                f" {len(images_with_overflow)} and {len(overflow_to_sample_mapping)}"
             )
 
         return images_with_overflow

--- a/src/transformers/models/layoutlmv2/processing_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/processing_layoutlmv2.py
@@ -138,8 +138,9 @@ class LayoutLMv2Processor(ProcessorMixin):
         for sample_idx in overflow_to_sample_mapping:
             images_with_overflow.append(images[sample_idx])
 
-        assert len(images_with_overflow) == len(
-            overflow_to_sample_mapping
-        ), f"Expected length of images to be the same as the length of overflow_to_sample_mapping, but got {len(images_with_overflow)} and {len(overflow_to_sample_mapping)}"
+        if len(images_with_overflow) != len(overflow_to_sample_mapping):
+            raise ValueError(
+                f"Expected length of images to be the same as the length of `overflow_to_sample_mapping`, but got {len(images_with_overflow)} and {len(overflow_to_sample_mapping)}"
+            )
 
         return images_with_overflow

--- a/src/transformers/models/layoutlmv2/processing_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/processing_layoutlmv2.py
@@ -91,9 +91,7 @@ class LayoutLMv2Processor(ProcessorMixin):
             )
 
         if return_overflowing_tokens is True and return_offsets_mapping is False:
-            raise ValueError(
-                "You cannot return overflowing tokens without returning the offsets mapping."
-            )
+            raise ValueError("You cannot return overflowing tokens without returning the offsets mapping.")
 
         # first, apply the feature extractor
         features = self.feature_extractor(images=images, return_tensors=return_tensors)
@@ -126,20 +124,22 @@ class LayoutLMv2Processor(ProcessorMixin):
             **kwargs,
         )
 
-        # add pixel values 
+        # add pixel values
         images = features.pop("pixel_values")
-        if return_overflowing_tokens is True: 
+        if return_overflowing_tokens is True:
             images = self.get_overflowing_images(images, encoded_inputs["overflow_to_sample_mapping"])
         encoded_inputs["image"] = images
 
         return encoded_inputs
-    
+
     def get_overflowing_images(self, images, overflow_to_sample_mapping):
-        # in case there's an overflow, ensure each `input_ids` sample is mapped to its corresponding image 
+        # in case there's an overflow, ensure each `input_ids` sample is mapped to its corresponding image
         images_with_overflow = []
         for sample_idx in overflow_to_sample_mapping:
             images_with_overflow.append(images[sample_idx])
 
-        assert len(images_with_overflow) == len(overflow_to_sample_mapping), f"Expected length of images to be the same as the length of overflow_to_sample_mapping, but got {len(images_with_overflow)} and {len(overflow_to_sample_mapping)}"
+        assert len(images_with_overflow) == len(
+            overflow_to_sample_mapping
+        ), f"Expected length of images to be the same as the length of overflow_to_sample_mapping, but got {len(images_with_overflow)} and {len(overflow_to_sample_mapping)}"
 
         return images_with_overflow

--- a/src/transformers/models/layoutlmv2/processing_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/processing_layoutlmv2.py
@@ -90,6 +90,11 @@ class LayoutLMv2Processor(ProcessorMixin):
                 "if you initialized the feature extractor with apply_ocr set to True."
             )
 
+        if return_overflowing_tokens is True and return_offsets_mapping is False:
+            raise ValueError(
+                "You cannot return overflowing tokens without returning the offsets mapping."
+            )
+
         # first, apply the feature extractor
         features = self.feature_extractor(images=images, return_tensors=return_tensors)
 
@@ -121,7 +126,20 @@ class LayoutLMv2Processor(ProcessorMixin):
             **kwargs,
         )
 
-        # add pixel values
-        encoded_inputs["image"] = features.pop("pixel_values")
+        # add pixel values 
+        images = features.pop("pixel_values")
+        if return_overflowing_tokens is True: 
+            images = self.get_overflowing_images(images, encoded_inputs["overflow_to_sample_mapping"])
+        encoded_inputs["image"] = images
 
         return encoded_inputs
+    
+    def get_overflowing_images(self, images, overflow_to_sample_mapping):
+        # in case there's an overflow, ensure each `input_ids` sample is mapped to its corresponding image 
+        images_with_overflow = []
+        for sample_idx in overflow_to_sample_mapping:
+            images_with_overflow.append(images[sample_idx])
+
+        assert len(images_with_overflow) == len(overflow_to_sample_mapping), f"Expected length of images to be the same as the length of overflow_to_sample_mapping, but got {len(images_with_overflow)} and {len(overflow_to_sample_mapping)}"
+
+        return images_with_overflow

--- a/tests/models/layoutlmv2/test_processor_layoutlmv2.py
+++ b/tests/models/layoutlmv2/test_processor_layoutlmv2.py
@@ -133,6 +133,39 @@ class LayoutLMv2ProcessorTest(unittest.TestCase):
         self.assertEqual(processor.feature_extractor.to_json_string(), feature_extractor_add_kwargs.to_json_string())
         self.assertIsInstance(processor.feature_extractor, LayoutLMv2FeatureExtractor)
 
+    @slow
+    def test_overflowing_tokens(self):
+        # In the case of overflowing tokens, test that we still have 1-to-1 mapping between the images and input_ids (sequences that are too long are broken down into multiple sequences).
+
+        from datasets import load_dataset
+
+        # set up
+        datasets = load_dataset("nielsr/funsd")
+        processor = LayoutLMv2Processor.from_pretrained("microsoft/layoutlmv2-base-uncased", revision="no_ocr")
+
+        def preprocess_data(examples):
+            images = [Image.open(path).convert("RGB") for path in examples["image_path"]]
+            words = examples["words"]
+            boxes = examples["bboxes"]
+            word_labels = examples["ner_tags"]
+            encoded_inputs = processor(
+                images,
+                words,
+                boxes=boxes,
+                word_labels=word_labels,
+                padding="max_length",
+                truncation=True,
+                return_overflowing_tokens=True,
+                stride=50,
+                return_offsets_mapping=True,
+                return_tensors="pt",
+            )
+            return encoded_inputs
+
+        train_data = preprocess_data(datasets["train"])
+
+        self.assertEqual(len(train_data["image"]), len(train_data["input_ids"]))
+
 
 # different use cases tests
 @require_torch


### PR DESCRIPTION
# What does this PR do?

Fixes #13554

Problem re-summarized: when `return_offsets_mapping` is set to True, `LayoutLMv2Processor` would break up sequences that are too long into multiple `input_ids` sequences, causing a mismatch between `input_ids` (longer in length in the case of overflowing tokens) and `images`. 

This fix would ensure the 1-to-1 mapping between the `images` and `input_ids`. 

**Reproducible Example:** (The assertion at the end would fail without the fix, pass with the fix)

```
import transformers
from PIL import Image
from transformers import LayoutLMv2Processor
from datasets import Features, Sequence, ClassLabel, Value, Array2D, Array3D, load_dataset
import torch

datasets = load_dataset("nielsr/funsd")
labels = datasets['train'].features['ner_tags'].feature.names
id2label = {v: k for v, k in enumerate(labels)}
label2id = {k: v for v, k in enumerate(labels)}

processor = LayoutLMv2Processor.from_pretrained("microsoft/layoutlmv2-base-uncased", revision="no_ocr")

def preprocess_data(examples):
  images = [Image.open(path).convert("RGB") for path in examples['image_path']]
  words = examples['words']
  boxes = examples['bboxes']
  word_labels = examples['ner_tags']
  encoded_inputs = processor(images, words, boxes=boxes, word_labels=word_labels,
                             padding="max_length", truncation=True,
                             return_overflowing_tokens=True,
                             stride=50,
                             return_offsets_mapping=True,
                             return_tensors="pt")
  return encoded_inputs

train_data = preprocess_data(datasets["train"])

# this assert would fail without this PR fix. 
assert len(train_data["image"]) == len(train_data["input_ids"])
```

## Required Input from Reviewers

Right now, the LayoutLMv2Processor would **return a list** for `encoded_inputs["image"]`, regardless of the value of `return_tensors`. If we want it to return a torch tensor in the case `return_tensors=="pt"`, we have to `torch.stack` the list (and do similar thing to support "np" and "tf"). 

Should I implement this in `get_overflowing_images`? Or should I just leave the return type as list and just print a warning? 

## Who can review?

@NielsRogge @sgugger @LysandreJik 

## P.S.

The `test_processor_case_1` in `test_processor_layoutlmv2.py` fails before this PR. I'd be happy to look at it as well but it's unrelated to this PR.