### PR TITLE
Ensure image feature extractors outputs pixel values of shape (batch_size, n_channels, height, width)

### DIFF
--- a/docs/source/en/autoclass_tutorial.mdx
+++ b/docs/source/en/autoclass_tutorial.mdx
@@ -29,7 +29,7 @@ In this tutorial, learn to:
 
 ## AutoTokenizer
 
-Nearly every NLP task begins with a tokenizer. A tokenizer converts your input into a format that can be processed by the model.
+Nearly every NLP task begins with a tokenizer. A tokenizer converts your input to a format that can be processed by the model.
 
 Load a tokenizer with [`AutoTokenizer.from_pretrained`]:
 

--- a/examples/research_projects/wav2vec2/FINE_TUNE_XLSR_WAV2VEC2.md
+++ b/examples/research_projects/wav2vec2/FINE_TUNE_XLSR_WAV2VEC2.md
@@ -163,7 +163,7 @@ $ pip install -r requirements.txt
 	- Load the given common voice dataset
 	- Create vocab for the language
 	- Load the model with given hyperparameters
-	- Pre-process the dataset to input into the model
+	- Pre-process the dataset to input to the model
 	- Run training
 	- Run evaluation
 

--- a/src/transformers/data/datasets/language_modeling.py
+++ b/src/transformers/data/datasets/language_modeling.py
@@ -258,7 +258,7 @@ class LineByLineWithSOPTextDataset(Dataset):
 
         # We DON'T just concatenate all of the tokens from a document into a long
         # sequence and choose an arbitrary split point because this would make the
-        # next sentence prediction task too easy. Instead, we split the input into
+        # next sentence prediction task too easy. Instead, we split the input to
         # segments "A" and "B" based on the actual "sentences" provided by the user
         # input.
         examples = []

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -166,7 +166,6 @@ class BatchFeature(UserDict):
             try:
                 if not is_tensor(value):
                     tensor = as_tensor(value)
-
                     self[key] = tensor
             except:  # noqa E722
                 if key == "overflowing_values":

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -273,19 +273,16 @@ class ImageFeatureExtractionMixin:
         size given, it will be padded (so the returned result has the size asked).
 
         Args:
-            image (`PIL.Image.Image` or `np.ndarray` or `torch.Tensor` of shape (n_channels, height, width) or (height, width, n_channels)): 
+            image (`PIL.Image.Image` or `np.ndarray` or `torch.Tensor` of shape (n_channels, height, width) or (height, width, n_channels)):
                 The image to resize.
             size (`int` or `Tuple[int, int]`):
                 The size to which crop the image.
 
         Returns:
-            new_image: A center cropped `PIL.Image.Image` or `np.ndarray` or `torch.Tensor` of shape: 
-            (n_channels, height, width).
+            new_image: A center cropped `PIL.Image.Image` or `np.ndarray` or `torch.Tensor` of shape: (n_channels,
+            height, width).
         """
         self._ensure_format_supported(image)
-
-        if is_torch_tensor(image):
-            import torch
 
         if not isinstance(size, tuple):
             size = (size, size)
@@ -345,5 +342,5 @@ class ImageFeatureExtractionMixin:
         new_image = new_image[
             ..., max(0, top) : min(new_image.shape[-2], bottom), max(0, left) : min(new_image.shape[-1], right)
         ]
-        
+
         return new_image

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -207,7 +207,7 @@ class ImageFeatureExtractionMixin:
 
     def resize(self, image, size, resample=PIL.Image.BILINEAR, default_to_square=True, max_size=None):
         """
-        Resizes `image`.
+        Resizes `image`. Enforces conversion of input to PIL.Image.
 
         Args:
             image (`PIL.Image.Image` or `np.ndarray` or `torch.Tensor`):
@@ -233,17 +233,9 @@ class ImageFeatureExtractionMixin:
                 edge may be shorter than `size`. Only used if `default_to_square` is `False`.
 
         Returns:
