### PR TITLE
Add OPT model parallelize

### DIFF
--- a/src/transformers/models/opt/modeling_opt.py
+++ b/src/transformers/models/opt/modeling_opt.py
@@ -542,10 +542,10 @@ class OPTDecoder(OPTPreTrainedModel):
         self.model_parallel = True
         self.first_device = "cpu" if "cpu" in self.device_map.keys() else f"cuda:{min(self.device_map.keys())}"
         self.last_device = f"cuda:{max(self.device_map.keys())}"
-        self.embed_tokens.to(self.first_device)
-        self.embed_positions.to(self.first_device)
+        self.embed_tokens = self.embed_tokens.to(self.first_device)
+        self.embed_positions = self.embed_positions.to(self.first_device)
         if self.project_in is not None:
-            self.project_in.to(self.first_device)
+            self.project_in = self.project_in.to(self.first_device)
         # Load onto devices
         for k, v in self.device_map.items():
             for block in v:
@@ -910,7 +910,7 @@ class OPTForCausalLM(OPTPreTrainedModel):
         self.model_parallel = True
         self.first_device = self.model.first_device
         self.last_device = self.model.last_device
-        self.lm_head.to(self.first_device)
+        self.lm_head = self.lm_head.to(self.first_device)
 
     def deparallelize(self):
         self.model.deparallelize()

--- a/src/transformers/models/opt/modeling_opt.py
+++ b/src/transformers/models/opt/modeling_opt.py
@@ -1087,7 +1087,7 @@ class OPTForCausalLM(OPTPreTrainedModel):
 
     @staticmethod
     def _reorder_cache(past, beam_idx):
-        reordered_past = ()
-        for layer_past in past:
-            reordered_past += (tuple(past_state.index_select(0, beam_idx) for past_state in layer_past),)
-        return reordered_past
+        return tuple(
+            tuple(past_state.index_select(0, beam_idx.to(past_state.device)) for past_state in layer_past)
+            for layer_past in past
+        )

--- a/tests/models/opt/test_modeling_opt.py
+++ b/tests/models/opt/test_modeling_opt.py
@@ -22,6 +22,7 @@ import unittest
 import timeout_decorator  # noqa
 
 from transformers import OPTConfig, is_torch_available
+from transformers.models.opt.modeling_opt import OPTDecoder
 from transformers.testing_utils import require_sentencepiece, require_tokenizers, require_torch, slow, torch_device
 from transformers.utils import cached_property
 
@@ -97,6 +98,9 @@ class OPTModelTester:
         self.embed_dim = embed_dim
         self.word_embed_proj_dim = word_embed_proj_dim
         self.is_encoder_decoder = False
+    
+    def get_large_model_config(self):
+        return OPTConfig.from_pretrained("facebook/opt-125m")
 
     def prepare_config_and_inputs(self):
         input_ids = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
@@ -178,9 +182,11 @@ class OPTModelTester:
 class OPTModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
     all_model_classes = (OPTModel, OPTForCausalLM) if is_torch_available() else ()
     all_generative_model_classes = (OPTForCausalLM,) if is_torch_available() else ()
+    all_parallelizable_model_classes = (OPTDecoder, OPTModel, OPTForCausalLM) if is_torch_available() else ()
     is_encoder_decoder = False
     test_pruning = False
     test_missing_keys = False
+    test_model_parallel = True
 
     def setUp(self):
         self.model_tester = OPTModelTester(self)


### PR DESCRIPTION
# Model Parallelism for OPT

Added ```parallelize``` and ```deparallelize``` methods on ```OPTDecoder```, ```OPTModel``` and ```OPTForCausalLM```.
Referred to ```gpt2``` model parallelize (https://github.com/huggingface/transformers/pull/8696).

Fixes #17240 

## Who can review?
Let me know if you need any modifications, @patrickvonplaten