### PR TITLE
Faster implementation for SentencePieceExtractor

### DIFF
--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -70,7 +70,6 @@ class SentencePieceExtractor:
         return merges
 
 
-
 def check_number_comma(piece: str) -> bool:
     return len(piece) < 2 or piece[-1] != "," or not piece[-2].isdigit()
 

--- a/tests/utils/test_convert_slow_tokenizer.py
+++ b/tests/utils/test_convert_slow_tokenizer.py
@@ -2,7 +2,7 @@ import unittest
 import warnings
 from dataclasses import dataclass
 
-from transformers.convert_slow_tokenizer import SpmConverter
+from transformers.convert_slow_tokenizer import SentencePieceExtractor, SpmConverter
 from transformers.testing_utils import get_tests_dir
 
 
@@ -12,6 +12,19 @@ class FakeOriginalTokenizer:
 
 
 class ConvertSlowTokenizerTest(unittest.TestCase):
+    def test_extract_merges(self):
+        vocab = {
+            "ab": 1,
+            "cd": 2,
+            "ef": 3,
+            "abef": 4,
+            "abcd": 5,
+            "bcd": 6,
+            "abcdef": 7,
+        }
+        merges = SentencePieceExtractor._extract_merges(vocab)
+        self.assertEqual(merges, [("ab", "ef"), ("ab", "cd"), ("abcd", "ef")])
+
     def test_spm_converter_bytefallback_warning(self):
         spm_model_file_without_bytefallback = get_tests_dir("fixtures/test_sentencepiece.model")
         spm_model_file_with_bytefallback = get_tests_dir("fixtures/test_sentencepiece_with_bytefallback.model")


### PR DESCRIPTION
# What does this PR do?

This PR is to improve `SentencePieceExtractor` extract method performance, which took several minutes when targeting vocabularies of tens of thousands of words.

For 44,876 words ( [repository](https://huggingface.co/rinna/japanese-gpt-1b) ), it used to take 290 seconds, but now it takes 0.2 seconds.
I've added a simple test, but let me know if you need anything else.
The experimental conditions and code are as follows.

result
```
vocabulary length: 44876, max word length: 16
normal: 290.2607123851776 secs
improved: 0.18401217460632324 secs
```

code
```python
import pickle
import time
from collections import defaultdict
from typing import List

vocab = pickle.load(open('vocab.pkl', 'rb'))

def normal(vocab: dict) -> List[str]:
    merges = []
    for piece_l in vocab.keys():
        for piece_r in vocab.keys():
            merge = f"{piece_l}{piece_r}"
            piece_id = vocab.get(merge, None)
            if piece_id:
                merges += [(piece_l, piece_r, piece_id)]
    return merges

def improved(vocab: dict) -> List[str]:
    merges = []
    prefixes = dict()
    for word in vocab.keys():
        for i in range(len(word)):
            prefixes[word[: i + 1]] = {word} | prefixes.setdefault(word[: i + 1], set())

    for word in vocab.keys():
        if len(prefixes[word]) > 1:
            for candidate in prefixes[word]:
                if word != candidate:
                    if candidate[len(word) :] in vocab:
                        piece_id = vocab.get(candidate, None)
                        merges += [(word, candidate[len(word) :], piece_id)]
    return merges

print(f'vocabulary length: {len(vocab)}, max word length: {max(len(word) for word in vocab.keys())}')
start = time.time()
result_normal = normal(vocab)
print(f'normal: {time.time() - start} secs')

start = time.time()
result_improved = improved(vocab)
print(f'improved: {time.time() - start} secs')

# confirm that results match
assert sorted(result_normal, key=lambda val: val[2]) == sorted(result_improved, key=lambda val: val[2])
```


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Did you write any new necessary tests?


## Who can review?
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@n1t0, @LysandreJik
