### PR TITLE
Fix memory leak issue in `torch_fx` tests

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -881,6 +881,8 @@ class ModelTesterMixin:
         self._create_and_check_torch_fx_tracing(config, inputs_dict, output_loss=True)
 
     def _create_and_check_torch_fx_tracing(self, config, inputs_dict, output_loss=False):
+        # This method has memory leak issue (caused by methods in `torch.jit`), so let's run it in a subprocess.
+        # See https://github.com/huggingface/transformers/issues/18525
         if not is_torch_fx_available() or not self.fx_compatible:
             return
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -210,7 +210,7 @@ def _run_torch_jit(in_queue, out_queue):
         try:
             traced_model = symbolic_trace(model, input_names)
             traced_output = traced_model(**filtered_inputs)
-        except:
+        except Exception:
             error = f"Couldn't trace module.\n{traceback.format_exc()}"
             raise
 
@@ -232,7 +232,7 @@ def _run_torch_jit(in_queue, out_queue):
         for i in range(num_outputs):
             try:
                 assert torch.allclose(model_output[i], traced_output[i])
-            except:
+            except Exception:
                 error = (
                     f"traced {i}th output doesn't match model {i}th output for"
                     f" {model_class}.\n{traceback.format_exc()}"
@@ -242,7 +242,7 @@ def _run_torch_jit(in_queue, out_queue):
         # Test that the model can be TorchScripted
         try:
             scripted = torch.jit.script(traced_model)
-        except:
+        except Exception:
             error = unittest.TestCase.fail(f"Could not TorchScript the traced model.\n{traceback.format_exc()}")
             raise
         scripted_output = scripted(**filtered_inputs)
@@ -251,7 +251,7 @@ def _run_torch_jit(in_queue, out_queue):
         for i in range(num_outputs):
             try:
                 assert torch.allclose(model_output[i], scripted_output[i])
-            except:
+            except Exception:
                 error = (
                     f"scripted {i}th output doesn't match model {i}th output for"
                     f" {model_class}.\n{traceback.format_exc()}"
@@ -266,7 +266,7 @@ def _run_torch_jit(in_queue, out_queue):
                     pickle.dump(traced_model, f)
                 with open(pkl_file_name, "rb") as f:
                     loaded = pickle.load(f)
-            except:
+            except Exception:
                 error = f"Couldn't serialize / deserialize the traced model.\n{traceback.format_exc()}"
                 raise
 
@@ -276,13 +276,13 @@ def _run_torch_jit(in_queue, out_queue):
             for i in range(num_outputs):
                 try:
                     assert torch.allclose(model_output[i], loaded_output[i])
-                except:
+                except Exception:
                     error = (
                         f"serialized model {i}th output doesn't match model {i}th output for"
                         f" {model_class}.\n{traceback.format_exc()}"
                     )
                     raise
-    except:
+    except Exception:
         if error is None:
             error = f"{traceback.format_exc()}"
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -138,6 +138,159 @@ TINY_T5 = "patrickvonplaten/t5-tiny-random"
 TINY_BERT_FOR_TOKEN_CLASSIFICATION = "hf-internal-testing/tiny-bert-for-token-classification"
 
 
+def _run_torch_jit(in_queue, out_queue):
+    import traceback
+
+    error = None
+
+    try:
+        _inputs = in_queue.get(timeout=30)
+
+        model_class = _inputs["model_class"]
+        configs_no_init = _inputs["configs_no_init"]
+        inputs = _inputs["inputs"]
+
+        model = model_class(config=configs_no_init)
+        model.to(torch_device)
+        model.eval()
+
+        if model.config.is_encoder_decoder:
+            model.config.use_cache = (
+                False  # FSTM still requires this hack -> FSTM should probably be refactored similar to BART afterward
+            )
+            labels = inputs.get("labels", None)
+            input_names = [
+                "attention_mask",
+                "decoder_attention_mask",
+                "decoder_input_ids",
+                "input_features",
+                "input_ids",
+                "input_values",
+            ]
+            if labels is not None:
+                input_names.append("labels")
+
+            filtered_inputs = {k: v for (k, v) in inputs.items() if k in input_names}
+            input_names = list(filtered_inputs.keys())
+        else:
+            input_names = [
+                "attention_mask",
+                "bbox",
+                "input_features",
+                "input_ids",
+                "input_values",
+                "pixel_values",
+                "token_type_ids",
+                "visual_feats",
+                "visual_pos",
+            ]
+
+            labels = inputs.get("labels", None)
+            start_positions = inputs.get("start_positions", None)
+            end_positions = inputs.get("end_positions", None)
+            if labels is not None:
+                input_names.append("labels")
+            if start_positions is not None:
+                input_names.append("start_positions")
+            if end_positions is not None:
+                input_names.append("end_positions")
+
+            filtered_inputs = {k: v for (k, v) in inputs.items() if k in input_names}
+            input_names = list(filtered_inputs.keys())
+
+            if (
+                isinstance(model, tuple(MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.values()))
+                and not hasattr(model.config, "problem_type")
+                or model.config.problem_type is None
+            ):
+                model.config.problem_type = "single_label_classification"
+
+        model_output = model(**filtered_inputs)
+
+        try:
+            traced_model = symbolic_trace(model, input_names)
+            traced_output = traced_model(**filtered_inputs)
+        except:
+            error = f"Couldn't trace module.\n{traceback.format_exc()}"
+            raise
+
+        def flatten_output(output):
+            flatten = []
+            for x in output:
+                if isinstance(x, (tuple, list)):
+                    flatten += flatten_output(x)
+                elif not isinstance(x, torch.Tensor):
+                    continue
+                else:
+                    flatten.append(x)
+            return flatten
+
+        model_output = flatten_output(model_output)
+        traced_output = flatten_output(traced_output)
+        num_outputs = len(model_output)
+
+        for i in range(num_outputs):
+            try:
+                assert torch.allclose(model_output[i], traced_output[i])
+            except:
+                error = (
+                    f"traced {i}th output doesn't match model {i}th output for"
+                    f" {model_class}.\n{traceback.format_exc()}"
+                )
+                raise
+
+        # Test that the model can be TorchScripted
+        try:
+            scripted = torch.jit.script(traced_model)
+        except:
+            error = unittest.TestCase.fail(f"Could not TorchScript the traced model.\n{traceback.format_exc()}")
+            raise
+        scripted_output = scripted(**filtered_inputs)
+        scripted_output = flatten_output(scripted_output)
+
+        for i in range(num_outputs):
+            try:
+                assert torch.allclose(model_output[i], scripted_output[i])
+            except:
+                error = (
+                    f"scripted {i}th output doesn't match model {i}th output for"
+                    f" {model_class}.\n{traceback.format_exc()}"
+                )
+                raise
+
+        # Test that the model can be serialized and restored properly
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            pkl_file_name = os.path.join(tmp_dir_name, "model.pkl")
+            try:
+                with open(pkl_file_name, "wb") as f:
+                    pickle.dump(traced_model, f)
+                with open(pkl_file_name, "rb") as f:
+                    loaded = pickle.load(f)
+            except:
+                error = f"Couldn't serialize / deserialize the traced model.\n{traceback.format_exc()}"
+                raise
+
+            loaded_output = loaded(**filtered_inputs)
+            loaded_output = flatten_output(loaded_output)
+
+            for i in range(num_outputs):
+                try:
+                    assert torch.allclose(model_output[i], loaded_output[i])
+                except:
+                    error = (
+                        f"serialized model {i}th output doesn't match model {i}th output for"
+                        f" {model_class}.\n{traceback.format_exc()}"
+                    )
+                    raise
+    except:
+        if error is None:
+            error = f"{traceback.format_exc()}"
+
+    results = {"error": error}
+    out_queue.put(results, timeout=30)
+    out_queue.join()
+
+
 @require_torch
 class ModelTesterMixin:
 
@@ -736,128 +889,42 @@ class ModelTesterMixin:
         configs_no_init.return_dict = False
 
         for model_class in self.all_model_classes:
-            model = model_class(config=configs_no_init)
-            model.to(torch_device)
-            model.eval()
             inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=output_loss)
 
+            # Note: `MKL_NUM_THREADS > 1` with `fork` will hang if the traced/scripted models call inputs.
+            # On CircleCI, it is set to `1`, so we are good.
+            start_methohd = "fork"
+            # `CUDA` works only with `spawn`.
+            if torch_device != "cpu":
+                start_methohd = "spawn"
+
+            ctx = torch.multiprocessing.get_context(start_methohd)
+
+            input_queue = ctx.Queue(1)
+            output_queue = ctx.JoinableQueue(1)
+
+            # We can't send `self` to the child, otherwise hanging forever.
+            _inputs = {
+                "model_class": model_class,
+                "configs_no_init": configs_no_init,
+                "inputs": inputs,
+            }
+            input_queue.put(_inputs, timeout=30)
+
+            process = ctx.Process(target=_run_torch_jit, args=(input_queue, output_queue))
+            process.start()
+            # Kill the child process if we can't get outputs from it in time: otherwise, the hanging subprocess prevents
+            # the test to exit properly.
             try:
-                if model.config.is_encoder_decoder:
-                    model.config.use_cache = False  # FSTM still requires this hack -> FSTM should probably be refactored similar to BART afterward
-                    labels = inputs.get("labels", None)
-                    input_names = [
-                        "attention_mask",
-                        "decoder_attention_mask",
-                        "decoder_input_ids",
-                        "input_features",
-                        "input_ids",
-                        "input_values",
-                    ]
-                    if labels is not None:
-                        input_names.append("labels")
-
-                    filtered_inputs = {k: v for (k, v) in inputs.items() if k in input_names}
-                    input_names = list(filtered_inputs.keys())
-
-                    model_output = model(**filtered_inputs)
-
-                    traced_model = symbolic_trace(model, input_names)
-                    traced_output = traced_model(**filtered_inputs)
-                else:
-                    input_names = [
-                        "attention_mask",
-                        "bbox",
-                        "input_features",
-                        "input_ids",
-                        "input_values",
-                        "pixel_values",
-                        "token_type_ids",
-                        "visual_feats",
-                        "visual_pos",
-                    ]
-
-                    labels = inputs.get("labels", None)
-                    start_positions = inputs.get("start_positions", None)
-                    end_positions = inputs.get("end_positions", None)
-                    if labels is not None:
-                        input_names.append("labels")
-                    if start_positions is not None:
-                        input_names.append("start_positions")
-                    if end_positions is not None:
-                        input_names.append("end_positions")
-
-                    filtered_inputs = {k: v for (k, v) in inputs.items() if k in input_names}
-                    input_names = list(filtered_inputs.keys())
-
-                    model_output = model(**filtered_inputs)
-
-                    if (
-                        isinstance(model, tuple(MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.values()))
-                        and not hasattr(model.config, "problem_type")
-                        or model.config.problem_type is None
-                    ):
-                        model.config.problem_type = "single_label_classification"
-
-                    traced_model = symbolic_trace(model, input_names)
-                    traced_output = traced_model(**filtered_inputs)
-
+                results = output_queue.get(timeout=30)
+                output_queue.task_done()
             except Exception as e:
-                self.fail(f"Couldn't trace module: {e}")
+                process.terminate()
+                self.fail(e)
+            process.join(timeout=30)
 
-            def flatten_output(output):
-                flatten = []
-                for x in output:
-                    if isinstance(x, (tuple, list)):
-                        flatten += flatten_output(x)
-                    elif not isinstance(x, torch.Tensor):
-                        continue
-                    else:
-                        flatten.append(x)
-                return flatten
-
-            model_output = flatten_output(model_output)
-            traced_output = flatten_output(traced_output)
-            num_outputs = len(model_output)
-
-            for i in range(num_outputs):
-                self.assertTrue(
-                    torch.allclose(model_output[i], traced_output[i]),
-                    f"traced {i}th output doesn't match model {i}th output for {model_class}",
-                )
-
-            # Test that the model can be TorchScripted
-            try:
-                scripted = torch.jit.script(traced_model)
-            except Exception as e:
-                self.fail(f"Could not TorchScript the traced model: {e}")
-            scripted_output = scripted(**filtered_inputs)
-            scripted_output = flatten_output(scripted_output)
-
-            for i in range(num_outputs):
-                self.assertTrue(
-                    torch.allclose(model_output[i], scripted_output[i]),
-                    f"scripted {i}th output doesn't match model {i}th output for {model_class}",
-                )
-
-            # Test that the model can be serialized and restored properly
-            with tempfile.TemporaryDirectory() as tmp_dir_name:
-                pkl_file_name = os.path.join(tmp_dir_name, "model.pkl")
-                try:
-                    with open(pkl_file_name, "wb") as f:
-                        pickle.dump(traced_model, f)
-                    with open(pkl_file_name, "rb") as f:
-                        loaded = pickle.load(f)
-                except Exception as e:
-                    self.fail(f"Couldn't serialize / deserialize the traced model: {e}")
-
-                loaded_output = loaded(**filtered_inputs)
-                loaded_output = flatten_output(loaded_output)
-
-                for i in range(num_outputs):
-                    self.assertTrue(
-                        torch.allclose(model_output[i], loaded_output[i]),
-                        f"serialized model {i}th output doesn't match model {i}th output for {model_class}",
-                    )
+            if results["error"] is not None:
+                self.fail(f'{results["error"]}')
 
     def test_headmasking(self):
         if not self.test_head_masking:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -138,158 +138,6 @@ TINY_T5 = "patrickvonplaten/t5-tiny-random"
 TINY_BERT_FOR_TOKEN_CLASSIFICATION = "hf-internal-testing/tiny-bert-for-token-classification"
 
 
-def _run_torch_jit(in_queue, out_queue):
-    import traceback
-
-    error = None
-
-    try:
-        _inputs = in_queue.get(timeout=30)
-
-        model_class = _inputs["model_class"]
-        configs_no_init = _inputs["configs_no_init"]
-        inputs = _inputs["inputs"]
-
-        model = model_class(config=configs_no_init)
-        model.to(torch_device)
-        model.eval()
-
-        if model.config.is_encoder_decoder:
-            # FSTM still requires this hack -> FSTM should probably be refactored similar to BART afterward
-            model.config.use_cache = False
-            labels = inputs.get("labels", None)
-            input_names = [
-                "attention_mask",
-                "decoder_attention_mask",
-                "decoder_input_ids",
-                "input_features",
-                "input_ids",
-                "input_values",
-            ]
-            if labels is not None:
-                input_names.append("labels")
-
-            filtered_inputs = {k: v for (k, v) in inputs.items() if k in input_names}
-            input_names = list(filtered_inputs.keys())
-        else:
-            input_names = [
-                "attention_mask",
-                "bbox",
-                "input_features",
-                "input_ids",
-                "input_values",
-                "pixel_values",
-                "token_type_ids",
-                "visual_feats",
-                "visual_pos",
-            ]
-
-            labels = inputs.get("labels", None)
-            start_positions = inputs.get("start_positions", None)
-            end_positions = inputs.get("end_positions", None)
-            if labels is not None:
-                input_names.append("labels")
-            if start_positions is not None:
-                input_names.append("start_positions")
-            if end_positions is not None:
-                input_names.append("end_positions")
-
-            filtered_inputs = {k: v for (k, v) in inputs.items() if k in input_names}
-            input_names = list(filtered_inputs.keys())
-
-            if (
-                isinstance(model, tuple(MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.values()))
-                and not hasattr(model.config, "problem_type")
-                or model.config.problem_type is None
-            ):
-                model.config.problem_type = "single_label_classification"
-
-        model_output = model(**filtered_inputs)
-
-        try:
-            traced_model = symbolic_trace(model, input_names)
-            traced_output = traced_model(**filtered_inputs)
-        except Exception:
-            error = f"Couldn't trace module.\n{traceback.format_exc()}"
-            raise
-
-        def flatten_output(output):
-            flatten = []
-            for x in output:
-                if isinstance(x, (tuple, list)):
-                    flatten += flatten_output(x)
-                elif not isinstance(x, torch.Tensor):
-                    continue
-                else:
-                    flatten.append(x)
-            return flatten
-
-        model_output = flatten_output(model_output)
-        traced_output = flatten_output(traced_output)
-        num_outputs = len(model_output)
-
-        for i in range(num_outputs):
-            try:
-                assert torch.allclose(model_output[i], traced_output[i])
-            except Exception:
-                error = (
-                    f"traced {i}th output doesn't match model {i}th output for"
-                    f" {model_class}.\n{traceback.format_exc()}"
-                )
-                raise
-
-        # Test that the model can be TorchScripted
-        try:
-            scripted = torch.jit.script(traced_model)
-        except Exception:
-            error = unittest.TestCase.fail(f"Could not TorchScript the traced model.\n{traceback.format_exc()}")
-            raise
-        scripted_output = scripted(**filtered_inputs)
-        scripted_output = flatten_output(scripted_output)
-
-        for i in range(num_outputs):
-            try:
-                assert torch.allclose(model_output[i], scripted_output[i])
-            except Exception:
-                error = (
-                    f"scripted {i}th output doesn't match model {i}th output for"
-                    f" {model_class}.\n{traceback.format_exc()}"
-                )
-                raise
-
-        # Test that the model can be serialized and restored properly
-        with tempfile.TemporaryDirectory() as tmp_dir_name:
-            pkl_file_name = os.path.join(tmp_dir_name, "model.pkl")
-            try:
-                with open(pkl_file_name, "wb") as f:
-                    pickle.dump(traced_model, f)
-                with open(pkl_file_name, "rb") as f:
-                    loaded = pickle.load(f)
-            except Exception:
-                error = f"Couldn't serialize / deserialize the traced model.\n{traceback.format_exc()}"
-                raise
-
-            loaded_output = loaded(**filtered_inputs)
-            loaded_output = flatten_output(loaded_output)
-
-            for i in range(num_outputs):
-                try:
-                    assert torch.allclose(model_output[i], loaded_output[i])
-                except Exception:
-                    error = (
-                        f"serialized model {i}th output doesn't match model {i}th output for"
-                        f" {model_class}.\n{traceback.format_exc()}"
-                    )
-                    raise
-    except Exception:
-        if error is None:
-            error = f"{traceback.format_exc()}"
-
-    results = {"error": error}
-    out_queue.put(results, timeout=30)
-    out_queue.join()
-
-
 @require_torch
 class ModelTesterMixin:
 
@@ -881,8 +729,6 @@ class ModelTesterMixin:
         self._create_and_check_torch_fx_tracing(config, inputs_dict, output_loss=True)
 
     def _create_and_check_torch_fx_tracing(self, config, inputs_dict, output_loss=False):
-        # This method has memory leak issue (caused by methods in `torch.jit`), so let's run it in a subprocess.
-        # See https://github.com/huggingface/transformers/issues/18525
         if not is_torch_fx_available() or not self.fx_compatible:
             return
 
@@ -890,42 +736,132 @@ class ModelTesterMixin:
         configs_no_init.return_dict = False
 
         for model_class in self.all_model_classes:
+            model = model_class(config=configs_no_init)
+            model.to(torch_device)
+            model.eval()
             inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=output_loss)
 
