### PR TITLE
Add missing lang tokens in M2M100Tokenizer.get_vocab

### DIFF
--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -280,7 +280,7 @@ class M2M100Tokenizer(PreTrainedTokenizer):
         return self.prefix_tokens + token_ids_0 + token_ids_1 + self.suffix_tokens
 
     def get_vocab(self) -> Dict:
-        vocab = self.encoder.copy()
+        vocab = {self.convert_ids_to_tokens(i): i for i in range(self.vocab_size)}
         vocab.update(self.added_tokens_encoder)
         return vocab
 

--- a/tests/models/m2m_100/test_tokenization_m2m_100.py
+++ b/tests/models/m2m_100/test_tokenization_m2m_100.py
@@ -89,7 +89,7 @@ class M2M100TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertEqual(vocab_keys[0], "</s>")
         self.assertEqual(vocab_keys[1], "<unk>")
         self.assertEqual(vocab_keys[-1], "<s>")
-        self.assertEqual(len(vocab_keys), 10)
+        self.assertEqual(len(vocab_keys), 110)
 
     def test_vocab_size(self):
         self.assertEqual(self.get_tokenizer().vocab_size, 117)
@@ -159,6 +159,9 @@ class M2M100TokenizerIntegrationTest(unittest.TestCase):
         self.assertEqual(self.tokenizer.get_lang_id("en"), 128022)
         self.assertEqual(self.tokenizer.get_lang_id("ro"), 128076)
         self.assertEqual(self.tokenizer.get_lang_id("mr"), 128063)
+
+    def test_get_vocab(self):
+        self.assertIn(self.tokenizer.get_lang_token("en"), self.tokenizer.get_vocab())
 
     def test_tokenizer_batch_encode_plus(self):
         self.tokenizer.src_lang = "en"


### PR DESCRIPTION
# What does this PR do?

The lang tokens were missing from `M2M100Tokenizer.get_vocab`. The `get_vocab` method is updated to match other multilingual tokenizers such as `NllbTokenizer` and `MBart50Tokenizer`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@n1t0, @LysandreJik, @SaulLu 