### PR TITLE
fix layoutlmv2 doc page

### DIFF
--- a/docs/source/en/model_doc/layoutlmv2.mdx
+++ b/docs/source/en/model_doc/layoutlmv2.mdx
@@ -44,13 +44,15 @@ including FUNSD (0.7895 -> 0.8420), CORD (0.9493 -> 0.9601), SROIE (0.9524 -> 0.
 RVL-CDIP (0.9443 -> 0.9564), and DocVQA (0.7295 -> 0.8672). The pre-trained LayoutLMv2 model is publicly available at
 this https URL.*
 
-LayoutLMv2 depends on `detectron2`, `torchvision` and `tesseract`. Run the
-following to install them: 
+LayoutLMv2 depends on `detectron2`. Run the following to install it: 
 ```
 python -m pip install 'git+https://github.com/facebookresearch/detectron2.git'
+```
+If you wish to use the OCR feature, you should also install `torchvision` and `tesseract`:
+```
 python -m pip install torchvision tesseract
 ```
-(If you are developing for LayoutLMv2, note that passing the doctests also requires the installation of these packages.)
+(If you are developing for LayoutLMv2, note that passing the doctests and certain tests for LayoutLMv2 requires the installation of all three packages.)
 
 Tips:
 

--- a/docs/source/en/model_doc/layoutlmv2.mdx
+++ b/docs/source/en/model_doc/layoutlmv2.mdx
@@ -48,11 +48,11 @@ LayoutLMv2 depends on `detectron2`. Run the following to install it:
 ```
 python -m pip install 'git+https://github.com/facebookresearch/detectron2.git'
 ```
-If you wish to use the OCR feature, you should also install `torchvision` and `tesseract`:
+If you wish to use the OCR feature, you should also install `torchvision` and `pytesseract`:
 ```
-python -m pip install torchvision tesseract
+python -m pip install torchvision pytesseract
 ```
-(If you are developing for LayoutLMv2, note that passing the doctests and certain tests for LayoutLMv2 requires the installation of all three packages.)
+(If you are developing for LayoutLMv2, note that passing the doctests and certain tests for LayoutLMv2 requires the installation of all three packages, in addition to the installation of `datasets` and `torch`.)
 
 Tips:
 


### PR DESCRIPTION
# What does this PR do?

Quick follow up PR to #17168 to address @NielsRogge 's comments

Clarify that the `torchvision` and `tesseract` packages are optional dependencies for LayoutLMv2.

## Who can review?
@sgugger @NielsRogge 
