### PR TITLE
Fix train_step, test_step and tests for CLIP

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1389,7 +1389,10 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
 
         # Run forward pass.
         with tf.GradientTape() as tape:
-            y_pred = self(x, training=True)
+            if self._using_dummy_loss and "return_loss" in arg_names:
+                y_pred = self(x, training=True, return_loss=True)
+            else:
+                y_pred = self(x, training=True)
             if self._using_dummy_loss:
                 loss = self.compiled_loss(y_pred.loss, y_pred.loss, sample_weight, regularization_losses=self.losses)
             else:
@@ -1492,7 +1495,10 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             y = {label_to_output.get(key, key): val for key, val in y.items()}
 
         # Run forward pass.
-        y_pred = self(x, training=False)
+        if self._using_dummy_loss and "return_loss" in arg_names:
+            y_pred = self(x, return_loss=True, training=False)
+        else:
+            y_pred = self(x, training=False)
         if self._using_dummy_loss:
             loss = self.compiled_loss(y_pred.loss, y_pred.loss, sample_weight, regularization_losses=self.losses)
         else:

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1394,12 +1394,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             else:
                 y_pred = self(x, training=True)
             if self._using_dummy_loss:
-                if y_pred.loss.shape.rank == 0:
-                    # Scalar losses confuse Keras - reshape to (1,) to avoid this
-                    y_pred_loss = tf.reshape(y_pred.loss, (1,))
-                else:
-                    y_pred_loss = y_pred.loss
-                loss = self.compiled_loss(y_pred_loss, y_pred_loss, sample_weight, regularization_losses=self.losses)
+                loss = self.compiled_loss(y_pred.loss, y_pred.loss, sample_weight, regularization_losses=self.losses)
             else:
                 loss = None
 
@@ -1505,12 +1500,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         else:
             y_pred = self(x, training=False)
         if self._using_dummy_loss:
-            if y_pred.loss.shape.rank == 0:
-                # Scalar losses confuse Keras - reshape to (1,) to avoid this
-                y_pred_loss = tf.reshape(y_pred.loss, (1,))
-            else:
-                y_pred_loss = y_pred.loss
-            loss = self.compiled_loss(y_pred_loss, y_pred_loss, sample_weight, regularization_losses=self.losses)
+            loss = self.compiled_loss(y_pred.loss, y_pred.loss, sample_weight, regularization_losses=self.losses)
         else:
             loss = None
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1394,7 +1394,12 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             else:
                 y_pred = self(x, training=True)
             if self._using_dummy_loss:
-                loss = self.compiled_loss(y_pred.loss, y_pred.loss, sample_weight, regularization_losses=self.losses)
+                if y_pred.loss.shape.rank == 0:
+                    # Scalar losses confuse Keras - reshape to (1,) to avoid this
+                    y_pred_loss = tf.reshape(y_pred.loss, (1,))
+                else:
+                    y_pred_loss = y_pred.loss
+                loss = self.compiled_loss(y_pred_loss, y_pred_loss, sample_weight, regularization_losses=self.losses)
             else:
                 loss = None
 
@@ -1500,7 +1505,12 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         else:
             y_pred = self(x, training=False)
         if self._using_dummy_loss:
-            loss = self.compiled_loss(y_pred.loss, y_pred.loss, sample_weight, regularization_losses=self.losses)
+            if y_pred.loss.shape.rank == 0:
+                # Scalar losses confuse Keras - reshape to (1,) to avoid this
+                y_pred_loss = tf.reshape(y_pred.loss, (1,))
+            else:
+                y_pred_loss = y_pred.loss
+            loss = self.compiled_loss(y_pred_loss, y_pred_loss, sample_weight, regularization_losses=self.losses)
         else:
             loss = None
 

--- a/src/transformers/models/clip/modeling_tf_clip.py
+++ b/src/transformers/models/clip/modeling_tf_clip.py
@@ -874,6 +874,7 @@ class TFCLIPMainLayer(tf.keras.layers.Layer):
         loss = None
         if return_loss:
             loss = clip_loss(logits_per_text)
+            loss = tf.reshape(loss, (1,))
 
         if not return_dict:
             output = (logits_per_image, logits_per_text, text_embeds, image_embeds, text_outputs, vision_outputs)

--- a/src/transformers/models/deit/modeling_tf_deit.py
+++ b/src/transformers/models/deit/modeling_tf_deit.py
@@ -852,6 +852,7 @@ class TFDeiTForMaskedImageModeling(TFDeiTPreTrainedModel):
             total_loss = tf.reduce_sum(reconstruction_loss * mask)
             num_masked_pixels = (tf.reduce_sum(mask) + 1e-5) * self.config.num_channels
             masked_im_loss = total_loss / num_masked_pixels
+            masked_im_loss = tf.reshape(masked_im_loss, (1,))
 
         if not return_dict:
             output = (reconstructed_pixel_values,) + outputs[1:]

