### PR TITLE
fix missing block when there is no failure

### DIFF
--- a/utils/notification_service_doc_tests.py
+++ b/utils/notification_service_doc_tests.py
@@ -167,7 +167,7 @@ class Message:
         if self.n_failures > 0:
             blocks.extend([self.category_failures])
 
-        if self.no_failures == 0:
+        if self.n_failures == 0:
             blocks.append(self.no_failures)
 
         return json.dumps(blocks)


### PR DESCRIPTION
# What does this PR do?

Currently, when doc test has no failure, we don't see anything other than `🤗 Results of the doc tests.` in slack report.
This is because the block defined in `no_failures` property is not included in `def payload`, as the condition `self.no_failures == 0` should be `self.n_failures == 0`.