### PR TITLE
Generate: add missing `**model_kwargs` in sample tests

### DIFF
--- a/tests/generation/test_generation_utils.py
+++ b/tests/generation/test_generation_utils.py
@@ -327,6 +327,7 @@ class GenerationTesterMixin:
             remove_invalid_values=True,
             **logits_warper_kwargs,
             **process_kwargs,
+            **model_kwargs,
         )
 
         torch.manual_seed(0)
@@ -361,6 +362,7 @@ class GenerationTesterMixin:
                 **kwargs,
                 **model_kwargs,
             )
+
         return output_sample, output_generate
 
     def _beam_search_generate(


### PR DESCRIPTION
# What does this PR do?

One call of the `sample`-related tests was missing `**model_kwargs`, which MAY explain the random failures we were seeing. 

I've run all `test_sample_generate_dict_output` tests 100x with no failures. Before this change, it was failing once every ~10 calls of `py.test tests/ -k test_sample_generate_dict_output`.