### PR TITLE
Support compilation via Torchdynamo, AOT Autograd, NVFuser

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -70,6 +70,7 @@ from .utils import (
     is_torch_tf32_available,
     is_torch_tpu_available,
     is_torchaudio_available,
+    is_torchdynamo_available,
     is_vision_available,
 )
 
@@ -462,6 +463,11 @@ if is_flax_available():
     jax_device = jax.default_backend()
 else:
     jax_device = None
+
+
+def require_torchdynamo(test_case):
+    """Decorator marking a test that requires TorchDynamo"""
+    return unittest.skipUnless(is_torchdynamo_available(), "test requires TorchDynamo")(test_case)
 
 
 def require_torch_gpu(test_case):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -34,7 +34,6 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Un
 
 from tqdm.auto import tqdm
 
-
 # Integrations must be imported before ML frameworks:
 from .integrations import (  # isort: split
     default_hp_search_backend,
@@ -2172,6 +2171,19 @@ class Trainer:
 
         return inputs
 
+    def torchdynamo_smart_context_manager(self):
+        """
+        A helper wrapper that creates an appropriate context manager for `torchdynamo`.
+        """
+        import torchdynamo
+        from torchdynamo.optimizations.training import aot_autograd_speedup_strategy
+
+        if self.args.use_torchdynamo:
+            ctx_manager = torchdynamo.optimize(aot_autograd_speedup_strategy)
+        else:
+            ctx_manager = contextlib.nullcontext()
+        return ctx_manager
+
     def autocast_smart_context_manager(self):
         """
         A helper wrapper that creates an appropriate context manager for `autocast` while feeding it the desired
@@ -2213,8 +2225,9 @@ class Trainer:
             loss_mb = smp_forward_backward(model, inputs, self.args.gradient_accumulation_steps, scaler=scaler)
             return loss_mb.reduce_mean().detach().to(self.args.device)
 
-        with self.autocast_smart_context_manager():
-            loss = self.compute_loss(model, inputs)
+        with self.torchdynamo_smart_context_manager():
+            with self.autocast_smart_context_manager():
+                loss = self.compute_loss(model, inputs)
 
         if self.args.n_gpu > 1:
             loss = loss.mean()  # mean() to average on multi-gpu parallel training
@@ -2907,8 +2920,9 @@ class Trainer:
                     logits = smp_nested_concat(logits_mb)
             else:
                 if has_labels:
-                    with self.autocast_smart_context_manager():
-                        loss, outputs = self.compute_loss(model, inputs, return_outputs=True)
+                    with self.torchdynamo_smart_context_manager():
+                        with self.autocast_smart_context_manager():
+                            loss, outputs = self.compute_loss(model, inputs, return_outputs=True)
                     loss = loss.mean().detach()
 
                     if isinstance(outputs, dict):
@@ -2917,8 +2931,9 @@ class Trainer:
                         logits = outputs[1:]
                 else:
                     loss = None
-                    with self.autocast_smart_context_manager():
-                        outputs = model(**inputs)
+                    with self.torchdynamo_smart_context_manager():
+                        with self.autocast_smart_context_manager():
+                            outputs = model(**inputs)
                     if isinstance(outputs, dict):
                         logits = tuple(v for k, v in outputs.items() if k not in ignore_keys)
                     else:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2198,8 +2198,6 @@ class Trainer:
                 ctx_manager = torchdynamo.optimize("eager")
             elif self.args.torchdynamo == "nvfuser":
                 ctx_manager = torchdynamo.optimize(aot_autograd_speedup_strategy)
-            elif self.args.torchdynamo is not None:
-                raise ValueError("torchdynamo training arg can be eager/nvfuser")
         return ctx_manager
 
     def autocast_smart_context_manager(self):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2198,8 +2198,8 @@ class Trainer:
                 ctx_manager = torchdynamo.optimize("eager")
             elif self.args.torchdynamo == "nvfuser":
                 ctx_manager = torchdynamo.optimize(aot_autograd_speedup_strategy)
-            else:
-                ctx_manager = contextlib.nullcontext()
+            elif self.args.torchdynamo is not None:
+                raise ValueError("torchdynamo training arg can be eager/nvfuser")
         return ctx_manager
 
     def autocast_smart_context_manager(self):

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -183,9 +183,8 @@ class Seq2SeqTrainer(Trainer):
             generated_tokens = self._pad_tensors_to_max_len(generated_tokens, gen_kwargs["max_length"])
 
         with torch.no_grad():
-            with self.torchdynamo_smart_context_manager():
-                with self.autocast_smart_context_manager():
-                    outputs = model(**inputs)
+            with self.compute_loss_context_manager():
+                outputs = model(**inputs)
             if has_labels:
                 if self.label_smoother is not None:
                     loss = self.label_smoother(outputs, inputs["labels"]).mean().detach()

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -183,8 +183,9 @@ class Seq2SeqTrainer(Trainer):
             generated_tokens = self._pad_tensors_to_max_len(generated_tokens, gen_kwargs["max_length"])
 
         with torch.no_grad():
-            with self.autocast_smart_context_manager():
-                outputs = model(**inputs)
+            with self.torchdynamo_smart_context_manager():
+                with self.autocast_smart_context_manager():
+                    outputs = model(**inputs)
             if has_labels:
                 if self.label_smoother is not None:
                     loss = self.label_smoother(outputs, inputs["labels"]).mean().detach()

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -450,6 +450,9 @@ class TrainingArguments:
         full_determinism (`bool`, *optional*, defaults to `False`)
             If `True`, [`enable_full_determinism`] is called instead of [`set_seed`] to ensure reproducible results in
             distributed training
+        use_torchdynamo ('bool`, `str`, defaults to `False`):
+            If `True`, TorchDynamo is called with AOT Autograd and nvfuser compiler to compile the appropriate portions
+            of the model.
     """
 
     output_dir: str = field(
@@ -879,6 +882,18 @@ class TrainingArguments:
                 "Whether to call enable_full_determinism instead of set_seed for reproducibility in distributed"
                 " training"
             )
+        },
+    )
+    use_torchdynamo: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether or not to use TorchDynamo. TorchDynamo is a Python level JIT compilers designed to make"
+                " unmodified PyTorch programs faster. TorchDynamo dynamically modifies the Python bytecode right"
+                " before its executed. It rewrites Python bytecode in order to extract sequences of PyTorch operations"
+                " and lift them up into Fx fraph. We can then pass these Fx graphs to other backend compilers. Here"
+                " we use AOT Autograd and nvfuser compiler."
+            ),
         },
     )
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -451,8 +451,8 @@ class TrainingArguments:
             If `True`, [`enable_full_determinism`] is called instead of [`set_seed`] to ensure reproducible results in
             distributed training
         torchdynamo (`str`, *optional*):