--- a/src/transformers/models/hubert/modeling_tf_hubert.py
+++ b/src/transformers/models/hubert/modeling_tf_hubert.py
@@ -1677,8 +1677,10 @@ class TFHubertForCTC(TFHubertPreTrainedModel):
 
             if self.config.ctc_loss_reduction == "sum":
                 loss = tf.reduce_sum(loss)
+                loss = tf.reshape(loss, (1,))
             if self.config.ctc_loss_reduction == "mean":
                 loss = tf.reduce_mean(loss)
+                loss = tf.reshape(loss, (1,))
         else:
             loss = None
 

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -95,7 +95,7 @@ class TFMobileBertPreTrainingLoss:
     computation.
     """
 
-    # Copied from transformers.models.bert.tf_modeling_bert.TFBertPreTrainingLoss.hf_compute_loss
+    # Copied from transformers.models.bert.modeling_tf_bert.TFBertPreTrainingLoss.hf_compute_loss
     def hf_compute_loss(self, labels: tf.Tensor, logits: tf.Tensor) -> tf.Tensor:
         loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(
             from_logits=True, reduction=tf.keras.losses.Reduction.NONE

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -1076,6 +1076,7 @@ class TFMobileBertForPreTraining(TFMobileBertPreTrainedModel, TFMobileBertPreTra
         prediction_scores = self.predictions(sequence_output)
         seq_relationship_score = self.seq_relationship(pooled_output)
 
+        total_loss = None
         if labels is not None and next_sentence_label is not None:
             d_labels = {"labels": labels}
             d_labels["next_sentence_label"] = next_sentence_label

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -87,7 +87,6 @@ TF_MOBILEBERT_PRETRAINED_MODEL_ARCHIVE_LIST = [
     # See all MobileBERT models at https://huggingface.co/models?filter=mobilebert
 ]
 
-# Copied from transformers.models.bert.tf_modeling_bert.TFBertPreTrainingLoss
 class TFMobileBertPreTrainingLoss:
     """
     Loss function suitable for BERT-like pretraining, that is, the task of pretraining a language model by combining
@@ -95,6 +94,7 @@ class TFMobileBertPreTrainingLoss:
     computation.
     """
 
+    # Copied from transformers.models.bert.tf_modeling_bert.TFBertPreTrainingLoss.hf_compute_loss
     def hf_compute_loss(self, labels: tf.Tensor, logits: tf.Tensor) -> tf.Tensor:
         loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(
             from_logits=True, reduction=tf.keras.losses.Reduction.NONE
@@ -116,6 +116,7 @@ class TFMobileBertPreTrainingLoss:
         reduced_masked_ns_loss = tf.reduce_sum(masked_ns_loss) / tf.reduce_sum(ns_loss_mask)
 
         return tf.reshape(reduced_masked_lm_loss + reduced_masked_ns_loss, (1,))
+
 
 class TFMobileBertIntermediate(tf.keras.layers.Layer):
     def __init__(self, config, **kwargs):

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -87,6 +87,7 @@ TF_MOBILEBERT_PRETRAINED_MODEL_ARCHIVE_LIST = [
     # See all MobileBERT models at https://huggingface.co/models?filter=mobilebert
 ]
 
+
 class TFMobileBertPreTrainingLoss:
     """
     Loss function suitable for BERT-like pretraining, that is, the task of pretraining a language model by combining

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -1040,6 +1040,8 @@ class TFMobileBertForPreTraining(TFMobileBertPreTrainedModel, TFMobileBertPreTra
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
+        labels: Optional[Union[np.ndarray, tf.Tensor]] = None,
+        next_sentence_label: Optional[Union[np.ndarray, tf.Tensor]] = None,
         training: Optional[bool] = False,
     ) -> Union[Tuple, TFMobileBertForPreTrainingOutput]:
         r"""

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -87,6 +87,35 @@ TF_MOBILEBERT_PRETRAINED_MODEL_ARCHIVE_LIST = [
     # See all MobileBERT models at https://huggingface.co/models?filter=mobilebert
 ]
 
+# Copied from transformers.models.bert.tf_modeling_bert.TFBertPreTrainingLoss
+class TFMobileBertPreTrainingLoss:
+    """
+    Loss function suitable for BERT-like pretraining, that is, the task of pretraining a language model by combining
+    NSP + MLM. .. note:: Any label of -100 will be ignored (along with the corresponding logits) in the loss
+    computation.
+    """
+
+    def hf_compute_loss(self, labels: tf.Tensor, logits: tf.Tensor) -> tf.Tensor:
+        loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(
+            from_logits=True, reduction=tf.keras.losses.Reduction.NONE
+        )
+
+        # Clip negative labels to zero here to avoid NaNs and errors - those positions will get masked later anyway
+        unmasked_lm_losses = loss_fn(y_true=tf.nn.relu(labels["labels"]), y_pred=logits[0])
+        # make sure only labels that are not equal to -100
+        # are taken into account for the loss computation
+        lm_loss_mask = tf.cast(labels["labels"] != -100, dtype=unmasked_lm_losses.dtype)
+        masked_lm_losses = unmasked_lm_losses * lm_loss_mask
+        reduced_masked_lm_loss = tf.reduce_sum(masked_lm_losses) / tf.reduce_sum(lm_loss_mask)
+
+        # Clip negative labels to zero here to avoid NaNs and errors - those positions will get masked later anyway
+        unmasked_ns_loss = loss_fn(y_true=tf.nn.relu(labels["next_sentence_label"]), y_pred=logits[1])
+        ns_loss_mask = tf.cast(labels["next_sentence_label"] != -100, dtype=unmasked_ns_loss.dtype)
+        masked_ns_loss = unmasked_ns_loss * ns_loss_mask
+
+        reduced_masked_ns_loss = tf.reduce_sum(masked_ns_loss) / tf.reduce_sum(ns_loss_mask)
+
+        return tf.reshape(reduced_masked_lm_loss + reduced_masked_ns_loss, (1,))
 
 class TFMobileBertIntermediate(tf.keras.layers.Layer):
     def __init__(self, config, **kwargs):
@@ -981,7 +1010,7 @@ class TFMobileBertModel(TFMobileBertPreTrainedModel):
     """,
     MOBILEBERT_START_DOCSTRING,
 )
