### PR TITLE
Remove next sentence prediction from supported ONNX tasks

### DIFF
--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -45,7 +45,6 @@ if is_torch_available():
         AutoModelForMaskedImageModeling,
         AutoModelForMaskedLM,
         AutoModelForMultipleChoice,
-        AutoModelForNextSentencePrediction,
         AutoModelForQuestionAnswering,
         AutoModelForSeq2SeqLM,
         AutoModelForSequenceClassification,
@@ -57,7 +56,6 @@ if is_tf_available():
         TFAutoModelForCausalLM,
         TFAutoModelForMaskedLM,
         TFAutoModelForMultipleChoice,
-        TFAutoModelForNextSentencePrediction,
         TFAutoModelForQuestionAnswering,
         TFAutoModelForSeq2SeqLM,
         TFAutoModelForSequenceClassification,
@@ -112,7 +110,6 @@ class FeaturesManager:
             "question-answering": AutoModelForQuestionAnswering,
             "image-classification": AutoModelForImageClassification,
             "masked-im": AutoModelForMaskedImageModeling,
-            "next-sentence-prediction": AutoModelForNextSentencePrediction,
         }
     if is_tf_available():
         _TASKS_TO_TF_AUTOMODELS = {
@@ -124,7 +121,6 @@ class FeaturesManager:
             "token-classification": TFAutoModelForTokenClassification,
             "multiple-choice": TFAutoModelForMultipleChoice,
             "question-answering": TFAutoModelForQuestionAnswering,
-            "next-sentence-prediction": TFAutoModelForNextSentencePrediction,
         }
 
     # Set of model topologies we support associated to the features supported by each topology and the factory
@@ -159,7 +155,6 @@ class FeaturesManager:
             "multiple-choice",
             "token-classification",
             "question-answering",
-            "next-sentence-prediction",
             onnx_config_cls=BertOnnxConfig,
         ),
         "big-bird": supported_features_mapping(
@@ -326,7 +321,6 @@ class FeaturesManager:
         "mobilebert": supported_features_mapping(
             "default",
             "masked-lm",
-            "next-sentence-prediction",
             "sequence-classification",
             "multiple-choice",
             "token-classification",


### PR DESCRIPTION
# What does this PR do?

This PR removes the `next-sentence-prediction` feature that was added in  https://github.com/huggingface/transformers/pull/17029 as part of the MobileBERT ONNX export. 

It turns out that the `forward()` method of MobileBERT and BERT includes `kwargs`, which is not supported with PyTorch's ONNX exporter. Since this feature is unlikely to be used for inference, the simplest solution is to remove it.

With this change, the ONNX slow tests all pass.