### PR TITLE
Change push CI to run on workflow_run event

### DIFF
--- a/.github/workflows/self-push-caller.yml
+++ b/.github/workflows/self-push-caller.yml
@@ -1,3 +1,4 @@
+# Used to trigger self-push CI
 name: Self-hosted runner (push-caller)
 
 on:
@@ -13,17 +14,8 @@ on:
 
 jobs:
   run_push_ci:
-    name: Run Push CI
+    name: Trigger Push CI
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout transformers
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
-          ssh-key: "${{ secrets.COMMIT_KEY }}"
-
-      - name: Checkout to branch push-ci
-        # A more strict way to make sure`push-ci` is exactly the same as `main` at the push event commit.
-        run: |
-          git checkout -b push-ci
-          git push -u origin push-ci --force
+      - name: Trigger push CI via workflow_run
+        run: echo "Trigger push CI via workflow_run"

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -1,9 +1,12 @@
 name: Self-hosted runner (push)
 
 on:
+  workflow_run:
+    workflows: ["Self-hosted runner (push-caller)"]
+    branches: ["main"]
+    types: [completed]
   push:
     branches:
-      - push-ci
       - ci_*
       - ci-*
     paths:


### PR DESCRIPTION
# What does this PR do?

The attempt in #17369 (to make commit history status checks less noisy) unfortunately has no effect.
After a discussion in [this comment](https://github.com/huggingface/transformers/pull/17369#issuecomment-1153846717), this PR changes push CI to be triggered by a `on: workflow_run` event.

Note the change only takes effect once this PR is merged into `main`, as mentioned in the doc. of [workflow_run](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run).

The result would be like in [accelerate](https://github.com/huggingface/accelerate), where the jobs in `on-merge.yml` won't be shown, and the workflow run page look like [this](https://github.com/huggingface/accelerate/actions/workflows/on-merge.yml).