-class TFMobileBertForPreTraining(TFMobileBertPreTrainedModel):
+class TFMobileBertForPreTraining(TFMobileBertPreTrainedModel, TFMobileBertPreTrainingLoss):
     def __init__(self, config, *inputs, **kwargs):
         super().__init__(config, *inputs, **kwargs)
         self.mobilebert = TFMobileBertMainLayer(config, name="mobilebert")
@@ -1043,10 +1072,17 @@ class TFMobileBertForPreTraining(TFMobileBertPreTrainedModel):
         prediction_scores = self.predictions(sequence_output)
         seq_relationship_score = self.seq_relationship(pooled_output)
 
+        if labels is not None and next_sentence_label is not None:
+            d_labels = {"labels": labels}
+            d_labels["next_sentence_label"] = next_sentence_label
+            total_loss = self.hf_compute_loss(labels=d_labels, logits=(prediction_scores, seq_relationship_score))
+
         if not return_dict:
-            return (prediction_scores, seq_relationship_score) + outputs[2:]
+            output = (prediction_scores, seq_relationship_score) + outputs[2:]
+            return ((total_loss,) + output) if total_loss is not None else output
 
         return TFMobileBertForPreTrainingOutput(
+            loss=total_loss,
             prediction_logits=prediction_scores,
             seq_relationship_logits=seq_relationship_score,
             hidden_states=outputs.hidden_states,

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -88,6 +88,7 @@ TF_MOBILEBERT_PRETRAINED_MODEL_ARCHIVE_LIST = [
 ]
 
 
+# Copied from transformers.models.bert.modeling_tf_bert.TFBertPreTrainingLoss
 class TFMobileBertPreTrainingLoss:
     """
     Loss function suitable for BERT-like pretraining, that is, the task of pretraining a language model by combining
@@ -95,7 +96,6 @@ class TFMobileBertPreTrainingLoss:
     computation.
     """
 
-    # Copied from transformers.models.bert.modeling_tf_bert.TFBertPreTrainingLoss.hf_compute_loss
     def hf_compute_loss(self, labels: tf.Tensor, logits: tf.Tensor) -> tf.Tensor:
         loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(
             from_logits=True, reduction=tf.keras.losses.Reduction.NONE

--- a/src/transformers/models/swin/modeling_tf_swin.py
+++ b/src/transformers/models/swin/modeling_tf_swin.py
@@ -1382,6 +1382,7 @@ class TFSwinForMaskedImageModeling(TFSwinPreTrainedModel):
             total_loss = tf.reduce_sum(reconstruction_loss * mask)
             num_masked_pixels = (tf.reduce_sum(mask) + 1e-5) * self.config.num_channels
             masked_im_loss = total_loss / num_masked_pixels
+            masked_im_loss = tf.reshape(masked_im_loss, (1,))
 
         if not return_dict:
             output = (reconstructed_pixel_values,) + outputs[2:]

--- a/src/transformers/models/tapas/modeling_tf_tapas.py
+++ b/src/transformers/models/tapas/modeling_tf_tapas.py
@@ -1431,7 +1431,7 @@ class TFTapasForQuestionAnswering(TFTapasPreTrainedModel):
             logits_aggregation = self.aggregation_classifier(pooled_output)
 
         # Total loss calculation
-        total_loss = 0.0
+        total_loss = tf.zeros(shape=(1,), dtype=tf.float32)
         calculate_loss = False
         if labels is not None:
             calculate_loss = True

--- a/src/transformers/models/vit_mae/modeling_tf_vit_mae.py
+++ b/src/transformers/models/vit_mae/modeling_tf_vit_mae.py
@@ -1085,6 +1085,7 @@ class TFViTMAEForPreTraining(TFViTMAEPreTrainedModel):
         loss = tf.reduce_mean(loss, axis=-1)  # [batch_size, num_patches], mean loss per patch
 
         loss = tf.reduce_sum(loss * mask) / tf.reduce_sum(mask)  # mean loss on removed patches
+        loss = tf.reshape(loss, (1,))
         return loss
 
     @unpack_inputs

--- a/tests/models/hubert/test_modeling_tf_hubert.py
+++ b/tests/models/hubert/test_modeling_tf_hubert.py
@@ -325,6 +325,10 @@ class TFHubertModelTest(TFModelTesterMixin, unittest.TestCase):
         model = TFHubertModel.from_pretrained("facebook/hubert-base-ls960")
         self.assertIsNotNone(model)
 
+    @unittest.skip("Loss shapes for CTC don't match the base test.")
+    def test_loss_computation(self):
+        pass
+
 
 @require_tf
 class TFHubertRobustModelTest(TFModelTesterMixin, unittest.TestCase):
@@ -442,6 +446,10 @@ class TFHubertRobustModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_model_from_pretrained(self):
         model = TFHubertModel.from_pretrained("facebook/hubert-large-ls960-ft")
         self.assertIsNotNone(model)
+
+    @unittest.skip("Loss shapes for CTC don't match the base test.")
+    def test_loss_computation(self):
+        pass
 
 
 @require_tf

--- a/tests/models/mobilebert/test_modeling_tf_mobilebert.py
+++ b/tests/models/mobilebert/test_modeling_tf_mobilebert.py
@@ -17,6 +17,7 @@
 import unittest
 
 from transformers import MobileBertConfig, is_tf_available
+from transformers.models.auto import get_values
 from transformers.testing_utils import require_tf, slow, tooslow
 
 from ...test_configuration_common import ConfigTester
@@ -27,6 +28,7 @@ if is_tf_available():
     import tensorflow as tf
 
     from transformers import (
+        TF_MODEL_FOR_PRETRAINING_MAPPING,
         TFMobileBertForMaskedLM,
         TFMobileBertForMultipleChoice,
         TFMobileBertForNextSentencePrediction,
@@ -57,6 +59,16 @@ class TFMobileBertModelTest(TFModelTesterMixin, unittest.TestCase):
     )
     test_head_masking = False
     test_onnx = False
+
+    # special case for ForPreTraining model, same as BERT tests
+    def _prepare_for_class(self, inputs_dict, model_class, return_labels=False):
+        inputs_dict = super()._prepare_for_class(inputs_dict, model_class, return_labels=return_labels)
+
+        if return_labels:
+            if model_class in get_values(TF_MODEL_FOR_PRETRAINING_MAPPING):
+                inputs_dict["next_sentence_label"] = tf.zeros(self.model_tester.batch_size, dtype=tf.int32)
+
+        return inputs_dict
 
     class TFMobileBertModelTester(object):
         def __init__(

--- a/tests/models/tapas/test_modeling_tf_tapas.py
+++ b/tests/models/tapas/test_modeling_tf_tapas.py
@@ -362,7 +362,7 @@ class TFTapasModelTester:
             "labels": labels,
         }
         result = model(inputs)
-        self.parent.assertEqual(result.loss.shape, ())
+        self.parent.assertEqual(result.loss.shape, (1,))
         self.parent.assertEqual(result.logits.shape, (self.batch_size, self.seq_length))
 
         # case 2: weak supervision for aggregation (WTQ)
@@ -377,7 +377,7 @@ class TFTapasModelTester:
             "float_answer": float_answer,
         }
         result = model(inputs)
-        self.parent.assertEqual(result.loss.shape, ())
+        self.parent.assertEqual(result.loss.shape, (1,))
         self.parent.assertEqual(result.logits.shape, (self.batch_size, self.seq_length))
         self.parent.assertEqual(result.logits_aggregation.shape, (self.batch_size, self.num_aggregation_labels))
 
@@ -393,7 +393,7 @@ class TFTapasModelTester:
             "aggregation_labels": aggregation_labels,
         }
         result = model(inputs)
