### PR TITLE
CLI: add stricter automatic checks to `pt-to-tf`

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -4,7 +4,8 @@ LABEL maintainer="Hugging Face"
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt update
-RUN apt install -y git libsndfile1-dev tesseract-ocr espeak-ng python3 python3-pip ffmpeg
+RUN apt install -y git libsndfile1-dev tesseract-ocr espeak-ng python3 python3-pip ffmpeg git-lfs
+RUN git lfs install
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 
 ARG REF=main

--- a/src/transformers/commands/pt_to_tf.py
+++ b/src/transformers/commands/pt_to_tf.py
@@ -82,7 +82,7 @@ class PTtoTFCommand(BaseTransformersCLICommand):
         train_parser.set_defaults(func=convert_command_factory)
 
     @staticmethod
-    def compare_pt_tf_models(pt_model: torch.nn.Module, pt_input: dict, tf_model: tf.keras.Model, tf_input: dict):
+    def compare_pt_tf_models(pt_model, pt_input, tf_model, tf_input):
         """
         Compares the tf and the pt models, given their inputs, returning a tuple with the maximum observed difference
         and its source.

--- a/src/transformers/commands/pt_to_tf.py
+++ b/src/transformers/commands/pt_to_tf.py
@@ -91,8 +91,7 @@ class PTtoTFCommand(BaseTransformersCLICommand):
         tf_outputs = tf_model(**tf_input, output_hidden_states=True)
 
         # 1. All keys must be the same
-        pt_output_names = set(pt_outputs.keys())
-        if pt_output_names != set(tf_outputs.keys()):
+        if set(pt_outputs.keys()) != set(tf_outputs.keys()):
             raise ValueError("The model outputs have different attributes, aborting.")
 
         # 2. For each key, ALL values must be the same

--- a/src/transformers/commands/pt_to_tf.py
+++ b/src/transformers/commands/pt_to_tf.py
@@ -95,11 +95,16 @@ class PTtoTFCommand(BaseTransformersCLICommand):
         pt_outputs = pt_model(**pt_input, output_hidden_states=True)
         tf_outputs = tf_model(**tf_input, output_hidden_states=True)
 
-        # 1. All keys must be the same
-        if set(pt_outputs.keys()) != set(tf_outputs.keys()):
-            raise ValueError("The model outputs have different attributes, aborting.")
+        # 1. All output attributes must be the same
+        pt_out_attrs = set(pt_outputs.keys())
+        tf_out_attrs = set(tf_outputs.keys())
+        if pt_out_attrs != tf_out_attrs:
+            raise ValueError(
+                f"The model outputs have different attributes, aborting. (Pytorch: {pt_out_attrs}, TensorFlow:"
+                f" {tf_out_attrs})"
+            )
 
-        # 2. For each key, ALL values must be the same
+        # 2. For each output attribute, ALL values must be the same
         def compate_pt_tf_values(pt_out, tf_out, attr_name=""):
             max_difference = 0
             max_difference_source = ""

--- a/src/transformers/commands/pt_to_tf.py
+++ b/src/transformers/commands/pt_to_tf.py
@@ -84,7 +84,7 @@ class PTtoTFCommand(BaseTransformersCLICommand):
     @staticmethod
     def compare_pt_tf_models(pt_model, pt_input, tf_model, tf_input):
         """
-        Compares the tf and the pt models, given their inputs, returning a tuple with the maximum observed difference
+        Compares the TensorFload and PyTorch models, given their inputs, returning a tuple with the maximum observed difference
         and its source.
         """
         pt_outputs = pt_model(**pt_input, output_hidden_states=True)
@@ -171,7 +171,7 @@ class PTtoTFCommand(BaseTransformersCLICommand):
         if architectures is None:  # No architecture defined -- use auto classes
             pt_class = getattr(import_module("transformers"), "AutoModel")
             tf_class = getattr(import_module("transformers"), "TFAutoModel")
-            self._logger.warn("No detected architecture, using auto classes")
+            self._logger.warn("No detected architecture, using AutoModel/TFAutoModel")
         else:  # Architecture defined -- use it
             if len(architectures) > 1:
                 raise ValueError(f"More than one architecture was found, aborting. (architectures = {architectures})")

--- a/src/transformers/commands/pt_to_tf.py
+++ b/src/transformers/commands/pt_to_tf.py
@@ -80,15 +80,17 @@ class PTtoTFCommand(BaseTransformersCLICommand):
             "--no-pr", action="store_true", help="Optional flag to NOT open a PR with converted weights."
         )
         train_parser.add_argument(
-            "--new-weights", action="store_true", help="Optional flag to create new TensorFlow weights, even if they already exist."
+            "--new-weights",
+            action="store_true",
+            help="Optional flag to create new TensorFlow weights, even if they already exist.",
         )
         train_parser.set_defaults(func=convert_command_factory)
 
     @staticmethod
     def compare_pt_tf_models(pt_model, pt_input, tf_model, tf_input):
         """
