### PR TITLE
Fix bug in gpt2's (from-scratch) special scaled weight initialization 

### DIFF
--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -484,7 +484,7 @@ class GPT2PreTrainedModel(PreTrainedModel):
         #
         # Reference (Megatron-LM): https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/model/gpt_model.py
         for name, p in module.named_parameters():
-            if "c_proj" in name and "weight" in name:
+            if name == 'c_proj.weight':
                 # Special Scaled Initialization --> There are 2 Layer Norms per Transformer Block
                 p.data.normal_(mean=0.0, std=(self.config.initializer_range / math.sqrt(2 * self.config.n_layer)))
 

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -484,7 +484,7 @@ class GPT2PreTrainedModel(PreTrainedModel):
         #
         # Reference (Megatron-LM): https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/model/gpt_model.py
         for name, p in module.named_parameters():
-            if name == 'c_proj.weight':
+            if name == "c_proj.weight":
                 # Special Scaled Initialization --> There are 2 Layer Norms per Transformer Block
                 p.data.normal_(mean=0.0, std=(self.config.initializer_range / math.sqrt(2 * self.config.n_layer)))
 


### PR DESCRIPTION

I randomly noticed a minor bug in the (from-scratch) weight initialization of gpt2, where the same tensor gets re-initialized over and over many times. I don't believe the significantly more common `from_pretrained` is impacted. The original discussion and explanation is here https://github.com/huggingface/transformers/pull/13573#discussion_r906288955 . 

The simplest reproduction is 

```python
from transformers import GPT2Model, GPT2Config
configuration = GPT2Config()
model = GPT2Model(configuration)
```

Then if you insert `print(id(p), name)` inside the if statement you'll see 4 inits of the same tensor, at each layer of the onion, e.g.:

```
139851709684832 c_proj.weight
139851709684832 attn.c_proj.weight
139851709684832 0.attn.c_proj.weight
139851709684832 h.0.attn.c_proj.weight
```

I verified that original code triggers the `if` statement 96 times, while this version triggers it 24 times, which is correct for a 12-layer model. I also ran `pytest tests/models/gpt2/test_modeling_gpt2.py`, without issues. The code is still not super satisfying (e.g. there is still one layer of overwriting present due the init in code block above, it only happens in the right order because of the way `self.apply` iterates depth-first over children, and we're "hard-coding" variable names present in different modules all the way up, but fixing this would be a bit bigger refactor.

cc potential gpt2 reviewers @patrickvonplaten, @LysandreJik and @sgugger, @siddk  from original thread