### PR TITLE
[deepspeed / testing] reset global state

### DIFF
--- a/src/transformers/deepspeed.py
+++ b/src/transformers/deepspeed.py
@@ -295,6 +295,12 @@ def set_hf_deepspeed_config(hf_deepspeed_config_obj):
     _hf_deepspeed_config_weak_ref = weakref.ref(hf_deepspeed_config_obj)
 
 
+def unset_hf_deepspeed_config():
+    # useful for unit tests to ensure the global state doesn't leak - call from `tearDown` method
+    global _hf_deepspeed_config_weak_ref
+    _hf_deepspeed_config_weak_ref = None
+
+
 def is_deepspeed_zero3_enabled():
     if _hf_deepspeed_config_weak_ref is not None and _hf_deepspeed_config_weak_ref() is not None:
         return _hf_deepspeed_config_weak_ref().is_zero3()


### PR DESCRIPTION
This PR:
- adds a reset to the global state at the end of each in-pytest deepspeed test (and API to do that)
- fixes `test_load_best_model_zero2_fp16` to run the trainingargs first to get the ds config state right

cc: @ydshieh, who discovered the issues on CI

@sgugger 