### PR TITLE
Add cross entropy loss with stable custom gradient

### DIFF
--- a/examples/flax/language-modeling/README.md
+++ b/examples/flax/language-modeling/README.md
@@ -338,6 +338,8 @@ of 2.36 and 57.0 respectively after 3 epochs on a single TPUv3-8.
 This should take around 4.5 hours.
 Training statistics can be accessed on directly on the 🤗 [hub](https://huggingface.co/patrickvonplaten/t5-base-norwegian/tensorboard)
 
+If you want to pre-train using `--dtype="bfloat16"`, make sure to set `--z_loss="1e-4"` to ensure stable gradients.
+
 ## BART: Denoising language modeling
 
 In the following, we demonstrate how to train a BART model 

--- a/examples/flax/language-modeling/losses.py
+++ b/examples/flax/language-modeling/losses.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+# coding=utf-8
+# Copyright 2021 The HuggingFace Team All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Loss functions."""
+from typing import Optional, Tuple
+
+import numpy as np
+
+import jax
+import jax.numpy as jnp
+from flax.training import common_utils
+
+
+@jax.custom_vjp
+def cross_entropy_with_logits(logits: jnp.ndarray, targets: jnp.ndarray, z_loss: float) -> jnp.ndarray:
+    """Computes cross entropy loss with stable custom gradient.
+
+    This function is copy of `cross_entropy_with_logits <https://github.com/google-research/t5x/blob/90d74fa703075d8b9808ae572602bc48759f8bcc/t5x/losses.py#L25`__ .
+
+    Authored by the T5X Authors
+
+    Computes a stabilized-gradient version of:
+      -jnp.sum(targets * nn.log_softmax(logits), axis=-1)
+
+    If z_loss > 0, then an auxiliary loss equal to z_loss*log(z)^2
+    will be added to the cross entropy loss (z = softmax normalization constant).
+    The two uses of z_loss are:
+    1. To keep the logits from drifting too far from zero, which can cause
+       unacceptable roundoff errors in bfloat16.
+    2. To encourage the logits to be normalized log-probabilities.
+
+    Args:
+      logits: [batch, length, num_classes] float array.
+      targets: categorical one-hot targets [batch, length, num_classes] float
+        array.
+      z_loss: coefficient for auxilliary z-loss loss term.
+
+    Returns:
+      tuple with the total loss and the z_loss, both
+      float arrays with shape [batch, length].
+    """
+    logits_sum = jax.scipy.special.logsumexp(logits, axis=-1, keepdims=True)
+    log_softmax = logits - logits_sum
+    loss = -jnp.sum(targets * log_softmax, axis=-1)
+    # Add auxilliary z-loss term.
+    log_z = jnp.squeeze(logits_sum, axis=-1)
+    total_z_loss = z_loss * jax.lax.square(log_z)
+    loss += total_z_loss
+    return loss, total_z_loss
+
+
+def _cross_entropy_with_logits_fwd(
+    logits: jnp.ndarray, targets: jnp.ndarray, z_loss: float = 0.0
+) -> Tuple[
+    jnp.ndarray, Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]
+]:
+    """Forward-mode of `cross_entropy_with_logits`."""
+    max_logit = logits.max(axis=-1, keepdims=True)
+    shifted = logits - max_logit
+    exp_shifted = jnp.exp(shifted)
+    sum_exp = jnp.sum(exp_shifted, axis=-1, keepdims=True)
+    log_softmax = shifted - jnp.log(sum_exp)
+    loss = -jnp.sum(targets * log_softmax, axis=-1)
+    # Add auxilliary z-loss term.
+    log_z = jnp.squeeze(jnp.log(sum_exp) + max_logit, axis=-1)
+    total_z_loss = z_loss * jax.lax.square(log_z)
+    loss += total_z_loss
+    return (loss, total_z_loss), (logits, targets, z_loss, exp_shifted, sum_exp, log_softmax, log_z)
+
+
+def _cross_entropy_with_logits_bwd(
+    res: Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray],
+    g: Tuple[jnp.ndarray, jnp.ndarray],
+) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Backward-mode of `cross_entropy_with_logits`."""
+    g = g[0]  # Ignore z_loss component as that is only used for logging.
+    logits, targets, z_loss, exp_shifted, sum_exp, log_softmax, log_z = res
+    # z-loss term adds the (2 * z_loss * log_z) factor.
+    deriv = jnp.expand_dims(1 + 2 * z_loss * log_z, -1) * exp_shifted / sum_exp - targets
+    g_logits = jnp.expand_dims(g, axis=-1) * deriv
+    g_targets = -jnp.expand_dims(g, axis=-1) * log_softmax
+    return (
+        jnp.asarray(g_logits, logits.dtype),
+        jnp.asarray(g_targets, targets.dtype),
+        jnp.array(0.0),
+    )  # sets z-loss coeff gradient to 0
+
+
+cross_entropy_with_logits.defvjp(_cross_entropy_with_logits_fwd, _cross_entropy_with_logits_bwd)
+
+
+def compute_weighted_cross_entropy(
+    logits: jnp.ndarray,
+    targets: jnp.ndarray,
+    weights: Optional[jnp.ndarray] = None,
+    label_smoothing: float = 0.0,
+    z_loss: float = 0.0,
+    loss_normalizing_factor: Optional[float] = None,
+) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Compute weighted cross entropy and entropy for log probs and targets.
+
+    Args:
+     logits: [batch, length, num_classes] float array.
+     targets: categorical targets [batch, length] int array.
+     weights: None or array of shape [batch, length].
+     label_smoothing: label smoothing constant, used to determine the on and off
+       values.
+     z_loss: coefficient for auxiliary z-loss loss term.
+     loss_normalizing_factor: Constant to divide loss by. If not specified, loss
+       will not be normalized. Intended for backward compatibility with T5-MTF
+       training. Should not normally be used.
+
+    Returns:
+      Tuple of scalar loss, z_loss, and weight sum.
+    """
+    if logits.ndim != targets.ndim + 1:
+        raise ValueError(
+            "Incorrect shapes. Got shape %s logits and %s targets" % (str(logits.shape), str(targets.shape))
+        )
+    vocab_size = logits.shape[-1]
+    confidence = 1.0 - label_smoothing
+    low_confidence = (1.0 - confidence) / (vocab_size - 1)
+    normalizing_constant = -(
+        confidence * jnp.log(confidence) + (vocab_size - 1) * low_confidence * jnp.log(low_confidence + 1e-20)
+    )
+    soft_targets = common_utils.onehot(targets, vocab_size, on_value=confidence, off_value=low_confidence)
+    total_loss, total_z_loss = cross_entropy_with_logits(logits, soft_targets, z_loss=z_loss)
+    total_loss = total_loss - normalizing_constant
+
+    weight_sum = np.prod(targets.shape)
+    if weights is not None:
+        total_loss = total_loss * weights
+        total_z_loss = total_z_loss * weights
+        weight_sum = jnp.sum(weights)
+
+    # By default, we do not normalize loss based on anything.
+    # We don't normalize based on batch size because the optimizers we use are
+    # pretty much scale invariant, so this simplifies things.
+    # We don't normalize based on number of non-padding tokens in order to treat
+    # each token as equally important regardless of sequence length.
+    if loss_normalizing_factor is not None:
+        total_loss /= loss_normalizing_factor
+        total_z_loss /= loss_normalizing_factor
+    return jnp.sum(total_loss), jnp.sum(total_z_loss), weight_sum


