### PR TITLE
Fixed documentation typo, parameter name is evaluation_strategy, not eval_strategy

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -305,8 +305,8 @@ class TrainingArguments:
 
             <Tip>
 
-            When set to `True`, the parameters `save_strategy` needs to be the same as `eval_strategy`, and in the case
-            it is "steps", `save_steps` must be a round multiple of `eval_steps`.
+            When set to `True`, the parameters `save_strategy` needs to be the same as `evaluation_strategy`, and in
+            the case it is "steps", `save_steps` must be a round multiple of `eval_steps`.
 
             </Tip>
 


### PR DESCRIPTION
Noticed that there was a typo in the documentation here:
https://huggingface.co/docs/transformers/v4.19.4/en/main_classes/trainer#transformers.TrainingArguments

I believe the parameter name should be `evaluation_strategy` and not `eval_strategy`