### PR TITLE
Revert "Skip tests relying on RepoNotFound errors until bug is fixed"

### DIFF
--- a/tests/models/auto/test_configuration_auto.py
+++ b/tests/models/auto/test_configuration_auto.py
@@ -88,7 +88,6 @@ class AutoConfigTest(unittest.TestCase):
             if "custom" in CONFIG_MAPPING._extra_content:
                 del CONFIG_MAPPING._extra_content["custom"]
 
-    @unittest.skip("Temp bug in the Hub not returning RepoNotFound errors.")
     def test_repo_not_found(self):
         with self.assertRaisesRegex(
             EnvironmentError, "bert-base is not a local folder and is not a valid model identifier"

--- a/tests/models/auto/test_feature_extraction_auto.py
+++ b/tests/models/auto/test_feature_extraction_auto.py
@@ -76,7 +76,6 @@ class AutoFeatureExtractorTest(unittest.TestCase):
         config = AutoFeatureExtractor.from_pretrained(SAMPLE_FEATURE_EXTRACTION_CONFIG)
         self.assertIsInstance(config, Wav2Vec2FeatureExtractor)
 
-    @unittest.skip("Temp bug in the Hub not returning RepoNotFound errors.")
     def test_repo_not_found(self):
         with self.assertRaisesRegex(
             EnvironmentError, "bert-base is not a local folder and is not a valid model identifier"

--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -328,7 +328,6 @@ class AutoModelTest(unittest.TestCase):
                 if CustomConfig in mapping._extra_content:
                     del mapping._extra_content[CustomConfig]
 
-    @unittest.skip("Temp bug in the Hub not returning RepoNotFound errors.")
     def test_repo_not_found(self):
         with self.assertRaisesRegex(
             EnvironmentError, "bert-base is not a local folder and is not a valid model identifier"

--- a/tests/models/auto/test_modeling_flax_auto.py
+++ b/tests/models/auto/test_modeling_flax_auto.py
@@ -77,7 +77,6 @@ class FlaxAutoModelTest(unittest.TestCase):
 
             eval(**tokens).block_until_ready()
 
-    @unittest.skip("Temp bug in the Hub not returning RepoNotFound errors.")
     def test_repo_not_found(self):
         with self.assertRaisesRegex(
             EnvironmentError, "bert-base is not a local folder and is not a valid model identifier"

--- a/tests/models/auto/test_modeling_tf_auto.py
+++ b/tests/models/auto/test_modeling_tf_auto.py
@@ -265,7 +265,6 @@ class TFAutoModelTest(unittest.TestCase):
                 if NewModelConfig in mapping._extra_content:
                     del mapping._extra_content[NewModelConfig]
 
-    @unittest.skip("Temp bug in the Hub not returning RepoNotFound errors.")
     def test_repo_not_found(self):
         with self.assertRaisesRegex(
             EnvironmentError, "bert-base is not a local folder and is not a valid model identifier"

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -142,7 +142,6 @@ class AutoTokenizerTest(unittest.TestCase):
 
             self.assertEqual(tokenizer.model_max_length, 512)
 
-    @unittest.skip("Temp bug in the Hub not returning RepoNotFound errors.")
     @require_tokenizers
     def test_tokenizer_identifier_non_existent(self):
         for tokenizer_class in [BertTokenizer, BertTokenizerFast, AutoTokenizer]:
@@ -330,7 +329,6 @@ class AutoTokenizerTest(unittest.TestCase):
         else:
             self.assertEqual(tokenizer.__class__.__name__, "NewTokenizer")
 
-    @unittest.skip("Temp bug in the Hub not returning RepoNotFound errors.")
     def test_repo_not_found(self):
         with self.assertRaisesRegex(
             EnvironmentError, "bert-base is not a local folder and is not a valid model identifier"

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -99,7 +99,6 @@ class GetFromCacheTests(unittest.TestCase):
         with self.assertRaisesRegex(EntryNotFoundError, "404 Client Error"):
             _ = get_from_cache(url)
 
-    @unittest.skip("Temp bug in the Hub not returning RepoNotFound errors.")
     def test_model_not_found(self):
         # Invalid model file.
         url = hf_bucket_url("bert-base", filename="pytorch_model.bin")
@@ -142,9 +141,8 @@ class GetFromCacheTests(unittest.TestCase):
         self.assertIsNone(get_file_from_repo("bert-base-cased", "ahah.txt"))
 
         # The function raises if the repository does not exist.
-        # Uncomment when bug is fixed.
-        # with self.assertRaisesRegex(EnvironmentError, "is not a valid model identifier"):
-        #     get_file_from_repo("bert-base-case", "config.json")
+        with self.assertRaisesRegex(EnvironmentError, "is not a valid model identifier"):
+            get_file_from_repo("bert-base-case", "config.json")
 
         # The function raises if the revision does not exist.
         with self.assertRaisesRegex(EnvironmentError, "is not a valid git identifier"):


### PR DESCRIPTION
Reverts huggingface/transformers#17646

Test will fail for now, but one day, a hero will fix them and we can click the "Relaunch workflow from failed" button to see them passing, and we will be able to be merge this PR.