### PR TITLE
[Pipeline] avoid importing tensorflow if not used

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -224,7 +224,7 @@ def infer_framework_load_model(
                 for architecture in config.architectures:
                     if architecture in dir(transformers_module):
                         class_tuple = class_tuple + (architecture,)
-        
+
         if look_tf:
             if model_classes:
                 class_tuple = class_tuple + model_classes.get("tf", (TFAutoModel,))


### PR DESCRIPTION
# What does this PR do?

Avoids loading unnecessary modules by `pipelines.base.infer_framework_load_model()` which could create some unexpected behaviour like tensorflow allocating all GPU memory.
@sgugger @LysandreJik 

Before:
```python
from transformers import pipeline
pipeline("text-classification")
# This would try importing `TFDistilBertForSequenceClassification`if both tensorflow and pytorch
# are available, and tensorflow would allocate all GPU memory, even if we expect to use
# the pytorch model
```

After:

```python
from transformers import pipeline
pipeline("text-classification")
# Only `DistilBertForSequenceClassification` is imported, and tensorflow is not called
```
