### PR TITLE
Explicitly set utf-8 for Windows in utils required for make fixup

### DIFF
--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -725,7 +725,7 @@ def check_docstrings_are_in_md():
     """Check all docstrings are in md"""
     files_with_rst = []
     for file in Path(PATH_TO_TRANSFORMERS).glob("**/*.py"):
-        with open(file, "r") as f:
+        with open(file, encoding="utf-8") as f:
             code = f.read()
         docstrings = code.split('"""')
 

--- a/utils/custom_init_isort.py
+++ b/utils/custom_init_isort.py
@@ -167,7 +167,7 @@ def sort_imports(file, check_only=True):
     """
     Sort `_import_structure` imports in `file`, `check_only` determines if we only check or overwrite.
     """
-    with open(file, "r") as f:
+    with open(file, encoding="utf-8") as f:
         code = f.read()
 
     if "_import_structure" not in code:
@@ -227,7 +227,7 @@ def sort_imports(file, check_only=True):
             return True
         else:
             print(f"Overwriting {file}.")
-            with open(file, "w") as f:
+            with open(file, "w", encoding="utf-8") as f:
                 f.write("\n".join(main_blocks))
 
 

--- a/utils/notification_service_doc_tests.py
+++ b/utils/notification_service_doc_tests.py
@@ -289,7 +289,7 @@ def retrieve_artifact(name: str):
         files = os.listdir(name)
         for file in files:
             try:
-                with open(os.path.join(name, file)) as f:
+                with open(os.path.join(name, file), encoding="utf-8") as f:
                     _artifact[file.split(".")[0]] = f.read()
             except UnicodeDecodeError as e:
                 raise ValueError(f"Could not open {os.path.join(name, file)}.") from e


### PR DESCRIPTION
# What does this PR do?

Had a little issue that I could not successfully run `make fixup` due to encoding issues. Windows still does not use UTF-8 by default unfortunately.

When looking through the whole codebase, I found other occurrences where the encoding has not been specified. These are _not_ fixed in this PR. This PR focuses on just the changes needed to at least allow the make commands to work.



## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?


## Who can review?

Tagging @LysandreJik who hinted me to use `make fixup` (here https://github.com/huggingface/transformers/pull/17629#issuecomment-1152359001)

