### PR TITLE
Update image segmentation pipeline test

### DIFF
--- a/tests/pipelines/test_pipelines_image_segmentation.py
+++ b/tests/pipelines/test_pipelines_image_segmentation.py
@@ -260,8 +260,8 @@ class ImageSegmentationPipelineTests(unittest.TestCase, metaclass=PipelineTestCa
                 {"score": 0.9987, "label": "remote", "mask": "7703408f54da1d0ebda47841da875e48"},
                 {"score": 0.9995, "label": "remote", "mask": "bd726918f10fed3efaef0091e11f923b"},
                 {"score": 0.9722, "label": "couch", "mask": "226d6dcb98bebc3fbc208abdc0c83196"},
-                {"score": 0.9994, "label": "cat", "mask": "fa5d8d5c329546ba5339f3095641ef56"}
-            ]
+                {"score": 0.9994, "label": "cat", "mask": "fa5d8d5c329546ba5339f3095641ef56"},
+            ],
         )
 
         outputs = image_segmenter(
@@ -284,7 +284,7 @@ class ImageSegmentationPipelineTests(unittest.TestCase, metaclass=PipelineTestCa
                     {"score": 0.9987, "label": "remote", "mask": "7703408f54da1d0ebda47841da875e48"},
                     {"score": 0.9995, "label": "remote", "mask": "bd726918f10fed3efaef0091e11f923b"},
                     {"score": 0.9722, "label": "couch", "mask": "226d6dcb98bebc3fbc208abdc0c83196"},
-                    {"score": 0.9994, "label": "cat", "mask": "fa5d8d5c329546ba5339f3095641ef56"}
+                    {"score": 0.9994, "label": "cat", "mask": "fa5d8d5c329546ba5339f3095641ef56"},
                 ],
                 [
                     {"score": 0.9094, "label": "blanket", "mask": "6500201749480f87154fd967783b2b97"},
@@ -292,9 +292,9 @@ class ImageSegmentationPipelineTests(unittest.TestCase, metaclass=PipelineTestCa
                     {"score": 0.9987, "label": "remote", "mask": "7703408f54da1d0ebda47841da875e48"},
                     {"score": 0.9995, "label": "remote", "mask": "bd726918f10fed3efaef0091e11f923b"},
                     {"score": 0.9722, "label": "couch", "mask": "226d6dcb98bebc3fbc208abdc0c83196"},
-                    {"score": 0.9994, "label": "cat", "mask": "fa5d8d5c329546ba5339f3095641ef56"}
-                ]
-            ]
+                    {"score": 0.9994, "label": "cat", "mask": "fa5d8d5c329546ba5339f3095641ef56"},
+                ],
+            ],
         )
 
     @require_torch

