### PR TITLE
Fix  when Accelerate is not installed

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2394,7 +2394,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 del state_dict
                 gc.collect()
 
-            save_offload_index(offload_index, offload_folder)
+            if offload_index is not None and len(offload_index) > 0:
+                save_offload_index(offload_index, offload_folder)
 
             if offload_state_dict:
                 # Load back temporarily offloaded state dict


### PR DESCRIPTION
# What does this PR do?

As pointed out in #17516, the current `from_pretrained` on the main branch tries to use a function in Accelerate even if it's not necessary. This PR adds a check on the offloading (which requires Accelerate and is enforced at [this line](https://github.com/huggingface/transformers/blob/58fb3c9f98877bf76efb03e376a5c92cf80f7952/src/transformers/modeling_utils.py#L1847) since it requires a `device_map`) before using that function.

Fixes #17516