### PR TITLE
[Kernel Fusion] Training benchmarks of Torchdynamo + AOTAutograd + NVFuser(many models)

### DIFF
--- a/hf_dynamo_aot.py
+++ b/hf_dynamo_aot.py
@@ -34,7 +34,7 @@ benchmarks = [
         [torch.bfloat16], # trilu not implemented for bfloat16
     ),
     (AutoConfig.from_pretrained("t5-small"), AutoModelForSeq2SeqLM, (4, 1024), [torch.bfloat16]),
-    (ReformerConfig(), AutoModelForMaskedLM, (8, 4096), []),
+    # (ReformerConfig(), AutoModelForMaskedLM, (8, 4096), []),
     (AutoConfig.from_pretrained("distilbert-base-uncased"),  AutoModelForMaskedLM, (8, 512), []),
     (AutoConfig.from_pretrained("roberta-base"),  AutoModelForMaskedLM, (16, 512), []),
     # (BigBirdConfig(attention_type="block_sparse"), AutoModelForMaskedLM, (2, 1024), [torch.bfloat16, torch.float16]), # Currently quite slow - needs investigation
@@ -45,7 +45,6 @@ benchmarks = [
     (AutoConfig.from_pretrained("google/mobilebert-uncased"), AutoModelForMaskedLM, (4, 512), []),
     (AutoConfig.from_pretrained("camembert-base"), AutoModelForMaskedLM, (8, 512), []),
     (AutoConfig.from_pretrained("microsoft/layoutlm-base-uncased"), AutoModelForMaskedLM, (8, 512), []),
-
 ]
 
 device = "cuda"

