### PR TITLE
Docker image build in parallel

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -3,7 +3,10 @@ name: Build docker images (scheduled)
 on:
   push:
     branches:
-      - test_docker_image_build_in_parallel
+      - docker-image*
+  repository_dispatch:
+  schedule:
+    - cron: "0 1 * * *"
 
 concurrency:
   group: docker-images-builds

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -3,10 +3,7 @@ name: Build docker images (scheduled)
 on:
   push:
     branches:
-      - docker-image*
-  repository_dispatch:
-  schedule:
-    - cron: "0 1 * * *"
+      - test_docker_image_build_in_parallel
 
 concurrency:
   group: docker-images-builds
@@ -41,7 +38,6 @@ jobs:
 
   latest-torch-deepspeed-docker:
     name: "Latest PyTorch + DeepSpeed"
-    needs: latest-docker
     runs-on: ubuntu-latest
     steps:
       -
@@ -93,7 +89,6 @@ jobs:
   latest-pytorch:
     name: "Latest PyTorch [dev]"
     runs-on: ubuntu-latest
-    needs: latest-torch-deepspeed-docker
     steps:
       -
         name: Set up Docker Buildx
@@ -118,7 +113,6 @@ jobs:
           tags: huggingface/transformers-pytorch-gpu
 
   latest-tensorflow:
-    needs: latest-pytorch
     name: "Latest TensorFlow [dev]"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -3,10 +3,7 @@ name: Build docker images (scheduled)
 on:
   push:
     branches:
-      - docker-image*
-  repository_dispatch:
-  schedule:
-    - cron: "0 1 * * *"
+      - test_docker_image_build_in_parallel
 
 concurrency:
   group: docker-images-builds


### PR DESCRIPTION
# What does this PR do?

Remove `needs` in `.github/workflows/build-docker-images.yml`, as it can run in parallel now.

See this [run page](https://github.com/huggingface/transformers/actions/runs/2389099113) v.s. the [previous run page](https://github.com/huggingface/transformers/actions/runs/2388105533), with 14 mins. v.s. 40 mins.