-            image: A resized `PIL.Image.Image` or `np.ndarray` or `torch.Tensor` of shape: (n_channels,
-            height, width).
+            image: A resized `PIL.Image.Image`.
         """
         self._ensure_format_supported(image)
-
-        if isinstance(image, PIL.Image.Image):
-            image_format = "pil"
-        elif isinstance(image, np.ndarray):
-            image_format = "np"
-        else:
-            image_format = "pt"
 
         if not isinstance(image, PIL.Image.Image):
             image = self.to_pil_image(image)
@@ -276,17 +268,7 @@ class ImageFeatureExtractionMixin:
 
                 size = (new_short, new_long) if width <= height else (new_long, new_short)
 
-        image.resize(size, resample=resample)
-
-        # Convert back to original image format
-        if image_format in ["np", "pt"]:
-            image = self.to_numpy_array(image)
-
-            if image_format == "pt":
-                import torch
-                image = torch.from_numpy(image)
-
-        return image
+        return image.resize(size, resample=resample)
 
     def center_crop(self, image, size):
         """

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -207,7 +207,7 @@ class ImageFeatureExtractionMixin:
 
     def resize(self, image, size, resample=PIL.Image.BILINEAR, default_to_square=True, max_size=None):
         """
-        Resizes `image`. Note that this will trigger a conversion of `image` to a PIL Image.
+        Resizes `image`.
 
         Args:
             image (`PIL.Image.Image` or `np.ndarray` or `torch.Tensor`):
@@ -231,8 +231,19 @@ class ImageFeatureExtractionMixin:
                 greater than `max_size` after being resized according to `size`, then the image is resized again so
                 that the longer edge is equal to `max_size`. As a result, `size` might be overruled, i.e the smaller
                 edge may be shorter than `size`. Only used if `default_to_square` is `False`.
+
+        Returns:
+            image: A resized `PIL.Image.Image` or `np.ndarray` or `torch.Tensor` of shape: (n_channels,
+            height, width).
         """
         self._ensure_format_supported(image)
+
+        if isinstance(image, PIL.Image.Image):
+            image_format = "pil"
+        elif isinstance(image, np.ndarray):
+            image_format = "np"
+        else:
+            image_format = "pt"
 
         if not isinstance(image, PIL.Image.Image):
             image = self.to_pil_image(image)
@@ -265,7 +276,17 @@ class ImageFeatureExtractionMixin:
 
                 size = (new_short, new_long) if width <= height else (new_long, new_short)
 
-        return image.resize(size, resample=resample)
+        image.resize(size, resample=resample)
+
+        # Convert back to original image format
+        if image_format in ["np", "pt"]:
+            image = self.to_numpy_array(image)
+
+            if image_format == "pt":
+                import torch
+                image = torch.from_numpy(image)
+
+        return image
 
     def center_crop(self, image, size):
         """

--- a/src/transformers/models/beit/feature_extraction_beit.py
+++ b/src/transformers/models/beit/feature_extraction_beit.py
@@ -98,11 +98,11 @@ class BeitFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin):
         self,
         images: ImageInput,
         segmentation_maps: ImageInput = None,
-        return_tensors: Optional[Union[str, TensorType]] = None,
+        return_tensors: Optional[Union[str, TensorType]] = "np",
         **kwargs
     ) -> BatchFeature:
         """
-        Main method to prepare for the model one or several image(s).
+        Main method to preprocess one or several image(s) to be fed as input to the model.
 
         <Tip warning={true}>
 

--- a/src/transformers/models/clip/feature_extraction_clip.py
+++ b/src/transformers/models/clip/feature_extraction_clip.py
@@ -89,11 +89,11 @@ class CLIPFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin):
         images: Union[
             Image.Image, np.ndarray, "torch.Tensor", List[Image.Image], List[np.ndarray], List["torch.Tensor"]  # noqa
         ],
