### PR TITLE
CLI: Add flag to push TF weights directly into main

### DIFF
--- a/src/transformers/commands/pt_to_tf.py
+++ b/src/transformers/commands/pt_to_tf.py
@@ -244,6 +244,7 @@ class PTtoTFCommand(BaseTransformersCLICommand):
             repo.git_add(auto_lfs_track=True)
             repo.git_commit("Add TF weights")
             repo.git_push(blocking=True)  # this prints a progress bar with the upload
+            self._logger.warn(f"TF weights pushed into {self._model_name}")
         else:
             if not self._no_pr:
                 # TODO: remove try/except when the upload to PR feature is released

--- a/src/transformers/commands/pt_to_tf.py
+++ b/src/transformers/commands/pt_to_tf.py
@@ -245,28 +245,27 @@ class PTtoTFCommand(BaseTransformersCLICommand):
             repo.git_commit("Add TF weights")
             repo.git_push(blocking=True)  # this prints a progress bar with the upload
             self._logger.warn(f"TF weights pushed into {self._model_name}")
-        else:
-            if not self._no_pr:
-                # TODO: remove try/except when the upload to PR feature is released
-                # (https://github.com/huggingface/huggingface_hub/pull/884)
-                try:
-                    self._logger.warn("Uploading the weights into a new PR...")
-                    hub_pr_url = upload_file(
-                        path_or_fileobj=tf_weights_path,
-                        path_in_repo=TF_WEIGHTS_NAME,
-                        repo_id=self._model_name,
-                        create_pr=True,
-                        pr_commit_summary="Add TF weights",
-                        pr_commit_description=(
-                            "Model converted by the `transformers`' `pt_to_tf` CLI -- all converted model outputs and"
-                            " hidden layers were validated against its Pytorch counterpart. Maximum crossload output"
-                            f" difference={max_crossload_diff:.3e}; Maximum converted output"
-                            f" difference={max_conversion_diff:.3e}."
-                        ),
-                    )
-                    self._logger.warn(f"PR open in {hub_pr_url}")
-                except TypeError:
-                    self._logger.warn(
-                        f"You can now open a PR in https://huggingface.co/{self._model_name}/discussions, manually"
-                        f" uploading the file in {tf_weights_path}"
-                    )
+        elif not self._no_pr:
+            # TODO: remove try/except when the upload to PR feature is released
+            # (https://github.com/huggingface/huggingface_hub/pull/884)
+            try:
+                self._logger.warn("Uploading the weights into a new PR...")
+                hub_pr_url = upload_file(
+                    path_or_fileobj=tf_weights_path,
+                    path_in_repo=TF_WEIGHTS_NAME,
+                    repo_id=self._model_name,
+                    create_pr=True,
+                    pr_commit_summary="Add TF weights",
+                    pr_commit_description=(
+                        "Model converted by the `transformers`' `pt_to_tf` CLI -- all converted model outputs and"
+                        " hidden layers were validated against its Pytorch counterpart. Maximum crossload output"
+                        f" difference={max_crossload_diff:.3e}; Maximum converted output"
+                        f" difference={max_conversion_diff:.3e}."
+                    ),
+                )
+                self._logger.warn(f"PR open in {hub_pr_url}")
+            except TypeError:
+                self._logger.warn(
+                    f"You can now open a PR in https://huggingface.co/{self._model_name}/discussions, manually"
+                    f" uploading the file in {tf_weights_path}"
+                )


### PR DESCRIPTION
# What does this PR do?

Adds the `--push` flag to the `pt-to-tf` CLI, to enabling pushing straight to main (assuming the user has the right permissions).

Why am I adding this flag? A few users mentioned that they would be interested in having TF weights silently pushed straight into their repos. With this flag, I can start building a local midnight cronjob to automate the conversions (starting with pushes for users that requested it, then PR opening on users interested in PRs, then 1 PR per user if not whitelisted), which can eventually be moved into a separate machine to continuously feed the TF ecosystem 🔥 