### PR TITLE
Unpin fsspec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,6 @@ _deps = [
     "fairscale>0.3",
     "faiss-cpu",
     "fastapi",
-    "fsspec!=2022.8.1",
     "filelock",
     "flake8>=3.8.3",
     "flax>=0.4.1",
@@ -291,7 +290,6 @@ extras["testing"] = (
         "datasets",
         "dill",
         "evaluate",
-        "fsspec", # can be removed once the fix is in Datasets
         "pytest-timeout",
         "black",
         "sacrebleu",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -15,7 +15,6 @@ deps = {
     "fairscale": "fairscale>0.3",
     "faiss-cpu": "faiss-cpu",
     "fastapi": "fastapi",
-    "fsspec": "fsspec!=2022.8.1",
     "filelock": "filelock",
     "flake8": "flake8>=3.8.3",
     "flax": "flax>=0.4.1",


### PR DESCRIPTION
# What does this PR do?

The `fsspec` team has made a patch release (2022.8.2) to fix their issue:
- fsspec/filesystem_spec#1032

They yanked both 2022.8.0 and 2022.8.1, so no need to pin to exclude them.

Follows:
- #18837
