### PR TITLE
install dev. version of accelerate in docker file

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -17,6 +17,8 @@ RUN python3 -m pip install --no-cache-dir torch-scatter -f https://data.pyg.org/
 RUN python3 -m pip install --no-cache-dir git+https://github.com/facebookresearch/detectron2.git pytesseract https://github.com/kpu/kenlm/archive/master.zip
 RUN python3 -m pip install -U "itsdangerous<2.1.0"
 
+RUN python3 -m pip install --no-cache-dir git+https://github.com/huggingface/accelerate@main#egg=accelerate
+
 # When installing in editable mode, `transformers` is not recognized as a package.
 # this line must be added in order for python to be aware of transformers.
 RUN cd transformers && python3 setup.py develop


### PR DESCRIPTION
# What does this PR do?

With an offline discussion with @muellerzr regarding this CI failure
```
tests/trainer/test_trainer.py::TrainerIntegrationTest::test_auto_batch_size_finder
(line 776)  ImportError:
```
I update the docker file in this PR. Will try to build the new docker image once this PR is merged.
