### PR TITLE
Fix metric calculation in examples and setup tests to run on multi-gpu for no_trainer scripts

### DIFF
--- a/examples/pytorch/image-classification/run_image_classification_no_trainer.py
+++ b/examples/pytorch/image-classification/run_image_classification_no_trainer.py
@@ -489,7 +489,7 @@ def main():
             predictions, references = accelerator.gather((predictions, batch["labels"]))
             # If we are in a multiprocess environment, the last batch has duplicates
             if accelerator.num_processes > 1:
-                if step == len(eval_dataloader):
+                if step == len(eval_dataloader) - 1:
                     predictions = predictions[: len(eval_dataloader.dataset) - samples_seen]
                     references = references[: len(eval_dataloader.dataset) - samples_seen]
                 else:

--- a/examples/pytorch/multiple-choice/run_swag_no_trainer.py
+++ b/examples/pytorch/multiple-choice/run_swag_no_trainer.py
@@ -574,7 +574,7 @@ def main():
             predictions, references = accelerator.gather((predictions, batch["labels"]))
             # If we are in a multiprocess environment, the last batch has duplicates
             if accelerator.num_processes > 1:
-                if step == len(eval_dataloader):
+                if step == len(eval_dataloader) - 1:
                     predictions = predictions[: len(eval_dataloader.dataset) - samples_seen]
                     references = references[: len(eval_dataloader.dataset) - samples_seen]
                 else:

--- a/examples/pytorch/semantic-segmentation/run_semantic_segmentation_no_trainer.py
+++ b/examples/pytorch/semantic-segmentation/run_semantic_segmentation_no_trainer.py
@@ -591,7 +591,7 @@ def main():
 
             # If we are in a multiprocess environment, the last batch has duplicates
             if accelerator.num_processes > 1:
-                if step == len(eval_dataloader):
+                if step == len(eval_dataloader) - 1:
                     predictions = predictions[: len(eval_dataloader.dataset) - samples_seen]
                     references = references[: len(eval_dataloader.dataset) - samples_seen]
                 else:

--- a/examples/pytorch/summarization/run_summarization_no_trainer.py
+++ b/examples/pytorch/summarization/run_summarization_no_trainer.py
@@ -310,7 +310,9 @@ def parse_args():
 
 def main():
     args = parse_args()
-
+    # Initialize the accelerator. We will let the accelerator handle device placement for us in this example.
+    # If we're using tracking, we also need to initialize it here and it will pick up all supported trackers in the environment
+    accelerator = Accelerator(log_with="all", logging_dir=args.output_dir) if args.with_tracking else Accelerator()
     if args.source_prefix is None and args.model_name_or_path in [
         "t5-small",
         "t5-base",
@@ -322,9 +324,6 @@ def main():
             "You're running a t5 model but didn't provide a source prefix, which is the expected, e.g. with "
             "`--source_prefix 'summarize: ' `"
         )