--- a/hf_dynamo_aot.py
+++ b/hf_dynamo_aot.py
@@ -1,0 +1,220 @@
+import copy
+import gc
+import sys
+import time
+
+import pandas as pd
+import torch
+import torch.nn as nn
+import transformers
+from black import nullcontext
+from torch import optim
+from torch.nn.utils import _stateless
+from transformers import AutoConfig
+from transformers import AutoModelForCausalLM
+from transformers import AutoModelForMaskedLM
+from transformers import AutoModelForSeq2SeqLM
+from transformers import BertConfig
+from transformers import BigBirdConfig
+from transformers import ReformerConfig
+
+import torchdynamo
+from torchdynamo.optimizations.backends import aot_autograd
+from torchdynamo.optimizations.training import aot_autograd_speedup_strategy
+from torchdynamo.testing import clone_me
+from torchdynamo.testing import same
+
+benchmarks = [
+    (AutoConfig.from_pretrained("albert-base-v2"), AutoModelForMaskedLM, (8, 512), []),
+    # (AutoConfig.from_pretrained("gpt2"), AutoModelForCausalLM, (4, 512), []),
+    # (BertConfig(), AutoModelForMaskedLM, (4, 512), []),
+    # (
+    #     AutoConfig.from_pretrained("allenai/longformer-base-4096"),
+    #     AutoModelForMaskedLM,
+    #     (2, 1024),
+    #     [torch.float16, torch.bfloat16],
+    # ),  # hmm, nans with float16
+    # (AutoConfig.from_pretrained("t5-small"), AutoModelForSeq2SeqLM, (4, 1024), [torch.float16, torch.bfloat16]), # Doesn't work with nn.utils._stateless for some reason...
+    # (AutoConfig.from_pretrained("facebook/bert-base"), AutoModelForSeq2SeqLM, (4, 512), []), # Doesn't work with nn.utils._stateless for some reason...
+    # (ReformerConfig(), AutoModelForMaskedLM, (8, 4096), []), # not sure...
+    # (BigBirdConfig(attention_type="block_sparse"), AutoModelForMaskedLM, (2, 1024), []), # not sure...
+    # (AutoConfig.from_pretrained("distilbert-base-uncased"),  AutoModelForMaskedLM, (8, 512), []), # encounters inf as a global value
+]
+
+torch.manual_seed(42)
+device = "cuda"
+
+
+class NullContext:
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+def get_cur_memory():
+    torch.cuda.synchronize()
+
+    gc.collect()
+    torch.cuda.empty_cache()
+    stats = torch.cuda.memory_stats()
+    peak_bytes_requirement = stats["allocated_bytes.all.current"]
+    print(f"Current memory requirement: {peak_bytes_requirement / 1024 ** 3:.2f} GB")
+    return peak_bytes_requirement
+
+
+def collect_results(model, prediction, loss):
+    results = []
+    results.append(prediction)
+    results.append(loss)
+    grads = dict()
+    for name, param in model.named_parameters():
+        grads[name + ".grad"] = clone_me(param.grad)
+    results.append(grads)
+    # for example in example_inputs:
+    #     if isinstance(example, (tuple, list)):
+    #         for inp in example:
+    #             if isinstance(inp, torch.Tensor):
+    #                 results.append(clone_me(inp.grad))
+    #     else:
+    #         if isinstance(example, torch.Tensor):
+    #             results.append(clone_me(example.grad))
+    return results
+
+
+@torchdynamo.skip
+def forward_pass(mod, inputs, collect_outputs=True):
+    return mod(*inputs)
+
+
+@torchdynamo.skip
+def forward_and_backward_pass(mod, inputs, collect_outputs=True):
+    mod.zero_grad(True)
+    pred = mod(*inputs)
+    loss = pred.loss.abs().sum()
+    loss.backward()
+    if collect_outputs:
+        return collect_results(mod, pred, loss)
+    return None
+
+
+def check_correctness(mod, train_inputs):
+    optimize_ctx = torchdynamo.optimize(aot_autograd_speedup_strategy)
+    torch.manual_seed(1337)
+    correct_result = forward_and_backward_pass(copy.deepcopy(mod), train_inputs)
+
+    torch.manual_seed(1337)
+    correct_rerun_result = forward_and_backward_pass(copy.deepcopy(mod), train_inputs)
+    if not same(correct_result, correct_rerun_result):
+        print("INCORRECT - Variation in Eager runs itself")
+        return False
+
+    torch.manual_seed(1337)
+    torchdynamo.reset()
+    try:
+        with optimize_ctx:
+            new_result = forward_and_backward_pass(mod, train_inputs)
+    except Exception:
+        print("ERROR")
+        return False
+
+    if not same(correct_result, new_result):
+        print("INCORRECT")
+        return False
+    return True
+
+
+def bench_model(name, mod, train_inputs):
+    if name == "eager":
+        optimize_ctx = NullContext()
+    else:
+        optimize_ctx = torchdynamo.optimize(aot_autograd_speedup_strategy)
+
+    with optimize_ctx:
+        m = None
+        for i in range(5):
+            out = mod(*train_inputs).loss.abs().sum()
+            if i == 4:
+                m = get_cur_memory()
+            out.backward()
+        iters = 20
+        torch.cuda.synchronize()
+        begin = time.time()
+        for _ in range(iters):
+            forward_and_backward_pass(mod, train_inputs, False)
+        torch.cuda.synchronize()
+    t = (time.time() - begin) / iters
+    print(name, (time.time() - begin) / iters)
+    return t, m
+
+
+model_header, dtype_header, nh, th, mh, tp, mp = (
+    "model",
+    "dtype",
+    "name",
+    "time (s)",
+    "mem (GB)",
+    "time %",
+    "mem %",
+)
+
+
+numerical_diffs = []
+results = []
+for config, model_type, input_size, not_supported_dtypes in benchmarks:
+    for dtype in [torch.float, torch.half, torch.bfloat16]:
+        if dtype in not_supported_dtypes:
+            continue
+        for attr in dir(config):
+            if "drop" in attr:
+                setattr(
+                    config, attr, 1e-60
+                )  # So we can check for correct gradients without eliminating the dropout computation
+        model = model_type.from_config(config).to(device, dtype=dtype)
+        input_ids = torch.randint(0, config.vocab_size, input_size).to(device)
+        decoder_ids = torch.randint(0, config.vocab_size, input_size).to(device)
+
+        train_inputs = (input_ids, decoder_ids)
+        # train_inputs = {"input_ids": input_ids, "labels": decoder_ids}
+
+        print("Did accuracy pass", check_correctness(model, train_inputs))
+        model_name = type(model).__name__
+        t, m = bench_model("eager", model, train_inputs)
+        results.append(
+            {
+                model_header: model_name,
+                dtype_header: str(dtype),
+                nh: "eager",
+                th: t,
+                mh: m / 2**30,
+            }
+        )
+        with torch.jit.fuser("fuser2"):
+            t, m = bench_model("dynamo_aot", model, train_inputs)
+        results.append(
+            {
+                model_header: model_name,
+                dtype_header: str(dtype),
+                nh: "dynamo_aot",
+                th: t,
+                mh: m / 2**30,
+            }
+        )
+
+        # calculate relative improvements
+        base_r = results[-2]
+        for r in results[-2:]:
+            r[tp] = round(100 * (r[th] - base_r[th]) / base_r[th])
+            r[mp] = round(100 * (r[mh] - base_r[mh]) / base_r[mh])
+        print(pd.DataFrame(results[-2:]).to_markdown(index=False, floatfmt=".3f"))
+
+        print()
+
+print(results)
+for model_name, dtype, err in numerical_diffs:
+    print(f"Numerical differences in {model_name} - {dtype} found")
+    print(err)
+    print()
+
+print(pd.DataFrame(results).to_markdown(index=False, floatfmt=".3f"))

