### PR TITLE
Pin ffspec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ _deps = [
     "fairscale>0.3",
     "faiss-cpu",
     "fastapi",
-    "ffspec!=2022.8.1",
+    "fsspec!=2022.8.1",
     "filelock",
     "flake8>=3.8.3",
     "flax>=0.4.1",
@@ -291,7 +291,7 @@ extras["testing"] = (
         "datasets",
         "dill",
         "evaluate",
-        "ffspec", # can be removed once the fix is in Datasets
+        "fsspec", # can be removed once the fix is in Datasets
         "pytest-timeout",
         "black",
         "sacrebleu",

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ _deps = [
     "fairscale>0.3",
     "faiss-cpu",
     "fastapi",
+    "ffspec!=2022.8.1",
     "filelock",
     "flake8>=3.8.3",
     "flax>=0.4.1",
@@ -290,6 +291,7 @@ extras["testing"] = (
         "datasets",
         "dill",
         "evaluate",
+        "ffspec", # can be removed once the fix is in Datasets
         "pytest-timeout",
         "black",
         "sacrebleu",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -15,7 +15,7 @@ deps = {
     "fairscale": "fairscale>0.3",
     "faiss-cpu": "faiss-cpu",
     "fastapi": "fastapi",
-    "ffspec": "ffspec!=2022.8.1",
+    "fsspec": "fsspec!=2022.8.1",
     "filelock": "filelock",
     "flake8": "flake8>=3.8.3",
     "flax": "flax>=0.4.1",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -15,6 +15,7 @@ deps = {
     "fairscale": "fairscale>0.3",
     "faiss-cpu": "faiss-cpu",
     "fastapi": "fastapi",
+    "ffspec": "ffspec!=2022.8.1",
     "filelock": "filelock",
     "flake8": "flake8>=3.8.3",
     "flax": "flax>=0.4.1",


### PR DESCRIPTION
# What does this PR do?

The recent test failures on XLNI are due to a release of ffspec. This PR excludes the problematic version to avoid the test failures.