### PR TITLE
Changed to filter out oddball list sizes

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -473,14 +473,15 @@ def main():
         if "train" not in tokenized_datasets:
             raise ValueError("--do_train requires a train dataset")
 
-        final_block_size = len(lm_datasets['train'][0]['input_ids'])
+        final_block_size = len(lm_datasets["train"][0]["input_ids"])
         # This ensures that the data is all of the same length going into training.
         # PyTorch does not like dealing with different list lengths
-        train_dataset = lm_datasets['train'].filter(lambda x: all([len(item) == final_block_size
-                                                                   for item in x.values()]),
-                                                    load_from_cache_file=not data_args.overwrite_cache,
-                                                    num_proc=data_args.preprocessing_num_workers,
-                                                    desc=f"Filtering out texts not of {final_block_size}")
+        train_dataset = lm_datasets["train"].filter(
+            lambda x: all([len(item) == final_block_size for item in x.values()]),
+            load_from_cache_file=not data_args.overwrite_cache,
+            num_proc=data_args.preprocessing_num_workers,
+            desc=f"Filtering out texts not of {final_block_size}",
+        )
 
         if data_args.max_train_samples is not None:
             max_train_samples = min(len(train_dataset), data_args.max_train_samples)

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -472,7 +472,16 @@ def main():
     if training_args.do_train:
         if "train" not in tokenized_datasets:
             raise ValueError("--do_train requires a train dataset")
-        train_dataset = lm_datasets["train"]
+
+        final_block_size = len(lm_datasets['train'][0]['input_ids'])
+        # This ensures that the data is all of the same length going into training.
+        # PyTorch does not like dealing with different list lengths
+        train_dataset = lm_datasets['train'].filter(lambda x: all([len(item) == final_block_size
+                                                                   for item in x.values()]),
+                                                    load_from_cache_file=not data_args.overwrite_cache,
+                                                    num_proc=data_args.preprocessing_num_workers,
+                                                    desc=f"Filtering out texts not of {final_block_size}")
+
         if data_args.max_train_samples is not None:
             max_train_samples = min(len(train_dataset), data_args.max_train_samples)
             train_dataset = train_dataset.select(range(max_train_samples))

--- a/examples/pytorch/language-modeling/run_clm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_clm_no_trainer.py
@@ -439,7 +439,14 @@ def main():
             desc=f"Grouping texts in chunks of {block_size}",
         )
 
-    train_dataset = lm_datasets["train"]
+    final_block_size = len(lm_datasets['train'][0]['input_ids'])
+    # This ensures that the data is all of the same length going into training.
+    # PyTorch does not like dealing with different list lengths
+    train_dataset = lm_datasets['train'].filter(lambda x: all([len(item) == final_block_size
+                                                               for item in x.values()]),
+                                                load_from_cache_file=not data_args.overwrite_cache,
+                                                num_proc=data_args.preprocessing_num_workers,
+                                                desc=f"Filtering out texts not of {final_block_size}")
     eval_dataset = lm_datasets["validation"]
 
     # Log a few random samples from the training set:

--- a/examples/pytorch/language-modeling/run_clm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_clm_no_trainer.py
@@ -439,14 +439,15 @@ def main():
             desc=f"Grouping texts in chunks of {block_size}",
         )
 
-    final_block_size = len(lm_datasets['train'][0]['input_ids'])
+    final_block_size = len(lm_datasets["train"][0]["input_ids"])
     # This ensures that the data is all of the same length going into training.
     # PyTorch does not like dealing with different list lengths
-    train_dataset = lm_datasets['train'].filter(lambda x: all([len(item) == final_block_size
-                                                               for item in x.values()]),
-                                                load_from_cache_file=not data_args.overwrite_cache,
-                                                num_proc=data_args.preprocessing_num_workers,
-                                                desc=f"Filtering out texts not of {final_block_size}")
+    train_dataset = lm_datasets["train"].filter(
+        lambda x: all([len(item) == final_block_size for item in x.values()]),
+        load_from_cache_file=not args.overwrite_cache,
+        num_proc=args.preprocessing_num_workers,
+        desc=f"Filtering out texts not of {final_block_size}",
+    )
     eval_dataset = lm_datasets["validation"]
 
     # Log a few random samples from the training set:

--- a/examples/pytorch/language-modeling/run_mlm.py
+++ b/examples/pytorch/language-modeling/run_mlm.py
@@ -484,7 +484,7 @@ def main():
         # https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasets.Dataset.map
 
         with training_args.main_process_first(desc="grouping texts together"):
