### PR TITLE
Fix OwlViT tests

### DIFF
--- a/src/transformers/models/owlvit/__init__.py
+++ b/src/transformers/models/owlvit/__init__.py
@@ -40,7 +40,7 @@ _import_structure = {
 
 
 try:
-    if not is_vision_available() or not is_torch_available():
+    if not is_vision_available():
         raise OptionalDependencyNotAvailable()
 except OptionalDependencyNotAvailable:
     pass

--- a/src/transformers/models/owlvit/__init__.py
+++ b/src/transformers/models/owlvit/__init__.py
@@ -72,7 +72,7 @@ if TYPE_CHECKING:
     from .processing_owlvit import OwlViTProcessor
 
     try:
-        if not is_vision_available() or not is_torch_available():
+        if not is_vision_available():
             raise OptionalDependencyNotAvailable()
     except OptionalDependencyNotAvailable:
         pass


### PR DESCRIPTION
# What does this PR do?

Should fix the errors on main with `ImportError: cannot import name 'OwlViTFeatureExtractor' from 'transformers'` on runners with torch not installed.