### PR TITLE
follow layoutlmv3 to avoid device error

### DIFF
--- a/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
@@ -90,8 +90,8 @@ class LayoutLMv2Embeddings(nn.Module):
         except IndexError as e:
             raise IndexError("The `bbox` coordinate values should be within 0-1000 range.") from e
 
-        h_position_embeddings = self.h_position_embeddings(bbox[:, :, 3] - bbox[:, :, 1])
-        w_position_embeddings = self.w_position_embeddings(bbox[:, :, 2] - bbox[:, :, 0])
+        h_position_embeddings = self.h_position_embeddings(torch.clip(bbox[:, :, 3] - bbox[:, :, 1], 0, 1023))
+        w_position_embeddings = self.w_position_embeddings(torch.clip(bbox[:, :, 2] - bbox[:, :, 0], 0, 1023))
 
         spatial_position_embeddings = torch.cat(
             [


### PR DESCRIPTION
# What does this PR do?

Slightly modify the way that we calculate the height and width embeddings for LayoutLMv2. The calculation is simply same as LayoutLMv3 to avoid the device-assert error when we run experiments on GPU. 

https://github.com/huggingface/transformers/blob/main/src/transformers/models/layoutlmv3/modeling_layoutlmv3.py#L270-L271

Fixes # (issue)




## Who can review?



Models:
 - LayoutLMv2: @patrickvonplaten @NielsRogge 


