### PR TITLE
Improve performance docs

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -87,8 +87,18 @@
     title: Training on many GPUs
   - local: perf_train_cpu
     title: Training on CPU
+  - local: perf_train_tpu
+    title: Training on TPUs
+  - local: perf_train_special
+    title: Training on Specialized Hardware
   - local: perf_infer_cpu
     title: Inference on CPU
+  - local: perf_infer_gpu_one
+    title: Inference on one GPU
+  - local: perf_infer_gpu_many
+    title: Inference on many GPUs
+  - local: perf_infer_special
+    title: Inference on Specialized Hardware
   - local: perf_hardware
     title: Custom hardware for training
   - local: testing

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -82,7 +82,7 @@
       title: Inference on Specialized Hardware
     - local: perf_hardware
       title: Custom hardware for training
-    title: Performance anc scalability
+    title: Performance and scalability
   - local: big_models
     title: Instantiating a big model
   - local: benchmarks

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -81,6 +81,7 @@
     - local: perf_infer_special
       title: Inference on Specialized Hardware
     - local: perf_hardware
+      title: Custom hardware for training
     title: Performance anc scalability
   - local: big_models
     title: Instantiating a big model
@@ -102,7 +103,6 @@
     title: "How to add a model to 🤗 Transformers?"
   - local: add_new_pipeline
     title: "How to add a pipeline to 🤗 Transformers?"
-    title: Custom hardware for training
   - local: testing
     title: Testing
   - local: pr_checks

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -59,8 +59,29 @@
     title: Converting TensorFlow Checkpoints
   - local: serialization
     title: Export 🤗 Transformers models
-  - local: performance
-    title: Performance and scalability
+  - sections:
+    - local: performance
+      title: Overview
+    - local: perf_train_gpu_one
+      title: Training on one GPU
+    - local: perf_train_gpu_many
+      title: Training on many GPUs
+    - local: perf_train_cpu
+      title: Training on CPU
+    - local: perf_train_tpu
+      title: Training on TPUs
+    - local: perf_train_special
+      title: Training on Specialized Hardware
+    - local: perf_infer_cpu
+      title: Inference on CPU
+    - local: perf_infer_gpu_one
+      title: Inference on one GPU
+    - local: perf_infer_gpu_many
+      title: Inference on many GPUs
+    - local: perf_infer_special
+      title: Inference on Specialized Hardware
+    - local: perf_hardware
+    title: Performance anc scalability
   - local: big_models
     title: Instantiating a big model
   - local: benchmarks
@@ -81,25 +102,6 @@
     title: "How to add a model to 🤗 Transformers?"
   - local: add_new_pipeline
     title: "How to add a pipeline to 🤗 Transformers?"
-  - local: perf_train_gpu_one
-    title: Training on one GPU
-  - local: perf_train_gpu_many
-    title: Training on many GPUs
-  - local: perf_train_cpu
-    title: Training on CPU
-  - local: perf_train_tpu
-    title: Training on TPUs
-  - local: perf_train_special
-    title: Training on Specialized Hardware
-  - local: perf_infer_cpu
-    title: Inference on CPU
-  - local: perf_infer_gpu_one
-    title: Inference on one GPU
-  - local: perf_infer_gpu_many
-    title: Inference on many GPUs
-  - local: perf_infer_special
-    title: Inference on Specialized Hardware
-  - local: perf_hardware
     title: Custom hardware for training
   - local: testing
     title: Testing

--- a/docs/source/en/perf_infer_gpu_many.mdx
+++ b/docs/source/en/perf_infer_gpu_many.mdx
@@ -1,0 +1,12 @@
+<!--Copyright 2022 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-->
+
+# Efficient Inference on a Multiple GPUs

--- a/docs/source/en/perf_infer_gpu_many.mdx
+++ b/docs/source/en/perf_infer_gpu_many.mdx
@@ -10,3 +10,5 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 -->
 
 # Efficient Inference on a Multiple GPUs
+
+_Coming soon_

--- a/docs/source/en/perf_infer_gpu_many.mdx
+++ b/docs/source/en/perf_infer_gpu_many.mdx
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 
 # Efficient Inference on a Multiple GPUs
 
-_Coming soon_
+This document will be completed soon with information on how to infer on a multiple GPUs. In the meantime you can checkout the [guide for inference on CPUs](perf_infer_cpu).

--- a/docs/source/en/perf_infer_gpu_many.mdx
+++ b/docs/source/en/perf_infer_gpu_many.mdx
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 
 # Efficient Inference on a Multiple GPUs
 