-        self.parent.assertEqual(result.loss.shape, ())
+        self.parent.assertEqual(result.loss.shape, (1,))
         self.parent.assertEqual(result.logits.shape, (self.batch_size, self.seq_length))
         self.parent.assertEqual(result.logits_aggregation.shape, (self.batch_size, self.num_aggregation_labels))
 

--- a/tests/models/tapas/test_modeling_tf_tapas.py
+++ b/tests/models/tapas/test_modeling_tf_tapas.py
@@ -502,6 +502,14 @@ class TFTapasModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_dataset_conversion(self):
         pass
 
+    @unittest.skip(reason="The default test gets NaN losses with the test-generated inputs")
+    def test_keras_fit(self):
+        pass
+
+    @unittest.skip(reason="The default test gets NaN losses with the test-generated inputs")
+    def test_loss_computation(self):
+        pass
+
 
 def prepare_tapas_single_inputs_for_inference():
     # Here we prepare a single table-question pair to test TAPAS inference on:

--- a/tests/models/wav2vec2/test_modeling_tf_wav2vec2.py
+++ b/tests/models/wav2vec2/test_modeling_tf_wav2vec2.py
@@ -53,7 +53,7 @@ class TFWav2Vec2ModelTester:
     def __init__(
         self,
         parent,
-        batch_size=13,
+        batch_size=3,
         seq_length=1024,
         is_training=False,
         hidden_size=16,
@@ -336,6 +336,10 @@ class TFWav2Vec2ModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_model_from_pretrained(self):
         model = TFWav2Vec2Model.from_pretrained("facebook/wav2vec2-base-960h")
         self.assertIsNotNone(model)
+    #
+    # @skip(reason="Dataset conversion crashes with the default options!")
+    # def test_dataset_conversion(self):
+    #     pass
 
 
 @require_tf

--- a/tests/models/wav2vec2/test_modeling_tf_wav2vec2.py
+++ b/tests/models/wav2vec2/test_modeling_tf_wav2vec2.py
@@ -341,6 +341,10 @@ class TFWav2Vec2ModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_dataset_conversion(self):
         pass
 
+    @unittest.skip(reason="Training goes OOM and crashes with the default options!")
+    def test_keras_fit(self):
+        pass
+
 
 @require_tf
 class TFWav2Vec2RobustModelTest(TFModelTesterMixin, unittest.TestCase):
@@ -461,6 +465,10 @@ class TFWav2Vec2RobustModelTest(TFModelTesterMixin, unittest.TestCase):
 
     @unittest.skip(reason="Dataset conversion goes OOM and crashes with the default options!")
     def test_dataset_conversion(self):
+        pass
+
+    @unittest.skip(reason="Training goes OOM and crashes with the default options!")
+    def test_keras_fit(self):
         pass
 
 

--- a/tests/models/wav2vec2/test_modeling_tf_wav2vec2.py
+++ b/tests/models/wav2vec2/test_modeling_tf_wav2vec2.py
@@ -337,10 +337,9 @@ class TFWav2Vec2ModelTest(TFModelTesterMixin, unittest.TestCase):
         model = TFWav2Vec2Model.from_pretrained("facebook/wav2vec2-base-960h")
         self.assertIsNotNone(model)
 
-    #
-    # @skip(reason="Dataset conversion crashes with the default options!")
-    # def test_dataset_conversion(self):
-    #     pass
+    @unittest.skip(reason="Dataset conversion goes OOM and crashes with the default options!")
+    def test_dataset_conversion(self):
+        pass
 
 
 @require_tf
@@ -459,6 +458,10 @@ class TFWav2Vec2RobustModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_model_from_pretrained(self):
         model = TFWav2Vec2Model.from_pretrained("facebook/wav2vec2-base-960h")
         self.assertIsNotNone(model)
+
+    @unittest.skip(reason="Dataset conversion goes OOM and crashes with the default options!")
+    def test_dataset_conversion(self):
+        pass
 
 
 @require_tf

--- a/tests/models/wav2vec2/test_modeling_tf_wav2vec2.py
+++ b/tests/models/wav2vec2/test_modeling_tf_wav2vec2.py
@@ -336,6 +336,7 @@ class TFWav2Vec2ModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_model_from_pretrained(self):
         model = TFWav2Vec2Model.from_pretrained("facebook/wav2vec2-base-960h")
         self.assertIsNotNone(model)
+
     #
     # @skip(reason="Dataset conversion crashes with the default options!")
     # def test_dataset_conversion(self):

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1359,7 +1359,6 @@ class TFModelTesterMixin:
                 continue
             # The number of elements in the loss should be the same as the number of elements in the label
             prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
-            breakpoint()
             added_label_names = sorted(list(prepared_for_class.keys() - inputs_dict.keys()), reverse=True)
             if not added_label_names:
                 continue  # This test is only for models with easily-separable labels

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -25,7 +25,7 @@ import unittest.mock as mock
 from dataclasses import fields
 from importlib import import_module
 from math import isnan
-from typing import List, Tuple, Union, get_args, get_origin, get_type_hints
+from typing import List, Tuple, Union, get_origin, get_type_hints
 
 from datasets import Dataset
 
@@ -131,7 +131,7 @@ def _return_type_has_loss(model):
         return False
     return_type = return_type["return"]
     if get_origin(return_type) is Union:
-        for type_annotation in get_args(return_type):
+        for type_annotation in return_type.__args__:
             if inspect.isclass(type_annotation) and issubclass(type_annotation, ModelOutput):
                 field_names = [field.name for field in fields(type_annotation)]
                 if "loss" in field_names:

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -191,7 +191,7 @@ class TFModelTesterMixin:
                 *get_values(TF_MODEL_FOR_PRETRAINING_MAPPING),
                 *get_values(TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING),
                 *get_values(TF_MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING),
-            ] and "labels" in dict(inspect.signature(self.call).parameters):
+            ] and "labels" in dict(inspect.signature(model_class.call).parameters):
                 inputs_dict["labels"] = tf.zeros(
                     (self.model_tester.batch_size, self.model_tester.seq_length), dtype=tf.int32
                 )

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1359,9 +1359,10 @@ class TFModelTesterMixin:
                 continue
             # The number of elements in the loss should be the same as the number of elements in the label
             prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
