### PR TITLE
XLA train step fixes

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -237,9 +237,9 @@ class PretrainedConfig(PushToHubMixin):
         use_bfloat16 (`bool`, *optional*, defaults to `False`):
             Whether or not the model should use BFloat16 scalars (only used by some TensorFlow models).
         tf_legacy_loss (`bool`, *optional*, defaults to `False`):
-            Whether the model should use legacy TensorFlow losses. Legacy losses have variable output
-            shapes and may not be XLA-compatible. This option is here for backward compatibility and will be
-            removed in Transformers v5.
+            Whether the model should use legacy TensorFlow losses. Legacy losses have variable output shapes and may
+            not be XLA-compatible. This option is here for backward compatibility and will be removed in Transformers
+            v5.
     """
     model_type: str = ""
     is_composition: bool = False

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -236,6 +236,9 @@ class PretrainedConfig(PushToHubMixin):
 
         use_bfloat16 (`bool`, *optional*, defaults to `False`):
             Whether or not the model should use BFloat16 scalars (only used by some TensorFlow models).
+        tf_legacy_loss (`bool`, *optional*, defaults to `False`):
+            Whether or not the model should use legacy TensorFlow losses. Legacy losses have variable output
+            shapes and may not be XLA-compatible.
     """
     model_type: str = ""
     is_composition: bool = False
@@ -260,6 +263,7 @@ class PretrainedConfig(PushToHubMixin):
         self.torchscript = kwargs.pop("torchscript", False)  # Only used by PyTorch models
         self.torch_dtype = kwargs.pop("torch_dtype", None)  # Only used by PyTorch models
         self.use_bfloat16 = kwargs.pop("use_bfloat16", False)
