### PR TITLE
Bug fix: move tensors to GPU in GeneralizedRCNN.inference()

### DIFF
--- a/examples/research_projects/lxmert/modeling_frcnn.py
+++ b/examples/research_projects/lxmert/modeling_frcnn.py
@@ -1895,16 +1895,20 @@ class GeneralizedRCNN(nn.Module):
             "pad_value": kwargs.get("pad_value", 0),
             "padding": kwargs.get("padding", None),
         }
+
+        current_device = images.device
+
         preds_per_image = torch.tensor([p.size(0) for p in boxes])
-        boxes = pad_list_tensors(boxes, preds_per_image, **subset_kwargs)
-        classes = pad_list_tensors(classes, preds_per_image, **subset_kwargs)
-        class_probs = pad_list_tensors(class_probs, preds_per_image, **subset_kwargs)
-        attrs = pad_list_tensors(attrs, preds_per_image, **subset_kwargs)
-        attr_probs = pad_list_tensors(attr_probs, preds_per_image, **subset_kwargs)
-        roi_features = pad_list_tensors(roi_features, preds_per_image, **subset_kwargs)
+        boxes = pad_list_tensors(boxes, preds_per_image, **subset_kwargs).to(current_device)
+        classes = pad_list_tensors(classes, preds_per_image, **subset_kwargs).to(current_device)
+        class_probs = pad_list_tensors(class_probs, preds_per_image, **subset_kwargs).to(current_device)
+        attrs = pad_list_tensors(attrs, preds_per_image, **subset_kwargs).to(current_device)
+        attr_probs = pad_list_tensors(attr_probs, preds_per_image, **subset_kwargs).to(current_device)
+        roi_features = pad_list_tensors(roi_features, preds_per_image, **subset_kwargs).to(current_device)
         subset_kwargs["padding"] = None
-        preds_per_image = pad_list_tensors(preds_per_image, None, **subset_kwargs)
-        sizes = pad_list_tensors(image_shapes, None, **subset_kwargs)
+        preds_per_image = pad_list_tensors(preds_per_image, None, **subset_kwargs).to(current_device)
+        sizes = pad_list_tensors(image_shapes, None, **subset_kwargs).to(current_device)
+
         normalized_boxes = norm_box(boxes, original_sizes)
         return OrderedDict(
             {


### PR DESCRIPTION
# What does this PR do?

This PR fixes a bug in `research_projects/lxmert`.

Currently, visual feature extraction using `GeneralizedRCNN` fails when `GeneralizedRCNN` is moved onto GPU
because some intermediate outputs in `GeneralizedRCNN.inference()` are generated and left on CPU.

I fixed the bug by adding `.to(<current_device>)` to the involved intermediate outputs.

I wonder if this PR requires addition of tests because `research_projects/lxmert` does not seems to have tests, so could you please inform me about proper action?


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
