### PR TITLE
Fix BLOOM DeepSpeed inference issue

### DIFF
--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -305,7 +305,7 @@ class BloomAttention(nn.Module):
         attn_weights = (attention_scores * self.layer_number) + attention_mask
         attn_weights = torch.max(attn_weights, torch.tensor(torch.finfo(attn_weights.dtype).min))
         attention_probs = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(input_dtype)
-        attention_probs = attention_probs * (~attention_mask.bool())
+        attention_probs = attention_probs
         # [batch_size, num_heads, q_length, k_length]
         attention_probs = self.attention_dropout(attention_probs)
 


### PR DESCRIPTION
# What does this PR do?

This PR tries to address a strange behaviour observed when inferring bloom-176 model using DeepSpeed!
My intuitions are:
- In the previous code we used `-10000` for the attention mask filling value whereas we should use `fp32.min` as it is written in the original cuda kernel of [`FusedScaledSoftmax`](https://github.com/bigscience-workshop/Megatron-DeepSpeed/blob/7b5f175b73a12d602cdadd3ee205ed666f6d4234/megatron/fused_kernels/scaled_masked_softmax.h#L288). This might lead to inconsistent result between the old version and the new version, but the new version should be considered as the correct one
- @RezaYazdaniAminabadi discovered that attention scores should not be multiplied by the attention mask after the softmax, which makes sense and could fix the issue

cc @RezaYazdaniAminabadi @stas00 @thomasw21 