### PR TITLE
Fix wrong PT/TF categories in CI report

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -643,10 +643,10 @@ if __name__ == "__main__":
                             artifact_path["gpu"]
                         ] += f"*{line}*\n_{stacktraces.pop(0)}_\n\n"
 
-                        if re.search("_tf_", line):
+                        if re.search("test_modeling_tf_", line):
                             model_results[model]["failed"]["TensorFlow"][artifact_path["gpu"]] += 1
 
-                        elif re.search("_flax_", line):
+                        elif re.search("test_modeling_flax_", line):
                             model_results[model]["failed"]["Flax"][artifact_path["gpu"]] += 1
 
                         elif re.search("test_modeling", line):


### PR DESCRIPTION
# What does this PR do?

Current `notification_service.py` has
```
if re.search("_tf_", line):
    model_results[model]["failed"]["TensorFlow"][artifact_path["gpu"]] += 1
```
which will put all `test_pt_tf_model_equivalence` under `TensorFlow` even it is from the PT (cross) tests, like
```
tests/models/albert/test_modeling_albert.py::AlbertModelTest::test_pt_tf_model_equivalence
```
This PR fixes this issue.