### PR TITLE
[WIP] Warning when passing padded input ids but no attention mask

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1027,9 +1027,15 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # Both cases look the same for `input_ids`, but one is correct behavior, the other one incorrect.
             # In this case, we should still throw a warning because most models don't have
             # <pad> == EOS or <pad> == BOS or <pad> == SEP.
-            is_pad_token_equal_to_bos_token = self.config.bos_token_id is not None and self.config.bos_token_id == self.config.pad_token_id
-            is_pad_token_equal_to_eos_token = self.config.eos_token_id is not None and self.config.eos_token_id == self.config.pad_token_id
-            is_pad_token_equal_to_sep_token = self.config.sep_token_id is not None and self.config.sep_token_id == self.config.pad_token_id
+            is_pad_token_equal_to_bos_token = (
+                self.config.bos_token_id is not None and self.config.bos_token_id == self.config.pad_token_id
+            )
+            is_pad_token_equal_to_eos_token = (
+                self.config.eos_token_id is not None and self.config.eos_token_id == self.config.pad_token_id
+            )
+            is_pad_token_equal_to_sep_token = (
+                self.config.sep_token_id is not None and self.config.sep_token_id == self.config.pad_token_id
+            )
 
             warn_string = (
                 f"The input IDs {input_ids} contains the `pad_token_id` {self.config.pad_token_id}, "
@@ -1038,21 +1044,24 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
             if is_pad_token_equal_to_bos_token:
                 warn_string += (
-                    "\nWe strongly recommend passing an `attention_mask` to avoid possibly incorrectly computing the attention weights. "
-                    f"\nYou can ignore this warning, if your `pad_token_id` {self.config.pad_token_id} is "
-                    f"identical to your `bos_token_id` {self.config.bos_token_id} AND your input is NOT padded."
+                    "\nWe strongly recommend passing an `attention_mask` to avoid possibly incorrectly computing the"
+                    " attention weights. \nYou can ignore this warning, if your `pad_token_id`"
+                    f" {self.config.pad_token_id} is identical to your `bos_token_id` {self.config.bos_token_id} AND"
+                    " your input is NOT padded."
                 )
             if is_pad_token_equal_to_eos_token:
                 warn_string += (
-                    "\nWe strongly recommend passing an `attention_mask` to avoid possibly incorrectly computing the attention weights. "
-                    f"\nYou can ignore this warning, if your `pad_token_id` {self.config.pad_token_id} is "
-                    f"identical to your `eos_token_id` {self.config.eos_token_id} AND your input is NOT padded."
+                    "\nWe strongly recommend passing an `attention_mask` to avoid possibly incorrectly computing the"
+                    " attention weights. \nYou can ignore this warning, if your `pad_token_id`"
+                    f" {self.config.pad_token_id} is identical to your `eos_token_id` {self.config.eos_token_id} AND"
+                    " your input is NOT padded."
                 )
             if is_pad_token_equal_to_sep_token:
                 warn_string += (
-                    "\nWe strongly recommend passing an `attention_mask` to avoid possibly incorrectly computing the attention weights. "
-                    f"\nYou can ignore this warning, if your `pad_token_id` {self.config.pad_token_id} is "
-                    f"identical to your `sep_token_id` {self.config.sep_token_id} AND your input is NOT padded."
+                    "\nWe strongly recommend passing an `attention_mask` to avoid possibly incorrectly computing the"
+                    " attention weights. \nYou can ignore this warning, if your `pad_token_id`"
+                    f" {self.config.pad_token_id} is identical to your `sep_token_id` {self.config.sep_token_id} AND"
+                    " your input is NOT padded."
                 )
             if not (is_pad_token_equal_to_bos_token or is_pad_token_equal_to_eos_token):
                 warn_string += (

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1026,9 +1026,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # and in right padding both <pad> and EOS could be in the end.
             # Both cases look the same for `input_ids`, but one is correct behavior, the other one incorrect.
             # In this case, we should still throw a warning because most models don't have
-            # <pad> == EOS or <pad> == BOS.
+            # <pad> == EOS or <pad> == BOS or <pad> == SEP.
             is_pad_token_equal_to_bos_token = self.config.bos_token_id is not None and self.config.bos_token_id == self.config.pad_token_id
             is_pad_token_equal_to_eos_token = self.config.eos_token_id is not None and self.config.eos_token_id == self.config.pad_token_id
+            is_pad_token_equal_to_sep_token = self.config.sep_token_id is not None and self.config.sep_token_id == self.config.pad_token_id
 
             warn_string = (
                 f"The input IDs {input_ids} contains the `pad_token_id` {self.config.pad_token_id}, "
@@ -1046,6 +1047,12 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     "\nWe strongly recommend passing an `attention_mask` to avoid possibly incorrectly computing the attention weights. "
                     f"\nYou can ignore this warning, if your `pad_token_id` {self.config.pad_token_id} is "
                     f"identical to your `eos_token_id` {self.config.eos_token_id} AND your input is NOT padded."
+                )
+            if is_pad_token_equal_to_sep_token:
+                warn_string += (
+                    "\nWe strongly recommend passing an `attention_mask` to avoid possibly incorrectly computing the attention weights. "
+                    f"\nYou can ignore this warning, if your `pad_token_id` {self.config.pad_token_id} is "
+                    f"identical to your `sep_token_id` {self.config.sep_token_id} AND your input is NOT padded."
                 )
             if not (is_pad_token_equal_to_bos_token or is_pad_token_equal_to_eos_token):
                 warn_string += (

--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -964,6 +964,7 @@ class BertModel(BertPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
+            self.warn_if_pad_token_in_input_ids_no_attention_mask(input_ids, attention_mask)
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

One of the most common mistake users make in Transformers IMO is that `input_ids` are padded, but no `attention_mask` is provided (we see many examples of this). As discussed multiple times, we **don't** want to infer the `attention_mask` automatically as this creates a lot of unmaintainable, "not-possible-to-deal-with" complexity.

A while ago, we discussed to throw a warning in this case, making sure it's done only once to not spam the user when calling the model multiple times. I'm not sure we found a good conclusion, but IMO it's important that we warn the user as too users (IMO) think the attention_mask is inferred from the padding tokens. This PR is tries to solve this and shows how it'd be implemented for just BERT. We would have to implement it for all other models then as well. Would very much like to hear your opinion here @sgugger @LysandreJik @patil-suraj  . Note that this PR will touch a lot of important functions / files, so it'd be very important to make the warning as clear as possible. 
I do however have a strong conviction that we should display such a warning.

No the warning function can display the following warning messages for a toy BERT example of passing just three input ids.

Possible warning messages:

1. Pad token present, no attention mask, eos, bos, sep all different from pad (that's **VERY** likely an error IMO):

**Displayed warning:**
```
The input IDs tensor([[0, 1, 1]]) contains the `pad_token_id` 0, but NO `attention_mask` is passed.
Padding the input IDs without passing an `attention_mask` leads to unexpected, possibly incorrect outputs.
```

2. Pad token present, no attention mask, eos or bos or sep same as pad:

**Displayed warning:**
```
The input IDs tensor([[0, 1, 1]]) contains the `pad_token_id` 0, but NO `attention_mask` is passed.
We strongly recommend passing an `attention_mask` to avoid possibly incorrectly computing the attention weights. 
You can ignore this warning, if your `pad_token_id` 0 is identical to your `sep_token_id` 0 AND your input is NOT padded.
```

3. Pad token present, no attention mask, two or more of eos, bos, sep identical to pad (don't think this exists actually):

**Displayed warning:**
```
The input IDs tensor([[0, 1, 1]]) contains the `pad_token_id` 0, but NO `attention_mask` is passed.
We strongly recommend passing an `attention_mask` to avoid possibly incorrectly computing the attention weights. 
You can ignore this warning, if your `pad_token_id` 0 is identical to your `bos_token_id` 0 AND your input is NOT padded.
We strongly recommend passing an `attention_mask` to avoid possibly incorrectly computing the attention weights. 
You can ignore this warning, if your `pad_token_id` 0 is identical to your `sep_token_id` 0 AND your input is NOT padded.
```

4. Otherwise no warning.

Also note that the warning only appears at the first forward call.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
