### PR TITLE
add warning to let the user know that the `__call__` method is faster than `encode` + `pad` for a fast tokenizer

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2821,8 +2821,8 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         Padding side (left/right) padding token ids are defined at the tokenizer level (with `self.padding_side`,
         `self.pad_token_id` and `self.pad_token_type_id`).
 
-        Please note that with a fast tokenizer a fast tokenizer, using the `__call__` method is faster than using the
-        `pad` method to get a padded encoding.
+        Please note that with a fast tokenizer, using the `__call__` method is faster than using a method to encode the
+        text followed by a call to the `pad` method to get a padded encoding.
 
         <Tip>
 
@@ -2873,10 +2873,10 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 Whether or not to print more information and warnings.
         """
         if self.__class__.__name__.endswith("Fast"):
-            logger.warning(
-                f"You're using a {self.__class__.__name__} tokenizer. Please note that with a fast tokenizer a fast"
-                " tokenizer, using the `__call__` method is faster than using the `pad` method to get a padded"
-                " encoding."
+            warnings.warn(
+                f"You're using a {self.__class__.__name__} tokenizer. Please note that with a fast tokenizer, using"
+                " the `__call__` method is faster than using a method to encode the text followed by a call to the"
+                " `pad` method to get a padded encoding."
             )
         # If we have a list of dicts, let's convert it in a dict of lists
         # We do this to allow using this method as a collate_fn function in PyTorch Dataloader

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2819,7 +2819,10 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         in the batch.
 
         Padding side (left/right) padding token ids are defined at the tokenizer level (with `self.padding_side`,
-        `self.pad_token_id` and `self.pad_token_type_id`)
+        `self.pad_token_id` and `self.pad_token_type_id`).
+
+        Please note that with a fast tokenizer a fast tokenizer, using the `__call__` method is faster than using the
+        `pad` method to get a padded encoding.
 
         <Tip>
 
@@ -2869,6 +2872,12 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             verbose (`bool`, *optional*, defaults to `True`):
                 Whether or not to print more information and warnings.
         """
