### PR TITLE
[ViLT] Remove ViltForQuestionAnswering from check_repo

### DIFF
--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -128,7 +128,6 @@ IGNORE_NON_AUTO_CONFIGURED = PRIVATE_MODELS.copy() + [
     "DPTForDepthEstimation",
     "DecisionTransformerGPT2Model",
     "GLPNForDepthEstimation",
-    "ViltForQuestionAnswering",
     "ViltForImagesAndTextClassification",
     "ViltForImageAndTextRetrieval",
     "ViltForTokenClassification",


### PR DESCRIPTION
# What does this PR do?

This PR removes `ViltForQuestionAnswering` from the IGNORE_NON_AUTO_CONFIGURED mapping, because ViLT is now supported by the `AutoModelForVisualQuestionAnswering` class (and corresponding VQA pipeline).

cc @sgugger, `make fixup` currently doesn't check this, would it be possible to automate this?