### PR TITLE
Fix test_inference_instance_segmentation_head

### DIFF
--- a/tests/models/maskformer/test_modeling_maskformer.py
+++ b/tests/models/maskformer/test_modeling_maskformer.py
@@ -380,9 +380,12 @@ class MaskFormerModelIntegrationTest(unittest.TestCase):
         self.assertEqual(
             masks_queries_logits.shape, (1, model.config.num_queries, inputs_shape[-2] // 4, inputs_shape[-1] // 4)
         )
-        expected_slice = torch.tensor(
-            [[-1.3738, -1.7725, -1.9365], [-1.5978, -1.9869, -2.1524], [-1.5796, -1.9271, -2.0940]]
-        ).to(torch_device)
+        expected_slice = [
+            [-1.3737124, -1.7724937, -1.9364233],
+            [-1.5977281, -1.9867939, -2.1523695],
+            [-1.5795398, -1.9269832, -2.093942],
+        ]
+        expected_slice = torch.tensor(expected_slice).to(torch_device)
         self.assertTrue(torch.allclose(masks_queries_logits[0, 0, :3, :3], expected_slice, atol=TOLERANCE))
         # class_queries_logits
         class_queries_logits = outputs.class_queries_logits


### PR DESCRIPTION
# What does this PR do?

Current `test_inference_instance_segmentation_head` (in `MaskFormerModelIntegrationTest`) failed in CI.
The expected slice 
```python
[[-1.3738, -1.7725, -1.9365], [-1.5978, -1.9869, -2.1524], [-1.5796, -1.9271, -2.0940]]
```
has precision `4` and `atol` argument (`TOLERANCE`) is also `1e-4`, which makes the difference at the boundary. This is **likely** the cause of test failures. Give more precision for the expected values should fix the issue.

```bash
(Pdb) diff1 # (with original expected values)
0.0001039505
(Pdb) diff2 # (with more precision)
1.4066696e-05
```

(However, I am not able to get the test failure with the original setting, launched manually in a GCP VM.)