### PR TITLE
fix run_clip README

### DIFF
--- a/examples/pytorch/contrastive-image-text/README.md
+++ b/examples/pytorch/contrastive-image-text/README.md
@@ -43,7 +43,10 @@ cd ..
 Having downloaded COCO dataset manually you should be able to load with the `ydshieh/coc_dataset_script` dataset loading script:
 
 ```py
-COCO_DIR = "data"
+import os
+import datasets
+
+COCO_DIR = os.path.join(os.getcwd(), "data")
 ds = datasets.load_dataset("ydshieh/coco_dataset_script", "2017", data_dir=COCO_DIR)
 ```
 
@@ -84,7 +87,7 @@ Finally, we can run the example script to train the model:
 python examples/pytorch/contrastive-image-text/run_clip.py \
     --output_dir ./clip-roberta-finetuned \
     --model_name_or_path ./clip-roberta \
-    --data_dir ./data \
+    --data_dir $PWD/data \
     --dataset_name ydshieh/coco_dataset_script \
     --dataset_config_name=2017 \
     --image_column image_path \


### PR DESCRIPTION
# What does this PR do?

Fix `run_clip` example's README.

The path should be the absolute path to the downloaded data directory (using relative path will make `load_dataset` look for the data directory on the Hub).

From slack discussion:
- _basically the base path used to resolve relative path corresponds to where the dataset is loaded from_
- _relative paths are transformed to the corresponding URL in the repo the script comes from_

Fix #18291