### PR TITLE
🐛 Properly raise `RepoNotFoundError` when not authenticated

### DIFF
--- a/examples/research_projects/lxmert/demo.ipynb
+++ b/examples/research_projects/lxmert/demo.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#%pip install-r requirements.txt"
+    "# %pip install-r requirements.txt"
    ]
   },
   {

--- a/examples/research_projects/visual_bert/demo.ipynb
+++ b/examples/research_projects/visual_bert/demo.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "source": [
-    "#%pip install-r requirements.txt"
+    "# %pip install-r requirements.txt"
    ],
    "outputs": [],
    "metadata": {}

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -84,6 +84,7 @@ DUMMY_DIFF_TOKENIZER_IDENTIFIER = "julien-c/dummy-diff-tokenizer"
 # Used to test the hub
 USER = "__DUMMY_TRANSFORMERS_USER__"
 PASS = "__DUMMY_TRANSFORMERS_PASS__"
+ACCESS_TOKEN = "hf_94wBhPGp6KrrTH3KDchhKpRxZwd6dmHWLL"
 ENDPOINT_STAGING = "https://moon-staging.huggingface.co"
 
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -84,7 +84,6 @@ DUMMY_DIFF_TOKENIZER_IDENTIFIER = "julien-c/dummy-diff-tokenizer"
 # Used to test the hub
 USER = "__DUMMY_TRANSFORMERS_USER__"
 PASS = "__DUMMY_TRANSFORMERS_PASS__"
-ACCESS_TOKEN = "hf_94wBhPGp6KrrTH3KDchhKpRxZwd6dmHWLL"
 ENDPOINT_STAGING = "https://moon-staging.huggingface.co"
 
 

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -38,6 +38,7 @@ import requests
 from filelock import FileLock
 from huggingface_hub import HfFolder, Repository, create_repo, list_repo_files, whoami
 from requests.exceptions import HTTPError
+from requests.models import Request, Response
 from transformers.utils.logging import tqdm
 
 from . import __version__, logging
@@ -398,20 +399,26 @@ class RevisionNotFoundError(HTTPError):
     """Raised when trying to access a hf.co URL with a valid repository but an invalid revision."""
 
 
-def _raise_for_status(request):
+def _raise_for_status(response: Response):
     """
     Internal version of `request.raise_for_status()` that will refine a potential HTTPError.
     """
-    if "X-Error-Code" in request.headers:
-        error_code = request.headers["X-Error-Code"]
+    if "X-Error-Code" in response.headers:
+        error_code = response.headers["X-Error-Code"]
         if error_code == "RepoNotFound":
-            raise RepositoryNotFoundError(f"404 Client Error: Repository Not Found for url: {request.url}")
+            raise RepositoryNotFoundError(f"404 Client Error: Repository Not Found for url: {response.url}")
         elif error_code == "EntryNotFound":
-            raise EntryNotFoundError(f"404 Client Error: Entry Not Found for url: {request.url}")
+            raise EntryNotFoundError(f"404 Client Error: Entry Not Found for url: {response.url}")
         elif error_code == "RevisionNotFound":
-            raise RevisionNotFoundError(f"404 Client Error: Revision Not Found for url: {request.url}")
+            raise RevisionNotFoundError(f"404 Client Error: Revision Not Found for url: {response.url}")
 
-    request.raise_for_status()
+    if response.status_code == 401:
+        raise RepositoryNotFoundError(
+            f"401 Client Error: Repository not found for url: {response.url}. "
+            "If the repo is private, make sure you are authenticated."
+        )
+
+    response.raise_for_status()
 
 
 def http_get(url: str, temp_file: BinaryIO, proxies=None, resume_size=0, headers: Optional[Dict[str, str]] = None):

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -38,7 +38,7 @@ import requests
 from filelock import FileLock
 from huggingface_hub import HfFolder, Repository, create_repo, list_repo_files, whoami
 from requests.exceptions import HTTPError
-from requests.models import Request, Response
+from requests.models import Response
 from transformers.utils.logging import tqdm
 
 from . import __version__, logging

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -413,6 +413,7 @@ def _raise_for_status(response: Response):
             raise RevisionNotFoundError(f"404 Client Error: Revision Not Found for url: {response.url}")
 
     if response.status_code == 401:
+        # The repo was not found and the user is not Authenticated
         raise RepositoryNotFoundError(
             f"401 Client Error: Repository not found for url: {response.url}. "
             "If the repo is private, make sure you are authenticated."

--- a/tests/models/auto/test_configuration_auto.py
+++ b/tests/models/auto/test_configuration_auto.py
@@ -88,7 +88,6 @@ class AutoConfigTest(unittest.TestCase):
             if "custom" in CONFIG_MAPPING._extra_content:
                 del CONFIG_MAPPING._extra_content["custom"]
 
-    @unittest.skip("Temp bug in the Hub not returning RepoNotFound errors.")
     def test_repo_not_found(self):
         with self.assertRaisesRegex(
             EnvironmentError, "bert-base is not a local folder and is not a valid model identifier"

--- a/tests/models/auto/test_feature_extraction_auto.py
+++ b/tests/models/auto/test_feature_extraction_auto.py
@@ -76,7 +76,6 @@ class AutoFeatureExtractorTest(unittest.TestCase):
         config = AutoFeatureExtractor.from_pretrained(SAMPLE_FEATURE_EXTRACTION_CONFIG)
         self.assertIsInstance(config, Wav2Vec2FeatureExtractor)
 
-    @unittest.skip("Temp bug in the Hub not returning RepoNotFound errors.")
     def test_repo_not_found(self):
         with self.assertRaisesRegex(
             EnvironmentError, "bert-base is not a local folder and is not a valid model identifier"

--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -328,7 +328,6 @@ class AutoModelTest(unittest.TestCase):
                 if CustomConfig in mapping._extra_content:
                     del mapping._extra_content[CustomConfig]
 
-    @unittest.skip("Temp bug in the Hub not returning RepoNotFound errors.")
     def test_repo_not_found(self):
         with self.assertRaisesRegex(
             EnvironmentError, "bert-base is not a local folder and is not a valid model identifier"

--- a/tests/models/auto/test_modeling_flax_auto.py
+++ b/tests/models/auto/test_modeling_flax_auto.py
@@ -77,7 +77,6 @@ class FlaxAutoModelTest(unittest.TestCase):
 
             eval(**tokens).block_until_ready()
 
-    @unittest.skip("Temp bug in the Hub not returning RepoNotFound errors.")
     def test_repo_not_found(self):
         with self.assertRaisesRegex(
             EnvironmentError, "bert-base is not a local folder and is not a valid model identifier"

--- a/tests/models/auto/test_modeling_tf_auto.py
+++ b/tests/models/auto/test_modeling_tf_auto.py
@@ -265,7 +265,6 @@ class TFAutoModelTest(unittest.TestCase):
                 if NewModelConfig in mapping._extra_content:
                     del mapping._extra_content[NewModelConfig]
 
-    @unittest.skip("Temp bug in the Hub not returning RepoNotFound errors.")
     def test_repo_not_found(self):
         with self.assertRaisesRegex(
             EnvironmentError, "bert-base is not a local folder and is not a valid model identifier"

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -142,7 +142,6 @@ class AutoTokenizerTest(unittest.TestCase):
 
             self.assertEqual(tokenizer.model_max_length, 512)
 
-    @unittest.skip("Temp bug in the Hub not returning RepoNotFound errors.")
     @require_tokenizers
     def test_tokenizer_identifier_non_existent(self):
         for tokenizer_class in [BertTokenizer, BertTokenizerFast, AutoTokenizer]:
@@ -330,7 +329,6 @@ class AutoTokenizerTest(unittest.TestCase):
         else:
             self.assertEqual(tokenizer.__class__.__name__, "NewTokenizer")
 
-    @unittest.skip("Temp bug in the Hub not returning RepoNotFound errors.")
     def test_repo_not_found(self):
         with self.assertRaisesRegex(
             EnvironmentError, "bert-base is not a local folder and is not a valid model identifier"

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -24,7 +24,7 @@ import transformers
 
 # Try to import everything from transformers to ensure every object can be loaded.
 from transformers import *  # noqa F406
-from transformers.testing_utils import DUMMY_UNKNOWN_IDENTIFIER
+from transformers.testing_utils import DUMMY_UNKNOWN_IDENTIFIER, ACCESS_TOKEN
 from transformers.utils import (
     CONFIG_NAME,
     FLAX_WEIGHTS_NAME,
@@ -99,11 +99,17 @@ class GetFromCacheTests(unittest.TestCase):
         with self.assertRaisesRegex(EntryNotFoundError, "404 Client Error"):
             _ = get_from_cache(url)
 
-    def test_model_not_found(self):
+    def test_model_not_found_not_authenticated(self):
+        # Invalid model file.
+        url = hf_bucket_url("bert-base", filename="pytorch_model.bin")
+        with self.assertRaisesRegex(RepositoryNotFoundError, "401 Client Error"):
+            _ = get_from_cache(url)
+
+    def test_model_not_found_authenticated(self):
         # Invalid model file.
         url = hf_bucket_url("bert-base", filename="pytorch_model.bin")
         with self.assertRaisesRegex(RepositoryNotFoundError, "404 Client Error"):
-            _ = get_from_cache(url)
+            _ = get_from_cache(url, use_auth_token=ACCESS_TOKEN)
 
     def test_revision_not_found(self):
         # Valid file but missing revision

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -99,7 +99,6 @@ class GetFromCacheTests(unittest.TestCase):
         with self.assertRaisesRegex(EntryNotFoundError, "404 Client Error"):
             _ = get_from_cache(url)
 
-    @unittest.skip("Temp bug in the Hub not returning RepoNotFound errors.")
     def test_model_not_found(self):
         # Invalid model file.
         url = hf_bucket_url("bert-base", filename="pytorch_model.bin")
@@ -142,9 +141,8 @@ class GetFromCacheTests(unittest.TestCase):
         self.assertIsNone(get_file_from_repo("bert-base-cased", "ahah.txt"))
 
         # The function raises if the repository does not exist.
-        # Uncomment when bug is fixed.
-        # with self.assertRaisesRegex(EnvironmentError, "is not a valid model identifier"):
-        #     get_file_from_repo("bert-base-case", "config.json")
+        with self.assertRaisesRegex(EnvironmentError, "is not a valid model identifier"):
+            get_file_from_repo("bert-base-case", "config.json")
 
         # The function raises if the revision does not exist.
         with self.assertRaisesRegex(EnvironmentError, "is not a valid git identifier"):

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -24,7 +24,7 @@ import transformers
 
 # Try to import everything from transformers to ensure every object can be loaded.
 from transformers import *  # noqa F406
-from transformers.testing_utils import DUMMY_UNKNOWN_IDENTIFIER, ACCESS_TOKEN
+from transformers.testing_utils import DUMMY_UNKNOWN_IDENTIFIER
 from transformers.utils import (
     CONFIG_NAME,
     FLAX_WEIGHTS_NAME,
@@ -100,16 +100,18 @@ class GetFromCacheTests(unittest.TestCase):
             _ = get_from_cache(url)
 
     def test_model_not_found_not_authenticated(self):
-        # Invalid model file.
+        # Invalid model id.
         url = hf_bucket_url("bert-base", filename="pytorch_model.bin")
         with self.assertRaisesRegex(RepositoryNotFoundError, "401 Client Error"):
             _ = get_from_cache(url)
 
+    @unittest.skip("No authentication when testing against prod")
     def test_model_not_found_authenticated(self):
-        # Invalid model file.
+        # Invalid model id.
         url = hf_bucket_url("bert-base", filename="pytorch_model.bin")
         with self.assertRaisesRegex(RepositoryNotFoundError, "404 Client Error"):
-            _ = get_from_cache(url, use_auth_token=ACCESS_TOKEN)
+            _ = get_from_cache(url, use_auth_token="hf_sometoken")
+            # ^ TODO - if we decide to unskip this: use a real / functional token
 
     def test_revision_not_found(self):
         # Valid file but missing revision


### PR DESCRIPTION
# What does this PR do?

Reverts #17646

If the user is not authenticated, the Hub now returns a 401 error if a repo is not found (either because it does not exist or it is private).

This PR catches that and properly raises `RepoNotFoundError` in `get_from_cache` to be consistent with the previous behaviour.