-        return_tensors: Optional[Union[str, TensorType]] = None,
+        return_tensors: Optional[Union[str, TensorType]] = "np",
         **kwargs
     ) -> BatchFeature:
         """
-        Main method to prepare for the model one or several image(s).
+        Main method to preprocess one or several image(s) to be fed as input to the model.
 
         <Tip warning={true}>
 

--- a/src/transformers/models/clip/processing_clip.py
+++ b/src/transformers/models/clip/processing_clip.py
@@ -39,7 +39,7 @@ class CLIPProcessor(ProcessorMixin):
         super().__init__(feature_extractor, tokenizer)
         self.current_processor = self.feature_extractor
 
-    def __call__(self, text=None, images=None, return_tensors=None, **kwargs):
+    def __call__(self, text=None, images=None, return_tensors="np", **kwargs):
         """
         Main method to prepare for the model one or several sequences(s) and image(s). This method forwards the `text`
         and `kwargs` arguments to CLIPTokenizerFast's [`~CLIPTokenizerFast.__call__`] if `text` is not `None` to encode

--- a/src/transformers/models/convnext/feature_extraction_convnext.py
+++ b/src/transformers/models/convnext/feature_extraction_convnext.py
@@ -85,10 +85,10 @@ class ConvNextFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMix
         self.image_std = image_std if image_std is not None else IMAGENET_DEFAULT_STD
 
     def __call__(
-        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = None, **kwargs
+        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = "np", **kwargs
     ) -> BatchFeature:
         """
-        Main method to prepare for the model one or several image(s).
+        Main method to preprocess one or several image(s) to be fed as input to the model.
 
         <Tip warning={true}>
 

--- a/src/transformers/models/deit/feature_extraction_deit.py
+++ b/src/transformers/models/deit/feature_extraction_deit.py
@@ -89,10 +89,10 @@ class DeiTFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin):
         self.image_std = image_std if image_std is not None else IMAGENET_DEFAULT_STD
 
     def __call__(
-        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = None, **kwargs
+        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = "np", **kwargs
     ) -> BatchFeature:
         """
-        Main method to prepare for the model one or several image(s).
+        Main method to preprocess one or several image(s) to be fed as input to the model.
 
         <Tip warning={true}>
 

--- a/src/transformers/models/detr/feature_extraction_detr.py
+++ b/src/transformers/models/detr/feature_extraction_detr.py
@@ -407,7 +407,7 @@ class DetrFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin):
         return_segmentation_masks: Optional[bool] = False,
         masks_path: Optional[pathlib.Path] = None,
         pad_and_return_pixel_mask: Optional[bool] = True,
-        return_tensors: Optional[Union[str, TensorType]] = None,
+        return_tensors: Optional[Union[str, TensorType]] = "np",
         **kwargs,
     ) -> BatchFeature:
         """

--- a/src/transformers/models/dpt/feature_extraction_dpt.py
+++ b/src/transformers/models/dpt/feature_extraction_dpt.py
@@ -131,10 +131,10 @@ class DPTFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin):
         return (new_width, new_height)
 
     def __call__(
-        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = None, **kwargs
+        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = "np", **kwargs
     ) -> BatchFeature:
         """
-        Main method to prepare for the model one or several image(s).
+        Main method to preprocess one or several image(s) to be fed as input to the model.
 
         <Tip warning={true}>
 

--- a/src/transformers/models/flava/feature_extraction_flava.py
+++ b/src/transformers/models/flava/feature_extraction_flava.py
@@ -258,11 +258,11 @@ class FlavaFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin)
         ],
         return_image_mask: Optional[bool] = None,
         return_codebook_pixels: Optional[bool] = None,
-        return_tensors: Optional[Union[str, TensorType]] = None,
+        return_tensors: Optional[Union[str, TensorType]] = "np",
         **kwargs: Any
     ) -> BatchFeature:
         """
-        Main method to prepare for the model one or several image(s).
+        Main method to preprocess one or several image(s) to be fed as input to the model.
 
         <Tip warning={true}>
 

--- a/src/transformers/models/glpn/feature_extraction_glpn.py
+++ b/src/transformers/models/glpn/feature_extraction_glpn.py
@@ -68,7 +68,7 @@ class GLPNFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin):
         return image
 
     def __call__(
-        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = None, **kwargs
+        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = "np", **kwargs
     ) -> BatchFeature:
         """
         Main method to prepare for the model one or several image(s).

