### PR TITLE
Improve error message Union not allowed

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -85,7 +85,9 @@ class HfArgumentParser(ArgumentParser):
         origin_type = getattr(field.type, "__origin__", field.type)
         if origin_type is Union:
             if len(field.type.__args__) != 2 or type(None) not in field.type.__args__:
-                raise ValueError("Only `Union[X, NoneType]` (i.e., `Optional[X]`) is allowed for `Union`")
+                raise ValueError("Only `Union[X, NoneType]` (i.e., `Optional[X]`) is allowed for `Union` because"
+                                 " the argument parser only supports one type per argument."
+                                 f" Problem encountered in field '{field.name}'")
             if bool not in field.type.__args__:
                 # filter `NoneType` in Union (except for `Union[bool, NoneType]`)
                 field.type = (

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -85,9 +85,11 @@ class HfArgumentParser(ArgumentParser):
         origin_type = getattr(field.type, "__origin__", field.type)
         if origin_type is Union:
             if len(field.type.__args__) != 2 or type(None) not in field.type.__args__:
-                raise ValueError("Only `Union[X, NoneType]` (i.e., `Optional[X]`) is allowed for `Union` because"
-                                 " the argument parser only supports one type per argument."
-                                 f" Problem encountered in field '{field.name}'")
+                raise ValueError(
+                    "Only `Union[X, NoneType]` (i.e., `Optional[X]`) is allowed for `Union` because"
+                    " the argument parser only supports one type per argument."
+                    f" Problem encountered in field '{field.name}'"
+                )
             if bool not in field.type.__args__:
                 # filter `NoneType` in Union (except for `Union[bool, NoneType]`)
                 field.type = (

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -88,7 +88,7 @@ class HfArgumentParser(ArgumentParser):
                 raise ValueError(
                     "Only `Union[X, NoneType]` (i.e., `Optional[X]`) is allowed for `Union` because"
                     " the argument parser only supports one type per argument."
-                    f" Problem encountered in field '{field.name}'"
+                    f" Problem encountered in field '{field.name}'."
                 )
             if bool not in field.type.__args__:
                 # filter `NoneType` in Union (except for `Union[bool, NoneType]`)


### PR DESCRIPTION
I am working with a lot of custom Dataclasses inside the `HfArgumentParser`, and while my Python code was technically correct (using `Union`), I did get the brief error message _Only `Union[X, NoneType]` (i.e., `Optional[X]`) is allowed for `Union`_. From the error message it was not clear what triggered it, and it took me a while to figure out why I could not use Union. My assumption now is that we cannot use Union due to limitations of `argparse` (I am not sure yet how I can allow for floats and ints though).

This PR simply clarifies the error message a bit and gives the field name of the offending item.

Minimal test case:

```python
from typing import Union

from dataclasses import dataclass, field
from transformers import HfArgumentParser


@dataclass
class OtherArguments:
    validation_size: Union[float, int] = field(
        default=0.2  # might be a float for percentage of training set or int for absolute split
    )


if __name__ == '__main__':
    dataclass_tester = OtherArguments(0.5)
    parser = HfArgumentParser((OtherArguments, ))

    oargs = parser.parse_args_into_dataclasses()
```

EDIT: my current solution to allow for floats and ints is below, but the PR is still useful in itself I think.

```python
from argparse import ArgumentTypeError
from typing import Union

from dataclasses import dataclass, field
from transformers import HfArgumentParser


def float_or_int(arg: str):
    # I am aware that this is very naive (e.g. scientific notations), but it works for my purposes.
    # Other suggestions welcome though
    likely_float = "." in arg  
    try:
        arg = float(arg)
    except ValueError:
        raise ArgumentTypeError(f"{arg} is not a float-able input")

    if not likely_float:
        arg = int(arg)
    return arg


@dataclass
class OtherArguments:
    validation_size: float_or_int = field(
        default=0.2,
        metadata={"help": "If a validation set is not present in your dataset, it will be created automatically from"
                          " the training set. You can set the ratio train/valid here (float) or an exact number of"
                          " samples that you wish to include in the validation set (int)."}
    )


if __name__ == '__main__':
    parser = HfArgumentParser((OtherArguments, ))

    oargs = parser.parse_args_into_dataclasses()[0]
    print(oargs.validation_size)
    print(type(oargs.validation_size))
```

@sgugger 