### PR TITLE
Try to make push CI less noisy on commit pages.

### DIFF
--- a/.github/workflows/self-push-caller.yml
+++ b/.github/workflows/self-push-caller.yml
@@ -1,0 +1,29 @@
+name: Self-hosted runner (push-caller)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "tests/**"
+      - ".github/**"
+      - "templates/**"
+      - "utils/**"
+
+jobs:
+  run_push_ci:
+    name: Run Push CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout transformers
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+          ssh-key: "${{ secrets.COMMIT_KEY }}"
+
+      - name: Checkout to branch push-ci
+        # A more strict way to make sure`push-ci` is exactly the same as `main` at the push event commit.
+        run: |
+          git checkout -b push-ci
+          git push -u origin push-ci --force

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -3,7 +3,7 @@ name: Self-hosted runner (push)
 on:
   push:
     branches:
-      - main
+      - push-ci
       - ci_*
       - ci-*
     paths:


### PR DESCRIPTION
# What does this PR do?

Try to make push CI less noisy on commit pages.
(Current commit page shows all push CI jobs (more than 256 now) status, which is noisy to check which tests failed.)

### Idea

  1. push to `main` -> trigger a workflow, that push to another branch `push-ci`
  2. push to `push-ci` -> trigger the actual push CI
~~- **TODO**: try to get failures in `2`, and add them to `1`. Fail the job if there is any failure.~~

Example run
[caller workflow run] https://github.com/huggingface/transformers/actions/runs/2358695597
[actual push CI run] https://github.com/huggingface/transformers/actions/runs/2358698408

