### PR TITLE
[BC] Fixing usage of text pairs

### DIFF
--- a/src/transformers/pipelines/text_classification.py
+++ b/src/transformers/pipelines/text_classification.py
@@ -135,7 +135,7 @@ class TextClassificationPipeline(Pipeline):
         if isinstance(inputs, dict):
             return self.tokenizer(**inputs, return_tensors=return_tensors, **tokenizer_kwargs)
         elif isinstance(inputs, list) and len(inputs) == 1 and isinstance(inputs[0], list) and len(inputs[0]) == 2:
-            # Manual BC use case where passing list of list of list is understood a proper text pair.
+            # It used to be valid to use a list of list of list for text pairs, keeping this path for BC
             return self.tokenizer(
                 text=inputs[0][0], text_pair=inputs[0][1], return_tensors=return_tensors, **tokenizer_kwargs
             )

--- a/src/transformers/pipelines/text_classification.py
+++ b/src/transformers/pipelines/text_classification.py
@@ -94,8 +94,9 @@ class TextClassificationPipeline(Pipeline):
         Classify the text(s) given as inputs.
 
         Args:
-            args (`str` or `List[str]`):
-                One or several texts (or one list of prompts) to classify.
+            args (`str` or `List[str]` or `Dict[str]`, or `List[Dict[str]]`):
+                One or several texts to classify. In order to use text pairs for your classification, you can send a
+                dictionnary containing `{"text", "text_pair"}` keys, or a list of those.
             return_all_scores (`bool`, *optional*, defaults to `False`):
                 Whether to return scores for all labels.
             function_to_apply (`str`, *optional*, defaults to `"default"`):

--- a/src/transformers/pipelines/text_classification.py
+++ b/src/transformers/pipelines/text_classification.py
@@ -131,6 +131,19 @@ class TextClassificationPipeline(Pipeline):
 
     def preprocess(self, inputs, **tokenizer_kwargs) -> Dict[str, GenericTensor]:
         return_tensors = self.framework
+        if isinstance(inputs, dict):
+            return self.tokenizer(**inputs, return_tensors=return_tensors, **tokenizer_kwargs)
+        elif isinstance(inputs, list) and len(inputs) == 1 and isinstance(inputs[0], list) and len(inputs[0]) == 2:
+            # Manual BC use case where passing list of list of list is understood a proper text pair.
+            return self.tokenizer(
+                text=inputs[0][0], text_pair=inputs[0][1], return_tensors=return_tensors, **tokenizer_kwargs
+            )
+        elif isinstance(inputs, list):
+            # This is likely an invalid usage of the pipeline attempting to pass text pairs.
+            raise ValueError(
+                """The pipeline received invalid inputs, if you are trying to send text pairs, you can try to send a dictionnary {"text":
+"My text", "text_pair": "My pair"} in order to send a text pair"""
+            )
         return self.tokenizer(inputs, return_tensors=return_tensors, **tokenizer_kwargs)
 
     def _forward(self, model_inputs):

--- a/src/transformers/pipelines/text_classification.py
+++ b/src/transformers/pipelines/text_classification.py
@@ -142,8 +142,8 @@ class TextClassificationPipeline(Pipeline):
         elif isinstance(inputs, list):
             # This is likely an invalid usage of the pipeline attempting to pass text pairs.
             raise ValueError(
-                """The pipeline received invalid inputs, if you are trying to send text pairs, you can try to send a dictionnary {"text":
-"My text", "text_pair": "My pair"} in order to send a text pair"""
+                "The pipeline received invalid inputs, if you are trying to send text pairs, you can try to send a dictionnary "
+                '`{"text": "My text", "text_pair": "My pair"}` in order to send a text pair.'
             )
         return self.tokenizer(inputs, return_tensors=return_tensors, **tokenizer_kwargs)
 

--- a/src/transformers/pipelines/text_classification.py
+++ b/src/transformers/pipelines/text_classification.py
@@ -142,8 +142,8 @@ class TextClassificationPipeline(Pipeline):
         elif isinstance(inputs, list):
             # This is likely an invalid usage of the pipeline attempting to pass text pairs.
             raise ValueError(
-                "The pipeline received invalid inputs, if you are trying to send text pairs, you can try to send a dictionnary "
-                '`{"text": "My text", "text_pair": "My pair"}` in order to send a text pair.'
+                "The pipeline received invalid inputs, if you are trying to send text pairs, you can try to send a"
+                ' dictionnary `{"text": "My text", "text_pair": "My pair"}` in order to send a text pair.'
             )
         return self.tokenizer(inputs, return_tensors=return_tensors, **tokenizer_kwargs)
 

--- a/tests/pipelines/test_pipelines_text_classification.py
+++ b/tests/pipelines/test_pipelines_text_classification.py
@@ -105,7 +105,7 @@ class TextClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTestC
         # This might be used a text pair, but tokenizer + pipe interaction
         # makes it hard to understand that it's not using the pair properly
         # https://github.com/huggingface/transformers/issues/17305
-        # We disabled this usage instead since the output is bogus anyway.
+        # We disabled this usage instead as it was outputting wrong outputs.
         invalid_input = [["HuggingFace is in ", "Paris is in France"]]
         with self.assertRaises(ValueError):
             text_classifier(invalid_input)

--- a/tests/pipelines/test_pipelines_text_classification.py
+++ b/tests/pipelines/test_pipelines_text_classification.py
@@ -93,3 +93,28 @@ class TextClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTestC
         )
         self.assertTrue(outputs[0]["label"] in model.config.id2label.values())
         self.assertTrue(outputs[1]["label"] in model.config.id2label.values())
+
+        valid_inputs = {"text": "HuggingFace is in ", "text_pair": "Paris is in France"}
+        outputs = text_classifier(valid_inputs)
+        self.assertEqual(
+            nested_simplify(outputs),
+            {"label": ANY(str), "score": ANY(float)},
+        )
+        self.assertTrue(outputs["label"] in model.config.id2label.values())
+
+        # This might be used a text pair, but tokenizer + pipe interaction
+        # makes it hard to understand that it's not using the pair properly
+        # https://github.com/huggingface/transformers/issues/17305
+        # We disabled this usage instead since the output is bogus anyway.
+        invalid_input = [["HuggingFace is in ", "Paris is in France"]]
+        with self.assertRaises(ValueError):
+            text_classifier(invalid_input)
+
+        # This used to be valid for doing text pairs
+        # We're keeping it working because of backward compatibility
+        outputs = text_classifier([[["HuggingFace is in ", "Paris is in France"]]])
+        self.assertEqual(
+            nested_simplify(outputs),
+            [{"label": ANY(str), "score": ANY(float)}],
+        )
+        self.assertTrue(outputs[0]["label"] in model.config.id2label.values())


### PR DESCRIPTION
# This contains a BC please read full description
# What does this PR do?

The BC is actually preventing users from misusing the pipeline since
users could have been willing to send text pairs and the pipeline would
instead understand the thing as a batch returning bogus results.

The correct usage of text pairs is preserved in this PR even when that
makes the code clunky.

Adds support for `{"text":..,, "text_pair": ...}` inputs for both dataset
iteration and more explicit usage to pairs.

Fixes #17305



<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->