-This document will be completed soon with information on how to infer on a multiple GPUs. In the meantime you can checkout the [guide for inference on CPUs](perf_infer_cpu).
+This document will be completed soon with information on how to infer on a multiple GPUs. In the meantime you can check out [the guide for training on a single GPU](perf_train_gpu_one) and [the guide for inference on CPUs](perf_infer_cpu).

--- a/docs/source/en/perf_infer_gpu_one.mdx
+++ b/docs/source/en/perf_infer_gpu_one.mdx
@@ -10,3 +10,5 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 -->
 
 # Efficient Inference on a Single GPU
+
+_Coming soon_

--- a/docs/source/en/perf_infer_gpu_one.mdx
+++ b/docs/source/en/perf_infer_gpu_one.mdx
@@ -1,0 +1,12 @@
+<!--Copyright 2022 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-->
+
+# Efficient Inference on a Single GPU

--- a/docs/source/en/perf_infer_gpu_one.mdx
+++ b/docs/source/en/perf_infer_gpu_one.mdx
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 
 # Efficient Inference on a Single GPU
 
-This document will be completed soon with information on how to infer on a single GPU. In the meantime you can checkout the [guide for inference on CPUs](perf_infer_cpu).
+This document will be completed soon with information on how to infer on a single GPU. In the meantime you can check out [the guide for training on a single GPU](perf_train_gpu_one) and [the guide for inference on CPUs](perf_infer_cpu).

--- a/docs/source/en/perf_infer_gpu_one.mdx
+++ b/docs/source/en/perf_infer_gpu_one.mdx
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 
 # Efficient Inference on a Single GPU
 
-_Coming soon_
+This document will be completed soon with information on how to infer on a single GPU. In the meantime you can checkout the [guide for inference on CPUs](perf_infer_cpu).

--- a/docs/source/en/perf_infer_special.mdx
+++ b/docs/source/en/perf_infer_special.mdx
@@ -1,0 +1,12 @@
+<!--Copyright 2022 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-->
+
+# Inference on Specialized Hardware

--- a/docs/source/en/perf_infer_special.mdx
+++ b/docs/source/en/perf_infer_special.mdx
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 
 # Inference on Specialized Hardware
 
-_Coming soon_
+This document will be completed soon with information on how to infer on specialized hardware. In the meantime you can checkout the [guide for inference on CPUs](perf_infer_cpu).

--- a/docs/source/en/perf_infer_special.mdx
+++ b/docs/source/en/perf_infer_special.mdx
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 
 # Inference on Specialized Hardware
 
-This document will be completed soon with information on how to infer on specialized hardware. In the meantime you can checkout the [guide for inference on CPUs](perf_infer_cpu).
+This document will be completed soon with information on how to infer on specialized hardware. In the meantime you can check out [the guide for inference on CPUs](perf_infer_cpu).

--- a/docs/source/en/perf_infer_special.mdx
+++ b/docs/source/en/perf_infer_special.mdx
@@ -10,3 +10,5 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 -->
 
 # Inference on Specialized Hardware
+
+_Coming soon_

--- a/docs/source/en/perf_train_gpu_many.mdx
+++ b/docs/source/en/perf_train_gpu_many.mdx
@@ -13,6 +13,12 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 
 When training on a single GPU is too slow or the model weights don't fit in a single GPUs memory we use a mutli-GPU setup. Switching from a single GPU to multiple requires some form of parallelism as the work needs to be distributed. There are several techniques to achieve parallism such as data, tensor, or pipeline parallism. However, there is no one solution to fit them all and which settings works best depends on the hardware you are running on. While the main concepts most likely will apply to any other framework, this article is focused on PyTorch-based implementations.
 
+<Tip>
+
+ Note: Most of the strategies introduced in the [single GPU section](perf_train_gpu_one) (such as mixed precision training or gradient accumulation) are generic and apply to training models in general so make sure to have a look at it before diving into the following sections such as multi-GPU or CPU training.
+
+</Tip>
+
 We will first discuss in depth various 1D parallelism techniques and their pros and cons and then look at how they can be combined into 2D and 3D parallelism to enable an even faster training and to support even bigger models. Various other powerful alternative approaches will be presented.
 
 ## Concepts

--- a/docs/source/en/perf_train_special.mdx
+++ b/docs/source/en/perf_train_special.mdx
@@ -11,4 +11,10 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 
 # Training on Specialized Hardware
 
-_Coming soon_
+<Tip>
+
+ Note: Most of the strategies introduced in the [single GPU section](perf_train_gpu_one) (such as mixed precision training or gradient accumulation) and [mutli-GPU section](perf_train_gpu_many) are generic and apply to training models in general so make sure to have a look at it before diving into this section.
+
+</Tip>
+
+This document will be completed soon with information on how to train on specialized hardware.

