### PR TITLE
Skip passes report for `--make-reports`

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1386,9 +1386,13 @@ def pytest_terminal_summary_main(tr, id):
         tr.summary_warnings()  # final warnings
 
     tr.reportchars = "wPpsxXEf"  # emulate -rA (used in summary_passes() and short_test_summary())
-    with open(report_files["passes"], "w") as f:
-        tr._tw = create_terminal_writer(config, f)
-        tr.summary_passes()
+
+    # Skip the `passes` report, as it starts to take more than 5 minutes, and sometimes it timeouts on CircleCI if it
+    # takes > 10 minutes (as this part doesn't generate any output on the terminal).
+    # (also, it seems there is no useful information in this report, and we rarely need to read it)
+    # with open(report_files["passes"], "w") as f:
+    #     tr._tw = create_terminal_writer(config, f)
+    #     tr.summary_passes()
 
     with open(report_files["summary_short"], "w") as f:
         tr._tw = create_terminal_writer(config, f)


### PR DESCRIPTION
# What does this PR do?

We sometimes have timeout on CircleCI. It turns out that the tests are finished (running in the workers, which exit at the end), but the main process is busy doing some reporting work when we specify `--make-reports`. More precisely, it is the `passes` report which takes time (as we include `Pp` in `tr.reportchars = "wPpsxXEf"`). From the 2 screenshots below (running with 64 models), we can see that currently it takes extra ~2-3 minutes at the end.

It seems that  `passes` report doesn't contain any useful information to us, therefore this PR skips generating it to avoid timeout.

- **without this PR**
<img width="448" alt="no-fix" src="https://user-images.githubusercontent.com/2521628/180396971-69f19b12-978b-4e19-8842-17d1af307d51.png">

- **with this PR**
<img width="452" alt="fix" src="https://user-images.githubusercontent.com/2521628/180396917-bb866363-efa3-4959-b5e3-e99ab283cc6c.png">

### One failed CircleCI job run
[Job](https://app.circleci.com/pipelines/github/huggingface/transformers/43738/workflows/325901ce-948e-4737-9a79-8a7fe9d6e27d/jobs/506868/resources)

<img width="452" alt="real" src="https://user-images.githubusercontent.com/2521628/180399481-a7f571bc-75f3-4826-b5d5-8c50c3164678.png">

