### PR TITLE
fix loading from pretrained for sharded model with `torch_dtype="auto"

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2037,7 +2037,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                         elif not is_sharded:
                             torch_dtype = get_state_dict_dtype(state_dict)
                         else:
-                            one_state_dict = load_state_dict(resolved_archive_file)
+                            one_state_dict = load_state_dict(resolved_archive_file[0])
                             torch_dtype = get_state_dict_dtype(one_state_dict)
                             del one_state_dict  # free CPU memory
                     else:


### PR DESCRIPTION
Fixes the following script which failed because `resolved_archive_file` is a list for sharded models and `load_state_dict`expects a path to a single file
```python
model = AutoModelForCausalLM.from_pretrained("bigscience/bloom", torch_dtype="auto")
```


