### PR TITLE
Fix slow CI by pinning resampy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,7 @@ _deps = [
     "ray[tune]",
     "regex!=2019.12.17",
     "requests",
+    "resampy<0.3.1",
     "rjieba",
     "rouge-score",
     "sacrebleu>=1.4.12,<2.0.0",
@@ -295,6 +296,7 @@ extras["testing"] = (
         "nltk",
         "GitPython",
         "hf-doc-builder",
+        "resampy",  # can be remoed once we can unpin resampy
         "protobuf",  # Can be removed once we can unpin protobuf
         "sacremoses",
         "rjieba",

--- a/setup.py
+++ b/setup.py
@@ -269,7 +269,7 @@ extras["sigopt"] = deps_list("sigopt")
 extras["integrations"] = extras["optuna"] + extras["ray"] + extras["sigopt"]
 
 extras["serving"] = deps_list("pydantic", "uvicorn", "fastapi", "starlette")
-extras["audio"] = deps_list("librosa", "pyctcdecode", "phonemizer")
+extras["audio"] = deps_list("librosa", "pyctcdecode", "phonemizer", "resampy")  # resampy can be removed once unpinned.
 # `pip install ".[speech]"` is deprecated and `pip install ".[torch-speech]"` should be used instead
 extras["speech"] = deps_list("torchaudio") + extras["audio"]
 extras["torch-speech"] = deps_list("torchaudio") + extras["audio"]
@@ -296,7 +296,6 @@ extras["testing"] = (
         "nltk",
         "GitPython",
         "hf-doc-builder",
-        "resampy",  # can be remoed once we can unpin resampy
         "protobuf",  # Can be removed once we can unpin protobuf
         "sacremoses",
         "rjieba",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -49,6 +49,7 @@ deps = {
     "ray[tune]": "ray[tune]",
     "regex": "regex!=2019.12.17",
     "requests": "requests",
+    "resampy": "resampy<0.3.1",
     "rjieba": "rjieba",
     "rouge-score": "rouge-score",
     "sacrebleu": "sacrebleu>=1.4.12,<2.0.0",


### PR DESCRIPTION
# What does this PR do?

The recent release of resampy (0.3.1) seems to suddenly make a lot of things (even unrelated to speech) very slow and the CI has several jobs timing out. This PR fixes that by pinning resampy to any previous version.