### PR TITLE
PyTorch 1.12.0 for scheduled CI

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["sh", "-lc"]
 # The following `ARG` are mainly used to specify the versions explicitly & directly in this docker file, and not meant
 # to be used as arguments for docker build (so far).
 
-ARG PYTORCH='1.11.0'
+ARG PYTORCH='1.12.0'
 # (not always a valid torch version)
 ARG INTEL_TORCH_EXT='1.11.0'
 # Example: `cu102`, `cu113`, etc.

--- a/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Hugging Face"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PYTORCH='1.11.0'
+ARG PYTORCH='1.12.0'
 # Example: `cu102`, `cu113`, etc.
 ARG CUDA='cu113'
 

--- a/docker/transformers-pytorch-gpu/Dockerfile
+++ b/docker/transformers-pytorch-gpu/Dockerfile
@@ -12,7 +12,7 @@ RUN git clone https://github.com/huggingface/transformers && cd transformers && 
 RUN python3 -m pip install --no-cache-dir -e ./transformers[dev-torch,testing]
 
 # If set to nothing, will install the latest version
-ARG PYTORCH='1.11.0'
+ARG PYTORCH='1.12.0'
 ARG TORCH_VISION=''
 ARG TORCH_AUDIO=''
 


### PR DESCRIPTION
# What does this PR do?

After the slack discussion, using PyTorch 1.12.0 for scheduled CI is a better idea, so we can see what to fix.

Another reason is that this (messy) block
https://github.com/huggingface/transformers/blob/39dad9768e75460d8bf92fc27d407562eaeb6bd0/docker/transformers-pytorch-gpu/Dockerfile#L19-L22
will change torch 1.11 (if specified) back to 1.12, as torchvision and torchaudio are installed separately from torch without specifying versions. It's better to avoid such situations.

Regarding the torch/torchvision/torchaudio correspondence, I have better approach in my past-ci PR.
