### PR TITLE
Add FP16 Support for SageMaker Model Parallel

### DIFF
--- a/src/transformers/sagemaker/training_args_sm.py
+++ b/src/transformers/sagemaker/training_args_sm.py
@@ -55,6 +55,7 @@ def is_sagemaker_model_parallel_available():
 
 if is_sagemaker_model_parallel_available():
     import smdistributed.modelparallel.torch as smp
+    
     smp.init()
 
 

--- a/src/transformers/sagemaker/training_args_sm.py
+++ b/src/transformers/sagemaker/training_args_sm.py
@@ -55,7 +55,6 @@ def is_sagemaker_model_parallel_available():
 
 if is_sagemaker_model_parallel_available():
     import smdistributed.modelparallel.torch as smp
-
     smp.init()
 
 

--- a/src/transformers/sagemaker/training_args_sm.py
+++ b/src/transformers/sagemaker/training_args_sm.py
@@ -55,7 +55,7 @@ def is_sagemaker_model_parallel_available():
 
 if is_sagemaker_model_parallel_available():
     import smdistributed.modelparallel.torch as smp
-    
+
     smp.init()
 
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1590,6 +1590,7 @@ class Trainer:
                     # Gradient clipping
                     if args.max_grad_norm is not None and args.max_grad_norm > 0 and not self.deepspeed:
                         # deepspeed does its own clipping
+                        
                         if self.do_grad_scaling:
                             # Reduce gradients first for XLA
                             if is_torch_tpu_available():

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -502,14 +502,6 @@ class Trainer:
                     f"setting to {smp.state.cfg.fp16}"
                 )
                 args.fp16 = smp.state.cfg.fp16
-            
-
-        
-        # FP16 + model parallelism in SageMaker: need to provide fp16 to SM_HP_MP_PARAMETERS
-        if is_sagemaker_mp_enabled() and args.fp16 and not smp.state.cfg.fp16:
-            raise ValueError(
-                "Using FP16 with SageMaker Model Parallelism needx to have 'fp16: True' in SM_HP_MP_PARAMETERS"
-            )
 
         if args.fp16 or args.bf16:
             if self.fsdp is not None:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1590,7 +1590,7 @@ class Trainer:
                     # Gradient clipping
                     if args.max_grad_norm is not None and args.max_grad_norm > 0 and not self.deepspeed:
                         # deepspeed does its own clipping
-                        
+
                         if self.do_grad_scaling:
                             # Reduce gradients first for XLA
                             if is_torch_tpu_available():

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -498,7 +498,7 @@ class Trainer:
             if args.fp16 != smp.state.cfg.fp16:
                 logger.warning(
                     f"FP16 provided in SM_HP_MP_PARAMETERS is {smp.state.cfg.fp16},"
-                    f"but FP16 provided in trainer argument is {args.fp16}",
+                    f"but FP16 provided in trainer argument is {args.fp16},"
                     f"setting to {smp.state.cfg.fp16}"
                 )
                 args.fp16 = smp.state.cfg.fp16

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -1027,9 +1027,10 @@ if is_sagemaker_mp_enabled():
         loss = outputs["loss"] if isinstance(outputs, dict) else outputs[0]
         loss /= gradient_accumulation_steps
         if scaler is not None:
-            loss = scaler.scale(loss).squeeze()
-
-        model.backward(loss)
+            scaled_loss = scaler.scale(loss).squeeze()
+            model.backward(scaled_loss)
+        else:
+            model.backward(loss)
         return loss
 
     @smp.step()


### PR DESCRIPTION
# What does this PR do?
(This PR is still pending some changes/fixes)
This PR adds support for SageMaker Model Parallel with FP16.

- To Enable fp16 with SMMP, user needs to add `fp16: True` to `SM_HP_MP_PARAMETERS`, when there's mismatch between `SM_HP_MP_PARAMETERS` and trainer args, a warning log would be printed and `SM_HP_MP_PARAMETERS` will be used as truth.
- Only do `uncale_` for `pp_rank` 0 in the beginning, as `scaler._scale `would be None at first for `pp_rank` > 0.
- Added `clip_master_grads` for grad clipping
- Some minor fixes




## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

