### PR TITLE
Change to FlavaProcessor in PROCESSOR_MAPPING_NAMES

### DIFF
--- a/src/transformers/models/auto/processing_auto.py
+++ b/src/transformers/models/auto/processing_auto.py
@@ -38,7 +38,7 @@ logger = logging.get_logger(__name__)
 PROCESSOR_MAPPING_NAMES = OrderedDict(
     [
         ("clip", "CLIPProcessor"),
-        ("flava", "FLAVAProcessor"),
+        ("flava", "FlavaProcessor"),
         ("groupvit", "CLIPProcessor"),
         ("layoutlmv2", "LayoutLMv2Processor"),
         ("layoutlmv3", "LayoutLMv3Processor"),


### PR DESCRIPTION
# What does this PR do?

`FLAVAProcessor` in `PROCESSOR_MAPPING_NAMES` should be `FlavaProcessor`.

Not getting problem when using `AutoProcessor.from_pretrained`, but `PROCESSOR_MAPPING[FlavaConfig]` will fail

### Errors

```python
from transformers import PROCESSOR_MAPPING, FlavaConfig, CLIPConfig, LayoutLMv2Config

processor_types = PROCESSOR_MAPPING[CLIPConfig]
print(processor_types)

processor_types = PROCESSOR_MAPPING[LayoutLMv2Config]
print(processor_types)

# This fails
processor_types = PROCESSOR_MAPPING[FlavaConfig]
print(processor_types)
```

with errors

```bash
Traceback (most recent call last):
  File "C:\Users\33611\Desktop\Project\transformers\temp.py", line 9, in <module>
    processor_types = PROCESSOR_MAPPING[FlavaConfig]
  File "C:\Users\33611\Desktop\Project\transformers\src\transformers\models\auto\auto_factory.py", line 565, in __getitem__
    return self._load_attr_from_module(model_type, model_name)
  File "C:\Users\33611\Desktop\Project\transformers\src\transformers\models\auto\auto_factory.py", line 579, in _load_attr_from_module
    return getattribute_from_module(self._modules[module_name], attr)
  File "C:\Users\33611\Desktop\Project\transformers\src\transformers\models\auto\auto_factory.py", line 539, in getattribute_from_module
    return getattribute_from_module(transformers_module, attr)
  File "C:\Users\33611\Desktop\Project\transformers\src\transformers\models\auto\auto_factory.py", line 539, in getattribute_from_module
    return getattribute_from_module(transformers_module, attr)
  File "C:\Users\33611\Desktop\Project\transformers\src\transformers\models\auto\auto_factory.py", line 539, in getattribute_from_module
    return getattribute_from_module(transformers_module, attr)
  [Previous line repeated 986 more times]
  File "C:\Users\33611\Desktop\Project\transformers\src\transformers\models\auto\auto_factory.py", line 538, in getattribute_from_module
    transformers_module = importlib.import_module("transformers")
  File "C:\Users\33611\miniconda3\envs\py39\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load
  File "<frozen importlib._bootstrap>", line 157, in __enter__
  File "<frozen importlib._bootstrap>", line 183, in _get_module_lock
  File "<frozen importlib._bootstrap>", line 59, in __init__
RecursionError: maximum recursion depth exceeded while calling a Python object

Process finished with exit code 1

```