### PR TITLE
Add magic method to our TF models to convert datasets with column inference

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -919,7 +919,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             shuffle (`bool`):
                 Whether to return samples from the dataset in random order. Usually `True` for training datasets and
                 `False` for validation/test datasets.
-            tokenizer (`PreTrainedTokenizer`, *optional*):
+            tokenizer ([`PreTrainedTokenizerBase`], *optional*):
                 A `PreTrainedTokenizer` that will be used to pad samples to create batches. Has no effect if a specific
                 `collate_fn` is passed instead.
             collate_fn (`Callable`, *optional*):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -921,7 +921,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         ]
         dataset = dataset.remove_columns(unwanted_columns)
         output_signature, _ = dataset._get_output_signature(
-            dataset, collate_fn=collate_fn, collate_fn_args=collate_fn_args
+            dataset, batch_size=None, collate_fn=collate_fn, collate_fn_args=collate_fn_args,
         )
         output_columns = list(output_signature.keys())
         feature_cols = [col for col in output_columns if col in model_inputs and col not in model_labels]

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -905,7 +905,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         prefetch: bool = True,
     ):
         """
-        Wraps a HuggingFace `Dataset` as a `tf.data.Dataset` with collation and batching. This method is designed to
+        Wraps a HuggingFace `datasets.Dataset` as a `tf.data.Dataset` with collation and batching. This method is designed to
         create a "ready-to-use" dataset that can be passed directly to Keras methods like `fit()` without further
         modification. The method will drop columns from the dataset if they don't match input names for the model. If
         you want to specify the column names to return rather than using the names that match this model, we recommend

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -919,9 +919,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         Args:
             dataset (`Any`):
                 A `datasets.Dataset` to be wrapped as a `tf.data.Dataset`.
-            batch_size (`int`, defaults to *8*):
+            batch_size (`int`, defaults to 8):
                 The size of batches to return.
-            shuffle (`bool`, defaults to *True*):
+            shuffle (`bool`, defaults to `True`):
                 Whether to return samples from the dataset in random order. Usually `True` for training datasets and
                 `False` for validation/test datasets.
             tokenizer ([`PreTrainedTokenizerBase`], *optional*):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -900,7 +900,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         shuffle: bool,
         tokenizer: Optional["PreTrainedTokenizerBase"] = None,
         collate_fn: Optional[Callable] = None,
-        collate_fn_args: Optional[dict] = None,
+        collate_fn_args: Optional[Dict[str, Any]] = None,
         drop_remainder: Optional[bool] = None,
         prefetch: bool = True,
     ):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -900,7 +900,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
 
     def prepare_tf_dataset(
         self,
-        dataset: "datasets.Dataset",
+        dataset: "datasets.Dataset",  # noqa:F821
         batch_size: int,
         shuffle: bool,
         tokenizer: Optional["PreTrainedTokenizerBase"] = None,
@@ -910,11 +910,11 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         prefetch: bool = True,
     ):
         """
-        Wraps a HuggingFace `datasets.Dataset` as a `tf.data.Dataset` with collation and batching. This method is designed to
-        create a "ready-to-use" dataset that can be passed directly to Keras methods like `fit()` without further
-        modification. The method will drop columns from the dataset if they don't match input names for the model. If
-        you want to specify the column names to return rather than using the names that match this model, we recommend
-        using `Dataset.to_tf_dataset()` instead.
+        Wraps a HuggingFace `datasets.Dataset` as a `tf.data.Dataset` with collation and batching. This method is
+        designed to create a "ready-to-use" dataset that can be passed directly to Keras methods like `fit()` without
+        further modification. The method will drop columns from the dataset if they don't match input names for the
+        model. If you want to specify the column names to return rather than using the names that match this model, we
+        recommend using `Dataset.to_tf_dataset()` instead.
 
         Args:
             dataset (`Any`):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -926,7 +926,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                 A function that collates samples from the dataset into a single batch. Defaults to
                 `DefaultDataCollator` if no `tokenizer` is supplied or `DataCollatorWithPadding` if a `tokenizer` is
                 passed.
