### PR TITLE
CLI: Don't check the model head when there is no model head

### DIFF
--- a/src/transformers/commands/pt_to_tf.py
+++ b/src/transformers/commands/pt_to_tf.py
@@ -286,7 +286,12 @@ class PTtoTFCommand(BaseTransformersCLICommand):
         crossload_differences = self.find_pt_tf_differences(pt_outputs, tf_from_pt_outputs)
         output_differences = {k: v for k, v in crossload_differences.items() if "hidden" not in k}
         hidden_differences = {k: v for k, v in crossload_differences.items() if "hidden" in k}
-        max_crossload_output_diff = max(output_differences.values()) if architectures is not None else 0.0
+        if len(output_differences) == 0 and architectures is not None:
+            raise ValueError(
+                f"Something went wrong -- the config file has architectures ({architectures}), but no model head"
+                " output was found. All outputs start with 'hidden'"
+            )
+        max_crossload_output_diff = max(output_differences.values()) if output_differences else 0.0
         max_crossload_hidden_diff = max(hidden_differences.values())
         if max_crossload_output_diff > MAX_ERROR or max_crossload_hidden_diff > self._max_hidden_error:
             raise ValueError(
@@ -310,7 +315,12 @@ class PTtoTFCommand(BaseTransformersCLICommand):
         conversion_differences = self.find_pt_tf_differences(pt_outputs, tf_outputs)
         output_differences = {k: v for k, v in conversion_differences.items() if "hidden" not in k}
         hidden_differences = {k: v for k, v in conversion_differences.items() if "hidden" in k}
-        max_conversion_output_diff = max(output_differences.values()) if architectures is not None else 0.0
+        if len(output_differences) == 0 and architectures is not None:
+            raise ValueError(
+                f"Something went wrong -- the config file has architectures ({architectures}), but no model head"
+                " output was found. All outputs start with 'hidden'"
+            )
+        max_conversion_output_diff = max(output_differences.values()) if output_differences else 0.0
         max_conversion_hidden_diff = max(hidden_differences.values())
         if max_conversion_output_diff > MAX_ERROR or max_conversion_hidden_diff > self._max_hidden_error:
             raise ValueError(

--- a/src/transformers/commands/pt_to_tf.py
+++ b/src/transformers/commands/pt_to_tf.py
@@ -286,7 +286,7 @@ class PTtoTFCommand(BaseTransformersCLICommand):
         crossload_differences = self.find_pt_tf_differences(pt_outputs, tf_from_pt_outputs)
         output_differences = {k: v for k, v in crossload_differences.items() if "hidden" not in k}
         hidden_differences = {k: v for k, v in crossload_differences.items() if "hidden" in k}
-        max_crossload_output_diff = max(output_differences.values())
+        max_crossload_output_diff = max(output_differences.values()) if architectures is not None else 0.0
         max_crossload_hidden_diff = max(hidden_differences.values())
         if max_crossload_output_diff > MAX_ERROR or max_crossload_hidden_diff > self._max_hidden_error:
             raise ValueError(
@@ -310,7 +310,7 @@ class PTtoTFCommand(BaseTransformersCLICommand):
         conversion_differences = self.find_pt_tf_differences(pt_outputs, tf_outputs)
         output_differences = {k: v for k, v in conversion_differences.items() if "hidden" not in k}
         hidden_differences = {k: v for k, v in conversion_differences.items() if "hidden" in k}
-        max_conversion_output_diff = max(output_differences.values())
+        max_conversion_output_diff = max(output_differences.values()) if architectures is not None else 0.0
         max_conversion_hidden_diff = max(hidden_differences.values())
         if max_conversion_output_diff > MAX_ERROR or max_conversion_hidden_diff > self._max_hidden_error:
             raise ValueError(


### PR DESCRIPTION
# What does this PR do?

As the title says -- when there is no model head, don't check it :)

When `architectures` is not defined, it is implied that there is no model head in the weights.