### PR TITLE
Update index.mdx

### DIFF
--- a/docs/source/en/index.mdx
+++ b/docs/source/en/index.mdx
@@ -28,7 +28,7 @@ Each 🤗 Transformers architecture is defined in a standalone Python module so 
 ## If you are looking for custom support from the Hugging Face team
 
 <a target="_blank" href="https://huggingface.co/support">
-    <img alt="HuggingFace Expert Acceleration Program" src="https://cdn-media.huggingface.co/marketing/transformers/new-support-improved.png" style="max-width: 600px; border: 1px solid #eee; border-radius: 4px; box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);">
+<img alt="HuggingFace Expert Acceleration Program" src="https://cdn-media.huggingface.co/marketing/transformers/new-support-improved.png" style="max-width: 600px; border: 1px solid #eee; border-radius: 4px; box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);">
 </a><br>
 
 ## Contents


### PR DESCRIPTION
# What does this PR do?
![Screen Shot 2022-06-03 at 2 57 06 PM](https://user-images.githubusercontent.com/5594118/171920956-28640a8b-4234-4efc-b9cf-2e692c0feb9a.png)

This removes the extra space in front of the new /support image. Thank you for the suggestion @sgugger ! 

Got too excited to merge the previous image update and missed this housekeeping fix. 