### PR TITLE
Rm hardcoded style fromdoc expert acc imgs

### DIFF
--- a/docs/source/en/index.mdx
+++ b/docs/source/en/index.mdx
@@ -28,7 +28,7 @@ Each 🤗 Transformers architecture is defined in a standalone Python module so 
 ## If you are looking for custom support from the Hugging Face team
 
 <a target="_blank" href="https://huggingface.co/support">
-    <img alt="HuggingFace Expert Acceleration Program" src="https://cdn-media.huggingface.co/marketing/transformers/new-support-improved.png" style="max-width: 600px; border: 1px solid #eee; border-radius: 4px; box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);">
+    <img alt="HuggingFace Expert Acceleration Program" src="https://cdn-media.huggingface.co/marketing/transformers/new-support-improved.png">
 </a><br>
 
 ## Contents

--- a/docs/source/en/index.mdx
+++ b/docs/source/en/index.mdx
@@ -28,7 +28,7 @@ Each 🤗 Transformers architecture is defined in a standalone Python module so 
 ## If you are looking for custom support from the Hugging Face team
 
 <a target="_blank" href="https://huggingface.co/support">
-    <img alt="HuggingFace Expert Acceleration Program" src="https://cdn-media.huggingface.co/marketing/transformers/new-support-improved.png">
+    <img alt="HuggingFace Expert Acceleration Program" src="https://cdn-media.huggingface.co/marketing/transformers/new-support-improved.png" class="max-w-[600px]">
 </a><br>
 
 ## Contents

--- a/docs/source/en/index.mdx
+++ b/docs/source/en/index.mdx
@@ -28,7 +28,7 @@ Each 🤗 Transformers architecture is defined in a standalone Python module so 
 ## If you are looking for custom support from the Hugging Face team
 
 <a target="_blank" href="https://huggingface.co/support">
-    <img alt="HuggingFace Expert Acceleration Program" src="https://cdn-media.huggingface.co/marketing/transformers/new-support-improved.png" class="max-w-[600px]">
+    <img alt="HuggingFace Expert Acceleration Program" src="https://cdn-media.huggingface.co/marketing/transformers/new-support-improved.png" class="!max-w-[600px]">
 </a><br>
 
 ## Contents

--- a/docs/source/es/index.mdx
+++ b/docs/source/es/index.mdx
@@ -27,7 +27,7 @@ Cada arquitectura de 🤗 Transformers se define en un módulo de Python indepen
 ## Si estás buscando soporte personalizado del equipo de Hugging Face
 
 <a target="_blank" href="https://huggingface.co/support">
-<img alt="HuggingFace Expert Acceleration Program" src="https://huggingface.co/front/thumbnails/support.png">
+<img alt="HuggingFace Expert Acceleration Program" src="https://huggingface.co/front/thumbnails/support.png" class="max-w-[600px]">
 </a><br>
 
 ## Contenidos

--- a/docs/source/es/index.mdx
+++ b/docs/source/es/index.mdx
@@ -27,7 +27,7 @@ Cada arquitectura de 🤗 Transformers se define en un módulo de Python indepen
 ## Si estás buscando soporte personalizado del equipo de Hugging Face
 
 <a target="_blank" href="https://huggingface.co/support">
-<img alt="HuggingFace Expert Acceleration Program" src="https://huggingface.co/front/thumbnails/support.png" style="max-width: 600px; border: 1px solid #eee; border-radius: 4px; box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);">
+<img alt="HuggingFace Expert Acceleration Program" src="https://huggingface.co/front/thumbnails/support.png">
 </a><br>
 
 ## Contenidos

--- a/docs/source/es/index.mdx
+++ b/docs/source/es/index.mdx
@@ -27,7 +27,7 @@ Cada arquitectura de 🤗 Transformers se define en un módulo de Python indepen
 ## Si estás buscando soporte personalizado del equipo de Hugging Face
 
 <a target="_blank" href="https://huggingface.co/support">
-<img alt="HuggingFace Expert Acceleration Program" src="https://huggingface.co/front/thumbnails/support.png" class="max-w-[600px]">
+<img alt="HuggingFace Expert Acceleration Program" src="https://huggingface.co/front/thumbnails/support.png" class="!max-w-[600px]">
 </a><br>
 
 ## Contenidos

--- a/docs/source/it/index.mdx
+++ b/docs/source/it/index.mdx
@@ -28,7 +28,7 @@ Ogni architettura di 🤗 Transformers è definita in un modulo Python indipende
 ## Se stai cercando supporto personalizzato dal team di Hugging Face
 
 <a target="_blank" href="https://huggingface.co/support">
-<img alt="HuggingFace Expert Acceleration Program" src="https://huggingface.co/front/thumbnails/support.png" class="max-w-[600px]">
+<img alt="HuggingFace Expert Acceleration Program" src="https://huggingface.co/front/thumbnails/support.png" class="!max-w-[600px]">
 </a><br>
 
 ## Contenuti

--- a/docs/source/it/index.mdx
+++ b/docs/source/it/index.mdx
@@ -28,7 +28,7 @@ Ogni architettura di 🤗 Transformers è definita in un modulo Python indipende
 ## Se stai cercando supporto personalizzato dal team di Hugging Face
 
 <a target="_blank" href="https://huggingface.co/support">
-<img alt="HuggingFace Expert Acceleration Program" src="https://huggingface.co/front/thumbnails/support.png" style="max-width: 600px; border: 1px solid #eee; border-radius: 4px; box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);">
+<img alt="HuggingFace Expert Acceleration Program" src="https://huggingface.co/front/thumbnails/support.png">
 </a><br>
 
 ## Contenuti

--- a/docs/source/it/index.mdx
+++ b/docs/source/it/index.mdx
@@ -28,7 +28,7 @@ Ogni architettura di 🤗 Transformers è definita in un modulo Python indipende
 ## Se stai cercando supporto personalizzato dal team di Hugging Face
 
 <a target="_blank" href="https://huggingface.co/support">
-<img alt="HuggingFace Expert Acceleration Program" src="https://huggingface.co/front/thumbnails/support.png">
+<img alt="HuggingFace Expert Acceleration Program" src="https://huggingface.co/front/thumbnails/support.png" class="max-w-[600px]">
 </a><br>
 
 ## Contenuti


### PR DESCRIPTION
Having a hardcoded style of `width:600px` is overriding hf.co doc styles for images, which is causing an overflowing problem on mobile

| before | after |
|--------|-------|
|    <img width="400" alt="Screenshot 2022-06-10 at 09 53 20" src="https://user-images.githubusercontent.com/11827707/173018283-a1d5e103-4bd6-4814-af25-f0d0fc9f3888.png">    |    <img width="400" alt="Screenshot 2022-06-10 at 09 53 12" src="https://user-images.githubusercontent.com/11827707/173018274-2227571a-702a-4c82-b103-3a5a1a4ae029.png">   |