### PR TITLE
Fix torchscript tests for GPT-NeoX

### DIFF
--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -264,7 +264,7 @@ class RotaryEmbedding(torch.nn.Module):
             emb = torch.cat((freqs, freqs), dim=-1).to(x.device)
             self.cos_cached = emb.cos()[None, None, :, :]
             self.sin_cached = emb.sin()[None, None, :, :]
-        return self.cos_cached[:seq_len, ...], self.sin_cached[:seq_len, ...]
+        return self.cos_cached[:seq_len, ...].to(x.device), self.sin_cached[:seq_len, ...].to(x.device)
 
 
 def rotate_half(x):

--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -207,7 +207,8 @@ class GPTNeoXAttention(nn.Module):
             query,
             key.transpose(1, 2),
             beta=1.0,
-            alpha=(1.0 / self.norm_factor),
+            alpha=(torch.tensor(1.0, dtype=self.norm_factor.dtype, device=self.norm_factor.device) / self.norm_factor),
+            # alpha=(1.0 / self.norm_factor),
         )
         attn_scores = attn_scores.view(batch_size, num_attention_heads, query_length, key_length)
 


### PR DESCRIPTION
# What does this PR do?

Fix torchscript tests for GPT-NeoX. The main issue comes from the fact that current `RotaryEmbedding` changes the model structure in `forward`.

This PR creates the necessary embeddings in `__init__`, which basically makes the cache (of embedding) mechanism useless. Furthermore, the attribute names seems a bit confusing now. We could probably add some attribute (ex. `init_sin_cos_cache_seq_len`) in config with a value `<= max_position_embeddings`, but I think it's way too much.

Not certain if it is worth it. However, with a PR opened, we have a reference.

The current failing test is 
https://github.com/huggingface/transformers/runs/7216768053?check_suite_focus=true