### PR TITLE
Delete `state_dict` to release memory as early as possible

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -438,8 +438,7 @@ def _load_state_dict_into_model(model_to_load, state_dict, start_prefix):
 
     load(model_to_load, state_dict, prefix=start_prefix)
     # Delete `state_dict` so it could be collected by GC earlier. Note that `state_dict` is a copy of the argument, so
-    # it's safe to delete it. We don't call `gc.collect` here, instead let GC make its own decision.
-    # See https://github.com/huggingface/transformers/issues/18782
+    # it's safe to delete it.
     del state_dict
 
     return error_msgs

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -434,7 +434,7 @@ def _load_state_dict_into_model(model_to_load, state_dict, start_prefix):
 
         for name, child in module._modules.items():
             if child is not None:
-                load(child, prefix + name + ".")
+                load(child, state_dict, prefix + name + ".")
 
     load(model_to_load, state_dict, prefix=start_prefix)
     # Delete `state_dict` so it could be collected by GC earlier. Note that `state_dict` is a copy of the argument, so

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -417,7 +417,7 @@ def _load_state_dict_into_model(model_to_load, state_dict, start_prefix):
 
     # PyTorch's `_load_from_state_dict` does not copy parameters in a module's descendants
     # so we need to apply the function recursively.
-    def load(module: nn.Module, prefix=""):
+    def load(module: nn.Module, state_dict, prefix=""):
         local_metadata = {} if metadata is None else metadata.get(prefix[:-1], {})
         args = (state_dict, prefix, local_metadata, True, [], [], error_msgs)
         if is_deepspeed_zero3_enabled():
@@ -436,7 +436,7 @@ def _load_state_dict_into_model(model_to_load, state_dict, start_prefix):
             if child is not None:
                 load(child, prefix + name + ".")
 
-    load(model_to_load, prefix=start_prefix)
+    load(model_to_load, state_dict, prefix=start_prefix)
     # Delete `state_dict` so it could be collected by GC earlier. Note that `state_dict` is a copy of the argument, so
     # it's safe to delete it. We don't call `gc.collect` here, instead let GC make its own decision.
     # See https://github.com/huggingface/transformers/issues/18782

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -437,6 +437,10 @@ def _load_state_dict_into_model(model_to_load, state_dict, start_prefix):
                 load(child, prefix + name + ".")
 
     load(model_to_load, prefix=start_prefix)
+    # Delete `state_dict` so it could be collected by GC earlier. Note that `state_dict` is a copy of the argument, so
+    # it's safe to delete it. We don't call `gc.collect` here, instead let GC make its own decision.
+    # See https://github.com/huggingface/transformers/issues/18782
+    del state_dict
 
     return error_msgs
 


### PR DESCRIPTION
# What does this PR do?

Fix #18782.

Note that this is not a real memory issue. A call to `gc.collect()` at the end of `from_pretrained()` works well too.

However this PR finds and simply `del state_dict` at the end of `_load_state_dict_into_model()`, and `GC` is able to perform housekeeping on its own at a earlier time.