### PR TITLE
Fix BLOOM's softmax for half precisions

### DIFF
--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -303,7 +303,9 @@ class BloomAttention(nn.Module):
         # We replace the scaled softmax by just a few line of code - [batch_size, num_heads, q_length, k_length]
         input_dtype = attention_scores.dtype
         attn_weights = (attention_scores * self.layer_number) + attention_mask
-        attn_weights = torch.clip(attn_weights, torch.finfo(attn_weights.dtype).min, torch.finfo(attn_weights.dtype).max) 
+        attn_weights = torch.clip(
+            attn_weights, torch.finfo(attn_weights.dtype).min, torch.finfo(attn_weights.dtype).max
+        )
         attention_probs = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(input_dtype)
         attention_probs = attention_probs * (~attention_mask.bool())
         # [batch_size, num_heads, q_length, k_length]

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -595,11 +595,13 @@ class BloomModel(BloomPreTrainedModel):
 
         if attention_mask is not None:
             # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]
-            expanded_attn_mask = _expand_mask(attention_mask, inputs_embeds.dtype, tgt_len=input_shape[-1])
-            combined_attention_mask = (
-                expanded_attn_mask if combined_attention_mask is None else expanded_attn_mask + combined_attention_mask
+            if combined_attention_mask is None:
+                combined_attention_mask = _expand_mask(attention_mask, inputs_embeds.dtype, tgt_len=input_shape[-1])
+            else:
+                combined_attention_mask.masked_fill_(
+                    ~attention_mask[:, None, None, :].to(torch.bool).expand_as(combined_attention_mask),
+                    -torch.inf,
             )
-
         return combined_attention_mask
 
     def set_input_embeddings(self, new_embeddings):

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -597,13 +597,10 @@ class BloomModel(BloomPreTrainedModel):
 
         if attention_mask is not None:
             # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]
-            if combined_attention_mask is None:
-                combined_attention_mask = _expand_mask(attention_mask, inputs_embeds.dtype, tgt_len=input_shape[-1])
-            else:
-                combined_attention_mask.masked_fill_(
-                    ~attention_mask[:, None, None, :].to(torch.bool).expand_as(combined_attention_mask),
-                    -torch.inf,
-                )
+            expanded_attn_mask = _expand_mask(attention_mask, inputs_embeds.dtype, tgt_len=input_shape[-1])
+            combined_attention_mask = (
+                expanded_attn_mask if combined_attention_mask is None else expanded_attn_mask + combined_attention_mask
+            )
         return combined_attention_mask
 
     def set_input_embeddings(self, new_embeddings):


### PR DESCRIPTION
This PR aims at fixing the following issues:

- In [this line](https://github.com/huggingface/transformers/blob/6561fbcc6e6d6e1a29fb848dc34710aa25feae78/src/transformers/models/bloom/modeling_bloom.py#L305), if we use minimum dtype values in the attention mask to mask some values. After adding a positive value, the masked values would come back to life. This PR proposes to use `-inf` in the attention mask instead, and only after the addition, we replace the inf values by the respective max/min dtype values
```python
        input_dtype = attention_scores.dtype
        attn_weights = (attention_scores * self.layer_number) + attention_mask # torch.finfo(torch.float16).min + 1 is no longer torch.finfo(torch.float16).min (no longer hidden)
        attn_weights = torch.max(attn_weights, torch.tensor(torch.finfo(attn_weights.dtype).min))
        attention_probs = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(input_dtype)
```
- Use `torch.clip` instead of `torch.max` to ensure we avoid both `-inf` and `+inf` for softmax 
- [Only relevent if we use `torch.finfo(dtype).min` in attention mask] In [this line](https://github.com/huggingface/transformers/blob/6561fbcc6e6d6e1a29fb848dc34710aa25feae78/src/transformers/models/bloom/modeling_bloom.py#L600), if we use the minimum dtype values, after performing the addition, we get mixed `-inf` and `torch.finfo(dtype).min` in the attention mask
 ```python
       if attention_mask is not None:
            # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]
            expanded_attn_mask = _expand_mask(attention_mask, inputs_embeds.dtype, tgt_len=input_shape[-1])
            combined_attention_mask = (
                expanded_attn_mask if combined_attention_mask is None else expanded_attn_mask + combined_attention_mask # this gives `-inf` when we substract a number from `torch.finfo(dtype).min`
            )
```

All tests (including slow ones) are passing. ✅
Related to: https://github.com/huggingface/transformers/pull/17437
Co-authored by: @younesbelkada 
cc @ydshieh @stas00