### PR TITLE
Fix FlaxBigBirdEmbeddings

### DIFF
--- a/src/transformers/models/big_bird/modeling_flax_big_bird.py
+++ b/src/transformers/models/big_bird/modeling_flax_big_bird.py
@@ -229,8 +229,8 @@ class FlaxBigBirdEmbeddings(nn.Module):
         hidden_states = inputs_embeds + token_type_embeddings + position_embeds
 
         # Layer Norm
-        hidden_states = self.LayerNorm(hidden_states)
         hidden_states = self.dropout(hidden_states, deterministic=deterministic)
+        hidden_states = self.LayerNorm(hidden_states)
         return hidden_states
 
 


### PR DESCRIPTION
# What does this PR do?

Current `FlaxBigBirdEmbeddings` applies layer norm before dropout, while `BigBirdEmbeddings` and Google's original `BigBird`
applies dropout first. This PR fixes this inconsistency.

Flax
(layernorm --> dropout)

https://github.com/huggingface/transformers/blob/6f29029b05df221c0c37fd2e87aeadc9cb6ce5d7/src/transformers/models/big_bird/modeling_flax_big_bird.py#L232-L233

PyTorch
(dropout immediately after embedding)
https://github.com/huggingface/transformers/blob/6f29029b05df221c0c37fd2e87aeadc9cb6ce5d7/src/transformers/models/big_bird/modeling_big_bird.py#L311-L312

Google
(dropout immediately after embedding)
https://github.com/google-research/bigbird/blob/5f2a5aa7fbab23e32e0e0b41c5f0192f0c023e05/bigbird/core/utils.py#L565-L566