-            The token that is used to set the backend compiler for TorchDynamo. Possible choices are ["eager", "nvfuser].
-            This is an experimental API and subject to change.
+            The token that is used to set the backend compiler for TorchDynamo. Possible choices are ["eager",
+            "nvfuser]. This is an experimental API and subject to change.
     """
 
     output_dir: str = field(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -450,7 +450,7 @@ class TrainingArguments:
         full_determinism (`bool`, *optional*, defaults to `False`)
             If `True`, [`enable_full_determinism`] is called instead of [`set_seed`] to ensure reproducible results in
             distributed training
-        use_torchdynamo ('bool`, `str`, defaults to `False`):
+        torchdynamo (`str`, *optional*):
             If `True`, TorchDynamo is called with AOT Autograd and nvfuser compiler to compile the appropriate portions
             of the model.
     """
@@ -884,15 +884,16 @@ class TrainingArguments:
             )
         },
     )
-    use_torchdynamo: bool = field(
-        default=False,
+    torchdynamo: Optional[str] = field(
+        default=None,
         metadata={
             "help": (
-                "Whether or not to use TorchDynamo. TorchDynamo is a Python level JIT compilers designed to make"
+                "Whether or not to use TorchDynamo. TorchDynamo is a Python level JIT compiler designed to make"
                 " unmodified PyTorch programs faster. TorchDynamo dynamically modifies the Python bytecode right"
                 " before its executed. It rewrites Python bytecode in order to extract sequences of PyTorch operations"
-                " and lift them up into Fx fraph. We can then pass these Fx graphs to other backend compilers. Here"
-                " we use AOT Autograd and nvfuser compiler."
+                " and lift them up into Fx graph. We can then pass these Fx graphs to other backend compilers. There"
+                " are two options - eager and nvfuser. Eager defaults to pytorch eager and is useful for debugging."
+                " nvfuser path uses AOT Autograd and nvfuser compiler to optimize the models."
             ),
         },
     )

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -890,7 +890,7 @@ class TrainingArguments:
             "help": (
                 "Sets up the backend compiler for TorchDynamo. TorchDynamo is a Python level JIT compiler designed to"
                 " make unmodified PyTorch programs faster. TorchDynamo dynamically modifies the Python bytecode right"
-                " before its executed. It rewrites Python bytecode in order to extract sequences of PyTorch operations"
+                " before its executed. It rewrites Python bytecode to extract sequences of PyTorch operations"
                 " and lifts them up into Fx graph. We can then pass these Fx graphs to other backend compilers. There"
                 " are two options - eager and nvfuser. Eager defaults to pytorch eager and is useful for debugging."
                 " nvfuser path uses AOT Autograd and nvfuser compiler to optimize the models."

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -451,8 +451,8 @@ class TrainingArguments:
             If `True`, [`enable_full_determinism`] is called instead of [`set_seed`] to ensure reproducible results in
             distributed training
         torchdynamo (`str`, *optional*):
-            If `True`, TorchDynamo is called with AOT Autograd and nvfuser compiler to compile the appropriate portions
-            of the model.
+            The token that is used to set the backend compiler for TorchDynamo. Possible choices are ["eager", "nvfuser].
+            This is an experimental API and subject to change.
     """
 
     output_dir: str = field(
@@ -888,13 +888,14 @@ class TrainingArguments:
         default=None,
         metadata={
             "help": (
-                "Whether or not to use TorchDynamo. TorchDynamo is a Python level JIT compiler designed to make"
-                " unmodified PyTorch programs faster. TorchDynamo dynamically modifies the Python bytecode right"
+                "Sets up the backend compiler for TorchDynamo. TorchDynamo is a Python level JIT compiler designed to"
+                " make unmodified PyTorch programs faster. TorchDynamo dynamically modifies the Python bytecode right"
                 " before its executed. It rewrites Python bytecode in order to extract sequences of PyTorch operations"
-                " and lift them up into Fx graph. We can then pass these Fx graphs to other backend compilers. There"
+                " and lifts them up into Fx graph. We can then pass these Fx graphs to other backend compilers. There"
                 " are two options - eager and nvfuser. Eager defaults to pytorch eager and is useful for debugging."
                 " nvfuser path uses AOT Autograd and nvfuser compiler to optimize the models."
             ),
+            "choices": ["eager", "nvfuser"],
         },
     )
 

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -130,6 +130,7 @@ from .import_utils import (
     is_torch_tf32_available,
     is_torch_tpu_available,
     is_torchaudio_available,
+    is_torchdynamo_available,
     is_training_run_on_sagemaker,
     is_vision_available,
     requires_backends,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -377,12 +377,7 @@ def is_torch_tpu_available():
 
 
 def is_torchdynamo_available():
-    try:
-        import torchdynamo
-
-        return True
-    except ImportError:
-        return False
+    return importlib.util.find_spec("torchdynamo") is not None
 
 
 def is_datasets_available():

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -376,6 +376,15 @@ def is_torch_tpu_available():
     return importlib.util.find_spec("torch_xla.core.xla_model") is not None
 
 
+def is_torchdynamo_available():
+    try:
+        import torchdynamo
+
+        return True
+    except ImportError:
+        return False
+
+
 def is_datasets_available():
     return _datasets_available
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1598,7 +1598,6 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
     @require_torch_gpu
     @require_torchdynamo
     def test_torchdynamo_full_eval(self):
-        debug = 0
         n_gpus = get_gpu_count()
 
         bs = 8

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1595,14 +1595,15 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
         # perfect world: fp32_init/2 == fp16_eval
         self.assertAlmostEqual(fp16_eval, fp32_init / 2, delta=5_000)
 
-    @require_torch_gpu
+    @require_torch_non_multi_gpu
     @require_torchdynamo
     def test_torchdynamo_full_eval(self):
+        # torchdynamo at the moment doesn't support DP/DDP, therefore require a single gpu
         n_gpus = get_gpu_count()
 
         bs = 8
         eval_len = 16 * n_gpus
-        # make the params somewhat big so that there will be enough RAM consumed to be able to
+        # make the params are somewhat big so that there will be enough RAM consumed to be able to
         # measure things. We should get about 64KB for a+b in fp32
         a = torch.ones(1000, bs) + 0.001
         b = torch.ones(1000, bs) - 0.001
@@ -1624,9 +1625,10 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
         metrics = trainer.evaluate()
         self.assertAlmostEqual(metrics["eval_loss"], original_eval_loss)
 
-    @require_torch_gpu
+    @require_torch_non_multi_gpu
     @require_torchdynamo
     def test_torchdynamo_memory(self):
+        # torchdynamo at the moment doesn't support DP/DDP, therefore require a single gpu
         class CustomTrainer(Trainer):
             def compute_loss(self, model, inputs, return_outputs=False):
                 x = inputs["x"]


### PR DESCRIPTION
# What does this PR do?

Adding support for TorchDynamo compilation with AOT Autograd and nvfuser backends. Detailed context available at - https://github.com/huggingface/transformers/pull/17204

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


--------------------

## TODO:

setup pt-nightly CI to run the tests in this PR, instructions:

```
# install torch-nightly
conda install pytorch torchvision torchaudio cudatoolkit=11.3 -c pytorch-nightly

# install functorch (and reinstall after `git pull` later if need to sync up)
git clone https://github.com/pytorch/functorch
cd functorch
rm -rf build
pip install -e .[aot]

cd ..
git clone https://github.com/pytorch/torchdynamo
cd torchdynamo
pip install -r requirements.txt
python setup.py develop
```

@ydshieh is adding this in this PR: https://github.com/huggingface/transformers/pull/17335 in commit: https://github.com/huggingface/transformers/pull/17335/commits/52e7021c6a1c8e2b2f749c6ce8daf078c6785c3e
