### PR TITLE
Clean README in post release job as well.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ To create the package for pypi.
 
 10. Copy the release notes from RELEASE.md to the tag in github once everything is looking hunky-dory.
 
-11. Run `make post-release` (or, for a patch release, `make post-patch`). If you were on a branch for the release,
+11. Run `make post-release` then run `make fix-copies`. If you were on a branch for the release,
     you need to go back to main before executing this.
 """
 

--- a/utils/release.py
+++ b/utils/release.py
@@ -123,7 +123,7 @@ def pre_release_work(patch=False):
     print(f"Updating version to {version}.")
     global_version_update(version, patch=patch)
     if not patch:
-        print("Cleaning main README")
+        print("Cleaning main README, don't forget to run `make fix-copies`.")
         clean_main_ref_in_model_list()
 
 
@@ -141,6 +141,8 @@ def post_release_work():
 
     print(f"Updating version to {version}.")
     global_version_update(version)
+    print("Cleaning main README, don't forget to run `make fix-copies`.")
+    clean_main_ref_in_model_list()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# What does this PR do?

The README cleanup (removing the main in the links to the doc) hasn't been done in the past releases because we do them on branches (so it has been done, but not on main). This PR redoes the cleanup in the `post-release` job (which is always done on main) and updates the instruction in the setup (no need to run `make post-patch` anymore but the post-release job will change the README so `make fix-copies` is necessary).