### PR TITLE
Split docs on modality

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -177,7 +177,6 @@
   - sections:
     - local: model_doc/auto
       title: Auto Classes
-<<<<<<< HEAD
     - isExpanded: false
       sections:
       - local: model_doc/albert

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -36,7 +36,7 @@
       title: Export 🤗 Transformers models
     - local: troubleshooting
       title: Troubleshoot
-    title: "General usage"
+    title: General usage
   - sections:
     - local: fast_tokenizers
       title: Use tokenizers from 🤗 Tokenizers
@@ -59,17 +59,17 @@
         title: Multiple choice
       title: Task guides
       isExpanded: false
-    title: "Natural Language Processing"
+    title: Natural Language Processing
   - sections:
     - local: tasks/audio_classification
       title: Audio classification
     - local: tasks/asr
       title: Automatic speech recognition
-    title: "Audio"
+    title: Audio
   - sections:
     - local: tasks/image_classification
       title: Image classification
-    title: "Computer Vision"
+    title: Computer Vision
   - sections:
     - local: performance
       title: Overview
@@ -99,7 +99,7 @@
       title: Instantiating a big model
     - local: debugging
       title: Debugging
-    title: "Performance and scalability"
+    title: Performance and scalability
   - sections:
     - local: contributing
       title: How to contribute to transformers?
@@ -111,7 +111,7 @@
       title: Testing
     - local: pr_checks
       title: Checks on a Pull Request
-    title: "Contribute"
+    title: Contribute
   - local: notebooks
     title: 🤗 Transformers Notebooks
   - local: community
@@ -120,7 +120,7 @@
     title: Benchmarks
   - local: migration
     title: Migrating from previous packages
-  title: "How-to guides"
+  title: How-to guides
 - sections:
   - local: philosophy
     title: Philosophy

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -101,7 +101,7 @@
     - local: debugging
       title: Debugging
     title: "Performance and scalability"
-  - section:
+  - sections:
     - local: contributing
       title: How to contribute to transformers?
     - local: add_new_model
@@ -174,6 +174,7 @@
   - sections:
     - local: model_doc/auto
       title: Auto Classes
+<<<<<<< HEAD
     - isExpanded: false
       sections:
       - local: model_doc/albert

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -21,13 +21,31 @@
     title: Share a model
   title: Tutorials
 - sections:
-  - local: fast_tokenizers
-    title: Use tokenizers from 🤗 Tokenizers
-  - local: create_a_model
-    title: Create a custom architecture
-  - local: custom_models
-    title: Sharing custom models
   - sections:
+    - local: create_a_model
+      title: Create a custom architecture
+    - local: custom_models
+      title: Sharing custom models
+    - local: run_scripts
+      title: Train with a script
+    - local: sagemaker
+      title: Run training on Amazon SageMaker
+    - local: converting_tensorflow_models
+      title: Converting TensorFlow Checkpoints
+    - local: serialization
+      title: Export 🤗 Transformers models
+    - local: benchmarks
+      title: Benchmarks
+    - local: migration
+      title: Migrating from previous packages
+    - local: troubleshooting
+      title: Troubleshoot
+    title: "General usage"
+  - sections:
+    - local: fast_tokenizers
+      title: Use tokenizers from 🤗 Tokenizers
+    - local: multilingual
+      title: Inference for multilingual models
     - local: tasks/sequence_classification
       title: Text classification
     - local: tasks/token_classification
@@ -42,23 +60,17 @@
       title: Summarization
     - local: tasks/multiple_choice
       title: Multiple choice
+    title: "NLP"
+  - sections:
     - local: tasks/audio_classification
       title: Audio classification
     - local: tasks/asr
       title: Automatic speech recognition
+    title: "Audio"
+  - sections:
     - local: tasks/image_classification
       title: Image classification
-    title: Fine-tune for downstream tasks
-  - local: run_scripts
-    title: Train with a script
-  - local: sagemaker
-    title: Run training on Amazon SageMaker
-  - local: multilingual
-    title: Inference for multilingual models
-  - local: converting_tensorflow_models
-    title: Converting TensorFlow Checkpoints
-  - local: serialization
-    title: Export 🤗 Transformers models
+    title: "Image"
   - sections:
     - local: performance
       title: Overview
@@ -84,32 +96,28 @@
       title: Inference on Specialized Hardware
     - local: perf_hardware
       title: Custom hardware for training
