### PR TITLE
Avoid nan during sampling in generate()

### DIFF
--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -1972,7 +1972,14 @@ class GenerationMixin:
 
             # To avoid all `-inf` along the vocab dimension (dim -1), which gives `nan` after `softmax` and error
             # in `torch.multinomial`.
-            _next_token_scores = torch.max(next_token_scores, torch.tensor(torch.finfo(next_token_scores.dtype).min, dtype=next_token_scores.dtype, device=next_token_scores.device))
+            _next_token_scores = torch.max(
+                next_token_scores,
+                torch.tensor(
+                    torch.finfo(next_token_scores.dtype).min,
+                    dtype=next_token_scores.dtype,
+                    device=next_token_scores.device,
+                ),
+            )
 
             # sample
             probs = nn.functional.softmax(_next_token_scores, dim=-1)


### PR DESCRIPTION
# What does this PR do?

Fix CI test error
```bash
            # sample
            probs = nn.functional.softmax(next_token_scores, dim=-1)
>           next_tokens = torch.multinomial(probs, num_samples=1).squeeze(1)
E           RuntimeError: probability tensor contains either `inf`, `nan` or element < 0
```
in
https://github.com/huggingface/transformers/runs/6959698965?check_suite_focus=true

The test `test_sample_generate` may still fail at
https://github.com/huggingface/transformers/blob/8f400775fc5bc1011a2674dcfd5408d30d69f678/tests/generation/test_generation_utils.py#L711
for some unknown reason. I think it is better to investigate this in another PR.