### PR TITLE
[utils] torch.cpu didn't exist in pt-1.9

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -305,7 +305,10 @@ def is_torch_bf16_available():
         is_torch_gpu_bf16_available = False
 
     # checking CPU
-    if not hasattr(torch.cpu.amp, "autocast"):
+    try:
+        # multiple levels of AttributeError depending on the pytorch version so do them all in one check
+        _ = torch.cpu.amp.autocast
+    except AttributeError:
         is_torch_cpu_bf16_available = False
 
     return is_torch_cpu_bf16_available or is_torch_gpu_bf16_available


### PR DESCRIPTION
PR https://github.com/huggingface/transformers/pull/17138 introduced another issue: `torch.cpu` didn't exist till pt-1.10