### PR TITLE
Fix dummy creation script

### DIFF
--- a/utils/check_dummies.py
+++ b/utils/check_dummies.py
@@ -26,7 +26,7 @@ PATH_TO_TRANSFORMERS = "src/transformers"
 _re_backend = re.compile(r"is\_([a-z_]*)_available()")
 # Matches from xxx import bla
 _re_single_line_import = re.compile(r"\s+from\s+\S*\s+import\s+([^\(\s].*)\n")
-_re_test_backend = re.compile(r"^\s+if\s+is\_[a-z]*\_available\(\)")
+_re_test_backend = re.compile(r"^\s+if\s+not\s+is\_[a-z]*\_available\(\)")
 
 
 DUMMY_CONSTANT = """
@@ -73,6 +73,8 @@ def read_init():
         # If the line is an if is_backend_available, we grab all objects associated.
         backend = find_backend(lines[line_index])
         if backend is not None:
+            while not lines[line_index].startswith("    else:"):
+                line_index += 1
             line_index += 1
 
             objects = []


### PR DESCRIPTION
# What does this PR do?

The `check_dummies` script was not adapted to the recent changes in the main init. As a result `make fix-copies` stopped creating dummy objects. By some miracle, none were missing, but this PR fixes the script (tested locally after adding new objects).