### PR DESCRIPTION
# What does this PR do?

This PR adds Flax code for a cross entropy loss calculation with an additional term to stabilize gradients for bfloat16 training.

The loss function is authored by the T5X Authors (https://github.com/google-research/t5x/blob/90d74fa703075d8b9808ae572602bc48759f8bcc/t5x/losses.py#L25)

Also add 'z_loss' as training argument to the T5 Flax pre-training script.

If z_loss > 0, then an auxiliary loss equal to z_loss*log(z)^2
will be added to the cross entropy loss (z = softmax normalization constant).

The two uses of z_loss are:
  1. To keep the logits from drifting too far from zero, which can cause
     unacceptable roundoff errors in bfloat16.
  2. To encourage the logits to be normalized log-probabilities.

While the z_loss function is only added to the t5 flax pretraining script, this loss function might be interesting for
other flax pre-training scripts. I did not test this.
Finally, there is a (currently unused) function `compute_weighted_cross_entropy` with z_loss and label smoothing,
which might be useful for other flax training scripts as well.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [*] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [*] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

No but I tested with the t5 flax norwegian script, bfloat16 and z_loss set to 1e-4, the setting used in t5 gin configs.

In my own tests I've seen the following consistently:
Without z_loss and bfloat16, the loss will either diverge or converge on a higher plateau than training with float32.
With z_loss and bfloat16, set to 1e-4, loss curves almost match curves with float32 training.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@patrickvonplaten, @patil-suraj

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.