-    # Initialize the accelerator. We will let the accelerator handle device placement for us in this example.
-    # If we're using tracking, we also need to initialize it here and it will pick up all supported trackers in the environment
-    accelerator = Accelerator(log_with="all", logging_dir=args.output_dir) if args.with_tracking else Accelerator()
     # Make one log on every process with the configuration for debugging.
     logging.basicConfig(
         format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",

--- a/examples/pytorch/summarization/run_summarization_no_trainer.py
+++ b/examples/pytorch/summarization/run_summarization_no_trainer.py
@@ -678,7 +678,7 @@ def main():
                         decoded_preds = decoded_preds[: len(eval_dataloader.dataset) - samples_seen]
                         decoded_labels = decoded_labels[: len(eval_dataloader.dataset) - samples_seen]
                     else:
-                        samples_seen += decoded_labels.shape[0]
+                        samples_seen += len(decoded_labels)
 
                 metric.add_batch(
                     predictions=decoded_preds,

--- a/examples/pytorch/summarization/run_summarization_no_trainer.py
+++ b/examples/pytorch/summarization/run_summarization_no_trainer.py
@@ -675,7 +675,7 @@ def main():
                 decoded_preds, decoded_labels = postprocess_text(decoded_preds, decoded_labels)
                 # If we are in a multiprocess environment, the last batch has duplicates
                 if accelerator.num_processes > 1:
-                    if step == len(eval_dataloader):
+                    if step == len(eval_dataloader) - 1:
                         decoded_preds = decoded_preds[: len(eval_dataloader.dataset) - samples_seen]
                         decoded_labels = decoded_labels[: len(eval_dataloader.dataset) - samples_seen]
                     else:

--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -68,7 +68,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
         # Write Accelerate config, will pick up on CPU, GPU, and multi-GPU
         cls.configPath = tempfile.mkdtemp()
         write_basic_config(save_location=cls.configPath)
-        cls._launch_args = ["accelerate", f"--config_file {cls.configPath}", "launch"]
+        cls._launch_args = ["accelerate", "launch", "--config_file", cls.configPath]
 
     @classmethod
     def tearDownClass(cls):

--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -77,7 +77,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
     def test_run_glue_no_trainer(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
-            {self.examples_dir}/text-classification/run_glue_no_trainer.py
+            {self.examples_dir}/pytorch/text-classification/run_glue_no_trainer.py
             --model_name_or_path distilbert-base-uncased
             --output_dir {tmp_dir}
             --train_file ./tests/fixtures/tests_samples/MRPC/train.csv
@@ -102,7 +102,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
     def test_run_clm_no_trainer(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
-            run_clm_no_trainer.py
+            {self.examples_dir}/pytorch/language-modeling/run_clm_no_trainer.py
             --model_name_or_path distilgpt2
             --train_file ./tests/fixtures/sample_text.txt
             --validation_file ./tests/fixtures/sample_text.txt
@@ -128,7 +128,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
     def test_run_mlm_no_trainer(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
-            run_mlm_no_trainer.py
+            {self.examples_dir}/pytorch/language-modeling/run_mlm_no_trainer.py
             --model_name_or_path distilroberta-base
             --train_file ./tests/fixtures/sample_text.txt
             --validation_file ./tests/fixtures/sample_text.txt
@@ -150,7 +150,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
 
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
-            run_ner_no_trainer.py
+            {self.examples_dir}/pytorch/token-classification/run_ner_no_trainer.py
             --model_name_or_path bert-base-uncased
             --train_file tests/fixtures/tests_samples/conll/sample.json
             --validation_file tests/fixtures/tests_samples/conll/sample.json
@@ -174,7 +174,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
     def test_run_squad_no_trainer(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
-            run_qa_no_trainer.py
+            {self.examples_dir}/pytorch/question-answering/run_qa_no_trainer.py
             --model_name_or_path bert-base-uncased
             --version_2_with_negative
             --train_file tests/fixtures/tests_samples/SQUAD/sample.json
@@ -200,7 +200,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
     def test_run_swag_no_trainer(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
-            run_swag_no_trainer.py
+            {self.examples_dir}/pytorch/multiple-choice/run_swag_no_trainer.py
             --model_name_or_path bert-base-uncased
             --train_file tests/fixtures/tests_samples/swag/sample.json
             --validation_file tests/fixtures/tests_samples/swag/sample.json
@@ -222,7 +222,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
     def test_run_summarization_no_trainer(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
-            run_summarization_no_trainer.py
+            {self.examples_dir}/pytorch/summarization/run_summarization_no_trainer.py
             --model_name_or_path t5-small
             --train_file tests/fixtures/tests_samples/xsum/sample.json
             --validation_file tests/fixtures/tests_samples/xsum/sample.json
@@ -249,7 +249,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
     def test_run_translation_no_trainer(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
-            run_translation_no_trainer.py
+            {self.examples_dir}/pytorch/translation/run_translation_no_trainer.py
             --model_name_or_path sshleifer/student_marian_en_ro_6_1
             --source_lang en
             --target_lang ro
@@ -280,7 +280,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
 
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
-            run_semantic_segmentation_no_trainer.py
+            {self.examples_dir}/pytorch/semantic-segmentation/run_semantic_segmentation_no_trainer.py
             --dataset_name huggingface/semantic-segmentation-test-sample
             --output_dir {tmp_dir}
             --max_train_steps=10
@@ -298,7 +298,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
     def test_run_image_classification_no_trainer(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
-            run_image_classification_no_trainer.py
+            {self.examples_dir}/pytorch/image-classification/run_image_classification_no_trainer.py
             --dataset_name huggingface/image-classification-test-sample
             --output_dir {tmp_dir}
             --num_warmup_steps=8

--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -22,7 +22,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import subprocesses
+import subprocess
 from unittest.mock import patch
 
 import torch

--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -66,13 +66,14 @@ class ExamplesTestsNoTrainer(TestCasePlus):
     @classmethod
     def setUpClass(cls):
         # Write Accelerate config, will pick up on CPU, GPU, and multi-GPU
-        cls.configPath = tempfile.mkdtemp()
-        write_basic_config(save_location=f'{cls.configPath}/default_config.yml')
+        cls.tmpdir = tempfile.mkdtemp()
+        cls.configPath = os.path.join(cls.tmpdir, "default_config.yml")
+        write_basic_config(save_location=cls.configPath)
         cls._launch_args = ["accelerate", "launch", "--config_file", cls.configPath]
 
     @classmethod
     def tearDownClass(cls):
-        shutil.rmtree(cls.configPath)
+        shutil.rmtree(cls.tmpdir)
 
     def test_run_glue_no_trainer(self):
         tmp_dir = self.get_auto_remove_tmp_dir()

--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -68,7 +68,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
         # Write Accelerate config, will pick up on CPU, GPU, and multi-GPU
         cls.configPath = tempfile.mkdtemp()
         write_basic_config(save_location=cls.configPath)
-        cls._launch_args = ["accelerate", "launch", f"--config_file {cls.configPath}"]
+        cls._launch_args = ["accelerate", f"--config_file {cls.configPath}", "launch"]
 
     @classmethod
     def tearDownClass(cls):

--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -67,7 +67,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
     def setUpClass(cls):
         # Write Accelerate config, will pick up on CPU, GPU, and multi-GPU
         cls.configPath = tempfile.mkdtemp()
-        write_basic_config(save_location=cls.configPath)
+        write_basic_config(save_location=f'{cls.configPath}/default_config.yml')
         cls._launch_args = ["accelerate", "launch", "--config_file", cls.configPath]
 
     @classmethod

--- a/examples/pytorch/text-classification/run_glue_no_trainer.py
+++ b/examples/pytorch/text-classification/run_glue_no_trainer.py
@@ -528,7 +528,7 @@ def main():
             predictions, references = accelerator.gather((predictions, batch["labels"]))
             # If we are in a multiprocess environment, the last batch has duplicates
             if accelerator.num_processes > 1:
-                if step == len(eval_dataloader):
+                if step == len(eval_dataloader) - 1:
                     predictions = predictions[: len(eval_dataloader.dataset) - samples_seen]
                     references = references[: len(eval_dataloader.dataset) - samples_seen]
                 else:

--- a/examples/pytorch/token-classification/run_ner_no_trainer.py
+++ b/examples/pytorch/token-classification/run_ner_no_trainer.py
@@ -683,7 +683,7 @@ def main():
             predictions_gathered, labels_gathered = accelerator.gather((predictions, labels))
             # If we are in a multiprocess environment, the last batch has duplicates
             if accelerator.num_processes > 1:
-                if step == len(eval_dataloader):
+                if step == len(eval_dataloader) - 1:
                     predictions_gathered = predictions_gathered[: len(eval_dataloader.dataset) - samples_seen]
                     labels_gathered = labels_gathered[: len(eval_dataloader.dataset) - samples_seen]
                 else:

--- a/examples/pytorch/translation/run_translation_no_trainer.py
+++ b/examples/pytorch/translation/run_translation_no_trainer.py
@@ -665,7 +665,7 @@ def main():
                         decoded_preds = decoded_preds[: len(eval_dataloader.dataset) - samples_seen]
                         decoded_labels = decoded_labels[: len(eval_dataloader.dataset) - samples_seen]
                     else:
-                        samples_seen += decoded_labels.shape[0]
+                        samples_seen += len(decoded_labels)
 
                 metric.add_batch(predictions=decoded_preds, references=decoded_labels)
         eval_metric = metric.compute()

--- a/examples/pytorch/translation/run_translation_no_trainer.py
+++ b/examples/pytorch/translation/run_translation_no_trainer.py
@@ -661,7 +661,7 @@ def main():
 
                 # If we are in a multiprocess environment, the last batch has duplicates
                 if accelerator.num_processes > 1:
-                    if step == len(eval_dataloader):
+                    if step == len(eval_dataloader) - 1:
                         decoded_preds = decoded_preds[: len(eval_dataloader.dataset) - samples_seen]
                         decoded_labels = decoded_labels[: len(eval_dataloader.dataset) - samples_seen]
                     else:


### PR DESCRIPTION
# What does this PR do?

This PR fixes all failing tests in a multi-gpu setting for all `no_trainer` example scripts. This includes an issue with when the logger was called before `Accelerator()` was created, adjusting when the conditional to add to the `samples_seen`, and adjusting `samples_seen` to use the length when the labels are just a list instead of a torch tensor.

Because the tests were rewritten to use `accelerate launch` and the new `write_basic_config`, these tests will automatically allocate themselves properly to test on multigpu, gpu, or cpu depending on what environment is available

Fixes # (issue):

Closes https://github.com/huggingface/transformers/issues/17214, https://github.com/huggingface/transformers/issues/17200


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@sgugger 