+        self.tf_legacy_loss = kwargs.pop("tf_legacy_loss", False)  # Only used by TensorFlow models
         self.pruned_heads = kwargs.pop("pruned_heads", {})
         self.tie_word_embeddings = kwargs.pop(
             "tie_word_embeddings", True

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -237,8 +237,9 @@ class PretrainedConfig(PushToHubMixin):
         use_bfloat16 (`bool`, *optional*, defaults to `False`):
             Whether or not the model should use BFloat16 scalars (only used by some TensorFlow models).
         tf_legacy_loss (`bool`, *optional*, defaults to `False`):
-            Whether or not the model should use legacy TensorFlow losses. Legacy losses have variable output
-            shapes and may not be XLA-compatible.
+            Whether the model should use legacy TensorFlow losses. Legacy losses have variable output
+            shapes and may not be XLA-compatible. This option is here for backward compatibility and will be
+            removed in Transformers v5.
     """
     model_type: str = ""
     is_composition: bool = False

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -207,7 +207,7 @@ class TFCausalLanguageModelingLoss:
         # make sure only labels that are not equal to -100 affect the loss
         loss_mask = tf.cast(labels != -100, dtype=unmasked_loss.dtype)
         # Avoid division by zero later
-        loss_denominator = tf.math.maximum(1, tf.reduce_sum(loss_mask, axis=1))
+        loss_denominator = tf.math.maximum(tf.cast(1, loss_mask.dtype), tf.reduce_sum(loss_mask, axis=1))
         masked_loss = unmasked_loss * loss_mask
         reduced_masked_loss = tf.reduce_sum(masked_loss, axis=1) / loss_denominator
         return reduced_masked_loss
@@ -266,7 +266,7 @@ class TFTokenClassificationLoss:
         # are taken into account as loss
         loss_mask = tf.cast(labels >= 0, dtype=unmasked_loss.dtype)
         # Avoid possible division by zero later
-        loss_denominator = tf.math.maximum(1, tf.reduce_sum(loss_mask, axis=1))
+        loss_denominator = tf.math.maximum(tf.cast(1, loss_mask.dtype), tf.reduce_sum(loss_mask, axis=1))
         # Masked positions will have a loss of NaN because -100 and -1 are not valid labels
         masked_loss = unmasked_loss * loss_mask
         reduced_masked_loss = tf.reduce_sum(masked_loss, axis=1) / loss_denominator

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -202,12 +202,12 @@ class TFCausalLanguageModelingLoss:
             labels = tf.boolean_mask(tf.reshape(labels, (-1,)), active_loss)
             return loss_fn(labels, reduced_logits)
 
+        # Clip negative labels to zero here to avoid NaNs and errors - those positions will get masked later anyway
+        unmasked_loss = loss_fn(tf.nn.relu(labels), logits)
         # make sure only labels that are not equal to -100 affect the loss
-        unmasked_loss = loss_fn(labels, logits)
         loss_mask = tf.cast(labels != -100, dtype=unmasked_loss.dtype)
         loss_denominator = tf.reduce_sum(loss_mask, axis=1)
-        # Masked positions will have a loss of NaN because -100 is not a valid label
-        masked_loss = tf.math.multiply_no_nan(unmasked_loss, loss_mask)
+        masked_loss = unmasked_loss * loss_mask
         reduced_masked_loss = tf.reduce_sum(masked_loss, axis=1) / loss_denominator
         return reduced_masked_loss
 
@@ -259,13 +259,14 @@ class TFTokenClassificationLoss:
 
             return loss_fn(labels, reduced_logits)
 
-        unmasked_loss = loss_fn(labels, logits)
+        # Clip negative labels to zero here to avoid NaNs and errors - those positions will get masked later anyway
+        unmasked_loss = loss_fn(tf.nn.relu(labels), logits)
         # make sure only labels that are not equal to -100 or -1
         # are taken into account as loss
         loss_mask = tf.cast(labels >= 0, dtype=unmasked_loss.dtype)
         loss_denominator = tf.reduce_sum(loss_mask, axis=1)
         # Masked positions will have a loss of NaN because -100 and -1 are not valid labels
-        masked_loss = tf.math.multiply_no_nan(unmasked_loss, loss_mask)
+        masked_loss = unmasked_loss * loss_mask
         reduced_masked_loss = tf.reduce_sum(masked_loss, axis=1) / loss_denominator
         return reduced_masked_loss
 
@@ -335,10 +336,11 @@ class TFNextSentencePredictionLoss:
         # make sure only labels that are not equal to -100
         # are taken into account as loss
 
-        unmasked_ns_loss = loss_fn(y_true=labels, y_pred=logits)
+        # Clip negative labels to zero here to avoid NaNs and errors - those positions will get masked later anyway
+        unmasked_ns_loss = loss_fn(y_true=tf.nn.relu(labels), y_pred=logits)
         ns_loss_mask = tf.cast(labels != -100, dtype=unmasked_ns_loss.dtype)
         # Just zero out samples where label is -100, no reduction
-        masked_ns_loss = tf.math.multiply_no_nan(unmasked_ns_loss, ns_loss_mask)
+        masked_ns_loss = unmasked_ns_loss * ns_loss_mask
 
         return masked_ns_loss
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -195,7 +195,7 @@ class TFCausalLanguageModelingLoss:
         loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(
             from_logits=True, reduction=tf.keras.losses.Reduction.NONE
         )
-        if self.config.get("tf_legacy_loss", False):
+        if self.config.tf_legacy_loss:
             # make sure only labels that are not equal to -100 affect the loss
             active_loss = tf.not_equal(tf.reshape(labels, (-1,)), -100)
             reduced_logits = tf.boolean_mask(tf.reshape(logits, (-1, shape_list(logits)[2])), active_loss)
@@ -246,7 +246,7 @@ class TFTokenClassificationLoss:
             if tf.math.reduce_any(labels == -1):
                 tf.print("Using `-1` to mask the loss for the token is deprecated. Please use `-100` instead.")
 
-        if self.config.get("tf_legacy_loss", False):
+        if self.config.tf_legacy_loss:
             # make sure only labels that are not equal to -100
             # are taken into account as loss
             if tf.math.reduce_any(labels == -1):
@@ -323,7 +323,7 @@ class TFNextSentencePredictionLoss:
         loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(
             from_logits=True, reduction=tf.keras.losses.Reduction.NONE
         )
-        if self.config.get("tf_legacy_loss", False):
+        if self.config.tf_legacy_loss:
             # make sure only labels that are not equal to -100
             # are taken into account as loss
             next_sentence_active_loss = tf.not_equal(tf.reshape(labels, (-1,)), -100)

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -206,7 +206,8 @@ class TFCausalLanguageModelingLoss:
         unmasked_loss = loss_fn(tf.nn.relu(labels), logits)
         # make sure only labels that are not equal to -100 affect the loss
         loss_mask = tf.cast(labels != -100, dtype=unmasked_loss.dtype)
-        loss_denominator = tf.reduce_sum(loss_mask, axis=1)
+        # Avoid division by zero later
+        loss_denominator = tf.math.maximum(1, tf.reduce_sum(loss_mask, axis=1))
         masked_loss = unmasked_loss * loss_mask
         reduced_masked_loss = tf.reduce_sum(masked_loss, axis=1) / loss_denominator
         return reduced_masked_loss
@@ -264,7 +265,8 @@ class TFTokenClassificationLoss:
         # make sure only labels that are not equal to -100 or -1
         # are taken into account as loss
         loss_mask = tf.cast(labels >= 0, dtype=unmasked_loss.dtype)
-        loss_denominator = tf.reduce_sum(loss_mask, axis=1)
+        # Avoid possible division by zero later
+        loss_denominator = tf.math.maximum(1, tf.reduce_sum(loss_mask, axis=1))
         # Masked positions will have a loss of NaN because -100 and -1 are not valid labels
         masked_loss = unmasked_loss * loss_mask
         reduced_masked_loss = tf.reduce_sum(masked_loss, axis=1) / loss_denominator

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1327,6 +1327,13 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         if not self._using_dummy_loss:
             data = data_adapter.expand_1d(data)
         x, y, sample_weight = data_adapter.unpack_x_y_sample_weight(data)
+        # If the inputs are mutable dictionaries, make a shallow copy of them because we will modify
+        # them during input/label pre-processing. This avoids surprising the user by wrecking their data.
+        # In addition, modifying mutable Python inputs makes XLA compilation impossible.
+        if isinstance(x, dict):
+            x = x.copy()
+        if isinstance(y, dict):
+            y = y.copy()
 
         # When using a dummy loss, we ensure that separate labels are copied to the correct model arguments,
         # if those keys are not already present in the input dict
@@ -1424,6 +1431,13 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         if not self._using_dummy_loss:
             data = data_adapter.expand_1d(data)
         x, y, sample_weight = data_adapter.unpack_x_y_sample_weight(data)
+        # If the inputs are mutable dictionaries, make a shallow copy of them because we will modify
+        # them during input/label pre-processing. This avoids surprising the user by wrecking their data.
+        # In addition, modifying mutable Python inputs makes XLA compilation impossible.
+        if isinstance(x, dict):
+            x = x.copy()
+        if isinstance(y, dict):
+            y = y.copy()
 
         # When using a dummy loss, we ensure that separate labels are copied to the correct model arguments,
         # if those keys are not already present in the input dict

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -86,7 +86,7 @@ class TFAlbertPreTrainingLoss:
         loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(
             from_logits=True, reduction=tf.keras.losses.Reduction.NONE
         )
-        if self.config.get("tf_legacy_loss", False):
+        if self.config.tf_legacy_loss:
             # make sure only labels that are not equal to -100
             # are taken into account as loss
             masked_lm_active_loss = tf.not_equal(tf.reshape(tensor=labels["labels"], shape=(-1,)), -100)

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -119,7 +119,7 @@ class TFAlbertPreTrainingLoss:
         # are taken into account for the loss computation
         lm_loss_mask = tf.cast(labels["labels"] != -100, dtype=unmasked_lm_losses.dtype)
         # Avoid division by zero later
-        lm_loss_denominator = tf.math.maximum(1, tf.reduce_sum(lm_loss_mask, axis=1))
+        lm_loss_denominator = tf.math.maximum(tf.cast(1, lm_loss_mask.dtype), tf.reduce_sum(lm_loss_mask, axis=1))
         masked_lm_losses = unmasked_lm_losses * lm_loss_mask
         reduced_masked_lm_loss = tf.reduce_sum(masked_lm_losses, axis=1) / lm_loss_denominator
 

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -123,7 +123,7 @@ class TFAlbertPreTrainingLoss:
 
         sop_logits = tf.reshape(logits[1], (-1, 2))
         unmasked_sop_loss = loss_fn(y_true=labels["sentence_order_label"], y_pred=sop_logits)
-        sop_loss_mask = labels["sentence_order_label"] != -100
+        sop_loss_mask = tf.cast(labels["sentence_order_label"] != -100, dtype=unmasked_sop_loss.dtype)
 
         # No reduction because this already has shape (num_samples,)
         masked_sop_loss = tf.math.multiply_no_nan(unmasked_sop_loss, sop_loss_mask)

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -118,7 +118,8 @@ class TFAlbertPreTrainingLoss:
         # make sure only labels that are not equal to -100
         # are taken into account for the loss computation
         lm_loss_mask = tf.cast(labels["labels"] != -100, dtype=unmasked_lm_losses.dtype)
-        lm_loss_denominator = tf.reduce_sum(lm_loss_mask, axis=1)
+        # Avoid division by zero later
+        lm_loss_denominator = tf.math.maximum(1, tf.reduce_sum(lm_loss_mask, axis=1))
         masked_lm_losses = unmasked_lm_losses * lm_loss_mask
         reduced_masked_lm_loss = tf.reduce_sum(masked_lm_losses, axis=1) / lm_loss_denominator
 

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -97,8 +97,9 @@ class TFAlbertPreTrainingLoss:
             masked_lm_labels = tf.boolean_mask(
                 tensor=tf.reshape(tensor=labels["labels"], shape=(-1,)), mask=masked_lm_active_loss
             )
-            sentence_order_active_loss = tf.not_equal(tf.reshape(tensor=labels["sentence_order_label"], shape=(-1,)),
-                                                      -100)
+            sentence_order_active_loss = tf.not_equal(
+                tf.reshape(tensor=labels["sentence_order_label"], shape=(-1,)), -100
+            )
             sentence_order_reduced_logits = tf.boolean_mask(
                 tensor=tf.reshape(tensor=logits[1], shape=(-1, 2)), mask=sentence_order_active_loss
             )

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -124,18 +124,21 @@ class TFBertPreTrainingLoss:
         loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(
             from_logits=True, reduction=tf.keras.losses.Reduction.NONE
         )
-        unmasked_lm_losses = loss_fn(y_true=labels["labels"], y_pred=logits[0])
+
+        # Clip negative labels to zero here to avoid NaNs and errors - those positions will get masked later anyway
+        unmasked_lm_losses = loss_fn(y_true=tf.nn.relu(labels["labels"]), y_pred=logits[0])
         # make sure only labels that are not equal to -100
         # are taken into account for the loss computation
         lm_loss_mask = tf.cast(labels["labels"] != -100, dtype=unmasked_lm_losses.dtype)
         lm_loss_denominator = tf.reduce_sum(lm_loss_mask, axis=1)
-        masked_lm_losses = tf.math.multiply_no_nan(unmasked_lm_losses, lm_loss_mask)
+        masked_lm_losses = unmasked_lm_losses * lm_loss_mask
         reduced_masked_lm_loss = tf.reduce_sum(masked_lm_losses, axis=1) / lm_loss_denominator
 
-        unmasked_ns_loss = loss_fn(y_true=labels["next_sentence_label"], y_pred=logits[1])
+        # Clip negative labels to zero here to avoid NaNs and errors - those positions will get masked later anyway
+        unmasked_ns_loss = loss_fn(y_true=tf.nn.relu(labels["next_sentence_label"]), y_pred=logits[1])
         ns_loss_mask = tf.cast(labels["next_sentence_label"] != -100, dtype=unmasked_ns_loss.dtype)
         # Just zero out samples where label is -100, no reduction
-        masked_ns_loss = tf.math.multiply_no_nan(unmasked_ns_loss, ns_loss_mask)
+        masked_ns_loss = unmasked_ns_loss * ns_loss_mask
 
         return reduced_masked_lm_loss + masked_ns_loss
 

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -130,7 +130,8 @@ class TFBertPreTrainingLoss:
         # make sure only labels that are not equal to -100
         # are taken into account for the loss computation
         lm_loss_mask = tf.cast(labels["labels"] != -100, dtype=unmasked_lm_losses.dtype)
-        lm_loss_denominator = tf.reduce_sum(lm_loss_mask, axis=1)
+        # Avoid potential division by zero later
+        lm_loss_denominator = tf.math.maximum(1, tf.reduce_sum(lm_loss_mask, axis=1))
         masked_lm_losses = unmasked_lm_losses * lm_loss_mask
         reduced_masked_lm_loss = tf.reduce_sum(masked_lm_losses, axis=1) / lm_loss_denominator
 

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -131,7 +131,7 @@ class TFBertPreTrainingLoss:
         # are taken into account for the loss computation
         lm_loss_mask = tf.cast(labels["labels"] != -100, dtype=unmasked_lm_losses.dtype)
         # Avoid potential division by zero later
-        lm_loss_denominator = tf.math.maximum(1, tf.reduce_sum(lm_loss_mask, axis=1))
+        lm_loss_denominator = tf.math.maximum(tf.cast(1, lm_loss_mask.dtype), tf.reduce_sum(lm_loss_mask, axis=1))
         masked_lm_losses = unmasked_lm_losses * lm_loss_mask
         reduced_masked_lm_loss = tf.reduce_sum(masked_lm_losses, axis=1) / lm_loss_denominator
 

--- a/src/transformers/models/led/modeling_tf_led.py
+++ b/src/transformers/models/led/modeling_tf_led.py
@@ -2518,7 +2518,7 @@ class TFLEDForConditionalGeneration(TFLEDPreTrainedModel):
         unmasked_loss = loss_fn(tf.nn.relu(labels), logits)
         # make sure only non-padding labels affect the loss
         loss_mask = tf.cast(labels != self.config.pad_token_id, dtype=unmasked_loss.dtype)
-        loss_denominator = tf.math.maximum(1, tf.reduce_sum(loss_mask, axis=1))
+        loss_denominator = tf.math.maximum(tf.cast(1, loss_mask.dtype), tf.reduce_sum(loss_mask, axis=1))
         masked_loss = unmasked_loss * loss_mask
         reduced_masked_loss = tf.reduce_sum(masked_loss, axis=1) / loss_denominator
         return reduced_masked_loss

--- a/src/transformers/models/led/modeling_tf_led.py
+++ b/src/transformers/models/led/modeling_tf_led.py
@@ -2518,7 +2518,7 @@ class TFLEDForConditionalGeneration(TFLEDPreTrainedModel):
         unmasked_loss = loss_fn(tf.nn.relu(labels), logits)
         # make sure only non-padding labels affect the loss
         loss_mask = tf.cast(labels != self.config.pad_token_id, dtype=unmasked_loss.dtype)
-        loss_denominator = tf.reduce_sum(loss_mask, axis=1)
+        loss_denominator = tf.math.maximum(1, tf.reduce_sum(loss_mask, axis=1))
         masked_loss = unmasked_loss * loss_mask
         reduced_masked_loss = tf.reduce_sum(masked_loss, axis=1) / loss_denominator
         return reduced_masked_loss

--- a/src/transformers/models/led/modeling_tf_led.py
+++ b/src/transformers/models/led/modeling_tf_led.py
@@ -2507,7 +2507,7 @@ class TFLEDForConditionalGeneration(TFLEDPreTrainedModel):
         loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(
             from_logits=True, reduction=tf.keras.losses.Reduction.NONE
         )
-        if self.config.get("tf_legacy_loss", False):
+        if self.config.tf_legacy_loss:
             melted_labels = tf.reshape(labels, (-1,))
             active_loss = tf.not_equal(melted_labels, self.config.pad_token_id)
             reduced_logits = tf.boolean_mask(tf.reshape(logits, (-1, shape_list(logits)[2])), active_loss)

--- a/src/transformers/models/rag/modeling_tf_rag.py
+++ b/src/transformers/models/rag/modeling_tf_rag.py
@@ -1333,31 +1333,50 @@ class TFRagTokenForGeneration(TFRagPreTrainedModel, TFCausalLanguageModelingLoss
     # Adopted modeling_tf_bart + add smooth_loss to match with pytorch version
     def hf_compute_loss(self, labels, y_pred, smooth_epsilon=0.0, from_logits=True, reduce_loss=False):
         """CrossEntropyLoss that ignores pad tokens"""
+        if self.config.tf_legacy_loss:
+            loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(
+                from_logits=True,
+                reduction=tf.keras.losses.Reduction.SUM,
+            )
+
+            if from_logits is False:  # convert to logits
+                eps = 1e-9
+                y_pred = tf.clip_by_value(y_pred, clip_value_min=eps, clip_value_max=1 - eps)
+                y_pred = tf.math.log(y_pred)
+
+            logits = y_pred
+            melted_labels = tf.reshape(labels, (-1,))
+            active_loss = tf.not_equal(melted_labels, self.config.generator.pad_token_id)
+
+            reduced_logits = tf.boolean_mask(tf.reshape(logits, (-1, logits.shape[2])), active_loss)
+            labels = tf.boolean_mask(melted_labels, active_loss)
+            nll_loss = loss_fn(labels, reduced_logits)
+
+            smooth_loss = -tf.reduce_sum(reduced_logits, axis=-1)
+            smooth_loss = tf.reduce_sum(smooth_loss)  # sum and squeeze like torch
+            eps_i = smooth_epsilon / reduced_logits.shape[-1]
+
+            loss = (1.0 - smooth_epsilon) * nll_loss + eps_i * smooth_loss
+
+            return loss
+
         loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(
-            from_logits=True,
-            reduction=tf.keras.losses.Reduction.SUM,
+            from_logits=from_logits,
+            reduction=tf.keras.losses.Reduction.NONE,
         )
+        unmasked_loss = loss_fn(labels, y_pred)
+        loss_mask = labels != self.config.generator.pad_token_id
+        nll_loss = tf.reduce_sum(tf.math.multiply_no_nan(unmasked_loss, loss_mask))
 
-        if from_logits is False:  # convert to logits
-            eps = 1e-9
-            y_pred = tf.clip_by_value(y_pred, clip_value_min=eps, clip_value_max=1 - eps)
-            y_pred = tf.math.log(y_pred)
-
-        logits = y_pred
-        melted_labels = tf.reshape(labels, (-1,))
-        active_loss = tf.not_equal(melted_labels, self.config.generator.pad_token_id)
-
-        reduced_logits = tf.boolean_mask(tf.reshape(logits, (-1, logits.shape[2])), active_loss)
-        labels = tf.boolean_mask(melted_labels, active_loss)
-        nll_loss = loss_fn(labels, reduced_logits)
-
-        smooth_loss = -tf.reduce_sum(reduced_logits, axis=-1)
-        smooth_loss = tf.reduce_sum(smooth_loss)  # sum and squeeze like torch
-        eps_i = smooth_epsilon / reduced_logits.shape[-1]
+        # Matt: This makes no sense to me, but I'm just copying the old loss in XLA-compatible form
+        smooth_loss = -tf.reduce_sum(tf.math.multiply_no_nan(y_pred, tf.expand_dims(labels, -1)), axis=-1)
+        smooth_loss = tf.reduce_sum(smooth_loss)
+        eps_i = smooth_epsilon / y_pred.shape[-1]
 
         loss = (1.0 - smooth_epsilon) * nll_loss + eps_i * smooth_loss
 
         return loss
+
 
 
 @add_start_docstrings_to_model_forward(

--- a/src/transformers/models/rag/modeling_tf_rag.py
+++ b/src/transformers/models/rag/modeling_tf_rag.py
@@ -1364,12 +1364,13 @@ class TFRagTokenForGeneration(TFRagPreTrainedModel, TFCausalLanguageModelingLoss
             from_logits=from_logits,
             reduction=tf.keras.losses.Reduction.NONE,
         )
+
         unmasked_loss = loss_fn(labels, y_pred)
         loss_mask = labels != self.config.generator.pad_token_id
-        nll_loss = tf.reduce_sum(tf.math.multiply_no_nan(unmasked_loss, loss_mask))
+        nll_loss = tf.reduce_sum(unmasked_loss * loss_mask)
 
         # Matt: This makes no sense to me, but I'm just copying the old loss in XLA-compatible form
-        smooth_loss = -tf.reduce_sum(tf.math.multiply_no_nan(y_pred, tf.expand_dims(labels, -1)), axis=-1)
+        smooth_loss = -tf.reduce_sum(y_pred * tf.expand_dims(labels, -1), axis=-1)
         smooth_loss = tf.reduce_sum(smooth_loss)
         eps_i = smooth_epsilon / y_pred.shape[-1]
 

--- a/src/transformers/models/rag/modeling_tf_rag.py
+++ b/src/transformers/models/rag/modeling_tf_rag.py
@@ -1378,7 +1378,6 @@ class TFRagTokenForGeneration(TFRagPreTrainedModel, TFCausalLanguageModelingLoss
         return loss
 
 
-
 @add_start_docstrings_to_model_forward(
     """
     A TF RAG-sequence model implementation. It performs RAG-sequence specific marginalization in the forward pass.

--- a/tests/models/rag/test_modeling_tf_rag.py
+++ b/tests/models/rag/test_modeling_tf_rag.py
@@ -512,6 +512,10 @@ class TFRagTestMixin:
         inputs_dict["generator_n_docs"] = 2
         self.check_model_with_mismatch_n_docs_value(**inputs_dict)
 
+    @unittest.skip("Loss has not yet been rewritten to be XLA compatible.")
+    def test_loss_computation(self):
+        pass
+
 
 @require_tf
 @require_retrieval

--- a/tests/models/rag/test_modeling_tf_rag.py
+++ b/tests/models/rag/test_modeling_tf_rag.py
@@ -512,10 +512,6 @@ class TFRagTestMixin:
         inputs_dict["generator_n_docs"] = 2
         self.check_model_with_mismatch_n_docs_value(**inputs_dict)
 
-    @unittest.skip("Loss has not yet been rewritten to be XLA compatible.")
-    def test_loss_computation(self):
-        pass
-
 
 @require_tf
 @require_retrieval

--- a/tests/models/xlnet/test_modeling_tf_xlnet.py
+++ b/tests/models/xlnet/test_modeling_tf_xlnet.py
@@ -403,7 +403,7 @@ class TFXLNetModelTest(TFModelTesterMixin, unittest.TestCase):
                 added_label = prepared_for_class[
                     sorted(list(prepared_for_class.keys() - inputs_dict.keys()), reverse=True)[0]
                 ]
-                loss_size = tf.size(added_label)
+                expected_loss_size = added_label.shape.as_list()[:1]
 
                 # `TFXLNetLMHeadModel` doesn't cut logits/labels
                 # if model.__class__ in get_values(TF_MODEL_FOR_CAUSAL_LM_MAPPING):
@@ -417,12 +417,12 @@ class TFXLNetModelTest(TFModelTesterMixin, unittest.TestCase):
                 input_ids = prepared_for_class.pop(input_name)
 
                 loss = model(input_ids, **prepared_for_class)[0]
-                self.assertEqual(loss.shape, [loss_size])
+                self.assertEqual(loss.shape.as_list(), expected_loss_size)
 
                 # Test that model correctly compute the loss with a dict
                 prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
                 loss = model(prepared_for_class)[0]
-                self.assertEqual(loss.shape, [loss_size])
+                self.assertEqual(loss.shape.as_list(), expected_loss_size)
 
                 # Test that model correctly compute the loss with a tuple
                 prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
@@ -453,7 +453,7 @@ class TFXLNetModelTest(TFModelTesterMixin, unittest.TestCase):
                 # Send to model
                 loss = model(tuple_input[:-1])[0]
 
-                self.assertEqual(loss.shape, [loss_size])
+                self.assertEqual(loss.shape.as_list(), expected_loss_size)
 
 
 @require_tf

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -42,6 +42,7 @@ config_common_kwargs = {
     "torchscript": True,
     "torch_dtype": "float16",
     "use_bfloat16": True,
+    "tf_legacy_loss": True,
     "pruned_heads": {"a": 1},
     "tie_word_embeddings": False,
     "is_decoder": True,

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1285,12 +1285,7 @@ class TFModelTesterMixin:
                 added_label = prepared_for_class[
                     sorted(list(prepared_for_class.keys() - inputs_dict.keys()), reverse=True)[0]
                 ]
-                loss_size = tf.size(added_label)
-
-                if model.__class__ in get_values(TF_MODEL_FOR_CAUSAL_LM_MAPPING):
-                    # if loss is causal lm loss, labels are shift, so that one label per batch
-                    # is cut
-                    loss_size = loss_size - self.model_tester.batch_size
+                expected_loss_size = added_label.shape.as_list()[:1]
 
                 # Test that model correctly compute the loss with kwargs
                 prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
@@ -1299,12 +1294,12 @@ class TFModelTesterMixin:
                 model_input = prepared_for_class.pop(input_name)
 
                 loss = model(model_input, **prepared_for_class)[0]
-                self.assertEqual(loss.shape, [loss_size])
+                self.assertEqual(loss.shape.as_list(), expected_loss_size)
 
                 # Test that model correctly compute the loss with a dict
                 prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
                 loss = model(prepared_for_class)[0]
-                self.assertEqual(loss.shape, [loss_size])
+                self.assertEqual(loss.shape.as_list(), expected_loss_size)
 
                 # Test that model correctly compute the loss with a tuple
                 prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
@@ -1335,7 +1330,7 @@ class TFModelTesterMixin:
                 # Send to model
                 loss = model(tuple_input[:-1])[0]
 
-                self.assertEqual(loss.shape, [loss_size])
+                self.assertEqual(loss.shape.as_list(), expected_loss_size)
 
     def test_keras_fit(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -23,6 +23,7 @@ import tempfile
 import unittest
 import unittest.mock as mock
 from importlib import import_module
+from math import isnan
 from typing import List, Tuple
 
 from datasets import Dataset
@@ -47,7 +48,7 @@ from transformers.testing_utils import (
 )
 from transformers.utils import logging
 from transformers.utils.generic import ModelOutput
-from math import isnan
+
 
 logger = logging.get_logger(__name__)
 

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -23,8 +23,8 @@ import tempfile
 import unittest
 import unittest.mock as mock
 from importlib import import_module
-from math import isnan
 from typing import List, Tuple
+from math import isnan
 
 from datasets import Dataset
 
@@ -1303,10 +1303,12 @@ class TFModelTesterMixin:
                 model_input = prepared_for_class.pop(input_name)
                 if "labels" in prepared_for_class:
                     labels = prepared_for_class["labels"].numpy()
-                    labels[0] = -100
-                    prepared_for_class["labels"] = tf.convert_to_tensor(labels)
-                    loss = model(model_input, **prepared_for_class)[0]
-                    self.assertEqual(loss.shape.as_list(), expected_loss_size)
+                    if len(labels.shape) > 1 and labels.shape[1] != 1:
+                        labels[0] = -100
+                        prepared_for_class["labels"] = tf.convert_to_tensor(labels)
+                        loss = model(model_input, **prepared_for_class)[0]
+                        self.assertEqual(loss.shape.as_list(), expected_loss_size)
+                        self.assertTrue(not np.any(np.isnan(loss.numpy())))
 
                 # Test that model correctly compute the loss with a dict
                 prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1296,6 +1296,16 @@ class TFModelTesterMixin:
                 loss = model(model_input, **prepared_for_class)[0]
                 self.assertEqual(loss.shape.as_list(), expected_loss_size)
 
+                # Test that model correctly compute the loss when we mask some positions
+                prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
+                possible_input_names = {"input_ids", "pixel_values", "input_features"}
+                input_name = possible_input_names.intersection(set(prepared_for_class)).pop()
+                model_input = prepared_for_class.pop(input_name)
+                if "labels" in prepared_for_class:
+                    prepared_for_class["labels"][0] = -100
+                loss = model(model_input, **prepared_for_class)[0]
+                self.assertEqual(loss.shape.as_list(), expected_loss_size)
+
                 # Test that model correctly compute the loss with a dict
                 prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
                 loss = model(prepared_for_class)[0]

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1302,9 +1302,11 @@ class TFModelTesterMixin:
                 input_name = possible_input_names.intersection(set(prepared_for_class)).pop()
                 model_input = prepared_for_class.pop(input_name)
                 if "labels" in prepared_for_class:
-                    prepared_for_class["labels"][0] = -100
-                loss = model(model_input, **prepared_for_class)[0]
-                self.assertEqual(loss.shape.as_list(), expected_loss_size)
+                    labels = prepared_for_class["labels"].numpy()
+                    labels[0] = -100
+                    prepared_for_class["labels"] = tf.convert_to_tensor(labels)
+                    loss = model(model_input, **prepared_for_class)[0]
+                    self.assertEqual(loss.shape.as_list(), expected_loss_size)
 
                 # Test that model correctly compute the loss with a dict
                 prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -23,8 +23,8 @@ import tempfile
 import unittest
 import unittest.mock as mock
 from importlib import import_module
-from typing import List, Tuple
 from math import isnan
+from typing import List, Tuple
 
 from datasets import Dataset
 

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -47,7 +47,7 @@ from transformers.testing_utils import (
 )
 from transformers.utils import logging
 from transformers.utils.generic import ModelOutput
-
+from math import isnan
 
 logger = logging.get_logger(__name__)
 
@@ -1397,6 +1397,7 @@ class TFModelTesterMixin:
                     shuffle=False,
                 )
                 val_loss1 = history1.history["val_loss"][0]
+                self.assertTrue(not isnan(val_loss1))
                 accuracy1 = {key: val[0] for key, val in history1.history.items() if key.endswith("accuracy")}
 
                 # We reinitialize the model here even though our learning rate was zero
@@ -1412,6 +1413,7 @@ class TFModelTesterMixin:
                     shuffle=False,
                 )
                 val_loss2 = history2.history["val_loss"][0]
+                self.assertTrue(not isnan(val_loss2))
                 accuracy2 = {key: val[0] for key, val in history2.history.items() if key.endswith("accuracy")}
                 self.assertTrue(np.allclose(val_loss1, val_loss2, atol=1e-2, rtol=1e-3))
                 self.assertEqual(history1.history.keys(), history2.history.keys())
@@ -1437,6 +1439,7 @@ class TFModelTesterMixin:
                     shuffle=False,
                 )
                 val_loss3 = history3.history["val_loss"][0]
