### PR TITLE
[LayoutLM] Add clarification to docs

### DIFF
--- a/docs/source/en/model_doc/layoutlm.mdx
+++ b/docs/source/en/model_doc/layoutlm.mdx
@@ -67,7 +67,9 @@ occurs. Those can be obtained using the Python Image Library (PIL) library for e
 ```python
 from PIL import Image
 
-image = Image.open("name_of_your_document - can be a png file, pdf, etc.")
+image = Image.open(
+    "name_of_your_document - can be a png, jpg, etc. of your documents (PDFs must be converted to images)."
+).convert("RGB")
 
 width, height = image.size
 ```

--- a/docs/source/en/model_doc/layoutlm.mdx
+++ b/docs/source/en/model_doc/layoutlm.mdx
@@ -67,9 +67,8 @@ occurs. Those can be obtained using the Python Image Library (PIL) library for e
 ```python
 from PIL import Image
 
-image = Image.open(
-    "name_of_your_document - can be a png, jpg, etc. of your documents (PDFs must be converted to images)."
-).convert("RGB")
+# Document can be a png, jpg, etc. PDFs must be converted to images.
+image = Image.open(name_of_your_document).convert("RGB")
 
 width, height = image.size
 ```

--- a/src/transformers/models/layoutlmv2/feature_extraction_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/feature_extraction_layoutlmv2.py
@@ -168,9 +168,8 @@ class LayoutLMv2FeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
         >>> from transformers import LayoutLMv2FeatureExtractor
         >>> from PIL import Image
 
-        >>> image = Image.open(
-        ...     "name_of_your_document - can be a png, jpg, etc. of your documents (PDFs must be converted to images)."
-        ... ).convert("RGB")
+        >>> # Document can be a png, jpg, etc. PDFs must be converted to images.
+        >>> image = Image.open(name_of_your_document).convert("RGB")
 
         >>> # option 1: with apply_ocr=True (default)
         >>> feature_extractor = LayoutLMv2FeatureExtractor()

--- a/src/transformers/models/layoutlmv2/feature_extraction_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/feature_extraction_layoutlmv2.py
@@ -168,7 +168,9 @@ class LayoutLMv2FeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
         >>> from transformers import LayoutLMv2FeatureExtractor
         >>> from PIL import Image
 
-        >>> image = Image.open("name_of_your_document - can be a png file, pdf, etc.").convert("RGB")
+        >>> image = Image.open(
+        ...     "name_of_your_document - can be a png, jpg, etc. of your documents (PDFs must be converted to images)."
+        ... ).convert("RGB")
 
         >>> # option 1: with apply_ocr=True (default)
         >>> feature_extractor = LayoutLMv2FeatureExtractor()

--- a/src/transformers/models/layoutlmv3/feature_extraction_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/feature_extraction_layoutlmv3.py
@@ -179,7 +179,9 @@ class LayoutLMv3FeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
         >>> from transformers import LayoutLMv3FeatureExtractor
         >>> from PIL import Image
 
-        >>> image = Image.open("name_of_your_document - can be a png file, pdf, etc.").convert("RGB")
+        >>> image = Image.open(
+        ...     "name_of_your_document - can be a png, jpg, etc. of your documents (PDFs must be converted to images)."
+        ... ).convert("RGB")
 
         >>> # option 1: with apply_ocr=True (default)
         >>> feature_extractor = LayoutLMv3FeatureExtractor()

--- a/src/transformers/models/layoutlmv3/feature_extraction_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/feature_extraction_layoutlmv3.py
@@ -179,9 +179,8 @@ class LayoutLMv3FeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
         >>> from transformers import LayoutLMv3FeatureExtractor
         >>> from PIL import Image
 
-        >>> image = Image.open(
-        ...     "name_of_your_document - can be a png, jpg, etc. of your documents (PDFs must be converted to images)."
-        ... ).convert("RGB")
+        >>> # Document can be a png, jpg, etc. PDFs must be converted to images.
+        >>> image = Image.open(name_of_your_document).convert("RGB")
 
         >>> # option 1: with apply_ocr=True (default)
         >>> feature_extractor = LayoutLMv3FeatureExtractor()


### PR DESCRIPTION
# What does this PR do?

This PR clarifies that PDFs must be converted to Pillow images for LayoutLM.

Fixes #18113