### PR TITLE
Ignore small batches of examples for CLM training

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -444,7 +444,13 @@ def main():
         # We drop the small remainder, we could add padding if the model supported it instead of this drop, you can
         # customize this part to your needs.
         if total_length >= block_size:
-            total_length = (total_length // block_size) * block_size
+             total_length = (total_length // block_size) * block_size
+        else:
+            # If `total_length` < `block_size`, we ignore the whole batch of `examples`. Otherwise, we might have
+            # examples of different lengths which gives the following error from `torch_default_data_collator`:
+            # `expected sequence of length X at dim 1 (got Y) during training`.
+            # See https://github.com/huggingface/transformers/issues/17875.
+            total_length = 0
         # Split by chunks of max_len.
         result = {
             k: [t[i : i + block_size] for i in range(0, total_length, block_size)]

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -444,7 +444,7 @@ def main():
         # We drop the small remainder, we could add padding if the model supported it instead of this drop, you can
         # customize this part to your needs.
         if total_length >= block_size:
-             total_length = (total_length // block_size) * block_size
+            total_length = (total_length // block_size) * block_size
         else:
             # If `total_length` < `block_size`, we ignore the whole batch of `examples`. Otherwise, we might have
             # examples of different lengths which gives the following error from `torch_default_data_collator`:


### PR DESCRIPTION
# What does this PR do?

Fix #17875.

In https://github.com/huggingface/transformers/blob/a5d504834d01dd1c7edf7c46d93c080cb5274eec/examples/pytorch/language-modeling/run_clm.py#L440

we drop remainder when `if total_length >= block_size`. However, If a batch of examples is too small to have long enough length, that batch will be used. If the whole dataset has only that batch, it is fine. Otherwise, we might get examples of different lengths, and get an error `expected sequence of length X at dim 1 (got Y) during training`.

The same question is also asked on [StackOverflow](https://stackoverflow.com/questions/71166789/huggingface-valueerror-expected-sequence-of-length-165-at-dim-1-got-128).

With this fix, an edge case is that the whole dataset is dropped (if it contains only small batches that are all dropped) - but this is very unlikely. **We can throw an error in this case however**.

**Once the fix is approved, I can apply the same change to TF/Flax example scripts too (if relevant there)**