-            collate_fn_args (`dict`, *optional*):
+            collate_fn_args (`Dict[str, Any]`, *optional*):
                 A dict of arguments to pass to the `collate_fn` alongside the list of samples.
             drop_remainder (`bool`, *optional*):
                 Whether to drop the final batch, if the batch_size does not evenly divide the dataset length. Defaults

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -22,7 +22,7 @@ import pickle
 import re
 import warnings
 from collections.abc import Mapping
-from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import h5py
 import numpy as np
@@ -59,8 +59,9 @@ from .utils import (
     is_offline_mode,
     is_remote_url,
     logging,
-    requires_backends
+    requires_backends,
 )
+
 
 if TYPE_CHECKING:
     from . import PreTrainedTokenizerBase
@@ -952,6 +953,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             collate_fn_args = dict()
         requires_backends(self, ["datasets"])
         import datasets
+
         if not isinstance(dataset, datasets.Dataset):
             raise TypeError("Dataset argument should be a datasets.Dataset!")
         model_inputs = list(dict(inspect.signature(self.call).parameters).keys())

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -35,6 +35,7 @@ from tensorflow.python.keras.saving import hdf5_format
 from huggingface_hub import Repository, list_repo_files
 from requests import HTTPError
 
+from . import DefaultDataCollator
 from .activations_tf import get_tf_activation
 from .configuration_utils import PretrainedConfig
 from .dynamic_module_utils import custom_object_save
@@ -895,13 +896,17 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
     def prepare_tf_dataset(
         self,
         dataset: Any,
-        collate_fn: Callable,
-        collate_fn_args: dict,
         batch_size: int,
         shuffle: bool,
+        collate_fn: Optional[Callable] = None,
+        collate_fn_args: Optional[dict] = None,
         drop_remainder: Optional[bool] = None,
         prefetch: bool = True,
     ):
+        if collate_fn is None:
+            collate_fn = DefaultDataCollator(return_tensors='tf')
+        if collate_fn_args is None:
+            collate_fn_args = dict()
         try:
             from datasets import Dataset
         except ImportError:

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -35,7 +35,7 @@ from tensorflow.python.keras.saving import hdf5_format
 from huggingface_hub import Repository, list_repo_files
 from requests import HTTPError
 
-from . import DefaultDataCollator, DataCollatorWithPadding, PreTrainedTokenizer
+from . import DataCollatorWithPadding, DefaultDataCollator, PreTrainedTokenizer
 from .activations_tf import get_tf_activation
 from .configuration_utils import PretrainedConfig
 from .dynamic_module_utils import custom_object_save
@@ -905,11 +905,11 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         prefetch: bool = True,
     ):
         """
-        Wraps a HuggingFace `Dataset` as a `tf.data.Dataset` with collation and batching. This method is designed
-        to create a "ready-to-use" dataset that can be passed directly to Keras methods like `fit()` without further
+        Wraps a HuggingFace `Dataset` as a `tf.data.Dataset` with collation and batching. This method is designed to
+        create a "ready-to-use" dataset that can be passed directly to Keras methods like `fit()` without further
         modification. The method will drop columns from the dataset if they don't match input names for the model. If
-        you want to specify the column names to return rather than using the names that match this model,
-        we recommend using `Dataset.to_tf_dataset()` instead.
+        you want to specify the column names to return rather than using the names that match this model, we recommend
+        using `Dataset.to_tf_dataset()` instead.
 
         Args:
             dataset (`Any`):
@@ -917,14 +917,14 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             batch_size (`int`):
                 The size of batches to return.
             shuffle (`bool`):
-                Whether to return samples from the dataset in random order. Usually `True` for training
-                datasets and `False` for validation/test datasets.
+                Whether to return samples from the dataset in random order. Usually `True` for training datasets and
+                `False` for validation/test datasets.
             tokenizer (`PreTrainedTokenizer`, *optional*):
                 A `PreTrainedTokenizer` that will be used to pad samples to create batches. Has no effect if a specific
                 `collate_fn` is passed instead.
             collate_fn (`Callable`, *optional*):
-                A function that collates samples from the dataset into a single batch. Defaults
-                to `DefaultDataCollator` if no `tokenizer` is supplied or `DataCollatorWithPadding` if a `tokenizer` is
+                A function that collates samples from the dataset into a single batch. Defaults to
+                `DefaultDataCollator` if no `tokenizer` is supplied or `DataCollatorWithPadding` if a `tokenizer` is
                 passed.
             collate_fn_args (`dict`, *optional*):
                 A dict of arguments to pass to the `collate_fn` alongside the list of samples.
@@ -932,8 +932,8 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                 Whether to drop the final batch, if the batch_size does not evenly divide the dataset length. Defaults
                 to the same setting as `shuffle`.
             prefetch (`bool`, defaults to `True`):
-                Whether to add prefetching to the end of the `tf.data` pipeline. This is almost always beneficial
-                for performance, but can be disabled in edge cases.
+                Whether to add prefetching to the end of the `tf.data` pipeline. This is almost always beneficial for
+                performance, but can be disabled in edge cases.
 
 
         Returns:

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -944,6 +944,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         Returns:
             `Dataset`: A `tf.data.Dataset` which is ready to pass to the Keras API.
         """
