### PR TITLE
Report value for a step instead of epoch.

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1138,9 +1138,7 @@ class Trainer:
             self.args.hf_deepspeed_config = HfTrainerDeepSpeedConfig(self.args.deepspeed)
             self.args.hf_deepspeed_config.trainer_config_process(self.args)
 
-    def _report_to_hp_search(
-        self, trial: Union["optuna.Trial", Dict[str, Any]], step: int, metrics: Dict[str, float]
-    ):
+    def _report_to_hp_search(self, trial: Union["optuna.Trial", Dict[str, Any]], step: int, metrics: Dict[str, float]):
         if self.hp_search_backend is None or trial is None:
             return
         self.objective = self.compute_objective(metrics.copy())

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1139,7 +1139,7 @@ class Trainer:
             self.args.hf_deepspeed_config.trainer_config_process(self.args)
 
     def _report_to_hp_search(
-        self, trial: Union["optuna.Trial", Dict[str, Any]], epoch: int, metrics: Dict[str, float]
+        self, trial: Union["optuna.Trial", Dict[str, Any]], step: int, metrics: Dict[str, float]
     ):
         if self.hp_search_backend is None or trial is None:
             return
@@ -1147,7 +1147,7 @@ class Trainer:
         if self.hp_search_backend == HPSearchBackend.OPTUNA:
             import optuna
 
-            trial.report(self.objective, epoch)
+            trial.report(self.objective, step)
             if trial.should_prune():
                 self.callback_handler.on_train_end(self.args, self.state, self.control)
                 raise optuna.TrialPruned()
@@ -1916,7 +1916,7 @@ class Trainer:
         metrics = None
         if self.control.should_evaluate:
             metrics = self.evaluate(ignore_keys=ignore_keys_for_eval)
-            self._report_to_hp_search(trial, epoch, metrics)
+            self._report_to_hp_search(trial, self.state.global_step, metrics)
 
         if self.control.should_save:
             self._save_checkpoint(model, trial, metrics=metrics)


### PR DESCRIPTION
# What does this PR do?
Report an objective function value for a step instead of epoch to optuna.

## I made this modification for the following reason:
If "eval_steps" is less than steps per epoch, there maybe warnings: `optuna/trial/_trial.py:592: UserWarning: The reported value is ignored because this ‘step’ 0 is already reported.`. This is because the epoch granularity is too coarse. So "step" are more appropriate than "epoch" here.

## Who can review?
Anyone in the community is free to review the PR once the tests have passed. 
@sgugger @LysandreJik 