+        if self.__class__.__name__.endswith("Fast"):
+            logger.warning(
+                f"You're using a {self.__class__.__name__} tokenizer. Please note that with a fast tokenizer a fast"
+                " tokenizer, using the `__call__` method is faster than using the `pad` method to get a padded"
+                " encoding."
+            )
         # If we have a list of dicts, let's convert it in a dict of lists
         # We do this to allow using this method as a collate_fn function in PyTorch Dataloader
         if isinstance(encoded_inputs, (list, tuple)) and isinstance(encoded_inputs[0], Mapping):

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2873,11 +2873,14 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 Whether or not to print more information and warnings.
         """
         if self.__class__.__name__.endswith("Fast"):
-            warnings.warn(
-                f"You're using a {self.__class__.__name__} tokenizer. Please note that with a fast tokenizer, using"
-                " the `__call__` method is faster than using a method to encode the text followed by a call to the"
-                " `pad` method to get a padded encoding."
-            )
+            if not self.deprecation_warnings.get("Asking-to-pad-a-fast-tokenizer", False):
+                logger.warning_advice(
+                    f"You're using a {self.__class__.__name__} tokenizer. Please note that with a fast tokenizer,"
+                    " using the `__call__` method is faster than using a method to encode the text followed by a call"
+                    " to the `pad` method to get a padded encoding."
+                )
+                self.deprecation_warnings["Asking-to-pad-a-fast-tokenizer"] = True
+
         # If we have a list of dicts, let's convert it in a dict of lists
         # We do this to allow using this method as a collate_fn function in PyTorch Dataloader
         if isinstance(encoded_inputs, (list, tuple)) and isinstance(encoded_inputs[0], Mapping):

--- a/tests/models/layoutlmv2/test_tokenization_layoutlmv2.py
+++ b/tests/models/layoutlmv2/test_tokenization_layoutlmv2.py
@@ -19,6 +19,7 @@ import re
 import shutil
 import tempfile
 import unittest
+import warnings
 from typing import List
 
 from transformers import AddedToken, LayoutLMv2TokenizerFast, SpecialTokensMixin, is_tf_available, is_torch_available
@@ -787,6 +788,42 @@ class LayoutLMv2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 input_p = tokenizer_r.pad(input_p, max_length=max_length, padding="max_length")
 
                 self.assert_batch_padded_input_match(input_r, input_p, max_length, pad_token_id)
+
+    def test_padding_warning_message_fast_tokenizer(self):
+        if not self.test_rust_tokenizer:
+            return
+
+        words, boxes = self.get_words_and_boxes_batch()
+
+        tokenizer_fast = self.get_rust_tokenizer()
+
+        encoding_fast = tokenizer_fast(
+            words,
+            boxes=boxes,
+        )
+
+        with warnings.catch_warnings(record=True) as w:
+            tokenizer_fast.pad(encoding_fast)
+        self.assertEqual(len(w), 1)
+        self.assertIn(
+            "Please note that with a fast tokenizer, using the `__call__` method is faster than using a method to"
+            " encode the text followed by a call to the `pad` method to get a padded encoding.",
+            str(w[0].message),
+        )
+
+        if not self.test_slow_tokenizer:
+            return
+
+        tokenizer_slow = self.get_tokenizer()
+
+        encoding_slow = tokenizer_slow(
+            words,
+            boxes=boxes,
+        )
+
+        with warnings.catch_warnings(record=True) as w:
+            tokenizer_slow.pad(encoding_slow)
+        self.assertEqual(len(w), 0)
 
     def test_call(self):
         # Tests that all call wrap to encode_plus and batch_encode_plus

--- a/tests/models/layoutlmv3/test_tokenization_layoutlmv3.py
+++ b/tests/models/layoutlmv3/test_tokenization_layoutlmv3.py
@@ -20,14 +20,23 @@ import re
 import shutil
 import tempfile
 import unittest
-import warnings
 from typing import List
 
-from transformers import AddedToken, LayoutLMv3TokenizerFast, SpecialTokensMixin, is_tf_available, is_torch_available
+from transformers import (
+    AddedToken,
+    LayoutLMv3TokenizerFast,
+    SpecialTokensMixin,
+    is_tf_available,
+    is_torch_available,
+    logging,
+)
 from transformers.models.layoutlmv3.tokenization_layoutlmv3 import VOCAB_FILES_NAMES, LayoutLMv3Tokenizer
 from transformers.testing_utils import is_pt_tf_cross_test, require_pandas, require_tokenizers, require_torch, slow
 
 from ...test_tokenization_common import SMALL_TRAINING_CORPUS, TokenizerTesterMixin, merge_model_tokenizer_mappings
+
+
+logger = logging.get_logger(__name__)
 
 
 @require_tokenizers
@@ -682,13 +691,13 @@ class LayoutLMv3TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             boxes=boxes,
         )
 
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertLogs("transformers", level="WARNING") as cm:
             tokenizer_fast.pad(encoding_fast)
-        self.assertEqual(len(w), 1)
+        self.assertEqual(len(cm.records), 1)
         self.assertIn(
             "Please note that with a fast tokenizer, using the `__call__` method is faster than using a method to"
             " encode the text followed by a call to the `pad` method to get a padded encoding.",
-            str(w[0].message),
+            cm.records[0].message,
         )
 
         if not self.test_slow_tokenizer:
@@ -701,9 +710,16 @@ class LayoutLMv3TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             boxes=boxes,
         )
 
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertLogs(level="WARNING") as cm:
+            # We want to assert there are no warnings, but the 'assertLogs' method does not support that.
+            # Therefore, we are adding a dummy warning, and then we will assert it is the only warning.
+            logger.warning("Dummy warning")
             tokenizer_slow.pad(encoding_slow)
-        self.assertEqual(len(w), 0)
+        self.assertEqual(len(cm.records), 1)
+        self.assertIn(
+            "Dummy warning",
+            cm.records[0].message,
+        )
 
     def test_call(self):
         # Tests that all call wrap to encode_plus and batch_encode_plus

--- a/tests/models/layoutxlm/test_tokenization_layoutxlm.py
+++ b/tests/models/layoutxlm/test_tokenization_layoutxlm.py
@@ -17,6 +17,7 @@ import inspect
 import shutil
 import tempfile
 import unittest
+import warnings
 from typing import List
 
 from transformers import AddedToken, LayoutXLMTokenizerFast, SpecialTokensMixin, is_tf_available, is_torch_available
@@ -696,6 +697,42 @@ class LayoutXLMTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 input_p = tokenizer_r.pad(input_p, max_length=max_length, padding="max_length")
 
                 self.assert_batch_padded_input_match(input_r, input_p, max_length, pad_token_id)
+
+    def test_padding_warning_message_fast_tokenizer(self):
+        if not self.test_rust_tokenizer:
+            return
+
+        words, boxes = self.get_words_and_boxes_batch()
+
+        tokenizer_fast = self.get_rust_tokenizer()
+
+        encoding_fast = tokenizer_fast(
+            words,
+            boxes=boxes,
+        )
+
+        with warnings.catch_warnings(record=True) as w:
+            tokenizer_fast.pad(encoding_fast)
+        self.assertEqual(len(w), 1)
+        self.assertIn(
+            "Please note that with a fast tokenizer, using the `__call__` method is faster than using a method to"
+            " encode the text followed by a call to the `pad` method to get a padded encoding.",
+            str(w[0].message),
+        )
+
+        if not self.test_slow_tokenizer:
+            return
+
+        tokenizer_slow = self.get_tokenizer()
+
+        encoding_slow = tokenizer_slow(
+            words,
+            boxes=boxes,
+        )
+
+        with warnings.catch_warnings(record=True) as w:
+            tokenizer_slow.pad(encoding_slow)
+        self.assertEqual(len(w), 0)
 
     def test_call(self):
         # Tests that all call wrap to encode_plus and batch_encode_plus


### PR DESCRIPTION
# What does this PR do?

In this PR I propose to specify in the docstring of the `pad` method and to log a warning when the pad method is called with a fast tokenizer. The goal is to encourage the user to use the `__call__` method to encode and pad their input at the same time since it will be faster then encoding and then padding it with the method `pad` (because it is not using the rust backend).


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