--- a/src/transformers/models/imagegpt/feature_extraction_imagegpt.py
+++ b/src/transformers/models/imagegpt/feature_extraction_imagegpt.py
@@ -98,11 +98,11 @@ class ImageGPTFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMix
         images: Union[
             Image.Image, np.ndarray, "torch.Tensor", List[Image.Image], List[np.ndarray], List["torch.Tensor"]  # noqa
         ],
-        return_tensors: Optional[Union[str, TensorType]] = None,
+        return_tensors: Optional[Union[str, TensorType]] = "np",
         **kwargs
     ) -> BatchFeature:
         """
-        Main method to prepare for the model one or several image(s).
+        Main method to preprocess one or several image(s) to be fed as input to the model.
 
         <Tip warning={true}>
 

--- a/src/transformers/models/layoutlmv2/feature_extraction_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/feature_extraction_layoutlmv2.py
@@ -121,10 +121,10 @@ class LayoutLMv2FeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
         self.ocr_lang = ocr_lang
 
     def __call__(
-        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = None, **kwargs
+        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = "np", **kwargs
     ) -> BatchFeature:
         """
-        Main method to prepare for the model one or several image(s).
+        Main method to preprocess one or several image(s) to be fed as input to the model.
 
         Args:
             images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`, `List[torch.Tensor]`):

--- a/src/transformers/models/layoutlmv3/feature_extraction_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/feature_extraction_layoutlmv3.py
@@ -141,10 +141,10 @@ class LayoutLMv3FeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
         self.ocr_lang = ocr_lang
 
     def __call__(
-        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = None, **kwargs
+        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = "np", **kwargs
     ) -> BatchFeature:
         """
-        Main method to prepare for the model one or several image(s).
+        Main method to preprocess one or several image(s) to be fed as input to the model.
 
         Args:
             images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`, `List[torch.Tensor]`):

--- a/src/transformers/models/led/modeling_led.py
+++ b/src/transformers/models/led/modeling_led.py
@@ -423,7 +423,7 @@ class LEDEncoderSelfAttention(nn.Module):
     def _sliding_chunks_query_key_matmul(self, query: torch.Tensor, key: torch.Tensor, window_overlap: int):
         """
         Matrix multiplication of query and key tensors using with a sliding window attention pattern. This
-        implementation splits the input into overlapping chunks of size 2w (e.g. 512 for pretrained LEDEncoder) with an
+        implementation splits the input to overlapping chunks of size 2w (e.g. 512 for pretrained LEDEncoder) with an
         overlap of size window_overlap
         """
         batch_size, seq_len, num_heads, head_dim = query.size()

--- a/src/transformers/models/led/modeling_tf_led.py
+++ b/src/transformers/models/led/modeling_tf_led.py
@@ -384,7 +384,7 @@ class TFLEDEncoderSelfAttention(tf.keras.layers.Layer):
     def _sliding_chunks_query_key_matmul(self, query, key, window_overlap):
         """
         Matrix multiplication of query and key tensors using with a sliding window attention pattern. This
-        implementation splits the input into overlapping chunks of size 2w (e.g. 512 for pretrained Longformer) with an
+        implementation splits the input to overlapping chunks of size 2w (e.g. 512 for pretrained Longformer) with an
         overlap of size window_overlap
         """
         batch_size, seq_len, num_heads, head_dim = shape_list(query)