-            # Note: `MKL_NUM_THREADS > 1` with `fork` will hang if the traced/scripted models call inputs.
-            # On CircleCI, it is set to `1`, so we are good.
-            start_methohd = "fork"
-            # `CUDA` works only with `spawn`.
-            if torch_device != "cpu":
-                start_methohd = "spawn"
-
-            ctx = torch.multiprocessing.get_context(start_methohd)
-
-            input_queue = ctx.Queue(1)
-            output_queue = ctx.JoinableQueue(1)
-
-            # We can't send `self` to the child, otherwise hanging forever.
-            _inputs = {
-                "model_class": model_class,
-                "configs_no_init": configs_no_init,
-                "inputs": inputs,
-            }
-            input_queue.put(_inputs, timeout=30)
-
-            process = ctx.Process(target=_run_torch_jit, args=(input_queue, output_queue))
-            process.start()
-            # Kill the child process if we can't get outputs from it in time: otherwise, the hanging subprocess prevents
-            # the test to exit properly.
             try:
-                results = output_queue.get(timeout=30)
-                output_queue.task_done()
-            except Exception as e:
-                process.terminate()
-                self.fail(e)
-            process.join(timeout=30)
+                if model.config.is_encoder_decoder:
+                    model.config.use_cache = False  # FSTM still requires this hack -> FSTM should probably be refactored similar to BART afterward
+                    labels = inputs.get("labels", None)
+                    input_names = [
+                        "attention_mask",
+                        "decoder_attention_mask",
+                        "decoder_input_ids",
+                        "input_features",
+                        "input_ids",
+                        "input_values",
+                    ]
+                    if labels is not None:
+                        input_names.append("labels")
 
