### PR TITLE
Add balanced strategies for device_map in from_pretrained

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1705,7 +1705,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
                 To have Accelerate compute the most optimized `device_map` automatically, set `device_map="auto"`. For
                 more information about each option see
-                [here](https://hf.co/docs/accelerate/main/big_modeling#designing-a-device-map).
+                [designing a device map](https://hf.co/docs/accelerate/main/big_modeling#designing-a-device-map).
             max_memory (`Dict`, *optional*):
                 A dictionary device identifier to maximum memory. Will default to the maximum memory available for each
                 GPU and the available CPU RAM if unset.

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1704,8 +1704,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 same device.
 
                 To have Accelerate compute the most optimized `device_map` automatically, set `device_map="auto"`. For
-                more information about each option see
-                [designing a device map](https://hf.co/docs/accelerate/main/big_modeling#designing-a-device-map).
+                more information about each option see [designing a device
+                map](https://hf.co/docs/accelerate/main/big_modeling#designing-a-device-map).
             max_memory (`Dict`, *optional*):
                 A dictionary device identifier to maximum memory. Will default to the maximum memory available for each
                 GPU and the available CPU RAM if unset.


### PR DESCRIPTION
# What does this PR do?

This PR brings to Transformers the functionality introduced in https://github.com/huggingface/accelerate/pull/534 .
Basically `device_map` can now take several options:
- `"sequential"` which corresponds to the current auto: fill each GPU sequentially (and if the user has lots of GPU spaces, some are not used at all)
- `"balanced"` which will split the model evenly across GPUs
- `"balanced_low_0"` which will split the model evenly across GPUs while leaving the most available memory on GPU 0, since that GPU might have more tensors on it when the outputs are used for some form of post-processing (generate and use_cache for instance)
- `"auto"` which now defaults to `"balanced"`.

When the user does not have enough GPU memory to accommodate the model, all the options are equivalent.