### PR TITLE
support ONNX export of XDropout in deberta{,_v2} and sew_d

### DIFF
--- a/src/transformers/models/deberta/modeling_deberta.py
+++ b/src/transformers/models/deberta/modeling_deberta.py
@@ -182,6 +182,21 @@ class XDropout(torch.autograd.Function):
         else:
             return grad_output, None
 
+    @staticmethod
+    def symbolic(g: torch._C.Graph, input: torch._C.Value, local_ctx: Union[float, DropoutContext]) -> torch._C.Value:
+      dropout_p = local_ctx
+      if isinstance(local_ctx, DropoutContext):
+        dropout_p = local_ctx.dropout
+      # StableDropout only calls this function when training.
+      train = True
+      # TODO: We should check if the opset_version being used to export
+      # is > 12 here, but there's no good way to do that. As-is, if the
+      # opset_version < 12, export will fail with a CheckerError.
+      # Once https://github.com/pytorch/pytorch/issues/78391 is fixed, do something like:
+      # if opset_version < 12:
+      #   return torch.onnx.symbolic_opset9.dropout(g, input, dropout_p, train)
+      return torch.onnx.symbolic_opset12.dropout(g, input, dropout_p, train)
+
 
 class StableDropout(nn.Module):
     """

--- a/src/transformers/models/deberta/modeling_deberta.py
+++ b/src/transformers/models/deberta/modeling_deberta.py
@@ -184,18 +184,18 @@ class XDropout(torch.autograd.Function):
 
     @staticmethod
     def symbolic(g: torch._C.Graph, input: torch._C.Value, local_ctx: Union[float, DropoutContext]) -> torch._C.Value:
-      dropout_p = local_ctx
-      if isinstance(local_ctx, DropoutContext):
-        dropout_p = local_ctx.dropout
-      # StableDropout only calls this function when training.
-      train = True
-      # TODO: We should check if the opset_version being used to export
-      # is > 12 here, but there's no good way to do that. As-is, if the
-      # opset_version < 12, export will fail with a CheckerError.
-      # Once https://github.com/pytorch/pytorch/issues/78391 is fixed, do something like:
-      # if opset_version < 12:
-      #   return torch.onnx.symbolic_opset9.dropout(g, input, dropout_p, train)
-      return torch.onnx.symbolic_opset12.dropout(g, input, dropout_p, train)
+        dropout_p = local_ctx
+        if isinstance(local_ctx, DropoutContext):
+            dropout_p = local_ctx.dropout
+        # StableDropout only calls this function when training.
+        train = True
+        # TODO: We should check if the opset_version being used to export
+        # is > 12 here, but there's no good way to do that. As-is, if the
+        # opset_version < 12, export will fail with a CheckerError.
+        # Once https://github.com/pytorch/pytorch/issues/78391 is fixed, do something like:
+        # if opset_version < 12:
+        #   return torch.onnx.symbolic_opset9.dropout(g, input, dropout_p, train)
+        return torch.onnx.symbolic_opset12.dropout(g, input, dropout_p, train)
 
 
 class StableDropout(nn.Module):

--- a/src/transformers/models/deberta_v2/modeling_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_deberta_v2.py
@@ -190,18 +190,18 @@ class XDropout(torch.autograd.Function):
 
     @staticmethod
     def symbolic(g: torch._C.Graph, input: torch._C.Value, local_ctx: Union[float, DropoutContext]) -> torch._C.Value:
-      dropout_p = local_ctx
-      if isinstance(local_ctx, DropoutContext):
-        dropout_p = local_ctx.dropout
-      # StableDropout only calls this function when training.
-      train = True
-      # TODO: We should check if the opset_version being used to export
-      # is > 12 here, but there's no good way to do that. As-is, if the
-      # opset_version < 12, export will fail with a CheckerError.
-      # Once https://github.com/pytorch/pytorch/issues/78391 is fixed, do something like:
-      # if opset_version < 12:
-      #   return torch.onnx.symbolic_opset9.dropout(g, input, dropout_p, train)
-      return torch.onnx.symbolic_opset12.dropout(g, input, dropout_p, train)
+        dropout_p = local_ctx
+        if isinstance(local_ctx, DropoutContext):
+            dropout_p = local_ctx.dropout
+        # StableDropout only calls this function when training.
+        train = True
+        # TODO: We should check if the opset_version being used to export
+        # is > 12 here, but there's no good way to do that. As-is, if the
+        # opset_version < 12, export will fail with a CheckerError.
+        # Once https://github.com/pytorch/pytorch/issues/78391 is fixed, do something like:
+        # if opset_version < 12:
+        #   return torch.onnx.symbolic_opset9.dropout(g, input, dropout_p, train)
+        return torch.onnx.symbolic_opset12.dropout(g, input, dropout_p, train)
 
 
 # Copied from transformers.models.deberta.modeling_deberta.StableDropout

--- a/src/transformers/models/deberta_v2/modeling_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_deberta_v2.py
@@ -188,6 +188,21 @@ class XDropout(torch.autograd.Function):
         else:
             return grad_output, None
 
+    @staticmethod
+    def symbolic(g: torch._C.Graph, input: torch._C.Value, local_ctx: Union[float, DropoutContext]) -> torch._C.Value:
+      dropout_p = local_ctx
+      if isinstance(local_ctx, DropoutContext):
+        dropout_p = local_ctx.dropout
+      # StableDropout only calls this function when training.
+      train = True
+      # TODO: We should check if the opset_version being used to export
+      # is > 12 here, but there's no good way to do that. As-is, if the
+      # opset_version < 12, export will fail with a CheckerError.
+      # Once https://github.com/pytorch/pytorch/issues/78391 is fixed, do something like:
+      # if opset_version < 12:
+      #   return torch.onnx.symbolic_opset9.dropout(g, input, dropout_p, train)
+      return torch.onnx.symbolic_opset12.dropout(g, input, dropout_p, train)
+
 
 # Copied from transformers.models.deberta.modeling_deberta.StableDropout
 class StableDropout(nn.Module):

--- a/src/transformers/models/sew_d/modeling_sew_d.py
+++ b/src/transformers/models/sew_d/modeling_sew_d.py
@@ -593,6 +593,21 @@ class XDropout(torch.autograd.Function):
         else:
             return grad_output, None
 
+    @staticmethod
+    def symbolic(g: torch._C.Graph, input: torch._C.Value, local_ctx: Union[float, DropoutContext]) -> torch._C.Value:
+        dropout_p = local_ctx
+        if isinstance(local_ctx, DropoutContext):
+            dropout_p = local_ctx.dropout
+        # StableDropout only calls this function when training.
+        train = True
+        # TODO: We should check if the opset_version being used to export
+        # is > 12 here, but there's no good way to do that. As-is, if the
+        # opset_version < 12, export will fail with a CheckerError.
+        # Once https://github.com/pytorch/pytorch/issues/78391 is fixed, do something like:
+        # if opset_version < 12:
+        #   return torch.onnx.symbolic_opset9.dropout(g, input, dropout_p, train)
+        return torch.onnx.symbolic_opset12.dropout(g, input, dropout_p, train)
+
 
 # Copied from transformers.models.deberta.modeling_deberta.StableDropout
 class StableDropout(nn.Module):

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
@@ -21,6 +22,11 @@ from transformers.testing_utils import require_onnx, require_rjieba, require_tf,
 
 if is_torch_available() or is_tf_available():
     from transformers.onnx.features import FeaturesManager
+
+if is_torch_available():
+    import torch
+
+    from transformers.models.deberta import modeling_deberta
 
 
 @require_onnx
@@ -339,19 +345,13 @@ class OnnxExportTestCaseV2(TestCase):
         self._onnx_export(test_name, name, model_name, feature, onnx_config_class_constructor)
 
 
-class LayerTestCase(TestCase):
-    """Tests export of specific Layers / Modules."""
+class StableDropoutTestCase(TestCase):
+    """Tests export of StableDropout module."""
 
     @require_torch
     @pytest.mark.filterwarnings("ignore:.*Dropout.*:UserWarning:torch.onnx.*")  # torch.onnx is spammy.
-    def test_StableDropout(self):
+    def test_training(self):
         """Tests export of StableDropout in training mode."""
-        import os
-
-        import torch
-
-        from transformers.models.deberta import modeling_deberta
-
         devnull = open(os.devnull, "wb")
         # drop_prob must be > 0 for the test to be meaningful
         sd = modeling_deberta.StableDropout(0.1)

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -346,8 +346,10 @@ class LayerTestCase(TestCase):
     def test_StableDropout(self):
         """Tests export of StableDropout in training mode."""
         import os
-        import torch
         import warnings
+
+        import torch
+
         from transformers.models.deberta import modeling_deberta
 
         devnull = open(os.devnull, "wb")


### PR DESCRIPTION
# What does this PR do?

Enables `torch.onnx.export` of the `StableDropout` module in training mode.
In training mode, the `XDropout` torch.autograd.Function is included. This change
adds a `symbolic` function to `XDropout` which produces an ONNX graph that
is equivalent to the `forward` function.


## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
No. LMK if you want me to open an issue.

- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).

No, LMK if there's some doc that I should update.

- [x] Did you write any new necessary tests?

## Who can review?

@LysandreJik
