### PR TITLE
Add AlbertTokenizer description information

### DIFF
--- a/src/transformers/models/albert/tokenization_albert.py
+++ b/src/transformers/models/albert/tokenization_albert.py
@@ -67,35 +67,37 @@ class AlbertTokenizer(PreTrainedTokenizer):
         You could use your sentincepiece model to build the AlbertTokenizer:
         ```python
         >>> from transformers import AlbertTokenizer
-        >>> tokenizer = AlbertTokenizer(vocab_file='Your/Sentincepiece/Model/Path',do_lower_case=False)
-        >>> tokenizer('I love huggingface.')
+
+        >>> tokenizer = AlbertTokenizer(vocab_file="Your/Sentincepiece/Model/Path", do_lower_case=False)
+        >>> tokenizer("I love huggingface.")
         {'input_ids': [1, 97, 9, 16, 5, 20, 2], 'token_type_ids': [0, 0, 0, 0, 0, 0, 0], 'attention_mask': [1, 1, 1, 1, 1, 1, 1]}
         ```
 
         You could still use AlbertTokenizer with the [`pipeline`]:
         ```python
-        >>> tokenizer=AlbertTokenizer.from_pretrained('albert-base-v2')
-        >>> tokenizer('I love huggingface.')
+        >>> tokenizer = AlbertTokenizer.from_pretrained("albert-base-v2")
+        >>> tokenizer("I love huggingface.")
         {'input_ids': [2, 31, 339, 20676, 6413, 9, 3], 'token_type_ids': [0, 0, 0, 0, 0, 0, 0], 'attention_mask': [1, 1, 1, 1, 1, 1, 1]}
         ```
+
         <Tip>
 
-        Due to some internal reasons, unexpected word segmentation may occur when initializing a tokenizer from scratch.
-        You could try to use [`from_pretrained`].
+        Due to some internal reasons, unexpected word segmentation may occur when initializing a tokenizer from
+        scratch. You could try to use [`from_pretrained`].
 
         For example:
 
         ```python
-        >>> tokenizer = AlbertTokenizer(vocab_file='Your/Sentincepiece/Model/Path',do_lower_case=False)
-        >>> tokenizer.tokenize('[CLS][SEP]')
+        >>> tokenizer = AlbertTokenizer(vocab_file="Your/Sentincepiece/Model/Path", do_lower_case=False)
+        >>> tokenizer.tokenize("[CLS][SEP]")
         ['[', 'CL', 'S', '][', 'SE', 'P', ']']
         ```
-        
+
         Using [`from_pretrained`]:
         ```python
-        >>> tokenizer.save_pretrained('Your/Save/Path')
-        >>> tokenizer = AlbertTokenizer.from_pretrained('Your/Save/Path')
-        >>> tokenizer.tokenize('[CLS][SEP]')
+        >>> tokenizer.save_pretrained("Your/Save/Path")
+        >>> tokenizer = AlbertTokenizer.from_pretrained("Your/Save/Path")
+        >>> tokenizer.tokenize("[CLS][SEP]")
         ['[CLS]', '[SEP]']
         ```
 

--- a/src/transformers/models/albert/tokenization_albert.py
+++ b/src/transformers/models/albert/tokenization_albert.py
@@ -72,7 +72,7 @@ class AlbertTokenizer(PreTrainedTokenizer):
         {'input_ids': [1, 97, 9, 16, 5, 20, 2], 'token_type_ids': [0, 0, 0, 0, 0, 0, 0], 'attention_mask': [1, 1, 1, 1, 1, 1, 1]}
         ```
 
-        You could still use AlbertTokenizer with the [`pipeline`]：
+        You could still use AlbertTokenizer with the [`pipeline`]:
         ```python
         >>> tokenizer=AlbertTokenizer.from_pretrained('albert-base-v2')
         >>> tokenizer('I love huggingface.')
@@ -80,7 +80,8 @@ class AlbertTokenizer(PreTrainedTokenizer):
         ```
         <Tip>
 
-        Due to some internal reasons, unexpected word segmentation may occur when initializing a tokenizer from scratch. You could try to use [`from_pretrained`].
+        Due to some internal reasons, unexpected word segmentation may occur when initializing a tokenizer from scratch.
+        You could try to use [`from_pretrained`].
 
         For example:
 
@@ -89,8 +90,8 @@ class AlbertTokenizer(PreTrainedTokenizer):
         >>> tokenizer.tokenize('[CLS][SEP]')
         ['[', 'CL', 'S', '][', 'SE', 'P', ']']
         ```
+        
         Using [`from_pretrained`]:
-
         ```python
         >>> tokenizer.save_pretrained('Your/Save/Path')
         >>> tokenizer = AlbertTokenizer.from_pretrained('Your/Save/Path')

--- a/src/transformers/models/albert/tokenization_albert.py
+++ b/src/transformers/models/albert/tokenization_albert.py
@@ -63,6 +63,43 @@ class AlbertTokenizer(PreTrainedTokenizer):
     This tokenizer inherits from [`PreTrainedTokenizer`] which contains most of the main methods. Users should refer to
     this superclass for more information regarding those methods.
 
+    Example:
+        You could use your sentincepiece model to build the AlbertTokenizer:
+        ```python
+        >>> from transformers import AlbertTokenizer
+        >>> tokenizer = AlbertTokenizer(vocab_file='Your/Sentincepiece/Model/Path',do_lower_case=False)
+        >>> tokenizer('I love huggingface.')
+        {'input_ids': [1, 97, 9, 16, 5, 20, 2], 'token_type_ids': [0, 0, 0, 0, 0, 0, 0], 'attention_mask': [1, 1, 1, 1, 1, 1, 1]}
+        ```
+
+        You could still use AlbertTokenizer with the [`pipeline`]：
+        ```python
+        >>> tokenizer=AlbertTokenizer.from_pretrained('albert-base-v2')
+        >>> tokenizer('I love huggingface.')
+        {'input_ids': [2, 31, 339, 20676, 6413, 9, 3], 'token_type_ids': [0, 0, 0, 0, 0, 0, 0], 'attention_mask': [1, 1, 1, 1, 1, 1, 1]}
+        ```
+        <Tip>
+
+        Due to some internal reasons, unexpected word segmentation may occur when initializing a tokenizer from scratch. You could try to use [`from_pretrained`].
+
+        For example:
+
+        ```python
+        >>> tokenizer = AlbertTokenizer(vocab_file='Your/Sentincepiece/Model/Path',do_lower_case=False)
+        >>> tokenizer.tokenize('[CLS][SEP]')
+        ['[', 'CL', 'S', '][', 'SE', 'P', ']']
+        ```
+        Using [`from_pretrained`]:
+
+        ```python
+        >>> tokenizer.save_pretrained('Your/Save/Path')
+        >>> tokenizer = AlbertTokenizer.from_pretrained('Your/Save/Path')
+        >>> tokenizer.tokenize('[CLS][SEP]')
+        ['[CLS]', '[SEP]']
+        ```
+
+        </Tip>
+
     Args:
         vocab_file (`str`):
             [SentencePiece](https://github.com/google/sentencepiece) file (generally has a *.spm* extension) that


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->
Hi, when I used Albert for pretraining, I found that the loss curve seemed abnormal. I did a number of checks and found that the data was not segmented as expected.I searched GitHub and found that this bug has been marked some times( #15003 #8999 ) and waiting to be fixed.

I guess we should definitely tell users about this problem before fixing it. This will help users win more debug time, right?


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
