### PR TITLE
Remove Flax OPT from `documentation_tests.txt`

### DIFF
--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -47,7 +47,6 @@ src/transformers/models/mobilebert/modeling_tf_mobilebert.py
 src/transformers/models/mobilevit/modeling_mobilevit.py
 src/transformers/models/opt/modeling_opt.py
 src/transformers/models/opt/modeling_tf_opt.py
-src/transformers/models/opt/modeling_flax_opt.py
 src/transformers/models/owlvit/modeling_owlvit.py
 src/transformers/models/pegasus/modeling_pegasus.py
 src/transformers/models/plbart/modeling_plbart.py


### PR DESCRIPTION
# What does this PR do?

Remove Flax OPT from `documentation_tests.txt` for now. The test uses the docker image `huggingface/transformers-all-latest-gpu` which has no JAX/Flax installed.


[Failed job run](https://github.com/huggingface/transformers/runs/7551001967?check_suite_focus=true)
Error:

```python
src/transformers/models/opt/modeling_flax_opt.py:20: in <module>
    import flax.linen as nn
E   ModuleNotFoundError: No module named 'flax'
```