### PR TITLE
Make datasets<=2.2.2 for a quick fix for test failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,8 @@ _deps = [
     "codecarbon==1.2.0",
     "cookiecutter==1.7.3",
     "dataclasses",
-    "datasets",
+    # TODO: change back once the fix is done on datasets side
+    "datasets<=2.2.2",
     "deepspeed>=0.6.5",
     "dill<0.3.5",
     "fairscale>0.3",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -8,7 +8,7 @@ deps = {
     "codecarbon": "codecarbon==1.2.0",
     "cookiecutter": "cookiecutter==1.7.3",
     "dataclasses": "dataclasses",
-    "datasets": "datasets",
+    "datasets": "datasets<=2.2.2",
     "deepspeed": "deepspeed>=0.6.5",
     "dill": "dill<0.3.5",
     "fairscale": "fairscale>0.3",


### PR DESCRIPTION
# What does this PR do?

Currently, we have a lot of test failures (scheduled CI) with

```
FileNotFoundError: Unable to find '/transformers/tests/extended/../fixtures/tests_samples/wmt_en_ro/train.json' at /transformers
```
which is caused by the release of `datasets 2.3.x`.

This PR changes to "datasets<=2.2.2" temporarily to avoid the test failures.