### PR TITLE
fix typo from emtpy to empty on decoding error messages

### DIFF
--- a/src/transformers/generation_beam_constraints.py
+++ b/src/transformers/generation_beam_constraints.py
@@ -139,7 +139,7 @@ class PhrasalConstraint(Constraint):
         super(Constraint, self).__init__()
 
         if not isinstance(token_ids, list) or len(token_ids) == 0:
-            raise ValueError(f"`token_ids` has to be a non-emtpy list, but is {token_ids}.")
+            raise ValueError(f"`token_ids` has to be a non-empty list, but is {token_ids}.")
         if any((not isinstance(token_id, int) or token_id < 0) for token_id in token_ids):
             raise ValueError(f"Each list in `token_ids` has to be a list of positive integers, but is {token_ids}.")
 
@@ -271,7 +271,7 @@ class DisjunctiveConstraint(Constraint):
         super(Constraint, self).__init__()
 
         if not isinstance(nested_token_ids, list) or len(nested_token_ids) == 0:
-            raise ValueError(f"`nested_token_ids` has to be a non-emtpy list, but is {nested_token_ids}.")
+            raise ValueError(f"`nested_token_ids` has to be a non-empty list, but is {nested_token_ids}.")
         if any(not isinstance(token_ids, list) for token_ids in nested_token_ids):
             raise ValueError(f"`nested_token_ids` has to be a list of lists, but is {nested_token_ids}.")
         if any(

--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -392,7 +392,7 @@ class NoBadWordsLogitsProcessor(LogitsProcessor):
     def __init__(self, bad_words_ids: List[List[int]], eos_token_id: int):
 
         if not isinstance(bad_words_ids, List) or len(bad_words_ids) == 0:
-            raise ValueError(f"`bad_words_ids` has to be a non-emtpy list, but is {bad_words_ids}.")
+            raise ValueError(f"`bad_words_ids` has to be a non-empty list, but is {bad_words_ids}.")
         if any(not isinstance(bad_word_ids, list) for bad_word_ids in bad_words_ids):
             raise ValueError(f"`bad_words_ids` has to be a list of lists, but is {bad_words_ids}.")
         if any(

--- a/src/transformers/generation_tf_logits_process.py
+++ b/src/transformers/generation_tf_logits_process.py
@@ -297,7 +297,7 @@ class TFNoBadWordsLogitsProcessor(TFLogitsProcessor):
     def __init__(self, bad_words_ids: List[List[int]], eos_token_id: int):
 
         if not isinstance(bad_words_ids, List) or len(bad_words_ids) == 0:
-            raise ValueError(f"`bad_words_ids` has to be a non-emtpy list, but is {bad_words_ids}.")
+            raise ValueError(f"`bad_words_ids` has to be a non-empty list, but is {bad_words_ids}.")
         if any(not isinstance(bad_word_ids, list) for bad_word_ids in bad_words_ids):
             raise ValueError(f"`bad_words_ids` has to be a list of lists, but is {bad_words_ids}.")
         if any(


### PR DESCRIPTION
# What does this PR do?

I am working with constrained generation a lot and a I keep seeing this error typo.
This PR fixes it in order for the error message to be a little freindlier.

cc @patrickvonplaten 