--- a/tests/pipelines/test_pipelines_image_segmentation.py
+++ b/tests/pipelines/test_pipelines_image_segmentation.py
@@ -255,13 +255,13 @@ class ImageSegmentationPipelineTests(unittest.TestCase, metaclass=PipelineTestCa
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {"score": 0.9094, "label": "blanket", "mask": "85144e4bf8d624c2c6175f7faf57eb30"},
-                {"score": 0.9941, "label": "cat", "mask": "f3a7f80220788acc0245ebc084df6afc"},
-                {"score": 0.9987, "label": "remote", "mask": "7703408f54da1d0ebda47841da875e48"},
-                {"score": 0.9995, "label": "remote", "mask": "bd726918f10fed3efaef0091e11f923b"},
-                {"score": 0.9722, "label": "couch", "mask": "226d6dcb98bebc3fbc208abdc0c83196"},
-                {"score": 0.9994, "label": "cat", "mask": "fa5d8d5c329546ba5339f3095641ef56"},
-            ],
+                {'score': 0.9094, 'label': 'blanket', 'mask': '6500201749480f87154fd967783b2b97'},
+                {'score': 0.9941, 'label': 'cat', 'mask': 'f3a7f80220788acc0245ebc084df6afc'},
+                {'score': 0.9987, 'label': 'remote', 'mask': '7703408f54da1d0ebda47841da875e48'},
+                {'score': 0.9995, 'label': 'remote', 'mask': 'bd726918f10fed3efaef0091e11f923b'},
+                {'score': 0.9722, 'label': 'couch', 'mask': '226d6dcb98bebc3fbc208abdc0c83196'},
+                {'score': 0.9994, 'label': 'cat', 'mask': 'fa5d8d5c329546ba5339f3095641ef56'}
+            ]
         )
 
         outputs = image_segmenter(
@@ -279,22 +279,22 @@ class ImageSegmentationPipelineTests(unittest.TestCase, metaclass=PipelineTestCa
             nested_simplify(outputs, decimals=4),
             [
                 [
-                    {"score": 0.9094, "label": "blanket", "mask": "85144e4bf8d624c2c6175f7faf57eb30"},
-                    {"score": 0.9941, "label": "cat", "mask": "f3a7f80220788acc0245ebc084df6afc"},
-                    {"score": 0.9987, "label": "remote", "mask": "7703408f54da1d0ebda47841da875e48"},
-                    {"score": 0.9995, "label": "remote", "mask": "bd726918f10fed3efaef0091e11f923b"},
-                    {"score": 0.9722, "label": "couch", "mask": "226d6dcb98bebc3fbc208abdc0c83196"},
-                    {"score": 0.9994, "label": "cat", "mask": "fa5d8d5c329546ba5339f3095641ef56"},
+                    {'score': 0.9094, 'label': 'blanket', 'mask': '6500201749480f87154fd967783b2b97'},
+                    {'score': 0.9941, 'label': 'cat', 'mask': 'f3a7f80220788acc0245ebc084df6afc'},
+                    {'score': 0.9987, 'label': 'remote', 'mask': '7703408f54da1d0ebda47841da875e48'},
+                    {'score': 0.9995, 'label': 'remote', 'mask': 'bd726918f10fed3efaef0091e11f923b'},
+                    {'score': 0.9722, 'label': 'couch', 'mask': '226d6dcb98bebc3fbc208abdc0c83196'},
+                    {'score': 0.9994, 'label': 'cat', 'mask': 'fa5d8d5c329546ba5339f3095641ef56'}
                 ],
                 [
-                    {"score": 0.9094, "label": "blanket", "mask": "85144e4bf8d624c2c6175f7faf57eb30"},
-                    {"score": 0.9941, "label": "cat", "mask": "f3a7f80220788acc0245ebc084df6afc"},
-                    {"score": 0.9987, "label": "remote", "mask": "7703408f54da1d0ebda47841da875e48"},
-                    {"score": 0.9995, "label": "remote", "mask": "bd726918f10fed3efaef0091e11f923b"},
-                    {"score": 0.9722, "label": "couch", "mask": "226d6dcb98bebc3fbc208abdc0c83196"},
-                    {"score": 0.9994, "label": "cat", "mask": "fa5d8d5c329546ba5339f3095641ef56"},
-                ],
-            ],
+                    {'score': 0.9094, 'label': 'blanket', 'mask': '6500201749480f87154fd967783b2b97'},
+                    {'score': 0.9941, 'label': 'cat', 'mask': 'f3a7f80220788acc0245ebc084df6afc'},
+                    {'score': 0.9987, 'label': 'remote', 'mask': '7703408f54da1d0ebda47841da875e48'},
+                    {'score': 0.9995, 'label': 'remote', 'mask': 'bd726918f10fed3efaef0091e11f923b'},
+                    {'score': 0.9722, 'label': 'couch', 'mask': '226d6dcb98bebc3fbc208abdc0c83196'},
+                    {'score': 0.9994, 'label': 'cat', 'mask': 'fa5d8d5c329546ba5339f3095641ef56'}
+                ]
+            ]
         )
 
     @require_torch

