### PR TITLE
Let's not cast them all

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -550,7 +550,11 @@ def _load_state_dict_into_meta_model(
             param_name = param_name[len(start_prefix) :]
 
         module_name = param_name
-        # We convert floating dtypes to the `dtype` passed.
+
+        # We convert floating dtypes to the `dtype` passed. We make sure that the
+        # parameter is a floating point parameter. Sometimes we want to keep the buffers
+        # in int/uint/bool and not cast them.
+        # Please see: https://github.com/huggingface/transformers/pull/18471 for more details
         if dtype is not None and torch.is_floating_point(param):
             param = param.to(dtype)
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -551,7 +551,7 @@ def _load_state_dict_into_meta_model(
 
         module_name = param_name
         # We convert floating dtypes to the `dtype` passed.
-        if dtype is not None and not str(param.dtype).startswith(("torch.int", "torch.uint", "torch.bool")):
+        if dtype is not None and torch.is_floating_point(param):
             param = param.to(dtype)
 
         if device_map is None:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -551,7 +551,7 @@ def _load_state_dict_into_meta_model(
 
         module_name = param_name
         # We convert floating dtypes to the `dtype` passed.
-        if dtype is not None and not str(param.dtype).startswith("torch.int"):
+        if dtype is not None and not str(param.dtype).startswith(("torch.int", "torch.uint", "torch.bool")):
             param = param.to(dtype)
 
         if device_map is None:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -551,10 +551,8 @@ def _load_state_dict_into_meta_model(
 
         module_name = param_name
 
-        # We convert floating dtypes to the `dtype` passed. We make sure that the
-        # parameter is a floating point parameter. Sometimes we want to keep the buffers
+        # We convert floating dtypes to the `dtype` passed.We want to keep the buffers/params
         # in int/uint/bool and not cast them.
-        # Please see: https://github.com/huggingface/transformers/pull/18471 for more details
         if dtype is not None and torch.is_floating_point(param):
             param = param.to(dtype)
 


### PR DESCRIPTION
# What does this PR do?

This PR is an alternative solution (and cleaner) to https://github.com/huggingface/transformers/pull/18467
An issue has been found when running this script:
```
import torch
from transformers import AutoTokenizer, AutoModelForCausalLM

tokenizer = AutoTokenizer.from_pretrained("Salesforce/codegen-2B-mono")
model = AutoModelForCausalLM.from_pretrained("Salesforce/codegen-2B-mono", device_map="auto", torch_dtype=torch.float16)

text = "def quicksort(l):"

encoded_input = tokenizer(text, return_tensors='pt')
output_sequences = model.generate(input_ids=encoded_input['input_ids'], attention_mask=encoded_input['attention_mask'])
print(tokenizer.decode(output_sequences[0], skip_special_tokens=True))
```
Since `torch_dtype=torch.float16` will cast all parameters of the models including the buffers, this will include also causal masks for some models. 

In some niche cases those buffers are in `uint` or `bool` instead of `int`. This PR should address this issue and check if the parameter is either an `uint`, `int` or `bool` before casting it.

cc @sgugger 

Ran codegen slow tests and the tests are passing, let me know if we need more checks! 

