### PR TITLE
Fix number of examples for iterable dataset in distributed training

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1088,6 +1088,10 @@ class Trainer:
         dataloader.dataset does not exist or has no length, estimates as best it can
         """
         try:
+            dataset = dataloader.dataset
+            # Special case for IterableDatasetShard, we need to dig deeper
+            if isinstance(dataset, IterableDatasetShard):
+                return len(dataloader.dataset.dataset)
             return len(dataloader.dataset)
         except (NameError, AttributeError, TypeError):  # no dataset or length, estimate by length of dataloader
             return len(dataloader) * self.args.per_device_train_batch_size


### PR DESCRIPTION
# What does this PR do?

As pointed out in #17913, when training in distributed mode with iterable datasets, the number of examples displayed is wrong. This is because we need to go grab the length of the underlying dataset of the `IterableDatasetShard`, not the length of the  `IterableDatasetShard` itself.

Fixes #17913