### PR TITLE
add dataset split and config to model-index in TrainingSummary.from_trainer

### DIFF
--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -586,8 +586,7 @@ class TrainingSummary:
                 if dataset_metadata is None:
                     dataset_metadata = [{
                         "config": one_dataset.info.config_name,
-                        "revision": one_dataset.version,
-                        "split": one_dataset.split
+                        "split": one_dataset.split.__str__()
                     }]
                 if dataset_tags is None:
                     dataset_tags = [default_tag]
@@ -767,7 +766,7 @@ def parse_log_history(log_history):
         while idx >= 0 and "eval_loss" not in log_history[idx]:
             idx -= 1
 
-        if idx > 0:
+        if idx >= 0:
             return None, None, log_history[idx]
         else:
             return None, None, None

--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -441,7 +441,7 @@ class TrainingSummary:
                 result["task"] = {"name": task_mapping[task_tag], "type": task_tag}
 
             if ds_tag is not None:
-                metadata = dataset_metadata_mapping.get(ds_tag, None) or {}
+                metadata = dataset_metadata_mapping.get(ds_tag, {})
                 result["dataset"] = {
                     "name": dataset_mapping[ds_tag],
                     "type": ds_tag,
@@ -584,7 +584,7 @@ class TrainingSummary:
             # Those are not real datasets from the Hub so we exclude them.
             if default_tag not in ["csv", "json", "pandas", "parquet", "text"]:
                 if dataset_metadata is None:
-                    dataset_metadata = [{"config": one_dataset.info.config_name, "split": one_dataset.split.__str__()}]
+                    dataset_metadata = [{"config": one_dataset.config_name, "split": str(one_dataset.split)}]
                 if dataset_tags is None:
                     dataset_tags = [default_tag]
                 if dataset_args is None:

--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -585,9 +585,9 @@ class TrainingSummary:
             if default_tag not in ["csv", "json", "pandas", "parquet", "text"]:
                 if dataset_metadata is None:
                     dataset_metadata = [{
-                        "config": one_dataset.config,
+                        "config": one_dataset.info.config_name,
                         "revision": one_dataset.version,
-                        "split": "train" if trainer.train_dataset is not None else "eval"
+                        "split": one_dataset.split
                     }]
                 if dataset_tags is None:
                     dataset_tags = [default_tag]

--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -384,6 +384,7 @@ class TrainingSummary:
     dataset: Optional[Union[str, List[str]]] = None
     dataset_tags: Optional[Union[str, List[str]]] = None
     dataset_args: Optional[Union[str, List[str]]] = None
+    dataset_metadata: Optional[Dict[str, Any]] = None
     eval_results: Optional[Dict[str, float]] = None
     eval_lines: Optional[List[str]] = None
     hyperparameters: Optional[Dict[str, Any]] = None
@@ -412,10 +413,12 @@ class TrainingSummary:
         dataset_names = _listify(self.dataset)
         dataset_tags = _listify(self.dataset_tags)
         dataset_args = _listify(self.dataset_args)
+        dataset_metadata = _listify(self.dataset_metadata)
         if len(dataset_args) < len(dataset_tags):
             dataset_args = dataset_args + [None] * (len(dataset_tags) - len(dataset_args))
         dataset_mapping = {tag: name for tag, name in zip(dataset_tags, dataset_names)}
         dataset_arg_mapping = {tag: arg for tag, arg in zip(dataset_tags, dataset_args)}
+        dataset_metadata_mapping = {tag: metadata for tag, metadata in zip(dataset_tags, dataset_metadata)}
 
         task_mapping = {
             task: TASK_TAG_TO_NAME_MAPPING[task] for task in _listify(self.tasks) if task in TASK_TAG_TO_NAME_MAPPING
@@ -438,7 +441,12 @@ class TrainingSummary:
                 result["task"] = {"name": task_mapping[task_tag], "type": task_tag}
 
             if ds_tag is not None:
-                result["dataset"] = {"name": dataset_mapping[ds_tag], "type": ds_tag}
+                metadata = dataset_metadata_mapping[ds_tag] or {}
+                result["dataset"] = {
+                    "name": dataset_mapping[ds_tag],
+                    "type": ds_tag,
+                    **metadata,
+                }
                 if dataset_arg_mapping[ds_tag] is not None:
                     result["dataset"]["args"] = dataset_arg_mapping[ds_tag]
 
@@ -565,6 +573,7 @@ class TrainingSummary:
         finetuned_from=None,
         tasks=None,
         dataset_tags=None,
+        dataset_metadata=None,
         dataset=None,
         dataset_args=None,
     ):
@@ -574,6 +583,12 @@ class TrainingSummary:
             default_tag = one_dataset.builder_name
             # Those are not real datasets from the Hub so we exclude them.
             if default_tag not in ["csv", "json", "pandas", "parquet", "text"]:
+                if dataset_metadata is None:
+                    dataset_metadata = [{
+                        "config": one_dataset.config,
+                        "revision": one_dataset.version,
+                        "split": "train" if trainer.train_dataset is not None else "eval"
+                    }]
                 if dataset_tags is None:
                     dataset_tags = [default_tag]
                 if dataset_args is None:
@@ -618,9 +633,10 @@ class TrainingSummary:
             model_name=model_name,
             finetuned_from=finetuned_from,
             tasks=tasks,
-            dataset_tags=dataset_tags,
             dataset=dataset,
+            dataset_tags=dataset_tags,
             dataset_args=dataset_args,
+            dataset_metadata=dataset_metadata,
             eval_results=eval_results,
             eval_lines=eval_lines,
             hyperparameters=hyperparameters,

--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -441,7 +441,7 @@ class TrainingSummary:
                 result["task"] = {"name": task_mapping[task_tag], "type": task_tag}
 
             if ds_tag is not None:
-                metadata = dataset_metadata_mapping[ds_tag] or {}
+                metadata = dataset_metadata_mapping.get(ds_tag, None) or {}
                 result["dataset"] = {
                     "name": dataset_mapping[ds_tag],
                     "type": ds_tag,

--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -584,10 +584,7 @@ class TrainingSummary:
             # Those are not real datasets from the Hub so we exclude them.
             if default_tag not in ["csv", "json", "pandas", "parquet", "text"]:
                 if dataset_metadata is None:
-                    dataset_metadata = [{
-                        "config": one_dataset.info.config_name,
-                        "split": one_dataset.split.__str__()
-                    }]
+                    dataset_metadata = [{"config": one_dataset.info.config_name, "split": one_dataset.split.__str__()}]
                 if dataset_tags is None:
                     dataset_tags = [default_tag]
                 if dataset_args is None:


### PR DESCRIPTION
# What does this PR do?

Add dataset split and config to model-index in TrainingSummary when generated with from_trainer on a HF Hub dataset

example: https://huggingface.co/loicmagne/pr_dataset_metadata/blob/main/README.md 


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@lewtun 
