### PR TITLE
raise atol for MT5OnnxConfig

### DIFF
--- a/src/transformers/models/mt5/configuration_mt5.py
+++ b/src/transformers/models/mt5/configuration_mt5.py
@@ -147,9 +147,9 @@ class MT5Config(PretrainedConfig):
         return self.num_layers
 
 
-# Copied from transformers.models.t5.configuration_t5.T5OnnxConfig
 class MT5OnnxConfig(OnnxSeq2SeqConfigWithPast):
     @property
+    # Copied from transformers.models.t5.configuration_t5.T5OnnxConfig.inputs
     def inputs(self) -> Mapping[str, Mapping[int, str]]:
         common_inputs = {
             "input_ids": {0: "batch", 1: "encoder_sequence"},
@@ -169,6 +169,7 @@ class MT5OnnxConfig(OnnxSeq2SeqConfigWithPast):
         return common_inputs
 
     @property
+    # Copied from transformers.models.t5.configuration_t5.T5OnnxConfig.default_onnx_opset
     def default_onnx_opset(self) -> int:
         return 13
 

--- a/src/transformers/models/mt5/configuration_mt5.py
+++ b/src/transformers/models/mt5/configuration_mt5.py
@@ -171,3 +171,7 @@ class MT5OnnxConfig(OnnxSeq2SeqConfigWithPast):
     @property
     def default_onnx_opset(self) -> int:
         return 13
+
+    @property
+    def atol_for_validation(self) -> float:
+        return 5e-4


### PR DESCRIPTION
# What does this PR do?

MT5 is newly added to ONNX tests, but currently failed with
```
AssertionError: mt5, seq2seq-lm -> Outputs values doesn't match between reference model and ONNX exported model: Got max absolute difference of: 0.000148773193359375

AssertionError: mt5, seq2seq-lm-with-past -> Outputs values doesn't match between reference model and ONNX exported model: Got max absolute difference of: 0.00020599365234375
```

[failed job run](https://github.com/huggingface/transformers/runs/7718274393?check_suite_focus=true)