### PR TITLE
CLI: reenable `pt_to_tf` test

### DIFF
--- a/tests/utils/test_cli.py
+++ b/tests/utils/test_cli.py
@@ -33,7 +33,6 @@ class CLITest(unittest.TestCase):
         self.assertIn("Platform", cs.out)
         self.assertIn("Using distributed or parallel set-up in script?", cs.out)
 
-    @unittest.skip("Joao will fix me tomorrow.")
     @is_pt_tf_cross_test
     @patch(
         "sys.argv", ["fakeprogrampath", "pt-to-tf", "--model-name", "hf-internal-testing/tiny-random-gptj", "--no-pr"]


### PR DESCRIPTION
# What does this PR do?

Reenables the `pt_to_tf` CLI test that was disabled a few days ago.

⚠️ Before this PR is merged, [this](https://huggingface.co/hf-internal-testing/tiny-random-gptj/discussions/1) hub PR must be merged, and CI must be rerun. This test model is also used in `tests/deepspeed/test_model_zoo.py`, not sure if the change will have implications there.

The problem was not due to code, but rather to problems in the config file of the test model. When `config.rotary_dim` is larger than `self.head_dim` (which is `config.hidden_size` divided by `config.num_attention_heads`), then we try to slice out of bounds in some tensors, causing downstream dimension-related exceptions -- e.g. [slicing here](https://github.com/huggingface/transformers/blob/main/src/transformers/models/gptj/modeling_tf_gptj.py#L229).