-            if results["error"] is not None:
-                self.fail(f'{results["error"]}')
+                    filtered_inputs = {k: v for (k, v) in inputs.items() if k in input_names}
+                    input_names = list(filtered_inputs.keys())
+
+                    model_output = model(**filtered_inputs)
+
+                    traced_model = symbolic_trace(model, input_names)
+                    traced_output = traced_model(**filtered_inputs)
+                else:
+                    input_names = [
+                        "attention_mask",
+                        "bbox",
+                        "input_features",
+                        "input_ids",
+                        "input_values",
+                        "pixel_values",
+                        "token_type_ids",
+                        "visual_feats",
+                        "visual_pos",
+                    ]
+
+                    labels = inputs.get("labels", None)
+                    start_positions = inputs.get("start_positions", None)
+                    end_positions = inputs.get("end_positions", None)
+                    if labels is not None:
+                        input_names.append("labels")
+                    if start_positions is not None:
+                        input_names.append("start_positions")
+                    if end_positions is not None:
+                        input_names.append("end_positions")
+
+                    filtered_inputs = {k: v for (k, v) in inputs.items() if k in input_names}
+                    input_names = list(filtered_inputs.keys())
+
+                    model_output = model(**filtered_inputs)
+
+                    if (
+                        isinstance(model, tuple(MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING.values()))
+                        and not hasattr(model.config, "problem_type")
+                        or model.config.problem_type is None
+                    ):
+                        model.config.problem_type = "single_label_classification"
+
+                    traced_model = symbolic_trace(model, input_names)
+                    traced_output = traced_model(**filtered_inputs)
+
+            except Exception as e:
+                self.fail(f"Couldn't trace module: {e}")
+
+            def flatten_output(output):
+                flatten = []
+                for x in output:
+                    if isinstance(x, (tuple, list)):
+                        flatten += flatten_output(x)
+                    elif not isinstance(x, torch.Tensor):
+                        continue
+                    else:
+                        flatten.append(x)
+                return flatten
+
+            model_output = flatten_output(model_output)
+            traced_output = flatten_output(traced_output)
+            num_outputs = len(model_output)
+
+            for i in range(num_outputs):
+                self.assertTrue(
+                    torch.allclose(model_output[i], traced_output[i]),
+                    f"traced {i}th output doesn't match model {i}th output for {model_class}",
+                )
+
+            # Test that the model can be TorchScripted
+            try:
+                scripted = torch.jit.script(traced_model)
+            except Exception as e:
+                self.fail(f"Could not TorchScript the traced model: {e}")
+            scripted_output = scripted(**filtered_inputs)
+            scripted_output = flatten_output(scripted_output)
+
+            for i in range(num_outputs):
+                self.assertTrue(
+                    torch.allclose(model_output[i], scripted_output[i]),
+                    f"scripted {i}th output doesn't match model {i}th output for {model_class}",
+                )
+
+            # Test that the model can be serialized and restored properly
+            with tempfile.TemporaryDirectory() as tmp_dir_name:
+                pkl_file_name = os.path.join(tmp_dir_name, "model.pkl")
+                try:
+                    with open(pkl_file_name, "wb") as f:
+                        pickle.dump(traced_model, f)
+                    with open(pkl_file_name, "rb") as f:
+                        loaded = pickle.load(f)
+                except Exception as e:
+                    self.fail(f"Couldn't serialize / deserialize the traced model: {e}")
+
+                loaded_output = loaded(**filtered_inputs)
+                loaded_output = flatten_output(loaded_output)
+
+                for i in range(num_outputs):
+                    self.assertTrue(
+                        torch.allclose(model_output[i], loaded_output[i]),
+                        f"serialized model {i}th output doesn't match model {i}th output for {model_class}",
+                    )
+
+            # Avoid memory leak. Without this, each call increase RAM usage by ~20MB.
+            # (Even with this call, there are still memory leak by ~0.04MB)
+            self.clear_torch_jit_class_registry()
 
     def test_headmasking(self):
         if not self.test_head_masking:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -155,9 +155,8 @@ def _run_torch_jit(in_queue, out_queue):
         model.eval()
 
         if model.config.is_encoder_decoder:
-            model.config.use_cache = (
-                False  # FSTM still requires this hack -> FSTM should probably be refactored similar to BART afterward
-            )
+            # FSTM still requires this hack -> FSTM should probably be refactored similar to BART afterward
+            model.config.use_cache = False
             labels = inputs.get("labels", None)
             input_names = [
                 "attention_mask",


### PR DESCRIPTION
# What does this PR do?

~~**Question**: On GPU VMs, we have to use `spawn`, see [here](https://github.com/huggingface/transformers/pull/18547#issuecomment-1210375716). However, it still hangs with `spawn` (I can't figure out this yet). Should we have 2 branches: one using new process for CPU VM (on CircleCI), and another one using the original approach (no new process - for GPU VM, like on scheduled CI)?~~

**I might have a solution!** --> send the model to the child process in CPU and send to CUDA device there.

~I am going to try `torch.multiprocessing` first.~ not working neither

----

Run torch_fx tests in a spawn process to avoid [memory issue](https://github.com/huggingface/transformers/issues/18525#issue-1331914135).

- See [this comment](https://github.com/huggingface/transformers/pull/18547#issuecomment-1210260525) for the effect
- The reason to use `JoinableQueue` instead of `Queue` for the outputs:

https://discuss.pytorch.org/t/using-torch-tensor-over-multiprocessing-queue-process-fails/2847