--- a/tests/pipelines/test_pipelines_image_segmentation.py
+++ b/tests/pipelines/test_pipelines_image_segmentation.py
@@ -255,12 +255,12 @@ class ImageSegmentationPipelineTests(unittest.TestCase, metaclass=PipelineTestCa
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {'score': 0.9094, 'label': 'blanket', 'mask': '6500201749480f87154fd967783b2b97'},
-                {'score': 0.9941, 'label': 'cat', 'mask': 'f3a7f80220788acc0245ebc084df6afc'},
-                {'score': 0.9987, 'label': 'remote', 'mask': '7703408f54da1d0ebda47841da875e48'},
-                {'score': 0.9995, 'label': 'remote', 'mask': 'bd726918f10fed3efaef0091e11f923b'},
-                {'score': 0.9722, 'label': 'couch', 'mask': '226d6dcb98bebc3fbc208abdc0c83196'},
-                {'score': 0.9994, 'label': 'cat', 'mask': 'fa5d8d5c329546ba5339f3095641ef56'}
+                {"score": 0.9094, "label": "blanket", "mask": "6500201749480f87154fd967783b2b97"},
+                {"score": 0.9941, "label": "cat", "mask": "f3a7f80220788acc0245ebc084df6afc"},
+                {"score": 0.9987, "label": "remote", "mask": "7703408f54da1d0ebda47841da875e48"},
+                {"score": 0.9995, "label": "remote", "mask": "bd726918f10fed3efaef0091e11f923b"},
+                {"score": 0.9722, "label": "couch", "mask": "226d6dcb98bebc3fbc208abdc0c83196"},
+                {"score": 0.9994, "label": "cat", "mask": "fa5d8d5c329546ba5339f3095641ef56"}
             ]
         )
 
@@ -279,20 +279,20 @@ class ImageSegmentationPipelineTests(unittest.TestCase, metaclass=PipelineTestCa
             nested_simplify(outputs, decimals=4),
             [
                 [
-                    {'score': 0.9094, 'label': 'blanket', 'mask': '6500201749480f87154fd967783b2b97'},
-                    {'score': 0.9941, 'label': 'cat', 'mask': 'f3a7f80220788acc0245ebc084df6afc'},
-                    {'score': 0.9987, 'label': 'remote', 'mask': '7703408f54da1d0ebda47841da875e48'},
-                    {'score': 0.9995, 'label': 'remote', 'mask': 'bd726918f10fed3efaef0091e11f923b'},
-                    {'score': 0.9722, 'label': 'couch', 'mask': '226d6dcb98bebc3fbc208abdc0c83196'},
-                    {'score': 0.9994, 'label': 'cat', 'mask': 'fa5d8d5c329546ba5339f3095641ef56'}
+                    {"score": 0.9094, "label": "blanket", "mask": "6500201749480f87154fd967783b2b97"},
+                    {"score": 0.9941, "label": "cat", "mask": "f3a7f80220788acc0245ebc084df6afc"},
+                    {"score": 0.9987, "label": "remote", "mask": "7703408f54da1d0ebda47841da875e48"},
+                    {"score": 0.9995, "label": "remote", "mask": "bd726918f10fed3efaef0091e11f923b"},
+                    {"score": 0.9722, "label": "couch", "mask": "226d6dcb98bebc3fbc208abdc0c83196"},
+                    {"score": 0.9994, "label": "cat", "mask": "fa5d8d5c329546ba5339f3095641ef56"}
                 ],
                 [
-                    {'score': 0.9094, 'label': 'blanket', 'mask': '6500201749480f87154fd967783b2b97'},
-                    {'score': 0.9941, 'label': 'cat', 'mask': 'f3a7f80220788acc0245ebc084df6afc'},
-                    {'score': 0.9987, 'label': 'remote', 'mask': '7703408f54da1d0ebda47841da875e48'},
-                    {'score': 0.9995, 'label': 'remote', 'mask': 'bd726918f10fed3efaef0091e11f923b'},
-                    {'score': 0.9722, 'label': 'couch', 'mask': '226d6dcb98bebc3fbc208abdc0c83196'},
-                    {'score': 0.9994, 'label': 'cat', 'mask': 'fa5d8d5c329546ba5339f3095641ef56'}
+                    {"score": 0.9094, "label": "blanket", "mask": "6500201749480f87154fd967783b2b97"},
+                    {"score": 0.9941, "label": "cat", "mask": "f3a7f80220788acc0245ebc084df6afc"},
+                    {"score": 0.9987, "label": "remote", "mask": "7703408f54da1d0ebda47841da875e48"},
+                    {"score": 0.9995, "label": "remote", "mask": "bd726918f10fed3efaef0091e11f923b"},
+                    {"score": 0.9722, "label": "couch", "mask": "226d6dcb98bebc3fbc208abdc0c83196"},
+                    {"score": 0.9994, "label": "cat", "mask": "fa5d8d5c329546ba5339f3095641ef56"}
                 ]
             ]
         )


