### PR TITLE
TF: Add missing cast to GPT-J

### DIFF
--- a/src/transformers/models/gptj/modeling_tf_gptj.py
+++ b/src/transformers/models/gptj/modeling_tf_gptj.py
@@ -222,7 +222,7 @@ class TFGPTJAttention(tf.keras.layers.Layer):
         key = self._split_heads(key, True)
         value = self._split_heads(value, False)
 
-        sincos = tf.gather(self.embed_positions, position_ids, axis=0)
+        sincos = tf.cast(tf.gather(self.embed_positions, position_ids, axis=0), hidden_states.dtype)
         sincos = tf.split(sincos, 2, axis=-1)
         if self.rotary_dim is not None:
             k_rot = key[:, :, :, : self.rotary_dim]


### PR DESCRIPTION
# What does this PR do?

Adds a missing cast, which was breaking the tests for mixed precision (which, for some weird cause, was also causing subsequent tests to fail 🤔 ) 

All slow tests pass after this change.