-            added_label = prepared_for_class[
-                sorted(list(prepared_for_class.keys() - inputs_dict.keys()), reverse=True)[0]
-            ]
+            added_label_names = sorted(list(prepared_for_class.keys() - inputs_dict.keys()), reverse=True)
+            if not added_label_names:
+                continue  # This test is only for models with easily-separable labels
+            added_label = prepared_for_class[added_label_names[0]]
             expected_loss_size = added_label.shape.as_list()[:1]
 
             # Test that model correctly compute the loss with kwargs

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1373,7 +1373,7 @@ class TFModelTesterMixin:
 
             # Test that model correctly compute the loss with kwargs
             prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
-            possible_input_names = {"input_ids", "pixel_values", "input_features"}
+            possible_input_names = {"input_ids", "pixel_values", "input_features", "input_values"}
             input_name = possible_input_names.intersection(set(prepared_for_class)).pop()
             model_input = prepared_for_class.pop(input_name)
 
@@ -1382,7 +1382,7 @@ class TFModelTesterMixin:
 
             # Test that model correctly compute the loss when we mask some positions
             prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
-            possible_input_names = {"input_ids", "pixel_values", "input_features"}
+            possible_input_names = {"input_ids", "pixel_values", "input_features", "input_values"}
             input_name = possible_input_names.intersection(set(prepared_for_class)).pop()
             model_input = prepared_for_class.pop(input_name)
             if "labels" in prepared_for_class:

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1359,6 +1359,7 @@ class TFModelTesterMixin:
                 continue
             # The number of elements in the loss should be the same as the number of elements in the label
             prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
