### PR TITLE
Fixes the LevitIntegrationTest

### DIFF
--- a/tests/models/levit/test_modeling_levit.py
+++ b/tests/models/levit/test_modeling_levit.py
@@ -418,6 +418,6 @@ class LevitModelIntegrationTest(unittest.TestCase):
         expected_shape = torch.Size((1, 1000))
         self.assertEqual(outputs.logits.shape, expected_shape)
 
-        expected_slice = torch.tensor([0.0096, -1.0084, -1.4318]).to(torch_device)
+        expected_slice = torch.tensor([1.0448, -0.3745, -1.8317]).to(torch_device)
 
         self.assertTrue(torch.allclose(outputs.logits[0, :3], expected_slice, atol=1e-4))


### PR DESCRIPTION
There was a mismatch of logits which wasn't corrected. It's done now. 
@NielsRogge 