### PR TITLE
[Issue template] Remove render tags

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -7,7 +7,6 @@ body:
     attributes:
       label: System Info
       description: Please share your system info with us. You can run the command `transformers-cli env` and copy-paste its output below.
-      render: shell
       placeholder: transformers version, platform, python version, ...
     validations:
       required: true
@@ -118,4 +117,3 @@ body:
     attributes:
       label: Expected behavior
       description: "A clear and concise description of what you would expect to happen."
-      render: shell


### PR DESCRIPTION
# What does this PR do?

This PR makes sure that people's comments on Github issues regarding "System info" and "Expected behaviour" aren't rendered as shell.

This makes them a lot more readable (at least for me).