### PR TITLE
Pin `detectron2` for CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1003,6 +1003,9 @@ jobs:
             - run: pip install --upgrade pip
             - run: pip install .[torch,testing,vision]
             - run: pip install torchvision
+            # The commit `36a65a0907d90ed591479b2ebaa8b61cfa0b4ef0` in `detectron2` break things.
+            # See https://github.com/facebookresearch/detectron2/commit/36a65a0907d90ed591479b2ebaa8b61cfa0b4ef0#comments.
+            # TODO: Revert this change back once the above issue is fixed.
             - run: python -m pip install 'git+https://github.com/facebookresearch/detectron2.git@5aeb252b194b93dc2879b4ac34bc51a31b5aee13'
             - run: sudo apt install tesseract-ocr
             - run: pip install pytesseract

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1003,7 +1003,7 @@ jobs:
             - run: pip install --upgrade pip
             - run: pip install .[torch,testing,vision]
             - run: pip install torchvision
-            - run: python -m pip install 'git+https://github.com/facebookresearch/detectron2.git'
+            - run: python -m pip install 'git+https://github.com/facebookresearch/detectron2.git@5aeb252b194b93dc2879b4ac34bc51a31b5aee13'
             - run: sudo apt install tesseract-ocr
             - run: pip install pytesseract
             - save_cache:


### PR DESCRIPTION
# What does this PR do?

The commit `36a65a0907d90ed591479b2ebaa8b61cfa0b4ef0` in `detectron2 ` break things, see [here](https://github.com/facebookresearch/detectron2/commit/36a65a0907d90ed591479b2ebaa8b61cfa0b4ef0#comments).

Ping the parent commit until that issue is fixed.

Issue found by @amyeroberts 