### PR TITLE
Remove DT_DOUBLE from the T5 graph

### DIFF
--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -268,7 +268,7 @@ class TFT5Attention(tf.keras.layers.Layer):
         max_exact = num_buckets // 2
         is_small = tf.math.less(relative_position, max_exact)
         relative_position_if_large = max_exact + tf.cast(
-            tf.math.log(relative_position / max_exact)
+            tf.math.log(tf.cast(relative_position, tf.float32) / tf.cast(max_exact, tf.float32))
             / math.log(max_distance / max_exact)
             * (num_buckets - max_exact),
             dtype=relative_position.dtype,


### PR DESCRIPTION
# What does this PR do?

This PR removes DT_DOUBLE aka tf.float64 from T5 TF graph. It comes from https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/math_ops.py#L1510 , two operands are int32 so TF casts them to float64 (`_TRUEDIV_TABLE[dtypes.int32] = dtypes.float64`).

Some accelerators do not support doubles so it's important to avoid them wherever possible.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@patrickvonplaten, @LysandreJik