### PR TITLE
fix: keras fit tests for segformer tf and minor refactors.

### DIFF
--- a/tests/models/segformer/test_modeling_tf_segformer.py
+++ b/tests/models/segformer/test_modeling_tf_segformer.py
@@ -18,8 +18,6 @@ import inspect
 import unittest
 from typing import List, Tuple
 
-import numpy as np
-
 from transformers import SegformerConfig
 from transformers.file_utils import is_tf_available, is_vision_available
 from transformers.testing_utils import require_tf, slow

--- a/tests/models/segformer/test_modeling_tf_segformer.py
+++ b/tests/models/segformer/test_modeling_tf_segformer.py
@@ -331,63 +331,67 @@ class TFSegformerModelTest(TFModelTesterMixin, unittest.TestCase):
 
             # todo: incorporate label support for semantic segmentation in `test_modeling_tf_common.py`.
 
+    @unittest.skipIf(
+        not is_tf_available() or len(tf.config.list_physical_devices("GPU")) == 0,
+        reason="TF (<=2.8) does not support backprop for grouped convolutions on CPU.",
+    )
     def test_dataset_conversion(self):
-        gpus = tf.config.list_physical_devices("GPU")
-        # Grouped convs aren't supported on CPUs for backprop.
-        if len(gpus) >= 1:
-            super().test_dataset_conversion()
+        super().test_dataset_conversion()
 
