### PR TITLE
[generate] return past_key_values

### DIFF
--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -1700,7 +1700,7 @@ class GenerationMixin:
         )
 
         use_cache = model_kwargs.get("use_cache")
-        output_past_key_values = use_cache if use_cache is not None else self.config.use_cache
+        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate if return_dict_in_generate is not None else self.config.return_dict_in_generate
         )
@@ -1962,7 +1962,7 @@ class GenerationMixin:
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         )
         use_cache = model_kwargs.get("use_cache")
-        output_past_key_values = use_cache if use_cache is not None else self.config.use_cache
+        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate if return_dict_in_generate is not None else self.config.return_dict_in_generate
         )
@@ -2224,7 +2224,7 @@ class GenerationMixin:
         output_scores = output_scores if output_scores is not None else self.config.output_scores
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         use_cache = model_kwargs.get("use_cache")
-        output_past_key_values = use_cache if use_cache is not None else self.config.use_cache
+        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         )
@@ -2555,7 +2555,7 @@ class GenerationMixin:
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         )
         use_cache = model_kwargs.get("use_cache")
-        output_past_key_values = use_cache if use_cache is not None else self.config.use_cache
+        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate if return_dict_in_generate is not None else self.config.return_dict_in_generate
         )
@@ -2873,7 +2873,7 @@ class GenerationMixin:
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         )
         use_cache = model_kwargs.get("use_cache")
-        output_past_key_values = use_cache if use_cache is not None else self.config.use_cache
+        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate if return_dict_in_generate is not None else self.config.return_dict_in_generate
         )
@@ -3250,7 +3250,7 @@ class GenerationMixin:
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         )
         use_cache = model_kwargs.get("use_cache")
-        output_past_key_values = use_cache if use_cache is not None else self.config.use_cache
+        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate if return_dict_in_generate is not None else self.config.return_dict_in_generate
         )

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -78,13 +78,19 @@ class GreedySearchDecoderOnlyOutput(ModelOutput):
         hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size, generated_length, hidden_size)`.
+        past_key_values (`Tuple[Tuple[Tuple[torch.Tensor]]]` returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
     scores: Optional[Tuple[torch.FloatTensor]] = None
     attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
-    past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.Tensor]]]] = None
 
 
 @dataclass
@@ -118,6 +124,12 @@ class GreedySearchEncoderDecoderOutput(ModelOutput):
         decoder_hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size, generated_length, hidden_size)`.
+        past_key_values (`Tuple[Tuple[Tuple[torch.Tensor]]]` returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -127,7 +139,7 @@ class GreedySearchEncoderDecoderOutput(ModelOutput):
     decoder_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     cross_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     decoder_hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
-    past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.Tensor]]]] = None
 
 
 @dataclass
@@ -151,13 +163,19 @@ class SampleDecoderOnlyOutput(ModelOutput):
         hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(num_return_sequences*batch_size, generated_length, hidden_size)`.
+        past_key_values (`Tuple[Tuple[Tuple[torch.Tensor]]]` returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
     scores: Optional[Tuple[torch.FloatTensor]] = None
     attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
-    past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.Tensor]]]] = None
 
 
 @dataclass
@@ -192,6 +210,12 @@ class SampleEncoderDecoderOutput(ModelOutput):
         decoder_hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size*num_return_sequences, generated_length, hidden_size)`.
+        past_key_values (`Tuple[Tuple[Tuple[torch.Tensor]]]` returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -201,7 +225,7 @@ class SampleEncoderDecoderOutput(ModelOutput):
     decoder_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     cross_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     decoder_hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
-    past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.Tensor]]]] = None
 
 
 @dataclass
@@ -229,6 +253,12 @@ class BeamSearchDecoderOnlyOutput(ModelOutput):
         hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size*num_beams*num_return_sequences, generated_length, hidden_size)`.
+        past_key_values (`Tuple[Tuple[Tuple[torch.Tensor]]]` returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -237,7 +267,7 @@ class BeamSearchDecoderOnlyOutput(ModelOutput):
     beam_indices: Optional[torch.LongTensor] = None
     attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
-    past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.Tensor]]]] = None
 
 
 @dataclass
@@ -278,6 +308,12 @@ class BeamSearchEncoderDecoderOutput(ModelOutput):
         decoder_hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size*num_beams*num_return_sequences, generated_length, hidden_size)`.
+        past_key_values (`Tuple[Tuple[Tuple[torch.Tensor]]]` returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -289,7 +325,7 @@ class BeamSearchEncoderDecoderOutput(ModelOutput):
     decoder_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     cross_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     decoder_hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
-    past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.Tensor]]]] = None
 
 
 @dataclass
@@ -317,6 +353,12 @@ class BeamSampleDecoderOnlyOutput(ModelOutput):
         hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size*num_beams, generated_length, hidden_size)`.
+        past_key_values (`Tuple[Tuple[Tuple[torch.Tensor]]]` returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -325,7 +367,7 @@ class BeamSampleDecoderOnlyOutput(ModelOutput):
     beam_indices: Optional[torch.LongTensor] = None
     attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
-    past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.Tensor]]]] = None
 
 
 @dataclass
@@ -364,6 +406,12 @@ class BeamSampleEncoderDecoderOutput(ModelOutput):
         decoder_hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size*num_beams, generated_length, hidden_size)`.
+        past_key_values (`Tuple[Tuple[Tuple[torch.Tensor]]]` returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -375,7 +423,7 @@ class BeamSampleEncoderDecoderOutput(ModelOutput):
     decoder_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     cross_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     decoder_hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
-    past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.Tensor]]]] = None
 
 
 GreedySearchOutput = Union[GreedySearchEncoderDecoderOutput, GreedySearchDecoderOnlyOutput]

--- a/tests/generation/test_generation_utils.py
+++ b/tests/generation/test_generation_utils.py
@@ -1512,6 +1512,10 @@ class GenerationTesterMixin:
     def _check_past_key_values_for_generate(
         self, batch_size, past_key_values, min_length, max_length, config, num_beam_groups=1
     ):
+        if config.use_cache is False:
+            self.assertIsNone(past_key_values)
+            return
+
         self.assertIsInstance(past_key_values, tuple)
         self.assertListEqual(
             [isinstance(iter_past_key_values, tuple) for iter_past_key_values in past_key_values],


### PR DESCRIPTION
# What does this PR do?

Allows returning `past_key_values` from `generate` when `use_cache=True`.

Like other returned values, `past_key_values` are also returned as `Tuple`, one element per generated token.

Fixes #17016