### PR TITLE
Add EntityPairClassification Pipeline, AutoClass & LUKE ONNX Support 

### DIFF
--- a/docs/source/en/serialization.mdx
+++ b/docs/source/en/serialization.mdx
@@ -74,6 +74,7 @@ Ready-made configurations include the following architectures:
 - LayoutLMv3
 - LeViT
 - LongT5
+- LUKE
 - M2M100
 - Marian
 - mBART

--- a/src/transformers/models/auto/__init__.py
+++ b/src/transformers/models/auto/__init__.py
@@ -66,6 +66,7 @@ else:
         "MODEL_FOR_VIDEO_CLASSIFICATION_MAPPING",
         "MODEL_FOR_VISION_2_SEQ_MAPPING",
         "MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING",
+        "MODEL_FOR_ENTITY_PAIR_CLASSIFICATION",
         "MODEL_MAPPING",
         "MODEL_WITH_LM_HEAD_MAPPING",
         "AutoModel",
@@ -94,6 +95,7 @@ else:
         "AutoModelForVision2Seq",
         "AutoModelForVisualQuestionAnswering",
         "AutoModelWithLMHead",
+        "AutoModelForEntityPairClassification",
     ]
 
 try:
@@ -209,6 +211,7 @@ if TYPE_CHECKING:
             MODEL_FOR_VIDEO_CLASSIFICATION_MAPPING,
             MODEL_FOR_VISION_2_SEQ_MAPPING,
             MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING,
+            MODEL_FOR_ENTITY_PAIR_CLASSIFICATION_MAPPING,
             MODEL_MAPPING,
             MODEL_WITH_LM_HEAD_MAPPING,
             AutoModel,
@@ -237,6 +240,7 @@ if TYPE_CHECKING:
             AutoModelForVision2Seq,
             AutoModelForVisualQuestionAnswering,
             AutoModelWithLMHead,
+            AutoModelForEntityPairClassification,
         )
 
     try:

--- a/src/transformers/models/auto/feature_extraction_auto.py
+++ b/src/transformers/models/auto/feature_extraction_auto.py
@@ -55,6 +55,7 @@ FEATURE_EXTRACTOR_MAPPING_NAMES = OrderedDict(
         ("layoutlmv2", "LayoutLMv2FeatureExtractor"),
         ("layoutlmv3", "LayoutLMv3FeatureExtractor"),
         ("levit", "LevitFeatureExtractor"),
+        ("luke", "LukeFeatureExtractor"),
         ("maskformer", "MaskFormerFeatureExtractor"),
         ("mctct", "MCTCTFeatureExtractor"),
         ("mobilevit", "MobileViTFeatureExtractor"),

--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -642,6 +642,13 @@ MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING_NAMES = OrderedDict(
     ]
 )
 
