### PR TITLE
Fix resizing bug in OWL-ViT

### DIFF
--- a/src/transformers/models/owlvit/feature_extraction_owlvit.py
+++ b/src/transformers/models/owlvit/feature_extraction_owlvit.py
@@ -50,13 +50,13 @@ class OwlViTFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin
     Args:
         do_resize (`bool`, *optional*, defaults to `True`):
             Whether to resize the shorter edge of the input to a certain `size`.
-        size (`int`, *optional*, defaults to 768):
+        size (`int`, *optional*, defaults to (768, 768):
             Resize the shorter edge of the input to the given size. Only has an effect if `do_resize` is set to `True`.
         resample (`int`, *optional*, defaults to `PIL.Image.BICUBIC`):
             An optional resampling filter. This can be one of `PIL.Image.NEAREST`, `PIL.Image.BOX`,
             `PIL.Image.BILINEAR`, `PIL.Image.HAMMING`, `PIL.Image.BICUBIC` or `PIL.Image.LANCZOS`. Only has an effect
             if `do_resize` is set to `True`.
-        do_center_crop (`bool`, *optional*, defaults to `True`):
+        do_center_crop (`bool`, *optional*, defaults to `False`):
             Whether to crop the input at the center. If the input size is smaller than `crop_size` along any edge, the
             image is padded with 0's and then center cropped.
         crop_size (`int`, *optional*, defaults to 768):
@@ -74,10 +74,10 @@ class OwlViTFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin
     def __init__(
         self,
         do_resize=True,
-        size=768,
+        size=(768, 768),
         resample=Image.BICUBIC,
         crop_size=768,
-        do_center_crop=True,
+        do_center_crop=False,
         do_normalize=True,
         image_mean=None,
         image_std=None,

--- a/src/transformers/models/owlvit/feature_extraction_owlvit.py
+++ b/src/transformers/models/owlvit/feature_extraction_owlvit.py
@@ -50,8 +50,10 @@ class OwlViTFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin
     Args:
         do_resize (`bool`, *optional*, defaults to `True`):
             Whether to resize the shorter edge of the input to a certain `size`.
-        size (`int`, *optional*, defaults to (768, 768):
-            Resize the shorter edge of the input to the given size. Only has an effect if `do_resize` is set to `True`.
+        size (`int` or `Tuple[int, int]`, *optional*, defaults to (768, 768)):
+            The size to use for resizing the image. Only has an effect if `do_resize` is set to `True`. If `size` is a
+            sequence like (h, w), output size will be matched to this. If `size` is an int, then image will be resized
+            to (size, size).
         resample (`int`, *optional*, defaults to `PIL.Image.BICUBIC`):
             An optional resampling filter. This can be one of `PIL.Image.NEAREST`, `PIL.Image.BOX`,
             `PIL.Image.BILINEAR`, `PIL.Image.HAMMING`, `PIL.Image.BICUBIC` or `PIL.Image.LANCZOS`. Only has an effect
@@ -195,7 +197,7 @@ class OwlViTFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin
         # transformations (resizing + center cropping + normalization)
         if self.do_resize and self.size is not None and self.resample is not None:
             images = [
-                self.resize(image=image, size=self.size, resample=self.resample, default_to_square=False)
+                self.resize(image=image, size=self.size, resample=self.resample, default_to_square=True)
                 for image in images
             ]
         if self.do_center_crop and self.crop_size is not None:


### PR DESCRIPTION
# What does this PR do?
Fixes a resizing issue in `OwlViTFeatureExtractor` that lead to the image/s getting resized along only one dimension and getting cropped along the other dimension later on in the preprocessing pipeline. The issue was due to defining the size as a single value instead of a tuple (768 instead of (768, 768)). 

The configuration files are updated and the `OwlViTProcessor `can correctly resize the input images now. This PR changes the default target `size` and sets default `do_center_crop` argument as False.

Fixes # 18553

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [X ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

@NielsRogge could you take a look?



