### PR TITLE
Remove circular imports in layoutlm/__init__.py

### DIFF
--- a/src/transformers/models/layoutlm/__init__.py
+++ b/src/transformers/models/layoutlm/__init__.py
@@ -25,8 +25,6 @@ from ...utils import (
     is_tokenizers_available,
     is_torch_available,
 )
-from .configuration_layoutlm import LAYOUTLM_PRETRAINED_CONFIG_ARCHIVE_MAP, LayoutLMConfig
-from .tokenization_layoutlm import LayoutLMTokenizer
 
 
 _import_structure = {


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

There are unused circular imports in `layoutlm/__init__.py`. The import `from transformers.onnx import OnnxConfig` currently leads to the following error:
```bash
Traceback (most recent call last):
  File "/home/regis/HuggingFace/dev/venv/lib/python3.8/site-packages/transformers/utils/import_utils.py", line 878, in _get_module
    return importlib.import_module("." + module_name, self.__name__)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 848, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/regis/HuggingFace/dev/venv/lib/python3.8/site-packages/transformers/models/__init__.py", line 19, in <module>
    from . import (
  File "/home/regis/HuggingFace/dev/venv/lib/python3.8/site-packages/transformers/models/layoutlm/__init__.py", line 28, in <module>
    from .configuration_layoutlm import LAYOUTLM_PRETRAINED_CONFIG_ARCHIVE_MAP, LayoutLMConfig
  File "/home/regis/HuggingFace/dev/venv/lib/python3.8/site-packages/transformers/models/layoutlm/configuration_layoutlm.py", line 22, in <module>
    from ...onnx import OnnxConfig, PatchingSpec
ImportError: cannot import name 'OnnxConfig' from 'transformers.onnx' (/home/regis/HuggingFace/dev/venv/lib/python3.8/site-packages/transformers/onnx/__init__.py)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/regis/HuggingFace/dev/venv/lib/python3.8/site-packages/transformers/utils/import_utils.py", line 878, in _get_module
    return importlib.import_module("." + module_name, self.__name__)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 848, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/regis/HuggingFace/dev/venv/lib/python3.8/site-packages/transformers/onnx/config.py", line 25, in <module>
    from .utils import ParameterFormat, compute_effective_axis_dimension, compute_serialized_parameters_size
  File "/home/regis/HuggingFace/dev/venv/lib/python3.8/site-packages/transformers/onnx/utils.py", line 19, in <module>
    from .. import AutoFeatureExtractor, AutoProcessor, AutoTokenizer
  File "<frozen importlib._bootstrap>", line 1039, in _handle_fromlist
  File "/home/regis/HuggingFace/dev/venv/lib/python3.8/site-packages/transformers/utils/import_utils.py", line 868, in __getattr__
    module = self._get_module(self._class_to_module[name])
  File "/home/regis/HuggingFace/dev/venv/lib/python3.8/site-packages/transformers/utils/import_utils.py", line 880, in _get_module
    raise RuntimeError(
RuntimeError: Failed to import transformers.models.auto because of the following error (look up to see its traceback):
cannot import name 'OnnxConfig' from 'transformers.onnx' (/home/regis/HuggingFace/dev/venv/lib/python3.8/site-packages/transformers/onnx/__init__.py)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "test_resnet_onnx.py", line 1, in <module>
    from transformers.onnx import OnnxConfig
  File "<frozen importlib._bootstrap>", line 1039, in _handle_fromlist
  File "/home/regis/HuggingFace/dev/venv/lib/python3.8/site-packages/transformers/utils/import_utils.py", line 868, in __getattr__
    module = self._get_module(self._class_to_module[name])
  File "/home/regis/HuggingFace/dev/venv/lib/python3.8/site-packages/transformers/utils/import_utils.py", line 880, in _get_module
    raise RuntimeError(
RuntimeError: Failed to import transformers.onnx.config because of the following error (look up to see its traceback):
Failed to import transformers.models.auto because of the following error (look up to see its traceback):
cannot import name 'OnnxConfig' from 'transformers.onnx' (/home/regis/HuggingFace/dev/venv/lib/python3.8/site-packages/transformers/onnx/__init__.py)
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
