### PR TITLE
Compute min_resolution in prepare_image_inputs

### DIFF
--- a/tests/test_feature_extraction_common.py
+++ b/tests/test_feature_extraction_common.py
@@ -68,10 +68,15 @@ def prepare_image_inputs(feature_extract_tester, equal_resolution=False, numpify
             )
     else:
         image_inputs = []
+
+        # To avoid getting image width/height 0
+        min_resolution = feature_extract_tester.min_resolution
+        if getattr(feature_extract_tester, "size_divisor", None):
+            # If `size_divisor` is defined, the image needs to have width/size >= `size_divisor`
+            min_resolution = max(feature_extract_tester.size_divisor, min_resolution)
+
         for i in range(feature_extract_tester.batch_size):
-            width, height = np.random.choice(
-                np.arange(feature_extract_tester.min_resolution, feature_extract_tester.max_resolution), 2
-            )
+            width, height = np.random.choice(np.arange(min_resolution, feature_extract_tester.max_resolution), 2)
             image_inputs.append(
                 np.random.randint(255, size=(feature_extract_tester.num_channels, width, height), dtype=np.uint8)
             )


### PR DESCRIPTION
# What does this PR do?

If `feature_extract_tester.min_resolution` is specified, the images have to be at least that large, otherwise we will get image width and/or height `0` and it gives error.

An error is [here](https://github.com/huggingface/transformers/runs/7071766841?check_suite_focus=true):
```
>       return self._new(self.im.resize(size, resample, box))
E       ValueError: height and width must be > 0
```


So far, we have the following in `GLPNFeatureExtractionTester` and other testers
```
        min_resolution=30,
        ...
        size_divisor=32,
```

issue spotted by @Rocketknight1 , thanks!