### PR TITLE
Fix Maskformer test

### DIFF
--- a/tests/models/maskformer/test_modeling_maskformer.py
+++ b/tests/models/maskformer/test_modeling_maskformer.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from tests.test_modeling_common import floats_tensor
 from transformers import DetrConfig, MaskFormerConfig, SwinConfig, is_torch_available, is_vision_available
-from transformers.testing_utils import require_torch, require_vision, slow, torch_device
+from transformers.testing_utils import require_torch, require_torch_multi_gpu, require_vision, slow, torch_device
 from transformers.utils import cached_property
 
 from ...test_configuration_common import ConfigTester
@@ -210,6 +210,13 @@ class MaskFormerModelTest(ModelTesterMixin, unittest.TestCase):
 
     @unittest.skip(reason="MaskFormer does not use token embeddings")
     def test_resize_tokens_embeddings(self):
+        pass
+
+    @require_torch_multi_gpu
+    @unittest.skip(
+        reason="MaskFormer has some layers using `add_module` which doesn't work well with `nn.DataParallel`"
+    )
+    def test_multi_gpu_data_parallel_forward(self):
         pass
 
     def test_forward_signature(self):


### PR DESCRIPTION
# What does this PR do?

Fix Maskformer test `test_multi_gpu_data_parallel_forward`.

Ignore the test, as the original workaround will break current checkpoints.

------
Original Attempt

I know we probably want to avoid using `nn.DataParallel(model)`. But before doing so, I just tried my best to fix tests.
After spending some time debugging, I find using `add_module` instead of `nn.Sequential` causing problems.

I am not sure if the change in this PR is what we prefer though.

@NielsRogge Is there any reason to use `add_module`? I don't know if the comment regarding `Provide backwards compatibility ...` is really necessary.

https://github.com/huggingface/transformers/blob/d88719581b34f301edcc7772d927d8a3e3a77af6/src/transformers/models/maskformer/modeling_maskformer.py#L1986