### PR TITLE
Good difficult issue override for the stalebot

### DIFF
--- a/scripts/stale.py
+++ b/scripts/stale.py
@@ -24,6 +24,7 @@ from github import Github
 LABELS_TO_EXEMPT = [
     "good first issue",
     "good second issue",
+    "good difficult issue",
     "feature request",
     "new model",
     "wip",


### PR DESCRIPTION
Ignores issue with the `Good difficult issue` label with the stalebot, as otherwise these get closed.