### PR TITLE
Change no trainer image_classification test

### DIFF
--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -305,12 +305,12 @@ class ExamplesTestsNoTrainer(TestCasePlus):
             --learning_rate 1e-4
             --per_device_train_batch_size 2
             --per_device_eval_batch_size 1
-            --max_train_steps 10
+            --max_train_steps 1
             --train_val_split 0.1
             --seed 42
             --output_dir {tmp_dir}
             --with_tracking
-            --checkpointing_steps epoch
+            --checkpointing_steps 1
         """.split()
 
         if is_cuda_and_apex_available():
@@ -318,6 +318,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
 
         _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
         result = get_results(tmp_dir)
-        self.assertGreaterEqual(result["eval_accuracy"], 0.8)
-        self.assertTrue(os.path.exists(os.path.join(tmp_dir, "epoch_0")))
+        # The base model scores a 25%
+        self.assertGreaterEqual(result["eval_accuracy"], 0.625)
+        self.assertTrue(os.path.exists(os.path.join(tmp_dir, "step_0")))
         self.assertTrue(os.path.exists(os.path.join(tmp_dir, "image_classification_no_trainer")))

--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -309,7 +309,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
             --train_val_split 0.1
             --seed 42
             --output_dir {tmp_dir}
-            """.split()
+        """.split()
 
         if is_cuda_and_apex_available():
             testargs.append("--fp16")

--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -305,7 +305,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
             --learning_rate 1e-4
             --per_device_train_batch_size 2
             --per_device_eval_batch_size 1
-            --max_train_steps 1
+            --max_train_steps 2
             --train_val_split 0.1
             --seed 42
             --output_dir {tmp_dir}

--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -309,6 +309,8 @@ class ExamplesTestsNoTrainer(TestCasePlus):
             --train_val_split 0.1
             --seed 42
             --output_dir {tmp_dir}
+            --with_tracking
+            --checkpointing_steps epoch
         """.split()
 
         if is_cuda_and_apex_available():
@@ -317,3 +319,5 @@ class ExamplesTestsNoTrainer(TestCasePlus):
         _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
         result = get_results(tmp_dir)
         self.assertGreaterEqual(result["eval_accuracy"], 0.8)
+        self.assertTrue(os.path.exists(os.path.join(tmp_dir, "epoch_0")))
+        self.assertTrue(os.path.exists(os.path.join(tmp_dir, "image_classification_no_trainer")))

--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -320,5 +320,5 @@ class ExamplesTestsNoTrainer(TestCasePlus):
         result = get_results(tmp_dir)
         # The base model scores a 25%
         self.assertGreaterEqual(result["eval_accuracy"], 0.625)
-        self.assertTrue(os.path.exists(os.path.join(tmp_dir, "step_0")))
+        self.assertTrue(os.path.exists(os.path.join(tmp_dir, "step_1")))
         self.assertTrue(os.path.exists(os.path.join(tmp_dir, "image_classification_no_trainer")))

--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -300,19 +300,20 @@ class ExamplesTestsNoTrainer(TestCasePlus):
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""
             {self.examples_dir}/pytorch/image-classification/run_image_classification_no_trainer.py
-            --dataset_name huggingface/image-classification-test-sample
-            --output_dir {tmp_dir}
-            --num_warmup_steps=8
-            --learning_rate=3e-3
-            --per_device_train_batch_size=2
-            --per_device_eval_batch_size=1
-            --checkpointing_steps epoch
-            --with_tracking
+            --model_name_or_path google/vit-base-patch16-224-in21k
+            --dataset_name hf-internal-testing/cats_vs_dogs_sample
+            --learning_rate 1e-4
+            --per_device_train_batch_size 2
+            --per_device_eval_batch_size 1
+            --max_train_steps 10
+            --train_val_split 0.1
             --seed 42
-        """.split()
+            --output_dir {tmp_dir}
+            """.split()
+
+        if is_cuda_and_apex_available():
+            testargs.append("--fp16")
 
         _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
         result = get_results(tmp_dir)
-        self.assertGreaterEqual(result["eval_accuracy"], 0.50)
-        self.assertTrue(os.path.exists(os.path.join(tmp_dir, "epoch_0")))
-        self.assertTrue(os.path.exists(os.path.join(tmp_dir, "image_classification_no_trainer")))
+        self.assertGreaterEqual(result["eval_accuracy"], 0.8)


### PR DESCRIPTION
# What does this PR do?

I noticed that this test has been failing for the last few months, and it's due to the fact that on a single GPU or CPU the tests pass (we hit 50% accuracy), but on multi GPU it's a hit or miss whether or not it does (each epoch/batch is either 50% or 0%, and we happen to miss that coin flip each time).

This PR modifies the no_trainer test to mimic the equivalent pytorch example tests, and I can confirm it passes repeatedly on a single GPU, CPU, and multi GPU: https://github.com/huggingface/transformers/blob/main/examples/pytorch/test_pytorch_examples.py#L390-L417


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger @NielsRogge 