+        requires_backends(self, ["datasets"])
+        import datasets
+
         if collate_fn is None:
             if tokenizer is None:
                 collate_fn = DefaultDataCollator(return_tensors="tf")
@@ -951,8 +954,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                 collate_fn = DataCollatorWithPadding(tokenizer=tokenizer, return_tensors="tf")
         if collate_fn_args is None:
             collate_fn_args = dict()
-        requires_backends(self, ["datasets"])
-        import datasets
 
         if not isinstance(dataset, datasets.Dataset):
             raise TypeError("Dataset argument should be a datasets.Dataset!")

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -904,7 +904,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         prefetch: bool = True,
     ):
         if collate_fn is None:
-            collate_fn = DefaultDataCollator(return_tensors='tf')
+            collate_fn = DefaultDataCollator(return_tensors="tf")
         if collate_fn_args is None:
             collate_fn_args = dict()
         try:
@@ -916,7 +916,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         model_labels = find_labels(self.__class__)
         unwanted_columns = [
             feature
-            for feature in self.features
+            for feature in dataset.features
             if feature not in model_inputs and feature not in ("label_ids", "label")
         ]
         dataset = dataset.remove_columns(unwanted_columns)

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -22,7 +22,7 @@ import pickle
 import re
 import warnings
 from collections.abc import Mapping
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
 
 import h5py
 import numpy as np
@@ -35,7 +35,7 @@ from tensorflow.python.keras.saving import hdf5_format
 from huggingface_hub import Repository, list_repo_files
 from requests import HTTPError
 
-from . import DataCollatorWithPadding, DefaultDataCollator, PreTrainedTokenizer
+from . import DataCollatorWithPadding, DefaultDataCollator
 from .activations_tf import get_tf_activation
 from .configuration_utils import PretrainedConfig
 from .dynamic_module_utils import custom_object_save
@@ -61,6 +61,9 @@ from .utils import (
     logging,
     requires_backends
 )