+            breakpoint()
             added_label_names = sorted(list(prepared_for_class.keys() - inputs_dict.keys()), reverse=True)
             if not added_label_names:
                 continue  # This test is only for models with easily-separable labels

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -142,6 +142,7 @@ def _return_type_has_loss(model):
     elif isinstance(return_type, ModelOutput):
         class_fields = fields(return_type)
         return "loss" in class_fields
+    return False
 
 
 @require_tf

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1355,7 +1355,7 @@ class TFModelTesterMixin:
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         for model_class in self.all_model_classes:
             model = model_class(config)
-            if getattr(model, "hf_compute_loss", None):
+            if getattr(model, "hf_compute_loss", None) and not _return_type_has_loss(model):
                 # The number of elements in the loss should be the same as the number of elements in the label
                 prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
                 added_label = prepared_for_class[

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -25,7 +25,8 @@ import unittest.mock as mock
 from dataclasses import fields
 from importlib import import_module
 from math import isnan
-from typing import List, Tuple, Union, get_origin, get_type_hints
+from typing import List, Tuple, Union, get_type_hints
+from types import UnionType
 
 from datasets import Dataset
 
@@ -130,7 +131,7 @@ def _return_type_has_loss(model):
     if "return" not in return_type:
         return False
     return_type = return_type["return"]
-    if get_origin(return_type) is Union:
+    if isinstance(return_type, UnionType):
         for type_annotation in return_type.__args__:
             if inspect.isclass(type_annotation) and issubclass(type_annotation, ModelOutput):
                 field_names = [field.name for field in fields(type_annotation)]

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -208,7 +208,6 @@ class TFModelTesterMixin:
                 inputs_dict["labels"] = tf.zeros(
                     (self.model_tester.batch_size, self.model_tester.seq_length), dtype=tf.int32
                 )
-            breakpoint()
 
         return inputs_dict
 

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -191,7 +191,7 @@ class TFModelTesterMixin:
                 *get_values(TF_MODEL_FOR_PRETRAINING_MAPPING),
                 *get_values(TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING),
                 *get_values(TF_MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING),
-            ]:
+            ] and "labels" in dict(inspect.signature(self.call).parameters):
                 inputs_dict["labels"] = tf.zeros(
                     (self.model_tester.batch_size, self.model_tester.seq_length), dtype=tf.int32
                 )
@@ -208,6 +208,7 @@ class TFModelTesterMixin:
                 inputs_dict["labels"] = tf.zeros(
                     (self.model_tester.batch_size, self.model_tester.seq_length), dtype=tf.int32
                 )
