### PR TITLE
Make TrainerHyperParameterSigOptIntegrationTest slow test

### DIFF
--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1901,6 +1901,7 @@ class TrainerHyperParameterRayIntegrationTest(unittest.TestCase):
             self.ray_hyperparameter_search()
 
 
+@slow
 @require_torch
 @require_sigopt
 class TrainerHyperParameterSigOptIntegrationTest(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

As discussed offline, make `TrainerHyperParameterSigOptIntegrationTest`  a slow test.