### PR TITLE
fix use_amp rename after pr 17138

### DIFF
--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -894,7 +894,7 @@ def extract_hyperparameters_from_trainer(trainer):
         hyperparameters["num_epochs"] = trainer.args.num_train_epochs
 
     if trainer.args.fp16:
-        if trainer.use_amp:
+        if trainer.use_cuda_amp:
             hyperparameters["mixed_precision_training"] = "Native AMP"
         elif trainer.use_apex:
             hyperparameters["mixed_precision_training"] = f"Apex, opt level {trainer.args.fp16_opt_level}"

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -546,7 +546,12 @@ class Trainer:
                 self.use_apex = True
 
         # FP16 + model parallelism in SageMaker: gradient clipping does not work for now so we raise a helpful error.
-        if is_sagemaker_mp_enabled() and self.use_amp and args.max_grad_norm is not None and args.max_grad_norm > 0:
+        if (
+            is_sagemaker_mp_enabled()
+            and self.use_cuda_amp
+            and args.max_grad_norm is not None
+            and args.max_grad_norm > 0
+        ):
             raise ValueError(
                 "SageMaker Model Parallelism in mixed precision mode does not support gradient clipping yet. Pass "
                 "along 'max_grad_norm': 0 in your hyperparameters."


### PR DESCRIPTION
PR https://github.com/huggingface/transformers/pull/17138 renamed `self.use_amp` to `self.use_cuda_amp` but didn't rename it everywhere so deepspeed tests were failing. This PR fixes a few missed bits.

@sgugger 

cc: @ydshieh who reported this 