### PR TITLE
Pin revision for LayoutLMForQuestionAnswering and TFLayoutLMForQuestionAnswering tests

### DIFF
--- a/src/transformers/models/layoutlm/modeling_layoutlm.py
+++ b/src/transformers/models/layoutlm/modeling_layoutlm.py
@@ -1285,7 +1285,9 @@ class LayoutLMForQuestionAnswering(LayoutLMPreTrainedModel):
         >>> import torch
 
         >>> tokenizer = AutoTokenizer.from_pretrained("impira/layoutlm-document-qa", add_prefix_space=True)
-        >>> model = LayoutLMForQuestionAnswering.from_pretrained("impira/layoutlm-document-qa", revision="1e3ebacae311132a7c4a8df2d350d7e4ffd6ff0a")
+        >>> model = LayoutLMForQuestionAnswering.from_pretrained(
+        ...     "impira/layoutlm-document-qa", revision="1e3ebacae311132a7c4a8df2d350d7e4ffd6ff0a"
+        ... )
 
         >>> dataset = load_dataset("nielsr/funsd", split="train")
         >>> example = dataset[0]

--- a/src/transformers/models/layoutlm/modeling_layoutlm.py
+++ b/src/transformers/models/layoutlm/modeling_layoutlm.py
@@ -1285,7 +1285,7 @@ class LayoutLMForQuestionAnswering(LayoutLMPreTrainedModel):
         >>> import torch
 
         >>> tokenizer = AutoTokenizer.from_pretrained("impira/layoutlm-document-qa", add_prefix_space=True)
-        >>> model = LayoutLMForQuestionAnswering.from_pretrained("impira/layoutlm-document-qa")
+        >>> model = LayoutLMForQuestionAnswering.from_pretrained("impira/layoutlm-document-qa", revision="1e3ebacae311132a7c4a8df2d350d7e4ffd6ff0a")
 
         >>> dataset = load_dataset("nielsr/funsd", split="train")
         >>> example = dataset[0]

--- a/src/transformers/models/layoutlm/modeling_layoutlm.py
+++ b/src/transformers/models/layoutlm/modeling_layoutlm.py
@@ -1286,7 +1286,7 @@ class LayoutLMForQuestionAnswering(LayoutLMPreTrainedModel):
 
         >>> tokenizer = AutoTokenizer.from_pretrained("impira/layoutlm-document-qa", add_prefix_space=True)
         >>> model = LayoutLMForQuestionAnswering.from_pretrained(
-        ...     "impira/layoutlm-document-qa", revision="1e3ebacae311132a7c4a8df2d350d7e4ffd6ff0a"
+        ...     "impira/layoutlm-document-qa", revision="1e3ebac"
         ... )
 
         >>> dataset = load_dataset("nielsr/funsd", split="train")

--- a/src/transformers/models/layoutlm/modeling_layoutlm.py
+++ b/src/transformers/models/layoutlm/modeling_layoutlm.py
@@ -1285,9 +1285,7 @@ class LayoutLMForQuestionAnswering(LayoutLMPreTrainedModel):
         >>> import torch
 
         >>> tokenizer = AutoTokenizer.from_pretrained("impira/layoutlm-document-qa", add_prefix_space=True)
-        >>> model = LayoutLMForQuestionAnswering.from_pretrained(
-        ...     "impira/layoutlm-document-qa", revision="1e3ebac"
-        ... )
+        >>> model = LayoutLMForQuestionAnswering.from_pretrained("impira/layoutlm-document-qa", revision="1e3ebac")
 
         >>> dataset = load_dataset("nielsr/funsd", split="train")
         >>> example = dataset[0]

--- a/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
+++ b/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
@@ -1448,7 +1448,7 @@ class TFLayoutLMForQuestionAnswering(TFLayoutLMPreTrainedModel, TFQuestionAnswer
         >>> from datasets import load_dataset
 
         >>> tokenizer = AutoTokenizer.from_pretrained("impira/layoutlm-document-qa", add_prefix_space=True)
-        >>> model = TFLayoutLMForQuestionAnswering.from_pretrained("impira/layoutlm-document-qa")
+        >>> model = TFLayoutLMForQuestionAnswering.from_pretrained("impira/layoutlm-document-qa", revision="1e3ebacae311132a7c4a8df2d350d7e4ffd6ff0a")
 
         >>> dataset = load_dataset("nielsr/funsd", split="train")
         >>> example = dataset[0]

--- a/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
+++ b/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
@@ -1448,7 +1448,9 @@ class TFLayoutLMForQuestionAnswering(TFLayoutLMPreTrainedModel, TFQuestionAnswer
         >>> from datasets import load_dataset
 
         >>> tokenizer = AutoTokenizer.from_pretrained("impira/layoutlm-document-qa", add_prefix_space=True)
-        >>> model = TFLayoutLMForQuestionAnswering.from_pretrained("impira/layoutlm-document-qa", revision="1e3ebacae311132a7c4a8df2d350d7e4ffd6ff0a")
+        >>> model = TFLayoutLMForQuestionAnswering.from_pretrained(
+        ...     "impira/layoutlm-document-qa", revision="1e3ebacae311132a7c4a8df2d350d7e4ffd6ff0a"
+        ... )
 
         >>> dataset = load_dataset("nielsr/funsd", split="train")
         >>> example = dataset[0]

--- a/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
+++ b/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
@@ -1449,7 +1449,7 @@ class TFLayoutLMForQuestionAnswering(TFLayoutLMPreTrainedModel, TFQuestionAnswer
 
         >>> tokenizer = AutoTokenizer.from_pretrained("impira/layoutlm-document-qa", add_prefix_space=True)
         >>> model = TFLayoutLMForQuestionAnswering.from_pretrained(
-        ...     "impira/layoutlm-document-qa", revision="1e3ebacae311132a7c4a8df2d350d7e4ffd6ff0a"
+        ...     "impira/layoutlm-document-qa", revision="1e3ebac"
         ... )
 
         >>> dataset = load_dataset("nielsr/funsd", split="train")

--- a/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
+++ b/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
@@ -1448,9 +1448,7 @@ class TFLayoutLMForQuestionAnswering(TFLayoutLMPreTrainedModel, TFQuestionAnswer
         >>> from datasets import load_dataset
 
         >>> tokenizer = AutoTokenizer.from_pretrained("impira/layoutlm-document-qa", add_prefix_space=True)
-        >>> model = TFLayoutLMForQuestionAnswering.from_pretrained(
-        ...     "impira/layoutlm-document-qa", revision="1e3ebac"
-        ... )
+        >>> model = TFLayoutLMForQuestionAnswering.from_pretrained("impira/layoutlm-document-qa", revision="1e3ebac")
 
         >>> dataset = load_dataset("nielsr/funsd", split="train")
         >>> example = dataset[0]


### PR DESCRIPTION
# What does this PR do?

The newly introduced tests for `LayoutLMForQuestionAnswering` and `TFLayoutLMForQuestionAnswering` broke due to a change to the weights in https://huggingface.co/impira/layoutlm-document-qa. To make sure a weights change does not break tests, I've pinned the revisions in these tests. I'll separately investigate the weights and debug if something is broken with them.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.

It was raised here: https://github.com/huggingface/transformers/pull/18407.

- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@NielsRogge @ydshieh

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
