### PR TITLE
Fix `TFRemBertModelTest.test_resize_token_embeddings`

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1465,9 +1465,14 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             ones.
         """
         new_lm_head_decoder = old_lm_head_decoder
-        is_input_output_equals = tf.reduce_any(
-            self._get_word_embedding_weight(self.get_input_embeddings()) == old_lm_head_decoder
-        )
+
+        input_embeddings = self.get_input_embeddings()
+        word_embedding = self._get_word_embedding_weight(input_embeddings)
+        is_input_output_equals = False
+        is_shape_equal = word_embedding.shape == old_lm_head_decoder.shape
+        if is_shape_equal:
+            is_input_output_equals = word_embedding == old_lm_head_decoder
+            is_input_output_equals = tf.reduce_any(is_input_output_equals)
 
         if old_lm_head_decoder is not None and not is_input_output_equals:
             old_embedding_dim = shape_list(old_lm_head_decoder)[1]


### PR DESCRIPTION
# What does this PR do?

Fix `TFRemBertModelTest.test_resize_token_embeddings`.

This method

https://github.com/huggingface/transformers/blob/028d4b7c8be2c2fc1146fcc1e9bd253c1a7ea346/src/transformers/modeling_tf_utils.py#L1449

assumes that `word_embedding_weight` has the same shape as `old_lm_head_decoder`, but this is not the case for `TFRemBertModel`, as it has `input_embedding_size` and `output_embedding_size` in config.

This PR checks the shape before checking the values. If shape is not equal, it means the input/output are not equal.

Fix the CI failure [here](https://github.com/huggingface/transformers/runs/6682139350?check_suite_focus=true)