### PR TITLE
Fix broken test for models with batchnorm

### DIFF
--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1386,7 +1386,8 @@ class TFModelTesterMixin:
                 model(model.dummy_inputs)  # Build the model so we can get some constant weights
                 model_weights = model.get_weights()
 
-                model.compile(optimizer=tf.keras.optimizers.SGD(0.0), metrics=metrics)
+                # Run eagerly to save some expensive compilation times
+                model.compile(optimizer=tf.keras.optimizers.SGD(0.0), run_eagerly=True, metrics=metrics)
                 # Make sure the model fits without crashing regardless of where we pass the labels
                 history1 = model.fit(
                     prepared_for_class,


### PR DESCRIPTION
One of the Keras tests assumed that fitting a model for one iteration with a learning rate of zero would not change any weights. This is not true for `BatchNorm`, which updates its running means and variances regardless! As a result, the model after the iteration had slightly different outputs, which caused the test to be very flaky. We now reinitialize the model after the single training epoch to make sure this doesn't happen.