### PR TITLE
TF: XLA-trainable DeBERTa v2

### DIFF
--- a/src/transformers/models/deberta/modeling_tf_deberta.py
+++ b/src/transformers/models/deberta/modeling_tf_deberta.py
@@ -119,7 +119,8 @@ class TFDebertaStableDropout(tf.keras.layers.Layer):
         Applies dropout to the inputs, as vanilla dropout, but also scales the remaining elements up by 1/drop_prob.
         """
         mask = tf.cast(
-            1 - tf.compat.v1.distributions.Bernoulli(probs=1 - self.drop_prob).sample(sample_shape=shape_list(inputs)),
+            1
+            - tf.compat.v1.distributions.Bernoulli(probs=1.0 - self.drop_prob).sample(sample_shape=shape_list(inputs)),
             tf.bool,
         )
         scale = tf.convert_to_tensor(1.0 / (1 - self.drop_prob), dtype=tf.float32)

--- a/src/transformers/models/deberta/modeling_tf_deberta.py
+++ b/src/transformers/models/deberta/modeling_tf_deberta.py
@@ -101,27 +101,6 @@ class TFDebertaXSoftmax(tf.keras.layers.Layer):
         return output
 
 
-def get_mask(input, dropout):
-    mask = tf.cast(
-        1 - tf.compat.v1.distributions.Bernoulli(probs=1 - dropout).sample(sample_shape=shape_list(input)), tf.bool
-    )
-    return mask, dropout
-
-
-@tf.custom_gradient
-def TFDebertaXDropout(input, local_ctx):
-    mask, dropout = get_mask(input, local_ctx)
-    scale = tf.convert_to_tensor(1.0 / (1 - dropout), dtype=tf.float32)
-    input = tf.cond(dropout > 0, lambda: tf.where(mask, 0.0, input) * scale, lambda: input)
-
-    def custom_grad(upstream_grad):
-        return tf.cond(
-            scale > 1, lambda: (tf.where(mask, 0.0, upstream_grad) * scale, None), lambda: (upstream_grad, None)
-        )
-
-    return input, custom_grad
-
-
 class TFDebertaStableDropout(tf.keras.layers.Layer):
     """
     Optimized dropout module for stabilizing the training
@@ -134,9 +113,26 @@ class TFDebertaStableDropout(tf.keras.layers.Layer):
         super().__init__(**kwargs)
         self.drop_prob = tf.convert_to_tensor(drop_prob, dtype=tf.float32)
 
+    @tf.custom_gradient
+    def xdropout(self, input):
+        """
+        Applies dropout to the input, as vanilla dropout, but also scales the remaining elements up by 1/drop_prob.
+        """
+        mask = tf.cast(
+            1 - tf.compat.v1.distributions.Bernoulli(probs=1 - self.drop_prob).sample(sample_shape=shape_list(input)),
+            tf.bool,
+        )
+        scale = tf.convert_to_tensor(1.0 / (1 - self.drop_prob), dtype=tf.float32)
+        input = tf.cond(self.drop_prob > 0, lambda: tf.where(mask, 0.0, input) * scale, lambda: input)
+
+        def grad(upstream):
+            return tf.cond(scale > 1, lambda: tf.where(mask, 0.0, upstream) * scale, lambda: upstream)
+
+        return input, grad
+
     def call(self, inputs: tf.Tensor, training: tf.Tensor = False):
-        if training and self.drop_prob > 0:
-            return TFDebertaXDropout(inputs, self.drop_prob)
+        if training:
+            return self.xdropout(inputs)
         return inputs
 
 

--- a/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
@@ -530,10 +530,7 @@ def take_along_axis(x, indices):
 
     # GPUs, on the other hand, prefer gathers instead of large one-hot+matmuls
     else:
-        flat_x = tf.reshape(x, (-1, x.shape[-1]))
-        flat_indices = tf.reshape(indices, (-1, indices.shape[-1]))
-        gathered = tf.gather(flat_x, flat_indices, batch_dims=1)
-        gathered = tf.reshape(gathered, shape_list(indices))
+        gathered = tf.gather(x, indices, batch_dims=2)
 
     return gathered
 

--- a/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
@@ -121,7 +121,8 @@ class TFDebertaV2StableDropout(tf.keras.layers.Layer):
         Applies dropout to the inputs, as vanilla dropout, but also scales the remaining elements up by 1/drop_prob.
         """
         mask = tf.cast(
-            1 - tf.compat.v1.distributions.Bernoulli(probs=1 - self.drop_prob).sample(sample_shape=shape_list(inputs)),
+            1
+            - tf.compat.v1.distributions.Bernoulli(probs=1.0 - self.drop_prob).sample(sample_shape=shape_list(inputs)),
             tf.bool,
         )
         scale = tf.convert_to_tensor(1.0 / (1 - self.drop_prob), dtype=tf.float32)

--- a/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
@@ -102,29 +102,6 @@ class TFDebertaV2XSoftmax(tf.keras.layers.Layer):
         return output
 
 
-# Copied from transformers.models.deberta.modeling_tf_deberta.get_mask
-def get_mask(input, dropout):
-    mask = tf.cast(
-        1 - tf.compat.v1.distributions.Bernoulli(probs=1 - dropout).sample(sample_shape=shape_list(input)), tf.bool
-    )
-    return mask, dropout
-
-
-@tf.custom_gradient
-# Copied from transformers.models.deberta.modeling_tf_deberta.TFDebertaXDropout
-def TFDebertaV2XDropout(input, local_ctx):
-    mask, dropout = get_mask(input, local_ctx)
-    scale = tf.convert_to_tensor(1.0 / (1 - dropout), dtype=tf.float32)
-    input = tf.cond(dropout > 0, lambda: tf.where(mask, 0.0, input) * scale, lambda: input)
-
-    def custom_grad(upstream_grad):
-        return tf.cond(
-            scale > 1, lambda: (tf.where(mask, 0.0, upstream_grad) * scale, None), lambda: (upstream_grad, None)
-        )
-
-    return input, custom_grad
-
-
 # Copied from transformers.models.deberta.modeling_tf_deberta.TFDebertaStableDropout with Deberta->DebertaV2
 class TFDebertaV2StableDropout(tf.keras.layers.Layer):
     """
@@ -138,9 +115,26 @@ class TFDebertaV2StableDropout(tf.keras.layers.Layer):
         super().__init__(**kwargs)
         self.drop_prob = tf.convert_to_tensor(drop_prob, dtype=tf.float32)
 
+    @tf.custom_gradient
+    def xdropout(self, input):
+        """
+        Applies dropout to the input, as vanilla dropout, but also scales the remaining elements up by 1/drop_prob.
+        """
+        mask = tf.cast(
+            1 - tf.compat.v1.distributions.Bernoulli(probs=1 - self.drop_prob).sample(sample_shape=shape_list(input)),
+            tf.bool,
+        )
+        scale = tf.convert_to_tensor(1.0 / (1 - self.drop_prob), dtype=tf.float32)
+        input = tf.cond(self.drop_prob > 0, lambda: tf.where(mask, 0.0, input) * scale, lambda: input)
+
+        def grad(upstream):
+            return tf.cond(scale > 1, lambda: tf.where(mask, 0.0, upstream) * scale, lambda: upstream)
+
+        return input, grad
+
     def call(self, inputs: tf.Tensor, training: tf.Tensor = False):
-        if training and self.drop_prob > 0:
-            return TFDebertaV2XDropout(inputs, self.drop_prob)
+        if training:
+            return self.xdropout(inputs)
         return inputs
 
 
@@ -525,10 +519,12 @@ def pos_dynamic_expand(pos_index, p2c_att, key_layer):
 def take_along_axis(x, indices):
     # Only a valid port of np.take_along_axis when the gather axis is -1
 
