### PR TITLE
Fix artifact path for cuda extension test in push CI

### DIFF
--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -353,14 +353,14 @@ jobs:
       - name: Failure short reports
         if: ${{ failure() }}
         continue-on-error: true
-        run: cat reports/${{ matrix.machine_type }}_tests_torch_cuda_extensions_gpu/failures_short.txt
+        run: cat /workspace/transformers/reports/${{ matrix.machine_type }}_tests_torch_cuda_extensions_gpu/failures_short.txt
 
       - name: Test suite reports artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.machine_type }}_run_tests_torch_cuda_extensions_gpu_test_reports
-          path: reports/${{ matrix.machine_type }}_tests_torch_cuda_extensions_gpu
+          path: /workspace/transformers/reports/${{ matrix.machine_type }}_tests_torch_cuda_extensions_gpu
 
   run_tests_torch_cuda_extensions_multi_gpu:
     name: Torch CUDA extension tests


### PR DESCRIPTION
# What does this PR do?

Fix artifact path for cuda extension test in push CI

### More details
In #17335, `working-director` is updated (a fix) for (single-gpu) cuda extension test, but the artifact path was not updated, which leads to strange slack report.

```bash
      - name: Run all non-slow selected tests on GPU
        working-directory: /workspace/transformers
        ...
```