--- a/src/transformers/models/levit/feature_extraction_levit.py
+++ b/src/transformers/models/levit/feature_extraction_levit.py
@@ -83,10 +83,10 @@ class LevitFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin)
         self.image_std = image_std
 
     def __call__(
-        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = None, **kwargs
+        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = "np", **kwargs
     ) -> BatchFeature:
         """
-        Main method to prepare for the model one or several image(s).
+        Main method to preprocess one or several image(s) to be fed as input to the model.
 
         <Tip warning={true}>
 

--- a/src/transformers/models/longformer/modeling_longformer.py
+++ b/src/transformers/models/longformer/modeling_longformer.py
@@ -802,7 +802,7 @@ class LongformerSelfAttention(nn.Module):
     def _sliding_chunks_query_key_matmul(self, query: torch.Tensor, key: torch.Tensor, window_overlap: int):
         """
         Matrix multiplication of query and key tensors using with a sliding window attention pattern. This
-        implementation splits the input into overlapping chunks of size 2w (e.g. 512 for pretrained Longformer) with an
+        implementation splits the input to overlapping chunks of size 2w (e.g. 512 for pretrained Longformer) with an
         overlap of size window_overlap
         """
         batch_size, seq_len, num_heads, head_dim = query.size()

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -913,7 +913,7 @@ class TFLongformerSelfAttention(tf.keras.layers.Layer):
     def _sliding_chunks_query_key_matmul(self, query, key, window_overlap):
         """
         Matrix multiplication of query and key tensors using with a sliding window attention pattern. This
-        implementation splits the input into overlapping chunks of size 2w (e.g. 512 for pretrained Longformer) with an
+        implementation splits the input to overlapping chunks of size 2w (e.g. 512 for pretrained Longformer) with an
         overlap of size window_overlap
         """
         batch_size, seq_len, num_heads, head_dim = shape_list(query)

--- a/src/transformers/models/maskformer/feature_extraction_maskformer.py
+++ b/src/transformers/models/maskformer/feature_extraction_maskformer.py
@@ -431,7 +431,7 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
         # return as BatchFeature
         data = {"pixel_values": pixel_values, "pixel_mask": pixel_mask}
         encoded_inputs = BatchFeature(data=data, tensor_type=return_tensors)
-        
+
         # we cannot batch them since they don't share a common class size
         if annotations:
             for label in annotations:

--- a/src/transformers/models/maskformer/feature_extraction_maskformer.py
+++ b/src/transformers/models/maskformer/feature_extraction_maskformer.py
@@ -163,7 +163,7 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
         segmentation_maps: ImageInput = None,
         pad_and_return_pixel_mask: Optional[bool] = True,
         instance_id_to_semantic_id: Optional[Dict[int, int]] = None,
-        return_tensors: Optional[Union[str, TensorType]] = None,
+        return_tensors: Optional[Union[str, TensorType]] = "np",
         **kwargs,
     ) -> BatchFeature:
         """

--- a/src/transformers/models/maskformer/modeling_maskformer.py
+++ b/src/transformers/models/maskformer/modeling_maskformer.py
@@ -481,7 +481,7 @@ def to_2tuple(x):
 # Copied from transformers.models.swin.modeling_swin.window_partition
 def window_partition(input_feature, window_size):
     """
-    Partitions the given input into windows.
+    Partitions the given input to windows.
     """
     batch_size, height, width, num_channels = input_feature.shape
     input_feature = input_feature.view(

--- a/src/transformers/models/poolformer/feature_extraction_poolformer.py
+++ b/src/transformers/models/poolformer/feature_extraction_poolformer.py
@@ -86,10 +86,10 @@ class PoolFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
         self.image_std = image_std if image_std is not None else IMAGENET_DEFAULT_STD
 
     def __call__(
-        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = None, **kwargs
+        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = "np", **kwargs
     ) -> BatchFeature:
         """
-        Main method to prepare for the model one or several image(s).
+        Main method to preprocess one or several image(s) to be fed as input to the model.
 
         <Tip warning={true}>
 

--- a/src/transformers/models/swin/modeling_swin.py
+++ b/src/transformers/models/swin/modeling_swin.py
@@ -212,7 +212,7 @@ def to_2tuple(x):
 
 def window_partition(input_feature, window_size):
     """
-    Partitions the given input into windows.
+    Partitions the given input to windows.
     """
     batch_size, height, width, num_channels = input_feature.shape
     input_feature = input_feature.view(

--- a/src/transformers/models/swin/modeling_tf_swin.py
+++ b/src/transformers/models/swin/modeling_tf_swin.py
@@ -211,7 +211,7 @@ def to_2tuple(x) -> Tuple[Any, Any]:
 
 def window_partition(input_feature: tf.Tensor, window_size: int) -> tf.Tensor:
     """
-    Partitions the given input into windows.
+    Partitions the given input to windows.
     """
     batch_size, height, width, num_channels = input_feature.shape
     input_feature = tf.reshape(

--- a/src/transformers/models/vilt/feature_extraction_vilt.py
+++ b/src/transformers/models/vilt/feature_extraction_vilt.py
@@ -182,7 +182,7 @@ class ViltFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin):
         self,
         images: ImageInput,
         pad_and_return_pixel_mask: Optional[bool] = True,
-        return_tensors: Optional[Union[str, TensorType]] = None,
+        return_tensors: Optional[Union[str, TensorType]] = "np",
         **kwargs
     ) -> BatchFeature:
         """

--- a/src/transformers/models/vit/feature_extraction_vit.py
+++ b/src/transformers/models/vit/feature_extraction_vit.py
@@ -141,10 +141,13 @@ class ViTFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin):
             images = [self.resize(image=image, size=self.size, resample=self.resample) for image in images]
 
             if isinstance(images[0], Image.Image):
