### PR TITLE
Fix template for new models in README

### DIFF
--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -495,8 +495,8 @@ MODELS_NOT_IN_README = [
 
 
 README_TEMPLATE = (
-    "1. **[{model_name}](https://huggingface.co/docs/transformers/model_doc/{model_type})** (from <FILL INSTITUTION>) "
-    "released with the paper [<FILL PAPER TITLE>](<FILL ARKIV LINK>) by <FILL AUTHORS>."
+    "1. **[{model_name}](https://huggingface.co/docs/main/transformers/model_doc/{model_type})** (from "
+    "<FILL INSTITUTION>) released with the paper [<FILL PAPER TITLE>](<FILL ARKIV LINK>) by <FILL AUTHORS>."
 )
 
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes the template for when `make fix-copies` adds new models to the README. They are probably new models that should be documented in main and not stable.