### PR TITLE
Make sharded checkpoints work in offline mode

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -552,8 +552,9 @@ def get_from_cache(
                 # the models might've been found if local_files_only=False
                 # Notify the user about that
                 if local_files_only:
-                    raise FileNotFoundError(
-                        "Cannot find the requested files in the cached path and outgoing traffic has been"
+                    fname = url.split("/")[-1]
+                    raise EntryNotFoundError(
+                        f"Cannot find the requested file ({fname}) in the cached path and outgoing traffic has been"
                         " disabled. To enable model look-ups and downloads online, set 'local_files_only'"
                         " to False."
                     )


### PR DESCRIPTION
# What does this PR do?

This PR make sharded checkpoint work in offline mode and add more information to an error we return.
The crux of the issue is that the `from_pretrained` method of the various models will catch `EntryNotFoundError` on the regular model weights file, but we return a `FileNotFoundError` in offline mode. I changed the error type at the root, to avoid making three modifications in the PyTorch/TF/Flax model classes, but can change if you don't find this suitable.