### PR TITLE
Revert to rescale and safely handle flag in owlvit config

### DIFF
--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -131,7 +131,7 @@ class ImageFeatureExtractionMixin:
 
         return image.convert("RGB")
 
-    def rescale_image(self, image: np.ndarray, scale: Union[float, int]) -> np.ndarray:
+    def rescale(self, image: np.ndarray, scale: Union[float, int]) -> np.ndarray:
         """
         Rescale a numpy image by scale amount
         """
@@ -163,7 +163,7 @@ class ImageFeatureExtractionMixin:
         rescale = isinstance(image.flat[0], np.integer) if rescale is None else rescale
 
         if rescale:
-            image = self.rescale_image(image.astype(np.float32), 1 / 255.0)
+            image = self.rescale(image.astype(np.float32), 1 / 255.0)
 
         if channel_first and image.ndim == 3:
             image = image.transpose(2, 0, 1)
@@ -214,9 +214,9 @@ class ImageFeatureExtractionMixin:
         # type it may need rescaling.
         elif rescale:
             if isinstance(image, np.ndarray):
-                image = self.rescale_image(image.astype(np.float32), 1 / 255.0)
+                image = self.rescale(image.astype(np.float32), 1 / 255.0)
             elif is_torch_tensor(image):
-                image = self.rescale_image(image.float(), 1 / 255.0)
+                image = self.rescale(image.float(), 1 / 255.0)
 
         if isinstance(image, np.ndarray):
             if not isinstance(mean, np.ndarray):

--- a/src/transformers/models/owlvit/feature_extraction_owlvit.py
+++ b/src/transformers/models/owlvit/feature_extraction_owlvit.py
@@ -85,6 +85,13 @@ class OwlViTFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin
         image_std=None,
         **kwargs
     ):
+        # Early versions of the OWL-ViT config on the hub had "rescale" as a flag. This clashes with the
+        # vision feature extractor method `rescale` as it would be set as an attribute during the super().__init__
+        # call. This is for backwards compatibility.
+        if "rescale" in kwargs:
+            rescale_val = kwargs.pop("rescale")
+            kwargs["do_rescale"] = rescale_val
+
         super().__init__(**kwargs)
         self.size = size
         self.resample = resample


### PR DESCRIPTION
# What does this PR do?

Reverts the `rescale_image` method name to back to `rescale`. This keeps the method inline with other method names such as `normalize`. 

This undoes the renaming in #18677 done to address failing tests caused by `rescale` key being in OWL-ViT config and the introduction of a `rescale` method in #18499. 

The OWL-ViT config has [since been updated](https://huggingface.co/google/owlvit-base-patch32/commit/17740e19dde58d657d21b970ead1cce0ea40f4da). As the model has been released, we rename the key in the config in case `rescale` is there for backwards compatibility. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?