### PR TITLE
docs for typical decoding

### DIFF
--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -940,6 +940,9 @@ class GenerationMixin:
             top_p (`float`, *optional*, defaults to 1.0):
                 If set to float < 1, only the most probable tokens with probabilities that add up to `top_p` or higher
                 are kept for generation.
+            typical_p (`float`, *optional*, defaults to 1.0):
+                The amount of probability mass from the original distribution to be considered in typical decoding.
+                If set to 1.0 it takes no effect. See [this paper](https://arxiv.org/pdf/2202.00666.pdf) for more details.
             repetition_penalty (`float`, *optional*, defaults to 1.0):
                 The parameter for repetition penalty. 1.0 means no penalty. See [this
                 paper](https://arxiv.org/pdf/1909.05858.pdf) for more details.


### PR DESCRIPTION
# What does this PR do?
Adds a description for the typical_p parameter in #15504, as the docs for this parameter was missing.


@cimeister 