### PR TITLE
Fix `test_number_of_steps_in_training_with_ipex`

### DIFF
--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -649,14 +649,14 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             # Regular training has n_epochs * len(train_dl) steps
             trainer = get_regression_trainer(learning_rate=0.1, use_ipex=True, bf16=mix_bf16, no_cuda=True)
             train_output = trainer.train()
-            self.assertEqual(train_output.global_step, self.n_epochs * 64 / self.batch_size)
+            self.assertEqual(train_output.global_step, self.n_epochs * 64 / trainer.args.train_batch_size)
 
             # Check passing num_train_epochs works (and a float version too):
             trainer = get_regression_trainer(
                 learning_rate=0.1, num_train_epochs=1.5, use_ipex=True, bf16=mix_bf16, no_cuda=True
             )
             train_output = trainer.train()
-            self.assertEqual(train_output.global_step, int(1.5 * 64 / self.batch_size))
+            self.assertEqual(train_output.global_step, int(1.5 * 64 / trainer.args.train_batch_size))
 
             # If we pass a max_steps, num_train_epochs is ignored
             trainer = get_regression_trainer(


### PR DESCRIPTION
# What does this PR do?

Fix `test_number_of_steps_in_training_with_ipex`.

## Details
This test uses `no_cuda=True`, which will change `n_gpu` to `0` (see `_setup_devices`), and `train_batch_size` will be `8` (with the default training args). However this line
https://github.com/huggingface/transformers/blob/93f48da2740ab69fd14e6bbb38d53c87b4809eda/tests/trainer/test_trainer.py#L590
is computed (earlier) with GPUs, and therefore the (total) batch size is `16` when 2 GPUs is available.

This cause the following error.

#### Currently test error
```bash
tests/trainer/test_trainer.py::TrainerIntegrationTest::test_number_of_steps_in_training_with_ipex
(line 652)  AssertionError: 24 != 12.0
```