### PR TITLE
fix --gpus option for docker

### DIFF
--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -126,7 +126,7 @@ jobs:
     runs-on: ${{ matrix.machines }}
     container:
       image: huggingface/transformers-all-latest-gpu
-      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: --gpus all --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     needs: setup
     steps:
       - name: Echo folder ${{ matrix.folders }}
@@ -208,7 +208,7 @@ jobs:
     runs-on: ${{ matrix.machines }}
     container:
       image: huggingface/transformers-pytorch-gpu
-      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: --gpus all --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     needs: setup
     steps:
       # Set machine type, i.e. `single-gpu` or `multi-gpu`. Here we just remove `-docker`.
@@ -252,7 +252,7 @@ jobs:
     runs-on: ${{ matrix.machines }}
     container:
       image: huggingface/transformers-tensorflow-gpu
-      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: --gpus all --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     needs: setup
     steps:
       # Set machine type, i.e. `single-gpu` or `multi-gpu`. Here we just remove `-docker`.


### PR DESCRIPTION
# What does this PR do?

Some multi-GPUs tests in scheduled CI workflow file use `--gpus 0`. I think it is an error, and we might test with only 1 GPU for those multi GPUs tests.

This PR fixes it. 

**Remark**: It's quite strange that, from the setup job log, we can see 2 GPUs in `nvidia-smi` while we have `options: --gpus 0`. I am not 100% sure if this PR has real value, but at least it avoids some confusing maybe.