### PR TITLE
[Test] Fix redirected links issue

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -252,18 +252,20 @@ def _patch_hf_hub_tqdm():
     yield
     huggingface_hub.file_download.tqdm = old_tqdm
 
+
 def get_redirected_link(repo_id):
     r"""
-    Tries to get a redirected link, otherwise return the same repo_id.
-    Code inspired from: https://stackoverflow.com/questions/20475552/python-requests-library-redirect-new-url
+    Tries to get a redirected link, otherwise return the same repo_id. Code inspired from:
+    https://stackoverflow.com/questions/20475552/python-requests-library-redirect-new-url
     """
     temp_link = f"{HUGGINGFACE_CO_RESOLVE_ENDPOINT}/{repo_id}"
     try:
         r = requests.head(temp_link, allow_redirects=True)
         repo_id = r.url.split(HUGGINGFACE_CO_RESOLVE_ENDPOINT)[-1][1:]
     except ValueError:
-        pass # Do nothing if the link is not redirected
+        pass  # Do nothing if the link is not redirected
     return repo_id
+
 
 def cached_file(
     path_or_repo_id: Union[str, os.PathLike],

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -252,6 +252,18 @@ def _patch_hf_hub_tqdm():
     yield
     huggingface_hub.file_download.tqdm = old_tqdm
 
+def get_redirected_link(repo_id):
+    r"""
+    Tries to get a redirected link, otherwise return the same repo_id.
+    Code inspired from: https://stackoverflow.com/questions/20475552/python-requests-library-redirect-new-url
+    """
+    temp_link = f"{HUGGINGFACE_CO_RESOLVE_ENDPOINT}/{repo_id}"
+    try:
+        r = requests.head(temp_link, allow_redirects=True)
+        repo_id = r.url.split(HUGGINGFACE_CO_RESOLVE_ENDPOINT)[-1][1:]
+    except ValueError:
+        pass # Do nothing if the link is not redirected
+    return repo_id
 
 def cached_file(
     path_or_repo_id: Union[str, os.PathLike],
@@ -341,6 +353,9 @@ def cached_file(
         cache_dir = str(cache_dir)
     user_agent = http_user_agent(user_agent)
     try:
+        # Load from redirected link if necessary
+        path_or_repo_id = get_redirected_link(path_or_repo_id)
+
         # Load from URL or cache if already cached
         with _patch_hf_hub_tqdm():
             resolved_file = hf_hub_download(

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -261,8 +261,8 @@ def get_redirected_link(repo_id):
     temp_link = f"{HUGGINGFACE_CO_RESOLVE_ENDPOINT}/{repo_id}"
     try:
         r = requests.head(temp_link, allow_redirects=True)
-        repo_id = r.url.split(HUGGINGFACE_CO_RESOLVE_ENDPOINT)[-1][1:]
-    except ValueError:
+        repo_id = r.url.replace(f"{HUGGINGFACE_CO_RESOLVE_ENDPOINT}/", "")
+    except BaseException:
         pass  # Do nothing if the link is not redirected
     return repo_id
 


### PR DESCRIPTION
# What does this PR do?

This PR tries to address the issue of loading a model when the original link is redirected. This happened for BLOOM models where the repo ids has been changed but the code does not take into account redirected links. 
I am not sure how to properly test if this does not break anything so I am putting this PR as a test PR, so feel free to ignore it.
Now loading BLOOM models with old naming works

```
from transformers import AutoModelForCausalLM, AutoTokenizer

model_name = "bigscience/bloom-350m"
tokenizer = AutoTokenizer.from_pretrained(model_name)
model = AutoModelForCausalLM.from_pretrained(model_name)
```

Also this can be done probably on the `huggingface_hub` level but I am not sure

Related to #18531