-            tokenized_datasets = tokenized_datasets.map(
+            lm_datasets = tokenized_datasets.map(
                 group_texts,
                 batched=True,
                 num_proc=data_args.preprocessing_num_workers,
@@ -495,7 +495,14 @@ def main():
     if training_args.do_train:
         if "train" not in tokenized_datasets:
             raise ValueError("--do_train requires a train dataset")
-        train_dataset = tokenized_datasets["train"]
+        final_block_size = len(lm_datasets['train'][0]['input_ids'])
+        # This ensures that the data is all of the same length going into training.
+        # PyTorch does not like dealing with different list lengths
+        train_dataset = lm_datasets['train'].filter(lambda x: all([len(item) == final_block_size
+                                                                   for item in x.values()]),
+                                                    load_from_cache_file=not data_args.overwrite_cache,
+                                                    num_proc=data_args.preprocessing_num_workers,
+                                                    desc=f"Filtering out texts not of {final_block_size}")
         if data_args.max_train_samples is not None:
             max_train_samples = min(len(train_dataset), data_args.max_train_samples)
             train_dataset = train_dataset.select(range(max_train_samples))
@@ -503,7 +510,7 @@ def main():
     if training_args.do_eval:
         if "validation" not in tokenized_datasets:
             raise ValueError("--do_eval requires a validation dataset")
-        eval_dataset = tokenized_datasets["validation"]
+        eval_dataset = lm_datasets["validation"]
         if data_args.max_eval_samples is not None:
             max_eval_samples = min(len(eval_dataset), data_args.max_eval_samples)
             eval_dataset = eval_dataset.select(range(max_eval_samples))

--- a/examples/pytorch/language-modeling/run_mlm.py
+++ b/examples/pytorch/language-modeling/run_mlm.py
@@ -495,14 +495,15 @@ def main():
     if training_args.do_train:
         if "train" not in tokenized_datasets:
             raise ValueError("--do_train requires a train dataset")
-        final_block_size = len(lm_datasets['train'][0]['input_ids'])
+        final_block_size = len(lm_datasets["train"][0]["input_ids"])
         # This ensures that the data is all of the same length going into training.
         # PyTorch does not like dealing with different list lengths
-        train_dataset = lm_datasets['train'].filter(lambda x: all([len(item) == final_block_size
-                                                                   for item in x.values()]),
-                                                    load_from_cache_file=not data_args.overwrite_cache,
-                                                    num_proc=data_args.preprocessing_num_workers,
-                                                    desc=f"Filtering out texts not of {final_block_size}")
+        train_dataset = lm_datasets["train"].filter(
+            lambda x: all([len(item) == final_block_size for item in x.values()]),
+            load_from_cache_file=not data_args.overwrite_cache,
+            num_proc=data_args.preprocessing_num_workers,
+            desc=f"Filtering out texts not of {final_block_size}",
+        )
         if data_args.max_train_samples is not None:
             max_train_samples = min(len(train_dataset), data_args.max_train_samples)
             train_dataset = train_dataset.select(range(max_train_samples))

--- a/examples/pytorch/language-modeling/run_mlm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_mlm_no_trainer.py
@@ -476,14 +476,15 @@ def main():
                 desc=f"Grouping texts in chunks of {max_seq_length}",
             )
 
-    final_block_size = len(lm_datasets['train'][0]['input_ids'])
+    final_block_size = len(lm_datasets["train"][0]["input_ids"])
     # This ensures that the data is all of the same length going into training.
     # PyTorch does not like dealing with different list lengths
-    train_dataset = lm_datasets['train'].filter(lambda x: all([len(item) == final_block_size
-                                                               for item in x.values()]),
-                                                load_from_cache_file=not args.overwrite_cache,
-                                                num_proc=args.preprocessing_num_workers,
-                                                desc=f"Filtering out texts not of {final_block_size}")
+    train_dataset = lm_datasets["train"].filter(
+        lambda x: all([len(item) == final_block_size for item in x.values()]),
+        load_from_cache_file=not args.overwrite_cache,
+        num_proc=args.preprocessing_num_workers,
+        desc=f"Filtering out texts not of {final_block_size}",
+    )
     eval_dataset = lm_datasets["validation"]
 
     # Conditional for small test subsets

--- a/examples/pytorch/language-modeling/run_plm.py
+++ b/examples/pytorch/language-modeling/run_plm.py
@@ -462,14 +462,15 @@ def main():
     if training_args.do_train:
         if "train" not in tokenized_datasets:
             raise ValueError("--do_train requires a train dataset")
-        final_block_size = len(lm_datasets['train'][0]['input_ids'])
+        final_block_size = len(lm_datasets["train"][0]["input_ids"])
         # This ensures that the data is all of the same length going into training.
         # PyTorch does not like dealing with different list lengths
-        train_dataset = lm_datasets['train'].filter(lambda x: all([len(item) == final_block_size
-                                                                   for item in x.values()]),
-                                                    load_from_cache_file=not data_args.overwrite_cache,
-                                                    num_proc=data_args.preprocessing_num_workers,
-                                                    desc=f"Filtering out texts not of {final_block_size}")
+        train_dataset = lm_datasets["train"].filter(
+            lambda x: all([len(item) == final_block_size for item in x.values()]),
+            load_from_cache_file=not data_args.overwrite_cache,
+            num_proc=data_args.preprocessing_num_workers,
+            desc=f"Filtering out texts not of {final_block_size}",
+        )
         if data_args.max_train_samples is not None:
             max_train_samples = min(len(train_dataset), data_args.max_train_samples)
             train_dataset = train_dataset.select(range(max_train_samples))


### PR DESCRIPTION
This PR fixes the issue of lists occasionally being of different sizes before being sent to `trainer.py`

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #18167


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger My apologies for the third ping in a week. I believe I found a solution that would be more acceptable.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
