### PR TITLE
Remove unused `activation_dropout` in OPT

### DIFF
--- a/src/transformers/models/opt/configuration_opt.py
+++ b/src/transformers/models/opt/configuration_opt.py
@@ -67,8 +67,6 @@ class OPTConfig(PretrainedConfig):
             The dropout probability for all fully connected layers in the embeddings, encoder, and pooler.
         attention_dropout (`float`, *optional*, defaults to 0.0):
             The dropout ratio for the attention probabilities.
-        activation_dropout (`float`, *optional*, defaults to 0.0):
-            The dropout ratio for activations inside the fully connected layer.
         layerdrop: (`float`, *optional*, defaults to 0.0):
             The LayerDrop probability. See the [LayerDrop paper](see https://arxiv.org/abs/1909.11556) for more
             details.
@@ -106,7 +104,6 @@ class OPTConfig(PretrainedConfig):
         word_embed_proj_dim=None,
         dropout=0.1,
         attention_dropout=0.0,
-        activation_dropout=0.0,
         num_attention_heads=12,
         activation_function="relu",
         layerdrop=0.0,
@@ -132,7 +129,6 @@ class OPTConfig(PretrainedConfig):
         self.num_hidden_layers = num_hidden_layers
         self.dropout = dropout
         self.attention_dropout = attention_dropout
-        self.activation_dropout = activation_dropout
         self.activation_function = activation_function
         self.init_std = init_std
         self.layerdrop = layerdrop

--- a/src/transformers/models/opt/modeling_opt.py
+++ b/src/transformers/models/opt/modeling_opt.py
@@ -281,8 +281,6 @@ class OPTDecoderLayer(nn.Module):
         self.dropout = config.dropout
         self.activation_fn = ACT2FN[config.activation_function]
 
-        self.activation_dropout = config.activation_dropout
-
         self.self_attn_layer_norm = nn.LayerNorm(self.embed_dim)
         self.fc1 = nn.Linear(self.embed_dim, config.ffn_dim)
         self.fc2 = nn.Linear(config.ffn_dim, self.embed_dim)


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/18309

PR for corresponding models
* https://huggingface.co/facebook/opt-125m/discussions/19
* https://huggingface.co/facebook/opt-350m/discussions/5
* https://huggingface.co/facebook/opt-1.3b/discussions/7
* https://huggingface.co/facebook/opt-2.7b/discussions/5
* https://huggingface.co/facebook/opt-6.7b/discussions/8
* https://huggingface.co/facebook/opt-13b/discussions/7
* https://huggingface.co/facebook/opt-30b/discussions/8
* https://huggingface.co/facebook/opt-66b/discussions/7


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker 