### PR TITLE
Explicit versions in docker files

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -8,7 +8,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 ARG PYTORCH='1.11.0'
 # (not always a valid torch version)
-ARG INTEL_TORCH_EXT = '1.11.0'
+ARG INTEL_TORCH_EXT='1.11.0'
 # Example: `cu102`, `cu113`, etc.
 ARG CUDA='cu113'
 

--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -16,7 +16,7 @@ RUN python3 -m pip install --no-cache-dir -U tensorflow
 RUN python3 -m pip uninstall -y flax jax
 
 RUN python3 -m pip install --no-cache-dir torch-scatter -f https://data.pyg.org/whl/torch-$(python3 -c "from torch import version; print(version.__version__.split('+')[0])")+cu113.html
-RUN python3 -m pip install --no-cache-dir intel_extension_for_pytorch==$(python3 -c "from torch import version; print(version.__version__.split('+')[0])")+cpu -f https://software.intel.com/ipex-whl-stable
+RUN python3 -m pip install --no-cache-dir intel_extension_for_pytorch==$(python3 -c 1.11.0+cpu -f https://software.intel.com/ipex-whl-stable
 
 RUN python3 -m pip install --no-cache-dir git+https://github.com/facebookresearch/detectron2.git pytesseract https://github.com/kpu/kenlm/archive/master.zip
 RUN python3 -m pip install -U "itsdangerous<2.1.0"

--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Hugging Face"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# If set to nothing, will install the latest version
+# So far mainly used to specify the versions explicitly here, and not meant to be used as arguments for docker build.
 ARG PYTORCH='1.11.0'
 ARG TORCH_VISION='0.12.0'
 ARG TORCH_AUDIO='0.11.0'

--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -3,11 +3,12 @@ LABEL maintainer="Hugging Face"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# So far mainly used to specify the versions explicitly here, and not meant to be used as arguments for docker build.
-ARG PYTORCH='1.11.0'
-ARG TORCH_VISION='0.12.0'
-ARG TORCH_AUDIO='0.11.0'
+# The following `ARG` are mainly used to specify the versions explicitly & directly in this docker file, and not meant
+# to be used as arguments for docker build (so far).
 
+ARG PYTORCH='1.11.0'
+# (not always a valid torch version)
+ARG INTEL_TORCH_EXT = '1.11.0'
 # Example: `cu102`, `cu113`, etc.
 ARG CUDA='cu113'
 
@@ -19,12 +20,12 @@ ARG REF=main
 RUN git clone https://github.com/huggingface/transformers && cd transformers && git checkout $REF
 RUN python3 -m pip install --no-cache-dir -e ./transformers[dev,onnxruntime]
 
-RUN python3 -m pip install --no-cache-dir -U torch==$PYTORCH torchvision==$TORCH_VISION torchaudio==$TORCH_AUDIO --extra-index-url https://download.pytorch.org/whl/$CUDA
+RUN python3 -m pip install --no-cache-dir -U torch==$PYTORCH torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/$CUDA
 RUN python3 -m pip install --no-cache-dir -U tensorflow
 RUN python3 -m pip uninstall -y flax jax
 
 RUN python3 -m pip install --no-cache-dir torch-scatter -f https://data.pyg.org/whl/torch-$PYTORCH+$CUDA.html
-RUN python3 -m pip install --no-cache-dir intel_extension_for_pytorch==$PYTORCH+cpu -f https://software.intel.com/ipex-whl-stable
+RUN python3 -m pip install --no-cache-dir intel_extension_for_pytorch==$INTEL_TORCH_EXT+cpu -f https://software.intel.com/ipex-whl-stable
 
 RUN python3 -m pip install --no-cache-dir git+https://github.com/facebookresearch/detectron2.git pytesseract https://github.com/kpu/kenlm/archive/master.zip
 RUN python3 -m pip install -U "itsdangerous<2.1.0"

--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -3,6 +3,14 @@ LABEL maintainer="Hugging Face"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# If set to nothing, will install the latest version
+ARG PYTORCH='1.11.0'
+ARG TORCH_VISION='0.12.0'
+ARG TORCH_AUDIO='0.11.0'
+
+# Example: `cu102`, `cu113`, etc.
+ARG CUDA='cu113'
+
 RUN apt update
 RUN apt install -y git libsndfile1-dev tesseract-ocr espeak-ng python3 python3-pip ffmpeg
 RUN python3 -m pip install --no-cache-dir --upgrade pip
@@ -11,12 +19,12 @@ ARG REF=main
 RUN git clone https://github.com/huggingface/transformers && cd transformers && git checkout $REF
 RUN python3 -m pip install --no-cache-dir -e ./transformers[dev,onnxruntime]
 
-RUN python3 -m pip install --no-cache-dir -U torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
+RUN python3 -m pip install --no-cache-dir -U torch==$PYTORCH torchvision==$TORCH_VISION torchaudio==$TORCH_AUDIO --extra-index-url https://download.pytorch.org/whl/$CUDA
 RUN python3 -m pip install --no-cache-dir -U tensorflow
 RUN python3 -m pip uninstall -y flax jax
 
-RUN python3 -m pip install --no-cache-dir torch-scatter -f https://data.pyg.org/whl/torch-$(python3 -c "from torch import version; print(version.__version__.split('+')[0])")+cu113.html
-RUN python3 -m pip install --no-cache-dir intel_extension_for_pytorch==$(python3 -c 1.11.0+cpu -f https://software.intel.com/ipex-whl-stable
+RUN python3 -m pip install --no-cache-dir torch-scatter -f https://data.pyg.org/whl/torch-$PYTORCH+$CUDA.html
+RUN python3 -m pip install --no-cache-dir intel_extension_for_pytorch==$PYTORCH+cpu -f https://software.intel.com/ipex-whl-stable
 
 RUN python3 -m pip install --no-cache-dir git+https://github.com/facebookresearch/detectron2.git pytesseract https://github.com/kpu/kenlm/archive/master.zip
 RUN python3 -m pip install -U "itsdangerous<2.1.0"


### PR DESCRIPTION
# What does this PR do?

@stas00 Here is the thread to discuss the version things in docker files.

- Objective:

  - We have more 3rd party libraries that depend on PyTorch version
  - Some of them need explicit versions, instead of using something like `$PYTORCH_VER`. For example, we have [1.11.200](https://www.intel.com/content/dam/develop/external/us/en/documents/ipex/whl-stable.html) in `intel_extension_for_pytorch-1.11.200+cpu-cp38-cp38-linux_x86_64.whl`
  - @stas00 suggest to specify the versions in the docker file(s), so we have better control.

- Implementation
  - The current attempt is not very good once we have more and more docker files, but so far it's OK.
  - If this is fine, I can **apply the same change to other docker files**.