### PR TITLE
Fix very long job failure text

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -654,9 +654,9 @@ if __name__ == "__main__":
                         if artifact_path["gpu"] not in model_results[model]["failures"]:
                             model_results[model]["failures"][artifact_path["gpu"]] = []
 
-                        model_results[model]["failures"][
-                            artifact_path["gpu"]
-                        ].append({"line": line, "trace": stacktraces.pop(0)})
+                        model_results[model]["failures"][artifact_path["gpu"]].append(
+                            {"line": line, "trace": stacktraces.pop(0)}
+                        )
 
                         if re.search("test_modeling_tf_", line):
                             model_results[model]["failed"]["TensorFlow"][artifact_path["gpu"]] += 1
@@ -743,9 +743,9 @@ if __name__ == "__main__":
                         if artifact_path["gpu"] not in additional_results[key]["failures"]:
                             additional_results[key]["failures"][artifact_path["gpu"]] = []
 
-                        additional_results[key]["failures"][
-                            artifact_path["gpu"]
-                        ].append({"line": line, "trace": stacktraces.pop(0)})
+                        additional_results[key]["failures"][artifact_path["gpu"]].append(
+                            {"line": line, "trace": stacktraces.pop(0)}
+                        )
 
     # To find the PR number in a commit title, for example, `Add AwesomeFormer model (#99999)`
     pr_number_re = re.compile(r"\(#(\d+)\)$")

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -407,8 +407,19 @@ class Message:
         )
 
     def get_reply_blocks(self, job_name, job_result, failures, device, text):
-        if len(failures) > 2500:
-            failures = "\n".join(failures.split("\n")[:20]) + "\n\n[Truncated]"
+        """
+        failures: A list with elements of the form {"line": full test name, "trace": error trace}
+        """
+        # `text` must be less than 3001 characters in Slack SDK
+        MAX_ERROR_TEXT = 3000 - len("[Truncated]")
+
+        text = ""
+        for idx, error in enumerate(failures):
+            new_text = text + f'*{error["line"]}*\n_{error["trace"]}_\n\n'
+            if len(new_text) > MAX_ERROR_TEXT:
+                text = text + "[Truncated]"
+                break
+            text = new_text
 
         title = job_name
         if device is not None:
@@ -638,11 +649,11 @@ if __name__ == "__main__":
                         line = line.split()[0].replace("\n", "")
 
                         if artifact_path["gpu"] not in model_results[model]["failures"]:
-                            model_results[model]["failures"][artifact_path["gpu"]] = ""
+                            model_results[model]["failures"][artifact_path["gpu"]] = []
 
                         model_results[model]["failures"][
                             artifact_path["gpu"]
-                        ] += f"*{line}*\n_{stacktraces.pop(0)}_\n\n"
+                        ].append({"line": line, "trace": stacktraces.pop(0)})
 
                         if re.search("test_modeling_tf_", line):
                             model_results[model]["failed"]["TensorFlow"][artifact_path["gpu"]] += 1
@@ -727,11 +738,11 @@ if __name__ == "__main__":
                         line = line.split()[0].replace("\n", "")
 
                         if artifact_path["gpu"] not in additional_results[key]["failures"]:
-                            additional_results[key]["failures"][artifact_path["gpu"]] = ""
+                            additional_results[key]["failures"][artifact_path["gpu"]] = []
 
                         additional_results[key]["failures"][
                             artifact_path["gpu"]
-                        ] += f"*{line}*\n_{stacktraces.pop(0)}_\n\n"
+                        ].append({"line": line, "trace": stacktraces.pop(0)})
 
     # To find the PR number in a commit title, for example, `Add AwesomeFormer model (#99999)`
     pr_number_re = re.compile(r"\(#(\d+)\)$")

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -411,15 +411,18 @@ class Message:
         failures: A list with elements of the form {"line": full test name, "trace": error trace}
         """
         # `text` must be less than 3001 characters in Slack SDK
+        # keep some room for adding "[Truncated]" when necessary
         MAX_ERROR_TEXT = 3000 - len("[Truncated]")
 
-        text = ""
+        failure_text = ""
         for idx, error in enumerate(failures):
-            new_text = text + f'*{error["line"]}*\n_{error["trace"]}_\n\n'
+            new_text = failure_text + f'*{error["line"]}*\n_{error["trace"]}_\n\n'
             if len(new_text) > MAX_ERROR_TEXT:
-                text = text + "[Truncated]"
+                # `failure_text` here has length <= 3000
+                failure_text = failure_text + "[Truncated]"
                 break
-            text = new_text
+            # `failure_text` here has length <= MAX_ERROR_TEXT
+            failure_text = new_text
 
         title = job_name
         if device is not None:
@@ -437,7 +440,7 @@ class Message:
         return [
             {"type": "header", "text": {"type": "plain_text", "text": title.upper(), "emoji": True}},
             content,
-            {"type": "section", "text": {"type": "mrkdwn", "text": failures}},
+            {"type": "section", "text": {"type": "mrkdwn", "text": failure_text}},
         ]
 
     def post_reply(self):


### PR DESCRIPTION
# What does this PR do?

Slack SDK have a limit of `3000` characters for "text" field. For some rare cases, we have very long test error trace.
See this [dummy job run](https://github.com/huggingface/transformers/runs/6753872641?check_suite_focus=true)

This PR tries to limit the length, so the report could be sent to Slack.
(Previous version has some check, but it didn't take into account that a single test failure could have very long trace itself along)


For the record, the test failure with very long trace is like
```
E           ValueError: torch.float32 is enabled but the following parameters have dtype that is not torch.float32: [('shared.weight', torch.float16), ('encoder.block.0.layer.0.SelfAttention.q.weight', torch.float16), ('encoder.block.0.layer.0.SelfAttention.k.weight', torch.float16), ('encoder.block.0.layer.0.SelfAttention.v.weight', torch.float16), ('encoder.block.0.layer.0.SelfAttention.o.weight', torch.float16), ('encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight', torch.float16), ('encoder.block.0.layer.0.layer_norm.weight', torch.float16), ('encoder.block.0.layer.1.DenseReluDense.wi.weight', torch.float16), ('encoder.block.0.layer.1.DenseReluDense.wo.weight', torch.float16), ('encoder.block.0.layer.1.layer_norm.weight', torch.float16), ('encoder.block.1.layer.0.SelfAttention.q.weight', torch.float16), ('encoder.block.1.layer.0.SelfAttention.k.weight', torch.float16), ('encoder.block.1.layer.0.SelfAttention.v.weight', torch.float16), ('encoder.block.1.layer.0.SelfAttention.o.weight', torch.float16), ('encoder.block.1.layer.0.layer_norm.weight', torch.float16), ('encoder.block.1.layer.1.DenseReluDense.wi.weight', torch.float16), ('encoder.block.1.layer.1.DenseReluDense.wo.weight', torch.float16), ('encoder.block.1.layer.1.layer_norm.weight', torch.float16), ('encoder.final_layer_norm.weight', torch.float16), ('decoder.block.0.layer.0.SelfAttention.q.weight', torch.float16), ('decoder.block.0.layer.0.SelfAttention.k.weight', torch.float16), ('decoder.block.0.layer.0.SelfAttention.v.weight', torch.float16), ('decoder.block.0.layer.0.SelfAttention.o.weight', torch.float16), ('decoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight', torch.float16), ('decoder.block.0.layer.0.layer_norm.weight', torch.float16), ('decoder.block.0.layer.1.EncDecAttention.q.weight', torch.float16), ('decoder.block.0.layer.1.EncDecAttention.k.weight', torch.float16), ('decoder.block.0.layer.1.EncDecAttention.v.weight', torch.float16), ('decoder.block.0.layer.1.EncDecAttention.o.weight', torch.float16), ('decoder.block.0.layer.1.layer_norm.weight', torch.float16), ('decoder.block.0.layer.2.DenseReluDense.wi.weight', torch.float16), ('decoder.block.0.layer.2.DenseReluDense.wo.weight', torch.float16), ('decoder.block.0.layer.2.layer_norm.weight', torch.float16), ('decoder.block.1.layer.0.SelfAttention.q.weight', torch.float16), ('decoder.block.1.layer.0.SelfAttention.k.weight', torch.float16), ('decoder.block.1.layer.0.SelfAttention.v.weight', torch.float16), ('decoder.block.1.layer.0.SelfAttention.o.weight', torch.float16), ('decoder.block.1.layer.0.layer_norm.weight', torch.float16), ('decoder.block.1.layer.1.EncDecAttention.q.weight', torch.float16), ('decoder.block.1.layer.1.EncDecAttention.k.weight', torch.float16), ('decoder.block.1.layer.1.EncDecAttention.v.weight', torch.float16), ('decoder.block.1.layer.1.EncDecAttention.o.weight', torch.float16), ('decoder.block.1.layer.1.layer_norm.weight', torch.float16), ('decoder.block.1.layer.2.DenseReluDense.wi.weight', torch.float16), ('decoder.block.1.layer.2.DenseReluDense.wo.weight', torch.float16), ('decoder.block.1.layer.2.layer_norm.weight', torch.float16), ('decoder.final_layer_norm.weight', torch.float16)]
```
