### PR TITLE
Add TFAutoModelForImageClassification to pipelines.py

### DIFF
--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -81,6 +81,7 @@ if is_tf_available():
         TF_MODEL_WITH_LM_HEAD_MAPPING,
         TFAutoModel,
         TFAutoModelForCausalLM,
+        TFAutoModelForImageClassification,
         TFAutoModelForMaskedLM,
         TFAutoModelForQuestionAnswering,
         TFAutoModelForSeq2SeqLM,
@@ -282,7 +283,7 @@ SUPPORTED_TASKS = {
     },
     "image-classification": {
         "impl": ImageClassificationPipeline,
-        "tf": (),
+        "tf": (TFAutoModelForImageClassification,) if is_tf_available() else (),
         "pt": (AutoModelForImageClassification,) if is_torch_available() else (),
         "default": {"model": {"pt": ("google/vit-base-patch16-224", "5dca96d")}},
         "type": "image",


### PR DESCRIPTION
# What does this PR do?

Add `TFAutoModelForImageClassification` to `pipelines.py`.

Fix the test failure mentioned [here](https://github.com/huggingface/transformers/pull/18079#issuecomment-1194352739).

Here is the [failed job run](https://github.com/huggingface/transformers/runs/7492640649?check_suite_focus=true)