### PR TITLE
[WIP] Introduce NestLayer

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -31,7 +31,7 @@ import h5py
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.keras import backend as K
-from tensorflow.python.keras.engine import data_adapter
+from tensorflow.python.keras.engine import base_layer, data_adapter
 from tensorflow.python.keras.engine.keras_tensor import KerasTensor
 from tensorflow.python.keras.saving import hdf5_format
 
@@ -964,104 +964,149 @@ def init_copy_embeddings(old_embeddings, new_num_tokens):
 
 class TFNestLayer(base_layer.Layer):
     """
-    Custom keras layer that subclasses tf.keras.layers.Layer to enable access to all sublayers
-    in a model of nested layers. This is necessary for certain keras model behaviour such
-    as displaying all layers on a `model.summary(epxand_nested=True)` call.
+    Custom keras layer that subclasses tf.keras.layers.Layer to enable access to all sublayers in a model of nested
+    layers. This is necessary for certain keras model behaviour such as displaying all layers on a
+    `model.summary(epxand_nested=True)` call.
+
+    All methods are from `keras.engine.training.Model`
 
     For example:
 
     # Cannot access sublayers
+    ```py
     >>> class LayerX(tf.keras.layers.Layer):
-    >>>     def __init__(self, **kwargs):
-    >>>         super().__init__(**kwargs)
-    >>>         self.l1 = tf.keras.layers.Dense(3)
-    >>>         self.l2 = tf.keras.layers.Dense(4)
+    ...     def __init__(self, **kwargs):
+    ...         super().__init__(**kwargs)
+    ...         self.l1 = tf.keras.layers.Dense(3)
+    ...         self.l2 = tf.keras.layers.Dense(4)
 
-    >>>     def call(self, inputs):
-    >>>         x = self.l1(inputs)
-    >>>         x = self.l2(x)
-    >>>         return x
+    ...     def call(self, inputs):
+    ...         x = self.l1(inputs)
+    ...         x = self.l2(x)
+    ...         return x
+
 
     >>> class LayerZ(tf.keras.layers.Layer):
-    >>>     def __init__(self, **kwargs):
-    >>>         super().__init__(**kwargs)
-    >>>         self.l1 = LayerX()
-    >>>         self.l2 = LayerX()
+    ...     def __init__(self, **kwargs):
+    ...         super().__init__(**kwargs)
+    ...         self.l1 = LayerX()
+    ...         self.l2 = LayerX()
 
-    >>>     def call(self, inputs):
-    >>>         x = self.l1(inputs)
-    >>>         x = self.l2(x)
-    >>>         return x
+    ...     def call(self, inputs):
+    ...         x = self.l1(inputs)
+    ...         x = self.l2(x)
+    ...         return x
+
 
     >>> class Model(tf.keras.Model):
-    >>>     def __init__(self, **kwargs):
-    >>>         super().__init__(**kwargs)
-    >>>         self.l1 = LayerZ()
-    >>>         self.l2 = LayerZ()
+    ...     def __init__(self, **kwargs):
+    ...         super().__init__(**kwargs)
+    ...         self.l1 = LayerZ()
+    ...         self.l2 = LayerZ()
 
-    >>>     def call(self, inputs):
-    >>>         x = self.l1(inputs)
-    >>>         x = self.l2(x)
-    >>>         return x
+    ...     def call(self, inputs):
+    ...         x = self.l1(inputs)
+    ...         x = self.l2(x)
+    ...         return x
+
 
     >>> prev_model = Model()
     >>> prev_model.build(input_shape=(None, 10))
     >>> prev_model.layers
     [<__main__.LayerZ at 0x29a1ef1f0>, <__main__.LayerZ at 0x2c31052e0>]
 
-    >>> hasattr(prev_model.layers[0], 'layers')
+    >>> hasattr(prev_model.layers[0], "layers")
     False
 
     # Can now access all sublayers
-    >>> class LayerX(NestLayer):
-    >>>     def __init__(self, **kwargs):
-    >>>         super().__init__(**kwargs)
-    >>>         self.l1 = tf.keras.layers.Dense(3)
-    >>>         self.l2 = tf.keras.layers.Dense(4)
 
-    >>>     def call(self, inputs):
-    >>>         x = self.l1(inputs)
-    >>>         x = self.l2(x)
-    >>>         return x
+    >>> class LayerX(TFNestLayer):
+    ...     def __init__(self, **kwargs):
+    ...         super().__init__(**kwargs)
+    ...         self.l1 = tf.keras.layers.Dense(3)
+    ...         self.l2 = tf.keras.layers.Dense(4)
+
+    ...     def call(self, inputs):
+    ...         x = self.l1(inputs)
+    ...         x = self.l2(x)
+    ...         return x
 
 
-    >>> class LayerZ(NestLayer):
-    >>>     def __init__(self, **kwargs):
-    >>>         super().__init__(**kwargs)
-    >>>         self.l1 = LayerX()
-    >>>         self.l2 = LayerX()
+    >>> class LayerZ(TFNestLayer):
+    ...     def __init__(self, **kwargs):
+    ...         super().__init__(**kwargs)
+    ...         self.l1 = LayerX()
+    ...         self.l2 = LayerX()
 
-    >>>     def call(self, inputs):
-    >>>         x = self.l1(inputs)
-    >>>         x = self.l2(x)
-    >>>         return x
+    ...     def call(self, inputs):
+    ...         x = self.l1(inputs)
+    ...         x = self.l2(x)
+    ...         return x
 
 
     >>> class NestLayerModel(tf.keras.Model):
-    >>>     def __init__(self, **kwargs):
-    >>>         super().__init__(**kwargs)
-    >>>         self.l1 = LayerZ()
-    >>>         self.l2 = LayerZ()
+    ...     def __init__(self, **kwargs):
+    ...         super().__init__(**kwargs)
+    ...         self.l1 = LayerZ()
+    ...         self.l2 = LayerZ()
 
-    >>>     def call(self, inputs):
-    >>>         x = self.l1(inputs)
-    >>>         x = self.l2(x)
-    >>>         return x
+    ...     def call(self, inputs):
+    ...         x = self.l1(inputs)
+    ...         x = self.l2(x)
+    ...         return x
+
 
     >>> nest_layer_model = NestLayerModel()
     >>> nest_layer_model.build(input_shape=(None, 10))
     >>> nest_layer_model.layers
     [<__main__.LayerZ at 0x2c116e100>, <__main__.LayerZ at 0x2c32188e0>]
 
-    >>> hasattr(nest_layer_model.layers[0], 'layers')
+    >>> hasattr(nest_layer_model.layers[0], "layers")
     True
+    ```
 
-    See related issue:
-    https://github.com/tensorflow/model-optimization/issues/638
+    See related issue: https://github.com/tensorflow/model-optimization/issues/638
     """
+
+    # From keras.engine.training.Model.layers
     @property
     def layers(self):
         return list(self._flatten_layers(include_self=False, recursive=False))
+
+    # From keras.engine.training.Model.get_layer
+    def get_layer(self, name=None, index=None):
+        """
+        Retrieves a layer based on either its name (unique) or index.
+
+        If `name` and `index` are both provided, `index` will take precedence. Indices are based on order of horizontal
+        graph traversal (bottom-up).
+
+        Args:
+            name: String, name of layer.
+            index: Integer, index of layer.
+
+        Returns:
+            A layer instance.
+        """
+        if index is not None and name is not None:
+            raise ValueError(f"Provide only a layer name or a layer index. Received: index={index}, name={name}.")
+
+        if index is not None:
+            if len(self.layers) <= index:
+                raise ValueError(
+                    f"Was asked to retrieve layer at index {index} but model only has {len(self.layers)} layers."
+                )
+            else:
+                return self.layers[index]
+
+        if name is not None:
+            for layer in self.layers:
+                if layer.name == name:
+                    return layer
+            raise ValueError(
+                f"No such layer: {name}. Existing layers are: {list(layer.name for layer in self.layers)}."
+            )
+        raise ValueError("Provide either a layer name or layer index at `get_layer`.")
 
 
 class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, PushToHubMixin):


### PR DESCRIPTION
# What does this PR do?

Outline for a new layer class to replace `tf.keras.layers.Layer` in our models. It extends `tf.keras.layers.Layer` to include two methods `get_layer` and `layers` from `tf.keras.Model`.

## Motivation

All of our TF models' layers are subclasses of `tf.keras.layers.Layer`. Unfortunately, when there are nested layers, we are not able to access the layers below the first level using the typical keras `layers` API. 

The main reason for introducing to be able to use our models as backbones. In DETR, we replace the ResNet backbone's [batchnorm layers to frozen batchnorm layers](https://github.com/huggingface/transformers/blob/2ab790e82d0759b667cd848a4d49e6ad65e15d59/src/transformers/models/detr/modeling_detr.py#L306). We need to be able to perform the same or similar operations on our TF models. This requires being able to access all of the layers, which is currently not possible. 

For example - our `TFResNetModel` will only show `TFResNetMainLayer` when we call `model.summary(expand_nested=True)` and `TFResNetMainLayer` has no property `layers`. 

```
In [1]: from transformers import TFResNetModel
In [2]: model_checkpoint = "microsoft/resnet-50"
In [3]: model = TFResNetModel.from_pretrained(model_checkpoint)
In [4]: model.summary(expand_nested=True)
Model: "tf_res_net_model"
_________________________________________________________________
 Layer (type)                Output Shape              Param #
=================================================================
 resnet (TFResNetMainLayer)  multiple                  23561152

=================================================================
Total params: 23,561,152
Trainable params: 23,508,032
Non-trainable params: 53,120
_________________________________________________________________

In [5]: model.layers
Out[5]: [<transformers.models.resnet.modeling_tf_resnet.TFResNetMainLayer at 0x17fb9daf0>]

In [6]: hasattr(model.layers[0], 'layers')
Out[6]: False
```

This is also necessary if we every want to be able to access the intermediate activation functions of our TF model.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
