### PR TITLE
fix FSDP ShardedGradScaler

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -565,9 +565,11 @@ class Trainer:
                     self.scaler = ShardedGradScaler()
                 elif self.fsdp is not None:
                     if self.amp_dtype == torch.float16:
-                        from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
+                        from torch.distributed.fsdp.sharded_grad_scaler import (
+                            ShardedGradScaler as FSDPShardedGradScaler,
+                        )
 
-                        self.scaler = ShardedGradScaler()
+                        self.scaler = FSDPShardedGradScaler()
                     else:
                         self.do_grad_scaling = False
                         self.use_cuda_amp = False
@@ -1366,6 +1368,8 @@ class Trainer:
                     transformer_cls_to_wrap = get_module_class_from_name(
                         model, self.args.fsdp_transformer_layer_cls_to_wrap
                     )
+                    if transformer_cls_to_wrap is None:
+                        raise Exception("Could not find the transformer layer class to wrap in the model.")
                     auto_wrap_policy = functools.partial(
                         transformer_auto_wrap_policy,
                         # Transformer layer class to wrap


### PR DESCRIPTION
# What does this PR do?

1. Fixes #18350 by renaming the import for FSDP ShardedGradScaler so that it doesn't change the scope of globally imported Fairscale ShardedGradScaler
2. Another minor change of raising error when transformer auto wrap class name is not found in the model.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