-    flat_x = tf.reshape(x, (-1, x.shape[-1]))
-    flat_indices = tf.reshape(indices, (-1, indices.shape[-1]))
-    gathered = tf.gather(flat_x, flat_indices, batch_dims=1)
-    gathered = tf.reshape(gathered, indices.shape)
+    # [B, S, P] -> [B, S, P, D]
+    one_hot_indices = tf.one_hot(indices, depth=x.shape[-1], dtype=x.dtype)
+
+    # if we ignore the first two dims, this is equivalent to multiplying a matrix (one hot) by a vector (x)
+    # grossly abusing notation: [B, S, P, D] . [B, S, D] = [B, S, P]
+    gathered = tf.einsum("ijkl,ijl->ijk", one_hot_indices, x)
 
     return gathered
 

--- a/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
@@ -113,24 +113,28 @@ class TFDebertaV2StableDropout(tf.keras.layers.Layer):
 
     def __init__(self, drop_prob, **kwargs):
         super().__init__(**kwargs)
-        self.drop_prob = tf.convert_to_tensor(drop_prob, dtype=tf.float32)
+        self.drop_prob = drop_prob
 
     @tf.custom_gradient
-    def xdropout(self, input):
+    def xdropout(self, inputs):
         """
-        Applies dropout to the input, as vanilla dropout, but also scales the remaining elements up by 1/drop_prob.
+        Applies dropout to the inputs, as vanilla dropout, but also scales the remaining elements up by 1/drop_prob.
         """
         mask = tf.cast(
-            1 - tf.compat.v1.distributions.Bernoulli(probs=1 - self.drop_prob).sample(sample_shape=shape_list(input)),
+            1 - tf.compat.v1.distributions.Bernoulli(probs=1 - self.drop_prob).sample(sample_shape=shape_list(inputs)),
             tf.bool,
         )
         scale = tf.convert_to_tensor(1.0 / (1 - self.drop_prob), dtype=tf.float32)
-        input = tf.cond(self.drop_prob > 0, lambda: tf.where(mask, 0.0, input) * scale, lambda: input)
+        if self.drop_prob > 0:
+            inputs = tf.where(mask, 0.0, inputs) * scale
 
         def grad(upstream):
-            return tf.cond(scale > 1, lambda: tf.where(mask, 0.0, upstream) * scale, lambda: upstream)
+            if self.drop_prob > 0:
+                return tf.where(mask, 0.0, upstream) * scale
+            else:
+                return upstream
 
-        return input, grad
+        return inputs, grad
 
     def call(self, inputs: tf.Tensor, training: tf.Tensor = False):
         if training:


### PR DESCRIPTION
# What does this PR do?

As discussed in https://github.com/huggingface/transformers/issues/18476 and https://github.com/huggingface/transformers/issues/18239, there are two problems while training DeBERTa v2 with TensorFlow:
1. `TFDebertaV2StableDropout` doesn't work at training time (actually, its logic is only triggered at training time, so it doesn't work at all :D)
2. TF complains about unknown shapes in `take_along_axis` (forward and backward passes, when the batch dim is `None`)

This PR fixes both problems above :) 

Problem 1. is got a straightforward fix. The gradient propagation code didn't have the right gradient shapes -- this PR simplifies and fixes it by moving all functions inside the special dropout class (compare to the original PT implementation [here](https://github.com/huggingface/transformers/blob/main/src/transformers/models/deberta_v2/modeling_deberta_v2.py#L173) -- also notice how much more elegant TF's code is ;)).

Problem 2. is tricker. The exception gets fixed with the addition of a `shape_list`, but the code is super slow on TPU. This PR adds an if/else pair of branches, one that is efficient on TPU, the other on GPU :)

_____________________________________________________

⚠️ These exceptions were not caught because deberta v2 and v3 rely on special config options -- e.g. https://huggingface.co/microsoft/deberta-v3-base/blob/main/config.json#L14

How can we ensure we properly test these configurations?