+
+if TYPE_CHECKING:
+    from . import PreTrainedTokenizerBase
 
 
 logger = logging.get_logger(__name__)

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -921,7 +921,10 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         ]
         dataset = dataset.remove_columns(unwanted_columns)
         output_signature, _ = dataset._get_output_signature(
-            dataset, batch_size=None, collate_fn=collate_fn, collate_fn_args=collate_fn_args,
+            dataset,
+            batch_size=None,
+            collate_fn=collate_fn,
+            collate_fn_args=collate_fn_args,
         )
         output_columns = list(output_signature.keys())
         feature_cols = [col for col in output_columns if col in model_inputs and col not in model_labels]

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -901,8 +901,8 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
     def prepare_tf_dataset(
         self,
         dataset: "datasets.Dataset",  # noqa:F821
-        batch_size: int,
-        shuffle: bool,
+        batch_size: int = 8,
+        shuffle: bool = True,
         tokenizer: Optional["PreTrainedTokenizerBase"] = None,
         collate_fn: Optional[Callable] = None,
         collate_fn_args: Optional[Dict[str, Any]] = None,
@@ -919,9 +919,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         Args:
             dataset (`Any`):
                 A `datasets.Dataset` to be wrapped as a `tf.data.Dataset`.
-            batch_size (`int`):
+            batch_size (`int`, defaults to *8*):
                 The size of batches to return.
-            shuffle (`bool`):
+            shuffle (`bool`, defaults to *True*):
                 Whether to return samples from the dataset in random order. Usually `True` for training datasets and
                 `False` for validation/test datasets.
             tokenizer ([`PreTrainedTokenizerBase`], *optional*):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -898,7 +898,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         dataset: Any,
         batch_size: int,
         shuffle: bool,
-        tokenizer: Optional[PreTrainedTokenizer] = None,
+        tokenizer: Optional["PreTrainedTokenizerBase"] = None,
         collate_fn: Optional[Callable] = None,
         collate_fn_args: Optional[dict] = None,
         drop_remainder: Optional[bool] = None,

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -2092,7 +2092,7 @@ class TFSharedEmbeddings(tf.keras.layers.Layer):
         super().__init__(**kwargs)
         self.vocab_size = vocab_size
         self.hidden_size = hidden_size
-        self.initializer_range = hidden_size ** -0.5 if initializer_range is None else initializer_range
+        self.initializer_range = hidden_size**-0.5 if initializer_range is None else initializer_range
 
     def build(self, input_shape):
         """

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -2092,7 +2092,7 @@ class TFSharedEmbeddings(tf.keras.layers.Layer):
         super().__init__(**kwargs)
         self.vocab_size = vocab_size
         self.hidden_size = hidden_size
-        self.initializer_range = hidden_size**-0.5 if initializer_range is None else initializer_range
+        self.initializer_range = hidden_size ** -0.5 if initializer_range is None else initializer_range
 
     def build(self, input_shape):
         """

--- a/tests/models/convnext/test_modeling_tf_convnext.py
+++ b/tests/models/convnext/test_modeling_tf_convnext.py
@@ -174,6 +174,13 @@ class TFConvNextModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_attention_outputs(self):
         pass
 
+    @unittest.skipIf(
+        not is_tf_available() or len(tf.config.list_physical_devices("GPU")) == 0,
+        reason="TF (<=2.8) does not support backprop for grouped convolutions on CPU.",
+    )
+    def test_dataset_conversion(self):
+        super().test_dataset_conversion()
+
     def test_hidden_states_output(self):
         def check_hidden_states_output(inputs_dict, config, model_class):
             model = model_class(config)

--- a/tests/models/tapas/test_modeling_tf_tapas.py
+++ b/tests/models/tapas/test_modeling_tf_tapas.py
@@ -503,7 +503,6 @@ class TFTapasModelTest(TFModelTesterMixin, unittest.TestCase):
         pass
 
 
-
 def prepare_tapas_single_inputs_for_inference():
     # Here we prepare a single table-question pair to test TAPAS inference on:
     data = {

--- a/tests/models/tapas/test_modeling_tf_tapas.py
+++ b/tests/models/tapas/test_modeling_tf_tapas.py
@@ -498,6 +498,11 @@ class TFTapasModelTest(TFModelTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_for_sequence_classification(*config_and_inputs)
 
+    @unittest.skip(reason="The default test gets NaN losses with the test-generated inputs")
+    def test_dataset_conversion(self):
+        pass
+
+
 
 def prepare_tapas_single_inputs_for_inference():
     # Here we prepare a single table-question pair to test TAPAS inference on:

--- a/tests/models/transfo_xl/test_modeling_tf_transfo_xl.py
+++ b/tests/models/transfo_xl/test_modeling_tf_transfo_xl.py
@@ -216,6 +216,10 @@ class TFTransfoXLModelTest(TFModelTesterMixin, unittest.TestCase):
             model = TFTransfoXLModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
+    @unittest.skip(reason="This model doesn't play well with fit() due to not returning a single loss.")
+    def test_dataset_conversion(self):
+        pass
+
 
 @require_tf
 class TFTransfoXLModelLanguageGenerationTest(unittest.TestCase):

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1524,7 +1524,7 @@ class TFModelTesterMixin:
             if isinstance(test_batch, tf.Tensor):
                 self.assertEqual(len(test_batch), len(input_dataset))  # Assert we didn't lose any data
             else:
-                self.assertEqual(len(test_batch), len(input_dataset))  # Assert we have all our columns
+                self.assertEqual(len(test_batch), len(input_dataset.features))  # Assert we have all our columns
                 for tensor in test_batch.values():
                     self.assertTrue(isinstance(tensor, tf.Tensor))
                     self.assertEqual(len(tensor), len(input_dataset))  # Assert we didn't lose any data
@@ -1540,8 +1540,10 @@ class TFModelTesterMixin:
                 self.assertGreater(len(test_batch_labels), 0)  # Assert the labels are present
                 feature_columns = 1 if isinstance(test_batch, tf.Tensor) else len(test_batch)
                 label_columns = 1 if isinstance(test_batch_labels, tf.Tensor) else len(test_batch_labels)
-                self.assertEqual(feature_columns + label_columns, len(input_dataset))  # Assert we didn't lose any cols
-                model.train_on_batch(test_batch)
+                # Assert we didn't lose any columns
+                self.assertEqual(feature_columns + label_columns, len(input_dataset.features))
+                model.compile(optimizer="sgd", run_eagerly=True)
+                model.train_on_batch(test_batch, test_batch_labels)
 
     def _generate_random_bad_tokens(self, num_bad_tokens, model):
         # special tokens cannot be bad tokens

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -25,6 +25,8 @@ import unittest.mock as mock
 from importlib import import_module
 from typing import List, Tuple
 
+from datasets import Dataset
+
 from huggingface_hub import delete_repo, login
 from requests.exceptions import HTTPError
 from transformers import is_tf_available, is_torch_available
@@ -1508,6 +1510,38 @@ class TFModelTesterMixin:
             # The main input is the name of the argument after `self`
             observed_main_input_name = list(model_signature.parameters.keys())[1]
             self.assertEqual(model_class.main_input_name, observed_main_input_name)
+
+    def test_dataset_conversion(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            tf_inputs_dict = self._prepare_for_class(inputs_dict, model_class, return_labels=False)
+            input_dataset = Dataset.from_dict(tf_inputs_dict)
+            tf_dataset = model.prepare_tf_dataset(
+                input_dataset, batch_size=len(input_dataset), drop_remainder=False, shuffle=False
+            )
+            test_batch = next(iter(tf_dataset))
+            if isinstance(test_batch, tf.Tensor):
+                self.assertEqual(len(test_batch), len(input_dataset))  # Assert we didn't lose any data
+            else:
+                self.assertEqual(len(test_batch), len(input_dataset))  # Assert we have all our columns
+                for tensor in test_batch.values():
+                    self.assertTrue(isinstance(tensor, tf.Tensor))
+                    self.assertEqual(len(tensor), len(input_dataset))  # Assert we didn't lose any data
+                    model.predict(test_batch)
+
+            if "labels" in inspect.signature(model_class.call).parameters.keys():
+                tf_inputs_dict = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
+                input_dataset = Dataset.from_dict(tf_inputs_dict)
+                tf_dataset = model.prepare_tf_dataset(
+                    input_dataset, batch_size=len(input_dataset), drop_remainder=False, shuffle=False
+                )
+                test_batch, test_batch_labels = next(iter(tf_dataset))
+                self.assertGreater(len(test_batch_labels), 0)  # Assert the labels are present
+                feature_columns = 1 if isinstance(test_batch, tf.Tensor) else len(test_batch)
+                label_columns = 1 if isinstance(test_batch_labels, tf.Tensor) else len(test_batch_labels)
+                self.assertEqual(feature_columns + label_columns, len(input_dataset))  # Assert we didn't lose any cols
+                model.train_on_batch(test_batch)
 
     def _generate_random_bad_tokens(self, num_bad_tokens, model):
         # special tokens cannot be bad tokens

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1553,15 +1553,15 @@ class TFModelTesterMixin:
                 feature_columns = 1 if isinstance(test_batch, tf.Tensor) else len(test_batch)
                 label_columns = 1 if isinstance(test_batch_labels, tf.Tensor) else len(test_batch_labels)
                 # Assert we discarded the unwanted extra column but kept everything else
-                if feature_columns + label_columns != len(input_dataset.features) - 1:
-                    breakpoint()
-                    print()
                 self.assertEqual(feature_columns + label_columns, len(input_dataset.features) - 1)
                 if isinstance(test_batch, dict):
                     self.assertNotIn("extra_unwanted_column", test_batch)
                 if isinstance(test_batch_labels, dict):
                     self.assertNotIn("extra_unwanted_column", test_batch_labels)
                 model.compile(optimizer="sgd", run_eagerly=True)
+                if isinstance(test_batch_labels, dict) and "aggregation_labels" in test_batch_labels:
+                    breakpoint()
+                    print()
                 model.train_on_batch(test_batch, test_batch_labels)
 
     def _generate_random_bad_tokens(self, num_bad_tokens, model):

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1531,7 +1531,8 @@ class TFModelTesterMixin:
                 for tensor in test_batch.values():
                     self.assertTrue(isinstance(tensor, tf.Tensor))
                     self.assertEqual(len(tensor), len(input_dataset))  # Assert we didn't lose any data
-                    model.predict(test_batch)
+                    breakpoint()
+                    model(test_batch, training=False)
 
             if "labels" in inspect.signature(model_class.call).parameters.keys():
                 tf_inputs_dict = self._prepare_for_class(inputs_dict, model_class, return_labels=True)

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1559,9 +1559,6 @@ class TFModelTesterMixin:
                 if isinstance(test_batch_labels, dict):
                     self.assertNotIn("extra_unwanted_column", test_batch_labels)
                 model.compile(optimizer="sgd", run_eagerly=True)
-                if isinstance(test_batch_labels, dict) and "aggregation_labels" in test_batch_labels:
-                    breakpoint()
-                    print()
                 model.train_on_batch(test_batch, test_batch_labels)
 
     def _generate_random_bad_tokens(self, num_bad_tokens, model):

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1540,6 +1540,8 @@ class TFModelTesterMixin:
 
             if "labels" in inspect.signature(model_class.call).parameters.keys():
                 tf_inputs_dict = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
+                if "labels" not in tf_inputs_dict:
+                    return  # This model isn't giving us labels after all, don't try training with it
                 tf_inputs_dict = {key: val for key, val in tf_inputs_dict.items() if "head_mask" not in key}
                 tf_inputs_dict["extra_unwanted_column"] = list(tf_inputs_dict.values())[0]  # Use a random other tensor
                 input_dataset = Dataset.from_dict(tf_inputs_dict)
@@ -1551,6 +1553,9 @@ class TFModelTesterMixin:
                 feature_columns = 1 if isinstance(test_batch, tf.Tensor) else len(test_batch)
                 label_columns = 1 if isinstance(test_batch_labels, tf.Tensor) else len(test_batch_labels)
                 # Assert we discarded the unwanted extra column but kept everything else
+                if feature_columns + label_columns != len(input_dataset.features) - 1:
+                    breakpoint()
+                    print()
                 self.assertEqual(feature_columns + label_columns, len(input_dataset.features) - 1)
                 if isinstance(test_batch, dict):
                     self.assertNotIn("extra_unwanted_column", test_batch)

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1516,7 +1516,11 @@ class TFModelTesterMixin:
         for model_class in self.all_model_classes:
             model = model_class(config)
             tf_inputs_dict = self._prepare_for_class(inputs_dict, model_class, return_labels=False)
-            tf_inputs_dict = {key: val for key, val in tf_inputs_dict.items() if "head_mask" not in key and isinstance(val, tf.Tensor)}
+            tf_inputs_dict = {
+                key: val
+                for key, val in tf_inputs_dict.items()
+                if "head_mask" not in key and isinstance(val, tf.Tensor)
+            }
             tf_inputs_dict["extra_unwanted_column"] = list(tf_inputs_dict.values())[0]  # Use a random other tensor
             input_dataset = Dataset.from_dict(tf_inputs_dict)
             tf_dataset = model.prepare_tf_dataset(

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1516,7 +1516,7 @@ class TFModelTesterMixin:
         for model_class in self.all_model_classes:
             model = model_class(config)
             tf_inputs_dict = self._prepare_for_class(inputs_dict, model_class, return_labels=False)
-            tf_inputs_dict["extra_unwanted_column"] = list(tf_inputs_dict.values())[0]
+            tf_inputs_dict["extra_unwanted_column"] = list(tf_inputs_dict.values())[0]  # Use a random other tensor
             input_dataset = Dataset.from_dict(tf_inputs_dict)
             tf_dataset = model.prepare_tf_dataset(
                 input_dataset, batch_size=len(input_dataset), drop_remainder=False, shuffle=False

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1531,7 +1531,6 @@ class TFModelTesterMixin:
                 for tensor in test_batch.values():
                     self.assertTrue(isinstance(tensor, tf.Tensor))
                     self.assertEqual(len(tensor), len(input_dataset))  # Assert we didn't lose any data
-                    breakpoint()
                     model(test_batch, training=False)
 
             if "labels" in inspect.signature(model_class.call).parameters.keys():

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1516,13 +1516,9 @@ class TFModelTesterMixin:
         for model_class in self.all_model_classes:
             model = model_class(config)
             tf_inputs_dict = self._prepare_for_class(inputs_dict, model_class, return_labels=False)
-            tf_inputs_dict = {key: val for key, val in tf_inputs_dict.items() if 'head_mask' not in key}
+            tf_inputs_dict = {key: val for key, val in tf_inputs_dict.items() if "head_mask" not in key}
             tf_inputs_dict["extra_unwanted_column"] = list(tf_inputs_dict.values())[0]  # Use a random other tensor
-            try:
-                input_dataset = Dataset.from_dict(tf_inputs_dict)
-            except:
-                breakpoint()
-                print()
+            input_dataset = Dataset.from_dict(tf_inputs_dict)
             tf_dataset = model.prepare_tf_dataset(
                 input_dataset, batch_size=len(input_dataset), drop_remainder=False, shuffle=False
             )
@@ -1540,7 +1536,7 @@ class TFModelTesterMixin:
 
             if "labels" in inspect.signature(model_class.call).parameters.keys():
                 tf_inputs_dict = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
-                tf_inputs_dict = {key: val for key, val in tf_inputs_dict.items() if 'head_mask' not in key}
+                tf_inputs_dict = {key: val for key, val in tf_inputs_dict.items() if "head_mask" not in key}
                 tf_inputs_dict["extra_unwanted_column"] = list(tf_inputs_dict.values())[0]  # Use a random other tensor
                 input_dataset = Dataset.from_dict(tf_inputs_dict)
                 tf_dataset = model.prepare_tf_dataset(

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1516,7 +1516,7 @@ class TFModelTesterMixin:
         for model_class in self.all_model_classes:
             model = model_class(config)
             tf_inputs_dict = self._prepare_for_class(inputs_dict, model_class, return_labels=False)
-            tf_inputs_dict = {key: val for key, val in tf_inputs_dict.items() if "head_mask" not in key}
+            tf_inputs_dict = {key: val for key, val in tf_inputs_dict.items() if "head_mask" not in key and isinstance(val, tf.Tensor)}
             tf_inputs_dict["extra_unwanted_column"] = list(tf_inputs_dict.values())[0]  # Use a random other tensor
             input_dataset = Dataset.from_dict(tf_inputs_dict)
             tf_dataset = model.prepare_tf_dataset(

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1516,8 +1516,13 @@ class TFModelTesterMixin:
         for model_class in self.all_model_classes:
             model = model_class(config)
             tf_inputs_dict = self._prepare_for_class(inputs_dict, model_class, return_labels=False)
+            tf_inputs_dict = {key: val for key, val in tf_inputs_dict.items() if 'head_mask' not in key}
             tf_inputs_dict["extra_unwanted_column"] = list(tf_inputs_dict.values())[0]  # Use a random other tensor
-            input_dataset = Dataset.from_dict(tf_inputs_dict)
+            try:
+                input_dataset = Dataset.from_dict(tf_inputs_dict)
+            except:
+                breakpoint()
+                print()
             tf_dataset = model.prepare_tf_dataset(
                 input_dataset, batch_size=len(input_dataset), drop_remainder=False, shuffle=False
             )
@@ -1535,6 +1540,7 @@ class TFModelTesterMixin:
 
             if "labels" in inspect.signature(model_class.call).parameters.keys():
                 tf_inputs_dict = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
+                tf_inputs_dict = {key: val for key, val in tf_inputs_dict.items() if 'head_mask' not in key}
                 tf_inputs_dict["extra_unwanted_column"] = list(tf_inputs_dict.values())[0]  # Use a random other tensor
                 input_dataset = Dataset.from_dict(tf_inputs_dict)
                 tf_dataset = model.prepare_tf_dataset(


### PR DESCRIPTION
Left to do:

- [x] Add docstring
- [x] Figure out what type to set for `dataset` (since `datasets` isn't imported)
- [x] Set default values for `batch_size` / `shuffle`?
- [x] Do we need to document this anywhere besides the docstring?
- [x] Anything else I forgot? (Reviewers please yell at me)