### PR TITLE
Better error in the Auto API when a dep is missing

### DIFF
--- a/src/transformers/models/auto/feature_extraction_auto.py
+++ b/src/transformers/models/auto/feature_extraction_auto.py
@@ -84,6 +84,12 @@ def feature_extractor_class_from_name(class_name: str):
         if getattr(extractor, "__name__", None) == class_name:
             return extractor
 
+    # We did not fine the class, but maybe it's because a dep is missing. In that case, the class will be in the main
+    # init and we return the proper dummy to get an appropriate error message.
+    main_module = importlib.import_module("transformers")
+    if hasattr(main_module, class_name):
+        return getattr(main_module, class_name)
+
     return None
 
 

--- a/src/transformers/models/auto/processing_auto.py
+++ b/src/transformers/models/auto/processing_auto.py
@@ -74,6 +74,12 @@ def processor_class_from_name(class_name: str):
         if getattr(processor, "__name__", None) == class_name:
             return processor
 
+    # We did not fine the class, but maybe it's because a dep is missing. In that case, the class will be in the main
+    # init and we return the proper dummy to get an appropriate error message.
+    main_module = importlib.import_module("transformers")
+    if hasattr(main_module, class_name):
+        return getattr(main_module, class_name)
+
     return None
 
 

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -287,6 +287,12 @@ def tokenizer_class_from_name(class_name: str):
             if getattr(tokenizer, "__name__", None) == class_name:
                 return tokenizer
 
+    # We did not fine the class, but maybe it's because a dep is missing. In that case, the class will be in the main
+    # init and we return the proper dummy to get an appropriate error message.
+    main_module = importlib.import_module("transformers")
+    if hasattr(main_module, class_name):
+        return getattr(main_module, class_name)
+
     return None
 
 


### PR DESCRIPTION
# What does this PR do?

As reported in #17266, the error message when an auto API is used to load a class that can't be loaded because a dep is missing is not helpful (it actually got worse since #17250).

This PR addresses the problem by returning the associated dummy class when the right class can't be loaded, which means the subsequent call to `from_pretrained` fails with a helpful error message. For instance, the sample given in #17266 will now error with:
```
ConvNextFeatureExtractor requires the PIL library but it was not found in your environment. You can install it with pip:
`pip install pillow`
```

Fixes #17266