### PR TITLE
Properly check for a TPU device in is_torch_tpu_available

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -399,12 +399,16 @@ def is_ftfy_available():
 def is_torch_tpu_available():
     if not _torch_available:
         return False
-    # This test is probably enough, but just in case, we unpack a bit.
     if importlib.util.find_spec("torch_xla") is None:
         return False
-    if importlib.util.find_spec("torch_xla.core") is None:
+    import torch_xla.core.xla_model as xm
+
+    # We need to check if `xla_device` can be found, will raise a RuntimeError if not
+    try:
+        xm.xla_device()
+        return True
+    except RuntimeError:
         return False
-    return importlib.util.find_spec("torch_xla.core.xla_model") is not None
 
 
 def is_torchdynamo_available():


### PR DESCRIPTION
# What does this PR do?

This PR adds a better check to see if a TPU is available in the environment when checking `is_torch_tpu_available` by adding a quick import check for `xm.tpu_device()`. This raises a `RuntimeError` if a TPU device is not found. 

Mimics solution in https://github.com/huggingface/accelerate/pull/456

Fixes # (issue)
https://github.com/huggingface/transformers/issues/17752

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger 