### PR TITLE
Reduce console spam when using the KerasMetricCallback

### DIFF
--- a/src/transformers/keras_callbacks.py
+++ b/src/transformers/keras_callbacks.py
@@ -202,7 +202,7 @@ class KerasMetricCallback(Callback):
 
                 predictions = self.model.generate(generation_inputs, attention_mask=attention_mask)
             else:
-                predictions = self.model.predict(batch)
+                predictions = self.model.predict(batch, verbose=0)
                 if isinstance(predictions, dict):
                     # This converts any dict-subclass to a regular dict
                     # Keras REALLY doesn't like it when we pass around a BatchEncoding or other derived class

--- a/src/transformers/keras_callbacks.py
+++ b/src/transformers/keras_callbacks.py
@@ -202,7 +202,7 @@ class KerasMetricCallback(Callback):
 
                 predictions = self.model.generate(generation_inputs, attention_mask=attention_mask)
             else:
-                predictions = self.model.predict(batch, verbose=0)
+                predictions = self.model.predict_on_batch(batch)
                 if isinstance(predictions, dict):
                     # This converts any dict-subclass to a regular dict
                     # Keras REALLY doesn't like it when we pass around a BatchEncoding or other derived class


### PR DESCRIPTION
Right now, `KerasMetricCallback` calls `model.predict()` while iterating over the input dataset. This results in some unwanted console spam when using metrics that do not call `generate()` (because `predict()` always creates a progress bar). Replacing it with `predict_on_batch` removes the spam and also improves performance of the callback.