### PR TITLE
Run tests if skip condition not met

### DIFF
--- a/tests/models/convnext/test_modeling_tf_convnext.py
+++ b/tests/models/convnext/test_modeling_tf_convnext.py
@@ -148,7 +148,7 @@ class TFConvNextModelTest(TFModelTesterMixin, unittest.TestCase):
         reason="TF (<=2.8) does not support backprop for grouped convolutions on CPU.",
     )
     def test_keras_fit(self):
-        pass
+        super().test_keras_fit()
 
     @unittest.skip(reason="ConvNext does not support input and output embeddings")
     def test_model_common_attributes(self):

--- a/tests/models/convnext/test_modeling_tf_convnext.py
+++ b/tests/models/convnext/test_modeling_tf_convnext.py
@@ -145,7 +145,7 @@ class TFConvNextModelTest(TFModelTesterMixin, unittest.TestCase):
 
     @unittest.skipIf(
         not is_tf_available() or len(tf.config.list_physical_devices("GPU")) == 0,
-        reason="TF (<=2.8) does not support backprop for grouped convolutions on CPU.",
+        reason="TF does not support backprop for grouped convolutions on CPU.",
     )
     def test_keras_fit(self):
         super().test_keras_fit()
@@ -176,7 +176,7 @@ class TFConvNextModelTest(TFModelTesterMixin, unittest.TestCase):
 
     @unittest.skipIf(
         not is_tf_available() or len(tf.config.list_physical_devices("GPU")) == 0,
-        reason="TF (<=2.8) does not support backprop for grouped convolutions on CPU.",
+        reason="TF does not support backprop for grouped convolutions on CPU.",
     )
     def test_dataset_conversion(self):
         super().test_dataset_conversion()

--- a/tests/models/regnet/test_modeling_tf_regnet.py
+++ b/tests/models/regnet/test_modeling_tf_regnet.py
@@ -138,7 +138,7 @@ class TFRegNetModelTest(TFModelTesterMixin, unittest.TestCase):
 
     @unittest.skipIf(
         not is_tf_available() or len(tf.config.list_physical_devices("GPU")) == 0,
-        reason="TF (<=2.8) does not support backprop for grouped convolutions on CPU.",
+        reason="TF does not support backprop for grouped convolutions on CPU.",
     )
     def test_keras_fit(self):
         super().test_keras_fit()

--- a/tests/models/regnet/test_modeling_tf_regnet.py
+++ b/tests/models/regnet/test_modeling_tf_regnet.py
@@ -141,7 +141,7 @@ class TFRegNetModelTest(TFModelTesterMixin, unittest.TestCase):
         reason="TF (<=2.8) does not support backprop for grouped convolutions on CPU.",
     )
     def test_keras_fit(self):
-        pass
+        super().test_keras_fit()
 
     @unittest.skip(reason="RegNet does not support input and output embeddings")
     def test_model_common_attributes(self):

--- a/tests/models/segformer/test_modeling_tf_segformer.py
+++ b/tests/models/segformer/test_modeling_tf_segformer.py
@@ -332,7 +332,7 @@ class TFSegformerModelTest(TFModelTesterMixin, unittest.TestCase):
 
     @unittest.skipIf(
         not is_tf_available() or len(tf.config.list_physical_devices("GPU")) == 0,
-        reason="TF (<=2.8) does not support backprop for grouped convolutions on CPU.",
+        reason="TF does not support backprop for grouped convolutions on CPU.",
     )
     def test_dataset_conversion(self):
         super().test_dataset_conversion()
@@ -342,7 +342,7 @@ class TFSegformerModelTest(TFModelTesterMixin, unittest.TestCase):
 
     @unittest.skipIf(
         not is_tf_available() or len(tf.config.list_physical_devices("GPU")) == 0,
-        reason="TF (<=2.8) does not support backprop for grouped convolutions on CPU.",
+        reason="TF does not support backprop for grouped convolutions on CPU.",
     )
     def test_keras_fit(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
# What does this PR do?

Some tests that had `unittest.skipIf` decorators weren't calling a test if the condition was false. This mean some test would be showing as passing even though they weren't being run. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