+MODEL_FOR_ENTITY_PAIR_CLASSIFICATION_MAPPING_NAMES = OrderedDict(
+    # Model for Entity Pair Classification
+    [
+        ("luke", "LukeForEntityPairClassification"),
+    ]
+)
+
 MODEL_FOR_MULTIPLE_CHOICE_MAPPING_NAMES = OrderedDict(
     [
         # Model for Multiple Choice mapping
@@ -803,6 +810,10 @@ MODEL_FOR_AUDIO_FRAME_CLASSIFICATION_MAPPING = _LazyAutoMapping(
 )
 MODEL_FOR_AUDIO_XVECTOR_MAPPING = _LazyAutoMapping(CONFIG_MAPPING_NAMES, MODEL_FOR_AUDIO_XVECTOR_MAPPING_NAMES)
 
+MODEL_FOR_ENTITY_PAIR_CLASSIFICATION_MAPPING = _LazyAutoMapping(
+    CONFIG_MAPPING_NAMES, MODEL_FOR_ENTITY_PAIR_CLASSIFICATION_MAPPING_NAMES
+)
+
 
 class AutoModel(_BaseAutoModelClass):
     _model_mapping = MODEL_MAPPING
@@ -855,6 +866,17 @@ class AutoModelForSequenceClassification(_BaseAutoModelClass):
 
 AutoModelForSequenceClassification = auto_class_update(
     AutoModelForSequenceClassification, head_doc="sequence classification"
+)
+
+
+class AutoModelForEntityPairClassification(_BaseAutoModelClass):
+    _model_mapping = MODEL_FOR_ENTITY_PAIR_CLASSIFICATION_MAPPING
+
+
+AutoModelForEntityPairClassification = auto_class_update(
+    AutoModelForEntityPairClassification,
+    head_doc="entity pair classification",
+    checkpoint_for_example="studio-ousia/luke-base",
 )
 
 

--- a/src/transformers/models/luke/__init__.py
+++ b/src/transformers/models/luke/__init__.py
@@ -22,7 +22,7 @@ from ...utils import OptionalDependencyNotAvailable, _LazyModule, is_torch_avail
 
 
 _import_structure = {
-    "configuration_luke": ["LUKE_PRETRAINED_CONFIG_ARCHIVE_MAP", "LukeConfig"],
+    "configuration_luke": ["LUKE_PRETRAINED_CONFIG_ARCHIVE_MAP", "LukeConfig", "LukeOnnxConfig"],
     "tokenization_luke": ["LukeTokenizer"],
 }
 
@@ -48,7 +48,7 @@ else:
 
 
 if TYPE_CHECKING:
-    from .configuration_luke import LUKE_PRETRAINED_CONFIG_ARCHIVE_MAP, LukeConfig
+    from .configuration_luke import LUKE_PRETRAINED_CONFIG_ARCHIVE_MAP, LukeConfig, LukeOnnxConfig
     from .tokenization_luke import LukeTokenizer
 
     try:

--- a/src/transformers/models/luke/configuration_luke.py
+++ b/src/transformers/models/luke/configuration_luke.py
@@ -149,8 +149,8 @@ class LukeOnnxConfig(OnnxConfig):
                 ("input_ids", {0: "batch", 1: "sequence"}),
                 ("attention_mask", {0: "batch", 1: "sequence"}),
                 ("entity_ids", {0: "batch", 1: "entities"}),
-                ("entity_position_ids", {0: "batch", 1: "entities", 2: "entity_embedding"}),
                 ("entity_attention_mask", {0: "batch", 1: "entities"}),
+                ("entity_position_ids", {0: "batch", 1: "entities", 2: "entity_embeddings"}),
             ]
         )
 
@@ -167,6 +167,7 @@ class LukeOnnxConfig(OnnxConfig):
         entity_spans=[[0, 5], [8, 10]],
         framework: Optional[TensorType] = None,
     ) -> Mapping[str, Any]:
+
         # Copied from OnnxConfig.generate_dummy_inputs
         # Did not use super(OnnxConfigWithPast, self).generate_dummy_inputs for code clarity.
         # If dynamic axis (-1) we forward with a fixed dimension of 2 samples to avoid optimizations made by ONNX

--- a/src/transformers/onnx/config.py
+++ b/src/transformers/onnx/config.py
@@ -102,6 +102,9 @@ class OnnxConfig(ABC):
         "seq2seq-lm": OrderedDict({"logits": {0: "batch", 1: "decoder_sequence"}}),
         "sequence-classification": OrderedDict({"logits": {0: "batch"}}),
         "token-classification": OrderedDict({"logits": {0: "batch", 1: "sequence"}}),
+        "entity-classification": OrderedDict({"logits": {0: "batch"}}),
+        "entity-pair-classification": OrderedDict({"logits": {0: "batch"}}),
+        "entity-span-classification": OrderedDict({"logits": {0: "batch"}}),
     }
 
     def __init__(self, config: "PretrainedConfig", task: str = "default", patching_specs: List[PatchingSpec] = None):

