### PR TITLE
Add datasets.Dataset to trainer type hints

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -285,8 +285,8 @@ class Trainer:
         model: Union[PreTrainedModel, nn.Module] = None,
         args: TrainingArguments = None,
         data_collator: Optional[DataCollator] = None,
-        train_dataset: Optional[Dataset] = None,
-        eval_dataset: Optional[Dataset] = None,
+        train_dataset: Union[Dataset, datasets.Dataset, None] = None,
+        eval_dataset: Union[Dataset, datasets.Dataset, None] = None,
         tokenizer: Optional[PreTrainedTokenizerBase] = None,
         model_init: Callable[[], PreTrainedModel] = None,
         compute_metrics: Optional[Callable[[EvalPrediction], Dict]] = None,
@@ -777,7 +777,7 @@ class Trainer:
                 process_index=self.args.process_index,
             )
 
-    def get_eval_dataloader(self, eval_dataset: Optional[Dataset] = None) -> DataLoader:
+    def get_eval_dataloader(self, eval_dataset: Union[Dataset, datasets.Dataset, None] = None) -> DataLoader:
         """
         Returns the evaluation [`~torch.utils.data.DataLoader`].
 
@@ -824,7 +824,7 @@ class Trainer:
             pin_memory=self.args.dataloader_pin_memory,
         )
 
-    def get_test_dataloader(self, test_dataset: Dataset) -> DataLoader:
+    def get_test_dataloader(self, test_dataset: Union[Dataset, datasets.Dataset]) -> DataLoader:
         """
         Returns the test [`~torch.utils.data.DataLoader`].
 
@@ -2380,7 +2380,7 @@ class Trainer:
 
     def evaluate(
         self,
-        eval_dataset: Optional[Dataset] = None,
+        eval_dataset: Union[Dataset, datasets.Dataset, None] = None,
         ignore_keys: Optional[List[str]] = None,
         metric_key_prefix: str = "eval",
     ) -> Dict[str, float]:
@@ -2448,7 +2448,10 @@ class Trainer:
         return output.metrics
 
     def predict(
-        self, test_dataset: Dataset, ignore_keys: Optional[List[str]] = None, metric_key_prefix: str = "test"
+        self,
+        test_dataset: Union[Dataset, datasets.Dataset],
+        ignore_keys: Optional[List[str]] = None,
+        metric_key_prefix: str = "test",
     ) -> PredictionOutput:
         """
         Run prediction and returns predictions and potential metrics.

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -21,8 +21,11 @@ from torch.utils.data import Dataset
 from .deepspeed import is_deepspeed_zero3_enabled
 from .trainer import Trainer
 from .trainer_utils import PredictionOutput
-from .utils import logging
+from .utils import is_datasets_available, logging
 
+
+if is_datasets_available():
+    import datasets
 
 logger = logging.get_logger(__name__)
 
@@ -30,7 +33,7 @@ logger = logging.get_logger(__name__)
 class Seq2SeqTrainer(Trainer):
     def evaluate(
         self,
-        eval_dataset: Optional[Dataset] = None,
+        eval_dataset: Union[Dataset, datasets.Dataset, None] = None,
         ignore_keys: Optional[List[str]] = None,
         metric_key_prefix: str = "eval",
         max_length: Optional[int] = None,
@@ -71,7 +74,7 @@ class Seq2SeqTrainer(Trainer):
 
     def predict(
         self,
-        test_dataset: Dataset,
+        test_dataset: Union[Dataset, datasets.Dataset],
         ignore_keys: Optional[List[str]] = None,
         metric_key_prefix: str = "test",
         max_length: Optional[int] = None,


### PR DESCRIPTION
# What does this PR do?

This fixes a minor type hinting issue. `Trainer.__init__` currently assumes that `train_dataset` (if not `None`) is of type `torch.util.data.Dataset` (or `Dataset` for short), but that is a generic type (just as e.g. `List` is generic and needs to be "filled" as in `List[str]`). This method also works perfectly well with `datasets.Dataset`, although this class _cannot_ be expressed with a generic type. There are two options:

1. Fix this upstream in Datasets by turning `datasets.Dataset` into a generic type or
2. Replace `Optional[Dataset]` with `Union[Dataset, datasets.Dataset, None]` in `Trainer` and `Seq2SeqTrainer`

This PR implements option 2.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sgugger