### PR TITLE
Log the decoder chosen by GenerationMixin

### DIFF
--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -1450,7 +1450,6 @@ class GenerationMixin:
             if stopping_criteria.max_length is None:
                 raise ValueError("`max_length` needs to be a stopping_criteria for now.")
 
-
             if log_decoder:
                 logger.info("Running beam search")
 

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -385,6 +385,8 @@ class GenerationMixin:
           `do_sample=False`.
         - *multinomial sampling* by calling [`~generation_utils.GenerationMixin.sample`] if `num_beams=1` and
           `do_sample=True`.
+        - *typical decoding* by calling [`~generation_utils.GenerationMixin.sample`] if `typical_p < 1.0` and
+          `do_sample=True`.
         - *beam-search decoding* by calling [`~generation_utils.GenerationMixin.beam_search`] if `num_beams>1` and
           `do_sample=False`.
         - *beam-search multinomial sampling* by calling [`~generation_utils.GenerationMixin.beam_sample`] if


### PR DESCRIPTION
# What does this PR do?

When calling `model.generate(content, log_decoder=True)`, the PR would log which decoder and warper(s) are actually used in generation.

I have a demo where I show text generated with different options (top_k, typical_p, repetition_penalty, num_beams, etc.). The final chosen decoding strategy is not obvious. It is tricky to test by comparing outputs because a generative model often returns different text on multiple runs.
By design the function tolerates mistakes -- if there is a missing arg (`typical_p=0.5` but no `do_sample=True`) or mismatched value (`typical_p=3`) or typo'd arg (`numBeams=2`) then the function silently chooses another decoding strategy.  The code does not flag these because the remaining `**kwargs` are passed to the model.
I believe the logger is the best place to check whether decoding actually happened as expected.

Example usage: https://colab.research.google.com/drive/1DpMnZkSCtZIiaONoxfzYxYI4vgiTNYLN?usp=sharing

- ~~The first commit is unnecessary thanks to #17186~~ Rebased on this PR and adding one additional section to the documentation about typical decoding
- I'm open to renaming or removing `log_decoder` to always do `logger.info` in these places
- If we always do `logger.info`, I could move logger calls into `BeamSearchScorer`. Trying to avoid adding too many args
- Could use `logger.warn` if these issues warrant it

Discussion: https://discuss.huggingface.co/t/logging-which-decoder-selected-in-generation/18133

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?