### PR DESCRIPTION
# What does this PR do?

The image segmentation pipeline tests - `tests/pipelines/test_pipelines_image_segmentation.py` - were failing after the merging of #1849  (49e44b216b2559e34e945d5dcdbbe2238859e29b). This was due to the difference in rescaling. 

Previously the images were rescaled by `image = image / 255`. In the new commit, a `rescale` method was added, and images rescaled using `image = image * scale`. This was known to cause small differences in the processed images (see
[PR comment](https://github.com/huggingface/transformers/pull/18499#discussion_r940347575)).

Testing locally, changing the `rescale` method to divide by a scale factor (255) resulted in the tests passing. It was therefore decided after discussion with @ydshieh the test values could be updated, as there was no logic difference between the commits.

## Comparing masks

The same code as in the segmentation pipeline was run to compare the output masks. 

```
#git_hash = "86d0b26d6c5566506b1be55002654b48d9c19ffe"
git_hash = "49e44b216b2559e34e945d5dcdbbe2238859e29b"

from transformers import pipeline
import numpy as np
model_id = "facebook/detr-resnet-50-panoptic"
image_segmenter = pipeline("image-segmentation", model=model_id)
outputs = image_segmenter("http://images.cocodataset.org/val2017/000000039769.jpg")
for i, o in enumerate(outputs):
    img = o['mask']
    np.save(f"img_{git_hash}_{i}", img)
    img.save(f"img_{git_hash}_{i}.png")
```

Mask generate for output 0 on commit hash 86d0b26d6c5566506b1be55002654b48d9c19ffe (parent commit)
![img_86d0b26d6c5566506b1be55002654b48d9c19ffe_0](https://user-images.githubusercontent.com/22614925/186147742-5f33e9da-e2d2-4c36-a7bc-90a1effa45ad.png)

Mask generate for output 0 on commit hash 49e44b216b2559e34e945d5dcdbbe2238859e29b
![img_49e44b216b2559e34e945d5dcdbbe2238859e29b_0](https://user-images.githubusercontent.com/22614925/186147710-fa89c61d-8c4e-47fa-9f44-a3c7ef319ef1.png)


Checking the pixel values, there was a single pixel difference
```
>>> git_hash_1 = "86d0b26d6c5566506b1be55002654b48d9c19ffe"
>>> git_hash_2 = "49e44b216b2559e34e945d5dcdbbe2238859e29b"
>>> 
>>> def max_diff(a, b):
>>>     return np.amax(np.abs(a - b))
>>> 
>>> for i in range(6):
>>>     print(f"\nComparing mask {i}")
>>>     img_orig = f"img_{git_hash_1}_{i}"
>>>     img_new = f"img_{git_hash_2}_{i}"
>>>     arr_orig = np.load(img_orig + ".npy")
>>>     arr_new = np.load(img_new + ".npy")
>>>     print(f"Max difference: ", max_diff(arr_orig, arr_new))
>>> 
>>>     m = arr_orig != arr_new
>>>     # image shape is 480 x 640
>>>     x = np.arange(480 * 640).reshape(480, 640)
>>>     print("No. pixels different: ", len(x[m]))
```

Output:
```
Comparing mask 0
Max difference:  255
No. pixels different:  1

Comparing mask 1
Max difference:  0
No. pixels different:  0

Comparing mask 2
Max difference:  0
No. pixels different:  0

Comparing mask 3
Max difference:  0
No. pixels different:  0

Comparing mask 4
Max difference:  0
No. pixels different:  0

Comparing mask 5
Max difference:  0
No. pixels different:  0
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
