### PR TITLE
Make attention_mask axes dynamic when exporting onnx

### DIFF
--- a/examples/research_projects/onnx/summarization/run_onnx_exporter.py
+++ b/examples/research_projects/onnx/summarization/run_onnx_exporter.py
@@ -135,6 +135,7 @@ def export_and_validate_model(model, tokenizer, onnx_file_path, num_beams, max_l
             output_names=["output_ids"],
             dynamic_axes={
                 "input_ids": {0: "batch", 1: "seq"},
+                "attention_mask": {0: "batch", 1: "seq"},
                 "output_ids": {0: "batch", 1: "seq_out"},
             },
             example_outputs=summary_ids,


### PR DESCRIPTION
# What does this PR do?

Make `attention_mask` axes dynamic when exporting onnx


## Who can review?
[@fatcat-z](https://github.com/fatcat-z)
