### PR TITLE
Mlflowcallback fix nonetype error

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -876,7 +876,7 @@ class MLflowCallback(TrainerCallback):
     def __del__(self):
         # if the previous run is not terminated correctly, the fluent API will
         # not let you start a new run before the previous one is killed
-        if self._auto_end_run and self._ml_flow and self._ml_flow.active_run() is not None:
+        if self._auto_end_run and callable(getattr(self._ml_flow, "active_run", None)) and self._ml_flow.active_run() is not None:
             self._ml_flow.end_run()
 
 

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -876,7 +876,11 @@ class MLflowCallback(TrainerCallback):
     def __del__(self):
         # if the previous run is not terminated correctly, the fluent API will
         # not let you start a new run before the previous one is killed
-        if self._auto_end_run and callable(getattr(self._ml_flow, "active_run", None)) and self._ml_flow.active_run() is not None:
+        if (
+            self._auto_end_run
+            and callable(getattr(self._ml_flow, "active_run", None))
+            and self._ml_flow.active_run() is not None
+        ):
             self._ml_flow.end_run()
 
 


### PR DESCRIPTION
# What does this PR do?

This PR fix some edge case error / race conditions with the garbage collector due to the use of a `__del__` finalizer in the MLflowCallback.

In some case, the following error may occur at the end of a script execution:
```
Exception ignored in: <function MLflowCallback.__del__ at 0x7f5ad8d73c10>
Traceback (most recent call last):
  File "/opt/conda/lib/python3.9/site-packages/transformers/integrations.py", line 879, in __del__
TypeError: 'NoneType' object is not callable
```
This PR check that `self._ml_flow` contain the `active_run()` method. Since it's in a `__del__` finalizer, `self._ml_flow` may return as a class 'module', not `None`, despite not referencing the `mlflow` module anymore.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sgugger I'm wondering if a unit test should be added for integrations callback. I don't see any for other integrations tho.