### PR TITLE
Ignore `test_multi_gpu_data_parallel_forward` for `LayoutLMV2`

### DIFF
--- a/tests/models/layoutlmv2/test_modeling_layoutlmv2.py
+++ b/tests/models/layoutlmv2/test_modeling_layoutlmv2.py
@@ -20,7 +20,7 @@ import random
 import tempfile
 import unittest
 
-from transformers.testing_utils import require_detectron2, require_torch, slow, torch_device
+from transformers.testing_utils import require_detectron2, require_torch, require_torch_multi_gpu, slow, torch_device
 from transformers.utils import is_detectron2_available, is_torch_available
 
 from ...test_configuration_common import ConfigTester
@@ -284,6 +284,16 @@ class LayoutLMv2ModelTest(ModelTesterMixin, unittest.TestCase):
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
+
+    @require_torch_multi_gpu
+    @unittest.skip(
+        reason=(
+            "LayoutLMV2 and its dependency `detectron2` have some layers using `add_module` which doesn't work well"
+            " with `nn.DataParallel`"
+        )
+    )
+    def test_multi_gpu_data_parallel_forward(self):
+        pass
 
     def test_model_various_embeddings(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()


### PR DESCRIPTION
# What does this PR do?

Ignore test_multi_gpu_data_parallel_forward for LayoutLMV2.

The reason to skip is the same as in #17864. (The usage of `add_module`)