+                self.assertTrue(not isnan(val_loss3))
                 accuracy3 = {key: val[0] for key, val in history3.history.items() if key.endswith("accuracy")}
                 self.assertTrue(np.allclose(val_loss1, val_loss3, atol=1e-2, rtol=1e-3))
                 self.assertEqual(history1.history.keys(), history3.history.keys())

--- a/tests/utils/test_modeling_tf_core.py
+++ b/tests/utils/test_modeling_tf_core.py
@@ -22,6 +22,7 @@ from importlib import import_module
 from transformers import is_tf_available
 from transformers.models.auto import get_values
 from transformers.testing_utils import _tf_gpu_memory_limit, require_tf, slow
+from math import isnan
 
 from ..test_modeling_tf_common import ids_tensor
 
@@ -133,6 +134,72 @@ class TFCoreModelTesterMixin:
 
             outputs = run_in_graph_mode()
             self.assertIsNotNone(outputs)
+
+    @slow
+    def test_xla_fit(self):
+        # This is a copy of the test_keras_fit method, but we use XLA compilation instead of eager
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            if getattr(model, "hf_compute_loss", None):
+                # Test that model correctly compute the loss with kwargs
+                prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
+                # Is there a better way to remove these decoder inputs?
+                prepared_for_class = {
+                    key: val
+                    for key, val in prepared_for_class.items()
+                    if key not in ("head_mask", "decoder_head_mask", "cross_attn_head_mask", "decoder_input_ids")
+                }
+
+                possible_label_cols = {
+                    "labels",
+                    "label",
+                    "label_ids",
+                    "start_positions",
+                    "start_position",
+                    "end_positions",
+                    "end_position",
+                    "next_sentence_label",
+                }
+                label_names = possible_label_cols.intersection(set(prepared_for_class))
+                self.assertGreater(len(label_names), 0, msg="No matching label names found!")
+                labels = {key: val for key, val in prepared_for_class.items() if key in label_names}
+                inputs_minus_labels = {key: val for key, val in prepared_for_class.items() if key not in label_names}
+                self.assertGreater(len(inputs_minus_labels), 0)
+
+                # Make sure it works with XLA!
+                model.compile(optimizer=tf.keras.optimizers.SGD(0.0), jit_compile=True)
+                # Make sure the model fits without crashing regardless of where we pass the labels
+                history = model.fit(
+                    prepared_for_class,
+                    validation_data=prepared_for_class,
+                    steps_per_epoch=1,
+                    validation_steps=1,
+                    shuffle=False,
+                    verbose=0,
+                )
+                loss = history.history["loss"][0]
+                self.assertTrue(not isnan(loss))
+                val_loss = history.history["val_loss"][0]
+                self.assertTrue(not isnan(val_loss))
+
+                # Now test it with separate labels, to make sure that path works in XLA too.
+                model = model_class(config)
+                model.compile(optimizer=tf.keras.optimizers.SGD(0.0), jit_compile=True)
+                history = model.fit(
+                    inputs_minus_labels,
+                    labels,
+                    validation_data=(inputs_minus_labels, labels),
+                    steps_per_epoch=1,
+                    validation_steps=1,
+                    shuffle=False,
+                    verbose=0,
+                )
+
+                loss = history.history["loss"][0]
+                self.assertTrue(not isnan(loss))
+                val_loss = history.history["val_loss"][0]
+                self.assertTrue(not isnan(val_loss))
 
     @slow
     def test_saved_model_creation(self):

