### PR TITLE
Add PyTorch 1.11 to past CI

### DIFF
--- a/.github/workflows/build-past-ci-docker-images.yml
+++ b/.github/workflows/build-past-ci-docker-images.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["1.10", "1.9", "1.8", "1.7", "1.6", "1.5", "1.4"]
+        version: ["1.11", "1.10", "1.9", "1.8", "1.7", "1.6", "1.5", "1.4"]
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/self-past-caller.yml
+++ b/.github/workflows/self-past-caller.yml
@@ -6,9 +6,19 @@ on:
       - run-past-ci*
 
 jobs:
+  run_past_ci_pytorch_1-11:
+    name: PyTorch 1.11
+    if: always()
+    uses: ./.github/workflows/self-past.yml
+    with:
+      framework: pytorch
+      version: "1.11"
+    secrets: inherit
+
   run_past_ci_pytorch_1-10:
     name: PyTorch 1.10
     if: always()
+    needs: [run_past_ci_pytorch_1-11]
     uses: ./.github/workflows/self-past.yml
     with:
       framework: pytorch

--- a/utils/past_ci_versions.py
+++ b/utils/past_ci_versions.py
@@ -4,6 +4,17 @@ import os
 
 past_versions_testing = {
     "pytorch": {
+        "1.11": {
+            "torch": "1.11.0",
+            "torchvision": "0.12.0",
+            "torchaudio": "0.11.0",
+            "python": 3.9,
+            "cuda": "cu113",
+            "install": (
+                "python3 -m pip install --no-cache-dir -U torch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0"
+                " --extra-index-url https://download.pytorch.org/whl/cu113"
+            ),
+        },
         "1.10": {
             "torch": "1.10.2",
             "torchvision": "0.11.3",

--- a/utils/past_ci_versions.py
+++ b/utils/past_ci_versions.py
@@ -8,7 +8,7 @@ past_versions_testing = {
             "torch": "1.11.0",
             "torchvision": "0.12.0",
             "torchaudio": "0.11.0",
-            "python": 3.10,
+            "python": 3.9,
             "cuda": "cu113",
             "install": (
                 "python3 -m pip install --no-cache-dir -U torch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0"

--- a/utils/past_ci_versions.py
+++ b/utils/past_ci_versions.py
@@ -8,7 +8,7 @@ past_versions_testing = {
             "torch": "1.11.0",
             "torchvision": "0.12.0",
             "torchaudio": "0.11.0",
-            "python": 3.9,
+            "python": 3.10,
             "cuda": "cu113",
             "install": (
                 "python3 -m pip install --no-cache-dir -U torch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0"


### PR DESCRIPTION
# What does this PR do?

Add PyTorch 1.11 to past CI (as PyTorch 1.12 is the current latest version).

I will re-run past CI once this PR is merged (for [this comment](https://github.com/huggingface/transformers/issues/18181#issuecomment-1189047657)).