### PR TITLE
Exclude Databricks from notebook env

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -460,6 +460,8 @@ def is_in_notebook():
             raise ImportError("console")
         if "VSCODE_PID" in os.environ:
             raise ImportError("vscode")
+        if "DATABRICKS_RUNTIME_VERSION" in os.environ:
+            raise ImportError("databricks")
 
         return importlib.util.find_spec("IPython") is not None
     except (AttributeError, ImportError, KeyError):


### PR DESCRIPTION
# What does this PR do?

This PR makes sures `is_in_notebook()` returns `False` when inside Databricks.
Fixes #17406 