+            breakpoint()
 
         return inputs_dict
 

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -204,6 +204,7 @@ class TFModelTesterMixin:
                 batch_size, num_channels, height, width = inputs_dict["pixel_values"].shape
                 inputs_dict["labels"] = tf.zeros((self.model_tester.batch_size, height, width), dtype=tf.int32)
             elif model_class.__name__.endswith("ForCTC"):
+                # When we have enough CTC models for an AutoClass, we should use their mapping instead of name checks
                 inputs_dict["labels"] = tf.zeros(
                     (self.model_tester.batch_size, self.model_tester.seq_length), dtype=tf.int32
                 )

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -25,8 +25,7 @@ import unittest.mock as mock
 from dataclasses import fields
 from importlib import import_module
 from math import isnan
-from typing import List, Tuple, Union, get_type_hints
-from types import UnionType
+from typing import List, Tuple, get_type_hints
 
 from datasets import Dataset
 
@@ -131,7 +130,7 @@ def _return_type_has_loss(model):
     if "return" not in return_type:
         return False
     return_type = return_type["return"]
-    if isinstance(return_type, UnionType):
+    if hasattr(return_type, "__args__"):  # Awkward check for union because UnionType only turns up in 3.10
         for type_annotation in return_type.__args__:
             if inspect.isclass(type_annotation) and issubclass(type_annotation, ModelOutput):
                 field_names = [field.name for field in fields(type_annotation)]

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -203,6 +203,10 @@ class TFModelTesterMixin:
             elif model_class in get_values(TF_MODEL_FOR_SEMANTIC_SEGMENTATION_MAPPING):
                 batch_size, num_channels, height, width = inputs_dict["pixel_values"].shape
                 inputs_dict["labels"] = tf.zeros((self.model_tester.batch_size, height, width), dtype=tf.int32)
+            elif model_class.__name__.endswith("ForCTC"):
+                inputs_dict["labels"] = tf.zeros(
+                    (self.model_tester.batch_size, self.model_tester.seq_length), dtype=tf.int32
+                )
 
         return inputs_dict
 

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1355,72 +1355,73 @@ class TFModelTesterMixin:
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         for model_class in self.all_model_classes:
             model = model_class(config)
-            if getattr(model, "hf_compute_loss", None) and not _return_type_has_loss(model):
-                # The number of elements in the loss should be the same as the number of elements in the label
-                prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
-                added_label = prepared_for_class[
-                    sorted(list(prepared_for_class.keys() - inputs_dict.keys()), reverse=True)[0]
-                ]
-                expected_loss_size = added_label.shape.as_list()[:1]
+            if not getattr(model, "hf_compute_loss", None) and not _return_type_has_loss(model):
+                continue
+            # The number of elements in the loss should be the same as the number of elements in the label
+            prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
+            added_label = prepared_for_class[
+                sorted(list(prepared_for_class.keys() - inputs_dict.keys()), reverse=True)[0]
+            ]
+            expected_loss_size = added_label.shape.as_list()[:1]
 
-                # Test that model correctly compute the loss with kwargs
-                prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
-                possible_input_names = {"input_ids", "pixel_values", "input_features"}
-                input_name = possible_input_names.intersection(set(prepared_for_class)).pop()
-                model_input = prepared_for_class.pop(input_name)
+            # Test that model correctly compute the loss with kwargs
+            prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
+            possible_input_names = {"input_ids", "pixel_values", "input_features"}
+            input_name = possible_input_names.intersection(set(prepared_for_class)).pop()
+            model_input = prepared_for_class.pop(input_name)
 
-                loss = model(model_input, **prepared_for_class)[0]
-                self.assertTrue(loss.shape.as_list() == expected_loss_size or loss.shape.as_list() == [1])
+            loss = model(model_input, **prepared_for_class)[0]
+            self.assertTrue(loss.shape.as_list() == expected_loss_size or loss.shape.as_list() == [1])
 
-                # Test that model correctly compute the loss when we mask some positions
-                prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
-                possible_input_names = {"input_ids", "pixel_values", "input_features"}
-                input_name = possible_input_names.intersection(set(prepared_for_class)).pop()
-                model_input = prepared_for_class.pop(input_name)
-                if "labels" in prepared_for_class:
-                    labels = prepared_for_class["labels"].numpy()
-                    if len(labels.shape) > 1 and labels.shape[1] != 1:
-                        labels[0] = -100
-                        prepared_for_class["labels"] = tf.convert_to_tensor(labels)
-                        loss = model(model_input, **prepared_for_class)[0]
-                        self.assertTrue(loss.shape.as_list() == expected_loss_size or loss.shape.as_list() == [1])
-                        self.assertTrue(not np.any(np.isnan(loss.numpy())))
+            # Test that model correctly compute the loss when we mask some positions
+            prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
+            possible_input_names = {"input_ids", "pixel_values", "input_features"}
+            input_name = possible_input_names.intersection(set(prepared_for_class)).pop()
+            model_input = prepared_for_class.pop(input_name)
+            if "labels" in prepared_for_class:
+                labels = prepared_for_class["labels"].numpy()
+                if len(labels.shape) > 1 and labels.shape[1] != 1:
+                    labels[0] = -100
+                    prepared_for_class["labels"] = tf.convert_to_tensor(labels)
+                    loss = model(model_input, **prepared_for_class)[0]
+                    self.assertTrue(loss.shape.as_list() == expected_loss_size or loss.shape.as_list() == [1])
+                    self.assertTrue(not np.any(np.isnan(loss.numpy())))
 
