### PR TITLE
TF: TFMarianMTModel final logits bias as a layer

### DIFF
--- a/src/transformers/models/marian/modeling_tf_marian.py
+++ b/src/transformers/models/marian/modeling_tf_marian.py
@@ -1279,9 +1279,6 @@ class BiasLayer(tf.keras.layers.Layer):
         super().__init__(name=name, **kwargs)
         self.bias = self.add_weight(name, shape=shape, initializer=initializer, trainable=trainable)
 
-    def call(self, x):
-        return x + self.bias
-
 
 @add_start_docstrings(
     "The MARIAN Model with a language modeling head. Can be used for summarization.",

--- a/src/transformers/models/marian/modeling_tf_marian.py
+++ b/src/transformers/models/marian/modeling_tf_marian.py
@@ -1277,6 +1277,9 @@ class BiasLayer(tf.keras.layers.Layer):
 
     def __init__(self, shape, initializer, trainable, name, **kwargs):
         super().__init__(name=name, **kwargs)
+        # Note: the name of this variable will NOT be scoped when serialized, i.e. it will not be in the format of
+        # "outer_layer/inner_layer/.../name:0". Instead, it will be "name:0". For further details, see:
+        # https://github.com/huggingface/transformers/pull/18833#issuecomment-1233090214
         self.bias = self.add_weight(name=name, shape=shape, initializer=initializer, trainable=trainable)
 
     def call(self, x):

--- a/src/transformers/models/marian/modeling_tf_marian.py
+++ b/src/transformers/models/marian/modeling_tf_marian.py
@@ -1277,7 +1277,7 @@ class BiasLayer(tf.keras.layers.Layer):
 
     def __init__(self, shape, initializer, trainable, name, **kwargs):
         super().__init__(name=name, **kwargs)
-        self.bias = self.add_weight(name, shape=shape, initializer=initializer, trainable=trainable)
+        self.bias = self.add_weight(name=name, shape=shape, initializer=initializer, trainable=trainable)
 
 
 @add_start_docstrings(
@@ -1296,7 +1296,7 @@ class TFMarianMTModel(TFMarianPreTrainedModel, TFCausalLanguageModelingLoss):
         self.use_cache = config.use_cache
         # final_bias_logits is registered as a buffer in pytorch, so not trainable for the sake of consistency.
         self._bias_layer = BiasLayer(
-            shape=[1, config.vocab_size], initializer="zeros", trainable=False, name="final_logits_bias"
+            name="final_logits_bias", shape=[1, config.vocab_size], initializer="zeros", trainable=False
         )
         self.final_logits_bias = self._bias_layer.bias  # alias to keep the same interface with PT
 


### PR DESCRIPTION
# What does this PR do?

Fixes #18802 

As stated in the issue above, `final_logits_bias` in `TFMarianMTModel` are not being loaded at `from_pretrained(...)` time. The PT model has this variable defined, and thus the outputs of the model in the two frameworks are very different (>1e-1).

Actually, these weights are also not being stored when the TF version is saved, for the same reason -- only layers are stored/loaded with the functions we are using (`.save_weights` and `.load_weights`), and this bias weight is not inside a layer.

As a solution, this PR moves the bias to a layer and creates an alias for it, resulting in no interface changes. After this change, the models from `Helsinki-NLP` can be converted with the `pt-to-tf` CLI, passing all the quality checks.

⚠️ Other models have this pattern, so I will apply the change to them in a separate PR if this one gets approved. 