### PR TITLE
Fix failing tests for XLA generation in TF

### DIFF
--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1685,13 +1685,15 @@ class TFModelTesterMixin:
             config.num_beams = num_beams
             config.num_return_sequences = num_return_sequences
 
-            if hasattr(config, "max_position_embeddings"):
-                try:
-                    config.max_position_embeddings = max_length
-                except NotImplementedError:
-                    # xlnet will raise an exception when trying to set
-                    # max_position_embeddings.
-                    pass
+            # fix config for models with additional sequence-length limiting settings
+            for var_name in ["max_position_embeddings", "max_target_positions"]:
+                if hasattr(config, var_name):
+                    try:
+                        setattr(config, var_name, max_length)
+                    except NotImplementedError:
+                        # xlnet will raise an exception when trying to set
+                        # max_position_embeddings.
+                        pass
 
             model = model_class(config)
 

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1684,6 +1684,15 @@ class TFModelTesterMixin:
             config.do_sample = False
             config.num_beams = num_beams
             config.num_return_sequences = num_return_sequences
+
+            if hasattr(config, "max_position_embeddings"):
+                try:
+                    config.max_position_embeddings = max_length
+                except NotImplementedError:
+                    # xlnet will raise an exception when trying to set
+                    # max_position_embeddings.
+                    pass
+
             model = model_class(config)
 
             if model.supports_xla_generation:
@@ -1713,15 +1722,6 @@ class TFModelTesterMixin:
 
         Either the model supports XLA generation and passes the inner test, or it raises an appropriate exception
         """
-        # TODO (Joao): find the issues related to the following models. They are passing the fast test, but failing
-        # the slow one.
-        if any(
-            [
-                model in str(self).lower()
-                for model in ["tfbart", "tfblenderbot", "tfmarian", "tfmbart", "tfopt", "tfpegasus"]
-            ]
-        ):
-            return
         num_beams = 8
         num_return_sequences = 2
         max_length = 128


### PR DESCRIPTION
# What does this PR do?

This PR fixes the failing tests for text generation in XLA mentioned in #17935. The issue was that the failing models had additional settings limiting the sequence length, which weren’t updated when creating the config-objects for the tests.

Fixes # 17935


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@gante @LysandreJik 