### PR TITLE
adding encoder/decoder normalize_before to BART models

### DIFF
--- a/src/transformers/models/bart/configuration_bart.py
+++ b/src/transformers/models/bart/configuration_bart.py
@@ -92,7 +92,12 @@ class BartConfig(PretrainedConfig):
         forced_eos_token_id (`int`, *optional*, defaults to 2):
             The id of the token to force as the last generated token when `max_length` is reached. Usually set to
             `eos_token_id`.
-
+        encoder_normalize_before (`bool`, *optional*, defaults to `False`):
+            Whether or not the LayerNorm is applied before each block in the encoder (not used by all models -- often
+            helps the model learn).
+        decoder_normalize_before (`bool`, *optional*, defaults to `False`):
+            Whether or not the LayerNorm is applied before each block in the decoder (not used by all models -- often
+            helps the model learn).
     Example:
 
     ```python
@@ -139,6 +144,8 @@ class BartConfig(PretrainedConfig):
         is_encoder_decoder=True,
         decoder_start_token_id=2,
         forced_eos_token_id=2,
+        encoder_normalize_before=False,
+        decoder_normalize_before=False,
         **kwargs
     ):
         self.vocab_size = vocab_size
@@ -161,6 +168,8 @@ class BartConfig(PretrainedConfig):
         self.use_cache = use_cache
         self.num_hidden_layers = encoder_layers
         self.scale_embedding = scale_embedding  # scale factor will be sqrt(d_model) if True
+        self.encoder_normalize_before = encoder_normalize_before
+        self.decoder_normalize_before = decoder_normalize_before
 
         super().__init__(
             num_labels=num_labels,

--- a/src/transformers/models/bart/modeling_bart.py
+++ b/src/transformers/models/bart/modeling_bart.py
@@ -920,7 +920,7 @@ class BartDecoder(BartPretrainedModel):
         self.layernorm_embedding = nn.LayerNorm(config.d_model)
 
         self.gradient_checkpointing = False
-        if config.encoder_normalize_before:
+        if config.decoder_normalize_before:
             self.layer_norm = nn.LayerNorm(config.d_model)
         else:
             self.layer_norm = None

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -850,7 +850,7 @@ class TFBartDecoder(tf.keras.layers.Layer):
         self.layers = [TFBartDecoderLayer(config, name=f"layers.{i}") for i in range(config.decoder_layers)]
         self.layernorm_embedding = tf.keras.layers.LayerNormalization(epsilon=1e-5, name="layernorm_embedding")
 
-        if config.encoder_normalize_before:
+        if config.decoder_normalize_before:
             self.layer_norm = tf.keras.layers.LayerNormalization(epsilon=1e-5, name="layer_norm")
         else:
             self.layer_norm = None

--- a/src/transformers/models/blenderbot_small/configuration_blenderbot_small.py
+++ b/src/transformers/models/blenderbot_small/configuration_blenderbot_small.py
@@ -91,6 +91,12 @@ class BlenderbotSmallConfig(PretrainedConfig):
         forced_eos_token_id (`int`, *optional*, defaults to 2):
             The id of the token to force as the last generated token when `max_length` is reached. Usually set to
             `eos_token_id`.
+        encoder_normalize_before (`bool`, *optional*, defaults to `False`):
+            Whether or not the LayerNorm is applied before each block in the encoder (not used by all models -- often
+            helps the model learn).
+        decoder_normalize_before (`bool`, *optional*, defaults to `False`):
+            Whether or not the LayerNorm is applied before each block in the decoder (not used by all models -- often
+            helps the model learn).
 
     Example:
 
@@ -137,6 +143,8 @@ class BlenderbotSmallConfig(PretrainedConfig):
         bos_token_id=1,
         eos_token_id=2,
         forced_eos_token_id=2,
+        encoder_normalize_before=False,
+        decoder_normalize_before=False,
         **kwargs
     ):
         self.vocab_size = vocab_size
@@ -159,6 +167,8 @@ class BlenderbotSmallConfig(PretrainedConfig):
         self.use_cache = use_cache
         self.num_hidden_layers = encoder_layers
         self.scale_embedding = scale_embedding  # scale factor will be sqrt(d_model) if True
+        self.encoder_normalize_before = encoder_normalize_before
+        self.decoder_normalize_before = decoder_normalize_before
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/src/transformers/models/marian/configuration_marian.py
+++ b/src/transformers/models/marian/configuration_marian.py
@@ -89,6 +89,12 @@ class MarianConfig(PretrainedConfig):
         forced_eos_token_id (`int`, *optional*, defaults to 0):
             The id of the token to force as the last generated token when `max_length` is reached. Usually set to
             `eos_token_id`.
+        encoder_normalize_before (`bool`, *optional*, defaults to `False`):
+            Whether or not the LayerNorm is applied before each block in the encoder (not used by all models -- often
+            helps the model learn).
+        decoder_normalize_before (`bool`, *optional*, defaults to `False`):
+            Whether or not the LayerNorm is applied before each block in the decoder (not used by all models -- often
+            helps the model learn).
 
     Examples:
 
@@ -136,6 +142,8 @@ class MarianConfig(PretrainedConfig):
         eos_token_id=0,
         forced_eos_token_id=0,
         share_encoder_decoder_embeddings=True,
+        encoder_normalize_before=False,
+        decoder_normalize_before=False,
         **kwargs
     ):
         self.vocab_size = vocab_size
@@ -160,6 +168,9 @@ class MarianConfig(PretrainedConfig):
         self.num_hidden_layers = encoder_layers
         self.scale_embedding = scale_embedding  # scale factor will be sqrt(d_model) if True
         self.share_encoder_decoder_embeddings = share_encoder_decoder_embeddings
+        self.encoder_normalize_before = encoder_normalize_before
+        self.decoder_normalize_before = decoder_normalize_before
+
         super().__init__(
             pad_token_id=pad_token_id,
             eos_token_id=eos_token_id,

--- a/src/transformers/models/marian/modeling_flax_marian.py
+++ b/src/transformers/models/marian/modeling_flax_marian.py
@@ -436,6 +436,7 @@ class FlaxMarianEncoderLayer(nn.Module):
             self.embed_dim, dtype=self.dtype, kernel_init=jax.nn.initializers.normal(self.config.init_std)
         )
         self.final_layer_norm = nn.LayerNorm(dtype=self.dtype, epsilon=1e-05)
+        self.normalize_before = self.config.encoder_normalize_before
 
     def __call__(
         self,
@@ -445,19 +446,25 @@ class FlaxMarianEncoderLayer(nn.Module):
         deterministic: bool = True,
     ) -> Tuple[jnp.ndarray]:
         residual = hidden_states
+        if self.normalize_before:
+            hidden_states = self.self_attn_layer_norm(hidden_states)
         hidden_states, attn_weights = self.self_attn(hidden_states=hidden_states, attention_mask=attention_mask)
 
         hidden_states = self.dropout_layer(hidden_states, deterministic=deterministic)
         hidden_states = residual + hidden_states
-        hidden_states = self.self_attn_layer_norm(hidden_states)
+        if not self.normalize_before:
+            hidden_states = self.self_attn_layer_norm(hidden_states)
 
         residual = hidden_states
+        if self.normalize_before:
+            hidden_states = self.final_layer_norm(hidden_states)
         hidden_states = self.activation_fn(self.fc1(hidden_states))
         hidden_states = self.activation_dropout_layer(hidden_states, deterministic=deterministic)
         hidden_states = self.fc2(hidden_states)
         hidden_states = self.dropout_layer(hidden_states, deterministic=deterministic)
         hidden_states = residual + hidden_states
-        hidden_states = self.final_layer_norm(hidden_states)
+        if not self.normalize_before:
+            hidden_states = self.final_layer_norm(hidden_states)
 
         outputs = (hidden_states,)
 
@@ -559,6 +566,7 @@ class FlaxMarianDecoderLayer(nn.Module):
             self.embed_dim, dtype=self.dtype, kernel_init=jax.nn.initializers.normal(self.config.init_std)
         )
         self.final_layer_norm = nn.LayerNorm(dtype=self.dtype, epsilon=1e-05)
+        self.normalize_before = self.config.decoder_normalize_before
 
     def __call__(
         self,
@@ -571,6 +579,8 @@ class FlaxMarianDecoderLayer(nn.Module):
         deterministic: bool = True,
     ) -> Tuple[jnp.ndarray]:
         residual = hidden_states
+        if self.normalize_before:
+            hidden_states = self.self_attn_layer_norm(hidden_states)
 
         # Self Attention
         hidden_states, self_attn_weights = self.self_attn(
@@ -578,12 +588,15 @@ class FlaxMarianDecoderLayer(nn.Module):
         )
         hidden_states = self.dropout_layer(hidden_states, deterministic=deterministic)
         hidden_states = residual + hidden_states
-        hidden_states = self.self_attn_layer_norm(hidden_states)
+        if not self.normalize_before:
+            hidden_states = self.self_attn_layer_norm(hidden_states)
 
         # Cross-Attention Block
         cross_attn_weights = None
         if encoder_hidden_states is not None:
             residual = hidden_states
+            if self.normalize_before:
+                hidden_states = self.encoder_attn_layer_norm(hidden_states)
 
             hidden_states, cross_attn_weights = self.encoder_attn(
                 hidden_states=hidden_states,
@@ -592,16 +605,20 @@ class FlaxMarianDecoderLayer(nn.Module):
             )
             hidden_states = self.dropout_layer(hidden_states, deterministic=deterministic)
             hidden_states = residual + hidden_states
-            hidden_states = self.encoder_attn_layer_norm(hidden_states)
+            if not self.normalize_before:
+                hidden_states = self.encoder_attn_layer_norm(hidden_states)
 
         # Fully Connected
         residual = hidden_states
+        if self.normalize_before:
+            hidden_states = self.final_layer_norm(hidden_states)
         hidden_states = self.activation_fn(self.fc1(hidden_states))
         hidden_states = self.activation_dropout_layer(hidden_states, deterministic=deterministic)
         hidden_states = self.fc2(hidden_states)
         hidden_states = self.dropout_layer(hidden_states, deterministic=deterministic)
         hidden_states = residual + hidden_states
-        hidden_states = self.final_layer_norm(hidden_states)
+        if not self.normalize_before:
+            hidden_states = self.final_layer_norm(hidden_states)
 
         outputs = (hidden_states,)
 

--- a/src/transformers/models/marian/modeling_tf_marian.py
+++ b/src/transformers/models/marian/modeling_tf_marian.py
@@ -351,6 +351,7 @@ class TFMarianEncoderLayer(tf.keras.layers.Layer):
         self.fc1 = tf.keras.layers.Dense(config.encoder_ffn_dim, name="fc1")
         self.fc2 = tf.keras.layers.Dense(self.embed_dim, name="fc2")
         self.final_layer_norm = tf.keras.layers.LayerNormalization(epsilon=1e-5, name="final_layer_norm")
+        self.normalize_before = config.encoder_normalize_before
 
     def call(
         self,
@@ -368,6 +369,8 @@ class TFMarianEncoderLayer(tf.keras.layers.Layer):
                 `(encoder_attention_heads,)`
         """
         residual = hidden_states
+        if self.normalize_before:
+            hidden_states = self.self_attn_layer_norm(hidden_states)
         hidden_states, self_attn_weights, _ = self.self_attn(
             hidden_states=hidden_states, attention_mask=attention_mask, layer_head_mask=layer_head_mask
         )
@@ -383,15 +386,19 @@ class TFMarianEncoderLayer(tf.keras.layers.Layer):
 
         hidden_states = self.dropout(hidden_states, training=training)
         hidden_states = residual + hidden_states
-        hidden_states = self.self_attn_layer_norm(hidden_states)
+        if not self.normalize_before:
+            hidden_states = self.self_attn_layer_norm(hidden_states)
 
         residual = hidden_states
+        if self.normalize_before:
+            hidden_states = self.final_layer_norm(hidden_states)
         hidden_states = self.activation_fn(self.fc1(hidden_states))
         hidden_states = self.activation_dropout(hidden_states, training=training)
         hidden_states = self.fc2(hidden_states)
         hidden_states = self.dropout(hidden_states, training=training)
         hidden_states = residual + hidden_states
-        hidden_states = self.final_layer_norm(hidden_states)
+        if not self.normalize_before:
+            hidden_states = self.final_layer_norm(hidden_states)
 
         return hidden_states, self_attn_weights
 
@@ -424,6 +431,7 @@ class TFMarianDecoderLayer(tf.keras.layers.Layer):
         self.fc1 = tf.keras.layers.Dense(config.decoder_ffn_dim, name="fc1")
         self.fc2 = tf.keras.layers.Dense(self.embed_dim, name="fc2")
         self.final_layer_norm = tf.keras.layers.LayerNormalization(epsilon=1e-5, name="final_layer_norm")
+        self.normalize_before = config.decoder_normalize_before
 
     def call(
         self,
@@ -452,6 +460,8 @@ class TFMarianDecoderLayer(tf.keras.layers.Layer):
             past_key_value (`Tuple(tf.Tensor)`): cached past key and value projection states
         """
         residual = hidden_states
+        if self.normalize_before:
+            hidden_states = self.self_attn_layer_norm(hidden_states)
 
         # Self Attention
         # decoder uni-directional self-attention cached key/values tuple is at positions 1,2
@@ -465,13 +475,16 @@ class TFMarianDecoderLayer(tf.keras.layers.Layer):
         )
         hidden_states = self.dropout(hidden_states, training=training)
         hidden_states = residual + hidden_states
-        hidden_states = self.self_attn_layer_norm(hidden_states)
+        if not self.normalize_before:
+            hidden_states = self.self_attn_layer_norm(hidden_states)
 
         # Cross-Attention Block
         cross_attn_present_key_value = None
         cross_attn_weights = None
         if encoder_hidden_states is not None:
             residual = hidden_states
+            if self.normalize_before:
+                hidden_states = self.encoder_attn_layer_norm(hidden_states)
 
             # cross_attn cached key/values tuple is at positions 3,4 of present_key_value tuple
             cross_attn_past_key_value = past_key_value[-2:] if past_key_value is not None else None
@@ -484,19 +497,23 @@ class TFMarianDecoderLayer(tf.keras.layers.Layer):
             )
             hidden_states = self.dropout(hidden_states, training=training)
             hidden_states = residual + hidden_states
-            hidden_states = self.encoder_attn_layer_norm(hidden_states)
+            if not self.normalize_before:
+                hidden_states = self.encoder_attn_layer_norm(hidden_states)
 
             # add cross-attn to positions 3,4 of present_key_value tuple
             present_key_value = present_key_value + cross_attn_present_key_value
 
         # Fully Connected
         residual = hidden_states
+        if self.normalize_before:
+            hidden_states = self.final_layer_norm(hidden_states)
         hidden_states = self.activation_fn(self.fc1(hidden_states))
         hidden_states = self.activation_dropout(hidden_states, training=training)
         hidden_states = self.fc2(hidden_states)
         hidden_states = self.dropout(hidden_states, training=training)
         hidden_states = residual + hidden_states
-        hidden_states = self.final_layer_norm(hidden_states)
+        if not self.normalize_before:
+            hidden_states = self.final_layer_norm(hidden_states)
 
         return (
             hidden_states,

--- a/src/transformers/models/plbart/configuration_plbart.py
+++ b/src/transformers/models/plbart/configuration_plbart.py
@@ -87,6 +87,12 @@ class PLBartConfig(PretrainedConfig):
         forced_eos_token_id (`int`, *optional*, defaults to 2):
             The id of the token to force as the last generated token when `max_length` is reached. Usually set to
             `eos_token_id`.
+        encoder_normalize_before (`bool`, *optional*, defaults to `False`):
+            Whether or not the LayerNorm is applied before each block in the encoder (not used by all models -- often
+            helps the model learn).
+        decoder_normalize_before (`bool`, *optional*, defaults to `False`):
+            Whether or not the LayerNorm is applied before each block in the decoder (not used by all models -- often
+            helps the model learn).
 
     Example:
 
@@ -131,6 +137,8 @@ class PLBartConfig(PretrainedConfig):
         bos_token_id=0,
         eos_token_id=2,
         forced_eos_token_id=2,
+        encoder_normalize_before=False,
+        decoder_normalize_before=False,
         **kwargs
     ):
         self.vocab_size = vocab_size
@@ -153,6 +161,9 @@ class PLBartConfig(PretrainedConfig):
         self.use_cache = use_cache
         self.num_hidden_layers = encoder_layers
         self.scale_embedding = scale_embedding  # scale factor will be sqrt(d_model) if True
+        self.encoder_normalize_before = encoder_normalize_before
+        self.decoder_normalize_before = decoder_normalize_before
+
         super().__init__(
             pad_token_id=pad_token_id,
             bos_token_id=bos_token_id,

--- a/src/transformers/models/plbart/modeling_plbart.py
+++ b/src/transformers/models/plbart/modeling_plbart.py
@@ -892,7 +892,7 @@ class PLBartDecoder(PLBartPreTrainedModel):
         self.layernorm_embedding = nn.LayerNorm(config.d_model)
 
         self.gradient_checkpointing = False
-        if config.encoder_normalize_before:
+        if config.decoder_normalize_before:
             self.layer_norm = nn.LayerNorm(config.d_model)
         else:
             self.layer_norm = None

--- a/src/transformers/models/plbart/modeling_plbart.py
+++ b/src/transformers/models/plbart/modeling_plbart.py
@@ -305,6 +305,7 @@ class PLBartEncoderLayer(nn.Module):
         self.fc1 = nn.Linear(self.embed_dim, config.encoder_ffn_dim)
         self.fc2 = nn.Linear(config.encoder_ffn_dim, self.embed_dim)
         self.final_layer_norm = nn.LayerNorm(self.embed_dim)
+        self.normalize_before = config.encoder_normalize_before
 
     def forward(
         self,
@@ -325,6 +326,8 @@ class PLBartEncoderLayer(nn.Module):
                 returned tensors for more detail.
         """
         residual = hidden_states
+        if self.normalize_before:
+            hidden_states = self.self_attn_layer_norm(hidden_states)
         hidden_states, attn_weights, _ = self.self_attn(
             hidden_states=hidden_states,
             attention_mask=attention_mask,
@@ -333,15 +336,19 @@ class PLBartEncoderLayer(nn.Module):
         )
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
         hidden_states = residual + hidden_states
-        hidden_states = self.self_attn_layer_norm(hidden_states)
+        if not self.normalize_before:
+            hidden_states = self.self_attn_layer_norm(hidden_states)
 
         residual = hidden_states
+        if self.normalize_before:
+            hidden_states = self.final_layer_norm(hidden_states)
         hidden_states = self.activation_fn(self.fc1(hidden_states))
         hidden_states = nn.functional.dropout(hidden_states, p=self.activation_dropout, training=self.training)
         hidden_states = self.fc2(hidden_states)
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
         hidden_states = residual + hidden_states
-        hidden_states = self.final_layer_norm(hidden_states)
+        if not self.normalize_before:
+            hidden_states = self.final_layer_norm(hidden_states)
 
         if hidden_states.dtype == torch.float16 and (
             torch.isinf(hidden_states).any() or torch.isnan(hidden_states).any()
@@ -384,6 +391,7 @@ class PLBartDecoderLayer(nn.Module):
         self.fc1 = nn.Linear(self.embed_dim, config.decoder_ffn_dim)
         self.fc2 = nn.Linear(config.decoder_ffn_dim, self.embed_dim)
         self.final_layer_norm = nn.LayerNorm(self.embed_dim)
+        self.normalize_before = config.decoder_normalize_before
 
     def forward(
         self,
@@ -416,6 +424,8 @@ class PLBartDecoderLayer(nn.Module):
                 returned tensors for more detail.
         """
         residual = hidden_states
+        if self.normalize_before:
+            hidden_states = self.self_attn_layer_norm(hidden_states)
 
         # Self Attention
         # decoder uni-directional self-attention cached key/values tuple is at positions 1,2
@@ -430,13 +440,16 @@ class PLBartDecoderLayer(nn.Module):
         )
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
         hidden_states = residual + hidden_states
-        hidden_states = self.self_attn_layer_norm(hidden_states)
+        if not self.normalize_before:
+            hidden_states = self.self_attn_layer_norm(hidden_states)
 
         # Cross-Attention Block
         cross_attn_present_key_value = None
         cross_attn_weights = None
         if encoder_hidden_states is not None:
             residual = hidden_states
+            if self.normalize_before:
+                hidden_states = self.encoder_attn_layer_norm(hidden_states)
 
             # cross_attn cached key/values tuple is at positions 3,4 of present_key_value tuple
             cross_attn_past_key_value = past_key_value[-2:] if past_key_value is not None else None
@@ -450,19 +463,23 @@ class PLBartDecoderLayer(nn.Module):
             )
             hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
             hidden_states = residual + hidden_states
-            hidden_states = self.encoder_attn_layer_norm(hidden_states)
+            if not self.normalize_before:
+                hidden_states = self.encoder_attn_layer_norm(hidden_states)
 
             # add cross-attn to positions 3,4 of present_key_value tuple
             present_key_value = present_key_value + cross_attn_present_key_value
 
         # Fully Connected
         residual = hidden_states
+        if self.normalize_before:
+            hidden_states = self.final_layer_norm(hidden_states)
         hidden_states = self.activation_fn(self.fc1(hidden_states))
         hidden_states = nn.functional.dropout(hidden_states, p=self.activation_dropout, training=self.training)
         hidden_states = self.fc2(hidden_states)
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
         hidden_states = residual + hidden_states
-        hidden_states = self.final_layer_norm(hidden_states)
+        if not self.normalize_before:
+            hidden_states = self.final_layer_norm(hidden_states)
 
         outputs = (hidden_states,)
 
@@ -694,6 +711,11 @@ class PLBartEncoder(PLBartPreTrainedModel):
         self.layernorm_embedding = nn.LayerNorm(embed_dim)
 
         self.gradient_checkpointing = False
+        if config.encoder_normalize_before:
+            self.layer_norm = nn.LayerNorm(embed_dim)
+        else:
+            self.layer_norm = None
+
         # Initialize weights and apply final processing
         self.post_init()
 
@@ -826,6 +848,9 @@ class PLBartEncoder(PLBartPreTrainedModel):
             if output_attentions:
                 all_attentions = all_attentions + (layer_outputs[1],)
 
+        if self.layer_norm:
+            hidden_states = self.layer_norm(hidden_states)
+
         if output_hidden_states:
             encoder_states = encoder_states + (hidden_states,)
 
@@ -867,6 +892,11 @@ class PLBartDecoder(PLBartPreTrainedModel):
         self.layernorm_embedding = nn.LayerNorm(config.d_model)
 
         self.gradient_checkpointing = False
+        if config.encoder_normalize_before:
+            self.layer_norm = nn.LayerNorm(config.d_model)
+        else:
+            self.layer_norm = None
+
         # Initialize weights and apply final processing
         self.post_init()
 
@@ -1090,6 +1120,9 @@ class PLBartDecoder(PLBartPreTrainedModel):
 
                 if encoder_hidden_states is not None:
                     all_cross_attentions += (layer_outputs[2],)
+
+        if self.layer_norm:
+            hidden_states = self.layer_norm(hidden_states)
 
         # add hidden states from the last decoder layer
         if output_hidden_states:


### PR DESCRIPTION
# What does this PR do?

This PR adds `encoder_normalize_before` and `decoder_normalize_before` parameters to BART models. These parameters control whether or not the `nn.LayerNorm` is applied before each block in the encoder/decoder (not used by all models -- often helps the model learn).

These parameters are already in use in `fairseq` see here for reference how it is used for [`TransformerEncoderLayerBase`](https://github.com/facebookresearch/fairseq/blob/f97cdf76d9cd20b16c3ff51f46382c2ed639bd17/fairseq/modules/transformer_layer.py#L164), [`TransformerDecoderLayerBase`](https://github.com/facebookresearch/fairseq/blob/f97cdf76d9cd20b16c3ff51f46382c2ed639bd17/fairseq/modules/transformer_layer.py#L385),  [`TransformerDecoderBase`](https://github.com/facebookresearch/fairseq/blob/f97cdf76d9cd20b16c3ff51f46382c2ed639bd17/fairseq/models/transformer/transformer_encoder.py#L101), and [`TransformerDecoderBase`](https://github.com/facebookresearch/fairseq/blob/f97cdf76d9cd20b16c3ff51f46382c2ed639bd17/fairseq/models/transformer/transformer_decoder.py#L126).

This PR simply implement the same logic that is: when `*_normalize_before` is set to `False` it behave exacly as it was before; when it is set to `True` it applys `nn.LayerNorm` before each block.

This PR is useful to load model trained with `fairseq` with that option active (e.g., [GENRE](https://github.com/facebookresearch/GENRE) -- see [here](https://github.com/facebookresearch/GENRE/blob/115095c3f526a7f12fc23f074f0da3ff7c63a2ad/scripts_mgenre/train.sh#L47)).

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

@patrickvonplaten
@patil-suraj
@ola13 
