### PR TITLE
Flax implementation of DPT

### DIFF
--- a/docs/source/en/index.mdx
+++ b/docs/source/en/index.mdx
@@ -214,7 +214,7 @@ Flax), PyTorch, and/or TensorFlow.
 |            DETR             |       ❌       |       ❌       |       ✅        |         ❌         |      ❌      |
 |         DistilBERT          |       ✅       |       ✅       |       ✅        |         ✅         |      ✅      |
 |             DPR             |       ✅       |       ✅       |       ✅        |         ✅         |      ❌      |
-|             DPT             |       ❌       |       ❌       |       ✅        |         ❌         |      ❌      |
+|             DPT             |       ❌       |       ❌       |       ✅        |         ❌         |      ✅      |
 |           ELECTRA           |       ✅       |       ✅       |       ✅        |         ✅         |      ✅      |
 |       Encoder decoder       |       ❌       |       ❌       |       ✅        |         ✅         |      ✅      |
 | FairSeq Machine-Translation |       ✅       |       ❌       |       ✅        |         ❌         |      ❌      |

--- a/docs/source/en/model_doc/dpt.mdx
+++ b/docs/source/en/model_doc/dpt.mdx
@@ -55,3 +55,18 @@ This model was contributed by [nielsr](https://huggingface.co/nielsr). The origi
 
 [[autodoc]] DPTForSemanticSegmentation
     - forward
+
+## FlaxDPTForSemanticSegmentation
+
+[[autodoc]] FlaxDPTForSemanticSegmentation
+    - __call__
+
+## FlaxDPTForDepthEstimation
+
+[[autodoc]] FlaxDPTForDepthEstimation
+    - __call__
+
+## FlaxDPTModel
+
+[[autodoc]] FlaxDPTModel
+    - __call__

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -2579,6 +2579,14 @@ else:
             "FlaxDistilBertPreTrainedModel",
         ]
     )
+    _import_structure["models.dpt"].extend(
+        [
+            "FlaxDPTModel",
+            "FlaxDPTPreTrainedModel",
+            "FlaxDPTForSemanticSegmentation",
+            "FlaxDPTForDepthEstimation",
+        ]
+    )
     _import_structure["models.electra"].extend(
         [
             "FlaxElectraForCausalLM",
@@ -4793,6 +4801,12 @@ if TYPE_CHECKING:
             FlaxDistilBertForTokenClassification,
             FlaxDistilBertModel,
             FlaxDistilBertPreTrainedModel,
+        )
+        from .models.dpt import (
+            FlaxDPTForDepthEstimation,
+            FlaxDPTForSemanticSegmentation,
+            FlaxDPTModel,
+            FlaxDPTPreTrainedModel,
         )
         from .models.electra import (
             FlaxElectraForCausalLM,

--- a/src/transformers/modeling_flax_outputs.py
+++ b/src/transformers/modeling_flax_outputs.py
@@ -640,3 +640,72 @@ class FlaxSeq2SeqQuestionAnsweringModelOutput(ModelOutput):
     encoder_last_hidden_state: Optional[jnp.ndarray] = None
     encoder_hidden_states: Optional[Tuple[jnp.ndarray]] = None
     encoder_attentions: Optional[Tuple[jnp.ndarray]] = None
+
+
+@flax.struct.dataclass
+class FlaxDepthEstimatorOutput(ModelOutput):
+    """
+    Base class for outputs of depth estimation models.
+
+    Args:
+        loss (`torch.FloatTensor` of shape `(1,)`, *optional*, returned when `labels` is provided):
+            Classification (or regression if config.num_labels==1) loss.
+        predicted_depth (`torch.FloatTensor` of shape `(batch_size, height, width)`):
+            Predicted depth for each pixel.
+
+        hidden_states (`tuple(torch.FloatTensor)`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
+            Tuple of `torch.FloatTensor` (one for the output of the embeddings, if the model has an embedding layer, +
+            one for the output of each layer) of shape `(batch_size, num_channels, height, width)`.
+
+            Hidden-states of the model at the output of each layer plus the optional initial embedding outputs.
+        attentions (`tuple(torch.FloatTensor)`, *optional*, returned when `output_attentions=True` is passed or when `config.output_attentions=True`):
+            Tuple of `torch.FloatTensor` (one for each layer) of shape `(batch_size, num_heads, patch_size,
+            sequence_length)`.
+
+            Attentions weights after the attention softmax, used to compute the weighted average in the self-attention
+            heads.
+    """
+
+    loss: jnp.ndarray = None
+    predicted_depth: jnp.ndarray = None
+    hidden_states: Optional[Tuple[jnp.ndarray]] = None
+    attentions: Optional[Tuple[jnp.ndarray]] = None
+
+
+@flax.struct.dataclass
+class FlaxSemanticSegmenterOutput(ModelOutput):
+    """
+    Base class for outputs of depth estimation models.
+
+    Args:
+        loss (`torch.FloatTensor` of shape `(1,)`, *optional*, returned when `labels` is provided):
+            Classification (or regression if config.num_labels==1) loss.
+        logits (`torch.FloatTensor` of shape `(batch_size, config.num_labels, logits_height, logits_width)`):
+            Classification scores for each pixel.
+
+            <Tip warning={true}>
+
+            The logits returned do not necessarily have the same size as the `pixel_values` passed as inputs. This is
+            to avoid doing two interpolations and lose some quality when a user needs to resize the logits to the
+            original image size as post-processing. You should always check your logits shape and resize as needed.
+
+            </Tip>
+
+        hidden_states (`tuple(torch.FloatTensor)`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
+            Tuple of `torch.FloatTensor` (one for the output of the embeddings, if the model has an embedding layer, +
+            one for the output of each layer) of shape `(batch_size, num_channels, height, width)`.
+
+            Hidden-states of the model at the output of each layer plus the optional initial embedding outputs.
+        attentions (`tuple(torch.FloatTensor)`, *optional*, returned when `output_attentions=True` is passed or when `config.output_attentions=True`):
+            Tuple of `torch.FloatTensor` (one for each layer) of shape `(batch_size, num_heads, patch_size,
+            sequence_length)`.
+
+            Attentions weights after the attention softmax, used to compute the weighted average in the self-attention
+            heads.
+    """
+
+    loss: jnp.ndarray = None
+    logits: jnp.ndarray = None
+    predicted_depth: jnp.ndarray = None
+    hidden_states: Optional[Tuple[jnp.ndarray]] = None
+    attentions: Optional[Tuple[jnp.ndarray]] = None

--- a/src/transformers/models/auto/modeling_flax_auto.py
+++ b/src/transformers/models/auto/modeling_flax_auto.py
@@ -37,6 +37,7 @@ FLAX_MODEL_MAPPING_NAMES = OrderedDict(
         ("blenderbot-small", "FlaxBlenderbotSmallModel"),
         ("clip", "FlaxCLIPModel"),
         ("distilbert", "FlaxDistilBertModel"),
+        ("dpt", "FlaxDPTModel"),
         ("electra", "FlaxElectraModel"),
         ("gpt2", "FlaxGPT2Model"),
         ("gpt_neo", "FlaxGPTNeoModel"),
@@ -211,6 +212,17 @@ FLAX_MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES = OrderedDict(
     ]
 )
 
+FLAX_MODEL_FOR_DEPTH_ESTIMATION_MAPPING = OrderedDict(
+    [
+        ("dpt", "FlaxDPTForDepthEstimation"),
+    ]
+)
+
+FLAX_MODEL_FOR_SEMANTIC_SEGMENTATION_MAPPING = OrderedDict(
+    [
+        ("dpt", "FlaxDPTForSemanticSegmentation"),
+    ]
+)
 
 FLAX_MODEL_MAPPING = _LazyAutoMapping(CONFIG_MAPPING_NAMES, FLAX_MODEL_MAPPING_NAMES)
 FLAX_MODEL_FOR_PRETRAINING_MAPPING = _LazyAutoMapping(CONFIG_MAPPING_NAMES, FLAX_MODEL_FOR_PRETRAINING_MAPPING_NAMES)
@@ -240,6 +252,12 @@ FLAX_MODEL_FOR_NEXT_SENTENCE_PREDICTION_MAPPING = _LazyAutoMapping(
 )
 FLAX_MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING = _LazyAutoMapping(
     CONFIG_MAPPING_NAMES, FLAX_MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES
+)
+FLAX_MODEL_FOR_DEPTH_ESTIMATION_MAPPING = _LazyAutoMapping(
+    CONFIG_MAPPING_NAMES, FLAX_MODEL_FOR_DEPTH_ESTIMATION_MAPPING
+)
+FLAX_MODEL_FOR_SEMANTIC_SEGMENTATION_MAPPING = _LazyAutoMapping(
+    CONFIG_MAPPING_NAMES, FLAX_MODEL_FOR_SEMANTIC_SEGMENTATION_MAPPING
 )
 
 
@@ -343,4 +361,22 @@ class FlaxAutoModelForSpeechSeq2Seq(_BaseAutoModelClass):
 
 FlaxAutoModelForSpeechSeq2Seq = auto_class_update(
     FlaxAutoModelForSpeechSeq2Seq, head_doc="sequence-to-sequence speech-to-text modeling"
+)
+
+
+class FlaxAutoModelForDepthEstimation(_BaseAutoModelClass):
+    _model_mapping = FLAX_MODEL_FOR_DEPTH_ESTIMATION_MAPPING
+
+
+FlaxAutoModelForDepthEstimation = auto_class_update(
+    FlaxAutoModelForDepthEstimation, head_doc="depth estimation modeling"
+)
+
+
+class FlaxAutoModelForSemanticSegmentation(_BaseAutoModelClass):
+    _model_mapping = FLAX_MODEL_FOR_SEMANTIC_SEGMENTATION_MAPPING
+
+
+FlaxAutoModelForSemanticSegmentation = auto_class_update(
+    FlaxAutoModelForSemanticSegmentation, head_doc="semantic segmentation modeling"
 )

--- a/src/transformers/models/dpt/__init__.py
+++ b/src/transformers/models/dpt/__init__.py
@@ -17,7 +17,13 @@
 # limitations under the License.
 from typing import TYPE_CHECKING
 
-from ...file_utils import _LazyModule, is_tokenizers_available, is_torch_available, is_vision_available
+from ...file_utils import (
+    _LazyModule,
+    is_flax_available,
+    is_tokenizers_available,
+    is_torch_available,
+    is_vision_available,
+)
 from ...utils import OptionalDependencyNotAvailable
 
 
@@ -43,6 +49,19 @@ else:
         "DPTForSemanticSegmentation",
         "DPTModel",
         "DPTPreTrainedModel",
+    ]
+
+try:
+    if not is_flax_available():
+        raise OptionalDependencyNotAvailable()
+except OptionalDependencyNotAvailable:
+    pass
+else:
+    _import_structure["modeling_flax_dpt"] = [
+        "FlaxDPTForSemanticSegmentation",
+        "FlaxDPTForDepthEstimation",
+        "FlaxDPTModel",
+        "FlaxDPTPreTrainedModel",
     ]
 
 
@@ -71,6 +90,18 @@ if TYPE_CHECKING:
             DPTPreTrainedModel,
         )
 
