### PR TITLE
Refactor `TFSwinLayer` to increase serving compatibility

### DIFF
--- a/src/transformers/models/swin/modeling_tf_swin.py
+++ b/src/transformers/models/swin/modeling_tf_swin.py
@@ -693,7 +693,7 @@ class TFSwinLayer(tf.keras.layers.Layer):
         return attn_mask
 
     def maybe_pad(
-        self, hidden_states: tf.Tensor, height: int, width: int, window_size: int
+        self, hidden_states: tf.Tensor, window_size: int, height: int, width: int
     ) -> Tuple[tf.Tensor, tf.Tensor]:
         pad_right = (window_size - width % window_size) % window_size
         pad_bottom = (window_size - height % window_size) % window_size
@@ -722,7 +722,7 @@ class TFSwinLayer(tf.keras.layers.Layer):
         hidden_states = self.layernorm_before(hidden_states, training=training)
         hidden_states = tf.reshape(hidden_states, (batch_size, height, width, channels))
         # pad hidden_states to multiples of window size
-        hidden_states, pad_values = self.maybe_pad(hidden_states, height, width)
+        hidden_states, pad_values = self.maybe_pad(hidden_states, window_size, height, width)
 
         _, height_pad, width_pad, _ = shape_list(hidden_states)
         # cyclic shift

--- a/src/transformers/models/swin/modeling_tf_swin.py
+++ b/src/transformers/models/swin/modeling_tf_swin.py
@@ -222,10 +222,13 @@ def window_partition(input_feature: tf.Tensor, window_size: int) -> tf.Tensor:
     return windows
 
 
-def window_reverse(windows: tf.Tensor, batch_size: int, window_size: int, height: int, width: int) -> tf.Tensor:
+def window_reverse(windows: tf.Tensor, window_size: int, height: int, width: int) -> tf.Tensor:
     """
     Merges windows to produce higher resolution features.
     """
+    x = tf.shape(windows)[0]
+    y = tf.cast(height * width / (window_size * window_size), tf.int32)
+    batch_size = tf.math.floordiv(x, y)
     windows = tf.reshape(
         windows, (batch_size, height // window_size, width // window_size, window_size, window_size, -1)
     )
@@ -745,7 +748,7 @@ class TFSwinLayer(tf.keras.layers.Layer):
         attention_output = attention_outputs[0]
 
         attention_windows = tf.reshape(attention_output, (-1, window_size, window_size, channels))
-        shifted_windows = window_reverse(attention_windows, batch_size, window_size, height_pad, width_pad)
+        shifted_windows = window_reverse(attention_windows, window_size, height_pad, width_pad)
 
         # reverse cyclic shift
         if shift_size > 0:


### PR DESCRIPTION
# What does this PR do?

This PR refactors two parts of `TFSwinLayer` like below, to increase serving compatibility on multiple accelerators.

### Fix incompatible type cast on several serving architecture

On the `window_reverse` function, there is incompatible computation on the graph when restoring batch size:

```python
x = shape_list(windows)[0]
y = tf.cast(height * width / (window_size * window_size), tf.int32)
batch_size = int(x / y) # <- Here
```

This operation can cause tracing failures depending on the accelerator or compiler SDKs. I have confirmed that AWS Neuron SDK (w/ Inferentia) cannot trace this part properly.

We have `batch_size` variable on graph inside `call()`, so I modified this function to use this value by passing it as a function argument.

### Fix mixed use of member & local variables

Several parts are using window size, but some use `window_size`, and some use `self.window_size`. This can cause tracing failure because of unclear separation between compile-time constants and runtime values.

This PR applies to fix this by not using `self.window_size` on everywhere, but only determining the actual window size on `call()`.

## Review

This PR is related with Swin Transformer and TensorFlow.
R: @amyeroberts 