### PR TITLE
Generate: validate arguments

### DIFF
--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -848,6 +848,11 @@ class GenerationMixin:
             for key in ["decoder_input_ids"]:
                 model_kwargs.pop(key, None)
 
+        # Transfo_XL does not use have "attention_mask" as an argument, and it is harmless (it is being passed in the
+        # tests, through)
+        if "transfoxl" in str(self).lower():
+            model_kwargs.pop("attention_mask", None)
+
         unused_model_args = []
         model_args = set(inspect.signature(self.prepare_inputs_for_generation).parameters)
         # `kwargs`` if often used to handle optional forward pass inputs like `attention_mask`. If

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -842,7 +842,7 @@ class GenerationMixin:
         return transition_scores
 
     def _validate_model_kwargs(self, model_kwargs: Dict[str, Any]):
-        """Validates model kwargs for generation."""
+        """Validates model kwargs for generation. Generate argument typos will also be caught here."""
         # Excludes arguments that are handled before calling the any model function
         if self.config.is_encoder_decoder:
             for key in ["decoder_input_ids"]:

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -1601,6 +1601,9 @@ class GenerationMixin:
             if num_beams <= 1:
                 raise ValueError("`num_beams` needs to be greater than 1 for constrained generation.")
 
+            if do_sample:
+                raise ValueError("`do_sample` needs to be false for constrained generation.")
+
             final_constraints = []
             if constraints is not None:
                 final_constraints = constraints

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -846,7 +846,7 @@ class GenerationMixin:
         # Excludes arguments that are handled before calling the any model function
         if self.config.is_encoder_decoder:
             for key in ["decoder_input_ids"]:
-                model_kwargs.pop(key)
+                model_kwargs.pop(key, None)
 
         unused_model_args = []
         model_args = set(inspect.signature(self.prepare_inputs_for_generation).parameters)

--- a/tests/generation/test_generation_utils.py
+++ b/tests/generation/test_generation_utils.py
@@ -2699,3 +2699,26 @@ class GenerationIntegrationTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             model.generate(input_ids, force_words_ids=[[[-1]]])
+
+    def test_validate_generation_inputs(self):
+        tokenizer = AutoTokenizer.from_pretrained("patrickvonplaten/t5-tiny-random")
+        model = AutoModelForSeq2SeqLM.from_pretrained("patrickvonplaten/t5-tiny-random")
+
+        encoder_input_str = "Hello world"
+        input_ids = tokenizer(encoder_input_str, return_tensors="pt").input_ids
+
+        # typos are quickly detected (the correct argument is `do_sample`)
+        with self.assertRaises(ValueError):
+            model.generate(
+                input_ids,
+                do_samples=True,
+            )
+
+        # arbitrary arguments that will not be used anywhere are also not accepted
+        with self.assertRaises(ValueError):
+            fake_model_kwargs = {"foo": "bar"}
+            model.generate(input_ids, **fake_model_kwargs)
+
+        # valid args that is not used by the generation submethod (greedy search in this case) also raise an exception
+        with self.assertRaises(ValueError):
+            model.generate(input_ids, temperature=2.0)

--- a/tests/generation/test_generation_utils.py
+++ b/tests/generation/test_generation_utils.py
@@ -2052,7 +2052,7 @@ class GenerationIntegrationTests(unittest.TestCase):
 
         # max_new_tokens and max_length serve the same purpose and should not be used together.
         with self.assertWarns(UserWarning):
-            gpt2_model.generate(decoder_input_ids=input_ids, max_new_tokens=10, max_length=20)
+            gpt2_model.generate(input_ids=input_ids, max_new_tokens=10, max_length=20)
 
     def test_encoder_decoder_generate_with_inputs_embeds(self):
         article = """Justin Timberlake and Jessica Biel, welcome to parenthood."""

--- a/tests/models/bigbird_pegasus/test_modeling_bigbird_pegasus.py
+++ b/tests/models/bigbird_pegasus/test_modeling_bigbird_pegasus.py
@@ -360,7 +360,7 @@ class BigBirdPegasusModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.
         if torch_device == "cuda":
             model.half()
         model.generate(**input_dict)
-        model.generate(**input_dict, do_sample=True, early_stopping=False, num_return_sequences=3)
+        model.generate(**input_dict, do_sample=True, num_return_sequences=3)
 
     @slow
     def test_batched_forward_original_full(self):


### PR DESCRIPTION
# What does this PR do?

NOTE: this PR is very experimental, feel free to trash it in the review process :)

A common cause for issues in `generate` is around it not behaving as expected, as arguments can be silently ignored as part of the selected generation submethod (greedy_search, sample, ...). Typos also often fly under the radar, as the method accepts `**model_kwargs`, which in turn are passed to models that also accept `**kwargs`.

This PR adds argument validation to `generate` in two separate steps:
1. `model_kwargs` are verified as soon as the method is called. Only arguments that the model actually uses in `prepare_inputs_for_generation` or in its forward pass are accepted. This means that typos are caught immediately. The exception enumerates all arguments that triggered this failed check, so the user can correct them.
2. Before calling the appropriate generate submethod, which is picked from the arguments, checks that all passed arguments will actually be used. If the user passes an argument that is not used in that particular submethod, throws an exception indicating the submethod that was triggered and the unaccepted arguments, so the user can fix either problem (correct the submethod or correct the arguments).

Although I think the checks are super useful, the code around it is not the prettiest. The first check has some logic for edge cases, and the second case requires passing the list of methods that will be called before the submethod in question. The PR is heavily commented in GH, feel free to cast your judgment!

P.S.: (seemingly) unrelated accelerate tests are failing in `run_examples_torch`

### Related issues
- https://github.com/huggingface/transformers/issues/18130
- https://github.com/huggingface/transformers/pull/17196
- (many other issues where users were confused because they were trying to use certain arguments that had no effect on the picked submethod)