### PR TITLE
add opt "flush_denormal" in training_args.

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -337,6 +337,11 @@ class Trainer:
         log_level = args.get_process_log_level()
         logging.set_verbosity(log_level)
 
+        if args.flush_denormal:
+            torch.set_flush_denormal(True)
+        else:
+            torch.set_flush_denormal(False)
+
         # force device and distributed setup init explicitly
         args._setup_devices
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -478,6 +478,9 @@ class TrainingArguments:
             are also available. See the [Ray documentation](
             https://docs.ray.io/en/latest/tune/api_docs/analysis.html#ray.tune.ExperimentAnalysis.get_best_trial) for
             more options.
+        flush_denormal (`bool`, *optional*, defaults to `False`):
+            enable flush denormal. Computations with denormal numbers are remarkably slower than normalized number. To
+            solve the low performance issue caused by denormal numbers, user could enable flush denormal
     """
 
     output_dir: str = field(
@@ -960,6 +963,16 @@ class TrainingArguments:
                 " (https://docs.ray.io/en/latest/tune/api_docs/analysis.html"
                 "#ray.tune.ExperimentAnalysis.get_best_trial)"
                 " for more options."
+            )
+        },
+    )
+    flush_denormal: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "enable flush denormal. Computations with denormal numbers are remarkably slower than normalized"
+                " number.To solve the low performance issue caused by denormal numbers, user could enable flush"
+                " denormal"
             )
         },
     )


### PR DESCRIPTION
To solve the low performance issue caused by denormal numbers, user could enable this opt

Signed-off-by: Wang, Yi A <yi.a.wang@intel.com>

# What does this PR do?
[Denormal number](https://en.wikipedia.org/wiki/Denormal_number) is used to store extremely small numbers which are close to 0. Computations with denormal numbers are remarkably slower than normalized number. To solve the low performance issue caused by denormal numbers, users can use the following opt "flush_denormal"

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@sgugger, please help review it
