### PR TITLE
Fix Trainer for Datasets that don't have dict items

### DIFF
--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -676,6 +676,8 @@ class RemoveColumnsCollator:
         self.message_logged = False
 
     def _remove_columns(self, feature: dict) -> dict:
+        if not isinstance(feature, dict):
+            return feature
         if not self.message_logged and self.logger and self.model_name:
             ignored_columns = list(set(feature.keys()) - set(self.signature_columns))
             if len(ignored_columns) > 0:


### PR DESCRIPTION
# What does this PR do?

This PR fixes a break in `Trainer` when the dataset items are not dictionaries.