### PR TITLE
Fix TFSegformerForSemanticSegmentation doctest

### DIFF
--- a/src/transformers/models/segformer/modeling_tf_segformer.py
+++ b/src/transformers/models/segformer/modeling_tf_segformer.py
@@ -849,8 +849,8 @@ class TFSegformerForSemanticSegmentation(TFSegformerPreTrainedModel):
         >>> outputs = model(**inputs, training=False)
         >>> # logits are of shape (batch_size, num_labels, height, width)
         >>> logits = outputs.logits
-        >>> logits.shape
-        (1, 150, 128, 128)
+        >>> list(logits.shape)
+        [1, 150, 128, 128]
         ```"""
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         output_hidden_states = (


### PR DESCRIPTION
# What does this PR do?

Fix `TFSegformerForSemanticSegmentation` doctest.
With @amyeroberts uploading `nvidia/mit-b0`, all doctests for TF Segformer pass now.

(I was waiting for a TF checkpoint and not fixed this one in the previous PR. This model (SemanticSegmentation) already had a TF checkpoint however)