### PR TITLE
 Added the timeout variable in training args to avoid socket timeouts in DDP calls

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -952,6 +952,20 @@ class TrainingArguments:
         },
     )
 
+    timeout: int = field(
+        default=1800,
+        metadata={
+            "help": (
+                "Variable to override the default timeout defined by PyTorch and "
+                "introduce a way to prevent Socket Timeouts when mapping large datasets"
+                "Expects timeout in seconds. Used for timeout argument in "
+                "torch.distributed.init_process_group calls. Please refer the PyTorch documentation"
+                "https://pytorch.org/docs/stable/distributed.html#torch.distributed.init_process_group"
+                " timeout is passed datetime object"
+            )
+        }
+    )
+
     def __post_init__(self):
         # Handle --use_env option in torch.distributed.launch (local_rank not passed as an arg then).
         # This needs to happen before any call to self.device or self.n_gpu.


### PR DESCRIPTION
Overriding the default timeout defined by PyTorch in **torch.distributed.init_process_group** calls by introducing a timeout argument and prevents Socket Timeouts

Added a custom timeout argument in **src/transformers/training_args.py**. It can be used to override the timeout argument in the **init_process_group** function call to avoid socket timeouts for mapping or tokenizing huge datasets that may take a longer time.

The timeout variable is a **int** type and default value is set to **1800(s)** which is default value in torch.distributed.init_process_group fn. 

The timeout datatype used in torch.distributed.init_process_group is a **datetime.timedelta** object that expects this timeout variable.

# What does this PR do?

Fixes #18054 #17106
