### PR TITLE
fix the error which will make shape not match occur.

### DIFF
--- a/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
@@ -42,6 +42,7 @@ from ...utils import (
 )
 from .configuration_layoutlmv2 import LayoutLMv2Config
 
+
 # soft dependency
 if is_detectron2_available():
     import detectron2

--- a/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
@@ -42,7 +42,6 @@ from ...utils import (
 )
 from .configuration_layoutlmv2 import LayoutLMv2Config
 
-
 # soft dependency
 if is_detectron2_available():
     import detectron2
@@ -1046,10 +1045,7 @@ class LayoutLMv2ForSequenceClassification(LayoutLMv2PreTrainedModel):
         device = input_ids.device if input_ids is not None else inputs_embeds.device
 
         visual_feature_map_size = self.config.image_feature_pool_shape[0] * self.config.image_feature_pool_shape[1]
-        visual_shape = torch.Size([
-            input_shape[0],
-            visual_feature_map_size
-        ])
+        visual_shape = torch.Size([input_shape[0], visual_feature_map_size])
         final_shape = torch.Size([input_shape[0], input_shape[1] + visual_feature_map_size])
 
         visual_bbox = self.layoutlmv2._calc_visual_bbox(

--- a/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
@@ -869,14 +869,9 @@ class LayoutLMv2Model(LayoutLMv2PreTrainedModel):
 
         input_shape = self._get_input_shape(input_ids, inputs_embeds)
         device = input_ids.device if input_ids is not None else inputs_embeds.device
-
-        visual_shape = list(input_shape)
-        visual_shape[1] = self.config.image_feature_pool_shape[0] * self.config.image_feature_pool_shape[1]
-        visual_shape = torch.Size(visual_shape)
-        # needs a new copy of input_shape for tracing. Otherwise wrong dimensions will occur
-        final_shape = list(self._get_input_shape(input_ids, inputs_embeds))
-        final_shape[1] += visual_shape[1]
-        final_shape = torch.Size(final_shape)
+        visual_feature_map_size = self.config.image_feature_pool_shape[0] * self.config.image_feature_pool_shape[1]
+        visual_shape = torch.Size([input_shape[0], visual_feature_map_size])
+        final_shape = torch.Size([input_shape[0], input_shape[1] + visual_feature_map_size])
 
         visual_bbox = self._calc_visual_bbox(self.config.image_feature_pool_shape, bbox, device, final_shape)
         final_bbox = torch.cat([bbox, visual_bbox], dim=1)
@@ -1050,12 +1045,12 @@ class LayoutLMv2ForSequenceClassification(LayoutLMv2PreTrainedModel):
 
         device = input_ids.device if input_ids is not None else inputs_embeds.device
 
-        visual_shape = list(input_shape)
-        visual_shape[1] = self.config.image_feature_pool_shape[0] * self.config.image_feature_pool_shape[1]
-        visual_shape = torch.Size(visual_shape)
-        final_shape = list(input_shape)
-        final_shape[1] += visual_shape[1]
-        final_shape = torch.Size(final_shape)
+        visual_feature_map_size = self.config.image_feature_pool_shape[0] * self.config.image_feature_pool_shape[1]
+        visual_shape = torch.Size([
+            input_shape[0],
+            visual_feature_map_size
+        ])
+        final_shape = torch.Size([input_shape[0], input_shape[1] + visual_feature_map_size])
 
         visual_bbox = self.layoutlmv2._calc_visual_bbox(
             self.config.image_feature_pool_shape, bbox, device, final_shape


### PR DESCRIPTION
# What does this PR do?

When using PyTorch for model trace, the size of feature map will be inconsistent, resulting in failure to export successfully. The reason is that += is used in the size calculation code, and the object that happens to be added happens to be a shallow copy object, causing input_shape to change. You can solve this problem by declaring variables directly.

# Test script
```python3
from einops import repeat
from transformers import BertTokenizerFast,LayoutXLMTokenizerFast,LayoutLMv2ForSequenceClassification
import torch


## dummy inputs
dummy_input_ids = torch.LongTensor(torch.randint(low=0, high=1000, size=(2,256)))#.cuda()
box = [[48, 84, 73, 128]] * 256
dummy_bboxes = repeat(torch.LongTensor(box).unsqueeze(0), '1 b s-> 2 b s')
dummy_attention_mask = torch.LongTensor(torch.randint( low=0, high=1024, size=(2, 256) ))#.cuda()
dummy_imgs = torch.randn(2, 3, 448, 448)#.cuda()
dummy_token_ids = torch.zeros_like(dummy_attention_mask)

dummy_inputs = [
    dummy_input_ids,
    dummy_bboxes,
    dummy_imgs,
    dummy_attention_mask,
    dummy_token_ids
    ]
with torch.no_grad():

    model = LayoutLMv2ForSequenceClassification.from_pretrained("microsoft/layoutlmv2-base-uncased", torchscript=True,num_labels=30522)
    model.eval()
    traced_model = torch.jit.trace(func=model,
                                       strict=False,  
                                       example_inputs=dummy_inputs)
torch.jit.save(traced_model,'temp.pt')
model = torch.jit.load('temp.pt')
model.eval()
with torch.no_grad():
    result = model(*dummy_inputs)
print(result)
```

**If the script is run directly before the code is modified, the feature map size will be inconsistent**

# Who can review?
@LysandreJik
