### PR TITLE
Fix decode_input_ids to bare T5Model and improve doc

### DIFF
--- a/docs/source/en/model_doc/t5.mdx
+++ b/docs/source/en/model_doc/t5.mdx
@@ -187,9 +187,9 @@ ignored. The code example below illustrates all of this.
 
 >>> # encode the targets
 >>> target_encoding = tokenizer(
-...     [output_sequence_1, output_sequence_2], 
-...     padding="longest", 
-...     max_length=max_target_length, 
+...     [output_sequence_1, output_sequence_2],
+...     padding="longest",
+...     max_length=max_target_length,
 ...     truncation=True,
 ...     return_tensors="pt",
 ... )

--- a/docs/source/en/model_doc/t5.mdx
+++ b/docs/source/en/model_doc/t5.mdx
@@ -187,12 +187,15 @@ ignored. The code example below illustrates all of this.
 
 >>> # encode the targets
 >>> target_encoding = tokenizer(
-...     [output_sequence_1, output_sequence_2], padding="longest", max_length=max_target_length, truncation=True
+...     [output_sequence_1, output_sequence_2], 
+...     padding="longest", 
+...     max_length=max_target_length, 
+...     truncation=True,
+...     return_tensors="pt",
 ... )
 >>> labels = target_encoding.input_ids
 
 >>> # replace padding token id's of the labels by -100 so it's ignored by the loss
->>> labels = torch.tensor(labels)
 >>> labels[labels == tokenizer.pad_token_id] = -100
 
 >>> # forward pass

--- a/src/transformers/models/t5/modeling_flax_t5.py
+++ b/src/transformers/models/t5/modeling_flax_t5.py
@@ -1388,7 +1388,7 @@ FLAX_T5_MODEL_DOCSTRING = """
     ... ).input_ids
     >>> decoder_input_ids = tokenizer("Studies show that", return_tensors="np").input_ids
 
-    >>> # preprocess: Prepend decoder_input_ids with start token which is pad token for T5Model. 
+    >>> # preprocess: Prepend decoder_input_ids with start token which is pad token for T5Model.
     >>> # This is not needed for T5ForConditionalGeneration as it does this internally using labels arg.
     >>> decoder_input_ids = model._shift_right(decoder_input_ids)
 

--- a/src/transformers/models/t5/modeling_flax_t5.py
+++ b/src/transformers/models/t5/modeling_flax_t5.py
@@ -1388,6 +1388,10 @@ FLAX_T5_MODEL_DOCSTRING = """
     ... ).input_ids
     >>> decoder_input_ids = tokenizer("Studies show that", return_tensors="np").input_ids
 
+    >>> # preprocess: Prepend decoder_input_ids with start token which is pad token for T5Model. 
+    >>> # This is not needed for T5ForConditionalGeneration as it does this internally using labels arg.
+    >>> decoder_input_ids = model._shift_right(decoder_input_ids)
+
     >>> # forward pass
     >>> outputs = model(input_ids=input_ids, decoder_input_ids=decoder_input_ids)
     >>> last_hidden_states = outputs.last_hidden_state

