### PR TITLE
Fix number of examples for iterable datasets in multiprocessing

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3047,6 +3047,8 @@ class Trainer:
                 num_samples = self.num_examples(dataloader)
             else:  # both len(dataloader.dataset) and len(dataloader) fail
                 num_samples = observed_num_examples
+        if num_samples == 0 and observed_num_examples > 0:
+            num_samples = observed_num_examples
 
         # Number of losses has been rounded to a multiple of batch_size and in a distributed training, the number of
         # samplers has been rounded to a multiple of batch_size, so we truncate.

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3040,7 +3040,7 @@ class Trainer:
             num_samples = len(eval_dataset)
         # The instance check is weird and does not actually check for the type, but whether the dataset has the right
         # methods. Therefore we need to make sure it also has the attribute.
-        elif isinstance(eval_dataset, IterableDatasetShard) and hasattr(eval_dataset, "num_examples"):
+        elif isinstance(eval_dataset, IterableDatasetShard) and getattr(eval_dataset, "num_examples", 0) > 0:
             num_samples = eval_dataset.num_examples
         else:
             if has_length(dataloader):


### PR DESCRIPTION
# What does this PR do?

As pointed out in #18608, `IterableDatasetShard.num_examples` is not always update in multiprocessing environments. This PR addresses that by ignoring the value in those cases. It also adds a stronger check of trusting the observed number of examples when for the reason the length is 0.

Fixes #18608