### PR TITLE
Fix expected loss values in some (m)T5 tests

### DIFF
--- a/tests/models/mt5/test_modeling_tf_mt5.py
+++ b/tests/models/mt5/test_modeling_tf_mt5.py
@@ -69,5 +69,5 @@ class TFMT5ModelIntegrationTest(unittest.TestCase):
         loss = model(input_ids, labels=labels).loss
         mtf_score = -tf.math.reduce_mean(loss).numpy()
 
-        EXPECTED_SCORE = -21.210594
+        EXPECTED_SCORE = -21.228168
         self.assertTrue(abs(mtf_score - EXPECTED_SCORE) < 2e-4)

--- a/tests/models/t5/test_modeling_tf_t5.py
+++ b/tests/models/t5/test_modeling_tf_t5.py
@@ -661,7 +661,7 @@ class TFT5ModelIntegrationTests(unittest.TestCase):
         loss = model(input_ids, labels=labels).loss
         mtf_score = -tf.math.reduce_mean(loss).numpy()
 
-        EXPECTED_SCORE = -4.7728806
+        EXPECTED_SCORE = -4.771147
         self.assertTrue(abs(mtf_score - EXPECTED_SCORE) < 1e-4)
 
     @slow
@@ -687,7 +687,7 @@ class TFT5ModelIntegrationTests(unittest.TestCase):
         loss = model(input_ids, labels=labels).loss
         mtf_score = -tf.math.reduce_mean(loss).numpy()
 
-        EXPECTED_SCORE = -14.753843
+        EXPECTED_SCORE = -14.757326
         self.assertTrue(abs(mtf_score - EXPECTED_SCORE) < 1e-4)
 
     @slow
@@ -711,7 +711,7 @@ class TFT5ModelIntegrationTests(unittest.TestCase):
         loss = model(input_ids, labels=labels).loss
         mtf_score = -tf.math.reduce_mean(loss).numpy()
 
-        EXPECTED_SCORE = -7.5949106
+        EXPECTED_SCORE = -7.592465
         self.assertTrue(abs(mtf_score - EXPECTED_SCORE) < 1e-4)
 
     @slow

--- a/tests/models/t5/test_modeling_tf_t5.py
+++ b/tests/models/t5/test_modeling_tf_t5.py
@@ -661,7 +661,7 @@ class TFT5ModelIntegrationTests(unittest.TestCase):
         loss = model(input_ids, labels=labels).loss
         mtf_score = -tf.math.reduce_mean(loss).numpy()
 
-        EXPECTED_SCORE = -4.7710114
+        EXPECTED_SCORE = -4.7728806
         self.assertTrue(abs(mtf_score - EXPECTED_SCORE) < 1e-4)
 
     @slow
@@ -687,7 +687,7 @@ class TFT5ModelIntegrationTests(unittest.TestCase):
         loss = model(input_ids, labels=labels).loss
         mtf_score = -tf.math.reduce_mean(loss).numpy()
 
-        EXPECTED_SCORE = -14.759922
+        EXPECTED_SCORE = -14.753843
         self.assertTrue(abs(mtf_score - EXPECTED_SCORE) < 1e-4)
 
     @slow
@@ -711,7 +711,7 @@ class TFT5ModelIntegrationTests(unittest.TestCase):
         loss = model(input_ids, labels=labels).loss
         mtf_score = -tf.math.reduce_mean(loss).numpy()
 
-        EXPECTED_SCORE = -7.594554
+        EXPECTED_SCORE = -7.5949106
         self.assertTrue(abs(mtf_score - EXPECTED_SCORE) < 1e-4)
 
     @slow


### PR DESCRIPTION
# What does this PR do?

Fix CI failures regarding some T5 and MT5 tests.

The PR #18013 and the subsequent fix in #18029  probably tried to get the expected loss values without setting

```python
os.environ["NVIDIA_TF32_OVERRIDE"] = "0"
```