### PR TITLE
Add link to Hub PR docs in model cards

### DIFF
--- a/model_cards/README.md
+++ b/model_cards/README.md
@@ -15,11 +15,7 @@ You can either:
 
 **What if you want to create or update a model card for a model you don't have write access to?**
 
-In that case, given that we don't have a Pull request system yet on huggingface.co (🤯),
-you can open an issue here, post the card's content, and tag the model author(s) and/or the Hugging Face team.
-
-We might implement a more seamless process at some point, so your early feedback is precious!
-Please let us know of any suggestion.
+In that case, you can open a [Hub pull request](https://github.com/huggingface/hub-docs/blob/4befd62fb1f7502c9143ab228da538abb2de10e4/docs/hub/repositories-pull-requests-discussions.md)! Check out the [announcement](https://huggingface.co/blog/community-update) of this feature for more details 🤗.
 
 ### What happened to the model cards here?
 


### PR DESCRIPTION
# What does this PR do?

This PR update the model card guide to point to the new Hub PR feature. I couldn't find the docs on https://huggingface.co/docs/hub/main so decided to link to the raw file for now.