--- a/src/transformers/onnx/config.py
+++ b/src/transformers/onnx/config.py
@@ -102,9 +102,9 @@ class OnnxConfig(ABC):
         "seq2seq-lm": OrderedDict({"logits": {0: "batch", 1: "decoder_sequence"}}),
         "sequence-classification": OrderedDict({"logits": {0: "batch"}}),
         "token-classification": OrderedDict({"logits": {0: "batch", 1: "sequence"}}),
-        "entity-classification": OrderedDict({"logits": {0: "batch"}}),
+        # "entity-classification": OrderedDict({"logits": {0: "batch"}}),
         "entity-pair-classification": OrderedDict({"logits": {0: "batch"}}),
-        "entity-span-classification": OrderedDict({"logits": {0: "batch"}}),
+        # "entity-span-classification": OrderedDict({"logits": {0: "batch"}}),
     }
 
     def __init__(self, config: "PretrainedConfig", task: str = "default", patching_specs: List[PatchingSpec] = None):

--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -7,6 +7,12 @@ from .. import PretrainedConfig, is_tf_available, is_torch_available
 from ..utils import logging
 from .config import OnnxConfig
 
+# Entity-Pair, Entity-Span and Entity Classification Heads are not supported by AutoModel Factory
+from transformers.models.luke import (
+    LukeForEntityClassification,
+    LukeForEntityPairClassification,
+    LukeForEntitySpanClassification,
+)
 
 if TYPE_CHECKING:
     from transformers import PreTrainedModel, TFPreTrainedModel
@@ -94,6 +100,9 @@ class FeaturesManager:
             "image-classification": AutoModelForImageClassification,
             "image-segmentation": AutoModelForImageSegmentation,
             "masked-im": AutoModelForMaskedImageModeling,
+            "entity-classification": LukeForEntityClassification,
+            "entity-pair-classification": LukeForEntityPairClassification,
+            "entity-span-classification": LukeForEntitySpanClassification,
         }
     if is_tf_available():
         _TASKS_TO_TF_AUTOMODELS = {
@@ -105,6 +114,9 @@ class FeaturesManager:
             "token-classification": TFAutoModelForTokenClassification,
             "multiple-choice": TFAutoModelForMultipleChoice,
             "question-answering": TFAutoModelForQuestionAnswering,
+            "entity-classification": LukeForEntityClassification,
+            "entity-pair-classification": LukeForEntityPairClassification,
+            "entity-span-classification": LukeForEntitySpanClassification,
         }
 
     # Set of model topologies we support associated to the features supported by each topology and the factory
@@ -342,6 +354,14 @@ class FeaturesManager:
             "seq2seq-lm",
             "seq2seq-lm-with-past",
             onnx_config_cls="models.longt5.LongT5OnnxConfig",
+        ),
+        "luke": supported_features_mapping(
+            "default",
+            "masked-lm",
+            "entity-classification",
+            "entity-pair-classification",
+            "entity-span-classification",
+            onnx_config_cls="models.luke.LukeOnnxConfig",
         ),
         "marian": supported_features_mapping(
             "default",

--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -9,9 +9,9 @@ from .config import OnnxConfig
 
 # Entity-Pair, Entity-Span and Entity Classification Heads are not supported by AutoModel Factory
 from transformers.models.luke import (
-    LukeForEntityClassification,
+    # LukeForEntityClassification,
     LukeForEntityPairClassification,
-    LukeForEntitySpanClassification,
+    # LukeForEntitySpanClassification,
 )
 
 if TYPE_CHECKING:
@@ -34,6 +34,7 @@ if is_torch_available():
         AutoModelForSeq2SeqLM,
         AutoModelForSequenceClassification,
         AutoModelForTokenClassification,
+        AutoModelForEntityPairClassification,
     )
 if is_tf_available():
     from transformers.models.auto import (
@@ -100,9 +101,9 @@ class FeaturesManager:
             "image-classification": AutoModelForImageClassification,
             "image-segmentation": AutoModelForImageSegmentation,
             "masked-im": AutoModelForMaskedImageModeling,
-            "entity-classification": LukeForEntityClassification,
-            "entity-pair-classification": LukeForEntityPairClassification,
-            "entity-span-classification": LukeForEntitySpanClassification,
+            # "entity-classification": LukeForEntityClassification,
+            "entity-pair-classification": AutoModelForEntityPairClassification,
+            # "entity-span-classification": LukeForEntitySpanClassification,
         }
     if is_tf_available():
         _TASKS_TO_TF_AUTOMODELS = {
@@ -114,9 +115,6 @@ class FeaturesManager:
             "token-classification": TFAutoModelForTokenClassification,
             "multiple-choice": TFAutoModelForMultipleChoice,
             "question-answering": TFAutoModelForQuestionAnswering,
-            "entity-classification": LukeForEntityClassification,
-            "entity-pair-classification": LukeForEntityPairClassification,
-            "entity-span-classification": LukeForEntitySpanClassification,
         }
 
     # Set of model topologies we support associated to the features supported by each topology and the factory
