### PR TITLE
HFTracer.trace can now take callables and torch.nn.Module

### DIFF
--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -834,7 +834,6 @@ class HFTracer(Tracer):
                 raise ValueError("Don't support composite output yet")
             rv.install_metadata(meta_out)
         except Exception as e:
-            # import pdb; pdb.set_trace()
             warnings.warn(f"Could not compute metadata for {kind} target {target}: {e}")
 
         return rv


### PR DESCRIPTION
# What does this PR do?

This PR enables to use the `HFTracer` "meta-tracing" features to trace any Python callable / `torch.nn.Module`.

For `transformers.PreTrainedModel`s, the method `HFTracer._generate_dummy_inputs` already takes care of creating the original dummy inputs needed to handle data-dependent control-flow in the forward pass. 

Now, the user can specify `dummy_inputs` directly to the `HFTracer.trace` method in order to be able to trace other things than `transformers.PreTrainedModel`s. This is useful for pattern matching for instance. 

This becomes possible:

```python
def f(x, y, z=None):
    temp =  x * y
    if z is not None:
        temp += z
    return temp

traced_f = HFTracer().trace(f, dummy_inputs={"x": torch.rand(1, 2), "y": torch.rand(1, 2)})
```

By default, if `dummy_inputs` is specified, every argument to `root` that is not in `dummy_inputs` will be considered a concrete arg (and thus added to `concrete_args`). You can disable that by setting `infer_concrete_args_from_dummy_inputs` to `False`. This is useful if want to provide custom dummy inputs for some inputs, while still keeping the `HFTracer._generate_dummy_inputs`  doing the work for other inputs (provided that `root` is a `transformers.PreTrainedModel` since only this case is supported for automatic dummy inputs generation).