### PR TITLE
CodeGen Fix causal mask for half precision

### DIFF
--- a/src/transformers/models/codegen/modeling_codegen.py
+++ b/src/transformers/models/codegen/modeling_codegen.py
@@ -151,7 +151,7 @@ class CodeGenAttention(nn.Module):
 
         # compute causal mask from causal mask buffer
         query_length, key_length = query.size(-2), key.size(-2)
-        causal_mask = self.causal_mask[:, :, key_length - query_length : key_length, :key_length]
+        causal_mask = self.causal_mask[:, :, key_length - query_length : key_length, :key_length].to(torch.uint8)
 
         # Keep the attention weights computation in fp32 to avoid overflow issues
         query = query.to(torch.float32)

--- a/src/transformers/models/codegen/modeling_codegen.py
+++ b/src/transformers/models/codegen/modeling_codegen.py
@@ -151,6 +151,10 @@ class CodeGenAttention(nn.Module):
 
         # compute causal mask from causal mask buffer
         query_length, key_length = query.size(-2), key.size(-2)
+
+        # Here we force cast the causal mask to uint8 to avoid errors related to torch.where
+        # combined with torch_dtype="auto" where it casts all variables including buffers to
+        # fp16. See the related issue here: https://github.com/huggingface/transformers/pull/18467
         causal_mask = self.causal_mask[:, :, key_length - query_length : key_length, :key_length].to(torch.uint8)
 
         # Keep the attention weights computation in fp32 to avoid overflow issues


### PR DESCRIPTION
# What does this PR do? 

This PR forces the causal mask to stay in `torch.uint8`. An error occurs when loading a model in half precision since `torch_dtype=torch.float16` casts also the buffers in fp16. Here is a minimal script to reproduce the error:
```
import torch
from transformers import AutoTokenizer, AutoModelForCausalLM

tokenizer = AutoTokenizer.from_pretrained("Salesforce/codegen-2B-mono")
model = AutoModelForCausalLM.from_pretrained("Salesforce/codegen-2B-mono", device_map="auto", torch_dtype=torch.float16)

text = "def quicksort(l):"

encoded_input = tokenizer(text, return_tensors='pt')
output_sequences = model.generate(input_ids=encoded_input['input_ids'], attention_mask=encoded_input['attention_mask'])
print(tokenizer.decode(output_sequences[0], skip_special_tokens=True))
```

In a future PR we could address non-casting the buffers (aka keeping them in their native `dtype`)

Can also confirm the slow tests pass!

cc @ydshieh 