### PR TITLE
Spanish Docs - fix gendered sentence

### DIFF
--- a/docs/source/es/index.mdx
+++ b/docs/source/es/index.mdx
@@ -35,7 +35,7 @@ Cada arquitectura de 🤗 Transformers se define en un módulo de Python indepen
 La documentación está organizada en cuatro partes:
 
 - **EMPEZAR** contiene un recorrido rápido e instrucciones de instalación para comenzar a usar 🤗 Transformers.
-- **TUTORIALES** son un excelente lugar para comenzar si eres nuevo en nuestra biblioteca. Esta sección te ayudará a obtener las habilidades básicas que necesitas para comenzar a usar 🤗 Transformers.
+- **TUTORIALES** es un excelente lugar para comenzar. Esta sección te ayudará a obtener las habilidades básicas que necesitas para comenzar a usar 🤗 Transformers.
 - **GUÍAS PRÁCTICAS** te mostrará cómo lograr un objetivo específico, cómo hacer fine-tuning a un modelo preentrenado para el modelado de lenguaje o cómo crear un cabezal para un modelo personalizado.
 - **GUÍAS CONCEPTUALES** proporciona más discusión y explicación de los conceptos e ideas subyacentes detrás de los modelos, las tareas y la filosofía de diseño de 🤗 Transformers. 
 


### PR DESCRIPTION
# What does this PR do?
Fixes a gendered sentence in [es/index.mdx](https://github.com/huggingface/transformers/blob/main/docs/source/es/index.mdx).

## Notes
FYI @osanseviero, I believe this was the sentence that was still gendered in the Spanish docs :)