### PR TITLE
Fix beam search computing wrong `next_indices`

### DIFF
--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -534,7 +534,6 @@ class GenerationMixin:
         model_kwargs: Optional[Dict[str, torch.Tensor]] = None,
         device: torch.device = None,
     ) -> torch.LongTensor:
-
         if model_kwargs is not None and "decoder_input_ids" in model_kwargs:
             return model_kwargs.pop("decoder_input_ids")
         else:
@@ -1665,7 +1664,6 @@ class GenerationMixin:
 
         this_peer_finished = False  # used by synced_gpus only
         while True:
-
             if synced_gpus:
                 # Under synced_gpus the `forward` call must continue until all gpus complete their sequence.
                 # The following logic allows an early break if all peers finished generating their sequence
@@ -1920,7 +1918,6 @@ class GenerationMixin:
         this_peer_finished = False  # used by synced_gpus only
         # auto-regressive generation
         while True:
-
             if synced_gpus:
                 # Under synced_gpus the `forward` call must continue until all gpus complete their sequence.
                 # The following logic allows an early break if all peers finished generating their sequence
@@ -2189,7 +2186,6 @@ class GenerationMixin:
 
         this_peer_finished = False  # used by synced_gpus only
         while True:
-
             if synced_gpus:
                 # Under synced_gpus the `forward` call must continue until all gpus complete their sequence.
                 # The following logic allows an early break if all peers finished generating their sequence
@@ -2502,7 +2498,6 @@ class GenerationMixin:
 
         this_peer_finished = False  # used by synced_gpus only
         while True:
-
             if synced_gpus:
                 # Under synced_gpus the `forward` call must continue until all gpus complete their sequence.
                 # The following logic allows an early break if all peers finished generating their sequence
@@ -2826,7 +2821,6 @@ class GenerationMixin:
 
         this_peer_finished = False  # used by synced_gpus only
         while True:
-
             if synced_gpus:
                 # Under synced_gpus the `forward` call must continue until all gpus complete their sequence.
                 # The following logic allows an early break if all peers finished generating their sequence
@@ -3024,7 +3018,6 @@ class GenerationMixin:
         synced_gpus: Optional[bool] = None,
         **model_kwargs,
     ) -> Union[BeamSearchOutput, torch.LongTensor]:
-
         r"""
         Generates sequences of token ids for models with a language modeling head using **constrained beam search
         decoding** and can be used for text-decoder, text-to-text, speech-to-text, and vision-to-text models.
@@ -3186,7 +3179,6 @@ class GenerationMixin:
 
         this_peer_finished = False  # used by synced_gpus only
         while True:
-
             if synced_gpus:
                 # Under synced_gpus the `forward` call must continue until all gpus complete their sequence.
                 # The following logic allows an early break if all peers finished generating their sequence
@@ -3250,7 +3242,7 @@ class GenerationMixin:
                 next_token_scores, 2 * num_beams, dim=1, largest=True, sorted=True
             )
 
-            next_indices = (next_tokens / vocab_size).long()
+            next_indices = torch.div(next_tokens, vocab_size, rounding_mode="floor").long()
             next_tokens = next_tokens % vocab_size
 
             # stateless


### PR DESCRIPTION
# What does this PR do?

Beam search used `next_indices = (next_tokens / vocab_size).long()` to compute the indices of the best beams. This, however, uses [torch.true_divide](https://pytorch.org/docs/stable/generated/torch.true_divide.html#torch-true-divide) which would lead to numerical errors and make the following snippet fail:
```py
import torch

next_tokens = torch.tensor([[0, 50257]], dtype=torch.int64, device='cuda:0')
vocab_size = 50257
expected_next_indices = torch.tensor([[0,1]], dtype=torch.int64, device='cuda:0')

next_indices = (next_tokens / vocab_size).long()
print(next_indices)

assert torch.all(next_indices == expected_next_indices)  # Fails
```

The simple fix in this PR uses floor division to avoid the aforementioned problem:
```py
# ...
next_indices = torch.div(next_tokens, vocab_size, rounding_mode='floor').long()
print(next_indices)

assert torch.all(next_indices == expected_next_indices)  # Passes
```

I have dug out this bug while recomputing the beam search scores by hand for gpt2. If needed, I can add an end-to-end high-level reproducibility test with gpt2 and the tricky input_ids, and possibly add it as a unit test.

## Who can review?

@patrickvonplaten