### PR TITLE
Fix minor typo in prose of model outputs documentation

### DIFF
--- a/docs/source/en/main_classes/output.mdx
+++ b/docs/source/en/main_classes/output.mdx
@@ -16,7 +16,7 @@ All models have outputs that are instances of subclasses of [`~utils.ModelOutput
 data structures containing all the information returned by the model, but that can also be used as tuples or
 dictionaries.
 
-Let's see of this looks on an example:
+Let's see how this looks in an example:
 
 ```python
 from transformers import BertTokenizer, BertForSequenceClassification


### PR DESCRIPTION
# What does this PR do?

Fixes a very minor typo in the documentation of the model outputs section.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Documentation: @sgugger
