### PR TITLE
Fix add model like 

### DIFF
--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -41,10 +41,12 @@ jobs:
         run: |
           . ~/venv/bin/activate
           python setup.py develop
-          transformer_loc=$(pip show transformers | grep "Location: " | cut -c11-)
-          transformer_repo_loc=$(pwd .)
-          if [ "$transformer_loc" != "$transformer_repo_loc/src" ]; then
-              echo "transformers is from $transformer_loc but it shoud be from $transformer_repo_loc/src."
+          transformers_install=$(pip list -e | grep transformers)
+          transformers_install_array=($transformers_install)
+          transformers_loc=${transformers_install_array[-1]}
+          transformers_repo_loc=$(pwd .)
+          if [ "$transformers_loc" != "$transformers_repo_loc" ]; then
+              echo "transformers is from $transformers_loc but it shoud be from $transformers_repo_loc/src."
               echo "A fix is required. Stop testing."
               exit 1
           fi


### PR DESCRIPTION
It seems that `pip show` does not return the same location as before for editable packages.

However, listing editable packages (`pip list -e`) returns the correct location in which it was installed. Doing it locally returns the following:

```
Package      Version     Editable project location
------------ ----------- ---------------------------------------------
transformers 4.22.0.dev0 /home/lysandre/Workspaces/python/transformers
```

I'm therefore updating the way to identify if we're looking at the correct install to use `pip list -e` instead of `pip show`.