### PR TITLE
Update notification service

### DIFF
--- a/.github/workflows/self-past.yml
+++ b/.github/workflows/self-past.yml
@@ -188,5 +188,5 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: test_failure_tables
-          path: /transformers/test_failure_tables
+          name: test_failure_tables_${{ inputs.framework }}-${{ inputs.version }}
+          path: test_failure_tables

--- a/.github/workflows/self-past.yml
+++ b/.github/workflows/self-past.yml
@@ -177,3 +177,14 @@ jobs:
         run: |
           pip install slack_sdk
           python utils/notification_service.py "${{ needs.setup.outputs.matrix }}"
+
+      # Create a directory to store test failure tables in the next step
+      - run: mkdir test_failure_tables
+
+      # Upload complete failure tables, as they might be big and only truncated versions could be sent to Slack.
+      - name: Failure table artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_failure_tables
+          path: /transformers/test_failure_tables

--- a/.github/workflows/self-past.yml
+++ b/.github/workflows/self-past.yml
@@ -164,6 +164,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
+
+      # Create a directory to store test failure tables in the next step
+      - name: Create directory
+        run: mkdir test_failure_tables
+
       - name: Send message to Slack
         env:
           CI_SLACK_BOT_TOKEN: ${{ secrets.CI_SLACK_BOT_TOKEN }}
@@ -177,9 +182,6 @@ jobs:
         run: |
           pip install slack_sdk
           python utils/notification_service.py "${{ needs.setup.outputs.matrix }}"
-
-      # Create a directory to store test failure tables in the next step
-      - run: mkdir test_failure_tables
 
       # Upload complete failure tables, as they might be big and only truncated versions could be sent to Slack.
       - name: Failure table artifacts

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -352,7 +352,9 @@ class Message:
 
         if self.n_model_failures > 0:
             blocks.append(self.category_failures)
-            blocks.extend(self.model_failures)
+            for block in self.model_failures:
+                if block["text"]["text"]:
+                    blocks.append(block)
 
         if self.n_additional_failures > 0:
             blocks.append(self.additional_failures)

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -352,7 +352,7 @@ class Message:
 
         if self.n_model_failures > 0:
             blocks.append(self.category_failures)
-            blocks.extend([self.model_failures])
+            blocks.extend(self.model_failures)
 
         if self.n_additional_failures > 0:
             blocks.append(self.additional_failures)

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -313,6 +313,24 @@ class Message:
             {"type": "section", "text": {"type": "mrkdwn", "text": module_failures_report}},
         ]
 
+        # Save complete tables - to be uploaded as artifacts
+        model_failures_report = prepare_reports(
+            title="These following model modules had failures",
+            header=model_header,
+            reports=sorted_model_reports,
+            to_truncate=False,
+        )
+        module_failures_report = prepare_reports(
+            title="The following non-model modules had failures",
+            header=module_header,
+            reports=sorted_module_reports,
+            to_truncate=False,
+        )
+        with open("model_failures_report.txt", "w", encoding="UTF-8") as fp:
+            fp.write(model_failures_report)
+        with open("module_failures_report.txt", "w", encoding="UTF-8") as fp:
+            fp.write(module_failures_report)
+
         return model_failure_sections
 
     @property
@@ -578,13 +596,16 @@ def retrieve_available_artifacts():
     return _available_artifacts
 
 
-def prepare_reports(title, header, reports):
+def prepare_reports(title, header, reports, to_truncate=True):
     report = ""
+
+    MAX_ERROR_TEXT = 3000 - len("[Truncated]")
+    if not to_truncate:
+        MAX_ERROR_TEXT = float('inf')
 
     if len(reports) > 0:
         # `text` must be less than 3001 characters in Slack SDK
         # keep some room for adding "[Truncated]" when necessary
-        MAX_ERROR_TEXT = 3000 - len("[Truncated]")
 
         for idx in range(len(reports)):
             _report = header + "\n".join(reports[:idx])

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -326,9 +326,10 @@ class Message:
             reports=sorted_module_reports,
             to_truncate=False,
         )
-        with open("model_failures_report.txt", "w", encoding="UTF-8") as fp:
+        # TODO: Pass the target path from GitHub workflow files
+        with open("test_failure_tables/model_failures_report.txt", "w", encoding="UTF-8") as fp:
             fp.write(model_failures_report)
-        with open("module_failures_report.txt", "w", encoding="UTF-8") as fp:
+        with open("test_failure_tables/module_failures_report.txt", "w", encoding="UTF-8") as fp:
             fp.write(module_failures_report)
 
         return model_failure_sections

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -809,7 +809,7 @@ if __name__ == "__main__":
 
     message = Message(title, ci_title, model_results, additional_results)
 
-    # send report only if there is any failure
-    if message.n_failures:
+    # send report only if there is any failure (for push CI)
+    if message.n_failures or ci_event != "push":
         message.post()
         message.post_reply()

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -313,23 +313,24 @@ class Message:
             {"type": "section", "text": {"type": "mrkdwn", "text": module_failures_report}},
         ]
 
