### PR TITLE
Fix test for BF16 detection

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1042,7 +1042,7 @@ class TrainingArguments:
             if self.no_cuda and not is_torch_bf16_cpu_available():
                 # cpu
                 raise ValueError("Your setup doesn't support bf16/cpu. You need torch>=1.10")
-            elif not is_torch_bf16_gpu_available():
+            elif not self.no_cuda and not is_torch_bf16_gpu_available():
                 # gpu
                 raise ValueError(
                     "Your setup doesn't support bf16/gpu. You need torch>=1.10, using Ampere GPU with cuda>=11.0"


### PR DESCRIPTION
# What does this PR do?

When `no_cuda=True`, we shouldn't try to detect the support for BF16 GPU.