### PR TITLE
[ASR Examples] Only filter training samples by audio length criterion

### DIFF
--- a/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
@@ -634,12 +634,14 @@ def main():
         def is_audio_in_length_range(length):
             return length > min_input_length and length < max_input_length
 
-        # filter data that is shorter than min_input_length
-        vectorized_datasets = vectorized_datasets.filter(
-            is_audio_in_length_range,
-            num_proc=num_workers,
-            input_columns=["input_length"],
-        )
+        # filter training data that is shorter than min_input_length or longer than
+        # max_input_length
+        if training_args.do_train:
+            vectorized_datasets["train"] = vectorized_datasets["train"].filter(
+                is_audio_in_length_range,
+                num_proc=num_workers,
+                input_columns=["input_length"],
+            )
 
     # 7. Next, we can prepare the training.
     # Let's use word error rate (WER) as our evaluation metric,

--- a/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
@@ -208,14 +208,14 @@ class DataTrainingArguments:
     max_duration_in_seconds: float = field(
         default=20.0,
         metadata={
-            "help": (
-                "Filter audio files that are longer than `max_duration_in_seconds` seconds to"
-                " 'max_duration_in_seconds`"
-            )
+            "help": "Filter audio files in the training set that are longer than `max_duration_in_seconds` seconds"
         },
     )
     min_duration_in_seconds: float = field(
-        default=0.0, metadata={"help": "Filter audio files that are shorter than `min_duration_in_seconds` seconds"}
+        default=0.0,
+        metadata={
+            "help": "Filter audio files in the training set that are shorter than `min_duration_in_seconds` seconds"
+        },
     )
     preprocessing_only: bool = field(
         default=False,

--- a/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
@@ -618,9 +618,9 @@ def main():
 
     if data_args.max_eval_duration_in_seconds is None:
         logger.warning(
-            "`max_eval_duration_in_seconds` is not provided. Filtering evaluation audio samples longer than"
-            " `max_duration_in_seconds`. This will be updated in Transformers v5: evaluation audio will not be"
-            " filtered by max duration if `max_eval_duration_in_seconds` is not provided."
+            "`max_eval_duration_in_seconds` is not provided. Filtering audio samples in the eval set longer than"
+            " `max_duration_in_seconds`. From Transformers v5, the eval set will not be filtered by maximum audio"
+            " length if `max_eval_duration_in_seconds` is not provided."
         )
         max_eval_input_length = max_input_length
     else:
@@ -628,9 +628,9 @@ def main():
 
     if data_args.min_eval_duration_in_seconds is None:
         logger.warning(
-            "`min_eval_duration_in_seconds` is not provided. Filtering evaluation audio samples shorter than"
-            " `min_duration_in_seconds`. This will be updated in Transformers v5: evaluation audio will not be"
-            " filtered by min duration if `min_eval_duration_in_seconds` is not provided."
+            "`min_eval_duration_in_seconds` is not provided. Filtering audio samples in the eval set longer than"
+            " `min_duration_in_seconds`. From Transformers v5, the eval set will not be filtered by minimum audio"
+            " length if `min_eval_duration_in_seconds` is not provided."
         )
         min_eval_input_length = min_input_length
     else:

--- a/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
@@ -217,6 +217,22 @@ class DataTrainingArguments:
             "help": "Filter audio files in the training set that are shorter than `min_duration_in_seconds` seconds"
         },
     )
+    max_eval_duration_in_seconds: float = field(
+        default=None,
+        metadata={
+            "help": (
+                "Filter audio files in the evaluation set that are longer than `max_eval_duration_in_seconds` seconds"
+            )
+        },
+    )
+    min_eval_duration_in_seconds: float = field(
+        default=None,
+        metadata={
+            "help": (
+                "Filter audio files in the evaluation set that are shorter than `min_eval_duration_in_seconds` seconds"
+            )
+        },
+    )
     preprocessing_only: bool = field(
         default=False,
         metadata={
@@ -599,6 +615,27 @@ def main():
     # derive max & min input length for sample rate & max duration
     max_input_length = data_args.max_duration_in_seconds * feature_extractor.sampling_rate
     min_input_length = data_args.min_duration_in_seconds * feature_extractor.sampling_rate
+
+    if data_args.max_eval_duration_in_seconds is None:
+        logger.warning(
+            "`max_eval_duration_in_seconds` is not provided. Filtering evaluation audio samples longer than"
+            " `max_duration_in_seconds`. This will be updated in Transformers v5: evaluation audio will not be"
+            " filtered by max duration if `max_eval_duration_in_seconds` is not provided."
+        )
+        max_eval_input_length = max_input_length
+    else:
+        max_eval_input_length = data_args.max_eval_duration_in_seconds * feature_extractor.sampling_rate
+
+    if data_args.min_eval_duration_in_seconds is None:
+        logger.warning(
+            "`min_eval_duration_in_seconds` is not provided. Filtering evaluation audio samples shorter than"
+            " `min_duration_in_seconds`. This will be updated in Transformers v5: evaluation audio will not be"
+            " filtered by min duration if `min_eval_duration_in_seconds` is not provided."
+        )
+        min_eval_input_length = min_input_length
+    else:
+        min_eval_input_length = data_args.min_eval_duration_in_seconds * feature_extractor.sampling_rate
+
     audio_column_name = data_args.audio_column_name
     num_workers = data_args.preprocessing_num_workers
 
@@ -639,6 +676,18 @@ def main():
         if training_args.do_train:
             vectorized_datasets["train"] = vectorized_datasets["train"].filter(
                 is_audio_in_length_range,
+                num_proc=num_workers,
+                input_columns=["input_length"],
+            )
+
+        # filter evaluation data that is shorter than min_eval_input_length or longer than
+        # max_eval_input_length
+        def is_eval_audio_in_length_range(length):
+            return length > min_eval_input_length and length < max_eval_input_length
+
+        if training_args.do_eval:
+            vectorized_datasets["eval"] = vectorized_datasets["eval"].filter(
+                is_eval_audio_in_length_range,
                 num_proc=num_workers,
                 input_columns=["input_length"],
             )

--- a/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
@@ -669,7 +669,7 @@ def main():
         )
 
         def is_audio_in_length_range(length):
-            return length > min_input_length and length < max_input_length
+            return min_input_length < length < max_input_length
 
         # filter training data that is shorter than min_input_length or longer than
         # max_input_length
@@ -683,7 +683,7 @@ def main():
         # filter evaluation data that is shorter than min_eval_input_length or longer than
         # max_eval_input_length
         def is_eval_audio_in_length_range(length):
-            return length > min_eval_input_length and length < max_eval_input_length
+            return min_eval_input_length < length < max_eval_input_length
 
         if training_args.do_eval:
             vectorized_datasets["eval"] = vectorized_datasets["eval"].filter(

--- a/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
@@ -404,16 +404,17 @@ def main():
             desc="preprocess train dataset",
         )
 
-    # filter data that is shorter than min_input_length or longer than
+    # filter training data that is shorter than min_input_length or longer than
     # max_input_length
     def is_audio_in_length_range(length):
         return length > min_input_length and length < max_input_length
 
-    vectorized_datasets = vectorized_datasets.filter(
-        is_audio_in_length_range,
-        num_proc=num_workers,
-        input_columns=["input_length"],
-    )
+    if training_args.do_train:
+        vectorized_datasets["train"] = vectorized_datasets["train"].filter(
+            is_audio_in_length_range,
+            num_proc=num_workers,
+            input_columns=["input_length"],
+        )
 
     # for large datasets it is advised to run the preprocessing on a
     # single machine first with `args.preprocessing_only` since there will mostly likely

--- a/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
@@ -390,9 +390,9 @@ def main():
 
     if data_args.max_eval_duration_in_seconds is None:
         logger.warning(
-            "`max_eval_duration_in_seconds` is not provided. Filtering evaluation audio samples longer than"
-            " `max_duration_in_seconds`. This will be updated in Transformers v5: evaluation audio will not be"
-            " filtered by max duration if `max_eval_duration_in_seconds` is not provided."
+            "`max_eval_duration_in_seconds` is not provided. Filtering audio samples in the eval set longer than"
+            " `max_duration_in_seconds`. From Transformers v5, the eval set will not be filtered by maximum audio"
+            " length if `max_eval_duration_in_seconds` is not provided."
         )
         max_eval_input_length = max_input_length
     else:
@@ -400,9 +400,9 @@ def main():
 
     if data_args.min_eval_duration_in_seconds is None:
         logger.warning(
-            "`min_eval_duration_in_seconds` is not provided. Filtering evaluation audio samples shorter than"
-            " `min_duration_in_seconds`. This will be updated in Transformers v5: evaluation audio will not be"
-            " filtered by min duration if `min_eval_duration_in_seconds` is not provided."
+            "`min_eval_duration_in_seconds` is not provided. Filtering audio samples in the eval set longer than"
+            " `min_duration_in_seconds`. From Transformers v5, the eval set will not be filtered by minimum audio"
+            " length if `min_eval_duration_in_seconds` is not provided."
         )
         min_eval_input_length = min_input_length
     else:

--- a/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
@@ -151,14 +151,14 @@ class DataTrainingArguments:
     max_duration_in_seconds: float = field(
         default=20.0,
         metadata={
-            "help": (
-                "Truncate audio files that are longer than `max_duration_in_seconds` seconds to"
-                " 'max_duration_in_seconds`"
-            )
+            "help": "Filter audio files in the training set that are longer than `max_duration_in_seconds` seconds"
         },
     )
     min_duration_in_seconds: float = field(
-        default=0.0, metadata={"help": "Filter audio files that are shorter than `min_duration_in_seconds` seconds"}
+        default=0.0,
+        metadata={
+            "help": "Filter audio files in the training set that are shorter than `min_duration_in_seconds` seconds"
+        },
     )
     preprocessing_only: bool = field(
         default=False,

--- a/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
@@ -160,6 +160,22 @@ class DataTrainingArguments:
             "help": "Filter audio files in the training set that are shorter than `min_duration_in_seconds` seconds"
         },
     )
+    max_eval_duration_in_seconds: float = field(
+        default=None,
+        metadata={
+            "help": (
+                "Filter audio files in the evaluation set that are longer than `max_eval_duration_in_seconds` seconds"
+            )
+        },
+    )
+    min_eval_duration_in_seconds: float = field(
+        default=None,
+        metadata={
+            "help": (
+                "Filter audio files in the evaluation set that are shorter than `min_eval_duration_in_seconds` seconds"
+            )
+        },
+    )
     preprocessing_only: bool = field(
         default=False,
         metadata={
@@ -371,6 +387,27 @@ def main():
     # We need to read the audio files as arrays and tokenize the targets.
     max_input_length = data_args.max_duration_in_seconds * feature_extractor.sampling_rate
     min_input_length = data_args.min_duration_in_seconds * feature_extractor.sampling_rate
+
+    if data_args.max_eval_duration_in_seconds is None:
+        logger.warning(
+            "`max_eval_duration_in_seconds` is not provided. Filtering evaluation audio samples longer than"
+            " `max_duration_in_seconds`. This will be updated in Transformers v5: evaluation audio will not be"
+            " filtered by max duration if `max_eval_duration_in_seconds` is not provided."
+        )
+        max_eval_input_length = max_input_length
+    else:
+        max_eval_input_length = data_args.max_eval_duration_in_seconds * feature_extractor.sampling_rate
+
+    if data_args.min_eval_duration_in_seconds is None:
+        logger.warning(
+            "`min_eval_duration_in_seconds` is not provided. Filtering evaluation audio samples shorter than"
+            " `min_duration_in_seconds`. This will be updated in Transformers v5: evaluation audio will not be"
+            " filtered by min duration if `min_eval_duration_in_seconds` is not provided."
+        )
+        min_eval_input_length = min_input_length
+    else:
+        min_eval_input_length = data_args.min_eval_duration_in_seconds * feature_extractor.sampling_rate
+
     audio_column_name = data_args.audio_column_name
     num_workers = data_args.preprocessing_num_workers
     text_column_name = data_args.text_column_name
@@ -412,6 +449,18 @@ def main():
     if training_args.do_train:
         vectorized_datasets["train"] = vectorized_datasets["train"].filter(
             is_audio_in_length_range,
+            num_proc=num_workers,
+            input_columns=["input_length"],
+        )
+
+    # filter evaluation data that is shorter than min_eval_input_length or longer than
+    # max_eval_input_length
+    def is_eval_audio_in_length_range(length):
+        return length > min_eval_input_length and length < max_eval_input_length
+
+    if training_args.do_eval:
+        vectorized_datasets["eval"] = vectorized_datasets["eval"].filter(
+            is_eval_audio_in_length_range,
             num_proc=num_workers,
             input_columns=["input_length"],
         )

--- a/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
@@ -444,7 +444,7 @@ def main():
     # filter training data that is shorter than min_input_length or longer than
     # max_input_length
     def is_audio_in_length_range(length):
-        return length > min_input_length and length < max_input_length
+        return min_input_length < length < max_input_length
 
     if training_args.do_train:
         vectorized_datasets["train"] = vectorized_datasets["train"].filter(
@@ -456,7 +456,7 @@ def main():
     # filter evaluation data that is shorter than min_eval_input_length or longer than
     # max_eval_input_length
     def is_eval_audio_in_length_range(length):
-        return length > min_eval_input_length and length < max_eval_input_length
+        return min_eval_input_length < length < max_eval_input_length
 
     if training_args.do_eval:
         vectorized_datasets["eval"] = vectorized_datasets["eval"].filter(

--- a/examples/research_projects/robust-speech-event/run_speech_recognition_ctc_bnb.py
+++ b/examples/research_projects/robust-speech-event/run_speech_recognition_ctc_bnb.py
@@ -621,12 +621,14 @@ def main():
         def is_audio_in_length_range(length):
             return length > min_input_length and length < max_input_length
 
-        # filter data that is shorter than min_input_length
-        vectorized_datasets = vectorized_datasets.filter(
-            is_audio_in_length_range,
-            num_proc=num_workers,
-            input_columns=["input_length"],
-        )
+        # filter training data that is shorter than min_input_length or longer than
+        # max_input_length
+        if training_args.do_train:
+            vectorized_datasets["train"] = vectorized_datasets["train"].filter(
+                is_audio_in_length_range,
+                num_proc=num_workers,
+                input_columns=["input_length"],
+            )
 
     # 7. Next, we can prepare the training.
     # Let's use word error rate (WER) as our evaluation metric,

--- a/examples/research_projects/robust-speech-event/run_speech_recognition_ctc_bnb.py
+++ b/examples/research_projects/robust-speech-event/run_speech_recognition_ctc_bnb.py
@@ -605,9 +605,9 @@ def main():
 
     if data_args.max_eval_duration_in_seconds is None:
         logger.warning(
-            "`max_eval_duration_in_seconds` is not provided. Filtering evaluation audio samples longer than"
-            " `max_duration_in_seconds`. This will be updated in Transformers v5: evaluation audio will not be"
-            " filtered by max duration if `max_eval_duration_in_seconds` is not provided."
+            "`max_eval_duration_in_seconds` is not provided. Filtering audio samples in the eval set longer than"
+            " `max_duration_in_seconds`. From Transformers v5, the eval set will not be filtered by maximum audio"
+            " length if `max_eval_duration_in_seconds` is not provided."
         )
         max_eval_input_length = max_input_length
     else:
@@ -615,9 +615,9 @@ def main():
 
     if data_args.min_eval_duration_in_seconds is None:
         logger.warning(
-            "`min_eval_duration_in_seconds` is not provided. Filtering evaluation audio samples shorter than"
-            " `min_duration_in_seconds`. This will be updated in Transformers v5: evaluation audio will not be"
-            " filtered by min duration if `min_eval_duration_in_seconds` is not provided."
+            "`min_eval_duration_in_seconds` is not provided. Filtering audio samples in the eval set longer than"
+            " `min_duration_in_seconds`. From Transformers v5, the eval set will not be filtered by minimum audio"
+            " length if `min_eval_duration_in_seconds` is not provided."
         )
         min_eval_input_length = min_input_length
     else:

--- a/examples/research_projects/robust-speech-event/run_speech_recognition_ctc_bnb.py
+++ b/examples/research_projects/robust-speech-event/run_speech_recognition_ctc_bnb.py
@@ -206,14 +206,14 @@ class DataTrainingArguments:
     max_duration_in_seconds: float = field(
         default=20.0,
         metadata={
-            "help": (
-                "Filter audio files that are longer than `max_duration_in_seconds` seconds to"
-                " 'max_duration_in_seconds`"
-            )
+            "help": "Filter audio files in the training set that are longer than `max_duration_in_seconds` seconds"
         },
     )
     min_duration_in_seconds: float = field(
-        default=0.0, metadata={"help": "Filter audio files that are shorter than `min_duration_in_seconds` seconds"}
+        default=0.0,
+        metadata={
+            "help": "Filter audio files in the training set that are shorter than `min_duration_in_seconds` seconds"
+        },
     )
     preprocessing_only: bool = field(
         default=False,

--- a/examples/research_projects/robust-speech-event/run_speech_recognition_ctc_bnb.py
+++ b/examples/research_projects/robust-speech-event/run_speech_recognition_ctc_bnb.py
@@ -656,7 +656,7 @@ def main():
         )
 
         def is_audio_in_length_range(length):
-            return length > min_input_length and length < max_input_length
+            return min_input_length < length < max_input_length
 
         # filter training data that is shorter than min_input_length or longer than
         # max_input_length
@@ -670,7 +670,7 @@ def main():
         # filter evaluation data that is shorter than min_eval_input_length or longer than
         # max_eval_input_length
         def is_eval_audio_in_length_range(length):
-            return length > min_eval_input_length and length < max_eval_input_length
+            return min_eval_input_length < length < max_eval_input_length
 
         if training_args.do_eval:
             vectorized_datasets["eval"] = vectorized_datasets["eval"].filter(


### PR DESCRIPTION
# What does this PR do?

We should only filter training samples by our audio length criterion when fine-tuning ASR systems. The eval and test sets should **not** be filtered. Doing so leads to partial datasets, and thus in-valid results.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@patrickvonplaten @anton-l 