### PR TITLE
Fix circular import in onnx.utils

### DIFF
--- a/src/transformers/onnx/utils.py
+++ b/src/transformers/onnx/utils.py
@@ -81,7 +81,8 @@ def get_preprocessor(model_name: str) -> Optional[Union["AutoTokenizer", "AutoFe
             returned. If both a tokenizer and a feature extractor exist, an error is raised. The function returns
             `None` if no preprocessor is found.
     """
-    from .. import AutoFeatureExtractor, AutoProcessor, AutoTokenizer
+    # Avoid circular imports by only importing this here.
+    from .. import AutoFeatureExtractor, AutoProcessor, AutoTokenizer # tests_ignore
 
     try:
         return AutoProcessor.from_pretrained(model_name)

--- a/src/transformers/onnx/utils.py
+++ b/src/transformers/onnx/utils.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 
 if TYPE_CHECKING:
-    from .. import AutoFeatureExtractor, AutoProcessor, AutoTokenizer # tests_ignore
+    from .. import AutoFeatureExtractor, AutoProcessor, AutoTokenizer  # tests_ignore
 
 
 class ParameterFormat(Enum):
@@ -82,7 +82,7 @@ def get_preprocessor(model_name: str) -> Optional[Union["AutoTokenizer", "AutoFe
             `None` if no preprocessor is found.
     """
     # Avoid circular imports by only importing this here.
-    from .. import AutoFeatureExtractor, AutoProcessor, AutoTokenizer # tests_ignore
+    from .. import AutoFeatureExtractor, AutoProcessor, AutoTokenizer  # tests_ignore
 
     try:
         return AutoProcessor.from_pretrained(model_name)

--- a/src/transformers/onnx/utils.py
+++ b/src/transformers/onnx/utils.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 
 if TYPE_CHECKING:
-    from .. import AutoFeatureExtractor, AutoProcessor, AutoTokenizer
+    from .. import AutoFeatureExtractor, AutoProcessor, AutoTokenizer # tests_ignore
 
 
 class ParameterFormat(Enum):

--- a/src/transformers/onnx/utils.py
+++ b/src/transformers/onnx/utils.py
@@ -14,9 +14,11 @@
 
 from ctypes import c_float, sizeof
 from enum import Enum
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
-from .. import AutoFeatureExtractor, AutoProcessor, AutoTokenizer
+
+if TYPE_CHECKING:
+    from .. import AutoFeatureExtractor, AutoProcessor, AutoTokenizer
 
 
 class ParameterFormat(Enum):
@@ -66,7 +68,7 @@ def compute_serialized_parameters_size(num_parameters: int, dtype: ParameterForm
     return num_parameters * dtype.size
 
 
-def get_preprocessor(model_name: str) -> Optional[Union[AutoTokenizer, AutoFeatureExtractor, AutoProcessor]]:
+def get_preprocessor(model_name: str) -> Optional[Union["AutoTokenizer", "AutoFeatureExtractor", "AutoProcessor"]]:
     """
     Gets a preprocessor (tokenizer, feature extractor or processor) that is available for `model_name`.
 
@@ -79,6 +81,8 @@ def get_preprocessor(model_name: str) -> Optional[Union[AutoTokenizer, AutoFeatu
             returned. If both a tokenizer and a feature extractor exist, an error is raised. The function returns
             `None` if no preprocessor is found.
     """
+    from .. import AutoFeatureExtractor, AutoProcessor, AutoTokenizer
+
     try:
         return AutoProcessor.from_pretrained(model_name)
     except (ValueError, OSError, KeyError):


### PR DESCRIPTION
# What does this PR do?

This PR fixes the circular import in `onnx.utils` that one can experiment right now with:
```py
from transformers.onnx import OnnxConfig
```

It comes form the fact that `onnx.utils` imports `AutoProcessor`, `AutoFeatureExtractor` and `AutoTokenizer`, which then requires all models to be initialized, which in turns requires all configs to be initialized and relies on `OnnxConfig`, hence a circular import.

Supercedes #17576 