+    try:
+        if not is_flax_available():
+            raise OptionalDependencyNotAvailable()
+    except OptionalDependencyNotAvailable:
+        pass
+    else:
+        from .modeling_flax_dpt import (
+            FlaxDPTForDepthEstimation,
+            FlaxDPTForSemanticSegmentation,
+            FlaxDPTModel,
+            FlaxDPTPreTrainedModel,
+        )
 
 else:
     import sys

--- a/src/transformers/models/dpt/modeling_flax_dpt.py
+++ b/src/transformers/models/dpt/modeling_flax_dpt.py
@@ -433,23 +433,6 @@ class FlaxDPTPreActResidualLayer(nn.Module):
 
         return hidden_state + residual
 
-    def __call__(self, hidden_state):
-        residual = hidden_state
-        hidden_state = self.activation1(hidden_state)
-
-        hidden_state = self.convolution1(hidden_state)
-
-        if self.use_batch_norm:
-            hidden_state = self.batch_norm1(hidden_state)
-
-        hidden_state = self.activation2(hidden_state)
-        hidden_state = self.convolution2(hidden_state)
-
-        if self.use_batch_norm:
-            hidden_state = self.batch_norm2(hidden_state)
-
-        return hidden_state + residual
-
 
 class FlaxDPTFeatureFusionLayer(nn.Module):
     config: DPTConfig

