### PR TITLE
BLOOM - modifying slow tests

### DIFF
--- a/tests/models/bloom/test_modeling_bloom.py
+++ b/tests/models/bloom/test_modeling_bloom.py
@@ -378,7 +378,9 @@ class BloomModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase)
     @require_torch_gpu
     def test_simple_generation(self):
         path_350m = "bigscience/bloom-350m"
-        model = BloomForCausalLM.from_pretrained(path_350m, torch_dtype=torch.float32, use_cache=False).cuda()
+        model = BloomForCausalLM.from_pretrained(
+            path_350m, torch_dtype=torch.float32, use_cache=False, revision="gs555750"
+        ).cuda()
         model = model.eval()
         tokenizer = BloomTokenizerFast.from_pretrained(path_350m)
 
@@ -393,7 +395,9 @@ class BloomModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase)
     @require_torch_gpu
     def test_batch_generation(self):
         path_350m = "bigscience/bloom-350m"
-        model = BloomForCausalLM.from_pretrained(path_350m, torch_dtype="auto", use_cache=True).cuda()
+        model = BloomForCausalLM.from_pretrained(
+            path_350m, torch_dtype="auto", use_cache=True, revision="gs555750"
+        ).cuda()
         model = model.eval()
         tokenizer = BloomTokenizerFast.from_pretrained(path_350m, padding_side="left")
 
@@ -413,7 +417,9 @@ class BloomModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase)
     @require_torch_gpu
     def test_batch_generation_padd(self):
         path_350m = "bigscience/bloom-350m"
-        model = BloomForCausalLM.from_pretrained(path_350m, torch_dtype=torch.float32, use_cache=True).cuda()
+        model = BloomForCausalLM.from_pretrained(
+            path_350m, torch_dtype=torch.float32, use_cache=True, revision="gs555750"
+        ).cuda()
         model = model.eval()
         tokenizer = BloomTokenizerFast.from_pretrained(path_350m, padding_side="left")
 
@@ -424,7 +430,10 @@ class BloomModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase)
         input_ids_without_pad = tokenizer.encode(input_sentence_without_pad, return_tensors="pt")
 
         greedy_output = model.generate(
-            input_ids["input_ids"].cuda(), attention_mask=input_ids["attention_mask"], max_length=50, do_sample=False
+            input_ids["input_ids"].cuda(),
+            attention_mask=input_ids["attention_mask"].cuda(),
+            max_length=50,
+            do_sample=False,
         )
         greedy_output_without_pad = model.generate(input_ids_without_pad.cuda(), max_length=50, do_sample=False)
 

--- a/tests/models/bloom/test_modeling_bloom.py
+++ b/tests/models/bloom/test_modeling_bloom.py
@@ -15,7 +15,6 @@
 #
 
 import math
-from tkinter import TRUE
 import unittest
 
 from transformers import BloomConfig, is_torch_available


### PR DESCRIPTION
# What does this PR do?

- changed the non passing tests to fp32
- reduced sequence length
- remove padding test

All these matters have been discussed on Slack but mainly:

1- Generations tests were not passing because the linear layers does not give the same results between torch 1.11 and torch 1.12
2- batched generation can be flaky sometimes in half precision mode, this should be expected. Therefore we reduce the sequence length of the generated output
3- One should **always** use `padding_side=left` when doing batched generations

cc @ydshieh @patrickvonplaten