-                images = [np.array(image) for image in images]
+                images = [np.array(image).transpose(2, 0, 1) for image in images]
 
         if self.do_normalize:
             images = [self.normalize(image=image, mean=self.image_mean, std=self.image_std) for image in images]
+
+        if isinstance(images[0], Image.Image):
+            images = [np.array(image).transpose(2, 0, 1) for image in images]
 
         # return as BatchFeature
         data = {"pixel_values": images}

--- a/src/transformers/models/vit/feature_extraction_vit.py
+++ b/src/transformers/models/vit/feature_extraction_vit.py
@@ -139,6 +139,10 @@ class ViTFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin):
         # transformations (resizing + normalization)
         if self.do_resize and self.size is not None:
             images = [self.resize(image=image, size=self.size, resample=self.resample) for image in images]
+
+            if isinstance(images[0], Image.Image):
+                images = [np.array(image) for image in images]
+
         if self.do_normalize:
             images = [self.normalize(image=image, mean=self.image_mean, std=self.image_std) for image in images]
 

--- a/src/transformers/models/vit/feature_extraction_vit.py
+++ b/src/transformers/models/vit/feature_extraction_vit.py
@@ -80,10 +80,10 @@ class ViTFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin):
         self.image_std = image_std if image_std is not None else IMAGENET_STANDARD_STD
 
     def __call__(
-        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = None, **kwargs
+        self, images: ImageInput, return_tensors: Optional[Union[str, TensorType]] = "np", **kwargs
     ) -> BatchFeature:
         """
-        Main method to prepare for the model one or several image(s).
+        Main method to preprocess one or several image(s) to be fed as input to the model.
 
         <Tip warning={true}>
 

--- a/src/transformers/models/yolos/feature_extraction_yolos.py
+++ b/src/transformers/models/yolos/feature_extraction_yolos.py
@@ -414,7 +414,7 @@ class YolosFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin)
         return_segmentation_masks: Optional[bool] = False,
         masks_path: Optional[pathlib.Path] = None,
         padding: Optional[bool] = True,
-        return_tensors: Optional[Union[str, TensorType]] = None,
+        return_tensors: Optional[Union[str, TensorType]] = "np",
         **kwargs,
     ) -> BatchFeature:
         """

--- a/tests/utils/test_image_utils.py
+++ b/tests/utils/test_image_utils.py
@@ -421,45 +421,6 @@ class ImageFeatureExtractionTester(unittest.TestCase):
             cropped_image = feature_extractor.center_crop(image, size)
             self.assertTrue(torch.equal(cropped_tensor, torch.tensor(feature_extractor.to_numpy_array(cropped_image))))
 