--- a/hf_dynamo_aot.py
+++ b/hf_dynamo_aot.py
@@ -1,3 +1,4 @@
+import argparse
 import copy
 import gc
 import time
@@ -16,19 +17,19 @@ from transformers import ReformerConfig
 import torchdynamo
 from torchdynamo.optimizations.training import aot_autograd_speedup_strategy
 from torchdynamo.testing import clone_me
+from torchdynamo.testing import collect_results
 from torchdynamo.testing import same
-from torchdynamo.utils import clone_inputs
 
 benchmarks = [
     (BertConfig(), AutoModelForMaskedLM, (4, 512), []),
-    (AutoConfig.from_pretrained("albert-base-v2"), AutoModelForMaskedLM, (8, 512), []),
-    (AutoConfig.from_pretrained("gpt2"), AutoModelForCausalLM, (4, 512), []),
-    (
-        AutoConfig.from_pretrained("allenai/longformer-base-4096"),
-        AutoModelForMaskedLM,
-        (2, 1024),
-        [torch.float16, torch.bfloat16],
-    ),  # hmm, nans with float16
+    # (AutoConfig.from_pretrained("albert-base-v2"), AutoModelForMaskedLM, (8, 512), []),
+    # (AutoConfig.from_pretrained("gpt2"), AutoModelForCausalLM, (4, 512), []),
+    # (
+    #     AutoConfig.from_pretrained("allenai/longformer-base-4096"),
+    #     AutoModelForMaskedLM,
+    #     (2, 1024),
+    #     [torch.float16, torch.bfloat16],
+    # ),  # hmm, nans with float16
     # (AutoConfig.from_pretrained("t5-small"), AutoModelForSeq2SeqLM, (4, 1024), [torch.float16, torch.bfloat16]), # Doesn't work with nn.utils._stateless for some reason...
     # (AutoConfig.from_pretrained("facebook/bert-base"), AutoModelForSeq2SeqLM, (4, 512), []), # Doesn't work with nn.utils._stateless for some reason...
     # (ReformerConfig(), AutoModelForMaskedLM, (8, 4096), []), # not sure...
@@ -62,18 +63,6 @@ def get_cur_memory():
 
 
 @torchdynamo.skip
-def collect_results(model, prediction, loss):
-    results = []
-    results.append(prediction)
-    results.append(loss)
-    grads = dict()
-    for name, param in model.named_parameters():
-        grads[name + ".grad"] = clone_me(param.grad)
-    results.append(grads)
-    return results
-
-
-@torchdynamo.skip
 def forward_pass(mod, inputs, collect_outputs=True):
     return mod(*inputs)
 
@@ -85,7 +74,7 @@ def forward_and_backward_pass(mod, inputs, collect_outputs=True):
     loss = pred.loss.mean()
     loss.backward()
     if collect_outputs:
-        return collect_results(mod, pred, loss)
+        return collect_results(mod, pred, loss, example_inputs=())
     return None
 
 
@@ -159,62 +148,81 @@ model_header, dtype_header, nh, th, mh, tp, mp, acc = (
 )
 
 
+def create_record(model_name, dtype, is_accurate, name, t, m):
+    return {
+        model_header: model_name,
+        dtype_header: str(dtype),
+        acc: is_accurate,
+        nh: name,
+        th: t,
+        mh: m / 2**30,
+    }
+
+
 numerical_diffs = []
 results = []
-for config, model_type, input_size, not_supported_dtypes in benchmarks:
-    for dtype in [torch.float, torch.half, torch.bfloat16]:
-        if dtype in not_supported_dtypes:
-            continue
-        for attr in dir(config):
-            if "drop" in attr:
-                setattr(
-                    config, attr, 1e-60
-                )  # So we can check for correct gradients without eliminating the dropout computation
-        model = model_type.from_config(config).to(device, dtype=dtype)
 
-        if USE_EVAL:
-            model.eval()
 
-        input_ids = torch.randint(0, config.vocab_size, input_size).to(device)
-        decoder_ids = torch.randint(0, config.vocab_size, input_size).to(device)
+def run_all():
+    for config, model_type, input_size, not_supported_dtypes in benchmarks:
+        for dtype in [torch.float, torch.half, torch.bfloat16]:
+            if dtype in not_supported_dtypes:
+                continue
+            for attr in dir(config):
+                if "drop" in attr:
+                    setattr(
+                        config, attr, 1e-60
+                    )  # So we can check for correct gradients without eliminating the dropout computation
+            model = model_type.from_config(config).to(device, dtype=dtype)
 
-        # train_inputs = (input_ids, decoder_ids)
-        train_inputs = {"input_ids": input_ids, "labels": decoder_ids}
+            if USE_EVAL:
+                model.eval()
 
-        is_accurate = check_correctness(model, train_inputs)
-        model_name = type(model).__name__
-        t, m = bench_model("eager", model, train_inputs)
-        results.append(
-            {
-                model_header: model_name,
-                dtype_header: str(dtype),
-                acc: is_accurate,
-                nh: "eager",
-                th: t,
-                mh: m / 2**30,
-            }
-        )
-        with torch.jit.fuser("fuser2"):
-            t, m = bench_model("dynamo_aot", model, train_inputs)
-        results.append(
-            {
-                model_header: model_name,
-                dtype_header: str(dtype),
-                nh: "dynamo_aot",
-                acc: is_accurate,
-                th: t,
-                mh: m / 2**30,
-            }
-        )
+            model_name = type(model).__name__
 
-        # calculate relative improvements
-        base_r = results[-2]
-        for r in results[-2:]:
-            r[tp] = round(100 * (r[th] - base_r[th]) / base_r[th])
-            r[mp] = round(100 * (r[mh] - base_r[mh]) / base_r[mh])
-        print(pd.DataFrame(results[-2:]).to_markdown(index=False, floatfmt=".3f"))
+            # Prepare inputs
+            input_ids = torch.randint(0, config.vocab_size, input_size).to(device)
+            decoder_ids = torch.randint(0, config.vocab_size, input_size).to(device)
+            train_inputs = {"input_ids": input_ids, "labels": decoder_ids}
 
-        print()
+            # Correctness check
+            is_accurate = check_correctness(model, train_inputs)
 
-print(results)
-print(pd.DataFrame(results).to_markdown(index=False, floatfmt=".3f"))
+            # Profile eager
+            t, m = bench_model("eager", model, train_inputs)
+            results.append(create_record(model_name, dtype, is_accurate, "eager", t, m))
+
+            # Profile Dynamo nvfuser
+            with torch.jit.fuser("fuser2"):
+                t, m = bench_model("dynamo_aot", model, train_inputs)
+            results.append(create_record(model_name, dtype, is_accurate, "dynamo_aot", t, m))
+
+            # calculate relative improvements
+            base_r = results[-2]
+            for r in results[-2:]:
+                r[tp] = round(100 * (r[th] - base_r[th]) / base_r[th])
+                r[mp] = round(100 * (r[mh] - base_r[mh]) / base_r[mh])
+            print(pd.DataFrame(results[-2:]).to_markdown(index=False, floatfmt=".3f"))
+
+    print("=== Final results ===")
+    print(pd.DataFrame(results).to_markdown(index=False, floatfmt=".3f"))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--use-eval-mode",
+        action="store_true",
+        help="sets model.eval() to reduce randomness",
+    )
+
+    args = parser.parse_args()
+    if args.use_eval_mode:
+        global USE_EVAL
+        USE_EVAL = True
+
+    run_all()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Note to maintainers: We are using this PR to collaborate and there is no intention yet to merge anything, so please ignore unless you want to experiment with the latest auto-speedups.