--- a/tests/utils/test_modeling_tf_core.py
+++ b/tests/utils/test_modeling_tf_core.py
@@ -18,11 +18,11 @@ import copy
 import os
 import tempfile
 from importlib import import_module
+from math import isnan
 
 from transformers import is_tf_available
 from transformers.models.auto import get_values
 from transformers.testing_utils import _tf_gpu_memory_limit, require_tf, slow
-from math import isnan
 
 from ..test_modeling_tf_common import ids_tensor
 


### PR DESCRIPTION
This PR makes a bunch of changes to the TF codebase to improve XLA support, in preparation for our upcoming big TF release. The goal is to allow users to use `jit_compile` on the vast majority of our models, which should yield large performance improvements for TF. In particular:

- Rewrites to the `train_step` and `test_step` so that any mutable Python input dicts are not modified in the step. This was a bad idea anyway, but it causes particular problems with XLA, which is very functional and hates side effects, like JAX.
- Rewrites to the common `hf_compute_loss` functions to ensure that static shapes are maintained throughout, so that XLA compilation is possible.
- Add a test to ensure that we can still fit models when XLA compilation is used. XLA compilation is quite expensive, which makes this test quite slow, so it's restricted to `core` models for now and tagged as `@slow`.

Left to do:
- [x] Fix XLA-incompatible model-specific  `hf_compute_loss` functions. On a quick search it looked like there were 4-5 of these, so it shouldn't take too long. Any use of `tf.boolean_mask` is a surefire sign that XLA compilation will break, because output shapes become data-dependent.
- [x] See if there's a way to test non-core models for XLA fit support without crippling performance. (No, but we're using the XLA losses in non-XLA tests by default, so that partially tests it for all models)