### PR TITLE
Fix template init

### DIFF
--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/__init__.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/__init__.py
@@ -169,7 +169,7 @@ if TYPE_CHECKING:
     from .tokenization_{{cookiecutter.lowercase_modelname}} import {{cookiecutter.camelcase_modelname}}Tokenizer
 
     try:
-        if not is_torch_available():
+        if not is_tokenizers_available():
             raise OptionalDependencyNotAvailable()
     except OptionalDependencyNotAvailable:
         pass


### PR DESCRIPTION
# What does this PR do?

During the revamp of all model inits, a typo stayed in the model templates init, which results in the model templates test failing. This PR fixes that.