## What was the issue with the previous AOTAutograd integration?
So, there was some investigation into applying AOTAutograd a couple months ago in this PR (https://github.com/huggingface/transformers/pull/15264). Although the performance results were quite promising, @stas00 and I found one major blocker - the potential for incorrect semantics. AOTAutograd is a tracing-based approach, and as such, it's fairly difficult for it to guarantee that its semantics are always correct. For example, data-dependent control flow, use of third-party libraries (like Numpy), or modification of global state all posed problems for integrating AOTAutograd into HuggingFace. Considering that HF has >100 models (and is adding more every day!), the burden of needing to ensure that AOTAutograd produces correct results would have been quite burdensome.

## TorchDynamo to the rescue
Luckily, now, there's another solution in the form of [Torchdynamo](https://dev-discuss.pytorch.org/t/torchdynamo-an-experiment-in-dynamic-python-bytecode-transformation/361) (from @jansel)! In contrast to tracing based approaches like `jit.trace` and AOTAutograd, Torchdynamo is *sound* - it should never produce incorrect results (modulo bugs). In comparison to approaches like `jit.script`, Torchdynamo is much more *complete* - it should allow any PyTorch code to be able to run, although it may not always speed things up.

The central approach that TorchDynamo takes is that as opposed to trying to live at the AST level (i.e. `jit.script`) or the object-level (i.e. tracing like `jit.trace`), it lives at the Python bytecode level. This is similar to the approach that language JITs like Javascript's V8 or JVM's Hotspot take. By living at this level, it's able to ensure that it can support *all* Python, as it can always fall back to eager-mode execution. Let's take an example of some code that would have been very problematic previously.

```
def f(x):
    a = x * 2
    b = a + torch.from_numpy(np.randn(5))
    if b.sum() > 0:
        return d.sin().sin()
    else:
        return d.cos().cos()
```
Not only does this have data-dependent control flow - it also has calls to external libraries that aren't PyTorch! (numpy in this case). TorchDynamo (morally) would rewrite this code into something like this:
```
def block1(x, np_tensor):
    a = x * 2
    b = a + np_tensor
    return b

def block2(b):
    return b.sin().sin()

def block3(b):
    return b.sin().sin()

def f_dynamo(x):
    b = block1(x, torch.from_numpy(np.randn(5))
    if b.sum() > 0:
        return block2(b)
    else:
        return block3(b)
```

Note that `block1`, `block2`, and `block3` are just simple straight line functions - exactly what AOTAutograd can handle! So, we can now apply AOTAutograd to each of those blocks.

In this way, TorchDynamo and AOTAutograd complement each other - TorchDynamo resolves the dynamic/non-traceable behavior that AOTAutograd can't handle, and AOTAutograd then provides static compilation that handles things like PyTorch's autograd.

So, what do you need to do to use AOTAutograd with Torchdynamo? Well, it's simple!
```
import torchdynamo
from torchdynamo.optimizations.training import aot_autograd_speedup_strategy
with torchdynamo.optimize(aot_autograd_speedup_strategy):
    # run your model here!
```

All of the above is simply to capture the graphs in the first place. However, after capturing the graphs, we need to actually speed them up. To do so, we pass them to [NVFuser](https://www.nvidia.com/en-us/on-demand/session/gtcspring21-s31952/), a PyTorch-native compiler for GPUs.

## Results
This script primarily comes from a great effort from @anijain2305. However, I want to note a couple of things.

1. In contrast with the pure AOTAutograd integration, where our benchmark only covered 3.5 models (and had some tricky to debug correctness issues), it was fairly trivial to extend this benchmarking to 14 models (with correctness testing for all of them!) In fact, the main bottleneck to adding more is just figuring out how to run more models (I pretty much exhausted all of the AutoConfig ones I could run easily).
2. For the most part, TorchDynamo + AOTAutograd improves both performance and memory usage. On some models, quite significantly (1.4x+ for MobileBert, FNet, and Albert), but it generally improves performance for nearly all models.
3. For many of these models, we *can't* produce a single graph to compile, often due to Numpy usage. Here, it's crucial that torchdynamo passes multiple graphs to AOTAutograd.
4. Currently, we feed the graphs produced by TorchDynamo and AOTAutograd into NVFuser. But, in the future, other backends should have no issues integrating into this as well (and in fact, we *have* some extra integrations, like TensorRT).

Run on A100:
```
$ python hf_dynamo_aot.py --run-dynamo-aot-efficient --nvfuser
```
Results:

| model                      | dtype          | name                 |   time (s) |   mem (GB) |   speedup |   mem comp ression |
|:---------------------------|:---------------|---------------------|-----------:|-----------:|----------:|------------------:|
| BertForMaskedLM            | float32  |eager                |      0.040 |      3.521 |     1.000 |             1.000 |
| BertForMaskedLM            | float32  |dynamo_aot_efficient |      0.037 |      3.516 |     1.094 |             1.001 |
| BertForMaskedLM            | float16  |eager                |      0.027 |      1.880 |     1.000 |             1.000 |
| BertForMaskedLM            | float16  |dynamo_aot_efficient |      0.023 |      1.885 |     1.155 |             0.997 |
| BertForMaskedLM            | bfloat16 |eager                |      0.027 |      1.874 |     1.000 |             1.000 |
| BertForMaskedLM            | bfloat16 |dynamo_aot_efficient |      0.023 |      1.867 |     1.154 |             1.003 |
| AlbertForMaskedLM          | float32  |eager                |      0.081 |      6.070 |     1.000 |             1.000 |
| AlbertForMaskedLM          | float32  |dynamo_aot_efficient |      0.056 |      3.943 |     1.442 |             1.539 |
| AlbertForMaskedLM          | float16  |eager                |      0.046 |      2.908 |     1.000 |             1.000 |
| AlbertForMaskedLM          | float16  |dynamo_aot_efficient |      0.035 |      1.971 |     1.338 |             1.475 |
| AlbertForMaskedLM          | bfloat16 |eager                |      0.048 |      2.866 |     1.000 |             1.000 |
| AlbertForMaskedLM          | bfloat16 |dynamo_aot_efficient |      0.035 |      1.972 |     1.374 |             1.453 |
| GPT2LMHeadModel            | float32  |eager                |      0.055 |      4.632 |     1.000 |             1.000 |
| GPT2LMHeadModel            | float32  |dynamo_aot_efficient |      0.043 |      3.791 |     1.280 |             1.222 |
| GPT2LMHeadModel            | float16  |eager                |      0.036 |      2.426 |     1.000 |             1.000 |
| GPT2LMHeadModel            | float16  |dynamo_aot_efficient |      0.029 |      2.018 |     1.213 |             1.203 |
| GPT2LMHeadModel            | bfloat16 |eager                |      0.036 |      2.425 |     1.000 |             1.000 |
| GPT2LMHeadModel            | bfloat16 |dynamo_aot_efficient |      0.030 |      1.998 |     1.208 |             1.214 |
| LongformerForMaskedLM      | float32  |eager                |      0.121 |      4.591 |     1.000 |             1.000 |
| LongformerForMaskedLM      | float32  |dynamo_aot_efficient |      0.120 |      4.585 |     1.006 |             1.001 |
| LongformerForMaskedLM      | float16  |eager                |      0.096 |      2.711 |     1.000 |             1.000 |
| LongformerForMaskedLM      | float16  |dynamo_aot_efficient |      0.096 |      2.705 |     1.005 |             1.002 |
| T5ForConditionalGeneration | float32  |eager                |      0.103 |      8.300 |     1.000 |             1.000 |
| T5ForConditionalGeneration | float32  |dynamo_aot_efficient |      0.098 |      7.831 |     1.050 |             1.060 |
| DistilBertForMaskedLM      | float32  |eager                |      0.045 |      3.492 |     1.000 |             1.000 |
| DistilBertForMaskedLM      | float32  |dynamo_aot_efficient |      0.043 |      3.497 |     1.038 |             0.999 |
| DistilBertForMaskedLM      | float16  |eager                |      0.026 |      1.870 |     1.000 |             1.000 |
| DistilBertForMaskedLM      | float16  |dynamo_aot_efficient |      0.027 |      1.871 |     0.963 |             0.999 |
| DistilBertForMaskedLM      | bfloat16 |eager                |      0.026 |      1.860 |     1.000 |             1.000 |
| DistilBertForMaskedLM      | bfloat16 |dynamo_aot_efficient |      0.027 |      1.861 |     0.986 |             1.000 |
| RobertaForMaskedLM         | float32  |eager                |      0.157 |     12.366 |     1.000 |             1.000 |
| RobertaForMaskedLM         | float32  |dynamo_aot_efficient |      0.135 |     12.341 |     1.164 |             1.002 |
| RobertaForMaskedLM         | float16  |eager                |      0.098 |      6.573 |     1.000 |             1.000 |
| RobertaForMaskedLM         | float16  |dynamo_aot_efficient |      0.088 |      6.567 |     1.114 |             1.001 |
| RobertaForMaskedLM         | bfloat16 |eager                |      0.101 |      6.579 |     1.000 |             1.000 |
| RobertaForMaskedLM         | bfloat16 |dynamo_aot_efficient |      0.088 |      6.559 |     1.140 |             1.003 |
| GPT2LMHeadModel            | float32  |eager                |      0.123 |      9.292 |     1.000 |             1.000 |
| GPT2LMHeadModel            | float32  |dynamo_aot_efficient |      0.098 |      7.108 |     1.256 |             1.307 |
| GPT2LMHeadModel            | float16  |eager                |      0.080 |      4.610 |     1.000 |             1.000 |
| GPT2LMHeadModel            | float16  |dynamo_aot_efficient |      0.067 |      3.767 |     1.182 |             1.224 |
| GPT2LMHeadModel            | bfloat16 |eager                |      0.081 |      4.779 |     1.000 |             1.000 |
| GPT2LMHeadModel            | bfloat16 |dynamo_aot_efficient |      0.068 |      3.763 |     1.191 |             1.270 |
| ElectraForMaskedLM         | float32  |eager                |      0.074 |      6.257 |     1.000 |             1.000 |
| ElectraForMaskedLM         | float32  |dynamo_aot_efficient |      0.064 |      6.258 |     1.151 |             1.000 |
| ElectraForMaskedLM         | float16  |eager                |      0.042 |      3.356 |     1.000 |             1.000 |
| ElectraForMaskedLM         | float16  |dynamo_aot_efficient |      0.039 |      3.347 |     1.092 |             1.003 |
| ElectraForMaskedLM         | bfloat16 |eager                |      0.044 |      3.367 |     1.000 |             1.000 |
| ElectraForMaskedLM         | bfloat16 |dynamo_aot_efficient |      0.039 |      3.341 |     1.124 |             1.008 |
| FNetForMaskedLM            | float32  |eager                |      0.055 |      4.974 |     1.000 |             1.000 |
| FNetForMaskedLM            | float32  |dynamo_aot_efficient |      0.038 |      2.802 |     1.429 |             1.775 |
| ConvBertForMaskedLM        | float32  |eager                |      0.090 |      5.809 |     1.000 |             1.000 |
| ConvBertForMaskedLM        | float32  |dynamo_aot_efficient |      0.085 |      5.795 |     1.058 |             1.002 |
| ConvBertForMaskedLM        | float16  |eager                |      0.064 |      3.021 |     1.000 |             1.000 |
| ConvBertForMaskedLM        | float16  |dynamo_aot_efficient |      0.062 |      3.009 |     1.024 |             1.004 |
| MobileBertForMaskedLM      | float32  |eager                |      0.104 |      2.474 |     1.000 |             1.000 |
| MobileBertForMaskedLM      | float32  |dynamo_aot_efficient |      0.069 |      2.576 |     1.499 |             0.961 |
| MobileBertForMaskedLM      | float16  |eager                |      0.101 |      1.329 |     1.000 |             1.000 |
| MobileBertForMaskedLM      | float16  |dynamo_aot_efficient |      0.067 |      1.423 |     1.499 |             0.934 |
| MobileBertForMaskedLM      | bfloat16 |eager                |      0.100 |      1.330 |     1.000 |             1.000 |
| MobileBertForMaskedLM      | bfloat16 |dynamo_aot_efficient |      0.067 |      1.423 |     1.504 |             0.935 |
| CamembertForMaskedLM       | float32  |eager                |      0.075 |      6.312 |     1.000 |             1.000 |
| CamembertForMaskedLM       | float32  |dynamo_aot_efficient |      0.065 |      6.317 |     1.151 |             0.999 |
| CamembertForMaskedLM       | float16  |eager                |      0.047 |      3.376 |     1.000 |             1.000 |
| CamembertForMaskedLM       | float16  |dynamo_aot_efficient |      0.044 |      3.366 |     1.084 |             1.003 |
| CamembertForMaskedLM       | bfloat16 |eager                |      0.049 |      3.390 |     1.000 |             1.000 |
| CamembertForMaskedLM       | bfloat16 |dynamo_aot_efficient |      0.044 |      3.370 |     1.113 |             1.006 |
| LayoutLMForMaskedLM        | float32  |eager                |      0.077 |      6.305 |     1.000 |             1.000 |
| LayoutLMForMaskedLM        | float32  |dynamo_aot_efficient |      0.067 |      6.305 |     1.149 |             1.000 |
| LayoutLMForMaskedLM        | float16  |eager                |      0.045 |      3.371 |     1.000 |             1.000 |
| LayoutLMForMaskedLM        | float16  |dynamo_aot_efficient |      0.042 |      3.373 |     1.089 |             0.999 |
| LayoutLMForMaskedLM        | bfloat16 |eager                |      0.047 |      3.389 |     1.000 |             1.000 |
| LayoutLMForMaskedLM        | bfloat16 |dynamo_aot_efficient |      0.042 |      3.371 |     1.118 |             1.005 |


### Limitations
There are a couple of limitations today (that we're working on addressing).

1. Like AOTAutograd, this pipeline currently requires static shape specialization. That is, when the input shapes change, we'll need to recompile.
2. The interaction with PyTorch's distributed features is somewhat untested.

### Reading resources:

AOTAutograd: https://docs.google.com/presentation/d/1rTt0BR2KChDQQTks2hHUtvHxtHQKwgQHVNrmbhj0byk/edit?usp=sharing
TorchDynamo: https://dev-discuss.pytorch.org/t/torchdynamo-an-experiment-in-dynamic-python-bytecode-transformation/361
Min-Cut rematerialization: https://dev-discuss.pytorch.org/t/min-cut-optimal-recomputation-i-e-activation-checkpointing-with-aotautograd/467/7
NVFuser: https://www.nvidia.com/en-us/on-demand/session/gtcspring21-s31952/