### PR TITLE
[tests] workaround for relative dataset path

### DIFF
--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -1001,7 +1001,7 @@ class TestDeepSpeedWithLauncher(TestCasePlus):
         remove_args_str: str = None,
     ):
         max_len = 32
-        data_dir = self.test_file_dir / "../fixtures/tests_samples/wmt_en_ro"
+        data_dir = self.tests_dir / "fixtures/tests_samples/wmt_en_ro"
         output_dir = self.get_auto_remove_tmp_dir()
         args = f"""
             --model_name_or_path {model_name}

--- a/tests/extended/test_trainer_ext.py
+++ b/tests/extended/test_trainer_ext.py
@@ -298,7 +298,7 @@ class TestTrainerExt(TestCasePlus):
         do_eval: bool = True,
         do_predict: bool = True,
     ):
-        data_dir = self.test_file_dir / "../fixtures/tests_samples/wmt_en_ro"
+        data_dir = self.tests_dir / "fixtures/tests_samples/wmt_en_ro"
         output_dir = self.get_auto_remove_tmp_dir()
         args_train = f"""
             --model_name_or_path {model_name}


### PR DESCRIPTION
`datasets==2.3.1` introduced a bug where it fails to load a dataset via a path that contains `..`. 

This PR works around it by avoiding this situation in the tests.

@sgugger, @ydshieh 