### PR TITLE
fix tolerance for a bloom slow test

### DIFF
--- a/tests/models/bloom/test_modeling_bloom.py
+++ b/tests/models/bloom/test_modeling_bloom.py
@@ -676,7 +676,7 @@ class BloomEmbeddingTest(unittest.TestCase):
         }
 
         if cuda_available:
-            self.assertEqual(MEAN_VALUE_LAST_LM, logits.last_hidden_state.mean().item())
+            self.assertAlmostEqual(MEAN_VALUE_LAST_LM, logits.last_hidden_state.mean().item(), places=4)
         else:
             self.assertAlmostEqual(MEAN_VALUE_LAST_LM, logits.last_hidden_state.mean().item(), places=3)
 


### PR DESCRIPTION
# What does this PR do?

FIxes a slow test that was ignored in the previous PR
- The number was not exactly equal due to some torch version mismatch when I did the tests on the DGX (when the test was designed) -> Note that the results of some operations are not similar across torch version compiled differently 
- Just changed the tolerance and seems to work fine
 cc @ydshieh 
