### PR TITLE
fix retribert's `test_torch_encode_plus_sent_to_model`

### DIFF
--- a/tests/models/retribert/test_tokenization_retribert.py
+++ b/tests/models/retribert/test_tokenization_retribert.py
@@ -379,7 +379,6 @@ class RetriBertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 # This should not fail
 
                 with torch.no_grad():  # saves some time
-
                     # The following lines are different from the common's ones
                     model.embed_questions(**encoded_sequence)
                     model.embed_questions(**batch_encoded_sequence)

--- a/tests/models/retribert/test_tokenization_retribert.py
+++ b/tests/models/retribert/test_tokenization_retribert.py
@@ -27,9 +27,9 @@ from transformers.models.bert.tokenization_bert import (
     _is_punctuation,
     _is_whitespace,
 )
-from transformers.testing_utils import require_tokenizers, slow
+from transformers.testing_utils import require_tokenizers, require_torch, slow
 
-from ...test_tokenization_common import TokenizerTesterMixin, filter_non_english
+from ...test_tokenization_common import TokenizerTesterMixin, filter_non_english, merge_model_tokenizer_mappings
 
 
 # Copied from transformers.tests.bert.test_modeling_bert.py with Bert->RetriBert
@@ -338,3 +338,48 @@ class RetriBertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 ]
                 self.assertListEqual(tokens_without_spe_char_p, expected_tokens)
                 self.assertListEqual(tokens_without_spe_char_r, expected_tokens)
+
+    # RetriBertModel doesn't define `get_input_embeddings` and it's forward method doesn't take only the output of the tokenizer as input
+    @require_torch
+    @slow
+    def test_torch_encode_plus_sent_to_model(self):
+        import torch
+
+        from transformers import MODEL_MAPPING, TOKENIZER_MAPPING
+
+        MODEL_TOKENIZER_MAPPING = merge_model_tokenizer_mappings(MODEL_MAPPING, TOKENIZER_MAPPING)
+
+        tokenizers = self.get_tokenizers(do_lower_case=False)
+        for tokenizer in tokenizers:
+            with self.subTest(f"{tokenizer.__class__.__name__}"):
+
+                if tokenizer.__class__ not in MODEL_TOKENIZER_MAPPING:
+                    return
+
+                config_class, model_class = MODEL_TOKENIZER_MAPPING[tokenizer.__class__]
+                config = config_class()
+
+                if config.is_encoder_decoder or config.pad_token_id is None:
+                    return
+
+                model = model_class(config)
+
+                # The following test is different from the common's one
+                self.assertGreaterEqual(model.bert_query.get_input_embeddings().weight.shape[0], len(tokenizer))
+
+                # Build sequence
+                first_ten_tokens = list(tokenizer.get_vocab().keys())[:10]
+                sequence = " ".join(first_ten_tokens)
+                encoded_sequence = tokenizer.encode_plus(sequence, return_tensors="pt")
+
+                # Ensure that the BatchEncoding.to() method works.
+                encoded_sequence.to(model.device)
+
+                batch_encoded_sequence = tokenizer.batch_encode_plus([sequence, sequence], return_tensors="pt")
+                # This should not fail
+
+                with torch.no_grad():  # saves some time
+
+                    # The following lines are different from the common's ones
+                    model.embed_questions(**encoded_sequence)
+                    model.embed_questions(**batch_encoded_sequence)


### PR DESCRIPTION
# What does this PR do?

This PR proposes a fix for the slow test `test_torch_encode_plus_sent_to_model` for RetriBert that failed in the CI daily that ran yesterday.

The error is due to the fact that RetriBert is not a classical model in the sense that the input can be fed to one or two encoders of the model. As a result `get_input_embeddings` is an unimplemented method and the forward method expects more arguments in input than what is outputed by the tokenizer.

I have therefore overridden the common test with a specific test for RetriBert that reflects these two specificities, which I will highlight them in a comment below.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed

## Local test

I've tested it by running:
```bash
RUN_SLOW=yes pytest tests/models/retribert/ -k test_torch_encode_plus_sent_to_model
```
output:
```
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.9.12, pytest-7.1.1, pluggy-1.0.0
rootdir: /home/lucile_huggingface_co/repos/transformers, configfile: setup.cfg
plugins: dash-2.3.1, hypothesis-6.41.0, timeout-2.1.0, forked-1.4.0, xdist-2.5.0
collected 98 items / 97 deselected / 1 selected                                                                                                                                                            

tests/models/retribert/test_tokenization_retribert.py .                                                                                                                                              [100%]

============================================================================== 1 passed, 97 deselected, 10 warnings in 5.38s ===============================================================================
```
