### PR TITLE
Revert "Change push CI to run on workflow_run event"

### DIFF
--- a/.github/workflows/self-push-caller.yml
+++ b/.github/workflows/self-push-caller.yml
@@ -1,4 +1,3 @@
-# Used to trigger self-push CI
 name: Self-hosted runner (push-caller)
 
 on:
@@ -14,8 +13,17 @@ on:
 
 jobs:
   run_push_ci:
-    name: Trigger Push CI
+    name: Run Push CI
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger push CI via workflow_run
-        run: echo "Trigger push CI via workflow_run"
+      - name: Checkout transformers
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+          ssh-key: "${{ secrets.COMMIT_KEY }}"
+
+      - name: Checkout to branch push-ci
+        # A more strict way to make sure`push-ci` is exactly the same as `main` at the push event commit.
+        run: |
+          git checkout -b push-ci
+          git push -u origin push-ci --force

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -1,12 +1,9 @@
 name: Self-hosted runner (push)
 
 on:
-  workflow_run:
-    workflows: ["Self-hosted runner (push-caller)"]
-    branches: ["main"]
-    types: [completed]
   push:
     branches:
+      - push-ci
       - ci_*
       - ci-*
     paths:


### PR DESCRIPTION
Reverts huggingface/transformers#17692

Really sorry, but the `notification_service.py` has error

```
Traceback (most recent call last):
  File "utils/notification_service.py", line 766, in <module>
    ci_author = ci_details["author"]["login"]
KeyError: 'author'
```

as the GH event is no longer coupled with a commit, and we lose some information about commit/author.
I need to change more things.

(On my own repo for testing, there is no `notification_service.py`. And this change of `workflow_run` can only be verified when being merged to `main`)