### PR TITLE
Adds OWLViT to models exportable with ONNX

### DIFF
--- a/docs/source/en/serialization.mdx
+++ b/docs/source/en/serialization.mdx
@@ -82,6 +82,7 @@ Ready-made configurations include the following architectures:
 - MobileViT
 - MT5
 - OpenAI GPT-2
+- OWL-ViT
 - Perceiver
 - PLBart
 - ResNet

--- a/src/transformers/models/owlvit/__init__.py
+++ b/src/transformers/models/owlvit/__init__.py
@@ -32,6 +32,7 @@ _import_structure = {
     "configuration_owlvit": [
         "OWLVIT_PRETRAINED_CONFIG_ARCHIVE_MAP",
         "OwlViTConfig",
+        "OwlViTOnnxConfig",
         "OwlViTTextConfig",
         "OwlViTVisionConfig",
     ],
@@ -66,6 +67,7 @@ if TYPE_CHECKING:
     from .configuration_owlvit import (
         OWLVIT_PRETRAINED_CONFIG_ARCHIVE_MAP,
         OwlViTConfig,
+        OwlViTOnnxConfig,
         OwlViTTextConfig,
         OwlViTVisionConfig,
     )

--- a/src/transformers/models/owlvit/configuration_owlvit.py
+++ b/src/transformers/models/owlvit/configuration_owlvit.py
@@ -16,9 +16,16 @@
 
 import copy
 import os
-from typing import Dict, Union
+from collections import OrderedDict
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Union
+
+
+if TYPE_CHECKING:
+    from ...processing_utils import ProcessorMixin
+    from ...utils import TensorType
 
 from ...configuration_utils import PretrainedConfig
+from ...onnx import OnnxConfig
 from ...utils import logging
 
 
@@ -334,3 +341,44 @@ class OwlViTConfig(PretrainedConfig):
         output["vision_config"] = self.vision_config.to_dict()
         output["model_type"] = self.__class__.model_type
         return output
+
+
+class OwlViTOnnxConfig(OnnxConfig):
+    @property
+    def inputs(self) -> Mapping[str, Mapping[int, str]]:
+        return OrderedDict(
+            [
+                ("input_ids", {0: "batch", 1: "sequence"}),
+                ("pixel_values", {0: "batch"}),
+                ("attention_mask", {0: "batch", 1: "sequence"}),
+            ]
+        )
+
+    @property
+    def outputs(self) -> Mapping[str, Mapping[int, str]]:
+        return OrderedDict(
+            [
+                ("logits_per_image", {0: "batch"}),
+                ("logits_per_text", {0: "batch"}),
+                ("text_embeds", {0: "batch"}),
+                ("image_embeds", {0: "batch"}),
+            ]
+        )
+
+    @property
+    def atol_for_validation(self) -> float:
+        return 1e-4
+
+    def generate_dummy_inputs(
+        self,
+        processor: "ProcessorMixin",
+        framework: Optional["TensorType"] = None,
+    ) -> Mapping[str, Any]:
+
+        text_input_dict = super().generate_dummy_inputs(processor.tokenizer, framework=framework)
+        image_input_dict = super().generate_dummy_inputs(processor.feature_extractor, framework=framework)
+        return {**text_input_dict, **image_input_dict}
+
+    @property
+    def default_onnx_opset(self) -> int:
+        return 14

--- a/src/transformers/models/owlvit/configuration_owlvit.py
+++ b/src/transformers/models/owlvit/configuration_owlvit.py
@@ -349,7 +349,7 @@ class OwlViTOnnxConfig(OnnxConfig):
         return OrderedDict(
             [
                 ("input_ids", {0: "batch", 1: "sequence"}),
-                ("pixel_values", {0: "batch"}),
+                ("pixel_values", {0: "batch", 1: "num_channels", 2: "height", 3: "width"}),
                 ("attention_mask", {0: "batch", 1: "sequence"}),
             ]
         )

--- a/src/transformers/models/owlvit/modeling_owlvit.py
+++ b/src/transformers/models/owlvit/modeling_owlvit.py
@@ -1069,7 +1069,7 @@ class OwlViTModel(OwlViTPreTrainedModel):
         # cosine similarity as logits
         logit_scale = self.logit_scale.exp()
         logits_per_text = torch.matmul(text_embeds, image_embeds.t()) * logit_scale
-        logits_per_image = logits_per_text.T
+        logits_per_image = logits_per_text.t()
 
         loss = None
         if return_loss:

--- a/src/transformers/models/owlvit/modeling_owlvit.py
+++ b/src/transformers/models/owlvit/modeling_owlvit.py
@@ -687,7 +687,10 @@ class OwlViTTextTransformer(nn.Module):
         last_hidden_state = self.final_layer_norm(last_hidden_state)
 
         # take features from the end of tokens embedding (end of token is the highest number in each sequence)
-        pooled_output = last_hidden_state[torch.arange(last_hidden_state.shape[0]), input_ids.argmax(dim=-1)]
+        # casting to torch.int for onnx compatibility: argmax doesn't support int64 inputs with opset 14
+        pooled_output = last_hidden_state[
+            torch.arange(last_hidden_state.shape[0]), input_ids.to(torch.int).argmax(dim=-1)
+        ]
 
         if not return_dict:
             return (last_hidden_state, pooled_output) + encoder_outputs[1:]

--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -401,6 +401,10 @@ class FeaturesManager:
             "seq2seq-lm-with-past",
             onnx_config_cls="models.m2m_100.M2M100OnnxConfig",
         ),
