### PR TITLE
Attempt to change Push CI to workflow_run

### DIFF
--- a/.github/workflows/self-push-caller.yml
+++ b/.github/workflows/self-push-caller.yml
@@ -1,3 +1,4 @@
+# Used to trigger self-push CI
 name: Self-hosted runner (push-caller)
 
 on:
@@ -13,17 +14,8 @@ on:
 
 jobs:
   run_push_ci:
-    name: Run Push CI
+    name: Trigger Push CI
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout transformers
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
-          ssh-key: "${{ secrets.COMMIT_KEY }}"
-
-      - name: Checkout to branch push-ci
-        # A more strict way to make sure`push-ci` is exactly the same as `main` at the push event commit.
-        run: |
-          git checkout -b push-ci
-          git push -u origin push-ci --force
+      - name: Trigger push CI via workflow_run
+        run: echo "Trigger push CI via workflow_run"

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -1,9 +1,12 @@
 name: Self-hosted runner (push)
 
 on:
+  workflow_run:
+    workflows: ["Self-hosted runner (push-caller)"]
+    branches: ["main"]
+    types: [completed]
   push:
     branches:
-      - push-ci
       - ci_*
       - ci-*
     paths:

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -31,10 +31,42 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       test_map: ${{ steps.set-matrix.outputs.test_map }}
     steps:
