### PR TITLE
Fix mock in `test_cached_files_are_used_when_internet_is_down`

### DIFF
--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -349,6 +349,7 @@ class ConfigTestUtils(unittest.TestCase):
         response_mock.status_code = 500
         response_mock.headers = {}
         response_mock.raise_for_status.side_effect = HTTPError
+        response_mock.json.return_value = {}
 
         # Download this model to make sure it's in the cache.
         _ = BertConfig.from_pretrained("hf-internal-testing/tiny-random-bert")

--- a/tests/test_feature_extraction_common.py
+++ b/tests/test_feature_extraction_common.py
@@ -172,6 +172,7 @@ class FeatureExtractorUtilTester(unittest.TestCase):
         response_mock.status_code = 500
         response_mock.headers = {}
         response_mock.raise_for_status.side_effect = HTTPError
+        response_mock.json.return_value = {}
 
         # Download this model to make sure it's in the cache.
         _ = Wav2Vec2FeatureExtractor.from_pretrained("hf-internal-testing/tiny-random-wav2vec2")

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2931,6 +2931,7 @@ class ModelUtilsTest(TestCasePlus):
         response_mock.status_code = 500
         response_mock.headers = {}
         response_mock.raise_for_status.side_effect = HTTPError
+        response_mock.json.return_value = {}
 
         # Download this model to make sure it's in the cache.
         _ = BertModel.from_pretrained("hf-internal-testing/tiny-random-bert")

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1924,6 +1924,7 @@ class UtilsFunctionsTest(unittest.TestCase):
         response_mock.status_code = 500
         response_mock.headers = {}
         response_mock.raise_for_status.side_effect = HTTPError
+        response_mock.json.return_value = {}
 
         # Download this model to make sure it's in the cache.
         _ = TFBertModel.from_pretrained("hf-internal-testing/tiny-random-bert")

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -3875,6 +3875,7 @@ class TokenizerUtilTester(unittest.TestCase):
         response_mock.status_code = 500
         response_mock.headers = {}
         response_mock.raise_for_status.side_effect = HTTPError
+        response_mock.json.return_value = {}
 
         # Download this model to make sure it's in the cache.
         _ = BertTokenizer.from_pretrained("hf-internal-testing/tiny-random-bert")


### PR DESCRIPTION
# What does this PR do?

Fix the CI that is currently breaking because of the [0.9.1 patch release](https://github.com/huggingface/huggingface_hub/releases/tag/v0.9.1) of `huggingface_hub`.

Problem is that we are looking at the response from the server when having a HTTPError. In the tests, the response is mocked which makes `response.json()` a mock instead of a dictionary. I now set it to `{}` which means an empty response from the server.


See [slack thread](https://huggingface.slack.com/archives/C01NE71C4F7/p1661526937492729) (internal link) for more context.

# Expected result

The CI should now pass correctly.