### PR TITLE
Unpin detectron2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1006,7 +1006,7 @@ jobs:
             # The commit `36a65a0907d90ed591479b2ebaa8b61cfa0b4ef0` in `detectron2` break things.
             # See https://github.com/facebookresearch/detectron2/commit/36a65a0907d90ed591479b2ebaa8b61cfa0b4ef0#comments.
             # TODO: Revert this change back once the above issue is fixed.
-            - run: python -m pip install 'git+https://github.com/facebookresearch/detectron2.git@5aeb252b194b93dc2879b4ac34bc51a31b5aee13'
+            - run: python -m pip install 'git+https://github.com/facebookresearch/detectron2.git'
             - run: sudo apt install tesseract-ocr
             - run: pip install pytesseract
             - save_cache:

--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -40,7 +40,7 @@ RUN python3 -m pip uninstall -y flax jax
 RUN python3 -m pip install --no-cache-dir torch-scatter -f https://data.pyg.org/whl/torch-$(python3 -c "from torch import version; print(version.__version__.split('+')[0])")+$CUDA.html
 RUN python3 -m pip install --no-cache-dir intel_extension_for_pytorch==$INTEL_TORCH_EXT+cpu -f https://software.intel.com/ipex-whl-stable
 
-RUN python3 -m pip install --no-cache-dir git+https://github.com/facebookresearch/detectron2.git@5aeb252b194b93dc2879b4ac34bc51a31b5aee13 pytesseract https://github.com/kpu/kenlm/archive/master.zip
+RUN python3 -m pip install --no-cache-dir git+https://github.com/facebookresearch/detectron2.git pytesseract https://github.com/kpu/kenlm/archive/master.zip
 RUN python3 -m pip install -U "itsdangerous<2.1.0"
 
 RUN python3 -m pip install --no-cache-dir git+https://github.com/huggingface/accelerate@main#egg=accelerate

--- a/docker/transformers-doc-builder/Dockerfile
+++ b/docker/transformers-doc-builder/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get -y update && apt-get install -y libsndfile1-dev && apt install -y te
 RUN python3 -m pip install --no-cache-dir ./transformers[deepspeed]
 
 RUN python3 -m pip install --no-cache-dir torch-scatter -f https://data.pyg.org/whl/torch-$(python -c "from torch import version; print(version.__version__.split('+')[0])")+cpu.html
-RUN python3 -m pip install --no-cache-dir torchvision git+https://github.com/facebookresearch/detectron2.git@5aeb252b194b93dc2879b4ac34bc51a31b5aee13 pytesseract https://github.com/kpu/kenlm/archive/master.zip
+RUN python3 -m pip install --no-cache-dir torchvision git+https://github.com/facebookresearch/detectron2.git pytesseract https://github.com/kpu/kenlm/archive/master.zip
 RUN python3 -m pip install --no-cache-dir pytorch-quantization --extra-index-url https://pypi.ngc.nvidia.com
 RUN python3 -m pip install -U "itsdangerous<2.1.0"
 

--- a/docker/transformers-pytorch-gpu/Dockerfile
+++ b/docker/transformers-pytorch-gpu/Dockerfile
@@ -23,7 +23,7 @@ RUN [ ${#TORCH_AUDIO} -gt 0 ] && VERSION='torchaudio=='TORCH_AUDIO'.*' ||  VERSI
 RUN python3 -m pip uninstall -y tensorflow flax
 
 RUN python3 -m pip install --no-cache-dir torch-scatter -f https://data.pyg.org/whl/torch-$(python3 -c "from torch import version; print(version.__version__.split('+')[0])")+cu113.html
-RUN python3 -m pip install --no-cache-dir git+https://github.com/facebookresearch/detectron2.git@5aeb252b194b93dc2879b4ac34bc51a31b5aee13 pytesseract https://github.com/kpu/kenlm/archive/master.zip
+RUN python3 -m pip install --no-cache-dir git+https://github.com/facebookresearch/detectron2.git pytesseract https://github.com/kpu/kenlm/archive/master.zip
 RUN python3 -m pip install -U "itsdangerous<2.1.0"
 
 # When installing in editable mode, `transformers` is not recognized as a package.

--- a/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
@@ -43,26 +43,12 @@ from ...utils import (
 from .configuration_layoutlmv2 import LayoutLMv2Config
 
 
-logger = logging.get_logger(__name__)
-
-
 # soft dependency
 if is_detectron2_available():
     import detectron2
+    from detectron2.modeling import META_ARCH_REGISTRY
 
-    try:
-        from detectron2.modeling import META_ARCH_REGISTRY
-    except ImportError:
-        # NOTE: This is a temporary fix because currently there are
-        # import problems when using detectron2 from master (see issues below)
-        # it's better to have a silent error here in case someone imports this file
-        # without using the model which without this hack would break.
-        logger.warning(
-            "The detectron2 import seems to be broken. See:"
-            "https://github.com/facebookresearch/detectron2/issues/4489 or"
-            "https://github.com/facebookresearch/detectron2/issues/4487"
-        )
-        pass
+logger = logging.get_logger(__name__)
 
 _CHECKPOINT_FOR_DOC = "microsoft/layoutlmv2-base-uncased"
 _CONFIG_FOR_DOC = "LayoutLMv2Config"


### PR DESCRIPTION
# What does this PR do?

Unpin `detectron2` that are introduced in #18701 and #18680, as the issue was fixed on its side

https://github.com/facebookresearch/detectron2/commit/3cfda4704cb3b23255f29d683cf05cbaf10daaa4

The test `run_tests_layoutlmv2_and_v3` is OK now:

https://app.circleci.com/pipelines/github/huggingface/transformers/46171/workflows/c82c09a9-f6f7-4e21-8732-6681083960ff/jobs/541901