-    title: Performance and scalability
-  - local: big_models
-    title: Instantiating a big model
-  - local: benchmarks
-    title: Benchmarks
-  - local: migration
-    title: Migrating from previous packages
-  - local: troubleshooting
-    title: Troubleshoot
-  - local: debugging
-    title: Debugging
+    - local: big_models
+      title: Instantiating a big model
+    - local: debugging
+      title: Debugging
+    title: "Performance and scalability"
+  - section:
+    - local: contributing
+      title: How to contribute to transformers?
+    - local: add_new_model
+      title: How to add a model to 🤗 Transformers?
+    - local: add_new_pipeline
+      title: How to add a pipeline to 🤗 Transformers?
+    - local: testing
+      title: Testing
+    - local: pr_checks
+      title: Checks on a Pull Request
+    title: "Contribute"
   - local: notebooks
     title: 🤗 Transformers Notebooks
   - local: community
-    title: Community
-  - local: contributing
-    title: How to contribute to transformers?
-  - local: add_new_model
-    title: How to add a model to 🤗 Transformers?
-  - local: add_new_pipeline
-    title: How to create a custom pipeline?
-  - local: testing
-    title: Testing
-  - local: pr_checks
-    title: Checks on a Pull Request
-  title: How-to guides
+    title: Community resources
+  title: "How-to guides"
 - sections:
   - local: philosophy
     title: Philosophy

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -59,7 +59,7 @@
         title: Multiple choice
       title: Task guides
       isExpanded: false
-    title: "NLP"
+    title: "Natural Language Processing"
   - sections:
     - local: tasks/audio_classification
       title: Audio classification
@@ -69,7 +69,7 @@
   - sections:
     - local: tasks/image_classification
       title: Image classification
-    title: "Image"
+    title: "Computer Vision"
   - sections:
     - local: performance
       title: Overview

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -34,10 +34,6 @@
       title: Converting TensorFlow Checkpoints
     - local: serialization
       title: Export 🤗 Transformers models
-    - local: benchmarks
-      title: Benchmarks
-    - local: migration
-      title: Migrating from previous packages
     - local: troubleshooting
       title: Troubleshoot
     title: "General usage"
@@ -46,20 +42,23 @@
       title: Use tokenizers from 🤗 Tokenizers
     - local: multilingual
       title: Inference for multilingual models
-    - local: tasks/sequence_classification
-      title: Text classification
-    - local: tasks/token_classification
-      title: Token classification
-    - local: tasks/question_answering
-      title: Question answering
-    - local: tasks/language_modeling
-      title: Language modeling
-    - local: tasks/translation
-      title: Translation
-    - local: tasks/summarization
-      title: Summarization
-    - local: tasks/multiple_choice
-      title: Multiple choice
+    - sections:
+      - local: tasks/sequence_classification
+        title: Text classification
+      - local: tasks/token_classification
+        title: Token classification
+      - local: tasks/question_answering
+        title: Question answering
+      - local: tasks/language_modeling
+        title: Language modeling
+      - local: tasks/translation
+        title: Translation
+      - local: tasks/summarization
+        title: Summarization
+      - local: tasks/multiple_choice
+        title: Multiple choice
+      title: Task guides
+      isExpanded: false
     title: "NLP"
   - sections:
     - local: tasks/audio_classification
@@ -117,6 +116,10 @@
     title: 🤗 Transformers Notebooks
   - local: community
     title: Community resources
+  - local: benchmarks
+    title: Benchmarks
+  - local: migration
+    title: Migrating from previous packages
   title: "How-to guides"
 - sections:
   - local: philosophy


### PR DESCRIPTION
Currently, audio and computer vision lack content or the existing content is mixed with NLP. This PR splits the `toctree` on modality to make it easier to discover content for audio/computer vision while also allowing us to also scale to any additional modalities we want to support. As we create additional content, these new sections make it easier to collect specific content in one place. For example, the upcoming `generate` docs can be placed in the NLP section.

This structure can also help us identify gaps in the docs between each modality to ensure documentation is complete. For example, NLP has a page about tokenizers, and we can create a similar page for the other modalities using feature extractors and processors.

Other sections include:

- General usage for modality-neutral content.
- Performance and scalability for content related to large models.
- Contribute for how to test, open a PR, and add models/pipelines.

After we split the docs, the next step would be to start planning and creating additional content to make the audio/computer vision sections more complete.

Looking forward to hearing what you think :)