-    @require_torch
-    def test_center_crop_channel_last(self):
-        feature_extractor = ImageFeatureExtractionMixin()
-        image = get_random_image(16, 32)
-
-        # Test on numpy array
-        array = feature_extractor.to_numpy_array(image)
-        array = array.transpose(1, 2, 0)
-
-        # Test various crop sizes: bigger on all dimensions, on one of the dimensions only and on both dimensions.
-        crop_sizes = [8, (8, 64), 20, (32, 64)]
-        for size in crop_sizes:
-            cropped_array = feature_extractor.center_crop(array, size)
-            self.assertTrue(isinstance(cropped_array, np.ndarray))
-
-            expected_size = (size, size) if isinstance(size, int) else size
-            self.assertEqual(cropped_array.shape[-2:], expected_size)
-
-            # Check result is consistent with PIL.Image.crop
-            cropped_image = feature_extractor.center_crop(image, size)
-            self.assertTrue(np.array_equal(cropped_array, feature_extractor.to_numpy_array(cropped_image)))
-
-        array = feature_extractor.to_numpy_array(image)
-        tensor = torch.tensor(array)
-        array = array.permute(2, 0, 1)
-
-        # Test various crop sizes: bigger on all dimensions, on one of the dimensions only and on both dimensions.
-        for size in crop_sizes:
-            cropped_tensor = feature_extractor.center_crop(tensor, size)
-            self.assertTrue(isinstance(cropped_tensor, torch.Tensor))
-
-            expected_size = (size, size) if isinstance(size, int) else size
-            self.assertEqual(cropped_tensor.shape[-2:], expected_size)
-
-            # Check result is consistent with PIL.Image.crop
-            cropped_image = feature_extractor.center_crop(image, size)
-            self.assertTrue(torch.equal(cropped_tensor, torch.tensor(feature_extractor.to_numpy_array(cropped_image))))
-
-
 @require_vision
 class LoadImageTester(unittest.TestCase):
     def test_load_img_local(self):

--- a/tests/utils/test_image_utils.py
+++ b/tests/utils/test_image_utils.py
@@ -421,6 +421,43 @@ class ImageFeatureExtractionTester(unittest.TestCase):
             cropped_image = feature_extractor.center_crop(image, size)
             self.assertTrue(torch.equal(cropped_tensor, torch.tensor(feature_extractor.to_numpy_array(cropped_image))))
 
+    @require_torch
+    def test_center_crop_channel_last(self):
+        feature_extractor = ImageFeatureExtractionMixin()
+        image = get_random_image(16, 32)
+
+        # Test on numpy array
+        array = feature_extractor.to_numpy_array(image)
+        array = array.transpose(1, 2, 0)
+        
+        # Test various crop sizes: bigger on all dimensions, on one of the dimensions only and on both dimensions.
+        crop_sizes = [8, (8, 64), 20, (32, 64)]
+        for size in crop_sizes:
+            cropped_array = feature_extractor.center_crop(array, size)
+            self.assertTrue(isinstance(cropped_array, np.ndarray))
+
+            expected_size = (size, size) if isinstance(size, int) else size
+            self.assertEqual(cropped_array.shape[-2:], expected_size)
+
+            # Check result is consistent with PIL.Image.crop
+            cropped_image = feature_extractor.center_crop(image, size)
+            self.assertTrue(np.array_equal(cropped_array, feature_extractor.to_numpy_array(cropped_image)))
+
+        array = feature_extractor.to_numpy_array(image)
+        tensor = torch.tensor(array)
+        array = array.permute(2, 0, 1)
+
+        # Test various crop sizes: bigger on all dimensions, on one of the dimensions only and on both dimensions.
+        for size in crop_sizes:
+            cropped_tensor = feature_extractor.center_crop(tensor, size)
+            self.assertTrue(isinstance(cropped_tensor, torch.Tensor))
+
+            expected_size = (size, size) if isinstance(size, int) else size
+            self.assertEqual(cropped_tensor.shape[-2:], expected_size)
+
+            # Check result is consistent with PIL.Image.crop
+            cropped_image = feature_extractor.center_crop(image, size)
+            self.assertTrue(torch.equal(cropped_tensor, torch.tensor(feature_extractor.to_numpy_array(cropped_image))))
 
 @require_vision
 class LoadImageTester(unittest.TestCase):

