### PR TITLE
Allow empty reference summaries

### DIFF
--- a/examples/pytorch/summarization/run_summarization.py
+++ b/examples/pytorch/summarization/run_summarization.py
@@ -515,11 +515,11 @@ def main():
         inputs, targets = [], []
         for i in range(len(examples[text_column])):
             if examples[text_column][i]:
-                if not examples[summary_column][i] and not warned_about_empty:
+                if not examples[summary_column][i] and not empty_summary_warning["warned"]:
                     logger.warning(
                         "Found an empty reference summary. This will be included in the preprocessed dataset."
                     )
-                    warned_about_empty = True
+                    empty_summary_warning["warned"] = True
                 inputs.append(examples[text_column][i])
                 targets.append(examples[summary_column][i])
 
@@ -540,7 +540,7 @@ def main():
         return model_inputs
 
     # A flag to determine whether we have already warned about empty summaries.
-    warned_about_empty = False
+    empty_summary_warning = {"warned": False}
 
     if training_args.do_train:
         if "train" not in raw_datasets:

--- a/examples/pytorch/summarization/run_summarization.py
+++ b/examples/pytorch/summarization/run_summarization.py
@@ -516,7 +516,12 @@ def main():
 
         inputs, targets = [], []
         for i in range(len(examples[text_column])):
-            if examples[text_column][i] is not None and examples[summary_column][i] is not None:
+            if examples[text_column][i]:
+                if not examples[summary_column][i]:
+                    logger.warning(
+                        f"Found an empty reference summary at index {i}. This will be included in the preprocessed"
+                        " dataset."
+                    )
                 inputs.append(examples[text_column][i])
                 targets.append(examples[summary_column][i])
 

--- a/examples/pytorch/summarization/run_summarization.py
+++ b/examples/pytorch/summarization/run_summarization.py
@@ -512,7 +512,6 @@ def main():
         )
 
     def preprocess_function(examples):
-        warned_about_empty = False
         inputs, targets = [], []
         for i in range(len(examples[text_column])):
             if examples[text_column][i]:
@@ -539,6 +538,9 @@ def main():
 
         model_inputs["labels"] = labels["input_ids"]
         return model_inputs
+
+    # A flag to determine whether we have already warned about empty summaries.
+    warned_about_empty = False
 
     if training_args.do_train:
         if "train" not in raw_datasets:

--- a/examples/pytorch/summarization/run_summarization.py
+++ b/examples/pytorch/summarization/run_summarization.py
@@ -516,7 +516,7 @@ def main():
 
         inputs, targets = [], []
         for i in range(len(examples[text_column])):
-            if examples[text_column][i] and examples[summary_column][i]:
+            if examples[text_column][i] is not None and examples[summary_column][i] is not None:
                 inputs.append(examples[text_column][i])
                 targets.append(examples[summary_column][i])
 

--- a/examples/pytorch/summarization/run_summarization.py
+++ b/examples/pytorch/summarization/run_summarization.py
@@ -512,16 +512,15 @@ def main():
         )
 
     def preprocess_function(examples):
-        # remove pairs where at least one record is None
-
+        warned_about_empty = False
         inputs, targets = [], []
         for i in range(len(examples[text_column])):
             if examples[text_column][i]:
-                if not examples[summary_column][i]:
+                if not examples[summary_column][i] and not warned_about_empty:
                     logger.warning(
-                        f"Found an empty reference summary at index {i}. This will be included in the preprocessed"
-                        " dataset."
+                        "Found an empty reference summary. This will be included in the preprocessed dataset."
                     )
+                    warned_about_empty = True
                 inputs.append(examples[text_column][i])
                 targets.append(examples[summary_column][i])
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

The `run_summarization.py` has a check to skip examples where either the `text_column` or `summary_column` is `None`.  However, the way the check was written would catch any falsely values, like an empty string.

This caused all examples to be skipped for datasets where either the `text_column` or `summary_column` was the empty string (e.g. the test set of the [MS^2 dataset](https://huggingface.co/datasets/allenai/mslr2022)).

This PR just updates the check so it looks for `None` values explicitly.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
