### PR TITLE
Fix contents in index.mdx to match docs' sidebar

### DIFF
--- a/docs/source/es/index.mdx
+++ b/docs/source/es/index.mdx
@@ -34,9 +34,9 @@ Cada arquitectura de 🤗 Transformers se define en un módulo de Python indepen
 
 La documentación está organizada en cinco partes:
 
-- **INICIANDO** contiene un recorrido rápido e instrucciones de instalación para comenzar a usar 🤗 Transformers.
+- **EMPEZAR** contiene un recorrido rápido e instrucciones de instalación para comenzar a usar 🤗 Transformers.
 - **TUTORIALES** son un excelente lugar para comenzar si eres nuevo en nuestra biblioteca. Esta sección te ayudará a obtener las habilidades básicas que necesitas para comenzar a usar 🤗 Transformers.
-- **GUÍAS HOW-TO** te mostrará cómo lograr un objetivo específico, cómo hacer fine-tuning a un modelo preentrenado para el modelado de lenguaje o cómo crear un cabezal para un modelo personalizado.
+- **GUÍAS PRÁCTICAS** te mostrará cómo lograr un objetivo específico, cómo hacer fine-tuning a un modelo preentrenado para el modelado de lenguaje o cómo crear un cabezal para un modelo personalizado.
 - **GUÍAS CONCEPTUALES** proporciona más discusión y explicación de los conceptos e ideas subyacentes detrás de los modelos, las tareas y la filosofía de diseño de 🤗 Transformers. 
 - **API** describe cada clase y función, agrupadas en:
 

--- a/docs/source/es/index.mdx
+++ b/docs/source/es/index.mdx
@@ -32,17 +32,12 @@ Cada arquitectura de 🤗 Transformers se define en un módulo de Python indepen
 
 ## Contenidos
 
-La documentación está organizada en cinco partes:
+La documentación está organizada en cuatro partes:
 
 - **EMPEZAR** contiene un recorrido rápido e instrucciones de instalación para comenzar a usar 🤗 Transformers.
 - **TUTORIALES** son un excelente lugar para comenzar si eres nuevo en nuestra biblioteca. Esta sección te ayudará a obtener las habilidades básicas que necesitas para comenzar a usar 🤗 Transformers.
 - **GUÍAS PRÁCTICAS** te mostrará cómo lograr un objetivo específico, cómo hacer fine-tuning a un modelo preentrenado para el modelado de lenguaje o cómo crear un cabezal para un modelo personalizado.
 - **GUÍAS CONCEPTUALES** proporciona más discusión y explicación de los conceptos e ideas subyacentes detrás de los modelos, las tareas y la filosofía de diseño de 🤗 Transformers. 
-- **API** describe cada clase y función, agrupadas en:
-
-  - **CLASES PRINCIPALES** para las clases principales exponiendo las APIs importantes de la biblioteca.
-  - **MODELOS** para las clases y funciones relacionadas con cada modelo implementado en la biblioteca.
-  - **AYUDANTES INTERNOS** para las clases y funciones que usamos internamente.
 
 La biblioteca actualmente contiene implementaciones de JAX, PyTorch y TensorFlow, pesos de modelos preentrenados, scripts de uso y utilidades de conversión para los siguientes modelos.
 


### PR DESCRIPTION
# What does this PR do?

Fix: Currently the sections in the content part of `index.mdx` do not match the sections in `_toctree.yml`. 