-        # Save complete tables - to be uploaded as artifacts
-        model_failures_report = prepare_reports(
-            title="These following model modules had failures",
-            header=model_header,
-            reports=sorted_model_reports,
-            to_truncate=False,
-        )
-        module_failures_report = prepare_reports(
-            title="The following non-model modules had failures",
-            header=module_header,
-            reports=sorted_module_reports,
-            to_truncate=False,
-        )
-        with open(os.path.join(os.getcwd(), "test_failure_tables/model_failures_report.txt"), "w", encoding="UTF-8") as fp:
-            fp.write(model_failures_report)
-        with open(os.path.join(os.getcwd(), "test_failure_tables/module_failures_report.txt"), "w", encoding="UTF-8") as fp:
-            fp.write(module_failures_report)
+        if ci_event.startswith("Past CI"):
+            # Save complete tables - to be uploaded as artifacts
+            model_failures_report = prepare_reports(
+                title="These following model modules had failures",
+                header=model_header,
+                reports=sorted_model_reports,
+                to_truncate=False,
+            )
+            module_failures_report = prepare_reports(
+                title="The following non-model modules had failures",
+                header=module_header,
+                reports=sorted_module_reports,
+                to_truncate=False,
+            )
+            with open(os.path.join(os.getcwd(), "test_failure_tables/model_failures_report.txt"), "w", encoding="UTF-8") as fp:
+                fp.write(model_failures_report)
+            with open(os.path.join(os.getcwd(), "test_failure_tables/module_failures_report.txt"), "w", encoding="UTF-8") as fp:
+                fp.write(module_failures_report)
 
         return model_failure_sections
 

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -327,9 +327,13 @@ class Message:
                 reports=sorted_module_reports,
                 to_truncate=False,
             )
-            with open(os.path.join(os.getcwd(), "test_failure_tables/model_failures_report.txt"), "w", encoding="UTF-8") as fp:
+            with open(
+                os.path.join(os.getcwd(), "test_failure_tables/model_failures_report.txt"), "w", encoding="UTF-8"
+            ) as fp:
                 fp.write(model_failures_report)
-            with open(os.path.join(os.getcwd(), "test_failure_tables/module_failures_report.txt"), "w", encoding="UTF-8") as fp:
+            with open(
+                os.path.join(os.getcwd(), "test_failure_tables/module_failures_report.txt"), "w", encoding="UTF-8"
+            ) as fp:
                 fp.write(module_failures_report)
 
         return model_failure_sections
@@ -602,14 +606,14 @@ def prepare_reports(title, header, reports, to_truncate=True):
 
     MAX_ERROR_TEXT = 3000 - len("[Truncated]")
     if not to_truncate:
-        MAX_ERROR_TEXT = float('inf')
+        MAX_ERROR_TEXT = float("inf")
 
     if len(reports) > 0:
         # `text` must be less than 3001 characters in Slack SDK
         # keep some room for adding "[Truncated]" when necessary
 
         for idx in range(len(reports)):
-            _report = header + "\n".join(reports[:idx + 1])
+            _report = header + "\n".join(reports[: idx + 1])
             new_report = f"{title}:\n```\n{_report}\n```\n"
             if len(new_report) > MAX_ERROR_TEXT:
                 # `report` here has length <= 3000

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -321,19 +321,18 @@ class Message:
                 reports=sorted_model_reports,
                 to_truncate=False,
             )
+            file_path = os.path.join(os.getcwd(), "test_failure_tables/model_failures_report.txt")
+            with open(file_path, "w", encoding="UTF-8") as fp:
+                fp.write(model_failures_report)
+
             module_failures_report = prepare_reports(
                 title="The following non-model modules had failures",
                 header=module_header,
                 reports=sorted_module_reports,
                 to_truncate=False,
             )
-            with open(
-                os.path.join(os.getcwd(), "test_failure_tables/model_failures_report.txt"), "w", encoding="UTF-8"
-            ) as fp:
-                fp.write(model_failures_report)
-            with open(
-                os.path.join(os.getcwd(), "test_failure_tables/module_failures_report.txt"), "w", encoding="UTF-8"
-            ) as fp:
+            file_path = os.path.join(os.getcwd(), "test_failure_tables/module_failures_report.txt")
+            with open(file_path, "w", encoding="UTF-8") as fp:
                 fp.write(module_failures_report)
 
         return model_failure_sections

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -313,8 +313,8 @@ class Message:
             {"type": "section", "text": {"type": "mrkdwn", "text": module_failures_report}},
         ]
 
+        # Save complete tables (for past CI) - to be uploaded as artifacts
         if ci_event.startswith("Past CI"):
-            # Save complete tables - to be uploaded as artifacts
             model_failures_report = prepare_reports(
                 title="These following model modules had failures",
                 header=model_header,
@@ -728,6 +728,8 @@ if __name__ == "__main__":
 
     unclassified_model_failures = []
 
+    # This prefix is used to get job links below. For past CI, we use `workflow_call`, which changes the job names from
+    # `Model tests (...)` to `PyTorch 1.5 / Model tests (...)` for example.
     job_name_prefix = ""
     if ci_event.startswith("Past CI - "):
         framework, version = ci_event.replace("Past CI - ", "").split("-")


### PR DESCRIPTION
# What does this PR do?

~~**Let me run a dummy test before merge**~~

- Fix failure report blocks (the tables) with too long text (might happen for past CI) - similar to #17630
  - A complete version of (long) tables are saved as artifacts 
- Still send successful report if it is not push CI (we are close to 0 failure now)

A dummy run with very long blocks

https://github.com/huggingface/transformers/runs/7094507618?check_suite_focus=true