### PR TITLE
Fix gradient checkpointing tests for `encoder-decoder` models

### DIFF
--- a/tests/models/speech_encoder_decoder/test_modeling_speech_encoder_decoder.py
+++ b/tests/models/speech_encoder_decoder/test_modeling_speech_encoder_decoder.py
@@ -403,6 +403,7 @@ class EncoderDecoderMixin:
         )
 
         model = SpeechEncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
+        model.to(torch_device)
         model.train()
         model.gradient_checkpointing_enable()
         model.config.decoder_start_token_id = 0

--- a/tests/models/vision_encoder_decoder/test_modeling_vision_encoder_decoder.py
+++ b/tests/models/vision_encoder_decoder/test_modeling_vision_encoder_decoder.py
@@ -331,6 +331,7 @@ class EncoderDecoderMixin:
         )
 
         model = VisionEncoderDecoderModel(encoder=encoder_model, decoder=decoder_model)
+        model.to(torch_device)
         model.train()
         model.gradient_checkpointing_enable()
         model.config.decoder_start_token_id = 0


### PR DESCRIPTION
# What does this PR do?

The recently added tests (#18697) didn't send the model to the correct device and caused some test failed. This PR fixes it.