### PR TITLE
Use explicit torch version in deepspeed CI

### DIFF
--- a/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="Hugging Face"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+ARG PYTORCH='1.11.0'
 # Example: `cu102`, `cu113`, etc.
 ARG CUDA='cu113'
 
@@ -16,7 +17,7 @@ RUN git clone https://github.com/huggingface/transformers && cd transformers && 
 # Install latest release PyTorch
 # (PyTorch must be installed before pre-compiling any DeepSpeed c++/cuda ops.)
 # (https://www.deepspeed.ai/tutorials/advanced-install/#pre-install-deepspeed-ops)
-RUN python3 -m pip install --no-cache-dir -U torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/$CUDA
+RUN python3 -m pip install --no-cache-dir -U torch==$PYTORCH torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/$CUDA
 
 RUN python3 -m pip install --no-cache-dir ./transformers[deepspeed-testing]
 

--- a/docker/transformers-pytorch-gpu/Dockerfile
+++ b/docker/transformers-pytorch-gpu/Dockerfile
@@ -12,7 +12,7 @@ RUN git clone https://github.com/huggingface/transformers && cd transformers && 
 RUN python3 -m pip install --no-cache-dir -e ./transformers[dev-torch,testing]
 
 # If set to nothing, will install the latest version
-ARG PYTORCH=''
+ARG PYTORCH='1.11.0'
 ARG TORCH_VISION=''
 ARG TORCH_AUDIO=''
 


### PR DESCRIPTION
# What does this PR do?

Use explicit torch version in DeepSpeed CI docker file, as we do in

https://github.com/huggingface/transformers/blob/d49c43e93fedc1ff7d58a3617fc8a3532af054ba/docker/transformers-all-latest-gpu/Dockerfile#L12