### PR TITLE
Restore original task in test_warning_logs

### DIFF
--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -777,9 +777,16 @@ class PipelineRegistryTest(unittest.TestCase):
         logger_ = transformers_logging.get_logger("transformers.pipelines.base")
 
         alias = "text-classification"
+        # Get the original task, so we can restore it at the end.
+        # (otherwise the subsequential tests in `TextClassificationPipelineTests` will fail)
+        original_task, original_task_options = PIPELINE_REGISTRY.check_task(alias)
+
         with CaptureLogger(logger_) as cm:
             PIPELINE_REGISTRY.register_pipeline(alias, {})
         self.assertIn(f"{alias} is already registered", cm.out)
+
+        # restore
+        PIPELINE_REGISTRY.register_pipeline(alias, original_task)
 
     @require_torch
     def test_register_pipeline(self):

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -781,12 +781,13 @@ class PipelineRegistryTest(unittest.TestCase):
         # (otherwise the subsequential tests in `TextClassificationPipelineTests` will fail)
         original_task, original_task_options = PIPELINE_REGISTRY.check_task(alias)
 
-        with CaptureLogger(logger_) as cm:
-            PIPELINE_REGISTRY.register_pipeline(alias, {})
-        self.assertIn(f"{alias} is already registered", cm.out)
-
-        # restore
-        PIPELINE_REGISTRY.register_pipeline(alias, original_task)
+        try:
+            with CaptureLogger(logger_) as cm:
+                PIPELINE_REGISTRY.register_pipeline(alias, {})
+            self.assertIn(f"{alias} is already registered", cm.out)
+        finally:
+            # restore
+            PIPELINE_REGISTRY.register_pipeline(alias, original_task)
 
     @require_torch
     def test_register_pipeline(self):


### PR DESCRIPTION
# What does this PR do?

`test_warning_logs` modifies `PIPELINE_REGISTRY` via `PIPELINE_REGISTRY.register_pipeline(alias, {})`, which fails the tests in `TextClassificationPipelineTests`.

This PR restores the original task at the end of `test_warning_logs`.

cc @aarnphm