### PR TITLE
Replace false parameter by a buffer

### DIFF
--- a/src/transformers/models/m2m_100/modeling_m2m_100.py
+++ b/src/transformers/models/m2m_100/modeling_m2m_100.py
@@ -131,9 +131,7 @@ class M2M100SinusoidalPositionalEmbedding(nn.Module):
             # in forward put the weights on the correct dtype and device of the param
             emb_weights = emb_weights.to(dtype=self.weights.dtype, device=self.weights.device)
 
-        self.weights = nn.Parameter(emb_weights)
-        self.weights.requires_grad = False
-        self.weights.detach_()
+        self.register_buffer("weights", emb_weights)
 
     @staticmethod
     def get_embedding(num_embeddings: int, embedding_dim: int, padding_idx: Optional[int] = None):

--- a/src/transformers/models/xglm/modeling_xglm.py
+++ b/src/transformers/models/xglm/modeling_xglm.py
@@ -173,9 +173,7 @@ class XGLMSinusoidalPositionalEmbedding(nn.Module):
             # in forward put the weights on the correct dtype and device of the param
             emb_weights = emb_weights.to(dtype=self.weights.dtype, device=self.weights.device)
 
-        self.weights = nn.Parameter(emb_weights)
-        self.weights.requires_grad = False
-        self.weights.detach_()
+        self.register_buffer("weights", emb_weights)
 
     @staticmethod
     def get_embedding(num_embeddings: int, embedding_dim: int, padding_idx: Optional[int] = None):


### PR DESCRIPTION
# What does this PR do?

The weights of the sinusoidal embedding are defined as a parameter with no grad in M2M100 (and thus XGLM), and never saved in the state dict. The problem is that when loading this with `low_cpu_mem_usage=True`, this false parameter will be replaced by an empty weight on the meta device, which is not re-initialized afterward (since it's not in the state dict). As a result, the model is not usable if `low_cpu_mem_usage=True` is used.

By replacing it with a buffer, the weight is ignore by init_empty_weights and thus preserved.