--- a/docs/source/en/perf_train_special.mdx
+++ b/docs/source/en/perf_train_special.mdx
@@ -10,3 +10,5 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 -->
 
 # Training on Specialized Hardware
+
+_Coming soon_

--- a/docs/source/en/perf_train_special.mdx
+++ b/docs/source/en/perf_train_special.mdx
@@ -1,0 +1,12 @@
+<!--Copyright 2022 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-->
+
+# Training on Specialized Hardware

--- a/docs/source/en/perf_train_tpu.mdx
+++ b/docs/source/en/perf_train_tpu.mdx
@@ -1,0 +1,12 @@
+<!--Copyright 2022 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-->
+
+# Training on TPUs

--- a/docs/source/en/perf_train_tpu.mdx
+++ b/docs/source/en/perf_train_tpu.mdx
@@ -11,4 +11,10 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 
 # Training on TPUs
 
-_Coming soon_
+<Tip>
+
+ Note: Most of the strategies introduced in the [single GPU section](perf_train_gpu_one) (such as mixed precision training or gradient accumulation) and [mutli-GPU section](perf_train_gpu_many) are generic and apply to training models in general so make sure to have a look at it before diving into this section.
+
+</Tip>
+
+This document will be completed soon with information on how to train on TPUs.

--- a/docs/source/en/perf_train_tpu.mdx
+++ b/docs/source/en/perf_train_tpu.mdx
@@ -10,3 +10,5 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 -->
 
 # Training on TPUs
+
+_Coming soon_

--- a/docs/source/en/performance.mdx
+++ b/docs/source/en/performance.mdx
@@ -46,11 +46,11 @@ In some cases training on a single GPU is still too slow or won't fit the large 
 
 ### TPU
 
-_Coming soon_
+[_Coming soon_](perf_train_tpu)
 
 ### Specialized Hardware
 
-_Coming soon_
+[_Coming soon_](perf_train_special)
 
 ## Inference
 
@@ -62,15 +62,15 @@ Efficient inference with large models in a production environment can be as chal
 
 ### Single GPU
 
-_Coming soon_
+[_Coming soon_](perf_infer_gpu_one)
 
 ### Multi-GPU
 
-_Coming soon_
+[_Coming soon_](perf_infer_gpu_many)
 
 ### Specialized Hardware
 
-_Coming soon_
+[_Coming soon_](perf_infer_special)
 
 ## Hardware
 

--- a/docs/source/en/performance.mdx
+++ b/docs/source/en/performance.mdx
@@ -68,11 +68,11 @@ Efficient inference with large models in a production environment can be as chal
 
 ### Single GPU
 
-[_Coming soon_](perf_infer_gpu_one)
+[Go to single GPU inference section](perf_infer_gpu_one)
 
 ### Multi-GPU
 
-[_Coming soon_](perf_infer_gpu_many)
+[Go to multi-GPU inference section](perf_infer_gpu_many)
 
 ### Specialized Hardware
 

--- a/docs/source/en/performance.mdx
+++ b/docs/source/en/performance.mdx
@@ -58,7 +58,7 @@ Efficient inference with large models in a production environment can be as chal
 
 ### CPU
 
-[Go to CPU inference section](perf_infer_cpu.mdx)
+[Go to CPU inference section](perf_infer_cpu)
 
 ### Single GPU
 

--- a/docs/source/en/performance.mdx
+++ b/docs/source/en/performance.mdx
@@ -24,7 +24,13 @@ This document serves as an overview and entry point for the methods that could b
 
 ## Training
 
-Training transformer models efficiently requires an accelerator such as a GPU or TPU. The most common case is where you only have a single GPU.
+Training transformer models efficiently requires an accelerator such as a GPU or TPU. The most common case is where you only have a single GPU, but there is also a section about mutli-GPU and CPU training (with more coming soon).
+
+<Tip>
+
+ Note: Most of the strategies introduced in the single GPU sections (such as mixed precision training or gradient accumulation) are generic and apply to training models in general so make sure to have a look at it before diving into the following sections such as multi-GPU or CPU training.
+
+</Tip>
 
 ### Single GPU
 


### PR DESCRIPTION
# What does this PR do?

As discussed with @stas00 this PR does the following things:
- adds files for missing sections so contributors can better find the place to add content.
- adds a disclaimer at the beginning stating that a lot of general training information is in the single GPU training section
- fixes the link of CPU inference

Looking at the ToC I was wondering whether we should add subsections like it is done for the tasks to make the main ToC a bit slimmer. Otherwise we have the main performance docs (the entry point) there plus all the other sections (~8-10). What do you think?

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?