### PR TITLE
Properly move cache when it is not in default path

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -1070,7 +1070,11 @@ if cache_version < 1:
             "`transformers.utils.move_cache()`."
         )
     try:
-        move_cache()
+        if TRANSFORMERS_CACHE != default_cache_path:
+            # Users set some env variable to customize cache storage
+            move_cache(TRANSFORMERS_CACHE, TRANSFORMERS_CACHE)
+        else:
+            move_cache()
     except Exception as e:
         trace = "\n".join(traceback.format_tb(e.__traceback__))
         logger.error(


### PR DESCRIPTION
# What does this PR do?

This PR respects the user env variable for the cache move when they set something different from the default path, as it's not working as expected right now (reported internally by @stas00 )