### PR TITLE
TF: Merge PT and TF behavior for Bart when no decoder_input_ids are passed

### DIFF
--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -1075,7 +1075,7 @@ class TFBartMainLayer(tf.keras.layers.Layer):
 
         # different to other models, Bart automatically creates decoder_input_ids from
         # input_ids if no decoder_input_ids are provided
-        if decoder_input_ids is None and input_ids is not None:
+        if decoder_input_ids is None and decoder_inputs_embeds is not None:
             if input_ids is None:
                 raise ValueError(
                     "If no `decoder_input_ids` or `decoder_inputs_embeds` are "

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -1073,14 +1073,16 @@ class TFBartMainLayer(tf.keras.layers.Layer):
         **kwargs
     ) -> Union[TFSeq2SeqModelOutput, Tuple[tf.Tensor]]:
 
-        if decoder_input_ids is None and decoder_inputs_embeds is None:
-            use_cache = False
-
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
-        )
-
+        # different to other models, Bart automatically creates decoder_input_ids from
+        # input_ids if no decoder_input_ids are provided
         if decoder_input_ids is None and input_ids is not None:
+            if input_ids is None:
+                raise ValueError(
+                    "If no `decoder_input_ids` or `decoder_inputs_embeds` are "
+                    "passed, `input_ids` cannot be `None`. Please pass either "
+                    "`input_ids` or `decoder_input_ids` or `decoder_inputs_embeds`."
+                )
+
             decoder_input_ids = shift_tokens_right(
                 input_ids, self.config.pad_token_id, self.config.decoder_start_token_id
             )

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -1075,7 +1075,7 @@ class TFBartMainLayer(tf.keras.layers.Layer):
 
         # different to other models, Bart automatically creates decoder_input_ids from
         # input_ids if no decoder_input_ids are provided
-        if decoder_input_ids is None and decoder_inputs_embeds is not None:
+        if decoder_input_ids is None and decoder_inputs_embeds is None:
             if input_ids is None:
                 raise ValueError(
                     "If no `decoder_input_ids` or `decoder_inputs_embeds` are "


### PR DESCRIPTION
# What does this PR do?

The main model for TF and PT have a different behavior when no `decoder_input_ids` are passed. Because of that, the same model with the same inputs has different outputs in the two platforms, in this specific input case.

Looking at the git blame, it seems like [this](https://github.com/huggingface/transformers/blob/main/src/transformers/models/bart/modeling_bart.py#L1202) `if` branch in PT has added after the TF model was added, and we possibly forgot to port it back.

Notes:
1. All slow tests for Bart were run locally;
2. This was caught with the [updated](https://github.com/huggingface/transformers/pull/17588) `pt-to-tf` CLI, which added much stricter tests.