### PR TITLE
Add PYTEST_TIMEOUT for CircleCI test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ jobs:
             OMP_NUM_THREADS: 1
             RUN_PT_TF_CROSS_TESTS: yes
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -110,6 +111,7 @@ jobs:
             OMP_NUM_THREADS: 1
             RUN_PT_TF_CROSS_TESTS: yes
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -145,6 +147,7 @@ jobs:
             OMP_NUM_THREADS: 1
             RUN_PT_FLAX_CROSS_TESTS: yes
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -183,6 +186,7 @@ jobs:
             OMP_NUM_THREADS: 1
             RUN_PT_FLAX_CROSS_TESTS: yes
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -215,6 +219,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -252,6 +257,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -284,6 +290,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -320,6 +327,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -351,6 +359,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -386,6 +395,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -417,6 +427,7 @@ jobs:
             OMP_NUM_THREADS: 1
             RUN_PIPELINE_TESTS: yes
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -454,6 +465,7 @@ jobs:
             OMP_NUM_THREADS: 1
             RUN_PIPELINE_TESTS: yes
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -486,6 +498,7 @@ jobs:
             OMP_NUM_THREADS: 1
             RUN_PIPELINE_TESTS: yes
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -521,6 +534,7 @@ jobs:
             OMP_NUM_THREADS: 1
             RUN_PIPELINE_TESTS: yes
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -550,6 +564,7 @@ jobs:
         environment:
             RUN_CUSTOM_TOKENIZERS: yes
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         steps:
             - checkout
             - restore_cache:
@@ -583,6 +598,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -618,6 +634,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -648,6 +665,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -682,6 +700,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -712,6 +731,7 @@ jobs:
             HUGGINGFACE_CO_STAGING: yes
             RUN_GIT_LFS_TESTS: yes
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -750,6 +770,7 @@ jobs:
             HUGGINGFACE_CO_STAGING: yes
             RUN_GIT_LFS_TESTS: yes
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -782,6 +803,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -815,6 +837,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -843,6 +866,7 @@ jobs:
         resource_class: large
         environment:
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         parallelism: 1
         steps:
             - checkout
@@ -871,6 +895,7 @@ jobs:
         resource_class: large
         environment:
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         parallelism: 1
         steps:
             - checkout
@@ -900,6 +925,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
+            PYTEST_TIMEOUT: 30
         resource_class: xlarge
         parallelism: 1
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
             OMP_NUM_THREADS: 1
             RUN_PT_TF_CROSS_TESTS: yes
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -111,7 +111,7 @@ jobs:
             OMP_NUM_THREADS: 1
             RUN_PT_TF_CROSS_TESTS: yes
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -147,7 +147,7 @@ jobs:
             OMP_NUM_THREADS: 1
             RUN_PT_FLAX_CROSS_TESTS: yes
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -186,7 +186,7 @@ jobs:
             OMP_NUM_THREADS: 1
             RUN_PT_FLAX_CROSS_TESTS: yes
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -219,7 +219,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -257,7 +257,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -290,7 +290,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -327,7 +327,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -359,7 +359,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -395,7 +395,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -427,7 +427,7 @@ jobs:
             OMP_NUM_THREADS: 1
             RUN_PIPELINE_TESTS: yes
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -465,7 +465,7 @@ jobs:
             OMP_NUM_THREADS: 1
             RUN_PIPELINE_TESTS: yes
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -498,7 +498,7 @@ jobs:
             OMP_NUM_THREADS: 1
             RUN_PIPELINE_TESTS: yes
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -534,7 +534,7 @@ jobs:
             OMP_NUM_THREADS: 1
             RUN_PIPELINE_TESTS: yes
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -564,7 +564,7 @@ jobs:
         environment:
             RUN_CUSTOM_TOKENIZERS: yes
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         steps:
             - checkout
             - restore_cache:
@@ -598,7 +598,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -634,7 +634,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -665,7 +665,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -700,7 +700,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -731,7 +731,7 @@ jobs:
             HUGGINGFACE_CO_STAGING: yes
             RUN_GIT_LFS_TESTS: yes
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -770,7 +770,7 @@ jobs:
             HUGGINGFACE_CO_STAGING: yes
             RUN_GIT_LFS_TESTS: yes
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -803,7 +803,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -837,7 +837,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:
@@ -866,7 +866,7 @@ jobs:
         resource_class: large
         environment:
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         parallelism: 1
         steps:
             - checkout
@@ -895,7 +895,7 @@ jobs:
         resource_class: large
         environment:
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         parallelism: 1
         steps:
             - checkout
@@ -925,7 +925,7 @@ jobs:
         environment:
             OMP_NUM_THREADS: 1
             TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 30
+            PYTEST_TIMEOUT: 120
         resource_class: xlarge
         parallelism: 1
         steps:

--- a/setup.py
+++ b/setup.py
@@ -139,8 +139,7 @@ _deps = [
     "pytest",
     "pytest-timeout",
     "pytest-xdist",
-    # To run the full tests -> This will be reverted.
-    "python>=3.6.0",
+    "python>=3.7.0",
     "ray[tune]",
     "regex!=2019.12.17",
     "requests",

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,8 @@ _deps = [
     "pytest",
     "pytest-timeout",
     "pytest-xdist",
-    "python>=3.7.0",
+    # To run the full tests -> This will be reverted.
+    "python>=3.6.0",
     "ray[tune]",
     "regex!=2019.12.17",
     "requests",


### PR DESCRIPTION
⚠️  Before merging, we need to **run the full tests on CircleCI** to see if there are slower tests that will fail and decide what to do with them.

# What does this PR do?
Add `PYTEST_TIMEOUT: 30` for CircleCI jobs:
```
environment:
    ...
    PYTEST_TIMEOUT: 30
```
The main goal is to avoid CircleCI's default 10 minute timeout that cancels the jobs. Also with this PR, we can see clearly which test (s) timeout.

