### PR TITLE
TF - Fix convnext classification example

### DIFF
--- a/src/transformers/models/convnext/modeling_tf_convnext.py
+++ b/src/transformers/models/convnext/modeling_tf_convnext.py
@@ -537,7 +537,7 @@ class TFConvNextForImageClassification(TFConvNextPreTrainedModel, TFSequenceClas
         >>> image = Image.open(requests.get(url, stream=True).raw)
 
         >>> feature_extractor = ConvNextFeatureExtractor.from_pretrained("facebook/convnext-tiny-224")
-        >>> model = TFViTForImageClassification.from_pretrained("facebook/convnext-tiny-224")
+        >>> model = TFConvNextForImageClassification.from_pretrained("facebook/convnext-tiny-224")
 
         >>> inputs = feature_extractor(images=image, return_tensors="tf")
         >>> outputs = model(**inputs)


### PR DESCRIPTION
# What does this PR do?

Fixes what probably was copy-paste mistake. As visible [here](https://huggingface.co/docs/transformers/main/en/model_doc/convnext#transformers.TFConvNextForImageClassification.call.example) -- the example doesn't run atm, it does with the fix.