@@ -358,9 +356,9 @@ class FeaturesManager:
         "luke": supported_features_mapping(
             "default",
             "masked-lm",
-            "entity-classification",
+            #            "entity-classification",
             "entity-pair-classification",
-            "entity-span-classification",
+            #            "entity-span-classification",
             onnx_config_cls="models.luke.LukeOnnxConfig",
         ),
         "marian": supported_features_mapping(

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -66,6 +66,7 @@ from .token_classification import (
     TokenClassificationPipeline,
 )
 from .visual_question_answering import VisualQuestionAnsweringPipeline
+from .entity_pair_classification import EntityPairClassificationPipeline
 from .zero_shot_classification import ZeroShotClassificationArgumentHandler, ZeroShotClassificationPipeline
 from .zero_shot_image_classification import ZeroShotImageClassificationPipeline
 
@@ -101,6 +102,7 @@ if is_torch_available():
         MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING,
         MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING,
         MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING,
+        MODEL_FOR_ENTITY_PAIR_CLASSIFICATION_MAPPING,
         AutoModel,
         AutoModelForAudioClassification,
         AutoModelForCausalLM,
@@ -117,6 +119,7 @@ if is_torch_available():
         AutoModelForTableQuestionAnswering,
         AutoModelForTokenClassification,
         AutoModelForVisualQuestionAnswering,
+        AutoModelForEntityPairClassification,
     )
 if TYPE_CHECKING:
     from ..modeling_tf_utils import TFPreTrainedModel
@@ -198,6 +201,15 @@ SUPPORTED_TASKS = {
                 "pt": ("google/tapas-base-finetuned-wtq", "69ceee2"),
                 "tf": ("google/tapas-base-finetuned-wtq", "69ceee2"),
             },
+        },
+        "type": "text",
+    },
+    "entity-pair-classification": {
+        "impl": EntityPairClassificationPipeline,
+        "pt": (AutoModelForEntityPairClassification,) if is_torch_available() else (),
+        "tf": (),
+        "default": {
+            "model": {"pt": {"studio-ousia/luke-base", "7438924"}},
         },
         "type": "text",
     },

