### PR TITLE
Exclude Databricks from notebook env only if the runtime is below 11.0

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -506,7 +506,9 @@ def is_in_notebook():
             raise ImportError("console")
         if "VSCODE_PID" in os.environ:
             raise ImportError("vscode")
-        if "DATABRICKS_RUNTIME_VERSION" in os.environ:
+        if "DATABRICKS_RUNTIME_VERSION" in os.environ and os.environ["DATABRICKS_RUNTIME_VERSION"] < "11.0":
+            # Databricks Runtime 11.0 and above uses IPython kernel by default so it should be compatible with Jupyter notebook.
+            # https://docs.microsoft.com/en-us/azure/databricks/notebooks/ipython-kernel
             raise ImportError("databricks")
 
         return importlib.util.find_spec("IPython") is not None

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -507,7 +507,7 @@ def is_in_notebook():
         if "VSCODE_PID" in os.environ:
             raise ImportError("vscode")
         if "DATABRICKS_RUNTIME_VERSION" in os.environ and os.environ["DATABRICKS_RUNTIME_VERSION"] < "11.0":
-            # Databricks Runtime 11.0 and above uses IPython kernel by default so it should be compatible with Jupyter notebook.
+            # Databricks Runtime 11.0 and above uses IPython kernel by default so it should be compatible with Jupyter notebook
             # https://docs.microsoft.com/en-us/azure/databricks/notebooks/ipython-kernel
             raise ImportError("databricks")
 


### PR DESCRIPTION
# What does this PR do?

This PR adds additional check to `is_in_notebook()` to return `False` in Databricks only if the Databricks Runtime is below 11.0. In Databricks Runtime 11.0 and above, IPython kernel is the default Python execution engine. Therefore it should be more compatible with Jupyter notebook https://docs.databricks.com/notebooks/ipython-kernel.html

https://github.com/huggingface/transformers/issues/17406#issuecomment-1172510084

## Additional Info

In Databricks Runtime 10.5 and earlier this is what the evaluation HTML output used to be. Therefore, we need to disable the notebook env. 
![image](https://user-images.githubusercontent.com/5300554/176943749-bf922f69-6bea-4ae7-82ae-4487b37967ba.png)

In Databricks Runtime 11.0 with the default IPython kernel, the output looks similar to that in Jupyter notebook. Therefore, I believe we no longer need to disable the notebook env.
![image](https://user-images.githubusercontent.com/5300554/176944081-56e7fc2d-f40c-4948-a572-53b553e0ffa6.png)

What does the value of `DATABRICKS_RUNTIME_VERSION` environment look like in Databricks notebook?
![image](https://user-images.githubusercontent.com/5300554/176944270-6d78b2be-50d5-428e-b191-c4e5a46cb7d2.png)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
