### PR TITLE
Migrate metric to Evaluate library for tensorflow examples 

### DIFF
--- a/examples/tensorflow/question-answering/requirements.txt
+++ b/examples/tensorflow/question-answering/requirements.txt
@@ -1,2 +1,3 @@
 datasets >= 1.4.0
 tensorflow >= 2.3.0
+evaluate >= 0.2.0

--- a/examples/tensorflow/question-answering/run_qa.py
+++ b/examples/tensorflow/question-answering/run_qa.py
@@ -26,8 +26,9 @@ from pathlib import Path
 from typing import Optional
 
 import tensorflow as tf
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 
+import evaluate
 import transformers
 from transformers import (
     AutoConfig,
@@ -600,7 +601,7 @@ def main():
         references = [{"id": ex["id"], "answers": ex[answer_column_name]} for ex in examples]
         return EvalPrediction(predictions=formatted_predictions, label_ids=references)
 
-    metric = load_metric("squad_v2" if data_args.version_2_with_negative else "squad")
+    metric = evaluate.load("squad_v2" if data_args.version_2_with_negative else "squad")
 
     def compute_metrics(p: EvalPrediction):
         return metric.compute(predictions=p.predictions, references=p.label_ids)

--- a/examples/tensorflow/summarization/requirements.txt
+++ b/examples/tensorflow/summarization/requirements.txt
@@ -1,0 +1,3 @@
+datasets >= 1.4.0
+tensorflow >= 2.3.0
+evaluate >= 0.2.0

--- a/examples/tensorflow/summarization/run_summarization.py
+++ b/examples/tensorflow/summarization/run_summarization.py
@@ -29,9 +29,10 @@ import datasets
 import nltk  # Here to have a nice missing dependency error message early on
 import numpy as np
 import tensorflow as tf
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 from tqdm import tqdm
 
+import evaluate
 import transformers
 from filelock import FileLock
 from transformers import (
@@ -634,7 +635,7 @@ def main():
         # endregion
 
         # region Metric
-        metric = load_metric("rouge")
+        metric = evaluate.load("rouge")
         # endregion
 
         # region Training

--- a/examples/tensorflow/text-classification/requirements.txt
+++ b/examples/tensorflow/text-classification/requirements.txt
@@ -2,3 +2,4 @@ datasets >= 1.1.3
 sentencepiece != 0.1.92
 protobuf
 tensorflow >= 2.3
+evaluate >= 0.2.0

--- a/examples/tensorflow/text-classification/run_glue.py
+++ b/examples/tensorflow/text-classification/run_glue.py
@@ -24,8 +24,9 @@ from typing import Optional
 
 import numpy as np
 import tensorflow as tf
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 
+import evaluate
 import transformers
 from transformers import (
     AutoConfig,
@@ -366,7 +367,7 @@ def main():
     # endregion
 
     # region Metric function
-    metric = load_metric("glue", data_args.task_name)
+    metric = evaluate.load("glue", data_args.task_name)
 
     def compute_metrics(preds, label_ids):
         preds = preds["logits"]

--- a/examples/tensorflow/token-classification/requirements.txt
+++ b/examples/tensorflow/token-classification/requirements.txt
@@ -1,0 +1,3 @@
+datasets >= 1.4.0
+tensorflow >= 2.3.0
+evaluate >= 0.2.0

--- a/examples/tensorflow/token-classification/run_ner.py
+++ b/examples/tensorflow/token-classification/run_ner.py
@@ -27,8 +27,9 @@ from typing import Optional
 import datasets
 import numpy as np
 import tensorflow as tf
-from datasets import ClassLabel, load_dataset, load_metric
+from datasets import ClassLabel, load_dataset
 
+import evaluate
 import transformers
 from transformers import (
     CONFIG_MAPPING,
@@ -478,7 +479,7 @@ def main():
         # endregion
 
         # Metrics
-        metric = load_metric("seqeval")
+        metric = evaluate.load("seqeval")
 
         def get_labels(y_pred, y_true):
             # Transform predictions and references tensos to numpy arrays

--- a/examples/tensorflow/translation/requirements.txt
+++ b/examples/tensorflow/translation/requirements.txt
@@ -1,0 +1,3 @@
+datasets >= 1.4.0
+tensorflow >= 2.3.0
+evaluate >= 0.2.0

--- a/examples/tensorflow/translation/run_translation.py
+++ b/examples/tensorflow/translation/run_translation.py
@@ -28,9 +28,10 @@ from typing import Optional
 import datasets
 import numpy as np
 import tensorflow as tf
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 from tqdm import tqdm
 
+import evaluate
 import transformers
 from transformers import (
     AutoConfig,
@@ -590,7 +591,7 @@ def main():
         # endregion
 
         # region Metric and postprocessing
-        metric = load_metric("sacrebleu")
+        metric = evaluate.load("sacrebleu")
 
         def postprocess_text(preds, labels):
             preds = [pred.strip() for pred in preds]


### PR DESCRIPTION
# What does this PR do?
Currently, tensorflow examples use the `load_metric` function from Datasets library, commit migrates function call to `load` function to Evaluate library.

Fix for #18306

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger 