### PR TITLE
[CodeGen] support device_map="auto" for sharded checkpoints

### DIFF
--- a/src/transformers/models/codegen/modeling_codegen.py
+++ b/src/transformers/models/codegen/modeling_codegen.py
@@ -332,6 +332,7 @@ class CodeGenPreTrainedModel(PreTrainedModel):
     config_class = CodeGenConfig
     base_model_prefix = "transformer"
     supports_gradient_checkpointing = True
+    _no_split_modules = ["CodeGenBlock"]
 
     def __init__(self, *inputs, **kwargs):
         super().__init__(*inputs, **kwargs)


### PR DESCRIPTION
# What does this PR do?

This PR adds the `_no_split_modules` attribute in `CodeGenPreTrainedModel` to be able to load the sharded checkpoint with `device_map="auto"`

cc @rooa 