### PR TITLE
[BLOOM] Clean modeling code

### DIFF
--- a/src/transformers/models/bloom/configuration_bloom.py
+++ b/src/transformers/models/bloom/configuration_bloom.py
@@ -214,14 +214,19 @@ class BloomOnnxConfig(OnnxConfigWithPast):
                 batch, seqlen = common_inputs["input_ids"].shape
                 # Not using the same length for past_key_values
                 past_key_values_length = seqlen + 2
-                past_shape = (
-                    batch,
+                head_dim = self._config.hidden_size // self.num_attention_heads
+                past_key_shape = (
+                    batch * self.num_attention_heads,
+                    head_dim,
                     past_key_values_length,
-                    self.num_attention_heads,
-                    self._config.hidden_size // self.num_attention_heads,
+                )
+                past_value_shape = (
+                    batch * self.num_attention_heads,
+                    past_key_values_length,
+                    head_dim,
                 )
                 ordered_inputs["past_key_values"] = [
-                    (torch.zeros(past_shape), torch.zeros(past_shape)) for _ in range(self.num_layers)
+                    (torch.zeros(past_key_shape), torch.zeros(past_value_shape)) for _ in range(self.num_layers)
                 ]
 
         ordered_inputs["attention_mask"] = common_inputs["attention_mask"]

--- a/src/transformers/models/bloom/configuration_bloom.py
+++ b/src/transformers/models/bloom/configuration_bloom.py
@@ -130,7 +130,6 @@ class BloomConfig(PretrainedConfig):
         attention_dropout=0.0,
         pretraining_tp=1,  # TP rank used when training with megatron
         slow_but_exact=False,
-        scale_attn_by_inverse_layer_idx=True,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -150,7 +149,6 @@ class BloomConfig(PretrainedConfig):
         self.bos_token_id = bos_token_id
         self.eos_token_id = eos_token_id
         self.slow_but_exact = slow_but_exact
-        self.scale_attn_by_inverse_layer_idx = scale_attn_by_inverse_layer_idx
 
         super().__init__(bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
 

--- a/src/transformers/models/bloom/configuration_bloom.py
+++ b/src/transformers/models/bloom/configuration_bloom.py
@@ -130,6 +130,7 @@ class BloomConfig(PretrainedConfig):
         attention_dropout=0.0,
         pretraining_tp=1,  # TP rank used when training with megatron
         slow_but_exact=False,
+        scale_attn_by_inverse_layer_idx=True,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -149,6 +150,7 @@ class BloomConfig(PretrainedConfig):
         self.bos_token_id = bos_token_id
         self.eos_token_id = eos_token_id
         self.slow_but_exact = slow_but_exact
+        self.scale_attn_by_inverse_layer_idx = scale_attn_by_inverse_layer_idx
 
         super().__init__(bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
 

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -689,7 +689,12 @@ class BloomModel(BloomPreTrainedModel):
 
         alibi = build_alibi_tensor(attention_mask, self.n_head, dtype=hidden_states.dtype)
 
-        causal_mask = self._prepare_attn_mask(attention_mask, input_shape=output_shape[:-1], inputs_embeds=inputs_embeds, past_key_values_length=past_key_values_length)
+        causal_mask = self._prepare_attn_mask(
+            attention_mask,
+            input_shape=output_shape[:-1],
+            inputs_embeds=inputs_embeds,
+            past_key_values_length=past_key_values_length,
+        )
 
         for i, (block, layer_past) in enumerate(zip(self.h, past_key_values)):
 
@@ -855,7 +860,9 @@ class BloomForCausalLM(BloomPreTrainedModel):
             batch_size, seq_length, vocab_size = shift_logits.shape
             # Flatten the tokens
             loss_fct = CrossEntropyLoss()
-            loss = loss_fct(shift_logits.view(batch_size * seq_length, vocab_size), shift_labels.view(batch_size * seq_length))
+            loss = loss_fct(
+                shift_logits.view(batch_size * seq_length, vocab_size), shift_labels.view(batch_size * seq_length)
+            )
 
         if not return_dict:
             output = (lm_logits,) + transformer_outputs[1:]
@@ -1003,7 +1010,9 @@ class BloomForSequenceClassification(BloomPreTrainedModel):
             elif self.config.problem_type == "single_label_classification":
                 batch_size, seq_length = labels.shape
                 loss_fct = CrossEntropyLoss()
-                loss = loss_fct(pooled_logits.view(batch_size * seq_length, self.num_labels), labels.view(batch_size * seq_length))
+                loss = loss_fct(
+                    pooled_logits.view(batch_size * seq_length, self.num_labels), labels.view(batch_size * seq_length)
+                )
             elif self.config.problem_type == "multi_label_classification":
                 loss_fct = BCEWithLogitsLoss()
                 loss = loss_fct(pooled_logits, labels)
@@ -1106,7 +1115,9 @@ class BloomForTokenClassification(BloomPreTrainedModel):
         if labels is not None:
             batch_size, seq_length = labels.shape
             loss_fct = CrossEntropyLoss()
-            loss = loss_fct(logits.view(batch_size * seq_length, self.num_labels), labels.view(batch_size * seq_length))
+            loss = loss_fct(
+                logits.view(batch_size * seq_length, self.num_labels), labels.view(batch_size * seq_length)
+            )
 
         if not return_dict:
             output = (logits,) + transformer_outputs[2:]

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -230,8 +230,8 @@ class BloomAttention(nn.Module):
 
         # Layer-wise attention scaling
         self.layer_number = max(1, layer_number)
-        self.inv_norm_factor = 1.0 / math.sqrt(self.head_dim)
-        self.beta = 1.0
+        self.inv_norm_factor = 1.0 / (math.sqrt(self.head_dim) * self.layer_number)
+        self.beta = 1.0 / self.layer_number
 
         self.query_key_value = nn.Linear(self.hidden_size, 3 * self.hidden_size, bias=True)
         self.dense = nn.Linear(self.hidden_size, self.hidden_size)
@@ -314,7 +314,7 @@ class BloomAttention(nn.Module):
         input_dtype = attention_scores.dtype
         attention_scores = attention_scores.float()
         attn_weights = torch.masked_fill(
-            attention_scores, attention_mask, torch.finfo(torch.float32).min
+            attention_scores * self.layer_number, attention_mask, torch.finfo(torch.float32).min
         )
         attention_probs = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(input_dtype)
 

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -779,7 +779,7 @@ class BloomForCausalLM(BloomPreTrainedModel):
     def set_output_embeddings(self, new_embeddings):
         self.lm_head = new_embeddings
 
-    def prepare_inputs_for_generation(self, input_ids: torch.LongTensor, use_cache: bool, past=None, attention_mask=None, **kwargs):
+    def prepare_inputs_for_generation(self, input_ids: torch.LongTensor, past=None, attention_mask=None, **kwargs):
         # only last token for inputs_ids if past is not None
         if past:
             input_ids = input_ids[:, -1].unsqueeze(-1)
@@ -787,7 +787,7 @@ class BloomForCausalLM(BloomPreTrainedModel):
         return {
             "input_ids": input_ids,
             "past_key_values": past,
-            "use_cache": use_cache,
+            "use_cache": kwargs.get("use_cache"),
             "attention_mask": attention_mask,
         }
 

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -312,8 +312,7 @@ class BloomAttention(nn.Module):
             present = None
 
         # [batch_size * num_heads, q_length, kv_length]
-        matmul_result = torch.baddbmm(
-            input=alibi,
+        matmul_result = alibi.baddbmm(
             batch1=query_layer,
             batch2=key_layer,
             beta=self.beta,
@@ -605,7 +604,7 @@ class BloomModel(BloomPreTrainedModel):
         return self.word_embeddings
 
     def _prepare_attn_mask(
-        self, attention_mask: torch.Tensor, input_shape: torch.Size, past_key_values_length: int
+        self, attention_mask: torch.Tensor, input_shape: Tuple[int, int], past_key_values_length: int
     ) -> torch.BoolTensor:
         # create causal mask
         # [batch_size, seq_length] -> [batch_size, 1, tgt_length, src_length]

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -272,7 +272,6 @@ class BloomAttention(nn.Module):
         use_cache=False,
         output_attentions=False,
     ):
-        alibi = alibi.to(hidden_states.device)  # to make the model possible to run under accelerate
         fused_qkv = self.query_key_value(hidden_states)  # [batch_size, seq_length, 3 x hidden_size]
 
         # 3 x [batch_size, seq_length, num_heads, head_dim]
@@ -288,8 +287,8 @@ class BloomAttention(nn.Module):
             # concatenate along seq_length dimension:
             #  - key: [batch_size * self.num_heads, head_dim, kv_length]
             #  - value: [batch_size * self.num_heads, kv_length, head_dim]
-            key_layer = torch.cat((past_key.type_as(key_layer), key_layer), dim=2)
-            value_layer = torch.cat((past_value.type_as(value_layer), value_layer), dim=1)
+            key_layer = torch.cat((past_key, key_layer), dim=2)
+            value_layer = torch.cat((past_value, value_layer), dim=1)
 
         _, _, kv_length = key_layer.shape
 

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -973,8 +973,8 @@ class BloomForSequenceClassification(BloomPreTrainedModel):
         labels: Optional[torch.Tensor] = None,
         use_cache: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
-        output_hidden_states: Optional[torch.bool] = None,
-        return_dict: Optional[torch.bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
         **deprecated_arguments
     ) -> Union[Tuple[torch.Tensor], SequenceClassifierOutputWithPast]:
         r"""

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -322,7 +322,7 @@ class BloomAttention(nn.Module):
         # change view to [batch_size, num_heads, q_length, kv_length]
         attention_scores = matmul_result.view(batch_size, self.num_heads, q_length, kv_length)
 
-        # we cast attention scores to fp32, compute scaled softmax and cast back into initial dtype - [batch_size, num_heads, q_length, kv_length]
+        # cast attention scores to fp32, compute scaled softmax and cast back to initial dtype - [batch_size, num_heads, q_length, kv_length]
         input_dtype = attention_scores.dtype
         # `float16` has a minimum value of -65504.0, whereas `bfloat16` and `float32` have a minimum value of `-3.4e+38`
         if input_dtype == torch.float16:
@@ -805,7 +805,7 @@ class BloomForCausalLM(BloomPreTrainedModel):
         attention_mask: Optional[torch.Tensor] = None,
         **kwargs
     ) -> dict:
-        # only last token for inputs_ids if past is not None
+        # only last token for input_ids if past is not None
         if past:
             input_ids = input_ids[:, -1].unsqueeze(-1)
 

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -709,7 +709,7 @@ class BloomModel(BloomPreTrainedModel):
 
         causal_mask = self._prepare_attn_mask(
             attention_mask,
-            input_shape=torch.Size(batch_size, seq_length),
+            input_shape=torch.Size((batch_size, seq_length)),
             past_key_values_length=past_key_values_length,
         )
 

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -903,18 +903,22 @@ class BloomForCausalLM(BloomPreTrainedModel):
         # key: layer_past[0] [batch_size * num_heads, head_dim, seq_length]
         # value: layer_past[1] [batch_size * num_heads, seq_length, head_dim]
         return tuple(
-            (
-                layer_past[0]
-                .view(batch_size, num_heads, head_dim, seq_length)
-                .index_select(0, beam_idx.to(layer_past[0].device))
-                .view(batch_size_times_num_heads, head_dim, seq_length),
-                layer_past[1]
-                .view(batch_size, num_heads, seq_length, head_dim)
-                .index_select(0, beam_idx.to(layer_past[1].device))
-                .view(batch_size_times_num_heads, seq_length, head_dim),
-            )
+            tuple(past_state.index_select(0, beam_idx.to(past_state.device)) for past_state in layer_past)
             for layer_past in past
         )
+        # return tuple(
+        #     (
+        #         layer_past[0]
+        #         .view(batch_size, num_heads, head_dim, seq_length)
+        #         .index_select(0, beam_idx.to(layer_past[0].device))
+        #         .view(batch_size_times_num_heads, head_dim, seq_length),
+        #         layer_past[1]
+        #         .view(batch_size, num_heads, seq_length, head_dim)
+        #         .index_select(0, beam_idx.to(layer_past[1].device))
+        #         .view(batch_size_times_num_heads, seq_length, head_dim),
+        #     )
+        #     for layer_past in past
+        # )
 
 
 @add_start_docstrings(

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -230,8 +230,8 @@ class BloomAttention(nn.Module):
 
         # Layer-wise attention scaling
         self.layer_number = max(1, layer_number)
-        self.inv_norm_factor = 1.0 / (math.sqrt(self.head_dim) * self.layer_number)
-        self.beta = 1.0 / self.layer_number
+        self.inv_norm_factor = 1.0 / math.sqrt(self.head_dim)
+        self.beta = 1.0
 
         self.query_key_value = nn.Linear(self.hidden_size, 3 * self.hidden_size, bias=True)
         self.dense = nn.Linear(self.hidden_size, self.hidden_size)
@@ -313,7 +313,7 @@ class BloomAttention(nn.Module):
         input_dtype = attention_scores.dtype
         attention_scores = attention_scores.float()
         attn_weights = torch.masked_fill(
-            attention_scores * self.layer_number, attention_mask, torch.finfo(torch.float32).min
+            attention_scores, attention_mask, torch.finfo(torch.float32).min
         )
         attention_probs = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(input_dtype)
 

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -588,7 +588,7 @@ class BloomModel(BloomPreTrainedModel):
         # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]
         combined_attention_mask = None
         device = attention_mask.device
-        seq_length, _ = input_shape
+        _, seq_length = input_shape
 
         if seq_length > 1:
             combined_attention_mask = _make_causal_mask(
@@ -649,7 +649,7 @@ class BloomModel(BloomPreTrainedModel):
         elif input_ids is not None:
             batch_size, seq_length = input_ids.shape
             input_ids = input_ids.view(batch_size, seq_length)
-            output_shape = input_ids.shape + (self.config.hidden_size,)
+            output_shape = input_ids.shape + (self.embed_dim,)
         elif inputs_embeds is not None:
             output_shape = inputs_embeds.shape
         else:

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -237,7 +237,8 @@ class BloomAttention(nn.Module):
 
     def _split_heads(self, fused_qkv: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
-        Split the last dimension into (num_heads, head_dim) without making any copies, results share same memory storage as `fused_qkv`
+        Split the last dimension into (num_heads, head_dim) without making any copies, results share same memory
+        storage as `fused_qkv`
 
         Args:
             fused_qkv (`torch.tensor`, *required*): [batch_size, seq_length, num_heads * 3 * head_dim]

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -600,7 +600,7 @@ class BloomModel(BloomPreTrainedModel):
 
         if seq_length > 1:
             combined_attention_mask = _make_causal_mask(
-                attention_mask.shape, device=device, past_key_values_length=past_key_values_length
+                input_shape, device=device, past_key_values_length=past_key_values_length
             )
 
         # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -279,11 +279,10 @@ class BloomAttention(nn.Module):
         (query_layer, key_layer, value_layer) = self._split_heads(fused_qkv)
 
         batch_size, q_length, _, _ = query_layer.shape
-        _, kv_length, _, _ = key_layer.shape
 
         query_layer = query_layer.transpose(1, 2).reshape(batch_size * self.num_heads, q_length, self.head_dim)
-        key_layer = key_layer.permute(0, 2, 3, 1).reshape(batch_size * self.num_heads, self.head_dim, kv_length)
-        value_layer = value_layer.transpose(1, 2).reshape(batch_size * self.num_heads, kv_length, self.head_dim)
+        key_layer = key_layer.permute(0, 2, 3, 1).reshape(batch_size * self.num_heads, self.head_dim, q_length)
+        value_layer = value_layer.transpose(1, 2).reshape(batch_size * self.num_heads, q_length, self.head_dim)
         if layer_past is not None:
             past_key, past_value = layer_past
             # concatenate along seq_length dimension:

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -313,9 +313,7 @@ class BloomAttention(nn.Module):
         # we cast attention scores to fp32, compute scaled softmax and cast back into initial dtype - [batch_size, num_heads, q_length, kv_length]        input_dtype = attention_scores.dtype
         input_dtype = attention_scores.dtype
         attention_scores = attention_scores.float()
-        attn_weights = torch.masked_fill(
-            attention_scores, attention_mask, torch.finfo(torch.float32).min
-        )
+        attn_weights = torch.masked_fill(attention_scores, attention_mask, torch.finfo(torch.float32).min)
         attention_probs = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(input_dtype)
 
         # [batch_size, num_heads, q_length, kv_length]

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -779,17 +779,15 @@ class BloomForCausalLM(BloomPreTrainedModel):
     def set_output_embeddings(self, new_embeddings):
         self.lm_head = new_embeddings
 
-    def prepare_inputs_for_generation(self, input_ids, past=None, **kwargs):
-        # only last token for inputs_ids if past is defined in kwargs
+    def prepare_inputs_for_generation(self, input_ids: torch.LongTensor, use_cache: bool, past=None, attention_mask=None, **kwargs):
+        # only last token for inputs_ids if past is not None
         if past:
             input_ids = input_ids[:, -1].unsqueeze(-1)
-
-        attention_mask = kwargs.get("attention_mask", None)
 
         return {
             "input_ids": input_ids,
             "past_key_values": past,
-            "use_cache": kwargs.get("use_cache"),
+            "use_cache": use_cache,
             "attention_mask": attention_mask,
         }
 

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -52,43 +52,40 @@ BLOOM_PRETRAINED_MODEL_ARCHIVE_LIST = [
 ]
 
 
-def _make_causal_mask(input_ids_shape: torch.Size, dtype: torch.dtype, past_key_values_length: int = 0):
+def _make_causal_mask(input_ids_shape: torch.Size, device: torch.device, past_key_values_length: int = 0):
     """
-    Make causal mask used for bi-directional self-attention.
+    Make causal mask used for self-attention.
     """
     batch_size, target_length = input_ids_shape
-    mask = torch.full((target_length, target_length), torch.finfo(dtype).min)
-    mask_cond = torch.arange(mask.size(-1))
-    intermediate_mask = mask_cond < (mask_cond + 1).view(mask.size(-1), 1)
-    mask.masked_fill_(intermediate_mask, 0)
-    mask = mask.to(dtype)
+    mask = torch.ones((target_length, target_length), dtype=torch.bool, device=device)
+    mask.triu_(diagonal=1)
 
     if past_key_values_length > 0:
-        mask = torch.cat([torch.zeros(target_length, past_key_values_length, dtype=dtype), mask], dim=-1)
+        past_key_values_mask = torch.zeros((target_length, past_key_values_length), dtype=torch.bool, device=device)
+        mask = torch.cat([past_key_values_mask, mask], dim=-1)
+
     expanded_mask = mask[None, None, :, :].expand(batch_size, 1, target_length, target_length + past_key_values_length)
     return expanded_mask
 
 
-def _expand_mask(mask: torch.Tensor, dtype: torch.dtype, tgt_len: int = None):
+def _expand_mask(mask: torch.Tensor, tgt_len: int = None):
     """
     Expands attention_mask from `[bsz, seq_len]` to `[bsz, 1, tgt_seq_len, src_seq_len]`.
     """
-    batch_size, source_length = mask.size()
+    batch_size, source_length = mask.shape
     tgt_len = tgt_len if tgt_len is not None else source_length
 
-    expanded_mask = mask[:, None, None, :].expand(batch_size, 1, tgt_len, source_length).to(dtype)
-
-    inverted_mask = 1.0 - expanded_mask
-
-    return inverted_mask.masked_fill(inverted_mask.to(torch.bool), torch.finfo(dtype).min)
+    expanded_mask = mask[:, None, None, :].to(torch.bool).expand(batch_size, 1, tgt_len, source_length)
+    return ~expanded_mask
 
 
-def build_alibi_tensor(attention_mask: torch.Tensor, n_head: int, dtype, device) -> torch.Tensor:
+def build_alibi_tensor(attention_mask: torch.Tensor, n_head: int, dtype: torch.dtype) -> torch.Tensor:
     """
     Link to paper: https://arxiv.org/abs/2108.12409 Alibi tensor is not causal as the original paper mentions, it
     relies on a translation invariance of softmax for quick implementation: with l being a tensor, and a fixed value
     `softmax(l+a) = softmax(l)`. Based on
     https://github.com/ofirpress/attention_with_linear_biases/blob/a35aaca144e0eb6b789dfcb46784c4b8e31b7983/fairseq/models/transformer.py#L742
+    TODO @thomasw21 this doesn't work as nicely due to the masking strategy, and so masking varies slightly.
 
     Args:
     Returns tensor shaped (batch_size * n_head, 1, max_seq_len)
@@ -101,17 +98,20 @@ def build_alibi_tensor(attention_mask: torch.Tensor, n_head: int, dtype, device)
         device (`torch.device`, *optional*, default=`torch.device('cpu')`):
             device of the output alibi tensor
     """
+    batch_size, seq_length = attention_mask.shape
     closest_power_of_2 = 2 ** math.floor(math.log2(n_head))
-    base = torch.tensor(2 ** (-(2 ** -(math.log2(closest_power_of_2) - 3))), device=device, dtype=torch.float32)
-    powers = torch.arange(1, 1 + closest_power_of_2, device=device, dtype=torch.int32)
+    base = torch.tensor(
+        2 ** (-(2 ** -(math.log2(closest_power_of_2) - 3))), device=attention_mask.device, dtype=torch.float32
+    )
+    powers = torch.arange(1, 1 + closest_power_of_2, device=attention_mask.device, dtype=torch.int32)
     slopes = torch.pow(base, powers)
 
     if closest_power_of_2 != n_head:
         extra_base = torch.tensor(
-            2 ** (-(2 ** -(math.log2(2 * closest_power_of_2) - 3))), device=device, dtype=torch.float32
+            2 ** (-(2 ** -(math.log2(2 * closest_power_of_2) - 3))), device=attention_mask.device, dtype=torch.float32
         )
         num_remaining_heads = min(closest_power_of_2, n_head - closest_power_of_2)
-        extra_powers = torch.arange(1, 1 + 2 * num_remaining_heads, 2, device=device, dtype=torch.int32)
+        extra_powers = torch.arange(1, 1 + 2 * num_remaining_heads, 2, device=attention_mask.device, dtype=torch.int32)
         slopes = torch.cat([slopes, torch.pow(extra_base, extra_powers)], dim=0)
 
     # Note: alibi will added to the attention bias that will be applied to the query, key product of attention
@@ -120,12 +120,9 @@ def build_alibi_tensor(attention_mask: torch.Tensor, n_head: int, dtype, device)
     # => the query_length dimension will then be broadcasted correctly
     # This is more or less identical to T5's relative position bias:
     # https://github.com/huggingface/transformers/blob/f681437203baa7671de3174b0fa583c349d9d5e1/src/transformers/models/t5/modeling_t5.py#L527
-    # batch_size = 1, n_head = n_head, query_length
-
-    arange_tensor = (attention_mask.cumsum(-1)[:, None, :].to(device) - 1) * attention_mask[:, None]
-    alibi = slopes.unsqueeze(-1) * arange_tensor
-    alibi = alibi * attention_mask[:, None]
-    return alibi.reshape(alibi.shape[0] * n_head, 1, -1).to(dtype)
+    arange_tensor = ((attention_mask.cumsum(dim=-1) - 1) * attention_mask)[:, None, :]
+    alibi = slopes[..., None] * arange_tensor
+    return alibi.reshape(batch_size * n_head, 1, seq_length).to(dtype)
 
 
 def dropout_add(x, residual, prob, training):
@@ -211,7 +208,7 @@ class BloomGelu(nn.Module):
 
 
 class BloomAttention(nn.Module):
-    def __init__(self, config, layer_number=None):
+    def __init__(self, config, layer_number):
         super().__init__()
 
         self.pretraining_tp = config.pretraining_tp
@@ -231,7 +228,8 @@ class BloomAttention(nn.Module):
 
         # Layer-wise attention scaling
         self.layer_number = max(1, layer_number)
-        self.norm_factor = math.sqrt(self.head_dim) * self.layer_number
+        self.inv_norm_factor = 1.0 / (math.sqrt(self.head_dim) * self.layer_number)
+        self.beta = 1.0 / self.layer_number
 
         self.query_key_value = nn.Linear(self.hidden_size, 3 * self.hidden_size, bias=True)
         self.dense = nn.Linear(self.hidden_size, self.hidden_size)
@@ -241,34 +239,33 @@ class BloomAttention(nn.Module):
         """
         Split the last dimension into (num_heads, head_dim)
         """
-        new_tensor_shape = fused_qkv.size()[:-1] + (self.num_heads, 3 * self.head_dim)
-        # new_tensor_shape = (fused_qkv.size(1), fused_qkv.size(0)*fused_qkv.size(2), fused_qkv.size(-1))
-        # fused_qkv = fused_qkv.transpose(1, 0)
-        fused_qkv = fused_qkv.reshape(*new_tensor_shape)
-        # fused_qkv = fused_qkv.permute(0, 2, 1, 3)
-        return torch.split(fused_qkv, self.head_dim, -1)
+        batch_size, seq_length, three_times_hidden_size = fused_qkv.shape
+        fused_qkv = fused_qkv.reshape(batch_size, seq_length, self.num_heads, 3 * self.head_dim)
+        return torch.split(fused_qkv, self.head_dim, dim=-1)
 
     def _merge_heads(self, x):
         # What we want to achieve is:
         # batch_size * num_heads, seq_len, head_dim -> batch_size, seq_len, num_heads * head_dim
+        batch_size_and_num_heads, seq_len, _ = x.shape
+        batch_size = batch_size_and_num_heads // self.num_heads
 
         # First view to decompose the batch size
         # batch_size*num_heads, seq_len, head_dim -> batch_size, num_heads, seq_len, head_dim
-        x = x.view(x.size(0) // self.num_heads, self.num_heads, x.size(1), self.head_dim)
+        x = x.view(batch_size, self.num_heads, seq_len, self.head_dim)
 
         # batch_size, num_heads, seq_len, head_dim -> batch_size, seq_len, num_heads, head_dim
         x = x.permute(0, 2, 1, 3)
 
         # batch_size, seq_len, num_heads, head_dim -> batch_size, seq_len, num_heads * head_dim
-        return x.reshape(x.size(0), x.size(1), self.num_heads * self.head_dim)
+        return x.reshape(batch_size, seq_len, self.num_heads * self.head_dim)
 
     def forward(
         self,
         hidden_states,
         residual,
+        alibi,
+        attention_mask,
         layer_past=None,
-        attention_mask=None,
-        alibi=None,
         head_mask=None,
         use_cache=False,
         output_attentions=False,
@@ -281,7 +278,7 @@ class BloomAttention(nn.Module):
 
         if layer_past is not None:
             past_key, past_value = layer_past
-            # concatenate along seq_length dimension -> [batch_size, qk_length, num_heads, head_dim]
+            # concatenate along seq_length dimension -> [batch_size, kv_length, num_heads, head_dim]
             key_layer = torch.cat((past_key.type_as(key_layer), key_layer), dim=1)
             value_layer = torch.cat((past_value.type_as(value_layer), value_layer), dim=1)
 
@@ -290,23 +287,29 @@ class BloomAttention(nn.Module):
         else:
             present = None
 
-        beta = 1.0 / self.layer_number
+        batch_size, q_length, _, _ = query_layer.shape
+        _, kv_length, _, _ = key_layer.shape
 
         # # [batch_size*num_heads, head_dim, q_length] x [batch_size*num_heads, head_dim, k_length] -> [batch_size*num_heads, q_length, k_length]
-        matmul_result = (1.0 / self.norm_factor) * torch.bmm(
-            query_layer.transpose(1, 2).reshape(-1, query_layer.shape[1], query_layer.shape[3]),
-            key_layer.permute(0, 2, 3, 1).reshape(-1, key_layer.shape[3], key_layer.shape[1]),
-        ) + beta * alibi
+        matmul_result = torch.baddbmm(
+            input=alibi,
+            batch1=query_layer.transpose(1, 2).reshape(batch_size * self.num_heads, q_length, self.head_dim),
+            batch2=key_layer.permute(0, 2, 3, 1).reshape(batch_size * self.num_heads, self.head_dim, kv_length),
+            beta=self.beta,
+            alpha=self.inv_norm_factor,
+        )
 
         # change view to [batch_size, num_heads, q_length, k_length]
-        attention_scores = matmul_result.view(-1, self.num_heads, matmul_result.size(1), matmul_result.size(2))
+        attention_scores = matmul_result.view(batch_size, self.num_heads, q_length, kv_length)
 
-        # We replace the scaled softmax by just a few line of code - [batch_size, num_heads, q_length, k_length]
+        # we cast attention scores to fp32, compute scaled softmax and cast back into initial dtype - [batch_size, num_heads, q_length, k_length]        input_dtype = attention_scores.dtype
         input_dtype = attention_scores.dtype
-        attn_weights = (attention_scores * self.layer_number) + attention_mask
-        attn_weights = torch.max(attn_weights, torch.tensor(torch.finfo(attn_weights.dtype).min))
+        attention_scores = attention_scores.float()
+        attn_weights = torch.masked_fill(
+            attention_scores * self.layer_number, attention_mask, torch.finfo(torch.float32).min
+        )
         attention_probs = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(input_dtype)
-        attention_probs = attention_probs * (~attention_mask.bool())
+
         # [batch_size, num_heads, q_length, k_length]
         attention_probs = self.attention_dropout(attention_probs)
 
@@ -314,11 +317,12 @@ class BloomAttention(nn.Module):
             attention_probs = attention_probs * head_mask
 
         # change view [batch_size x num_heads, q_length, k_length]
-        attention_probs_reshaped = attention_probs.view(*matmul_result.shape)
+        attention_probs_reshaped = attention_probs.view(batch_size * self.num_heads, q_length, kv_length)
 
         # matmul: [batch_size * num_heads, q_length, head_dim]
         context_layer = torch.bmm(
-            attention_probs_reshaped, value_layer.transpose(1, 2).reshape(-1, value_layer.size(1), value_layer.size(3))
+            attention_probs_reshaped,
+            value_layer.transpose(1, 2).reshape(batch_size * self.num_heads, kv_length, self.head_dim),
         )
 
         # change view [batch_size, num_heads, q_length, head_dim]
@@ -326,7 +330,7 @@ class BloomAttention(nn.Module):
 
         # aggregate results across tp ranks. See here: https://github.com/pytorch/pytorch/issues/76232
         if self.pretraining_tp > 1 and self.slow_but_exact:
-            slices = context_layer.shape[-1] / self.pretraining_tp
+            slices = self.config.hidden_size / self.pretraining_tp
             output_tensor = torch.zeros_like(context_layer)
             for i in range(self.pretraining_tp):
                 output_tensor = output_tensor + nn.functional.linear(
@@ -377,7 +381,7 @@ class BloomMLP(nn.Module):
 
 
 class BloomBlock(nn.Module):
-    def __init__(self, config, layer_number=None):
+    def __init__(self, config, layer_number):
         super().__init__()
         hidden_size = config.hidden_size
 
@@ -394,12 +398,12 @@ class BloomBlock(nn.Module):
     def forward(
         self,
         hidden_states,
+        alibi,
+        attention_mask,
         layer_past=None,
-        attention_mask=None,
         head_mask=None,
         use_cache=False,
         output_attentions=False,
-        alibi=None,
     ):
         # hidden_states: [batch_size, seq_length, hidden_size]
 
@@ -563,7 +567,6 @@ class BloomModel(BloomPreTrainedModel):
 
         # Embedding + LN Embedding
         self.word_embeddings = nn.Embedding(config.vocab_size, self.embed_dim)
-
         self.word_embeddings_layernorm = LayerNorm(self.embed_dim, eps=config.layer_norm_epsilon)
 
         # Transformer blocks
@@ -584,16 +587,19 @@ class BloomModel(BloomPreTrainedModel):
         # create causal mask
         # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]
         combined_attention_mask = None
-        if input_shape[-1] > 1:
+        device = attention_mask.device
+        seq_length, _ = input_shape
+
+        if seq_length > 1:
             combined_attention_mask = _make_causal_mask(
-                input_shape, inputs_embeds.dtype, past_key_values_length=past_key_values_length
-            ).to(attention_mask.device)
+                input_shape, device=device, past_key_values_length=past_key_values_length
+            )
 
         if attention_mask is not None:
             # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]
-            expanded_attn_mask = _expand_mask(attention_mask, inputs_embeds.dtype, tgt_len=input_shape[-1])
+            expanded_attn_mask = _expand_mask(attention_mask, tgt_len=seq_length)
             combined_attention_mask = (
-                expanded_attn_mask if combined_attention_mask is None else expanded_attn_mask + combined_attention_mask
+                expanded_attn_mask if combined_attention_mask is None else expanded_attn_mask | combined_attention_mask
             )
 
         return combined_attention_mask
@@ -641,10 +647,11 @@ class BloomModel(BloomPreTrainedModel):
         if input_ids is not None and inputs_embeds is not None:
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
-            input_shape = input_ids.size()
-            input_ids = input_ids.view(-1, input_shape[-1])
+            batch_size, seq_length = input_ids.shape
+            input_ids = input_ids.view(batch_size, seq_length)
+            output_shape = input_ids.shape + (self.config.hidden_size,)
         elif inputs_embeds is not None:
-            input_shape = inputs_embeds.size()[:-1]
+            output_shape = inputs_embeds.shape
         else:
             raise ValueError("You have to specify either input_ids or inputs_embeds")
 
@@ -662,8 +669,6 @@ class BloomModel(BloomPreTrainedModel):
 
         hidden_states = self.word_embeddings_layernorm(inputs_embeds)
 
-        output_shape = input_shape + (hidden_states.size(-1),)
-
         presents = () if use_cache else None
         all_self_attentions = () if output_attentions else None
         all_hidden_states = () if output_hidden_states else None
@@ -678,11 +683,13 @@ class BloomModel(BloomPreTrainedModel):
         if attention_mask is None:
             attention_mask = torch.ones((hidden_states.shape[0], current_sequence_length), device=hidden_states.device)
         else:
+            batch_size, seq_length = attention_mask.shape
+            attention_mask = attention_mask.view(batch_size, seq_length)
             attention_mask = attention_mask.to(hidden_states.device)
 
-        alibi = build_alibi_tensor(attention_mask, self.n_head, hidden_states.dtype, hidden_states.device)
+        alibi = build_alibi_tensor(attention_mask, self.n_head, dtype=hidden_states.dtype)
 
-        causal_mask = self._prepare_attn_mask(attention_mask, input_shape, inputs_embeds, past_key_values_length)
+        causal_mask = self._prepare_attn_mask(attention_mask, input_shape=output_shape[:-1], inputs_embeds=inputs_embeds, past_key_values_length=past_key_values_length)
 
         for i, (block, layer_past) in enumerate(zip(self.h, past_key_values)):
 
@@ -700,14 +707,14 @@ class BloomModel(BloomPreTrainedModel):
                 def create_custom_forward(module):
                     def custom_forward(*inputs):
                         # None for past_key_value
-                        return module(*inputs, use_cache, output_attentions, alibi)
+                        return module(*inputs, use_cache=use_cache, output_attentions=output_attentions)
 
                     return custom_forward
 
                 outputs = torch.utils.checkpoint.checkpoint(
                     create_custom_forward(block),
                     hidden_states,
-                    None,
+                    alibi,
                     causal_mask,
                     head_mask[i],
                 )
@@ -845,9 +852,10 @@ class BloomForCausalLM(BloomPreTrainedModel):
             # Shift so that tokens < n predict n
             shift_logits = lm_logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()
+            batch_size, seq_length, vocab_size = shift_logits.shape
             # Flatten the tokens
             loss_fct = CrossEntropyLoss()
-            loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
+            loss = loss_fct(shift_logits.view(batch_size * seq_length, vocab_size), shift_labels.view(batch_size * seq_length))
 
         if not return_dict:
             output = (lm_logits,) + transformer_outputs[1:]
@@ -966,7 +974,7 @@ class BloomForSequenceClassification(BloomPreTrainedModel):
             sequence_lengths = -1
         else:
             if input_ids is not None:
-                sequence_lengths = torch.ne(input_ids, self.config.pad_token_id).sum(-1) - 1
+                sequence_lengths = torch.ne(input_ids, self.config.pad_token_id).sum(dim=-1) - 1
             else:
                 sequence_lengths = -1
                 logger.warning(
@@ -993,8 +1001,9 @@ class BloomForSequenceClassification(BloomPreTrainedModel):
                 else:
                     loss = loss_fct(pooled_logits, labels)
             elif self.config.problem_type == "single_label_classification":
+                batch_size, seq_length = labels.shape
                 loss_fct = CrossEntropyLoss()
-                loss = loss_fct(pooled_logits.view(-1, self.num_labels), labels.view(-1))
+                loss = loss_fct(pooled_logits.view(batch_size * seq_length, self.num_labels), labels.view(batch_size * seq_length))
             elif self.config.problem_type == "multi_label_classification":
                 loss_fct = BCEWithLogitsLoss()
                 loss = loss_fct(pooled_logits, labels)
@@ -1095,8 +1104,9 @@ class BloomForTokenClassification(BloomPreTrainedModel):
 
         loss = None
         if labels is not None:
+            batch_size, seq_length = labels.shape
             loss_fct = CrossEntropyLoss()
-            loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))
+            loss = loss_fct(logits.view(batch_size * seq_length, self.num_labels), labels.view(batch_size * seq_length))
 
         if not return_dict:
             output = (logits,) + transformer_outputs[2:]

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -312,7 +312,7 @@ class BloomAttention(nn.Module):
             # FIXME @thomasw21: `.view(...).transpose(0,1)` is used to be backward compatible
             present = (
                 key_layer.view(batch_size, self.num_heads, self.head_dim, kv_length).transpose(1, 3),
-                value_layer.view(batch_size, self.num_heads, kv_length, self.head_dim).tranpose(1, 2),
+                value_layer.view(batch_size, self.num_heads, kv_length, self.head_dim).transpose(1, 2),
             )
         else:
             present = None

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -509,7 +509,7 @@ BLOOM_INPUTS_DOCSTRING = r"""
     Args:
         input_ids (`torch.LongTensor` of shape `(batch_size, input_ids_length)`):
             `input_ids_length` = `sequence_length` if `past_key_values` is `None` else
-            `past_key_values[0][0].shape[-2]` (`sequence_length` of input past key value states). Indices of input
+            `past_key_values[0][0].shape[2]` (`sequence_length` of input past key value states). Indices of input
             sequence tokens in the vocabulary.
 
             If `past_key_values` is used, only `input_ids` that do not have their past calculated should be passed as
@@ -523,6 +523,10 @@ BLOOM_INPUTS_DOCSTRING = r"""
             Contains precomputed hidden-states (key and values in the attention blocks) as computed by the model (see
             `past_key_values` output below). Can be used to speed up sequential decoding. The `input_ids` which have
             their past given to this model should not be passed as `input_ids` as they have already been computed.
+
+            Each element of `past_key_values` is a tuple (past_key, past_value):
+            - past_key: [batch_size * num_heads, head_dim, kv_length]
+            - past_value: [batch_size * num_heads, kv_length, head_dim]
         attention_mask (`torch.FloatTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Mask to avoid performing attention on padding token indices. Mask values selected in `[0, 1]`:
 

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -64,7 +64,7 @@ def _make_causal_mask(
     mask[:, past_key_values_length:].triu_(diagonal=1)
 
     if past_key_values_length > 0:
-        mask[:, past_key_values_length:] = False
+        mask[:, :past_key_values_length] = False
 
     expanded_mask = mask[None, None, :, :].expand(batch_size, 1, target_length, target_length + past_key_values_length)
     return expanded_mask

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -590,12 +590,12 @@ class BloomModel(BloomPreTrainedModel):
     def get_input_embeddings(self):
         return self.word_embeddings
 
-    def _prepare_attn_mask(self, attention_mask: torch.Tensor, past_key_values_length: int):
+    def _prepare_attn_mask(self, attention_mask: torch.Tensor, input_shape: torch.Size, past_key_values_length: int):
         # create causal mask
         # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]
         combined_attention_mask = None
         device = attention_mask.device
-        _, seq_length = attention_mask.shape
+        _, seq_length = input_shape
 
         if seq_length > 1:
             combined_attention_mask = _make_causal_mask(
@@ -693,6 +693,7 @@ class BloomModel(BloomPreTrainedModel):
 
         causal_mask = self._prepare_attn_mask(
             attention_mask,
+            input_shape=torch.Size((batch_size, seq_length)),
             past_key_values_length=past_key_values_length,
         )
 

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -897,15 +897,15 @@ class BloomForCausalLM(BloomPreTrainedModel):
         [`~PreTrainedModel.beam_sample`] is called. This is required to match `past_key_values` with the correct
         beam_idx at every generation step.
         """
-        batch_size_times_num_heads, head_dim, seq_length = past[0][0].shape
-        batch_size = len(beam_idx)
-        num_heads = batch_size_times_num_heads // batch_size
-        # key: layer_past[0] [batch_size * num_heads, head_dim, seq_length]
-        # value: layer_past[1] [batch_size * num_heads, seq_length, head_dim]
         return tuple(
             tuple(past_state.index_select(0, beam_idx.to(past_state.device)) for past_state in layer_past)
             for layer_past in past
         )
+        # batch_size_times_num_heads, head_dim, seq_length = past[0][0].shape
+        # batch_size = len(beam_idx)
+        # num_heads = batch_size_times_num_heads // batch_size
+        # # key: layer_past[0] [batch_size * num_heads, head_dim, seq_length]
+        # # value: layer_past[1] [batch_size * num_heads, seq_length, head_dim]
         # return tuple(
         #     (
         #         layer_past[0]

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -292,6 +292,8 @@ class BloomAttention(nn.Module):
             key_layer = torch.cat((past_key.type_as(key_layer), key_layer), dim=2)
             value_layer = torch.cat((past_value.type_as(value_layer), value_layer), dim=1)
 
+        _, _, kv_length = key_layer.shape
+
         if use_cache is True:
             present = (key_layer, value_layer)
         else:

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -709,7 +709,7 @@ class BloomModel(BloomPreTrainedModel):
 
         causal_mask = self._prepare_attn_mask(
             attention_mask,
-            input_shape=torch.Size((batch_size, seq_length)),
+            input_shape=torch.Size(batch_size, seq_length),
             past_key_values_length=past_key_values_length,
         )
 

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -883,7 +883,7 @@ class BloomForCausalLM(BloomPreTrainedModel):
         [`~PreTrainedModel.beam_sample`] is called. This is required to match `past_key_values` with the correct
         beam_idx at every generation step.
         """
-        batch_size_times_num_heads, head_dim, seq_length = past[0].shape
+        batch_size_times_num_heads, head_dim, seq_length = past[0][0].shape
         batch_size = len(beam_idx)
         num_heads = batch_size_times_num_heads // batch_size
         # key: layer_past[0] [batch_size * num_heads, head_dim, seq_length]
@@ -891,7 +891,7 @@ class BloomForCausalLM(BloomPreTrainedModel):
         return tuple(
             (
                 layer_past[0].view(batch_size, num_heads, head_dim, seq_length).index_select(0, beam_idx.to(layer_past[0].device)).view(batch_size_times_num_heads, head_dim, seq_length),
-                layer_past[1].view(batch_size, num_heads, head_dim, seq_length).index_select(0, beam_idx.to(layer_past[1].device)).view(batch_size_times_num_heads, seq_length, head_dim)
+                layer_past[1].view(batch_size, num_heads, seq_length, head_dim).index_select(0, beam_idx.to(layer_past[1].device)).view(batch_size_times_num_heads, seq_length, head_dim)
             )
             for layer_past in past
         )

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -208,7 +208,7 @@ class BloomGelu(nn.Module):
 
 
 class BloomAttention(nn.Module):
-    def __init__(self, config: BloomConfig, layer_number: int):
+    def __init__(self, config: BloomConfig):
         super().__init__()
 
         self.pretraining_tp = config.pretraining_tp
@@ -227,13 +227,8 @@ class BloomAttention(nn.Module):
             )
 
         # Layer-wise attention scaling
-        self.layer_number = max(1, layer_number)
         self.inv_norm_factor = 1.0 / math.sqrt(self.head_dim)
         self.beta = 1.0
-        self.scale_attn_by_inverse_layer_idx = config.scale_attn_by_inverse_layer_idx
-        if self.scale_attn_by_inverse_layer_idx:
-            self.inv_norm_factor /= self.layer_number
-            self.beta /= self.layer_number
 
         self.query_key_value = nn.Linear(self.hidden_size, 3 * self.hidden_size, bias=True)
         self.dense = nn.Linear(self.hidden_size, self.hidden_size)
@@ -333,10 +328,6 @@ class BloomAttention(nn.Module):
         # `float16` has a minimum value of -65504.0, whereas `bfloat16` and `float32` have a minimum value of `-3.4e+38`
         if input_dtype == torch.float16:
             attention_scores = attention_scores.to(torch.float)
-
-        if self.scale_attn_by_inverse_layer_idx:
-            attention_scores = attention_scores * self.layer_number
-
         attn_weights = torch.masked_fill(attention_scores, attention_mask, torch.finfo(attention_scores.dtype).min)
         attention_probs = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(input_dtype)
 
@@ -408,13 +399,13 @@ class BloomMLP(nn.Module):
 
 
 class BloomBlock(nn.Module):
-    def __init__(self, config: BloomConfig, layer_number: int):
+    def __init__(self, config: BloomConfig):
         super().__init__()
         hidden_size = config.hidden_size
 
         self.input_layernorm = LayerNorm(hidden_size, eps=config.layer_norm_epsilon)
         self.num_heads = config.n_head
-        self.self_attention = BloomAttention(config, layer_number=layer_number)
+        self.self_attention = BloomAttention(config)
         self.post_attention_layernorm = LayerNorm(hidden_size, eps=config.layer_norm_epsilon)
 
         self.mlp = BloomMLP(config)
@@ -600,7 +591,7 @@ class BloomModel(BloomPreTrainedModel):
         self.word_embeddings_layernorm = LayerNorm(self.embed_dim, eps=config.layer_norm_epsilon)
 
         # Transformer blocks
-        self.h = nn.ModuleList([BloomBlock(config, layer_number=layer_number) for layer_number in range(config.num_hidden_layers)])
+        self.h = nn.ModuleList([BloomBlock(config) for _ in range(config.num_hidden_layers)])
 
         # Final Layer Norm
         self.ln_f = LayerNorm(self.embed_dim, eps=config.layer_norm_epsilon)

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -312,6 +312,7 @@ class BloomAttention(nn.Module):
             present = None
 
         # [batch_size * num_heads, q_length, kv_length]
+        # we use `torch.Tensor.baddbmm` instead of `torch.baddbmm` as the latter isn't supported by TorchScript v1.11
         matmul_result = alibi.baddbmm(
             batch1=query_layer,
             batch2=key_layer,

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -890,8 +890,8 @@ class BloomForCausalLM(BloomPreTrainedModel):
         # value: layer_past[1] [batch_size * num_heads, seq_length, head_dim]
         return tuple(
             (
-                layer_past[0].view(batch_size, num_heads, seq_length).index_select(0, beam_idx.to(layer_past[0].device)).view(batch_size_times_num_heads, head_dim, seq_length),
-                layer_past[1].view(batch_size, num_heads, seq_length).index_select(0, beam_idx.to(layer_past[1].device)).view(batch_size_times_num_heads, seq_length, head_dim)
+                layer_past[0].view(batch_size, num_heads, head_dim, seq_length).index_select(0, beam_idx.to(layer_past[0].device)).view(batch_size_times_num_heads, head_dim, seq_length),
+                layer_past[1].view(batch_size, num_heads, head_dim, seq_length).index_select(0, beam_idx.to(layer_past[1].device)).view(batch_size_times_num_heads, seq_length, head_dim)
             )
             for layer_past in past
         )

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -709,7 +709,7 @@ class BloomModel(BloomPreTrainedModel):
 
         causal_mask = self._prepare_attn_mask(
             attention_mask,
-            input_shape=torch.Size((batch_size, seq_length)),
+            input_shape=(batch_size, seq_length),
             past_key_values_length=past_key_values_length,
         )
 

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -330,7 +330,7 @@ class BloomAttention(nn.Module):
 
         # aggregate results across tp ranks. See here: https://github.com/pytorch/pytorch/issues/76232
         if self.pretraining_tp > 1 and self.slow_but_exact:
-            slices = self.config.hidden_size / self.pretraining_tp
+            slices = self.hidden_size / self.pretraining_tp
             output_tensor = torch.zeros_like(context_layer)
             for i in range(self.pretraining_tp):
                 output_tensor = output_tensor + nn.functional.linear(

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -508,9 +508,8 @@ BLOOM_START_DOCSTRING = r"""
 BLOOM_INPUTS_DOCSTRING = r"""
     Args:
         input_ids (`torch.LongTensor` of shape `(batch_size, input_ids_length)`):
-            `input_ids_length` = `sequence_length` if `past_key_values` is `None` else
-            `past_key_values[0][0].shape[2]` (`sequence_length` of input past key value states). Indices of input
-            sequence tokens in the vocabulary.
+            `input_ids_length` = `sequence_length` if `past_key_values` is `None` else `past_key_values[0][0].shape[2]`
+            (`sequence_length` of input past key value states). Indices of input sequence tokens in the vocabulary.
 
             If `past_key_values` is used, only `input_ids` that do not have their past calculated should be passed as
             `input_ids`.

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -230,8 +230,8 @@ class BloomAttention(nn.Module):
 
         # Layer-wise attention scaling
         self.layer_number = max(1, layer_number)
-        self.inv_norm_factor = 1.0 / (math.sqrt(self.head_dim) * self.layer_number)
-        self.beta = 1.0 / self.layer_number
+        self.inv_norm_factor = 1.0 / math.sqrt(self.head_dim)
+        self.beta = 1.0
 
         self.query_key_value = nn.Linear(self.hidden_size, 3 * self.hidden_size, bias=True)
         self.dense = nn.Linear(self.hidden_size, self.hidden_size)
@@ -314,7 +314,7 @@ class BloomAttention(nn.Module):
         input_dtype = attention_scores.dtype
         attention_scores = attention_scores.float()
         attn_weights = torch.masked_fill(
-            attention_scores * self.layer_number, attention_mask, torch.finfo(torch.float32).min
+            attention_scores, attention_mask, torch.finfo(torch.float32).min
         )
         attention_probs = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(input_dtype)
 
@@ -328,10 +328,7 @@ class BloomAttention(nn.Module):
         attention_probs_reshaped = attention_probs.view(batch_size * self.num_heads, q_length, kv_length)
 
         # matmul: [batch_size * num_heads, q_length, head_dim]
-        context_layer = torch.bmm(
-            attention_probs_reshaped,
-            value_layer,
-        )
+        context_layer = torch.bmm(attention_probs_reshaped, value_layer)
 
         # change view [batch_size, num_heads, q_length, head_dim]
         context_layer = self._merge_heads(context_layer)

--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -640,7 +640,7 @@ class HFTracer(Tracer):
     # Feature flag for proxying accesses to buffer values
     proxy_buffer_attributes: bool = True
     allow_insert_stateless_mods: bool = True
-    _TORCH_METHODS_TO_PATCH = ["arange", "zeros", "ones", "full", "full_like", "eye", "empty", "tensor", "Size"]
+    _TORCH_METHODS_TO_PATCH = ["arange", "zeros", "ones", "full", "full_like", "eye", "empty", "tensor"]
 
     def __init__(self, autowrap_modules=(math,), autowrap_functions=()):
 

--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -640,7 +640,7 @@ class HFTracer(Tracer):
     # Feature flag for proxying accesses to buffer values
     proxy_buffer_attributes: bool = True
     allow_insert_stateless_mods: bool = True
-    _TORCH_METHODS_TO_PATCH = ["arange", "zeros", "ones", "full", "full_like", "eye", "empty", "tensor"]
+    _TORCH_METHODS_TO_PATCH = ["arange", "zeros", "ones", "full", "full_like", "eye", "empty", "tensor", "Size"]
 
     def __init__(self, autowrap_modules=(math,), autowrap_functions=()):
 


### PR DESCRIPTION
# What does this PR do?

**THERE'S A BREAKING CHANGE**: `past_key_values` changes in terms of format, is that acceptable @sgugger @patrickvonplaten ?

## Changes

Make a pass at cleaning up some code:
 - convert `causal_mask` to bool tensor and use it via mask.
 - simplify `causal_mask` creation function.
 - revert back to `baddbmm` instead of `bmm`, it was unclear why this was changed, and training codebase uses `baddbmm`.
 - switch back `attention_scores` upcasting to fp32 as it mimics the training procedure the closest.
 - remove `self.layer_number` normalization. It was introduced in Meg-DS to prevent overflow when computing attention scores in float16, but it doesn't seem to impact the model at all here.
 - remove a `reshape` in `.split_head()` which reduces memory footprint and increases throughput
 - remove multiple reshapes when computing `QKV` with past values. Though this introduces a **BREAKING CHANGE** where `past_key` instead of being stored in `[batch_size, num_heads, seq_length, head_dim]` it's stored in `[batch_size * num_heads, head_dim, seq_length]`.
 - explicit all dimensions when computing `.view`, `.reshape`
 - standardize namings for `batch_size`, `seq_length` etc ...
 - type hint improvements

## Speed-up in generation

Using the following script:
```python
from transformers import AutoTokenizer, AutoModelForCausalLM
from timeit import timeit

def main():
    model_name = "bigscience/bloom-350m"
    max_length = 50
    batch_size = 16
    model = AutoModelForCausalLM.from_pretrained(model_name).cuda()
    tokenizer = AutoTokenizer.from_pretrained(model_name)

    texts = ["Hello my name is"] * batch_size
    input_ids = tokenizer.batch_encode_plus(texts, return_tensors="pt").to("cuda")

    print(timeit(lambda: model.generate(**input_ids, max_length=max_length), number=100))


if __name__ == "__main__":
    main()
```
Results on A100:
```
This branch: 67.85658120410517
main: 78.72558180289343
```