### PR TITLE
Update expected values in constrained beam search tests

### DIFF
--- a/tests/generation/test_generation_utils.py
+++ b/tests/generation/test_generation_utils.py
@@ -2509,9 +2509,13 @@ class GenerationIntegrationTests(unittest.TestCase):
 
         self.assertListEqual(
             generated_text,
+            # [
+            #     "The soldiers were not prepared and didn't know how big the big weapons would be, so they scared them"
+            #     " off. They had no idea what to do",
+            # ],
             [
-                "The soldiers were not prepared and didn't know how big the big weapons would be, so they scared them"
-                " off. They had no idea what to do",
+                "The soldiers were not prepared and didn't know what to do. They had no idea how they would react if"
+                " the enemy attacked them, big weapons scared"
             ],
         )
 
@@ -2548,9 +2552,13 @@ class GenerationIntegrationTests(unittest.TestCase):
 
         self.assertListEqual(
             generated_text,
+            # [
+            #     "The soldiers, who were all scared and screaming at each other as they tried to get out of the",
+            #     "The child was taken to a local hospital where she screamed and scared for her life, police said.",
+            # ],
             [
-                "The soldiers, who were all scared and screaming at each other as they tried to get out of the",
-                "The child was taken to a local hospital where she screamed and scared for her life, police said.",
+                "The soldiers, who had been stationed at the base for more than a year before being evacuated screaming scared",
+                "The child was taken to a local hospital where he died.\n 'I don't think screaming scared",
             ],
         )
 
@@ -2584,9 +2592,13 @@ class GenerationIntegrationTests(unittest.TestCase):
 
         self.assertListEqual(
             generated_text,
+            # [
+            #     "The soldiers, who were all scared and screaming at each other as they tried to get out of the",
+            #     "The child was taken to a local hospital where she screamed and scared for her life, police said.",
+            # ],
             [
-                "The soldiers, who were all scared and screaming at each other as they tried to get out of the",
-                "The child was taken to a local hospital where she screamed and scared for her life, police said.",
+                "The soldiers, who had been stationed at the base for more than a year before being evacuated screaming scared",
+                "The child was taken to a local hospital where he died.\n 'I don't think screaming scared",
             ],
         )
 
@@ -2612,7 +2624,7 @@ class GenerationIntegrationTests(unittest.TestCase):
 
         outputs = tokenizer.batch_decode(outputs, skip_special_tokens=True)
 
-        self.assertListEqual(outputs, ["Wie alter sind Sie?"])
+        self.assertListEqual(outputs, ["Wie alt sind Sie?"])
 
     @slow
     def test_constrained_beam_search_example_integration(self):
@@ -2656,7 +2668,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         )
         outputs = tokenizer.batch_decode(outputs, skip_special_tokens=True)
 
-        self.assertListEqual(outputs, ["Wie alter sind Sie?"])
+        self.assertListEqual(outputs, ["Wie alt sind Sie?"])
 
     def test_constrained_beam_search_mixin_type_checks(self):
         tokenizer = AutoTokenizer.from_pretrained("patrickvonplaten/t5-tiny-random")

--- a/tests/generation/test_generation_utils.py
+++ b/tests/generation/test_generation_utils.py
@@ -2509,10 +2509,6 @@ class GenerationIntegrationTests(unittest.TestCase):
 
         self.assertListEqual(
             generated_text,
-            # [
-            #     "The soldiers were not prepared and didn't know how big the big weapons would be, so they scared them"
-            #     " off. They had no idea what to do",
-            # ],
             [
                 "The soldiers were not prepared and didn't know what to do. They had no idea how they would react if"
                 " the enemy attacked them, big weapons scared"
@@ -2552,10 +2548,6 @@ class GenerationIntegrationTests(unittest.TestCase):
 
         self.assertListEqual(
             generated_text,
-            # [
-            #     "The soldiers, who were all scared and screaming at each other as they tried to get out of the",
-            #     "The child was taken to a local hospital where she screamed and scared for her life, police said.",
-            # ],
             [
                 "The soldiers, who had been stationed at the base for more than a year before being evacuated"
                 " screaming scared",
@@ -2593,10 +2585,6 @@ class GenerationIntegrationTests(unittest.TestCase):
 
         self.assertListEqual(
             generated_text,
-            # [
-            #     "The soldiers, who were all scared and screaming at each other as they tried to get out of the",
-            #     "The child was taken to a local hospital where she screamed and scared for her life, police said.",
-            # ],
             [
                 "The soldiers, who had been stationed at the base for more than a year before being evacuated"
                 " screaming scared",

--- a/tests/generation/test_generation_utils.py
+++ b/tests/generation/test_generation_utils.py
@@ -2557,7 +2557,8 @@ class GenerationIntegrationTests(unittest.TestCase):
             #     "The child was taken to a local hospital where she screamed and scared for her life, police said.",
             # ],
             [
-                "The soldiers, who had been stationed at the base for more than a year before being evacuated screaming scared",
+                "The soldiers, who had been stationed at the base for more than a year before being evacuated"
+                " screaming scared",
                 "The child was taken to a local hospital where he died.\n 'I don't think screaming scared",
             ],
         )
@@ -2597,7 +2598,8 @@ class GenerationIntegrationTests(unittest.TestCase):
             #     "The child was taken to a local hospital where she screamed and scared for her life, police said.",
             # ],
             [
-                "The soldiers, who had been stationed at the base for more than a year before being evacuated screaming scared",
+                "The soldiers, who had been stationed at the base for more than a year before being evacuated"
+                " screaming scared",
                 "The child was taken to a local hospital where he died.\n 'I don't think screaming scared",
             ],
         )


### PR DESCRIPTION
# What does this PR do?

Update expected values in constrained beam search tests.

#17814 changed `generation_utils.py` which gives new expected values in the test.

(otherwise test failed - as in the current CI report)