### PR TITLE
Fix add new model like frameworks

### DIFF
--- a/src/transformers/commands/add_new_model_like.py
+++ b/src/transformers/commands/add_new_model_like.py
@@ -844,14 +844,23 @@ def add_model_to_main_init(
     new_lines = []
     framework = None
     while idx < len(lines):
+        new_framework = False
         if not is_empty_line(lines[idx]) and find_indent(lines[idx]) == 0:
             framework = None
         elif lines[idx].lstrip().startswith("if not is_torch_available"):
             framework = "pt"
+            new_framework = True
         elif lines[idx].lstrip().startswith("if not is_tf_available"):
             framework = "tf"
+            new_framework = True
         elif lines[idx].lstrip().startswith("if not is_flax_available"):
             framework = "flax"
+            new_framework = True
+
+        if new_framework:
+            # For a new framework, we need to skip until the else: block to get where the imports are.
+            while lines[idx].strip() != "else:":
+                idx += 1
 
         # Skip if we are in a framework not wanted.
         if framework is not None and frameworks is not None and framework not in frameworks:

--- a/src/transformers/commands/add_new_model_like.py
+++ b/src/transformers/commands/add_new_model_like.py
@@ -860,6 +860,7 @@ def add_model_to_main_init(
         if new_framework:
             # For a new framework, we need to skip until the else: block to get where the imports are.
             while lines[idx].strip() != "else:":
+                new_lines.append(lines[idx])
                 idx += 1
 
         # Skip if we are in a framework not wanted.


### PR DESCRIPTION
# What does this PR do?

 When selecting specific frameworks with `transformers-cli add-new-model-like`, all objects are still added to the main init. This is due to the change in all our inits and the command not being properly adapted.

This PR will fix it!