--- a/src/transformers/models/t5/modeling_flax_t5.py
+++ b/src/transformers/models/t5/modeling_flax_t5.py
@@ -1389,7 +1389,7 @@ FLAX_T5_MODEL_DOCSTRING = """
     >>> decoder_input_ids = tokenizer("Studies show that", return_tensors="np").input_ids
 
     >>> # preprocess: Prepend decoder_input_ids with start token which is pad token for T5Model.
-    >>> # This is not needed for T5ForConditionalGeneration as it does this internally using labels arg.
+    >>> # This is not needed for torch's T5ForConditionalGeneration as it does this internally using labels arg.
     >>> decoder_input_ids = model._shift_right(decoder_input_ids)
 
     >>> # forward pass

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -1376,6 +1376,10 @@ class T5Model(T5PreTrainedModel):
         ... ).input_ids  # Batch size 1
         >>> decoder_input_ids = tokenizer("Studies show that", return_tensors="pt").input_ids  # Batch size 1
 
+        >>> # preprocess: Prepend decoder_input_ids with start token which is pad token for T5Model. 
+        >>> # This is not needed for T5ForConditionalGeneration as it does this internally using labels arg.
+        >>> decoder_input_ids = model._shift_right(decoder_input_ids)
+
         >>> # forward pass
         >>> outputs = model(input_ids=input_ids, decoder_input_ids=decoder_input_ids)
         >>> last_hidden_states = outputs.last_hidden_state

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -1377,7 +1377,7 @@ class T5Model(T5PreTrainedModel):
         >>> decoder_input_ids = tokenizer("Studies show that", return_tensors="pt").input_ids  # Batch size 1
 
         >>> # preprocess: Prepend decoder_input_ids with start token which is pad token for T5Model.
-        >>> # This is not needed for T5ForConditionalGeneration as it does this internally using labels arg.
+        >>> # This is not needed for torch's T5ForConditionalGeneration as it does this internally using labels arg.
         >>> decoder_input_ids = model._shift_right(decoder_input_ids)
 
         >>> # forward pass

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -1376,7 +1376,7 @@ class T5Model(T5PreTrainedModel):
         ... ).input_ids  # Batch size 1
         >>> decoder_input_ids = tokenizer("Studies show that", return_tensors="pt").input_ids  # Batch size 1
 
-        >>> # preprocess: Prepend decoder_input_ids with start token which is pad token for T5Model. 
+        >>> # preprocess: Prepend decoder_input_ids with start token which is pad token for T5Model.
         >>> # This is not needed for T5ForConditionalGeneration as it does this internally using labels arg.
         >>> decoder_input_ids = model._shift_right(decoder_input_ids)
 

--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -1181,7 +1181,7 @@ class TFT5Model(TFT5PreTrainedModel):
         >>> decoder_input_ids = tokenizer("Studies show that", return_tensors="tf").input_ids  # Batch size 1
 
         >>> # preprocess: Prepend decoder_input_ids with start token which is pad token for T5Model.
-        >>> # This is not needed for T5ForConditionalGeneration as it does this internally using labels arg.
+        >>> # This is not needed for torch's T5ForConditionalGeneration as it does this internally using labels arg.
         >>> decoder_input_ids = model._shift_right(decoder_input_ids)
 
         >>> # forward pass

--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -1180,7 +1180,7 @@ class TFT5Model(TFT5PreTrainedModel):
         ... ).input_ids  # Batch size 1
         >>> decoder_input_ids = tokenizer("Studies show that", return_tensors="tf").input_ids  # Batch size 1
 
-        >>> # preprocess: Prepend decoder_input_ids with start token which is pad token for T5Model. 
+        >>> # preprocess: Prepend decoder_input_ids with start token which is pad token for T5Model.
         >>> # This is not needed for T5ForConditionalGeneration as it does this internally using labels arg.
         >>> decoder_input_ids = model._shift_right(decoder_input_ids)
 

--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -1180,6 +1180,10 @@ class TFT5Model(TFT5PreTrainedModel):
         ... ).input_ids  # Batch size 1
         >>> decoder_input_ids = tokenizer("Studies show that", return_tensors="tf").input_ids  # Batch size 1
 
+        >>> # preprocess: Prepend decoder_input_ids with start token which is pad token for T5Model. 
+        >>> # This is not needed for T5ForConditionalGeneration as it does this internally using labels arg.
+        >>> decoder_input_ids = model._shift_right(decoder_input_ids)
+
         >>> # forward pass
         >>> outputs = model(input_ids, decoder_input_ids=decoder_input_ids)
         >>> last_hidden_states = outputs.last_hidden_state


### PR DESCRIPTION
# What does this PR do?

* Fix 1: use the tokenizer to obtain the labels as tensors. `docs/source/en/model_doc/t5.mdx`
*  Fix 2: `src/transformers/models/t5/`
    * Present case: T5 prepends the decoder_input_ids with pad token. This preprocessing is handled internally by `T5ForConditionalGeneration` by shifting the labels to the right. 
    * Issue: This preprocessing needs to be done manually while using bare T5Model. This is missing from the example which uses bare T5Model.
    * Proposed Fix: Added a preprocessing step in the example so that the input matches with what T5 expects at its decoder. The PR reuses the `_shift_right()` method which is an internal function to T5. Please let me know if we can rename `_shift_right()` to `shift_right()` or if there is a better way to handle this.


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


@sgugger @patrickvonplaten @patil-suraj