-                # Test that model correctly compute the loss with a dict
-                prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
-                loss = model(prepared_for_class)[0]
-                self.assertTrue(loss.shape.as_list() == expected_loss_size or loss.shape.as_list() == [1])
+            # Test that model correctly compute the loss with a dict
+            prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
+            loss = model(prepared_for_class)[0]
+            self.assertTrue(loss.shape.as_list() == expected_loss_size or loss.shape.as_list() == [1])
 
-                # Test that model correctly compute the loss with a tuple
-                prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
+            # Test that model correctly compute the loss with a tuple
+            prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
 
-                # Get keys that were added with the _prepare_for_class function
-                label_keys = prepared_for_class.keys() - inputs_dict.keys()
-                signature = inspect.signature(model.call).parameters
-                signature_names = list(signature.keys())
+            # Get keys that were added with the _prepare_for_class function
+            label_keys = prepared_for_class.keys() - inputs_dict.keys()
+            signature = inspect.signature(model.call).parameters
+            signature_names = list(signature.keys())
 
-                # Create a dictionary holding the location of the tensors in the tuple
-                tuple_index_mapping = {0: input_name}
-                for label_key in label_keys:
-                    label_key_index = signature_names.index(label_key)
-                    tuple_index_mapping[label_key_index] = label_key
-                sorted_tuple_index_mapping = sorted(tuple_index_mapping.items())
-                # Initialize a list with their default values, update the values and convert to a tuple
-                list_input = []
+            # Create a dictionary holding the location of the tensors in the tuple
+            tuple_index_mapping = {0: input_name}
+            for label_key in label_keys:
+                label_key_index = signature_names.index(label_key)
+                tuple_index_mapping[label_key_index] = label_key
+            sorted_tuple_index_mapping = sorted(tuple_index_mapping.items())
+            # Initialize a list with their default values, update the values and convert to a tuple
+            list_input = []
 
-                for name in signature_names:
-                    if name != "kwargs":
-                        list_input.append(signature[name].default)
+            for name in signature_names:
+                if name != "kwargs":
+                    list_input.append(signature[name].default)
 
-                for index, value in sorted_tuple_index_mapping:
-                    list_input[index] = prepared_for_class[value]
+            for index, value in sorted_tuple_index_mapping:
+                list_input[index] = prepared_for_class[value]
 
-                tuple_input = tuple(list_input)
+            tuple_input = tuple(list_input)
 
-                # Send to model
-                loss = model(tuple_input[:-1])[0]
+            # Send to model
+            loss = model(tuple_input[:-1])[0]
 
-                self.assertTrue(loss.shape.as_list() == expected_loss_size or loss.shape.as_list() == [1])
+            self.assertTrue(loss.shape.as_list() == expected_loss_size or loss.shape.as_list() == [1])
 
     def check_keras_fit_results(self, val_loss1, val_loss2, atol=1e-2, rtol=1e-3):
         self.assertTrue(np.allclose(val_loss1, val_loss2, atol=atol, rtol=rtol))
@@ -1430,7 +1431,7 @@ class TFModelTesterMixin:
         for model_class in self.all_model_classes:
             model = model_class(config)
             if not getattr(model, "hf_compute_loss", False) and not _return_type_has_loss(model):
-                return
+                continue
             # Test that model correctly compute the loss with kwargs
             prepared_for_class = self._prepare_for_class(inputs_dict.copy(), model_class, return_labels=True)
             # Is there a better way to remove these decoder inputs?


### PR DESCRIPTION
CLIP models were not being tested correctly with `fit()` because the test skipped models without a `hf_compute_loss` method. This skip was added to skip base models like `TFBERTModel` that do not have specific output heads and losses. However, it also skips models like CLIP that do not use `compute_loss` / `hf_compute_loss` methods.

The new test checks whether the model's return type dataclass has a `loss` key, which is a more reliable check. Enabling this reveals the bug in `fit()` for TFClip, so this PR also includes fixes to `train_step` and `test_step` for CLIP and models like it that require `return_loss=True` to be passed, but do not set it by default.

Draft for now because this will likely flush out other bugs or cause other problems!

Fixes #18670.