### PR TITLE
Add Ray's scope to training arguments

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -297,7 +297,7 @@ def run_hp_search_ray(trainer, n_trials: int, direction: str, **kwargs) -> BestR
         num_samples=n_trials,
         **kwargs,
     )
-    best_trial = analysis.get_best_trial(metric="objective", mode=direction[:3])
+    best_trial = analysis.get_best_trial(metric="objective", mode=direction[:3], scope=trainer.args.ray_scope)
     best_run = BestRun(best_trial.trial_id, best_trial.last_result["objective"], best_trial.config)
     if _tb_writer is not None:
         trainer.add_callback(_tb_writer)

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -459,7 +459,7 @@ class TrainingArguments:
         ray_scope (`str`, *optional*, defaults to `"last"`):
             The scope to use when doing hyperparameter search with Ray. By default, `"last"` will be used. Ray will
             then use the last checkpoint of all trials, compare those, and select the best one. However, other options
-            are also available. See the 
+            are also available. See the
             [Ray documentation](https://docs.ray.io/en/latest/tune/api_docs/analysis.html#ray.tune.ExperimentAnalysis.get_best_trial)
             for more options.
     """
@@ -926,15 +926,14 @@ class TrainingArguments:
         default="last",
         metadata={
             "help": (
-                "The scope to use when doing hyperparameter search with Ray. By default, `\"last\"` will be used. Ray will"
-                " then use the last checkpoint of all trials, compare those, and select the best one. However, other options"
-                " are also available. See the Ray documentation"
+                'The scope to use when doing hyperparameter search with Ray. By default, `"last"` will be used. Ray'
+                " will then use the last checkpoint of all trials, compare those, and select the best one. However,"
+                " other options are also available. See the Ray documentation"
                 " (https://docs.ray.io/en/latest/tune/api_docs/analysis.html#ray.tune.ExperimentAnalysis.get_best_trial)"
                 " for more options."
             )
         },
     )
-        
 
     def __post_init__(self):
         # Handle --use_env option in torch.distributed.launch (local_rank not passed as an arg then).

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -461,7 +461,8 @@ class TrainingArguments:
             then use the last checkpoint of all trials, compare those, and select the best one. However, other options
             are also available. See the
             [Ray documentation](
-            https://docs.ray.io/en/latest/tune/api_docs/analysis.html#ray.tune.ExperimentAnalysis.get_best_trial)
+            https://docs.ray.io/en/latest/tune/api_docs/analysis.html\
+            #ray.tune.ExperimentAnalysis.get_best_trial)
             for more options.
     """
 
@@ -929,9 +930,9 @@ class TrainingArguments:
             "help": (
                 'The scope to use when doing hyperparameter search with Ray. By default, `"last"` will be used. Ray'
                 " will then use the last checkpoint of all trials, compare those, and select the best one. However,"
-                " other options are also available. See the Ray documentation ("
-                "https://docs.ray.io/en/latest/tune/api_docs/analysis.html#ray.tune.ExperimentAnalysis.get_best_trial"
-                ")"
+                " other options are also available. See the Ray documentation"
+                " (https://docs.ray.io/en/latest/tune/api_docs/analysis.html"
+                "#ray.tune.ExperimentAnalysis.get_best_trial)"
                 " for more options."
             )
         },

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -456,6 +456,12 @@ class TrainingArguments:
         torchdynamo (`str`, *optional*):
             The token that is used to set the backend compiler for TorchDynamo. Possible choices are ["eager",
             "nvfuser]. This is an experimental API and subject to change.
+        ray_scope (`str`, *optional*, defaults to `"last"`):
+            The scope to use when doing hyperparameter search with Ray. By default, `"last"` will be used. Ray will
+            then use the last checkpoint of all trials, compare those, and select the best one. However, other options
+            are also available. See the 
+            [Ray documentation](https://docs.ray.io/en/latest/tune/api_docs/analysis.html#ray.tune.ExperimentAnalysis.get_best_trial)
+            for more options.
     """
 
     output_dir: str = field(
@@ -916,6 +922,19 @@ class TrainingArguments:
             "choices": ["eager", "nvfuser"],
         },
     )
+    ray_scope: Optional[str] = field(
+        default="last",
+        metadata={
+            "help": (
+                "The scope to use when doing hyperparameter search with Ray. By default, `"last"` will be used. Ray will"
+                " then use the last checkpoint of all trials, compare those, and select the best one. However, other options"
+                " are also available. See the Ray documentation"
+                " (https://docs.ray.io/en/latest/tune/api_docs/analysis.html#ray.tune.ExperimentAnalysis.get_best_trial)"
+                " for more options."
+            )
+        },
+    )
+        
 
     def __post_init__(self):
         # Handle --use_env option in torch.distributed.launch (local_rank not passed as an arg then).

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -926,7 +926,7 @@ class TrainingArguments:
         default="last",
         metadata={
             "help": (
-                "The scope to use when doing hyperparameter search with Ray. By default, `"last"` will be used. Ray will"
+                "The scope to use when doing hyperparameter search with Ray. By default, `\"last\"` will be used. Ray will"
                 " then use the last checkpoint of all trials, compare those, and select the best one. However, other options"
                 " are also available. See the Ray documentation"
                 " (https://docs.ray.io/en/latest/tune/api_docs/analysis.html#ray.tune.ExperimentAnalysis.get_best_trial)"

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -459,11 +459,8 @@ class TrainingArguments:
         ray_scope (`str`, *optional*, defaults to `"last"`):
             The scope to use when doing hyperparameter search with Ray. By default, `"last"` will be used. Ray will
             then use the last checkpoint of all trials, compare those, and select the best one. However, other options
-            are also available. See the
-            [Ray documentation](
-            https://docs.ray.io/en/latest/tune/api_docs/analysis.html\
-            #ray.tune.ExperimentAnalysis.get_best_trial)
-            for more options.
+            are also available. See the [Ray documentation]( https://docs.ray.io/en/latest/tune/api_docs/analysis.html\
+            #ray.tune.ExperimentAnalysis.get_best_trial) for more options.
     """
 
     output_dir: str = field(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -459,8 +459,9 @@ class TrainingArguments:
         ray_scope (`str`, *optional*, defaults to `"last"`):
             The scope to use when doing hyperparameter search with Ray. By default, `"last"` will be used. Ray will
             then use the last checkpoint of all trials, compare those, and select the best one. However, other options
-            are also available. See the [Ray documentation]( https://docs.ray.io/en/latest/tune/api_docs/analysis.html\
-#ray.tune.ExperimentAnalysis.get_best_trial) for more options.
+            are also available. See the [Ray documentation](
+            https://docs.ray.io/en/latest/tune/api_docs/analysis.html#ray.tune.ExperimentAnalysis.get_best_trial) for
+            more options.
     """
 
     output_dir: str = field(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -460,7 +460,7 @@ class TrainingArguments:
             The scope to use when doing hyperparameter search with Ray. By default, `"last"` will be used. Ray will
             then use the last checkpoint of all trials, compare those, and select the best one. However, other options
             are also available. See the [Ray documentation]( https://docs.ray.io/en/latest/tune/api_docs/analysis.html\
-            #ray.tune.ExperimentAnalysis.get_best_trial) for more options.
+#ray.tune.ExperimentAnalysis.get_best_trial) for more options.
     """
 
     output_dir: str = field(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -460,7 +460,8 @@ class TrainingArguments:
             The scope to use when doing hyperparameter search with Ray. By default, `"last"` will be used. Ray will
             then use the last checkpoint of all trials, compare those, and select the best one. However, other options
             are also available. See the
-            [Ray documentation](https://docs.ray.io/en/latest/tune/api_docs/analysis.html#ray.tune.ExperimentAnalysis.get_best_trial)
+            [Ray documentation](
+            https://docs.ray.io/en/latest/tune/api_docs/analysis.html#ray.tune.ExperimentAnalysis.get_best_trial)
             for more options.
     """
 
@@ -928,8 +929,9 @@ class TrainingArguments:
             "help": (
                 'The scope to use when doing hyperparameter search with Ray. By default, `"last"` will be used. Ray'
                 " will then use the last checkpoint of all trials, compare those, and select the best one. However,"
-                " other options are also available. See the Ray documentation"
-                " (https://docs.ray.io/en/latest/tune/api_docs/analysis.html#ray.tune.ExperimentAnalysis.get_best_trial)"
+                " other options are also available. See the Ray documentation ("
+                "https://docs.ray.io/en/latest/tune/api_docs/analysis.html#ray.tune.ExperimentAnalysis.get_best_trial"
+                ")"
                 " for more options."
             )
         },


### PR DESCRIPTION
# What does this PR do?

As discussed in https://github.com/huggingface/transformers/issues/16683, it often happens that you want more control over gridsearch. By default, Ray will run different trials with different hyperparameters, and then select the best one based on the loss (or other metric) of each trial's _final_ checkpoint. That's not always what you want however (when some trials converge faster than others and therefore overfit in the same number of steps). Luckily Ray allows [other options](https://docs.ray.io/en/latest/tune/api_docs/analysis.html#ray.tune.ExperimentAnalysis.get_best_trial). With this PR, the user gets a little bit more control over how to use Ray's search.

<!-- Remove if not applicable -->

Fixes #16683 


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. **Discussed but never received an official reply. Got some community responses of others who would like to see this change, however.**
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).


## Who can review?

@richardliaw, @amogkam
