### PR TITLE
Pin black to 22.3.0 to benefit from a stable --preview flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ if stale_egg_info.exists():
 _deps = [
     "Pillow",
     "accelerate>=0.10.0",
-    "black~=22.0,>=22.3",
+    "black==22.3",
     "codecarbon==1.2.0",
     "cookiecutter==1.7.3",
     "dataclasses",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -4,7 +4,7 @@
 deps = {
     "Pillow": "Pillow",
     "accelerate": "accelerate>=0.10.0",
-    "black": "black~=22.0,>=22.3",
+    "black": "black==22.3",
     "codecarbon": "codecarbon==1.2.0",
     "cookiecutter": "cookiecutter==1.7.3",
     "dataclasses": "dataclasses",


### PR DESCRIPTION
Pins black to 22.3.0 in order to benefit from the `--preview` flag continuously. This flag adds reformats for strings, exceptions, logs, and others.

The recent black 22.6.0 version's `--preview` flag isn't compatible with the 22.3.0 and results in line changes. 

This PR pins 22.3.0 as it was deemed the path with the least friction.