--- a/src/transformers/pipelines/entity_pair_classification.py
+++ b/src/transformers/pipelines/entity_pair_classification.py
@@ -1,0 +1,61 @@
+import warnings
+from typing import Dict
+
+import numpy as np
+
+from ..utils import ExplicitEnum, add_end_docstrings, is_tf_available, is_torch_available
+from .base import PIPELINE_INIT_ARGS, GenericTensor, Pipeline
+
+
+if is_tf_available():
+    from ..models.auto.modeling_tf_auto import TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
+
+if is_torch_available():
+    from ..models.auto.modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
+
+
+def softmax(_outputs):
+    maxes = np.max(_outputs, axis=-1, keepdims=True)
+    shifted_exp = np.exp(_outputs - maxes)
+    return shifted_exp / shifted_exp.sum(axis=-1, keepdims=True)
+
+
+class EntityPairClassificationPipeline(Pipeline):
+    """
+    Entity Pair classification pipeline using any `ModelForEntityPairClassification`.
+
+    This entity pair classification pipeline can currently be loaded from [`pipeline`] using the following task identifier:
+    `"entity-pair-classification"` (for classifying the relationship between two tokens).
+
+    The models that this pipeline can use are models that have been fine-tuned on an entity-pair classification task. See
+    the up-to-date list of available models on
+    """
+
+    def _sanitize_parameters(self, **kwargs):
+        preprocess_kwargs = {}
+        return preprocess_kwargs, {}, {}
+
+    def preprocess(self, inputs, **tokenizer_kwargs) -> Dict[str, GenericTensor]:
+        return_tensors = self.framework
+        if isinstance(inputs, dict):
+            entity_spans = [tuple(x) for x in inputs["entity_spans"]]
+            return self.tokenizer(
+                text=inputs["text"], entity_spans=entity_spans, return_tensors=return_tensors, **tokenizer_kwargs
+            )
+        else:
+            # This is likely an invalid usage of the pipeline attempting to pass text pairs.
+            raise ValueError(
+                "The pipeline received invalid inputs, if you are trying to send text alongside entity_spans, you can try to send a"
+                ' dictionnary `{"text": "My text", "entity_spans": [[1,2][3,4]] }` in order to perform entity pair classification.'
+            )
+
+    def _forward(self, model_inputs):
+        return self.model(**model_inputs)
+
+    def postprocess(self, model_outputs):
+        logits = model_outputs.logits
+        probabilities = softmax(logits)
+        best_class = np.argmax(probabilities)
+        label = self.model.config.id2label[best_class]
+        score = probabilities[best_class][0].item()
+        return {"label": label, "confidence": score, "probabilities": probabilities, "best_class_id": best_class}

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -420,6 +420,8 @@ MODEL_MAPPING = None
 
 MODEL_WITH_LM_HEAD_MAPPING = None
 
+MODEL_FOR_ENTITY_PAIR_CLASSIFICATION_MAPPING = None
+
 
 class AutoModel(metaclass=DummyObject):
     _backends = ["torch"]
@@ -590,6 +592,13 @@ class AutoModelForVision2Seq(metaclass=DummyObject):
 
 
 class AutoModelForVisualQuestionAnswering(metaclass=DummyObject):
+    _backends = ["torch"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torch"])
+
+
+class AutoModelForEntityPairClassification(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -203,6 +203,7 @@ PYTORCH_EXPORT_MODELS = {
     ("layoutlm", "microsoft/layoutlm-base-uncased"),
     ("layoutlmv3", "microsoft/layoutlmv3-base"),
     ("levit", "facebook/levit-128S"),
+    ("luke", "studio-ousia/luke-base"),
     ("vit", "google/vit-base-patch16-224"),
     ("deit", "facebook/deit-small-patch16-224"),
     ("beit", "microsoft/beit-base-patch16-224"),


### PR DESCRIPTION
# What does this PR do?

This PR started out in adding support for Luke in ONNX.

To not break existing AutoPatterns in [FeaturesManager](src/transformers/onnx/features.py), [AutoModelForEntityPairClassification](src/transformers/models/auto/modeling_auto.py) has also been added.

Additionally, a pipeline for [EntityPairClassification](src/transformers/pipelines/entity_pair_classification.py) has been added to make the task more supported overall by the library.

Note: A previous PR (https://github.com/huggingface/transformers/pull/16562) has been closed / not merged for LUKE ONNX support. I believe this PR addresses the remaining comments in that one.

All ONNX tests pass - happy to implement any additional comments for the Pipeline / Autoclass.

I have only implemented one of the additional Tasks `EntityPairClassification` - if this has been done to the appropriate standard, I can also implement it for the other two remaining Luke Heads which are not currently supported `Span Classification` &  `Entity Classification`

@NielsRogge - Worked on the original LUKE implementation
@lewtun & @michaelbenayoun  - Reviewed the previous PR


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
<img width="991" alt="Screenshot 2022-08-08 at 13 27 00" src="https://user-images.githubusercontent.com/42403093/183430054-26ee3d97-c9b3-43c8-b844-cde031b263e0.png">

