### PR TITLE
[CLIP] Add padding embeddings

### DIFF
--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -100,6 +100,7 @@ class CLIPTextConfig(PretrainedConfig):
         attention_dropout=0.0,
         initializer_range=0.02,
         initializer_factor=1.0,
+        use_padding_embeddings=False,
         pad_token_id=1,
         bos_token_id=0,
         eos_token_id=2,
@@ -119,6 +120,7 @@ class CLIPTextConfig(PretrainedConfig):
         self.initializer_range = initializer_range
         self.initializer_factor = initializer_factor
         self.attention_dropout = attention_dropout
+        self.use_padding_embeddings = use_padding_embeddings
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path: Union[str, os.PathLike], **kwargs) -> "PretrainedConfig":

--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -172,7 +172,8 @@ class CLIPTextEmbeddings(nn.Module):
         embeddings = inputs_embeds + position_embeddings
 
         if self.use_padding_embeddings and attention_mask is not None:
-            embeddings = torch.where(attention_mask, embeddings, self.padding_embedding(position_ids))
+            padding_embeddings = self.padding_embedding(position_ids)
+            embeddings = torch.where(attention_mask.bool().unsqueeze(-1), embeddings, padding_embeddings)
 
         return embeddings
 


### PR DESCRIPTION
# What does this PR do?

This PR adds optional per-token padding embeddings (not the usual kind of padding, these are closer to postion embeddings in implementation).

These are needed to convert GLIDE text encoders: https://github.com/openai/glide-text2im/blob/18bf97a07446874693263715af6a73a09cbe81e2/glide_text2im/text2im_model.py#L66
