### PR TITLE
Pin protobouf that breaks TensorBoard in PyTorch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ _deps = [
     "packaging>=20.0",
     "parameterized",
     "phonemizer",
-    "protobuf",
+    "protobuf<=3.20.1",
     "psutil",
     "pyyaml>=5.1",
     "pydantic",
@@ -293,6 +293,7 @@ extras["testing"] = (
         "nltk",
         "GitPython",
         "hf-doc-builder",
+        "protobuf", # Can be removed once we can unpin protobuf
         "sacremoses",
         "rjieba"
     )

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -38,7 +38,7 @@ deps = {
     "packaging": "packaging>=20.0",
     "parameterized": "parameterized",
     "phonemizer": "phonemizer",
-    "protobuf": "protobuf",
+    "protobuf": "protobuf<=3.20.1",
     "psutil": "psutil",
     "pyyaml": "pyyaml>=5.1",
     "pydantic": "pydantic",


### PR DESCRIPTION
# What does this PR do?

The recent release of Protobuf (4.21) has broken TensorBoard in PyTorch and thus multiple tests. This PR pins protobuf to fix said tests.