### PR TITLE
Fix ci_url might be None

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -741,14 +741,14 @@ if __name__ == "__main__":
     ci_title = os.environ.get("CI_TITLE")
     ci_url = os.environ.get("CI_COMMIT_URL")
 
-    commit_number = ci_url.split("/")[-1]
-    ci_detail_url = f"https://api.github.com/repos/huggingface/transformers/commits/{commit_number}"
-    ci_details = requests.get(ci_detail_url).json()
-    ci_author = ci_details["author"]["login"]
-
     if ci_title is not None:
         assert ci_url is not None
         ci_title = ci_title.strip().split("\n")[0].strip()
+
+        commit_number = ci_url.split("/")[-1]
+        ci_detail_url = f"https://api.github.com/repos/huggingface/transformers/commits/{commit_number}"
+        ci_details = requests.get(ci_detail_url).json()
+        ci_author = ci_details["author"]["login"]
 
         merged_by = None
         # Find the PR number (if any) and change the url to the actual PR page.

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -745,7 +745,7 @@ if __name__ == "__main__":
         assert ci_url is not None
         ci_title = ci_title.strip().split("\n")[0].strip()
 
-        # Retrieve the PR title and author login to complete the report 
+        # Retrieve the PR title and author login to complete the report
         commit_number = ci_url.split("/")[-1]
         ci_detail_url = f"https://api.github.com/repos/huggingface/transformers/commits/{commit_number}"
         ci_details = requests.get(ci_detail_url).json()

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -745,6 +745,7 @@ if __name__ == "__main__":
         assert ci_url is not None
         ci_title = ci_title.strip().split("\n")[0].strip()
 
+        # Retrieve the PR title and author login to complete the report 
         commit_number = ci_url.split("/")[-1]
         ci_detail_url = f"https://api.github.com/repos/huggingface/transformers/commits/{commit_number}"
         ci_details = requests.get(ci_detail_url).json()


### PR DESCRIPTION
# What does this PR do?

In `notification_service.py`, we have

```
    ci_url = os.environ.get("CI_COMMIT_URL")

    commit_number = ci_url.split("/")[-1]
```
but `ci_url` might be `None`, for example, for scheduled CI.

This PR moves the involved block inside 

```
    if ci_title is not None:
        assert ci_url is not None
```
(i.e. only for push CI)