+    @unittest.skipIf(
+        not is_tf_available() or len(tf.config.list_physical_devices("GPU")) == 0,
+        reason="TF (<=2.8) does not support backprop for grouped convolutions on CPU.",
+    )
     def test_keras_fit(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-        gpus = tf.config.list_physical_devices("GPU")
 
         def apply(model):
-            if getattr(model, "hf_compute_loss", None):
-                model_weights = model.get_weights()
+            model(model.dummy_inputs)
+            model_weights = model.get_weights()
 
-                # Test that model correctly compute the loss with kwargs
-                for_segmentation = True if model_class.__name__ == "TFSegformerForSemanticSegmentation" else False
-                _, prepared_for_class = self.model_tester.prepare_config_and_inputs_for_keras_fit(
-                    for_segmentation=for_segmentation
-                )
+            model.compile(optimizer=tf.keras.optimizers.SGD(0.0), run_eagerly=True)
 
-                label_names = {"labels"}
-                self.assertGreater(len(label_names), 0, msg="No matching label names found!")
-                labels = {key: val for key, val in prepared_for_class.items() if key in label_names}
-                inputs_minus_labels = {key: val for key, val in prepared_for_class.items() if key not in label_names}
-                self.assertGreater(len(inputs_minus_labels), 0)
-                model.compile(optimizer=tf.keras.optimizers.SGD(0.0), run_eagerly=True)
+            # Test that model correctly compute the loss with kwargs
+            for_segmentation = True if model_class.__name__ == "TFSegformerForSemanticSegmentation" else False
+            _, input_for_model_fit = self.model_tester.prepare_config_and_inputs_for_keras_fit(
+                for_segmentation=for_segmentation
+            )
 
-                # Make sure the model fits without crashing regardless of where we pass the labels
-                history1 = model.fit(
-                    prepared_for_class,
-                    validation_data=prepared_for_class,
-                    steps_per_epoch=1,
-                    validation_steps=1,
-                    shuffle=False,
-                )
-                val_loss1 = history1.history["val_loss"][0]
+            label_names = {"labels"}
+            self.assertGreater(len(label_names), 0, msg="No matching label names found!")
+            labels = {key: val for key, val in input_for_model_fit.items() if key in label_names}
+            inputs_minus_labels = {key: val for key, val in input_for_model_fit.items() if key not in label_names}
+            self.assertGreater(len(inputs_minus_labels), 0)
 
-                # We reinitialize the model here even though our learning rate was zero
-                # because BatchNorm updates weights by means other than gradient descent.
-                model.set_weights(model_weights)
-                history2 = model.fit(
-                    inputs_minus_labels,
-                    labels,
-                    validation_data=(inputs_minus_labels, labels),
-                    steps_per_epoch=1,
-                    validation_steps=1,
-                    shuffle=False,
-                )
-                val_loss2 = history2.history["val_loss"][0]
-                self.assertTrue(np.allclose(val_loss1, val_loss2, atol=1e-2, rtol=1e-3))
+            # Make sure the model fits without crashing regardless of where we pass the labels
+            history1 = model.fit(
+                input_for_model_fit,
+                validation_data=input_for_model_fit,
+                steps_per_epoch=1,
+                validation_steps=1,
+                shuffle=False,
+            )
+            val_loss1 = history1.history["val_loss"][0]
+
+            # We reinitialize the model here even though our learning rate was zero
+            # because BatchNorm updates weights by means other than gradient descent.
+            model.set_weights(model_weights)
+            history2 = model.fit(
+                inputs_minus_labels,
+                labels,
+                validation_data=(inputs_minus_labels, labels),
+                steps_per_epoch=1,
+                validation_steps=1,
+                shuffle=False,
+            )
+            val_loss2 = history2.history["val_loss"][0]
+            self.assertTrue(np.allclose(val_loss1, val_loss2, atol=1e-2, rtol=1e-3))
 
         for model_class in self.all_model_classes:
             # Since `TFSegformerModel` cannot operate with the default `fit()` method.
             if model_class.__name__ != "TFSegformerModel":
-                # Grouped convs and backprop with them isn't supported on CPUs.
                 model = model_class(config)
-                if len(gpus) > 1:
+                if getattr(model, "hf_compute_loss", None):
                     apply(model)
 
     def test_loss_computation(self):


### PR DESCRIPTION
Fixes the issues as noticed in: https://github.com/huggingface/transformers/runs/7485048615?check_suite_focus=true. 

I don't have access to an instance having multiple GPUs at the moment, but I figured out the root cause of the issue. 

https://github.com/huggingface/transformers/blob/df5e4232f59e6fea08911eddd0adc965d1b59c15/tests/models/segformer/test_modeling_tf_segformer.py#L346

^ I wasn't calling the model on some sample inputs, which is why the weights retrieved from `get_weights()` were zero. That has been fixed in this PR. 

I tested it locally in isolation with the following snippet (I acknowledge that it's not super clean):

```py
from transformers import TFSegformerForImageClassification, TFSegformerForSemanticSegmentation, SegformerConfig

import tensorflow as tf

from tests.test_modeling_tf_common import floats_tensor, ids_tensor
import numpy as np

batch_size = 13
image_size = 64
num_channels = 3
num_encoder_blocks = 4
depths = [2, 2, 2, 2]
sr_ratios = [8, 4, 2, 1]
hidden_sizes = [16, 32, 64, 128]
downsampling_rates = [1, 4, 8, 16]
num_attention_heads = [1, 2, 4, 8]
is_training = True
use_labels = True
hidden_act = "gelu"
hidden_dropout_prob = 0.1
attention_probs_dropout_prob = 0.1
initializer_range = 0.02
num_labels = 3


def get_config():
    return SegformerConfig(
        image_size=image_size,
        num_channels=num_channels,
        num_encoder_blocks=num_encoder_blocks,
        depths=depths,
        hidden_sizes=hidden_sizes,
        num_attention_heads=num_attention_heads,
        hidden_act=hidden_act,
        hidden_dropout_prob=hidden_dropout_prob,
        attention_probs_dropout_prob=attention_probs_dropout_prob,
        initializer_range=initializer_range,
        num_labels=num_labels
    )

def prepare_config_and_inputs(for_semseg=True):
    pixel_values = floats_tensor([batch_size, num_channels, image_size, image_size])

    if for_semseg:
        labels = ids_tensor([batch_size, image_size, image_size], num_labels)
    else:
        labels = tf.zeros((batch_size))

    config = get_config()
    return config, pixel_values, labels


model_classes = (TFSegformerForImageClassification, TFSegformerForSemanticSegmentation)

for model_class in model_classes:
    if model_class == TFSegformerForSemanticSegmentation:
        config, pixel_values, labels = prepare_config_and_inputs(for_semseg=True)
    else:
        config, pixel_values, labels = prepare_config_and_inputs(for_semseg=False)
    
    input_for_model_fit = {"pixel_values": pixel_values, "labels": labels}

    model = model_class(config)
    model(model.dummy_inputs)
    model_weights = model.get_weights()
    
    model.compile(optimizer=tf.keras.optimizers.SGD(0.0), run_eagerly=True)
    
    history1 = model.fit(
        input_for_model_fit,
        validation_data=input_for_model_fit,
        steps_per_epoch=1,
        validation_steps=1,
        shuffle=False,
    )
    val_loss1 = history1.history["val_loss"][0]

    label_names = {"labels"}
    
    labels = {key: val for key, val in input_for_model_fit.items() if key in label_names}
    inputs_minus_labels = {key: val for key, val in input_for_model_fit.items() if key not in label_names}

    # We reinitialize the model here even though our learning rate was zero
    # because BatchNorm updates weights by means other than gradient descent.
    model.set_weights(model_weights)
    history2 = model.fit(
        inputs_minus_labels,
        labels,
        validation_data=(inputs_minus_labels, labels),
        steps_per_epoch=1,
        validation_steps=1,
        shuffle=False,
    )
    val_loss2 = history2.history["val_loss"][0]

    print(np.allclose(val_loss1, val_loss2, atol=1e-2, rtol=1e-3))
```

@amyeroberts @Rocketknight1 @sgugger 