### PR TITLE
Inference benchmarks of Torchdynamo + FX2TRT(now in Torch-TensorRT)  

### DIFF
--- a/hf_dynamo.py
+++ b/hf_dynamo.py
@@ -1,0 +1,500 @@
+import argparse
+import copy
+import gc
+import time
+from functools import partial
+
+import numpy as np
+import pandas as pd
+import torch
+from transformers import AutoConfig
+from transformers import AutoModelForCausalLM, AutoModelForMaskedLM, AutoModelForSeq2SeqLM
+from transformers import BertConfig, ReformerConfig, XLNetModel, XLNetConfig
+
+import torchdynamo
+from torchdynamo.optimizations import backends
+from torchdynamo.optimizations.training import aot_autograd_debug_strategy1
+from torchdynamo.optimizations.training import aot_autograd_speedup_strategy
+from torchdynamo.testing import collect_results
+from torchdynamo.testing import same
+
+torch.backends.cuda.matmul.allow_tf32 = True
+
+## TODO
+# 1) Add run_only argument and refactor
+# 2) Figure out how to get a large number of configs and model automatically. Go beyond Torchbench.
+
+# benchmarks = [
+    # (BertConfig(), AutoModelForMaskedLM, (4, 512), []),
+    # (AutoConfig.from_pretrained("albert-base-v2"), AutoModelForMaskedLM, (8, 512), []),
+    # (AutoConfig.from_pretrained("gpt2"), AutoModelForCausalLM, (4, 512), []),
+    # # (
+    # #     AutoConfig.from_pretrained("allenai/longformer-base-4096"),  # Longformer is not good for fx2trt
+    # #     AutoModelForMaskedLM,
+    # #     (2, 1024),
+    # #     [torch.bfloat16], # trilu not implemented for bfloat16
+    # # ),
+    # (AutoConfig.from_pretrained("t5-small"), AutoModelForSeq2SeqLM, (1, 1024), [torch.bfloat16]),
+    # #(ReformerConfig(), AutoModelForMaskedLM, (8, 4096), []), # Reformer is not good for fx2trt
+    # (AutoConfig.from_pretrained("distilbert-base-uncased"),  AutoModelForMaskedLM, (8, 512), []),
+    # (AutoConfig.from_pretrained("roberta-base"),  AutoModelForMaskedLM, (16, 512), []),
+    # # (BigBirdConfig(attention_type="block_sparse"), AutoModelForMaskedLM, (2, 1024), [torch.bfloat16, torch.float16]), # Currently quite slow - needs investigation
+    # (AutoConfig.from_pretrained("distilgpt2"), AutoModelForCausalLM, (16, 512), []),
+    # (AutoConfig.from_pretrained("google/electra-base-discriminator"), AutoModelForMaskedLM, (8, 512), []),
+    # (AutoConfig.from_pretrained("google/fnet-base"), AutoModelForMaskedLM, (8, 512), [torch.bfloat16, torch.float16]),
+    # (AutoConfig.from_pretrained("YituTech/conv-bert-base"), AutoModelForMaskedLM, (8, 512), [torch.bfloat16]),
+    # (AutoConfig.from_pretrained("google/mobilebert-uncased"), AutoModelForMaskedLM, (4, 512), []),
+    # (AutoConfig.from_pretrained("camembert-base"), AutoModelForMaskedLM, (8, 512), []),
+    # (AutoConfig.from_pretrained("microsoft/layoutlm-base-uncased"), AutoModelForMaskedLM, (8, 512), []),
+# ]
+
+benchmarks = [
+    # batch size = 1
+    (BertConfig(), AutoModelForMaskedLM, (1, 512), []),
+    (AutoConfig.from_pretrained("albert-base-v2"), AutoModelForMaskedLM, (1, 512), []),
+    (AutoConfig.from_pretrained("gpt2"), AutoModelForCausalLM, (1, 512), []),
+    # (
+    #     AutoConfig.from_pretrained("allenai/longformer-base-4096"),  # Longformer is not suitable for fx2trt
+    #     AutoModelForMaskedLM,
+    #     (2, 1024),
+    #     [torch.bfloat16], # trilu not implemented for bfloat16
+    # ),
+    (AutoConfig.from_pretrained("t5-small"), AutoModelForSeq2SeqLM, (1, 512), []),
+    #(ReformerConfig(), AutoModelForMaskedLM, (8, 4096), []), # Reformer is not suitable for fx2trt
+    (AutoConfig.from_pretrained("distilbert-base-uncased"),  AutoModelForMaskedLM, (1, 512), []),
+    (AutoConfig.from_pretrained("roberta-base"),  AutoModelForMaskedLM, (1, 512), []),
+    # (BigBirdConfig(attention_type="block_sparse"), AutoModelForMaskedLM, (2, 1024), []), # Birdbird is not suitable for fx2trt
+    (AutoConfig.from_pretrained("distilgpt2"), AutoModelForCausalLM, (1, 512), []),
+    (AutoConfig.from_pretrained("google/electra-base-discriminator"), AutoModelForMaskedLM, (1, 512), []),
+    #(AutoConfig.from_pretrained("google/fnet-base"), AutoModelForMaskedLM, (4, 512), []), #  not supported by fx2trt
+    (AutoConfig.from_pretrained("YituTech/conv-bert-base"), AutoModelForMaskedLM, (1, 512), []),
+    (AutoConfig.from_pretrained("google/mobilebert-uncased"), AutoModelForMaskedLM, (1, 512), []),
+    (AutoConfig.from_pretrained("camembert-base"), AutoModelForMaskedLM, (1, 512), []),
+    (AutoConfig.from_pretrained("microsoft/layoutlm-base-uncased"), AutoModelForMaskedLM, (1, 512), []),
+    # batch size = 4
+    (BertConfig(), AutoModelForMaskedLM, (4, 512), []),
+    (AutoConfig.from_pretrained("albert-base-v2"), AutoModelForMaskedLM, (4, 512), []),
+    (AutoConfig.from_pretrained("gpt2"), AutoModelForCausalLM, (4, 512), []),
+    # (
+    #     AutoConfig.from_pretrained("allenai/longformer-base-4096"),  # Longformer is not suitable for fx2trt
+    #     AutoModelForMaskedLM,
+    #     (2, 1024),
+    #     [torch.bfloat16], # trilu not implemented for bfloat16
+    # ),
+    (AutoConfig.from_pretrained("t5-small"), AutoModelForSeq2SeqLM, (4, 512), []),
+    #(ReformerConfig(), AutoModelForMaskedLM, (8, 4096), []), # Reformer is not suitable for fx2trt
+    (AutoConfig.from_pretrained("distilbert-base-uncased"),  AutoModelForMaskedLM, (4, 512), []),
+    (AutoConfig.from_pretrained("roberta-base"),  AutoModelForMaskedLM, (4, 512), []),
+    # (BigBirdConfig(attention_type="block_sparse"), AutoModelForMaskedLM, (2, 1024), []), # Birdbird is not suitable for fx2trt
+    (AutoConfig.from_pretrained("distilgpt2"), AutoModelForCausalLM, (4, 512), []),
+    (AutoConfig.from_pretrained("google/electra-base-discriminator"), AutoModelForMaskedLM, (4, 512), []),
+    #(AutoConfig.from_pretrained("google/fnet-base"), AutoModelForMaskedLM, (4, 512), []), #  not supported by fx2trt
+    (AutoConfig.from_pretrained("YituTech/conv-bert-base"), AutoModelForMaskedLM, (4, 512), []),
+    (AutoConfig.from_pretrained("google/mobilebert-uncased"), AutoModelForMaskedLM, (4, 512), []),
+    (AutoConfig.from_pretrained("camembert-base"), AutoModelForMaskedLM, (4, 512), []),
+    (AutoConfig.from_pretrained("microsoft/layoutlm-base-uncased"), AutoModelForMaskedLM, (4, 512), []),
+    # batch size = 8
+    (BertConfig(), AutoModelForMaskedLM, (8, 512), []),
+    (AutoConfig.from_pretrained("albert-base-v2"), AutoModelForMaskedLM, (8, 512), []),
+    (AutoConfig.from_pretrained("gpt2"), AutoModelForCausalLM, (8, 512), []),
+    # (
+    #     AutoConfig.from_pretrained("allenai/longformer-base-4096"),  # Longformer is not suitable for fx2trt
+    #     AutoModelForMaskedLM,
+    #     (2, 1024),
+    #     [torch.bfloat16], # trilu not implemented for bfloat16
+    # ),
+    (AutoConfig.from_pretrained("t5-small"), AutoModelForSeq2SeqLM, (8, 512), []),
+    #(ReformerConfig(), AutoModelForMaskedLM, (8, 4096), []), # Reformer is not suitable for fx2trt
+    (AutoConfig.from_pretrained("distilbert-base-uncased"),  AutoModelForMaskedLM, (8, 512), []),
+    (AutoConfig.from_pretrained("roberta-base"),  AutoModelForMaskedLM, (8, 512), []),
+    # (BigBirdConfig(attention_type="block_sparse"), AutoModelForMaskedLM, (2, 1024), []), # Birdbird is not suitable for fx2trt
+    (AutoConfig.from_pretrained("distilgpt2"), AutoModelForCausalLM, (8, 512), []),
+    (AutoConfig.from_pretrained("google/electra-base-discriminator"), AutoModelForMaskedLM, (8, 512), []),
+    #(AutoConfig.from_pretrained("google/fnet-base"), AutoModelForMaskedLM, (4, 512), []), #  not supported by fx2trt
+    (AutoConfig.from_pretrained("YituTech/conv-bert-base"), AutoModelForMaskedLM, (8, 512), []),
+    (AutoConfig.from_pretrained("google/mobilebert-uncased"), AutoModelForMaskedLM, (8, 512), []),
+    (AutoConfig.from_pretrained("camembert-base"), AutoModelForMaskedLM, (8, 512), []),
+    (AutoConfig.from_pretrained("microsoft/layoutlm-base-uncased"), AutoModelForMaskedLM, (8, 512), []),
+]
+
+device = "cuda"
+
+
+class NullContext:
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+@torchdynamo.skip
+def get_cur_memory():
+    torch.cuda.synchronize()
+
+    gc.collect()
+    torch.cuda.empty_cache()
+    stats = torch.cuda.memory_stats()
+    peak_bytes_requirement = stats["allocated_bytes.all.current"]
+    # print(f"Current memory requirement: {peak_bytes_requirement / 1024 ** 3:.2f} GB")
+    return peak_bytes_requirement
+
+
+@torchdynamo.skip
+def forward_pass(mod, inputs, collect_outputs=True):
+    return mod(*inputs)
+
+
+@torchdynamo.skip
+def forward_and_backward_pass(mod, inputs, collect_outputs=True):
+    mod.zero_grad(True)
+    pred = mod(**inputs)
+    loss = pred.loss
+    loss.backward()
+    if collect_outputs:
+        # Only check correctness of loss and gradients
+        return collect_results(mod, loss, loss, example_inputs=())
+    return None
+
+
+@torchdynamo.skip
+def check_correctness(args, mod, inputs, optimize_ctx, optimize_name):
+    torch.manual_seed(1337)
+    if args.use_eval_mode:
+        correct_result = forward_pass(copy.deepcopy(mod), inputs)
+    else:
+        correct_result = forward_and_backward_pass(copy.deepcopy(mod), inputs)
+
+    torch.manual_seed(1337)
+    if args.use_eval_mode:
+        correct_rerun_result = forward_pass(copy.deepcopy(mod), inputs)
+    else:
+        correct_rerun_result = forward_and_backward_pass(copy.deepcopy(mod), inputs)
+
+    if not same(correct_result, correct_rerun_result):
+        print("INCORRECT - Variation in Eager runs itself")
+        return False
+
+    torch.manual_seed(1337)
+    torchdynamo.reset()
+    nvfuser_ctx = torch.jit.fuser("fuser2") if args.nvfuser else NullContext()
+    if args.use_eval_mode:
+        try:
+            with optimize_ctx, nvfuser_ctx:
+                new_result = forward_pass(mod, inputs)
+        except Exception:
+            print("ERROR")
+            return False
+    else:
+        try:
+            with optimize_ctx, nvfuser_ctx:
+                new_result = forward_and_backward_pass(mod, inputs)
+        except Exception:
+            print("ERROR")
+            return False
+    if optimize_name == "dynamo_fx2trt_fp16":
+        cos_similarity = True
+    else:
+        cos_similarity = False
+
+    if not same(correct_result, new_result, cos_similarity=cos_similarity, tol=1e-2):
+        print("INCORRECT")
+        return False
+    return True
+
+
+synchronize = torch.cuda.synchronize
+
+
+def timed(model, model_iter_fn, train_inputs, timings=1, return_result=False):
+    synchronize()
+    torch.manual_seed(1337)
+    t0 = time.perf_counter()
+    # Dont collect outputs to correctly measure timing
+    for _ in range(timings):
+        result = model_iter_fn(model, train_inputs, collect_outputs=False)
+        synchronize()
+    t1 = time.perf_counter()
+    # print("===timed=", t1-t0)
+    return (t1 - t0, result) if return_result else t1 - t0
+
+
+@torchdynamo.skip
+def bench_model_eval(args, name, mod, eval_inputs, optimize_ctx):
+    if type(optimize_ctx) == NullContext:
+        # Profile memory
+        m = None
+        for i in range(5):
+            out = mod(*eval_inputs)
+            if i == 4:
+                m = get_cur_memory()
+
+        # Warmup
+        iters = 5
+        for _ in range(iters):
+            timed(mod, forward_pass, eval_inputs)
+        synchronize()
+
+        # Profile time
+        iters = 50
+        synchronize()
+        timings = []
+        for _ in range(iters):
+            timings.append(timed(mod, forward_pass, eval_inputs))
+        t = np.median(timings, axis=0)
+    else:
+        # does not need recompile for torchdynamo, demo for fx2trt only
+        with torchdynamo.run():
+            # Profile memory
+            m = None
+            for i in range(5):
+                out = mod(*eval_inputs)
+                if i == 4:
+                    m = get_cur_memory()
+
+            # Warmup
+            iters = 5
+            for _ in range(iters):
+                timed(mod, forward_pass, eval_inputs)
+            synchronize()
+
+            # Profile time
+            iters = 50
+            synchronize()
+            timings = []
+            for _ in range(iters):
+                timings.append(timed(mod, forward_pass, eval_inputs))
+            t = np.median(timings, axis=0)
+
+    print(name, t, m)
+    return t, m
+
+
+@torchdynamo.skip
+def bench_model(args, name, mod, train_inputs, optimize_ctx):
+    nvfuser_ctx = torch.jit.fuser("fuser2") if args.nvfuser else NullContext()
+    with optimize_ctx, nvfuser_ctx:
+        # Profile memory
+        m = None
+        for i in range(5):
+            out = mod(**train_inputs).loss.abs().sum()
+            if i == 4:
+                m = get_cur_memory()
+            out.backward()
+
+        # Warmup
+        iters = 5
+        for _ in range(iters):
+            timed(mod, forward_and_backward_pass, train_inputs)
+        synchronize()
+
+        # Profile time
+        iters = 50
+        synchronize()
+        timings = []
+        for _ in range(iters):
+            timings.append(timed(mod, forward_and_backward_pass, train_inputs))
+        t = np.median(timings, axis=0)
+
+    print(name, t, m)
+    return t, m
+
+
+model_header, dtype_header, nh, th, mh, sp, mp, acc = (
+    "model",
+    "dtype",
+    "name",
+    "time (s)",
+    "mem (GB)",
+    "speedup",
+    "mem_compression",
+    "is_accurate",
+)
+
+
+def create_record(model_name, dtype, is_accurate, name, t, m):
+    return {
+        model_header: model_name,
+        dtype_header: str(dtype),
+        acc: is_accurate,
+        nh: name,
+        th: t,
+        mh: m / 2 ** 30,
+    }
+
+
+numerical_diffs = []
+results = []
+
+
+def load_model(config, model_type, dtype, args):
+    for attr in dir(config):
+        if "drop" in attr and isinstance(getattr(config, attr), float):
+            setattr(
+                config, attr, 1e-30
+            )  # So we can check for correct gradients without eliminating the dropout computation
+    model = model_type.from_config(config).to(device, dtype=dtype)
+    if args.use_eval_mode:
+        model.eval()
+    else:
+        model.train()
+    return model
+
+
+def run_all(args, optimize_ctx, optimize_name):
+    for config, model_type, input_size, not_supported_dtypes in benchmarks:
+        for dtype in [torch.float, torch.half, torch.bfloat16]:
+            if dtype in not_supported_dtypes:
+                continue
+
+            model = load_model(config, model_type, dtype, args)
+
+            model_name = type(model).__name__
+            # Prepare inputs
+            input_ids = torch.randint(0, config.vocab_size, input_size).to(device)
+            decoder_ids = torch.randint(0, config.vocab_size, input_size).to(device)
+            train_inputs = {"input_ids": input_ids, "labels": decoder_ids}
+
+            # Correctness check
+            is_accurate = check_correctness(args, model, train_inputs, optimize_ctx)
+
+            # Profile eager
+            t, m = bench_model(args, "eager", model, train_inputs, NullContext())
+            results.append(create_record(model_name, dtype, is_accurate, "eager", t, m))
+
+            # Profile Dynamo nvfuser
+            t, m = bench_model(args, optimize_name, model, train_inputs, optimize_ctx)
+            results.append(create_record(model_name, dtype, is_accurate, optimize_name, t, m))
+
+            # calculate relative improvements
+            base_r = results[-2]
+            for r in results[-2:]:
+                r[sp] = round(base_r[th] / r[th], 3)
+                r[mp] = round(base_r[mh] / r[mh], 3)
+            print(pd.DataFrame(results[-2:]).to_markdown(index=False, floatfmt=".3f"))
+
+    print("=== Final results ===")
+    print(pd.DataFrame(results).to_markdown(index=False, floatfmt=".3f"))
+
+class ArgsToKwargsWrapper(torch.nn.Module):
+    def __init__(self, model):
+        super(ArgsToKwargsWrapper, self).__init__()
+        self.model = model
+
+    def forward(self, input_ids, decoder_input_ids):
+        return self.model(input_ids=input_ids, decoder_input_ids=decoder_input_ids)
+
+def run_all_eval(args, optimize_ctx, optimize_name, dtype):
+    for config, model_type, input_size, not_supported_dtypes in benchmarks:
+        if dtype in not_supported_dtypes:
+            continue
+
+        model = load_model(config, model_type, dtype, args)
+
+        model_name = type(model).__name__
+
+        # Prepare inputs
+        input_ids = torch.randint(0, config.vocab_size, input_size).to(device)
+
+        if model_type.__name__ == "AutoModelForSeq2SeqLM":
+            model = ArgsToKwargsWrapper(model)
+            eval_inputs = (input_ids, input_ids, )
+        else:
+            eval_inputs = (input_ids,)
+
+        # Correctness check
+        is_accurate = check_correctness(args, model, eval_inputs, optimize_ctx, optimize_name)
+        # Profile eager
+        t, m = bench_model_eval(args, "eager", model, eval_inputs, NullContext())
+        results.append(create_record(model_name, dtype, is_accurate, "eager", t, m))
+
+        # Profile Dynamo nvfuser
+        t, m = bench_model_eval(args, optimize_name, model, eval_inputs, optimize_ctx)
+        results.append(create_record(model_name, dtype, is_accurate, optimize_name, t, m))
+
+        # calculate relative improvements
+        base_r = results[-2]
+        for r in results[-2:]:
+            r[sp] = round(base_r[th] / r[th], 3)
+            r[mp] = round(base_r[mh] / r[mh], 3)
+        print(pd.DataFrame(results[-2:]).to_markdown(index=False, floatfmt=".3f"))
+
+    print("=== Final results ===")
+    print(pd.DataFrame(results).to_markdown(index=False, floatfmt=".3f"))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--use-eval-mode",
+        action="store_true",
+        help="sets model.eval() to reduce randomness",
+    )
+    parser.add_argument("--nvfuser", action="store_true", help="enable nvfuser globally")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--run-dynamo-eager",
+        action="store_true",
+        help="Use Dynamo eager",
+    )
+    group.add_argument(
+        "--run-dynamo-aot-eager",
+        action="store_true",
+        help="Use Dynamo with AOT Autograd with eager backend",
+    )
+    group.add_argument(
+        "--run-dynamo-aot-efficient",
+        action="store_true",
+        help="Use Dynamo eager",
+    )
+    group.add_argument(
+        "--run-dynamo-fx2trt-fp16",
+        action="store_true",
+        help="Use Dynamo with fx2trt fp16",
+    )
+    group.add_argument(
+        "--run-dynamo-fx2trt-fp32",
+        action="store_true",
+        help="Use Dynamo with fx2trt fp32",
+    )
+    args = parser.parse_args()
+    optimize_ctx = NullContext()
+    optimize_name = "eager"
+
+    if args.run_dynamo_eager:
+        optimize_ctx = torchdynamo.optimize("eager")
+        optimize_name = "dynamo_eager"
+    elif args.run_dynamo_aot_eager:
+        optimize_ctx = torchdynamo.optimize(aot_autograd_debug_strategy1)
+        optimize_name = "dynamo_aot_eager"
+    elif args.run_dynamo_aot_efficient:
+        optimize_ctx = torchdynamo.optimize(aot_autograd_speedup_strategy)
+        optimize_name = "dynamo_aot_efficient"
+        # Put nvfuser context inside torchdynamo.optimize
+        args.nvfuser = True
+    elif args.run_dynamo_fx2trt_fp16:
+        optimize_ctx = torchdynamo.optimize(
+            backends.fx2trt_compiler_fp16
+        )
+        optimize_name = "dynamo_fx2trt_fp16"
+    elif args.run_dynamo_fx2trt_fp32:
+        optimize_ctx = torchdynamo.optimize(
+            backends.fx2trt_compiler
+        )
+        optimize_name = "dynamo_fx2trt_fp32"
+    if args.use_eval_mode:
+        experiment = run_all_eval
+        # fp16
+        if optimize_name == "dynamo_fx2trt_fp16":
+            experiment = partial(experiment, dtype=torch.float16)
+        if optimize_name == "dynamo_fx2trt_fp32":
+            experiment = partial(experiment, dtype=torch.float32)
+    else:
+        experiment = run_all
+
+    experiment = partial(experiment, optimize_ctx=optimize_ctx, optimize_name=optimize_name)
+    experiment(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hey HF folks:
I propose this PR as performance results preview for our SOTA inference engine combining torchdynamo+fx2trt. This PR is the based on the sound and great work in #17240 (cc @Chillee @jansel). Since the importance of torchdynamo is already emphasized in #17240, I will skip it and focus on the inference efforts we proposed by combining torchdynamo + fx2trt.  
# A short introduction about fx2trt
It is library tool developed by Meta team (cc @yinghai) to lower the FX graph to TensorRT on GPU to take advantage of its various optimization paths. The library itself was just merged into [Torch-TensorRT](https://github.com/pytorch/TensorRT) as one of its two lowering paths to TensorRT running on GPU.
 
# Results
This script primarily comes from a great effort from @anijain2305 and I added some inference implementation logic there.  
Some highlights about the results:
1. Compared with FX integration, it is important that torchdynamo could handle those corner cases where FX could not like control flow or set item operation. That is the main the reason we could extend our implementation to these 12 models. Actually, maybe more models could be run but I just follow the same model pool from #17204 
2. The experiments are run across different batch sizes from 1 to 4 and 8. The speedup is compared against the eager model. The trend is that speedup is pretty high on small batch size like 1 but get slower down when the batch size is increased. The reason behind it could be that torch eager mode is low efficiency on handling the small computation kernel while on large kernels, TRT and eager model would call similar kernel implementations. So their perf gap is reduced on large batch size.
3. TensorRT has accuracy degradation problem in float16 mode because of its optimization techniques. I changed the accuracy validation standard as [Cosine Similarity](https://pytorch.org/docs/stable/generated/torch.nn.CosineSimilarity.html) which is also another important evaluation standard on the accuracy against eager mode. For float32 mode, the absolute difference is used as standard.

Run on A100:
```
To run for fp32 mode:
$ python hf_dynamo.py --run-dynamo-fx2trt-fp32 --use-eval-mode
 

To run for fp16 mode:
$ python hf_dynamo.py --run-dynamo-fx2trt-fp16 --use-eval-mode
```
cc @stas00  

=== Final results for fp16 ===
**Batch size = 1**

| model                      | dtype         | is_accurate   | name               |   time (s) |   mem (GB) |   speedup |   mem_compression |
|:---------------------------|:--------------|:--------------|:-------------------|-----------:|-----------:|----------:|------------------:|
| BertForMaskedLM            | torch.float16 | True          | eager              |      0.010 |      0.458 |     1.000 |             1.000 |
| BertForMaskedLM            | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.003 |      0.240 |     2.930 |             1.906 |
| AlbertForMaskedLM          | torch.float16 | True          | eager              |      0.012 |      0.417 |     1.000 |             1.000 |
| AlbertForMaskedLM          | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.004 |      0.051 |     2.775 |             8.257 |
| GPT2LMHeadModel            | torch.float16 | True          | eager              |      0.013 |      0.630 |     1.000 |             1.000 |
| GPT2LMHeadModel            | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.006 |      0.316 |     2.314 |             1.991 |
| T5ForConditionalGeneration | torch.float16 | True          | eager              |      0.021 |      0.504 |     1.000 |             1.000 |
| T5ForConditionalGeneration | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.024 |      0.162 |     0.898 |             3.115 |
| DistilBertForMaskedLM      | torch.float16 | True          | eager              |      0.006 |      0.273 |     1.000 |             1.000 |
| DistilBertForMaskedLM      | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.003 |      0.158 |     2.119 |             1.722 |
| RobertaForMaskedLM         | torch.float16 | True          | eager              |      0.011 |      0.506 |     1.000 |             1.000 |
| RobertaForMaskedLM         | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.006 |      0.290 |     1.986 |             1.743 |
| GPT2LMHeadModel            | torch.float16 | True          | eager              |      0.006 |      0.446 |     1.000 |             1.000 |
| GPT2LMHeadModel            | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.003 |      0.220 |     1.909 |             2.026 |
| ElectraForMaskedLM         | torch.float16 | True          | eager              |      0.010 |      0.458 |     1.000 |             1.000 |
| ElectraForMaskedLM         | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.003 |      0.241 |     3.044 |             1.900 |
| ConvBertForMaskedLM        | torch.float16 | True          | eager              |      0.020 |      0.459 |     1.000 |             1.000 |
| ConvBertForMaskedLM        | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.021 |      0.231 |     0.944 |             1.985 |
| MobileBertForMaskedLM      | torch.float16 | True          | eager              |      0.040 |      0.297 |     1.000 |             1.000 |
| MobileBertForMaskedLM      | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.006 |      0.128 |     6.693 |             2.312 |
| CamembertForMaskedLM       | torch.float16 | True          | eager              |      0.011 |      0.460 |     1.000 |             1.000 |
| CamembertForMaskedLM       | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.005 |      0.241 |     2.075 |             1.906 |
| LayoutLMForMaskedLM        | torch.float16 | True          | eager              |      0.011 |      0.466 |     1.000 |             1.000 |
| LayoutLMForMaskedLM        | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.004 |      0.247 |     3.031 |             1.885 |
  
**Batch size = 4**  

| model                      | dtype         | is_accurate   | name               |   time (s) |   mem (GB) |   speedup |   mem_compression |
|:---------------------------|:--------------|:--------------|:-------------------|-----------:|-----------:|----------:|------------------:|
| BertForMaskedLM            | torch.float16 | True          | eager              |      0.012 |      1.185 |     1.000 |             1.000 |
| BertForMaskedLM            | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.008 |      0.326 |     1.445 |             3.631 |
| AlbertForMaskedLM          | torch.float16 | True          | eager              |      0.013 |      1.455 |     1.000 |             1.000 |
| AlbertForMaskedLM          | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.005 |      0.137 |     2.508 |            10.610 |
| GPT2LMHeadModel            | torch.float16 | True          | eager              |      0.014 |      1.826 |     1.000 |             1.000 |
| GPT2LMHeadModel            | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.008 |      0.515 |     1.705 |             3.549 |
| T5ForConditionalGeneration | torch.float16 | True          | eager              |      0.025 |      1.684 |     1.000 |             1.000 |
| T5ForConditionalGeneration | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.024 |      0.291 |     1.055 |             5.778 |
| DistilBertForMaskedLM      | torch.float16 | True          | eager              |      0.007 |      0.687 |     1.000 |             1.000 |
| DistilBertForMaskedLM      | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.006 |      0.253 |     1.227 |             2.721 |
| RobertaForMaskedLM         | torch.float16 | True          | eager              |      0.015 |      1.288 |     1.000 |             1.000 |
| RobertaForMaskedLM         | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.012 |      0.427 |     1.246 |             3.012 |
| GPT2LMHeadModel            | torch.float16 | True          | eager              |      0.008 |      1.120 |     1.000 |             1.000 |
| GPT2LMHeadModel            | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.006 |      0.394 |     1.430 |             2.842 |
| ElectraForMaskedLM         | torch.float16 | True          | eager              |      0.013 |      1.186 |     1.000 |             1.000 |
| ElectraForMaskedLM         | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.008 |      0.329 |     1.517 |             3.605 |
| ConvBertForMaskedLM        | torch.float16 | True          | eager              |      0.021 |      1.243 |     1.000 |             1.000 |
| ConvBertForMaskedLM        | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.020 |      0.321 |     1.077 |             3.876 |
| MobileBertForMaskedLM      | torch.float16 | True          | eager              |      0.043 |      0.893 |     1.000 |             1.000 |
| MobileBertForMaskedLM      | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.009 |      0.221 |     4.923 |             4.046 |
| CamembertForMaskedLM       | torch.float16 | True          | eager              |      0.014 |      1.189 |     1.000 |             1.000 |
| CamembertForMaskedLM       | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.011 |      0.331 |     1.302 |             3.597 |
| LayoutLMForMaskedLM        | torch.float16 | True          | eager              |      0.012 |      1.189 |     1.000 |             1.000 |
| LayoutLMForMaskedLM        | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.009 |      0.330 |     1.443 |             3.599 |  

**Batch size = 8**  

| model                      | dtype         | is_accurate   | name               |   time (s) |   mem (GB) |   speedup |   mem_compression |
|:---------------------------|:--------------|:--------------|:-------------------|-----------:|-----------:|----------:|------------------:|
| BertForMaskedLM            | torch.float16 | True          | eager              |      0.015 |      2.156 |     1.000 |             1.000 |
| BertForMaskedLM            | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.014 |      0.439 |     1.014 |             4.916 |
| AlbertForMaskedLM          | torch.float16 | True          | eager              |      0.017 |      2.840 |     1.000 |             1.000 |
| AlbertForMaskedLM          | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.009 |      0.250 |     1.892 |            11.361 |
| GPT2LMHeadModel            | torch.float16 | True          | eager              |      0.021 |      3.393 |     1.000 |             1.000 |
| GPT2LMHeadModel            | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.015 |      0.780 |     1.376 |             4.349 |
| T5ForConditionalGeneration | torch.float16 | True          | eager              |      0.025 |      3.243 |     1.000 |             1.000 |
| T5ForConditionalGeneration | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.027 |      0.465 |     0.929 |             6.977 |
| DistilBertForMaskedLM      | torch.float16 | True          | eager              |      0.009 |      1.237 |     1.000 |             1.000 |
| DistilBertForMaskedLM      | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.009 |      0.371 |     0.904 |             3.334 |
| RobertaForMaskedLM         | torch.float16 | True          | eager              |      0.018 |      2.335 |     1.000 |             1.000 |
| RobertaForMaskedLM         | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.019 |      0.618 |     0.958 |             3.781 |
| GPT2LMHeadModel            | torch.float16 | True          | eager              |      0.013 |      2.001 |     1.000 |             1.000 |
| GPT2LMHeadModel            | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.010 |      0.626 |     1.285 |             3.197 |
| ElectraForMaskedLM         | torch.float16 | True          | eager              |      0.015 |      2.156 |     1.000 |             1.000 |
| ElectraForMaskedLM         | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.014 |      0.444 |     1.023 |             4.857 |
| ConvBertForMaskedLM        | torch.float16 | True          | eager              |      0.022 |      2.273 |     1.000 |             1.000 |
| ConvBertForMaskedLM        | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.024 |      0.439 |     0.937 |             5.180 |
| MobileBertForMaskedLM      | torch.float16 | True          | eager              |      0.042 |      1.685 |     1.000 |             1.000 |
| MobileBertForMaskedLM      | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.013 |      0.343 |     3.265 |             4.909 |
| CamembertForMaskedLM       | torch.float16 | True          | eager              |      0.016 |      2.171 |     1.000 |             1.000 |
| CamembertForMaskedLM       | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.017 |      0.453 |     0.950 |             4.792 |
| LayoutLMForMaskedLM        | torch.float16 | True          | eager              |      0.015 |      2.163 |     1.000 |             1.000 |
| LayoutLMForMaskedLM        | torch.float16 | True          | dynamo_fx2trt_fp16 |      0.015 |      0.445 |     1.010 |             4.859 |  

  
=== Final results for fp32 ===  
**Batch size = 1**    
| model                      | dtype         | is_accurate   | name               |   time (s) |   mem (GB) |   speedup |   mem_compression |
|:---------------------------|:--------------|:--------------|:-------------------|-----------:|-----------:|----------:|------------------:|
| BertForMaskedLM            | torch.float32 | True          | eager              |      0.010 |      0.905 |     1.000 |             1.000 |
| BertForMaskedLM            | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.004 |      0.468 |     2.371 |             1.936 |
| AlbertForMaskedLM          | torch.float32 | True          | eager              |      0.011 |      0.839 |     1.000 |             1.000 |
| AlbertForMaskedLM          | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.004 |      0.100 |     2.563 |             8.401 |
| GPT2LMHeadModel            | torch.float32 | True          | eager              |      0.011 |      1.237 |     1.000 |             1.000 |
| GPT2LMHeadModel            | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.005 |      0.616 |     2.163 |             2.009 |
| T5ForConditionalGeneration | torch.float32 | True          | eager              |      0.015 |      0.648 |     1.000 |             1.000 |
| T5ForConditionalGeneration | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.008 |      0.318 |     1.879 |             2.038 |
| DistilBertForMaskedLM      | torch.float32 | True          | eager              |      0.006 |      0.534 |     1.000 |             1.000 |
| DistilBertForMaskedLM      | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.003 |      0.313 |     2.080 |             1.705 |
| RobertaForMaskedLM         | torch.float32 | True          | eager              |      0.011 |      0.998 |     1.000 |             1.000 |
| RobertaForMaskedLM         | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.006 |      0.563 |     1.707 |             1.773 |
| GPT2LMHeadModel            | torch.float32 | True          | eager              |      0.006 |      0.879 |     1.000 |             1.000 |
| GPT2LMHeadModel            | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.003 |      0.429 |     1.987 |             2.050 |
| ElectraForMaskedLM         | torch.float32 | True          | eager              |      0.010 |      0.902 |     1.000 |             1.000 |
| ElectraForMaskedLM         | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.004 |      0.471 |     2.478 |             1.914 |
| ConvBertForMaskedLM        | torch.float32 | True          | eager              |      0.019 |      0.926 |     1.000 |             1.000 |
| ConvBertForMaskedLM        | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.017 |      0.462 |     1.088 |             2.004 |
| MobileBertForMaskedLM      | torch.float32 | True          | eager              |      0.039 |      0.593 |     1.000 |             1.000 |
| MobileBertForMaskedLM      | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.007 |      0.257 |     5.388 |             2.305 |
| CamembertForMaskedLM       | torch.float32 | True          | eager              |      0.011 |      0.904 |     1.000 |             1.000 |
| CamembertForMaskedLM       | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.006 |      0.474 |     1.833 |             1.908 |
| LayoutLMForMaskedLM        | torch.float32 | True          | eager              |      0.011 |      0.918 |     1.000 |             1.000 |
| LayoutLMForMaskedLM        | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.005 |      0.483 |     2.391 |             1.900 |
  
**Batch size = 4** 
   
| model                      | dtype         | is_accurate   | name               |   time (s) |   mem (GB) |   speedup |   mem_compression |
|:---------------------------|:--------------|:--------------|:-------------------|-----------:|-----------:|----------:|------------------:|
| BertForMaskedLM            | torch.float32 | True          | eager              |      0.015 |      2.361 |     1.000 |             1.000 |
| BertForMaskedLM            | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.011 |      0.643 |     1.334 |             3.672 |
| AlbertForMaskedLM          | torch.float32 | True          | eager              |      0.015 |      2.906 |     1.000 |             1.000 |
| AlbertForMaskedLM          | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.009 |      0.271 |     1.740 |            10.734 |
| GPT2LMHeadModel            | torch.float32 | True          | eager              |      0.016 |      3.631 |     1.000 |             1.000 |
| GPT2LMHeadModel            | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.012 |      1.012 |     1.412 |             3.589 |
| T5ForConditionalGeneration | torch.float32 | True          | eager              |      0.017 |      1.982 |     1.000 |             1.000 |
| T5ForConditionalGeneration | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.011 |      0.579 |     1.472 |             3.424 |
| DistilBertForMaskedLM      | torch.float32 | True          | eager              |      0.007 |      1.364 |     1.000 |             1.000 |
| DistilBertForMaskedLM      | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.007 |      0.498 |     1.109 |             2.741 |
| RobertaForMaskedLM         | torch.float32 | True          | eager              |      0.014 |      2.568 |     1.000 |             1.000 |
| RobertaForMaskedLM         | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.014 |      0.850 |     1.028 |             3.022 |
| GPT2LMHeadModel            | torch.float32 | True          | eager              |      0.009 |      2.227 |     1.000 |             1.000 |
| GPT2LMHeadModel            | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.007 |      0.777 |     1.336 |             2.866 |
| ElectraForMaskedLM         | torch.float32 | True          | eager              |      0.013 |      2.360 |     1.000 |             1.000 |
| ElectraForMaskedLM         | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.011 |      0.648 |     1.182 |             3.640 |
| ConvBertForMaskedLM        | torch.float32 | True          | eager              |      0.020 |      2.475 |     1.000 |             1.000 |
| ConvBertForMaskedLM        | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.019 |      0.639 |     1.054 |             3.874 |
| MobileBertForMaskedLM      | torch.float32 | True          | eager              |      0.041 |      1.783 |     1.000 |             1.000 |
| MobileBertForMaskedLM      | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.011 |      0.441 |     3.610 |             4.047 |
| CamembertForMaskedLM       | torch.float32 | True          | eager              |      0.013 |      2.375 |     1.000 |             1.000 |
| CamembertForMaskedLM       | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.013 |      0.658 |     1.010 |             3.610 |
| LayoutLMForMaskedLM        | torch.float32 | True          | eager              |      0.013 |      2.373 |     1.000 |             1.000 |
| LayoutLMForMaskedLM        | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.011 |      0.655 |     1.182 |             3.620 |
  
**Batch size = 8** 
   
| model                      | dtype         | is_accurate   | name               |   time (s) |   mem (GB) |   speedup |   mem_compression |
|:---------------------------|:--------------|:--------------|:-------------------|-----------:|-----------:|----------:|------------------:|
| BertForMaskedLM            | torch.float32 | True          | eager              |      0.024 |      4.309 |     1.000 |             1.000 |
| BertForMaskedLM            | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.020 |      0.874 |     1.184 |             4.928 |
| AlbertForMaskedLM          | torch.float32 | True          | eager              |      0.029 |      5.679 |     1.000 |             1.000 |
| AlbertForMaskedLM          | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.016 |      0.500 |     1.787 |            11.367 |
| GPT2LMHeadModel            | torch.float32 | True          | eager              |      0.031 |      6.769 |     1.000 |             1.000 |
| GPT2LMHeadModel            | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.022 |      1.548 |     1.436 |             4.374 |
| T5ForConditionalGeneration | torch.float32 | True          | eager              |      0.020 |      3.725 |     1.000 |             1.000 |
| T5ForConditionalGeneration | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.019 |      0.924 |     1.018 |             4.033 |
| DistilBertForMaskedLM      | torch.float32 | True          | eager              |      0.014 |      2.470 |     1.000 |             1.000 |
| DistilBertForMaskedLM      | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.012 |      0.743 |     1.115 |             3.325 |
| RobertaForMaskedLM         | torch.float32 | True          | eager              |      0.026 |      4.670 |     1.000 |             1.000 |
| RobertaForMaskedLM         | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.024 |      1.236 |     1.070 |             3.779 |
| GPT2LMHeadModel            | torch.float32 | True          | eager              |      0.018 |      3.993 |     1.000 |             1.000 |
| GPT2LMHeadModel            | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.013 |      1.243 |     1.356 |             3.211 |
| ElectraForMaskedLM         | torch.float32 | True          | eager              |      0.024 |      4.315 |     1.000 |             1.000 |
| ElectraForMaskedLM         | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.020 |      0.892 |     1.210 |             4.837 |
| ConvBertForMaskedLM        | torch.float32 | True          | eager              |      0.030 |      4.525 |     1.000 |             1.000 |
| ConvBertForMaskedLM        | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.031 |      0.882 |     0.991 |             5.133 |
| MobileBertForMaskedLM      | torch.float32 | True          | eager              |      0.044 |      3.371 |     1.000 |             1.000 |
| MobileBertForMaskedLM      | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.019 |      0.685 |     2.338 |             4.921 |
| CamembertForMaskedLM       | torch.float32 | True          | eager              |      0.024 |      4.338 |     1.000 |             1.000 |
| CamembertForMaskedLM       | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.022 |      0.903 |     1.098 |             4.802 |
| LayoutLMForMaskedLM        | torch.float32 | True          | eager              |      0.024 |      4.322 |     1.000 |             1.000 |
| LayoutLMForMaskedLM        | torch.float32 | True          | dynamo_fx2trt_fp32 |      0.020 |      0.888 |     1.185 |             4.869 |  