--- a/src/transformers/models/dpt/modeling_flax_dpt.py
+++ b/src/transformers/models/dpt/modeling_flax_dpt.py
@@ -1,0 +1,1138 @@
+# coding=utf-8
+# Copyright 2022 Intel Labs, OpenMMLab and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Flax DPT (Dense Prediction Transformers) model.
+
+TThis implementation is heavily inspired by OpenMMLab's implementation, found here:
+https://github.com/open-mmlab/mmsegmentation/blob/master/mmseg/models/decode_heads/dpt_head.py.
+
+"""
+import math
+from typing import Optional, Tuple
+
+import flax.linen as nn
+import jax
+import jax.numpy as jnp
+import optax
+from flax.core.frozen_dict import FrozenDict, freeze, unfreeze
+from flax.linen.attention import dot_product_attention_weights
+from flax.traverse_util import flatten_dict, unflatten_dict
+
+from ...modeling_flax_outputs import (
+    FlaxBaseModelOutput,
+    FlaxBaseModelOutputWithPooling,
+    FlaxDepthEstimatorOutput,
+    FlaxSemanticSegmenterOutput,
+)
+from ...modeling_flax_utils import ACT2FN, FlaxPreTrainedModel
+from ...utils import add_start_docstrings, add_start_docstrings_to_model_forward
+from .configuration_dpt import DPTConfig
+
+
+DPT_START_DOCSTRING = r"""
+    This model inherits from [`FlaxPreTrainedModel`]. Check the superclass documentation for the generic methods the
+    library implements for all its model (such as downloading, saving and converting weights from PyTorch models) This
+    model is also a Flax Linen [flax.linen.Module](https://flax.readthedocs.io/en/latest/flax.linen.html#module)
+    subclass. Use it as a regular Flax linen Module and refer to the Flax documentation for all matter related to
+    general usage and behavior. Finally, this model supports inherent JAX features such as:
+    - [Just-In-Time (JIT) compilation](https://jax.readthedocs.io/en/latest/jax.html#just-in-time-compilation-jit)
+    - [Automatic Differentiation](https://jax.readthedocs.io/en/latest/jax.html#automatic-differentiation)
+    - [Vectorization](https://jax.readthedocs.io/en/latest/jax.html#vectorization-vmap)
+    - [Parallelization](https://jax.readthedocs.io/en/latest/jax.html#parallelization-pmap)
+    Parameters:
+        config ([`ViTConfig`]): Model configuration class with all the parameters of the model.
+            Initializing with a config file does not load the weights associated with the model, only the
+            configuration. Check out the [`~FlaxPreTrainedModel.from_pretrained`] method to load the model weights.
+        dtype (`jax.numpy.dtype`, *optional*, defaults to `jax.numpy.float32`):
+            The data type of the computation. Can be one of `jax.numpy.float32`, `jax.numpy.float16` (on GPUs) and
+            `jax.numpy.bfloat16` (on TPUs). This can be used to enable mixed-precision training or half-precision
+            inference on GPUs or TPUs. If specified all the computation will be performed with the given `dtype`.
+            **Note that this only specifies the dtype of the computation and does not influence the dtype of model
+            parameters.** If you wish to change the dtype of the model parameters, see [`~FlaxPreTrainedModel.to_fp16`]
+            and [`~FlaxPreTrainedModel.to_bf16`].
+"""
+
+DPT_INPUTS_DOCSTRING = r"""
+    Args:
+        pixel_values (`numpy.ndarray` of shape `(batch_size, num_channels, height, width)`):
+            Pixel values. Pixel values can be obtained using [`DPTFeatureExtractor`]. See
+            [`DPTFeatureExtractor.__call__`] for details.
+        output_attentions (`bool`, *optional*):
+            Whether or not to return the attentions tensors of all attention layers. See `attentions` under returned
+            tensors for more detail.
+        output_hidden_states (`bool`, *optional*):
+            Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors for
+            more detail.
+        return_dict (`bool`, *optional*):
+            Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
+"""
+
+
+class FlaxPatchEmbeddings(nn.Module):
+
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32  # the dtype of the computation
+
+    def setup(self):
+        image_size = self.config.image_size
+        patch_size = self.config.patch_size
+        num_patches = (image_size // patch_size) * (image_size // patch_size)
+        self.num_patches = num_patches
+        self.projection = nn.Conv(
+            self.config.hidden_size,
+            kernel_size=(patch_size, patch_size),
+            strides=(patch_size, patch_size),
+            padding="VALID",
+            dtype=self.dtype,
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range),
+        )
+
+    def __call__(self, pixel_values):
+        x = self.projection(pixel_values)
+        batch_size, _, _, channels = x.shape
+        return jnp.reshape(x, (batch_size, -1, channels))
+
+
+class FlaxDPTEmbeddings(nn.Module):
+    """Construct the CLS token, position and patch embeddings."""
+
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32  # the dtype of the computation
+
+    def setup(self):
+        self.cls_token = self.param("cls_token", nn.initializers.zeros, (1, 1, self.config.hidden_size))
+        self.patch_embeddings = FlaxPatchEmbeddings(self.config, dtype=self.dtype)
+        num_patches = self.patch_embeddings.num_patches
+        self.position_embeddings = self.param(
+            "position_embeddings", nn.initializers.zeros, (1, num_patches + 1, self.config.hidden_size)
+        )
+        self.dropout = nn.Dropout(rate=self.config.hidden_dropout_prob)
+
+    def __call__(self, pixel_values, deterministic=True):
+        batch_size = pixel_values.shape[0]
+
+        embeddings = self.patch_embeddings(pixel_values)
+
+        cls_tokens = jnp.broadcast_to(self.cls_token, (batch_size, 1, self.config.hidden_size))
+        embeddings = jnp.concatenate((cls_tokens, embeddings), axis=1)
+        embeddings = embeddings + self.position_embeddings
+        embeddings = self.dropout(embeddings, deterministic=deterministic)
+        return embeddings
+
+
+class FlaxViTSelfAttention(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32  # the dtype of the computation
+
+    def setup(self):
+        if self.config.hidden_size % self.config.num_attention_heads != 0:
+            raise ValueError(
+                "`config.hidden_size`: {self.config.hidden_size} has to be a multiple of `config.num_attention_heads`:"
+                " {self.config.num_attention_heads}"
+            )
+
+        self.query = nn.Dense(
+            self.config.hidden_size,
+            dtype=self.dtype,
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range),
+            use_bias=self.config.qkv_bias,
+        )
+        self.key = nn.Dense(
+            self.config.hidden_size,
+            dtype=self.dtype,
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range),
+            use_bias=self.config.qkv_bias,
+        )
+        self.value = nn.Dense(
+            self.config.hidden_size,
+            dtype=self.dtype,
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range),
+            use_bias=self.config.qkv_bias,
+        )
+
+    def __call__(self, hidden_states, deterministic: bool = True, output_attentions: bool = False):
+        head_dim = self.config.hidden_size // self.config.num_attention_heads
+
+        query_states = self.query(hidden_states).reshape(
+            hidden_states.shape[:2] + (self.config.num_attention_heads, head_dim)
+        )
+        value_states = self.value(hidden_states).reshape(
+            hidden_states.shape[:2] + (self.config.num_attention_heads, head_dim)
+        )
+        key_states = self.key(hidden_states).reshape(
+            hidden_states.shape[:2] + (self.config.num_attention_heads, head_dim)
+        )
+
+        dropout_rng = None
+        if not deterministic and self.config.attention_probs_dropout_prob > 0.0:
+            dropout_rng = self.make_rng("dropout")
+
+        attn_weights = dot_product_attention_weights(
+            query_states,
+            key_states,
+            dropout_rng=dropout_rng,
+            dropout_rate=self.config.attention_probs_dropout_prob,
+            broadcast_dropout=True,
+            deterministic=deterministic,
+            dtype=self.dtype,
+            precision=None,
+        )
+
+        attn_output = jnp.einsum("...hqk,...khd->...qhd", attn_weights, value_states)
+        attn_output = attn_output.reshape(attn_output.shape[:2] + (-1,))
+
+        outputs = (attn_output, attn_weights) if output_attentions else (attn_output,)
+        return outputs
+
+
+class FlaxDPTViTOutput(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32  # the dtype of the computation
+
+    def setup(self):
+        self.dense = nn.Dense(
+            self.config.hidden_size,
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range),
+            dtype=self.dtype,
+        )
+        self.dropout = nn.Dropout(rate=self.config.hidden_dropout_prob)
+
+    def __call__(self, hidden_states, attention_output, deterministic: bool = True):
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.dropout(hidden_states, deterministic=deterministic)
+        hidden_states = hidden_states + attention_output
+        return hidden_states
+
+
+class FlaxDPTViTSelfOutput(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32  # the dtype of the computation
+
+    def setup(self):
+        self.dense = nn.Dense(
+            self.config.hidden_size,
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range),
+            dtype=self.dtype,
+        )
+        self.dropout = nn.Dropout(rate=self.config.hidden_dropout_prob)
+
+    def __call__(self, hidden_states, input_tensor, deterministic: bool = True):
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.dropout(hidden_states, deterministic=deterministic)
+        return hidden_states
+
+
+class FlaxDPTViTAttention(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32
+
+    def setup(self):
+        self.attention = FlaxViTSelfAttention(self.config, dtype=self.dtype)
+        self.output = FlaxDPTViTSelfOutput(self.config, dtype=self.dtype)
+
+    def __call__(self, hidden_states, deterministic=True, output_attentions: bool = False):
+        attn_outputs = self.attention(hidden_states, deterministic=deterministic, output_attentions=output_attentions)
+        attn_output = attn_outputs[0]
+        hidden_states = self.output(attn_output, hidden_states, deterministic=deterministic)
+
+        outputs = (hidden_states,)
+
+        if output_attentions:
+            outputs += (attn_outputs[1],)
+
+        return outputs
+
+
+class FlaxDPTViTIntermediate(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32  # the dtype of the computation
+
+    def setup(self):
+        self.dense = nn.Dense(
+            self.config.intermediate_size,
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range),
+            dtype=self.dtype,
+        )
+        self.activation = ACT2FN[self.config.hidden_act]
+
+    def __call__(self, hidden_states):
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.activation(hidden_states)
+        return hidden_states
+
+
+# DPT reassemble & Fusion
+class FlaxDPTReassembleLayer(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32
+    factor: int = 1
+    channels: int = None
+
+    def setup(self):
+        # projection
+        self.projection = nn.Conv(
+            self.config.hidden_size,
+            kernel_size=(1, 1),
+            dtype=self.dtype,
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range),
+        )
+
+        # up/down sampling depending on factor
+        if self.factor > 1:
+            self.resize = nn.ConvTranspose(
+                self.channels, kernel_size=(self.factor, self.factor), strides=(self.factor, self.factor)
+            )
+        elif self.factor < 1:
+            # so should downsample
+            self.resize = nn.Conv(
+                self.channels,
+                kernel_size=(3, 3),
+                strides=(int(1 / self.factor), int(1 / self.factor)),
+                dtype=self.dtype,
+                kernel_init=jax.nn.initializers.normal(self.config.initializer_range),
+            )
+
+    def __call__(self, hidden_state):
+        hidden_state = self.projection(hidden_state)
+        if self.factor != 1:
+            hidden_state = self.resize(hidden_state)
+        return hidden_state
+
+
+class FlaxDPTReassembleStage(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32
+
+    def setup(self):
+
+        self.layers = [
+            FlaxDPTReassembleLayer(self.config, factor=factor, channels=self.config.neck_hidden_sizes[i])
+            for i, factor in zip(range(len(self.config.neck_hidden_sizes)), self.config.reassemble_factors)
+        ]
+
+        if self.config.readout_type == "project":
+            self.readout_projects = [
+                nn.Sequential([nn.Dense(self.config.hidden_size), ACT2FN[self.config.hidden_act]])
+                for _ in range(len(self.config.neck_hidden_sizes))
+            ]
+
+    def __call__(self, hidden_states):
+        """
+        Args:
+            hidden_states (`List[torch.FloatTensor]`, each of shape `(batch_size, sequence_length + 1, hidden_size)`):
+                List of hidden states from the backbone.
+        """
+        out = []
+
+        for i, hidden_state in enumerate(hidden_states):
+            # reshape to (B, C, H, W)
+            hidden_state, cls_token = hidden_state[:, 1:], hidden_state[:, 0]
+            batch_size, sequence_length, num_channels = hidden_state.shape
+            size = int(math.sqrt(sequence_length))
+            hidden_state = jnp.reshape(hidden_state, (batch_size, size, size, num_channels))
+
+            feature_shape = hidden_state.shape
+            if self.config.readout_type == "project":
+                # reshape to (B, H*W, C)
+                hidden_state = jnp.reshape(hidden_state, (batch_size, size * size, num_channels))
+                readout = jnp.expand_dims(cls_token, axis=1)
+                readout = jnp.repeat(readout, size * size, axis=1)
+                # concatenate the readout token to the hidden states and project
+                hidden_state = self.readout_projects[i](jnp.concatenate((hidden_state, readout), axis=-1))
+                # reshape back to (B, C, H, W)
+                hidden_state = jnp.reshape(hidden_state, feature_shape)
+            elif self.config.readout_type == "add":
+                hidden_state = jnp.reshape(hidden_state, (batch_size, size * size, num_channels)) + jnp.expand_dims(
+                    cls_token, axis=-1
+                )
+                hidden_state = jnp.reshape(hidden_state, feature_shape)
+            hidden_state = self.layers[i](hidden_state)
+            out.append(hidden_state)
+
+        return out
+
+
+class FlaxDPTFeatureFusionStage(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32
+
+    def setup(self):
+        super().__init__()
+        self.layers = [FlaxDPTFeatureFusionLayer(self.config) for _ in range(len(self.config.neck_hidden_sizes))]
+
+    def __call__(self, hidden_states):
+        # reversing the hidden_states, we start from the last
+        hidden_states = hidden_states[::-1]
+
+        fused_hidden_states = []
+        # first layer only uses the last hidden_state
+        fused_hidden_state = self.layers[0](hidden_states[0])
+        fused_hidden_states.append(fused_hidden_state)
+        # looping from the last layer to the second
+        for hidden_state, layer in zip(hidden_states[1:], self.layers[1:]):
+            fused_hidden_state = layer(fused_hidden_state, hidden_state)
+            fused_hidden_states.append(fused_hidden_state)
+
+        return fused_hidden_states
+
+
+class FlaxDPTPreActResidualLayer(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32
+
+    def setup(self):
+
+        self.use_batch_norm = self.config.use_batch_norm_in_fusion_residual
+        self.activation1 = ACT2FN["relu"]
+        self.convolution1 = nn.Conv(
+            self.config.fusion_hidden_size,
+            kernel_size=(3, 3),
+            strides=(1, 1),
+            padding=1,
+            use_bias=not self.use_batch_norm,
+        )
+
+        self.activation2 = ACT2FN["relu"]
+        self.convolution2 = nn.Conv(
+            self.config.fusion_hidden_size,
+            kernel_size=(3, 3),
+            strides=(1, 1),
+            padding=1,
+            use_bias=not self.use_batch_norm,
+        )
+
+        if self.use_batch_norm:
+            self.batch_norm1 = nn.BatchNorm(use_running_average=False)
+            self.batch_norm2 = nn.BatchNorm(use_running_average=False)
+
+    def __call__(self, hidden_state):
+        residual = hidden_state
+        hidden_state = self.activation1(hidden_state)
+
+        hidden_state = self.convolution1(hidden_state)
+
+        if self.use_batch_norm:
+            hidden_state = self.batch_norm1(hidden_state)
+
+        hidden_state = self.activation2(hidden_state)
+        hidden_state = self.convolution2(hidden_state)
+
+        if self.use_batch_norm:
+            hidden_state = self.batch_norm2(hidden_state)
+
+        return hidden_state + residual
+
+    def __call__(self, hidden_state):
+        residual = hidden_state
+        hidden_state = self.activation1(hidden_state)
+
+        hidden_state = self.convolution1(hidden_state)
+
+        if self.use_batch_norm:
+            hidden_state = self.batch_norm1(hidden_state)
+
+        hidden_state = self.activation2(hidden_state)
+        hidden_state = self.convolution2(hidden_state)
+
+        if self.use_batch_norm:
+            hidden_state = self.batch_norm2(hidden_state)
+
+        return hidden_state + residual
+
+
+class FlaxDPTFeatureFusionLayer(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32
+    align_corners: bool = True
+
+    def setup(self):
+        self.projection = nn.Conv(self.config.fusion_hidden_size, kernel_size=(1, 1))  # , bias=True)
+
+        self.residual_layer1 = FlaxDPTPreActResidualLayer(self.config)
+        self.residual_layer2 = FlaxDPTPreActResidualLayer(self.config)
+        self.upsample = FlaxDPTUpsample()
+
+    def __call__(self, hidden_state, residual=None):
+        if residual is not None:
+            if hidden_state.shape != residual.shape:
+                size = hidden_state.shape
+                residual = self.upsample(residual, size)
+            hidden_state = hidden_state + self.residual_layer1(residual)
+
+        hidden_state = self.residual_layer2(hidden_state)
+        hidden_state = self.upsample(hidden_state)
+        hidden_state = self.projection(hidden_state)
+
+        return hidden_state
+
+
+class FlaxDPTViTLayer(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32  # the dtype of the computation
+
+    def setup(self):
+        self.attention = FlaxDPTViTAttention(self.config, dtype=self.dtype)
+        self.intermediate = FlaxDPTViTIntermediate(self.config, dtype=self.dtype)
+        self.output = FlaxDPTViTOutput(self.config, dtype=self.dtype)
+        self.layernorm_before = nn.LayerNorm(epsilon=self.config.layer_norm_eps, dtype=self.dtype)
+        self.layernorm_after = nn.LayerNorm(epsilon=self.config.layer_norm_eps, dtype=self.dtype)
+
+    def __call__(self, hidden_states, deterministic: bool = True, output_attentions: bool = False):
+        attention_outputs = self.attention(
+            self.layernorm_before(hidden_states),  # in ViT, layernorm is applied before self-attention
+            deterministic=deterministic,
+            output_attentions=output_attentions,
+        )
+
+        attention_output = attention_outputs[0]
+
+        # first residual connection
+        attention_output = attention_output + hidden_states
+
+        # in ViT, layernorm is also applied after self-attention
+        layer_output = self.layernorm_after(attention_output)
+
+        hidden_states = self.intermediate(layer_output)
+        hidden_states = self.output(hidden_states, attention_output, deterministic=deterministic)
+
+        outputs = (hidden_states,)
+
+        if output_attentions:
+            outputs += (attention_outputs[1],)
+        return outputs
+
+
+class FlaxDPTViTLayerCollection(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32  # the dtype of the computation
+
+    def setup(self):
+        self.layers = [
+            FlaxDPTViTLayer(self.config, name=str(i), dtype=self.dtype) for i in range(self.config.num_hidden_layers)
+        ]
+
+    def __call__(
+        self,
+        hidden_states,
+        deterministic: bool = True,
+        output_attentions: bool = False,
+        output_hidden_states: bool = False,
+        return_dict: bool = True,
+    ):
+
+        all_attentions = () if output_attentions else None
+        all_hidden_states = () if output_hidden_states else None
+
+        for i, layer in enumerate(self.layers):
+            if output_hidden_states:
+                all_hidden_states += (hidden_states,)
+
+            layer_outputs = layer(hidden_states, deterministic=deterministic, output_attentions=output_attentions)
+
+            hidden_states = layer_outputs[0]
+
+            if output_attentions:
+                all_attentions += (layer_outputs[1],)
+
+        if output_hidden_states:
+            all_hidden_states += (hidden_states,)
+
+        if not return_dict:
+            return tuple(v for v in [hidden_states, all_hidden_states, all_attentions] if v is not None)
+
+        return FlaxBaseModelOutput(
+            last_hidden_state=hidden_states, hidden_states=all_hidden_states, attentions=all_attentions
+        )
+
+
+class FlaxDPTViTPooler(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32  # the dtype of the computation
+
+    def setup(self):
+        self.dense = nn.Dense(
+            self.config.hidden_size,
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range),
+            dtype=self.dtype,
+        )
+
+    def __call__(self, hidden_states):
+        cls_hidden_state = hidden_states[:, 0]
+        cls_hidden_state = self.dense(cls_hidden_state)
+        return nn.tanh(cls_hidden_state)
+
+
+class FlaxDPTViTEncoder(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32  # the dtype of the computation
+
+    def setup(self):
+        self.layer = FlaxDPTViTLayerCollection(self.config, dtype=self.dtype)
+
+    def __call__(
+        self,
+        hidden_states,
+        deterministic: bool = True,
+        output_attentions: bool = False,
+        output_hidden_states: bool = False,
+        return_dict: bool = True,
+    ):
+        return self.layer(
+            hidden_states,
+            deterministic=deterministic,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+
+
+DPT_START_DOCSTRING = r"""
+    This model is a Flax [jax.nn.Module](https://jax.readthedocs.io/en/latest/jax.nn.html?highlight=nn.Module)
+    subclass. Use it as a regular Flax Module and refer to the Flax documentation for all matter related to general
+    usage and behavior.
+
+    Parameters:
+        config ([`DPTConfig`]): Model configuration class with all the parameters of the model.
+            Initializing with a config file does not load the weights associated with the model, only the
+            configuration. Check out the [`~PreTrainedModel.from_pretrained`] method to load the model weights.
+"""
+
+DPT_INPUTS_DOCSTRING = r"""
+    Args:
+        pixel_values (`jax.numpy.array` of shape `(batch_size, num_channels, height, width)`):
+            Pixel values. Pixel values can be obtained using [`ViTFeatureExtractor`]. See
+            [`ViTFeatureExtractor.__call__`] for details.
+
+        output_attentions (`bool`, *optional*):
+            Whether or not to return the attentions tensors of all attention layers. See `attentions` under returned
+            tensors for more detail.
+        output_hidden_states (`bool`, *optional*):
+            Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors for
+            more detail.
+        return_dict (`bool`, *optional*):
+            Whether or not to return a [`~file_utils.ModelOutput`] instead of a plain tuple.
+"""
+
+
+class FlaxDPTPreTrainedModel(FlaxPreTrainedModel):
+    """
+    An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
+    models.
+    """
+
+    config_class = DPTConfig
+    base_model_prefix = "dpt"
+    main_input_name = "pixel_values"
+    module_class: nn.Module = None
+
+    def __init__(
+        self,
+        config: DPTConfig,
+        input_shape=None,
+        seed: int = 0,
+        dtype: jnp.dtype = jnp.float32,
+        _do_init: bool = True,
+        **kwargs
+    ):
+        module = self.module_class(config=config, dtype=dtype, **kwargs)
+        if input_shape is None:
+            input_shape = (1, config.image_size, config.image_size, 3)
+        super().__init__(config, module, input_shape=input_shape, seed=seed, dtype=dtype, _do_init=_do_init)
+
+    def init_weights(self, rng: jax.random.PRNGKey, input_shape: Tuple, params: FrozenDict = None) -> FrozenDict:
+        # init input tensors
+        pixel_values = jnp.zeros(input_shape, dtype=self.dtype)
+
+        params_rng, dropout_rng = jax.random.split(rng)
+        rngs = {"params": params_rng, "dropout": dropout_rng}
+
+        random_params = self.module.init(rngs, pixel_values, return_dict=False)["params"]
+
+        if params is not None:
+            random_params = flatten_dict(unfreeze(random_params))
+            params = flatten_dict(unfreeze(params))
+            for missing_key in self._missing_keys:
+                params[missing_key] = random_params[missing_key]
+            self._missing_keys = set()
+            return freeze(unflatten_dict(params))
+        else:
+            return random_params
+
+    @add_start_docstrings_to_model_forward(DPT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
+    def __call__(
+        self,
+        pixel_values,
+        params: dict = None,
+        dropout_rng: jax.random.PRNGKey = None,
+        train: bool = False,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        labels: Optional[jnp.ndarray] = None,
+    ):
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        return_dict = return_dict if return_dict is not None else self.config.return_dict
+
+        pixel_values = jnp.transpose(pixel_values, (0, 2, 3, 1))
+        # Handle any PRNG if needed
+        rngs = {}
+        if dropout_rng is not None:
+            rngs["dropout"] = dropout_rng
+
+        return self.module.apply(
+            {"params": params or self.params},
+            jnp.array(pixel_values, dtype=jnp.float32),
+            not train,
+            output_attentions,
+            output_hidden_states,
+            return_dict,
+            labels,
+            rngs=rngs,
+        )
+
+
+class FlaxDPTModule(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32  # the dtype of the computation
+    add_pooling_layer: bool = True
+
+    def setup(self):
+        self.embeddings = FlaxDPTEmbeddings(self.config, dtype=self.dtype)
+        self.encoder = FlaxDPTViTEncoder(self.config, dtype=self.dtype)
+        self.layernorm = nn.LayerNorm(epsilon=self.config.layer_norm_eps, dtype=self.dtype)
+        self.pooler = FlaxDPTViTPooler(self.config, dtype=self.dtype) if self.add_pooling_layer else None
+
+    def __call__(
+        self,
+        pixel_values,
+        deterministic: bool = True,
+        output_attentions: bool = False,
+        output_hidden_states: bool = False,
+        return_dict: bool = True,
+        labels: Optional[jnp.ndarray] = None,
+    ):
+
+        hidden_states = self.embeddings(pixel_values, deterministic=deterministic)
+
+        outputs = self.encoder(
+            hidden_states,
+            deterministic=deterministic,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+        hidden_states = outputs[0]
+        hidden_states = self.layernorm(hidden_states)
+        pooled = self.pooler(hidden_states) if self.add_pooling_layer else None
+
+        if not return_dict:
+            # if pooled is None, don't return it
+            if pooled is None:
+                return (hidden_states,) + outputs[1:]
+            return (hidden_states, pooled) + outputs[1:]
+
+        return FlaxBaseModelOutputWithPooling(
+            last_hidden_state=hidden_states,
+            pooler_output=pooled,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+
+
+@add_start_docstrings(
+    """
+    DPT Model with a semantic segmentation head on top e.g. for ADE20k, CityScapes.
+    """,
+    DPT_START_DOCSTRING,
+)
+class FlaxDPTModel(FlaxDPTPreTrainedModel):
+    module_class = FlaxDPTModule
+
+
+class FlaxDPTNeck(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32
+
+    def setup(self):
+        # postprocessing
+        self.reassemble_stage = FlaxDPTReassembleStage(self.config)
+        self.conv_list = [
+            nn.Conv(self.config.fusion_hidden_size, kernel_size=(3, 3), padding=1, use_bias=False)
+            for i in range(len(self.config.neck_hidden_sizes))
+        ]
+        # fusion
+        self.fusion_stage = FlaxDPTFeatureFusionStage(self.config)
+
+    def __call__(self, hidden_states):
+        if not isinstance(hidden_states, list):
+            raise ValueError("hidden_states should be a list of tensors")
+
+        if len(hidden_states) != len(self.config.neck_hidden_sizes):
+            raise ValueError("The number of hidden states should be equal to the number of neck hidden sizes.")
+
+        # postprocess hidden states
+        features = self.reassemble_stage(hidden_states)
+
+        features = [self.conv_list[i](feature) for i, feature in enumerate(features)]
+
+        # fusion blocks
+        output = self.fusion_stage(features)
+
+        return output
+
+
+class FlaxDPTUpsample(nn.Module):
+    scale: int = 2
+    method: str = "bilinear"
+
+    def setup(self):
+        pass
+
+    def __call__(self, x, output_size=None):
+        if output_size is None:
+            output_size = x.shape
+            output_size = (output_size[0], output_size[1] * self.scale, output_size[2] * self.scale, output_size[3])
+        return jax.image.resize(x, output_size, method="bilinear")
+
+
+class FlaxDPTDepthEstimationHead(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32
+
+    def setup(self):
+
+        features = self.config.fusion_hidden_size
+        self.head = nn.Sequential(
+            [
+                nn.Conv(features // 2, kernel_size=(3, 3), strides=(1, 1), padding=1),
+                FlaxDPTUpsample(scale=2, method="bilinear"),
+                nn.Conv(32, kernel_size=(3, 3), strides=(1, 1), padding=1),
+                ACT2FN["relu"],
+                nn.Conv(1, kernel_size=(1, 1), strides=(1, 1), padding=0),
+                ACT2FN["relu"],
+            ]
+        )
+
+    def __call__(self, hidden_states):
+        # use last features
+        hidden_states = hidden_states[self.config.head_in_index]
+
+        predicted_depth = self.head(hidden_states)
+
+        predicted_depth = jnp.squeeze(predicted_depth, -1)
+
+        return predicted_depth
+
+
+class FlaxDPTForDepthEstimationModule(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32
+
+    def setup(self):
+
+        self.dpt = FlaxDPTModule(self.config, add_pooling_layer=False)
+
+        # Neck
+        self.neck = FlaxDPTNeck(self.config)
+
+        # Depth estimation head
+        self.head = FlaxDPTDepthEstimationHead(self.config)
+
+    @add_start_docstrings_to_model_forward(DPT_INPUTS_DOCSTRING)
+    def __call__(
+        self,
+        pixel_values,
+        deterministic: bool = True,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+        labels=None,
+    ):
+        r"""
+        labels (`torch.LongTensor` of shape `(batch_size, height, width)`, *optional*):
+            Ground truth depth estimation maps for computing the loss.
+
+        Returns:
+
+        Examples:
+        ```python
+        >>> from transformers import DPTFeatureExtractor, DPTForDepthEstimation
+        >>> import torch
+        >>> import numpy as np
+        >>> from PIL import Image
+        >>> import requests
+
+        >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+        >>> image = Image.open(requests.get(url, stream=True).raw)
+
+        >>> feature_extractor = DPTFeatureExtractor.from_pretrained("Intel/dpt-large")
+        >>> model = DPTForDepthEstimation.from_pretrained("Intel/dpt-large")
+
+        >>> # prepare image for the model
+        >>> inputs = feature_extractor(images=image, return_tensors="pt")
+
+        >>> with torch.no_grad():
+        ...     outputs = model(**inputs)
+        ...     predicted_depth = outputs.predicted_depth
+
+        >>> # interpolate to original size
+        >>> prediction = torch.nn.functional.interpolate(
+        ...     predicted_depth.unsqueeze(1),
+        ...     size=image.size[::-1],
+        ...     mode="bicubic",
+        ...     align_corners=False,
+        ... )
+
+        >>> # visualize the prediction
+        >>> output = prediction.squeeze().cpu().numpy()
+        >>> formatted = (output * 255 / np.max(output)).astype("uint8")
+        >>> depth = Image.fromarray(formatted)
+        ```"""
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+
+        outputs = self.dpt(
+            pixel_values,
+            output_attentions=output_attentions,
+            output_hidden_states=True,  # we need the intermediate hidden states
+            return_dict=return_dict,
+        )
+
+        hidden_states = outputs.hidden_states if return_dict else outputs
+
+        # only keep certain features based on config.backbone_out_indices
+        # note that the hidden_states also include the initial embeddings
+        if return_dict:
+            hidden_states = [
+                feature for idx, feature in enumerate(hidden_states) if idx in self.config.backbone_out_indices
+            ]
+        else:
+            hidden_states = [
+                feature for idx, feature in enumerate(hidden_states[1]) if idx in self.config.backbone_out_indices
+            ]
+
+        hidden_states = self.neck(hidden_states)
+
+        predicted_depth = self.head(hidden_states)
+
+        loss = None
+        if labels is not None:
+            raise NotImplementedError("Training is not implemented yet")
+
+        if not return_dict:
+            if output_hidden_states:
+                output = (predicted_depth,) + outputs[1:]
+            else:
+                output = (predicted_depth,) + outputs[2:]
+            return ((loss,) + output) if loss is not None else output
+
+        return FlaxDepthEstimatorOutput(
+            loss=loss,
+            predicted_depth=predicted_depth,
+            hidden_states=outputs.hidden_states if output_hidden_states else None,
+            attentions=outputs.attentions,
+        )
+
+
+@add_start_docstrings(
+    """
+    DPT Model with a depth estimation head on top (consisting of 3 convolutional layers) e.g. for KITTI, NYUv2.
+    """,
+    DPT_START_DOCSTRING,
+)
+class FlaxDPTForDepthEstimation(FlaxDPTPreTrainedModel):
+    module_class = FlaxDPTForDepthEstimationModule
+
+
+class FlaxDPTSemanticSegmentationHead(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32
+
+    # TODO: Change this to make sure BatchNorm + Dropout work / Put them outside a Sequential Module
+    def setup(self):
+        features = self.config.fusion_hidden_size
+        self.head = nn.Sequential(
+            [
+                nn.Conv(features, kernel_size=(3, 3), padding=1),
+                # nn.BatchNorm(use_running_average=False),
+                ACT2FN["relu"],
+                # nn.Dropout(self.config.semantic_classifier_dropout, deterministic=False),
+                nn.Conv(self.config.num_labels, kernel_size=(1, 1)),
+                FlaxDPTUpsample(scale=2, method="bilinear"),
+            ]
+        )
+
+    def __call__(self, hidden_states):
+        # use last features
+        hidden_states = hidden_states[self.config.head_in_index]
+
+        logits = self.head(hidden_states)
+
+        return logits
+
+
+class FlaxDPTAuxiliaryHead(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32
+
+    # TODO: Change this to make sure BatchNorm + Dropout work / Put them outside a Sequential Module
+    def setup(self):
+        features = self.config.fusion_hidden_size
+        self.head = nn.Sequential(
+            [
+                nn.Conv(features, kernel_size=(3, 3), padding=1, use_bias=False),  # bias=False
+                # nn.BatchNorm(use_running_average=False),
+                ACT2FN["relu"],
+                # nn.Dropout(0.1, deterministic=False),
+                nn.Conv(self.config.num_labels, kernel_size=(1, 1)),
+            ]
+        )
+
+    def __call__(self, hidden_states):
+        logits = self.head(hidden_states)
+
+        return logits
+
+
+class FlaxDPTForSemanticSegmentationModule(nn.Module):
+    config: DPTConfig
+    dtype: jnp.dtype = jnp.float32
+
+    def setup(self):
+
+        self.dpt = FlaxDPTModule(self.config, add_pooling_layer=False)
+
+        # Neck
+        self.neck = FlaxDPTNeck(self.config)
+
+        # Segmentation head(s)
+        self.head = FlaxDPTSemanticSegmentationHead(self.config)
+        self.auxiliary_head = FlaxDPTAuxiliaryHead(self.config) if self.config.use_auxiliary_head else None
+
+        self.upsample = FlaxDPTUpsample(scale=2, method="bilinear")
+
+    @add_start_docstrings_to_model_forward(DPT_INPUTS_DOCSTRING)
+    def __call__(
+        self,
+        pixel_values=None,
+        deterministic: bool = True,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+        labels=None,
+    ):
+        r"""
+        labels (`torch.LongTensor` of shape `(batch_size, height, width)`, *optional*):
+            Ground truth semantic segmentation maps for computing the loss. Indices should be in `[0, ...,
+            config.num_labels - 1]`. If `config.num_labels > 1`, a classification loss is computed (Cross-Entropy).
+
+        Returns:
+
+        Examples:
+        ```python
+        >>> from transformers import DPTFeatureExtractor, DPTForSemanticSegmentation
+        >>> from PIL import Image
+        >>> import requests
+
+        >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+        >>> image = Image.open(requests.get(url, stream=True).raw)
+
+        >>> feature_extractor = DPTFeatureExtractor.from_pretrained("Intel/dpt-large-ade")
+        >>> model = DPTForSemanticSegmentation.from_pretrained("Intel/dpt-large-ade")
+
+        >>> inputs = feature_extractor(images=image, return_tensors="pt")
+
+        >>> outputs = model(**inputs)
+        >>> logits = outputs.logits
+        ```"""
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+
+        outputs = self.dpt(
+            pixel_values,
+            output_attentions=output_attentions,
+            output_hidden_states=True,  # we need the intermediate hidden states
+            return_dict=return_dict,
+        )
+
+        hidden_states = outputs.hidden_states if return_dict else outputs
+
+        # only keep certain features based on config.backbone_out_indices
+        # note that the hidden_states also include the initial embeddings
+        if return_dict:
+            hidden_states = [
+                feature for idx, feature in enumerate(hidden_states) if idx in self.config.backbone_out_indices
+            ]
+        else:
+            hidden_states = [
+                feature for idx, feature in enumerate(hidden_states[1]) if idx in self.config.backbone_out_indices
+            ]
+        hidden_states = self.neck(hidden_states)
+
+        logits = self.head(hidden_states)
+
+        auxiliary_logits = None
+        if self.auxiliary_head is not None:
+            auxiliary_logits = self.auxiliary_head(hidden_states[-1])
+
+        loss = None
+        if labels is not None:
+            if self.config.num_labels == 1:
+                raise ValueError("The number of labels should be greater than one")
+            else:
+                # upsample logits to the images' original size
+                output_shape = (logits.shape[0], labels.shape[1], labels.shape[2], logits.shape[3])
+                upsampled_logits = self.upsample(logits, output_shape)
+
+                if auxiliary_logits is not None:
+                    upsampled_auxiliary_logits = self.upsample(auxiliary_logits, output_shape)
+                # compute weighted loss
+                # Copied from: https://flax.readthedocs.io/en/latest/notebooks/annotated_mnist.html
+                labels_onehot = jax.nn.one_hot(labels, num_classes=self.config.num_labels)
+                main_loss = optax.softmax_cross_entropy(logits=upsampled_logits, labels=labels_onehot).mean()
+                auxiliary_loss = optax.softmax_cross_entropy(
+                    logits=upsampled_auxiliary_logits, labels=labels_onehot
+                ).mean()
+                loss = main_loss + self.config.auxiliary_loss_weight * auxiliary_loss
+
+        if not return_dict:
+            if output_hidden_states:
+                output = (logits,) + outputs[1:]
+            else:
+                output = (logits,) + outputs[2:]
+            return ((loss,) + output) if loss is not None else output
+
+        return FlaxSemanticSegmenterOutput(
+            loss=loss,
+            logits=logits,
+            hidden_states=outputs.hidden_states if output_hidden_states else None,
+            attentions=outputs.attentions,
+        )
+
+
+@add_start_docstrings(
+    """
+    DPT Model with a semantic segmentation head on top e.g. for ADE20k, CityScapes.
+    """,
+    DPT_START_DOCSTRING,
+)
+class FlaxDPTForSemanticSegmentation(FlaxDPTPreTrainedModel):
+    module_class = FlaxDPTForSemanticSegmentationModule

--- a/src/transformers/utils/dummy_flax_objects.py
+++ b/src/transformers/utils/dummy_flax_objects.py
@@ -592,6 +592,34 @@ class FlaxDistilBertPreTrainedModel(metaclass=DummyObject):
         requires_backends(self, ["flax"])
 
 
+class FlaxDPTForDepthEstimation(metaclass=DummyObject):
+    _backends = ["flax"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["flax"])
+
+
+class FlaxDPTForSemanticSegmentation(metaclass=DummyObject):
+    _backends = ["flax"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["flax"])
+
+
+class FlaxDPTModel(metaclass=DummyObject):
+    _backends = ["flax"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["flax"])
+
+
+class FlaxDPTPreTrainedModel(metaclass=DummyObject):
+    _backends = ["flax"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["flax"])
+
+
 class FlaxElectraForCausalLM(metaclass=DummyObject):
     _backends = ["flax"]
 

--- a/tests/models/dpt/test_modeling_flax_dpt.py
+++ b/tests/models/dpt/test_modeling_flax_dpt.py
@@ -20,7 +20,7 @@ import unittest
 import numpy as np
 
 from transformers import DPTConfig, is_flax_available
-from transformers.testing_utils import require_flax, slow, is_pt_flax_cross_test
+from transformers.testing_utils import is_pt_flax_cross_test, require_flax, slow
 
 from ...test_configuration_common import ConfigTester
 from ...test_modeling_flax_common import FlaxModelTesterMixin, floats_tensor, ids_tensor
@@ -141,15 +141,17 @@ class FlaxDPTModelTest(FlaxModelTesterMixin, unittest.TestCase):
     def test_config(self):
         self.config_tester.run_common_tests()
 
-
     @is_pt_flax_cross_test
     def test_equivalence_pt_to_flax(self):
-        import torch
-        import transformers
         import tempfile
-        import jax.numpy as jnp 
-        from transformers.testing_utils import torch_device
+
+        import torch
+
+        import jax.numpy as jnp
+        import transformers
         from transformers.modeling_flax_pytorch_utils import convert_pytorch_state_dict_to_flax
+        from transformers.testing_utils import torch_device
+
         # It might be better to put this inside the for loop below (because we modify the config there).
         # But logically, it is fine.
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
@@ -163,7 +165,7 @@ class FlaxDPTModelTest(FlaxModelTesterMixin, unittest.TestCase):
 
                 # prepare inputs
                 prepared_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
-                prepared_inputs_dict.pop('labels')
+                prepared_inputs_dict.pop("labels")
                 pt_inputs = {k: torch.tensor(v.tolist(), device=torch_device) for k, v in prepared_inputs_dict.items()}
 
                 # load corresponding PyTorch class
@@ -204,18 +206,17 @@ class FlaxDPTModelTest(FlaxModelTesterMixin, unittest.TestCase):
                 self.assertEqual(fx_keys, pt_keys)
                 self.check_outputs(fx_outputs_loaded.to_tuple(), pt_outputs.to_tuple(), model_class, names=fx_keys)
 
-
     @is_pt_flax_cross_test
     def test_equivalence_flax_to_pt(self):
-        import torch
-        import transformers
         import tempfile
-        import jax.numpy as jnp 
-        
+
+        import torch
+
+        import jax.numpy as jnp
+        import transformers
+        from transformers.modeling_flax_pytorch_utils import load_flax_weights_in_pytorch_model
         from transformers.testing_utils import torch_device
 
-        from transformers.modeling_flax_pytorch_utils import load_flax_weights_in_pytorch_model
-        
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         for model_class in self.all_model_classes:
@@ -227,9 +228,9 @@ class FlaxDPTModelTest(FlaxModelTesterMixin, unittest.TestCase):
 
                 # prepare inputs
                 prepared_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
-                prepared_inputs_dict.pop('labels')
+                prepared_inputs_dict.pop("labels")
                 pt_inputs = {k: torch.tensor(v.tolist(), device=torch_device) for k, v in prepared_inputs_dict.items()}
-            
+
                 # load corresponding PyTorch class
                 pt_model_class_name = model_class.__name__[4:]  # Skip the "Flax" at the beginning
                 pt_model_class = getattr(transformers, pt_model_class_name)
@@ -274,7 +275,6 @@ class FlaxDPTModelTest(FlaxModelTesterMixin, unittest.TestCase):
 
                 self.assertEqual(fx_keys, pt_keys)
                 self.check_outputs(fx_outputs.to_tuple(), pt_outputs_loaded.to_tuple(), model_class, names=fx_keys)
-
 
     # We neeed to override this test because ViT's forward signature is different than text models.
     def test_forward_signature(self):

--- a/tests/models/dpt/test_modeling_flax_dpt.py
+++ b/tests/models/dpt/test_modeling_flax_dpt.py
@@ -1,0 +1,187 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Testing suite for the Flax DPT model. """
+
+import inspect
+import unittest
+
+import numpy as np
+
+from transformers import DPTConfig, is_flax_available
+from transformers.testing_utils import require_flax, slow
+
+from ...test_configuration_common import ConfigTester
+from ...test_modeling_flax_common import FlaxModelTesterMixin, floats_tensor, ids_tensor
+
+
+if is_flax_available():
+
+    import jax
+    from transformers.models.dpt.modeling_flax_dpt import (
+        FlaxDPTForDepthEstimation,
+        FlaxDPTForSemanticSegmentation,
+        FlaxDPTModel,
+    )
+
+
+class FlaxDPTModelTester(unittest.TestCase):
+    def __init__(
+        self,
+        parent,
+        batch_size=2,
+        image_size=32,
+        patch_size=16,
+        num_channels=3,
+        is_training=True,
+        use_labels=False,
+        hidden_size=32,
+        num_hidden_layers=4,
+        backbone_out_indices=[0, 1, 2, 3],
+        num_attention_heads=4,
+        intermediate_size=37,
+        hidden_act="gelu",
+        hidden_dropout_prob=0.1,
+        attention_probs_dropout_prob=0.1,
+        initializer_range=0.02,
+        num_labels=3,
+        scope=None,
+    ):
+        self.parent = parent
+        self.batch_size = batch_size
+        self.image_size = image_size
+        self.patch_size = patch_size
+        self.num_channels = num_channels
+        self.is_training = is_training
+        self.use_labels = use_labels
+        self.hidden_size = hidden_size
+        self.num_hidden_layers = num_hidden_layers
+        self.backbone_out_indices = backbone_out_indices
+        self.num_attention_heads = num_attention_heads
+        self.intermediate_size = intermediate_size
+        self.hidden_act = hidden_act
+        self.hidden_dropout_prob = hidden_dropout_prob
+        self.attention_probs_dropout_prob = attention_probs_dropout_prob
+        self.initializer_range = initializer_range
+        self.num_labels = num_labels
+        self.scope = scope
+        # sequence length of DPT = num_patches + 1 (we add 1 for the [CLS] token)
+        num_patches = (image_size // patch_size) ** 2
+        self.seq_length = num_patches + 1
+
+    def prepare_config_and_inputs(self):
+        pixel_values = floats_tensor([self.batch_size, self.num_channels, self.image_size, self.image_size])
+
+        labels = None
+        if self.use_labels:
+            labels = ids_tensor([self.batch_size, self.image_size, self.image_size], self.num_labels)
+
+        config = DPTConfig(
+            image_size=self.image_size,
+            patch_size=self.patch_size,
+            num_channels=self.num_channels,
+            hidden_size=self.hidden_size,
+            num_hidden_layers=self.num_hidden_layers,
+            backbone_out_indices=self.backbone_out_indices,
+            num_attention_heads=self.num_attention_heads,
+            intermediate_size=self.intermediate_size,
+            hidden_act=self.hidden_act,
+            hidden_dropout_prob=self.hidden_dropout_prob,
+            attention_probs_dropout_prob=self.attention_probs_dropout_prob,
+            is_decoder=False,
+            initializer_range=self.initializer_range,
+        )
+
+        return config, pixel_values, labels
+
+    def create_and_check_model(self, config, pixel_values, labels):
+
+        model = FlaxDPTModel(config=config)
+        result = model(pixel_values)
+        # expected sequence length = num_patches + 1 (we add 1 for the [CLS] token)
+        image_size = (self.image_size, self.image_size)
+        patch_size = (self.patch_size, self.patch_size)
+        num_patches = (image_size[1] // patch_size[1]) * (image_size[0] // patch_size[0])
+        self.parent.assertEqual(result.last_hidden_state.shape, (self.batch_size, num_patches + 1, self.hidden_size))
+
+    def prepare_config_and_inputs_for_common(self):
+        config_and_inputs = self.prepare_config_and_inputs()
+        (
+            config,
+            pixel_values,
+            labels,
+        ) = config_and_inputs
+        inputs_dict = {"pixel_values": pixel_values, "labels": labels}
+        return config, inputs_dict
+
+
+@require_flax
+class FlaxViTModelTest(FlaxModelTesterMixin, unittest.TestCase):
+
+    all_model_classes = (
+        (FlaxDPTModel, FlaxDPTForSemanticSegmentation, FlaxDPTForDepthEstimation) if is_flax_available() else ()
+    )
+
+    def setUp(self) -> None:
+        self.model_tester = FlaxDPTModelTester(self)
+        self.config_tester = ConfigTester(self, config_class=DPTConfig, has_text_modality=False, hidden_size=37)
+
+    def test_config(self):
+        self.config_tester.run_common_tests()
+
+    # We neeed to override this test because ViT's forward signature is different than text models.
+    def test_forward_signature(self):
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            signature = inspect.signature(model.__call__)
+            # signature.parameters is an OrderedDict => so arg_names order is deterministic
+            arg_names = [*signature.parameters.keys()]
+
+            expected_arg_names = ["pixel_values"]
+            self.assertListEqual(arg_names[:1], expected_arg_names)
+
+    # We need to override this test because ViT expects pixel_values instead of input_ids
+    def test_jit_compilation(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            with self.subTest(model_class.__name__):
+                prepared_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
+                model = model_class(config)
+
+                @jax.jit
+                def model_jitted(pixel_values, **kwargs):
+                    return model(pixel_values=pixel_values, **kwargs)
+
+                with self.subTest("JIT Enabled"):
+                    jitted_outputs = model_jitted(**prepared_inputs_dict).to_tuple()
+
+                with self.subTest("JIT Disabled"):
+                    with jax.disable_jit():
+                        outputs = model_jitted(**prepared_inputs_dict).to_tuple()
+
+                self.assertEqual(len(outputs), len(jitted_outputs))
+                for jitted_output, output in zip(jitted_outputs, outputs):
+                    self.assertEqual(jitted_output.shape, output.shape)
+
+    @slow
+    def test_model_from_pretrained(self):
+        for model_class_name in self.all_model_classes:
+            model = model_class_name.from_pretrained("Intel/dpt-large", from_pt=True)
+            outputs = model(np.ones((1, 3, 384, 384)))
+            self.assertIsNotNone(outputs)
+
+    # TODO: add tests for segmentation and depth estimation (logits)

--- a/tests/models/dpt/test_modeling_flax_dpt.py
+++ b/tests/models/dpt/test_modeling_flax_dpt.py
@@ -127,7 +127,7 @@ class FlaxDPTModelTester(unittest.TestCase):
 
 
 @require_flax
-class FlaxViTModelTest(FlaxModelTesterMixin, unittest.TestCase):
+class FlaxDPTModelTest(FlaxModelTesterMixin, unittest.TestCase):
 
     all_model_classes = (
         (FlaxDPTModel, FlaxDPTForSemanticSegmentation, FlaxDPTForDepthEstimation) if is_flax_available() else ()

--- a/tests/models/dpt/test_modeling_flax_dpt.py
+++ b/tests/models/dpt/test_modeling_flax_dpt.py
@@ -20,7 +20,7 @@ import unittest
 import numpy as np
 
 from transformers import DPTConfig, is_flax_available
-from transformers.testing_utils import require_flax, slow
+from transformers.testing_utils import require_flax, slow, is_pt_flax_cross_test
 
 from ...test_configuration_common import ConfigTester
 from ...test_modeling_flax_common import FlaxModelTesterMixin, floats_tensor, ids_tensor
@@ -84,6 +84,7 @@ class FlaxDPTModelTester(unittest.TestCase):
         pixel_values = floats_tensor([self.batch_size, self.num_channels, self.image_size, self.image_size])
 
         labels = None
+
         if self.use_labels:
             labels = ids_tensor([self.batch_size, self.image_size, self.image_size], self.num_labels)
 
@@ -139,6 +140,141 @@ class FlaxDPTModelTest(FlaxModelTesterMixin, unittest.TestCase):
 
     def test_config(self):
         self.config_tester.run_common_tests()
+
+
+    @is_pt_flax_cross_test
+    def test_equivalence_pt_to_flax(self):
+        import torch
+        import transformers
+        import tempfile
+        import jax.numpy as jnp 
+        from transformers.testing_utils import torch_device
+        from transformers.modeling_flax_pytorch_utils import convert_pytorch_state_dict_to_flax
+        # It might be better to put this inside the for loop below (because we modify the config there).
+        # But logically, it is fine.
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            with self.subTest(model_class.__name__):
+
+                # Output all for aggressive testing
+                config.output_hidden_states = True
+                config.output_attentions = self.has_attentions
+
+                # prepare inputs
+                prepared_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
+                prepared_inputs_dict.pop('labels')
+                pt_inputs = {k: torch.tensor(v.tolist(), device=torch_device) for k, v in prepared_inputs_dict.items()}
+
+                # load corresponding PyTorch class
+                pt_model_class_name = model_class.__name__[4:]  # Skip the "Flax" at the beginning
+                pt_model_class = getattr(transformers, pt_model_class_name)
+
+                pt_model = pt_model_class(config).eval()
+                # Flax models don't use the `use_cache` option and cache is not returned as a default.
+                # So we disable `use_cache` here for PyTorch model.
+                pt_model.config.use_cache = False
+                fx_model = model_class(config, dtype=jnp.float32)
+
+                fx_state = convert_pytorch_state_dict_to_flax(pt_model.state_dict(), fx_model)
+                fx_model.params = fx_state
+
+                # send pytorch model to the correct device
+                pt_model.to(torch_device)
+
+                with torch.no_grad():
+                    pt_outputs = pt_model(**pt_inputs)
+                fx_outputs = fx_model(**prepared_inputs_dict)
+
+                fx_keys = tuple([k for k, v in fx_outputs.items() if v is not None])
+                pt_keys = tuple([k for k, v in pt_outputs.items() if v is not None])
+
+                self.assertEqual(fx_keys, pt_keys)
+                self.check_outputs(fx_outputs.to_tuple(), pt_outputs.to_tuple(), model_class, names=fx_keys)
+
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    pt_model.save_pretrained(tmpdirname)
+                    fx_model_loaded = model_class.from_pretrained(tmpdirname, from_pt=True)
+
+                fx_outputs_loaded = fx_model_loaded(**prepared_inputs_dict)
+
+                fx_keys = tuple([k for k, v in fx_outputs_loaded.items() if v is not None])
+                pt_keys = tuple([k for k, v in pt_outputs.items() if v is not None])
+
+                self.assertEqual(fx_keys, pt_keys)
+                self.check_outputs(fx_outputs_loaded.to_tuple(), pt_outputs.to_tuple(), model_class, names=fx_keys)
+
+
+    @is_pt_flax_cross_test
+    def test_equivalence_flax_to_pt(self):
+        import torch
+        import transformers
+        import tempfile
+        import jax.numpy as jnp 
+        
+        from transformers.testing_utils import torch_device
+
+        from transformers.modeling_flax_pytorch_utils import load_flax_weights_in_pytorch_model
+        
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            with self.subTest(model_class.__name__):
+
+                # Output all for aggressive testing
+                config.output_hidden_states = True
+                config.output_attentions = self.has_attentions
+
+                # prepare inputs
+                prepared_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
+                prepared_inputs_dict.pop('labels')
+                pt_inputs = {k: torch.tensor(v.tolist(), device=torch_device) for k, v in prepared_inputs_dict.items()}
+            
+                # load corresponding PyTorch class
+                pt_model_class_name = model_class.__name__[4:]  # Skip the "Flax" at the beginning
+                pt_model_class = getattr(transformers, pt_model_class_name)
+
+                pt_model = pt_model_class(config).eval()
+                # Flax models don't use the `use_cache` option and cache is not returned as a default.
+                # So we disable `use_cache` here for PyTorch model.
+                pt_model.config.use_cache = False
+                fx_model = model_class(config, dtype=jnp.float32)
+
+                pt_model = load_flax_weights_in_pytorch_model(pt_model, fx_model.params)
+
+                # make sure weights are tied in PyTorch
+                pt_model.tie_weights()
+
+                # send pytorch model to the correct device
+                pt_model.to(torch_device)
+
+                with torch.no_grad():
+                    pt_outputs = pt_model(**pt_inputs)
+                fx_outputs = fx_model(**prepared_inputs_dict)
+
+                fx_keys = tuple([k for k, v in fx_outputs.items() if v is not None])
+                pt_keys = tuple([k for k, v in pt_outputs.items() if v is not None])
+
+                self.assertEqual(fx_keys, pt_keys)
+                self.check_outputs(fx_outputs.to_tuple(), pt_outputs.to_tuple(), model_class, names=fx_keys)
+
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    fx_model.save_pretrained(tmpdirname)
+                    pt_model_loaded = pt_model_class.from_pretrained(tmpdirname, from_flax=True)
+
+                # send pytorch model to the correct device
+                pt_model_loaded.to(torch_device)
+                pt_model_loaded.eval()
+
+                with torch.no_grad():
+                    pt_outputs_loaded = pt_model_loaded(**pt_inputs)
+
+                fx_keys = tuple([k for k, v in fx_outputs.items() if v is not None])
+                pt_keys = tuple([k for k, v in pt_outputs_loaded.items() if v is not None])
+
+                self.assertEqual(fx_keys, pt_keys)
+                self.check_outputs(fx_outputs.to_tuple(), pt_outputs_loaded.to_tuple(), model_class, names=fx_keys)
+
 
     # We neeed to override this test because ViT's forward signature is different than text models.
     def test_forward_signature(self):

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -147,6 +147,8 @@ IGNORE_NON_AUTO_CONFIGURED = PRIVATE_MODELS.copy() + [
     "FlaxCLIPTextModel",
     "FlaxCLIPVisionModel",
     "FlaxWav2Vec2ForCTC",
+    "FlaxDPTForSemanticSegmentation",
+    "FlaxDPTForDepthEstimation",
     "DetrForSegmentation",
     "DPRReader",
     "FlaubertForQuestionAnswering",


### PR DESCRIPTION
# What does this PR do?

I tried to implement DPT (Dense Prediction with Transformers) in Flax during my free time! 🚀 
By the way it is the first Segmentation and Depth Estimation model implemented in Flax!

Nits/TODOs:
- [x] Figure out how to properly call `BatchNorm` and `Dropout` inside a `Sequential` 
- [ ] Test equivalency tests 
- [ ] Write documentation - For now they're just copy/pasted
Quetions:
- Why the loss is not implemented in `modeling_dpt.py` ? I can probably help on that since I have already implemented the loss for a university project: https://github.com/antocad/FocusOnDepth/blob/master/FOD/Loss.py 
 
cc @NielsRogge @sanchit-gandhi @patil-suraj 