+      # Necessary to get the correct branch name and commit SHA for `workflow_run` event
+      # We also take into account the `push` event (we might want to test some changes in a branch)
+      - name: Prepare custom environment variables
+        shell: bash
+        run: |
+          CI_BRANCH_PUSH=${{ github.event.ref }}
+          CI_BRANCH_PUSH=${CI_BRANCH_PUSH/'refs/heads/'/''}
+          CI_BRANCH_WORKFLOW_RUN=${{ github.event.workflow_run.head_branch }}
+          CI_SHA_PUSH=${{ github.event.head_commit.id }}
+          CI_SHA_WORKFLOW_RUN=${{ github.event.workflow_run.head_sha }}
+          echo $CI_BRANCH_PUSH
+          echo $CI_BRANCH_WORKFLOW_RUN
+          echo $CI_SHA_PUSH
+          echo $CI_SHA_WORKFLOW_RUN       
+          [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
+          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
+          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_COMMIT_URL=$CI_COMMIT_URL_PUSH" >> $GITHUB_ENV || echo "CI_COMMIT_URL=$CI_COMMIT_URL_WORKFLOW_RUN" >> $GITHUB_ENV
+
+      - name: print environment variables
+        run: |
+          echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
+          echo "env.CI_SHA = ${{ env.CI_SHA }}"
+          echo "env.CI_COMMIT_URL = ${{ env.CI_COMMIT_URL }}"
+
       - name: Checkout transformers
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
+
+      - name: Update clone use environment variables
+        run: |
+          echo "original branch = $(git branch --show-current)"
+          git fetch && git checkout ${{ env.CI_BRANCH }}
+          echo "updated branch = $(git branch --show-current)"
+          git checkout ${{ env.CI_SHA }}
+          echo "log = $(git log -n 1)"
 
       - name: Cleanup
         run: |
@@ -87,6 +119,39 @@ jobs:
       image: huggingface/transformers-all-latest-gpu
       options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
+      # Necessary to get the correct branch name and commit SHA for `workflow_run` event
+      # We also take into account the `push` event (we might want to test some changes in a branch)
+      - name: Prepare custom environment variables
+        shell: bash
+        run: |
+          CI_BRANCH_PUSH=${{ github.event.ref }}
+          CI_BRANCH_PUSH=${CI_BRANCH_PUSH/'refs/heads/'/''}
+          CI_BRANCH_WORKFLOW_RUN=${{ github.event.workflow_run.head_branch }}
+          CI_SHA_PUSH=${{ github.event.head_commit.id }}
+          CI_SHA_WORKFLOW_RUN=${{ github.event.workflow_run.head_sha }}
+          echo $CI_BRANCH_PUSH
+          echo $CI_BRANCH_WORKFLOW_RUN
+          echo $CI_SHA_PUSH
+          echo $CI_SHA_WORKFLOW_RUN       
+          [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
+          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
+          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_COMMIT_URL=$CI_COMMIT_URL_PUSH" >> $GITHUB_ENV || echo "CI_COMMIT_URL=$CI_COMMIT_URL_WORKFLOW_RUN" >> $GITHUB_ENV
+
+      - name: print environment variables
+        run: |
+          echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
+          echo "env.CI_SHA = ${{ env.CI_SHA }}"
+          echo "env.CI_COMMIT_URL = ${{ env.CI_COMMIT_URL }}"            
+
+      - name: Update clone use environment variables
+        working-directory: /transformers
+        run: |
+          echo "original branch = $(git branch --show-current)"
+          git fetch && git checkout ${{ env.CI_BRANCH }}
+          echo "updated branch = $(git branch --show-current)"
+          git checkout ${{ env.CI_SHA }}
+          echo "log = $(git log -n 1)"
+
       - name: Echo folder ${{ matrix.folders }}
         shell: bash
         # For folders like `models/bert`, set an env. var. (`matrix_folders`) to `models_bert`, which will be used to
@@ -98,10 +163,6 @@ jobs:
           matrix_folders=${matrix_folders/'models/'/'models_'}
           echo "$matrix_folders"
           echo "matrix_folders=$matrix_folders" >> $GITHUB_ENV
-
-      - name: Update clone
-        working-directory: /transformers
-        run: git fetch && git checkout ${{ github.sha }}
 
       - name: NVIDIA-SMI
         run: |
@@ -144,6 +205,39 @@ jobs:
       image: huggingface/transformers-all-latest-gpu
       options: --gpus all --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
+      # Necessary to get the correct branch name and commit SHA for `workflow_run` event
+      # We also take into account the `push` event (we might want to test some changes in a branch)
+      - name: Prepare custom environment variables
+        shell: bash
+        run: |
+          CI_BRANCH_PUSH=${{ github.event.ref }}
+          CI_BRANCH_PUSH=${CI_BRANCH_PUSH/'refs/heads/'/''}
+          CI_BRANCH_WORKFLOW_RUN=${{ github.event.workflow_run.head_branch }}
+          CI_SHA_PUSH=${{ github.event.head_commit.id }}
+          CI_SHA_WORKFLOW_RUN=${{ github.event.workflow_run.head_sha }}
+          echo $CI_BRANCH_PUSH
+          echo $CI_BRANCH_WORKFLOW_RUN
+          echo $CI_SHA_PUSH
+          echo $CI_SHA_WORKFLOW_RUN       
+          [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
+          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
+          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_COMMIT_URL=$CI_COMMIT_URL_PUSH" >> $GITHUB_ENV || echo "CI_COMMIT_URL=$CI_COMMIT_URL_WORKFLOW_RUN" >> $GITHUB_ENV
+
+      - name: print environment variables
+        run: |
+          echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
+          echo "env.CI_SHA = ${{ env.CI_SHA }}"
+          echo "env.CI_COMMIT_URL = ${{ env.CI_COMMIT_URL }}"
+
+      - name: Update clone use environment variables
+        working-directory: /transformers
+        run: |
+          echo "original branch = $(git branch --show-current)"
+          git fetch && git checkout ${{ env.CI_BRANCH }}
+          echo "updated branch = $(git branch --show-current)"
+          git checkout ${{ env.CI_SHA }}
+          echo "log = $(git log -n 1)"
+
       - name: Echo folder ${{ matrix.folders }}
         shell: bash
         # For folders like `models/bert`, set an env. var. (`matrix_folders`) to `models_bert`, which will be used to
@@ -155,10 +249,6 @@ jobs:
           matrix_folders=${matrix_folders/'models/'/'models_'}
           echo "$matrix_folders"
           echo "matrix_folders=$matrix_folders" >> $GITHUB_ENV
-
-      - name: Update clone
-        working-directory: /transformers
-        run: git fetch && git checkout ${{ github.sha }}
 
       - name: NVIDIA-SMI
         run: |
@@ -201,9 +291,38 @@ jobs:
       image: huggingface/transformers-pytorch-deepspeed-latest-gpu
       options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
-      - name: Update clone
+      # Necessary to get the correct branch name and commit SHA for `workflow_run` event
+      # We also take into account the `push` event (we might want to test some changes in a branch)
+      - name: Prepare custom environment variables
+        shell: bash
+        run: |
+          CI_BRANCH_PUSH=${{ github.event.ref }}
+          CI_BRANCH_PUSH=${CI_BRANCH_PUSH/'refs/heads/'/''}
+          CI_BRANCH_WORKFLOW_RUN=${{ github.event.workflow_run.head_branch }}
+          CI_SHA_PUSH=${{ github.event.head_commit.id }}
+          CI_SHA_WORKFLOW_RUN=${{ github.event.workflow_run.head_sha }}
+          echo $CI_BRANCH_PUSH
+          echo $CI_BRANCH_WORKFLOW_RUN
+          echo $CI_SHA_PUSH
+          echo $CI_SHA_WORKFLOW_RUN       
+          [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
+          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
+          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_COMMIT_URL=$CI_COMMIT_URL_PUSH" >> $GITHUB_ENV || echo "CI_COMMIT_URL=$CI_COMMIT_URL_WORKFLOW_RUN" >> $GITHUB_ENV
+
+      - name: print environment variables
+        run: |
+          echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
+          echo "env.CI_SHA = ${{ env.CI_SHA }}"
+          echo "env.CI_COMMIT_URL = ${{ env.CI_COMMIT_URL }}"
+
+      - name: Update clone use environment variables
         working-directory: /workspace/transformers
-        run: git fetch && git checkout ${{ github.sha }}
+        run: |
+          echo "original branch = $(git branch --show-current)"
+          git fetch && git checkout ${{ env.CI_BRANCH }}
+          echo "updated branch = $(git branch --show-current)"
+          git checkout ${{ env.CI_SHA }}
+          echo "log = $(git log -n 1)"
 
       # To avoid unknown test failures
       - name: Pre build DeepSpeed *again*
@@ -217,10 +336,12 @@ jobs:
           nvidia-smi
 
       - name: Environment
+        working-directory: /workspace/transformers
         run: |
           python utils/print_env.py
 
       - name: Run all non-slow selected tests on GPU
+        working-directory: /workspace/transformers
         # TODO: Here we pass all tests in the 2 folders for simplicity. It's better to pass only the identified tests.
         run: |
           python -m pytest -n 1 --dist=loadfile -v --make-reports=${{ matrix.machine_type }}_tests_torch_cuda_extensions_gpu tests/deepspeed tests/extended
@@ -250,9 +371,38 @@ jobs:
       image: huggingface/transformers-pytorch-deepspeed-latest-gpu
       options: --gpus all --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
-      - name: Update clone
+      # Necessary to get the correct branch name and commit SHA for `workflow_run` event
+      # We also take into account the `push` event (we might want to test some changes in a branch)
+      - name: Prepare custom environment variables
+        shell: bash
+        run: |
+          CI_BRANCH_PUSH=${{ github.event.ref }}
+          CI_BRANCH_PUSH=${CI_BRANCH_PUSH/'refs/heads/'/''}
+          CI_BRANCH_WORKFLOW_RUN=${{ github.event.workflow_run.head_branch }}
+          CI_SHA_PUSH=${{ github.event.head_commit.id }}
+          CI_SHA_WORKFLOW_RUN=${{ github.event.workflow_run.head_sha }}
+          echo $CI_BRANCH_PUSH
+          echo $CI_BRANCH_WORKFLOW_RUN
+          echo $CI_SHA_PUSH
+          echo $CI_SHA_WORKFLOW_RUN       
+          [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
+          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
+          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_COMMIT_URL=$CI_COMMIT_URL_PUSH" >> $GITHUB_ENV || echo "CI_COMMIT_URL=$CI_COMMIT_URL_WORKFLOW_RUN" >> $GITHUB_ENV
+
+      - name: print environment variables
+        run: |
+          echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
+          echo "env.CI_SHA = ${{ env.CI_SHA }}"
+          echo "env.CI_COMMIT_URL = ${{ env.CI_COMMIT_URL }}"
+
+      - name: Update clone use environment variables
         working-directory: /workspace/transformers
-        run: git fetch && git checkout ${{ github.sha }}
+        run: |
+          echo "original branch = $(git branch --show-current)"
+          git fetch && git checkout ${{ env.CI_BRANCH }}
+          echo "updated branch = $(git branch --show-current)"
+          git checkout ${{ env.CI_SHA }}
+          echo "log = $(git log -n 1)"
 
       # To avoid unknown test failures
       - name: Pre build DeepSpeed *again*
@@ -300,7 +450,40 @@ jobs:
         run_tests_torch_cuda_extensions_multi_gpu
     ]
     steps:
+      # Necessary to get the correct branch name and commit SHA for `workflow_run` event
+      # We also take into account the `push` event (we might want to test some changes in a branch)
+      - name: Prepare custom environment variables
+        shell: bash
+        run: |
+          CI_BRANCH_PUSH=${{ github.event.ref }}
+          CI_BRANCH_PUSH=${CI_BRANCH_PUSH/'refs/heads/'/''}
+          CI_BRANCH_WORKFLOW_RUN=${{ github.event.workflow_run.head_branch }}
+          CI_SHA_PUSH=${{ github.event.head_commit.id }}
+          CI_SHA_WORKFLOW_RUN=${{ github.event.workflow_run.head_sha }}
+          echo $CI_BRANCH_PUSH
+          echo $CI_BRANCH_WORKFLOW_RUN
+          echo $CI_SHA_PUSH
+          echo $CI_SHA_WORKFLOW_RUN       
+          [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
+          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
+          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_COMMIT_URL=$CI_COMMIT_URL_PUSH" >> $GITHUB_ENV || echo "CI_COMMIT_URL=$CI_COMMIT_URL_WORKFLOW_RUN" >> $GITHUB_ENV
+
+      - name: print environment variables
+        run: |
+          echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
+          echo "env.CI_SHA = ${{ env.CI_SHA }}"
+          echo "env.CI_COMMIT_URL = ${{ env.CI_COMMIT_URL }}"
+
       - uses: actions/checkout@v2
+
+      - name: Update clone use environment variables
+        run: |
+          echo "original branch = $(git branch --show-current)"
+          git fetch && git checkout ${{ env.CI_BRANCH }}
+          echo "updated branch = $(git branch --show-current)"
+          git checkout ${{ env.CI_SHA }}
+          echo "log = $(git log -n 1)"
+
       - uses: actions/download-artifact@v2
       - name: Send message to Slack
         env:
@@ -310,8 +493,9 @@ jobs:
           CI_SLACK_CHANNEL_DUMMY_TESTS: ${{ secrets.CI_SLACK_CHANNEL_DUMMY_TESTS }}
           CI_SLACK_REPORT_CHANNEL_ID: ${{ secrets.CI_SLACK_CHANNEL_ID }}
           CI_EVENT: push
-          CI_TITLE: ${{ github.event.head_commit.message }}
-          CI_COMMIT_URL: ${{ github.event.head_commit.url }}
+          CI_TITLE_PUSH: ${{ github.event.head_commit.message }}
+          CI_TITLE_WORKFLOW_RUN: ${{ github.event.workflow_run.head_commit.message }}
+          CI_SHA: ${{ env.CI_SHA }}
         # We pass `needs.setup.outputs.matrix` as the argument. A processing in `notification_service.py` to change
         # `models/bert` to `models_bert` is required, as the artifact names use `_` instead of `/`.
         run: |

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -38,14 +38,12 @@ jobs:
       # We also take into account the `push` event (we might want to test some changes in a branch)
       - name: Prepare custom environment variables
         shell: bash
-        """
-          - `CI_BRANCH_PUSH`: The branch name from the push event
-          - `CI_BRANCH_WORKFLOW_RUN`: The name of the branch on which this workflow is triggered by `workflow_run` event
-          - `CI_BRANCH`: The non-empty branch name from the above two (one and only one of them is empty)
-          - `CI_SHA_PUSH`: The commit SHA from the push event
-          - `CI_SHA_WORKFLOW_RUN`: The commit SHA that triggers this workflow by `workflow_run` event
-          - `CI_SHA`: The non-empty commit SHA from the above two (one and only one of them is empty)
-        """
+        # `CI_BRANCH_PUSH`: The branch name from the push event
+        # `CI_BRANCH_WORKFLOW_RUN`: The name of the branch on which this workflow is triggered by `workflow_run` event
+        # `CI_BRANCH`: The non-empty branch name from the above two (one and only one of them is empty)
+        # `CI_SHA_PUSH`: The commit SHA from the push event
+        # `CI_SHA_WORKFLOW_RUN`: The commit SHA that triggers this workflow by `workflow_run` event
+        # `CI_SHA`: The non-empty commit SHA from the above two (one and only one of them is empty)
         run: |
           CI_BRANCH_PUSH=${{ github.event.ref }}
           CI_BRANCH_PUSH=${CI_BRANCH_PUSH/'refs/heads/'/''}

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Update clone use environment variables
+      - name: Update clone using environment variables
         run: |
           echo "original branch = $(git branch --show-current)"
           git fetch && git checkout ${{ env.CI_BRANCH }}
@@ -142,7 +142,7 @@ jobs:
           echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
           echo "env.CI_SHA = ${{ env.CI_SHA }}"         
 
-      - name: Update clone use environment variables
+      - name: Update clone using environment variables
         working-directory: /transformers
         run: |
           echo "original branch = $(git branch --show-current)"
@@ -226,7 +226,7 @@ jobs:
           echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
           echo "env.CI_SHA = ${{ env.CI_SHA }}"
 
-      - name: Update clone use environment variables
+      - name: Update clone using environment variables
         working-directory: /transformers
         run: |
           echo "original branch = $(git branch --show-current)"
@@ -310,7 +310,7 @@ jobs:
           echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
           echo "env.CI_SHA = ${{ env.CI_SHA }}"
 
-      - name: Update clone use environment variables
+      - name: Update clone using environment variables
         working-directory: /workspace/transformers
         run: |
           echo "original branch = $(git branch --show-current)"
@@ -388,7 +388,7 @@ jobs:
           echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
           echo "env.CI_SHA = ${{ env.CI_SHA }}"
 
-      - name: Update clone use environment variables
+      - name: Update clone using environment variables
         working-directory: /workspace/transformers
         run: |
           echo "original branch = $(git branch --show-current)"
@@ -467,7 +467,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Update clone use environment variables
+      - name: Update clone using environment variables
         run: |
           echo "original branch = $(git branch --show-current)"
           git fetch && git checkout ${{ env.CI_BRANCH }}

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -47,13 +47,11 @@ jobs:
           echo $CI_SHA_WORKFLOW_RUN       
           [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
           [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
-          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_COMMIT_URL=$CI_COMMIT_URL_PUSH" >> $GITHUB_ENV || echo "CI_COMMIT_URL=$CI_COMMIT_URL_WORKFLOW_RUN" >> $GITHUB_ENV
 
       - name: print environment variables
         run: |
           echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
           echo "env.CI_SHA = ${{ env.CI_SHA }}"
-          echo "env.CI_COMMIT_URL = ${{ env.CI_COMMIT_URL }}"
 
       - name: Checkout transformers
         uses: actions/checkout@v2
@@ -135,13 +133,11 @@ jobs:
           echo $CI_SHA_WORKFLOW_RUN       
           [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
           [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
-          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_COMMIT_URL=$CI_COMMIT_URL_PUSH" >> $GITHUB_ENV || echo "CI_COMMIT_URL=$CI_COMMIT_URL_WORKFLOW_RUN" >> $GITHUB_ENV
 
       - name: print environment variables
         run: |
           echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
-          echo "env.CI_SHA = ${{ env.CI_SHA }}"
-          echo "env.CI_COMMIT_URL = ${{ env.CI_COMMIT_URL }}"            
+          echo "env.CI_SHA = ${{ env.CI_SHA }}"         
 
       - name: Update clone use environment variables
         working-directory: /transformers
@@ -221,13 +217,11 @@ jobs:
           echo $CI_SHA_WORKFLOW_RUN       
           [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
           [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
-          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_COMMIT_URL=$CI_COMMIT_URL_PUSH" >> $GITHUB_ENV || echo "CI_COMMIT_URL=$CI_COMMIT_URL_WORKFLOW_RUN" >> $GITHUB_ENV
 
       - name: print environment variables
         run: |
           echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
           echo "env.CI_SHA = ${{ env.CI_SHA }}"
-          echo "env.CI_COMMIT_URL = ${{ env.CI_COMMIT_URL }}"
 
       - name: Update clone use environment variables
         working-directory: /transformers
@@ -307,13 +301,11 @@ jobs:
           echo $CI_SHA_WORKFLOW_RUN       
           [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
           [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
-          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_COMMIT_URL=$CI_COMMIT_URL_PUSH" >> $GITHUB_ENV || echo "CI_COMMIT_URL=$CI_COMMIT_URL_WORKFLOW_RUN" >> $GITHUB_ENV
 
       - name: print environment variables
         run: |
           echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
           echo "env.CI_SHA = ${{ env.CI_SHA }}"
-          echo "env.CI_COMMIT_URL = ${{ env.CI_COMMIT_URL }}"
 
       - name: Update clone use environment variables
         working-directory: /workspace/transformers
@@ -387,13 +379,11 @@ jobs:
           echo $CI_SHA_WORKFLOW_RUN       
           [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
           [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
-          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_COMMIT_URL=$CI_COMMIT_URL_PUSH" >> $GITHUB_ENV || echo "CI_COMMIT_URL=$CI_COMMIT_URL_WORKFLOW_RUN" >> $GITHUB_ENV
 
       - name: print environment variables
         run: |
           echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
           echo "env.CI_SHA = ${{ env.CI_SHA }}"
-          echo "env.CI_COMMIT_URL = ${{ env.CI_COMMIT_URL }}"
 
       - name: Update clone use environment variables
         working-directory: /workspace/transformers
@@ -466,13 +456,11 @@ jobs:
           echo $CI_SHA_WORKFLOW_RUN       
           [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
           [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
-          [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_COMMIT_URL=$CI_COMMIT_URL_PUSH" >> $GITHUB_ENV || echo "CI_COMMIT_URL=$CI_COMMIT_URL_WORKFLOW_RUN" >> $GITHUB_ENV
 
       - name: print environment variables
         run: |
           echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
           echo "env.CI_SHA = ${{ env.CI_SHA }}"
-          echo "env.CI_COMMIT_URL = ${{ env.CI_COMMIT_URL }}"
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -47,7 +47,7 @@ jobs:
           echo $CI_BRANCH_PUSH
           echo $CI_BRANCH_WORKFLOW_RUN
           echo $CI_SHA_PUSH
-          echo $CI_SHA_WORKFLOW_RUN       
+          echo $CI_SHA_WORKFLOW_RUN
           [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
           [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
 
@@ -133,14 +133,14 @@ jobs:
           echo $CI_BRANCH_PUSH
           echo $CI_BRANCH_WORKFLOW_RUN
           echo $CI_SHA_PUSH
-          echo $CI_SHA_WORKFLOW_RUN       
+          echo $CI_SHA_WORKFLOW_RUN
           [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
           [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
 
       - name: print environment variables
         run: |
           echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
-          echo "env.CI_SHA = ${{ env.CI_SHA }}"         
+          echo "env.CI_SHA = ${{ env.CI_SHA }}"
 
       - name: Update clone using environment variables
         working-directory: /transformers
@@ -217,7 +217,7 @@ jobs:
           echo $CI_BRANCH_PUSH
           echo $CI_BRANCH_WORKFLOW_RUN
           echo $CI_SHA_PUSH
-          echo $CI_SHA_WORKFLOW_RUN       
+          echo $CI_SHA_WORKFLOW_RUN
           [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
           [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
 
@@ -301,7 +301,7 @@ jobs:
           echo $CI_BRANCH_PUSH
           echo $CI_BRANCH_WORKFLOW_RUN
           echo $CI_SHA_PUSH
-          echo $CI_SHA_WORKFLOW_RUN       
+          echo $CI_SHA_WORKFLOW_RUN
           [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
           [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
 
@@ -379,7 +379,7 @@ jobs:
           echo $CI_BRANCH_PUSH
           echo $CI_BRANCH_WORKFLOW_RUN
           echo $CI_SHA_PUSH
-          echo $CI_SHA_WORKFLOW_RUN       
+          echo $CI_SHA_WORKFLOW_RUN
           [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
           [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
 
@@ -456,7 +456,7 @@ jobs:
           echo $CI_BRANCH_PUSH
           echo $CI_BRANCH_WORKFLOW_RUN
           echo $CI_SHA_PUSH
-          echo $CI_SHA_WORKFLOW_RUN       
+          echo $CI_SHA_WORKFLOW_RUN
           [[ ! -z "$CI_BRANCH_PUSH" ]] && echo "CI_BRANCH=$CI_BRANCH_PUSH" >> $GITHUB_ENV || echo "CI_BRANCH=$CI_BRANCH_WORKFLOW_RUN" >> $GITHUB_ENV
           [[ ! -z "$CI_SHA_PUSH" ]] && echo "CI_SHA=$CI_SHA_PUSH" >> $GITHUB_ENV || echo "CI_SHA=$CI_SHA_WORKFLOW_RUN" >> $GITHUB_ENV
 

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -38,6 +38,14 @@ jobs:
       # We also take into account the `push` event (we might want to test some changes in a branch)
       - name: Prepare custom environment variables
         shell: bash
+        """
+          - `CI_BRANCH_PUSH`: The branch name from the push event
+          - `CI_BRANCH_WORKFLOW_RUN`: The name of the branch on which this workflow is triggered by `workflow_run` event
+          - `CI_BRANCH`: The non-empty branch name from the above two (one and only one of them is empty)
+          - `CI_SHA_PUSH`: The commit SHA from the push event
+          - `CI_SHA_WORKFLOW_RUN`: The commit SHA that triggers this workflow by `workflow_run` event
+          - `CI_SHA`: The non-empty commit SHA from the above two (one and only one of them is empty)
+        """
         run: |
           CI_BRANCH_PUSH=${{ github.event.ref }}
           CI_BRANCH_PUSH=${CI_BRANCH_PUSH/'refs/heads/'/''}
@@ -124,6 +132,7 @@ jobs:
       # We also take into account the `push` event (we might want to test some changes in a branch)
       - name: Prepare custom environment variables
         shell: bash
+        # For the meaning of these environment variables, see the job `Setup`
         run: |
           CI_BRANCH_PUSH=${{ github.event.ref }}
           CI_BRANCH_PUSH=${CI_BRANCH_PUSH/'refs/heads/'/''}
@@ -208,6 +217,7 @@ jobs:
       # We also take into account the `push` event (we might want to test some changes in a branch)
       - name: Prepare custom environment variables
         shell: bash
+        # For the meaning of these environment variables, see the job `Setup`
         run: |
           CI_BRANCH_PUSH=${{ github.event.ref }}
           CI_BRANCH_PUSH=${CI_BRANCH_PUSH/'refs/heads/'/''}
@@ -292,6 +302,7 @@ jobs:
       # We also take into account the `push` event (we might want to test some changes in a branch)
       - name: Prepare custom environment variables
         shell: bash
+        # For the meaning of these environment variables, see the job `Setup`
         run: |
           CI_BRANCH_PUSH=${{ github.event.ref }}
           CI_BRANCH_PUSH=${CI_BRANCH_PUSH/'refs/heads/'/''}
@@ -370,6 +381,7 @@ jobs:
       # We also take into account the `push` event (we might want to test some changes in a branch)
       - name: Prepare custom environment variables
         shell: bash
+        # For the meaning of these environment variables, see the job `Setup`
         run: |
           CI_BRANCH_PUSH=${{ github.event.ref }}
           CI_BRANCH_PUSH=${CI_BRANCH_PUSH/'refs/heads/'/''}
@@ -447,6 +459,7 @@ jobs:
       # We also take into account the `push` event (we might want to test some changes in a branch)
       - name: Prepare custom environment variables
         shell: bash
+        # For the meaning of these environment variables, see the job `Setup`
         run: |
           CI_BRANCH_PUSH=${{ github.event.ref }}
           CI_BRANCH_PUSH=${CI_BRANCH_PUSH/'refs/heads/'/''}

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -584,8 +584,59 @@ def retrieve_available_artifacts():
 
 if __name__ == "__main__":
 
+    org = "huggingface"
+    repo = "transformers"
+    repository_full_name = f"{org}/{repo}"
+
     # This env. variable is set in workflow file (under the job `send_results`).
     ci_event = os.environ["CI_EVENT"]
+
+    # To find the PR number in a commit title, for example, `Add AwesomeFormer model (#99999)`
+    pr_number_re = re.compile(r"\(#(\d+)\)$")
+
+    title = f"🤗 Results of the {ci_event} tests."
+    # Add Commit/PR title with a link for push CI
+    # (check the title in 2 env. variables - depending on the CI is triggered via `push` or `workflow_run` event)
+    ci_title_push = os.environ.get("CI_TITLE_PUSH")
+    ci_title_workflow_run = os.environ.get("CI_TITLE_WORKFLOW_RUN")
+    ci_title = ci_title_push if ci_title_push else ci_title_workflow_run
+
+    ci_sha = os.environ.get("CI_SHA")
+
+    ci_url = None
+    if ci_sha:
+        ci_url = f"https://github.com/{repository_full_name}/commit/{ci_sha}"
+
+    if ci_title is not None:
+        assert ci_url is not None
+        ci_title = ci_title.strip().split("\n")[0].strip()
+
+        # Retrieve the PR title and author login to complete the report
+        commit_number = ci_url.split("/")[-1]
+        ci_detail_url = f"https://api.github.com/repos/{repository_full_name}/commits/{commit_number}"
+        ci_details = requests.get(ci_detail_url).json()
+        ci_author = ci_details["author"]["login"]
+
+        merged_by = None
+        # Find the PR number (if any) and change the url to the actual PR page.
+        numbers = pr_number_re.findall(ci_title)
+        if len(numbers) > 0:
+            pr_number = numbers[0]
+            ci_detail_url = f"https://api.github.com/repos/{repository_full_name}/pulls/{pr_number}"
+            ci_details = requests.get(ci_detail_url).json()
+
+            ci_author = ci_details["user"]["login"]
+            ci_url = f"https://github.com/{repository_full_name}/pull/{pr_number}"
+
+            merged_by = ci_details["merged_by"]["login"]
+
+        if merged_by is None:
+            ci_title = f"<{ci_url}|{ci_title}>\nAuthor: {ci_author}"
+        else:
+            ci_title = f"<{ci_url}|{ci_title}>\nAuthor: {ci_author} | Merged by: {merged_by}"
+
+    else:
+        ci_title = ""
 
     arguments = sys.argv[1:][0]
     try:
@@ -746,45 +797,6 @@ if __name__ == "__main__":
                         additional_results[key]["failures"][artifact_path["gpu"]].append(
                             {"line": line, "trace": stacktraces.pop(0)}
                         )
-
-    # To find the PR number in a commit title, for example, `Add AwesomeFormer model (#99999)`
-    pr_number_re = re.compile(r"\(#(\d+)\)$")
-
-    title = f"🤗 Results of the {ci_event} tests."
-    # Add PR title with a link for push CI
-    ci_title = os.environ.get("CI_TITLE")
-    ci_url = os.environ.get("CI_COMMIT_URL")
-
-    if ci_title is not None:
-        assert ci_url is not None
-        ci_title = ci_title.strip().split("\n")[0].strip()
-
-        # Retrieve the PR title and author login to complete the report
-        commit_number = ci_url.split("/")[-1]
-        ci_detail_url = f"https://api.github.com/repos/huggingface/transformers/commits/{commit_number}"
-        ci_details = requests.get(ci_detail_url).json()
-        ci_author = ci_details["author"]["login"]
-
-        merged_by = None
-        # Find the PR number (if any) and change the url to the actual PR page.
-        numbers = pr_number_re.findall(ci_title)
-        if len(numbers) > 0:
-            pr_number = numbers[0]
-            ci_detail_url = f"https://api.github.com/repos/huggingface/transformers/pulls/{pr_number}"
-            ci_details = requests.get(ci_detail_url).json()
-
-            ci_author = ci_details["user"]["login"]
-            ci_url = f"https://github.com/huggingface/transformers/pull/{pr_number}"
-
-            merged_by = ci_details["merged_by"]["login"]
-
-        if merged_by is None:
-            ci_title = f"<{ci_url}|{ci_title}>\nAuthor: {ci_author}"
-        else:
-            ci_title = f"<{ci_url}|{ci_title}>\nAuthor: {ci_author} | Merged by: {merged_by}"
-
-    else:
-        ci_title = ""
 
     message = Message(title, ci_title, model_results, additional_results)
 

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -608,7 +608,12 @@ if __name__ == "__main__":
         ci_url = f"https://github.com/{repository_full_name}/commit/{ci_sha}"
 
     if ci_title is not None:
-        assert ci_url is not None
+        if ci_url is None:
+            raise ValueError(
+                "When a title is found (`ci_title`), it means a `push` event or a `workflow_run` even "
+                "(triggered by another `push` event), and the commit SHA has to be provided in order to create the URL "
+                "to the commit page."
+            )
         ci_title = ci_title.strip().split("\n")[0].strip()
 
         # Retrieve the PR title and author login to complete the report

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -610,9 +610,9 @@ if __name__ == "__main__":
     if ci_title is not None:
         if ci_url is None:
             raise ValueError(
-                "When a title is found (`ci_title`), it means a `push` event or a `workflow_run` even "
-                "(triggered by another `push` event), and the commit SHA has to be provided in order to create the URL "
-                "to the commit page."
+                "When a title is found (`ci_title`), it means a `push` event or a `workflow_run` even (triggered by "
+                "another `push` event), and the commit SHA has to be provided in order to create the URL to the "
+                "commit page."
             )
         ci_title = ci_title.strip().split("\n")[0].strip()
 


### PR DESCRIPTION
# What does this PR do?

This is a fix for #17692 :

- Use the correct properties to get the information (branch/commit-SHA, etc.) for both `push` and `workflow_run` event type 
  - Even if we consider only the `workflow_run` event triggered by a push to `main` branch, we still need to use `github.event.workflow_run.head_sha` to get the correct SHA (otherwise, in the case where 2 PRs merged into `main` in a very short time period, the first one will get the latest commit SHA)
  - Currently, the push CI could still be triggered by `push` event if the branch is **NOT** `main`. The main purpose is for testing a particular branch. This is why I need to consider both event type.

**NOTE**: I have verified the change extensively in my own (dummy) repo. However, the part regarding the actual CI tests + the part of slack report are not verified. **The part regarding preparing the necessary information for slack report is verified.** Since the `workflow_run` could be launched only when the PR is merged into `main`, I hope there is no other unexpected issue in this PR 🙏.


