### PR TITLE
Add an option to `HfArgumentParser.parse_{dict,json_file}` to raise an Exception when there extra keys

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -243,7 +243,8 @@ class HfArgumentParser(ArgumentParser):
             json_file (`str` or `os.PathLike`):
                 File name of the json file to parse
             allow_extra_keys (`bool`, *optional*, defaults to `False`):
-                Defaults to False. If False, will raise an exception if the json file contains keys that are not parsed.
+                Defaults to False. If False, will raise an exception if the json file contains keys that are not
+                parsed.
 
         Returns:
             Tuple consisting of:

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -234,24 +234,21 @@ class HfArgumentParser(ArgumentParser):
 
             return (*outputs,)
 
-    def parse_json_file(self, json_file: str, allow_extra_keys: bool = True) -> Tuple[DataClass, ...]:
+    def parse_json_file(self, json_file: str, allow_extra_keys: bool = False) -> Tuple[DataClass, ...]:
         """
         Alternative helper method that does not use `argparse` at all, instead loading a json file and populating the
         dataclass types.
 
         Args:
-            json_file:
+            json_file (`str` or `os.PathLike`):
                 File name of the json file to parse
-            allow_extra_keys:
-                Defaults to True. If False, will raise an exception if the json file contains keys that are not parsed.
+            allow_extra_keys (`bool`, *optional*, defaults to `False`):
+                Defaults to False. If False, will raise an exception if the json file contains keys that are not parsed.
 
         Returns:
             Tuple consisting of:
 
-                - the dataclass instances in the same order as they were passed to the initializer.abspath
-                - if applicable, an additional namespace for more (non-dataclass backed) arguments added to the parser
-                  after initialization.
-                - The potential list of remaining argument strings. (same as argparse.ArgumentParser.parse_known_args)
+                - the dataclass instances in the same order as they were passed to the initializer.
         """
         data = json.loads(Path(json_file).read_text())
         unused_keys = set(data.keys())
@@ -264,26 +261,23 @@ class HfArgumentParser(ArgumentParser):
             outputs.append(obj)
         if not allow_extra_keys and unused_keys:
             raise ValueError(f"Some keys are not used by the HfArgumentParser: {sorted(unused_keys)}")
-        return (*outputs,)
+        return tuple(outputs)
 
-    def parse_dict(self, args: dict, allow_extra_keys: bool = True) -> Tuple[DataClass, ...]:
+    def parse_dict(self, args: Dict[str, Any], allow_extra_keys: bool = False) -> Tuple[DataClass, ...]:
         """
         Alternative helper method that does not use `argparse` at all, instead uses a dict and populating the dataclass
         types.
 
         Args:
-            args:
+            args (`dict`):
                 dict containing config values
-            allow_extra_keys:
-                Defaults to True. If False, will raise an exception if the dict contains keys that are not parsed.
+            allow_extra_keys (`bool`, *optional*, defaults to `False`):
+                Defaults to False. If False, will raise an exception if the dict contains keys that are not parsed.
 
         Returns:
             Tuple consisting of:
 
-                - the dataclass instances in the same order as they were passed to the initializer.abspath
-                - if applicable, an additional namespace for more (non-dataclass backed) arguments added to the parser
-                  after initialization.
-                - The potential list of remaining argument strings. (same as argparse.ArgumentParser.parse_known_args)
+                - the dataclass instances in the same order as they were passed to the initializer.
         """
         unused_keys = set(args.keys())
         outputs = []
@@ -295,4 +289,4 @@ class HfArgumentParser(ArgumentParser):
             outputs.append(obj)
         if not allow_extra_keys and unused_keys:
             raise ValueError(f"Some keys are not used by the HfArgumentParser: {sorted(unused_keys)}")
-        return (*outputs,)
+        return tuple(outputs)

--- a/tests/utils/test_hf_argparser.py
+++ b/tests/utils/test_hf_argparser.py
@@ -253,7 +253,7 @@ class HfArgumentParserTest(unittest.TestCase):
             "bar": 3.14,
             "baz": "42",
             "flag": True,
-            "extra": 42
+            "extra": 42,
         }
 
         self.assertRaises(ValueError, parser.parse_dict, args_dict, allow_extra_keys=False)

--- a/tests/utils/test_hf_argparser.py
+++ b/tests/utils/test_hf_argparser.py
@@ -245,6 +245,19 @@ class HfArgumentParserTest(unittest.TestCase):
         args = BasicExample(**args_dict)
         self.assertEqual(parsed_args, args)
 
+    def test_parse_dict_extra_key(self):
+        parser = HfArgumentParser(BasicExample)
+
+        args_dict = {
+            "foo": 12,
+            "bar": 3.14,
+            "baz": "42",
+            "flag": True,
+            "extra": 42
+        }
+
+        self.assertRaises(ValueError, parser.parse_dict, args_dict, allow_extra_keys=False)
+
     def test_integration_training_args(self):
         parser = HfArgumentParser(TrainingArguments)
         self.assertIsNotNone(parser)


### PR DESCRIPTION
I added an option to `HfArgumentParser.parse_{dict,json_file}` to raise an Exception when there extra keys. The option is off by default, for backward compatibility.

For users of these functions, misspelled or incorrect keys in the parsed files/dicts could lead to hard-to-find errors, like putting `batch_size` in your config and wondering why the Trainer is using a different one, because the actual name is `per_device_train_batch_size`. The option will output a very similar error message to the normal argparse.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [X] Did you write any new necessary tests?


## Who can review?

@sgugger 