-        Compares the TensorFload and PyTorch models, given their inputs, returning a tuple with the maximum observed difference
-        and its source.
+        Compares the TensorFload and PyTorch models, given their inputs, returning a tuple with the maximum observed
+        difference and its source.
         """
         pt_outputs = pt_model(**pt_input, output_hidden_states=True)
         tf_outputs = tf_model(**tf_input, output_hidden_states=True)

--- a/src/transformers/commands/pt_to_tf.py
+++ b/src/transformers/commands/pt_to_tf.py
@@ -89,7 +89,7 @@ class PTtoTFCommand(BaseTransformersCLICommand):
     @staticmethod
     def compare_pt_tf_models(pt_model, pt_input, tf_model, tf_input):
         """
-        Compares the TensorFload and PyTorch models, given their inputs, returning a tuple with the maximum observed
+        Compares the TensorFlow and PyTorch models, given their inputs, returning a tuple with the maximum observed
         difference and its source.
         """
         pt_outputs = pt_model(**pt_input, output_hidden_states=True)
@@ -105,7 +105,7 @@ class PTtoTFCommand(BaseTransformersCLICommand):
             )
 
         # 2. For each output attribute, ALL values must be the same
-        def compate_pt_tf_values(pt_out, tf_out, attr_name=""):
+        def _compate_pt_tf_models(pt_out, tf_out, attr_name=""):
             max_difference = 0
             max_difference_source = ""
 
@@ -127,14 +127,14 @@ class PTtoTFCommand(BaseTransformersCLICommand):
                     else:
                         branch_name = root_name + f"[{i}]"
                         tf_item = tf_out[i]
-                    difference, difference_source = compate_pt_tf_values(pt_item, tf_item, branch_name)
+                    difference, difference_source = _compate_pt_tf_models(pt_item, tf_item, branch_name)
                     if difference > max_difference:
                         max_difference = difference
                         max_difference_source = difference_source
 
             return max_difference, max_difference_source
 
-        return compate_pt_tf_values(pt_outputs, tf_outputs)
+        return _compate_pt_tf_models(pt_outputs, tf_outputs)
 
     def __init__(self, model_name: str, local_dir: str, no_pr: bool, new_weights: bool, *args):
         self._logger = logging.get_logger("transformers-cli/pt_to_tf")


### PR DESCRIPTION
# What does this PR do?

Last week I introduced the `pt-to-tf` CLI (https://github.com/huggingface/transformers/pull/17497), enabling automatic weight conversion followed by PR opening.

This PR makes four changes related to that CLI:
1. Uses the appropriate model class to load the model, to ensure the head's weights also get converted;
2. Adds much stricter checks -- ALL model outputs (with `output_hidden_states=True`) are verified;
3. Adds a flag to create new TF weights, even if they already exist;
4. Updates the docker file for the scheduled tests to install `git lfs` -- I did it for the circleci workflows in the original PR, but forgot to do it for the scheduled tests.

🚨 This also means I will double-check previously open Hub PRs (about 10), to confirm that the model head is present in the TF weights (I suspect it isn't in some cases 😢 ) and that the outputs pass the stricter tests.

For context, if the conversion fails because of a difference in the model outputs, we get a message like this one:
<img width="1013" alt="Screenshot 2022-06-07 at 17 00 12" src="https://user-images.githubusercontent.com/12240844/172427441-e1fd63e4-7887-47bf-8827-9209bc1df78a.png">