### PR TITLE
Fix dtype getter

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -152,7 +152,7 @@ def get_first_parameter_dtype(parameter: Union[nn.Module, GenerationMixin, "Modu
 
 def get_parameter_dtype(parameter: Union[nn.Module, GenerationMixin, "ModuleUtilsMixin"]):
     """
-    Returns the first found floating dtype in parameters if there is one, otherwise returns the last dtype it found.
+    Returns the first found floating dtype in parameters if there is one, otherwise returns the first dtype it found.
     """
     try:
         for t in parameter.parameters():
@@ -160,7 +160,7 @@ def get_parameter_dtype(parameter: Union[nn.Module, GenerationMixin, "ModuleUtil
                 return t.dtype
         # if no floating dtype was found return whatever the first dtype is
         else:
-            return t.dtype
+            return next(parameter.parameters()).dtype
 
     except StopIteration:
         # For nn.DataParallel compatibility in PyTorch 1.5
@@ -175,7 +175,8 @@ def get_parameter_dtype(parameter: Union[nn.Module, GenerationMixin, "ModuleUtil
                 return tuple[1].dtype
         # fallback to any dtype the model has even if not floating
         else:
-            return tuple[1].dtype
+            first_tuple = next(gen)
+            return first_tuple[1].dtype
 
 
 def get_state_dict_float_dtype(state_dict):
@@ -191,7 +192,7 @@ def get_state_dict_float_dtype(state_dict):
 
 def get_state_dict_dtype(state_dict):
     """
-    Returns the first found floating dtype in `state_dict` if there is one, otherwise returns the last dtype.
+    Returns the first found floating dtype in `state_dict` if there is one, otherwise returns the first dtype.
     """
     for t in state_dict.values():
         if t.is_floating_point():
@@ -199,7 +200,7 @@ def get_state_dict_dtype(state_dict):
 
     # if no floating dtype was found return whatever the first dtype is
     else:
-        return t.dtype
+        return next(state_dict.values()).dtype
 
 
 def convert_file_size_to_int(size: Union[int, str]):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -152,18 +152,17 @@ def get_first_parameter_dtype(parameter: Union[nn.Module, GenerationMixin, "Modu
 
 def get_parameter_dtype(parameter: Union[nn.Module, GenerationMixin, "ModuleUtilsMixin"]):
     """
-    Returns the first found floating dtype in parameters if there is one, otherwise returns the first dtype it found.
+    Returns the first found floating dtype in parameters if there is one, otherwise returns the last dtype it found.
     """
-    first_dtype = None
+    lastt_dtype = None
     for t in parameter.parameters():
-        if first_dtype is None:
-            first_dtype = t.dtype
+        last_dtype = t.dtype
         if t.is_floating_point():
             return t.dtype
 
-    if first_dtype is not None:
+    if last_dtype is not None:
         # if no floating dtype was found return whatever the first dtype is
-        return first_dtype
+        return last_dtype
 
     else:
         # For nn.DataParallel compatibility in PyTorch > 1.5
@@ -172,14 +171,14 @@ def get_parameter_dtype(parameter: Union[nn.Module, GenerationMixin, "ModuleUtil
             return tuples
 
         gen = parameter._named_members(get_members_fn=find_tensor_attributes)
-        first_tuple = None
+        last_tuple = None
         for tuple in gen:
-            first_tuple = tuple
+            last_tuple = tuple
             if tuple[1].is_floating_point():
                 return tuple[1].dtype
 
-        # fallback to the first_dtype
-        return first_tuple[1].dtype
+        # fallback to the last dtype
+        return last_tuple[1].dtype
 
 
 def get_state_dict_float_dtype(state_dict):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -154,7 +154,7 @@ def get_parameter_dtype(parameter: Union[nn.Module, GenerationMixin, "ModuleUtil
     """
     Returns the first found floating dtype in parameters if there is one, otherwise returns the last dtype it found.
     """
-    lastt_dtype = None
+    last_dtype = None
     for t in parameter.parameters():
         last_dtype = t.dtype
         if t.is_floating_point():

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -139,7 +139,7 @@ def get_first_parameter_dtype(parameter: Union[nn.Module, GenerationMixin, "Modu
     try:
         return next(parameter.parameters()).dtype
     except StopIteration:
-        # For nn.DataParallel compatibility in PyTorch 1.5
+        # For nn.DataParallel compatibility in PyTorch > 1.5
 
         def find_tensor_attributes(module: nn.Module) -> List[Tuple[str, Tensor]]:
             tuples = [(k, v) for k, v in module.__dict__.items() if torch.is_tensor(v)]
@@ -160,13 +160,13 @@ def get_parameter_dtype(parameter: Union[nn.Module, GenerationMixin, "ModuleUtil
             first_dtype = t.dtype
         if t.is_floating_point():
             return t.dtype
-    
+
     if first_dtype is not None:
         # if no floating dtype was found return whatever the first dtype is
         return first_dtype
 
     else:
-        # For nn.DataParallel compatibility in PyTorch 1.5
+        # For nn.DataParallel compatibility in PyTorch > 1.5
         def find_tensor_attributes(module: nn.Module) -> List[Tuple[str, Tensor]]:
             tuples = [(k, v) for k, v in module.__dict__.items() if torch.is_tensor(v)]
             return tuples


### PR DESCRIPTION
# What does this PR do?

This PR is a better fix for #17656 as I've had time to dive deeper into this issue. The problem does appear when the model is wrapped in a `DataParallel` object, and not just for PyTorch 1.5. 