### PR TITLE
Fix torch version check in Vilt

### DIFF
--- a/src/transformers/models/vilt/modeling_vilt.py
+++ b/src/transformers/models/vilt/modeling_vilt.py
@@ -41,7 +41,7 @@ from .configuration_vilt import ViltConfig
 
 logger = logging.get_logger(__name__)
 
-if torch.__version__ < (1, 10, 0):
+if version.parse(torch.__version__) < version.parse("1.10.0"):
     logger.warning(
         f"You are using torch=={torch.__version__}, but torch>=1.10.0 is required to use "
         "ViltModel. Please upgrade torch."


### PR DESCRIPTION
# What does this PR do?

This line fails when torch < 1.10.0
https://github.com/huggingface/transformers/blob/1fc4b2a13223b9069f9969344117a2994261939c/src/transformers/models/vilt/modeling_vilt.py#L44

In  this case, `torch.__version__` is of type `str` instead of `torch.torch_version.TorchVersion` and can't compare to a tuple.

This leads to strange error message when other models being tested, for example (the use of `get_values` below)

```
    def test_training(self):
        for model_class in self.all_model_classes:
            ....
            if model_class in get_values(MODEL_MAPPING):
                continue
```