### PR TITLE
Minor update of `run_call_with_unpacked_inputs`

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -398,7 +398,7 @@ def unpack_inputs(func):
         fn_args_and_kwargs.update(dict(zip(func.__code__.co_varnames[1:], args)))
 
         # Encoder Decoder models delegate the application of the configuration options to their inner models.
-        if "encoder_decoder" in str(self).lower():
+        if "EncoderDecoder" in type(self).__name__:
             config = None
         else:
             config = self.config

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -398,7 +398,7 @@ def unpack_inputs(func):
         fn_args_and_kwargs.update(dict(zip(func.__code__.co_varnames[1:], args)))
 
         # Encoder Decoder models delegate the application of the configuration options to their inner models.
-        if "EncoderDecoder" in type(self).__name__:
+        if "EncoderDecoder" in self.__class__.__name__:
             config = None
         else:
             config = self.config


### PR DESCRIPTION
# What does this PR do?

Use `type(self).__name__` instead of `str(self).lower()`.

This is a follow-up of [this comment](https://github.com/huggingface/transformers/pull/18097#discussion_r926907848) by @gante.