### PR TITLE
For model long-t5-tglobal-x, fix 'float' object cannot be interpreted as an integer

### DIFF
--- a/src/transformers/models/longt5/modeling_longt5.py
+++ b/src/transformers/models/longt5/modeling_longt5.py
@@ -177,7 +177,7 @@ def _make_global_fixed_block_ids(
     fixed_block_mask = torch.cumsum(fixed_block_mask, axis=1) - fixed_block_mask
     mask = torch.where(attention_mask != 0.0, 1.0, -1000.0).type(attention_mask.dtype)
     global_block_ids = torch.floor(mask + fixed_block_mask - 1.0).type(attention_mask.dtype)
-    _global_block_ids_lower_bound = torch.tensor(-1.0, dtype=global_block_ids.dtype, device=global_block_ids.device)
+    _global_block_ids_lower_bound = torch.tensor(-1, dtype=global_block_ids.dtype, device=global_block_ids.device)
     global_block_ids = torch.where(
         global_block_ids > _global_block_ids_lower_bound, global_block_ids, _global_block_ids_lower_bound
     )


### PR DESCRIPTION
On line 180, `torch.tensor(-1.0, dtype=global_block_ids.dtype)` gives the error __TypeError: 'float' object cannot be interpreted as an integer__ .  This is because the dtype here is `int64`.  For `dtype=int64`, this needs to simply be `-1`.  

This impacts the `long-t5-tglogbal-x` model.  It does not impact the `long-t5-local-x` version which does not appear to call this line in the code.

The torch version where I see this is 1.11.0+cu113.  I'm not certain if older, or non-gpu versions of torch allowed this but 1.11.0+cu113 does not.

Note that torch does not complain when casting an int to a float so it should be safe to change this to `-1` even if there are occasions where `global_block_ids.dtype` is a float.

# What does this PR do?

Fixes # (no issue # created). 
There is a simple error in the code where torch fails when trying to create a constant int64 tensor using `-1.0` instead of `-1`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
This model is new.  I would suggest someone from the original upload team review this.  Here are the first 3 in the file history.. 
@stancld, @PhungVanDuy, @sgugger