--- a/tests/utils/test_image_utils.py
+++ b/tests/utils/test_image_utils.py
@@ -429,7 +429,7 @@ class ImageFeatureExtractionTester(unittest.TestCase):
         # Test on numpy array
         array = feature_extractor.to_numpy_array(image)
         array = array.transpose(1, 2, 0)
-        
+
         # Test various crop sizes: bigger on all dimensions, on one of the dimensions only and on both dimensions.
         crop_sizes = [8, (8, 64), 20, (32, 64)]
         for size in crop_sizes:
@@ -458,6 +458,7 @@ class ImageFeatureExtractionTester(unittest.TestCase):
             # Check result is consistent with PIL.Image.crop
             cropped_image = feature_extractor.center_crop(image, size)
             self.assertTrue(torch.equal(cropped_tensor, torch.tensor(feature_extractor.to_numpy_array(cropped_image))))
+
 
 @require_vision
 class LoadImageTester(unittest.TestCase):

--- a/tests/utils/test_image_utils.py
+++ b/tests/utils/test_image_utils.py
@@ -421,6 +421,45 @@ class ImageFeatureExtractionTester(unittest.TestCase):
             cropped_image = feature_extractor.center_crop(image, size)
             self.assertTrue(torch.equal(cropped_tensor, torch.tensor(feature_extractor.to_numpy_array(cropped_image))))
 
+    @require_torch
+    def test_center_crop_channel_last(self):
+        feature_extractor = ImageFeatureExtractionMixin()
+        image = get_random_image(16, 32)
+
+        # Test on numpy array
+        array = feature_extractor.to_numpy_array(image)
+        array = array.transpose(1, 2, 0)
+
+        # Test various crop sizes: bigger on all dimensions, on one of the dimensions only and on both dimensions.
+        crop_sizes = [8, (8, 64), 20, (32, 64)]
+        for size in crop_sizes:
+            cropped_array = feature_extractor.center_crop(array, size)
+            self.assertTrue(isinstance(cropped_array, np.ndarray))
+
+            expected_size = (size, size) if isinstance(size, int) else size
+            self.assertEqual(cropped_array.shape[-2:], expected_size)
+
+            # Check result is consistent with PIL.Image.crop
+            cropped_image = feature_extractor.center_crop(image, size)
+            self.assertTrue(np.array_equal(cropped_array, feature_extractor.to_numpy_array(cropped_image)))
+
+        array = feature_extractor.to_numpy_array(image)
+        tensor = torch.tensor(array)
+        array = array.permute(2, 0, 1)
+
+        # Test various crop sizes: bigger on all dimensions, on one of the dimensions only and on both dimensions.
+        for size in crop_sizes:
+            cropped_tensor = feature_extractor.center_crop(tensor, size)
+            self.assertTrue(isinstance(cropped_tensor, torch.Tensor))
+
+            expected_size = (size, size) if isinstance(size, int) else size
+            self.assertEqual(cropped_tensor.shape[-2:], expected_size)
+
+            # Check result is consistent with PIL.Image.crop
+            cropped_image = feature_extractor.center_crop(image, size)
+            self.assertTrue(torch.equal(cropped_tensor, torch.tensor(feature_extractor.to_numpy_array(cropped_image))))
+
+
 @require_vision
 class LoadImageTester(unittest.TestCase):
     def test_load_img_local(self):


### PR DESCRIPTION
Fixes #15055 #17526 

- center_crop in image_utils.py now can process numpy and torch images of shape (n_channels, height, width) and (height, width, n_channels), and returns cropped image of shape (n_channels, height, width).
- Fixed feature extractors that inherit from ImageFeatureExtractionMixin to always return numpy arrays or tensors of shape (batch_size, n_channels, height, width)