+        "owlvit": supported_features_mapping(
+            "default",
+            onnx_config_cls="models.owlvit.OwlViTOnnxConfig",
+        ),
         "perceiver": supported_features_mapping(
             "image-classification",
             "masked-lm",

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -204,6 +204,7 @@ PYTORCH_EXPORT_MODELS = {
     ("layoutlm", "microsoft/layoutlm-base-uncased"),
     ("layoutlmv3", "microsoft/layoutlmv3-base"),
     ("levit", "facebook/levit-128S"),
+    ("owlvit", "google/owlvit-base-patch32"),
     ("vit", "google/vit-base-patch16-224"),
     ("deit", "facebook/deit-small-patch16-224"),
     ("beit", "microsoft/beit-base-patch16-224"),


### PR DESCRIPTION
Output for tests on my local machine:

```bash
(transformers) ➜  transformers git:(owlvit_onnx) ✗ RUN_SLOW=1 pytest tests/onnx/test_onnx_v2.py -v -k "owlvit" --full-trace
================================================================== test session starts ===================================================================
platform darwin -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0 -- /Users/dhruv/Documents/code/transformers/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/dhruv/Documents/code/transformers, configfile: setup.cfg
collected 410 items / 408 deselected / 2 selected                                                                                                        

tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_101_owlvit_default PASSED                                                    [ 50%]
tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_on_cuda_101_owlvit_default PASSED                                            [100%]

==================================================================== warnings summary ====================================================================
tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_101_owlvit_default
  /Users/dhruv/Documents/code/transformers/src/transformers/image_utils.py:223: DeprecationWarning: BILINEAR is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BILINEAR instead.
    def resize(self, image, size, resample=PIL.Image.BILINEAR, default_to_square=True, max_size=None):

tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_101_owlvit_default
  /Users/dhruv/Documents/code/transformers/src/transformers/models/owlvit/feature_extraction_owlvit.py:80: DeprecationWarning: BICUBIC is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BICUBIC instead.
    resample=Image.BICUBIC,

tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_101_owlvit_default
tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_on_cuda_101_owlvit_default
  /Users/dhruv/Documents/code/transformers/src/transformers/models/owlvit/modeling_owlvit.py:272: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
    if attn_weights.size() != (bsz * self.num_heads, tgt_len, src_len):

tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_101_owlvit_default
tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_on_cuda_101_owlvit_default
  /Users/dhruv/Documents/code/transformers/src/transformers/models/owlvit/modeling_owlvit.py:312: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
    if attn_output.size() != (bsz * self.num_heads, tgt_len, self.head_dim):

tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_101_owlvit_default
tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_on_cuda_101_owlvit_default
  /Users/dhruv/Documents/code/transformers/src/transformers/models/owlvit/modeling_owlvit.py:709: TracerWarning: torch.tensor results are registered as constants in the trace. You can safely ignore this warning if you use this function to create tensors out of constant variables that would be the same every time you call this function. In any other case, this might cause the trace to be incorrect.
    mask.fill_(torch.tensor(float("-inf")))

tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_101_owlvit_default
tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_on_cuda_101_owlvit_default
  /Users/dhruv/Documents/code/transformers/src/transformers/models/owlvit/modeling_owlvit.py:280: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
    if causal_attention_mask.size() != (bsz, 1, tgt_len, src_len):

tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_101_owlvit_default
tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_on_cuda_101_owlvit_default
  /Users/dhruv/Documents/code/transformers/src/transformers/models/owlvit/modeling_owlvit.py:289: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
    if attention_mask.size() != (bsz, 1, tgt_len, src_len):

tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_101_owlvit_default
tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_on_cuda_101_owlvit_default
  /Users/dhruv/Documents/code/transformers/.venv/lib/python3.8/site-packages/torch/onnx/symbolic_opset9.py:4592: UserWarning: Exporting aten::index operator of advanced indexing in opset 14 is achieved by combination of multiple ONNX operators, including Reshape, Transpose, Concat, and Gather. If indices include negative values, the exported graph will produce incorrect results.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================== 2 passed, 408 deselected, 14 warnings in 44.45s =====================================================
```

Note: Haven't tested this on GPU yet, don't have a GPU machine with me currently.

Also, this is for the `default` task of OWLViT. The `object-detection` task isn't supported by AutoModel yet, because of which if I add that to onnx it's failing currently. Should I make the change for AutoModel as well? 

cc: @ChainYo 