### PR TITLE
Fix `no_trainer` CI

### DIFF
--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -19,16 +19,15 @@ import json
 import logging
 import os
 import shutil
-import subprocess
 import sys
 import tempfile
+from unittest import mock
 
 import torch
 
 from accelerate.utils import write_basic_config
-from transformers.testing_utils import TestCasePlus, get_gpu_count, slow, torch_device, run_command
+from transformers.testing_utils import TestCasePlus, get_gpu_count, run_command, slow, torch_device
 from transformers.utils import is_apex_available
-from unittest import mock
 
 
 logging.basicConfig(level=logging.DEBUG)

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1563,6 +1563,7 @@ def to_2tuple(x):
         return x
     return (x, x)
 
+
 # These utils relate to ensuring the right error message is received when running scripts
 class SubprocessCallException(Exception):
     pass

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -20,6 +20,7 @@ import os
 import re
 import shlex
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -27,7 +28,7 @@ from collections.abc import Mapping
 from distutils.util import strtobool
 from io import StringIO
 from pathlib import Path
-from typing import Iterator, Union
+from typing import Iterator, List, Union
 from unittest import mock
 
 from transformers import logging as transformers_logging
@@ -1561,3 +1562,24 @@ def to_2tuple(x):
     if isinstance(x, collections.abc.Iterable):
         return x
     return (x, x)
+
+# These utils relate to ensuring the right error message is received when running scripts
+class SubprocessCallException(Exception):
+    pass
+
+
+def run_command(command: List[str], return_stdout=False):
+    """
+    Runs `command` with `subprocess.check_output` and will potentially return the `stdout`. Will also properly capture
+    if an error occured while running `command`
+    """
+    try:
+        output = subprocess.check_output(command, stderr=subprocess.STDOUT)
+        if return_stdout:
+            if hasattr(output, "decode"):
+                output = output.decode("utf-8")
+            return output
+    except subprocess.CalledProcessError as e:
+        raise SubprocessCallException(
+            f"Command `{' '.join(command)}` failed with the following error:\n\n{e.output.decode()}"
+        ) from e


### PR DESCRIPTION
# What does this PR do?

This PR fixes the no_trainer tests silently failing due to a similar reason in Accelerate [here](https://github.com/huggingface/accelerate/pull/517)

- Adds a new way to call subprocess that properly contains the stack trace raised in the error
- Reduces the passing result needed for the image classification example, as on a single GPU it reaches 62.5% but on multi gpu it hits 60%

Requires https://github.com/huggingface/accelerate/pull/547 to be merged first


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger 