### PR TITLE
Fix TrainingArguments help section

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -803,12 +803,12 @@ class TrainingArguments:
             )
         },
     )
-    fsdp_transformer_layer_cls_to_wrap: str = field(
+    fsdp_transformer_layer_cls_to_wrap: Optional[str] = field(
         default=None,
         metadata={
             "help": (
                 "Transformer layer class name (case-sensitive) to wrap ,e.g, `BertLayer`, `GPTJBlock`, `T5Block` .... "
-                "(useful only when `fsdp` flag is passed).",
+                "(useful only when `fsdp` flag is passed)."
             )
         },
     )


### PR DESCRIPTION
# What does this PR do?

A typo was introduced in #18134 with a trailing comma that has nothing to do here. It broke the `--help` for all example scripts, as reported in #18222, this PR fixes it and adds a type annotation.

Fixes #18222