### PR TITLE
Use multiple workers for DataLoader at prediction step for Trainer

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -939,6 +939,7 @@ class Trainer:
             batch_size=self.args.eval_batch_size,
             collate_fn=data_collator,
             drop_last=self.args.dataloader_drop_last,
+            num_workers=self.args.dataloader_num_workers,
             pin_memory=self.args.dataloader_pin_memory,
         )
 


### PR DESCRIPTION
# What does this PR do?

Fixes #17749 by adding a parameter in the DataLoader init call of the test data_loader, so that we can use multiple workers for data preparation during prediction time.

@sgugger, I tag you because this is a Trainer related PR