### PR TITLE
Clean up utils.hub using the latest from hf_hub

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ _deps = [
     "fugashi>=1.0",
     "GitPython<3.1.19",
     "hf-doc-builder>=0.3.0",
-    "huggingface-hub>=0.8.1,<1.0",
+    "huggingface-hub>=0.9.0,<1.0",
     "importlib_metadata",
     "ipadic>=1.0.0,<2.0",
     "isort>=5.5.4",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -22,7 +22,7 @@ deps = {
     "fugashi": "fugashi>=1.0",
     "GitPython": "GitPython<3.1.19",
     "hf-doc-builder": "hf-doc-builder>=0.3.0",
-    "huggingface-hub": "huggingface-hub>=0.8.1,<1.0",
+    "huggingface-hub": "huggingface-hub>=0.9.0,<1.0",
     "importlib_metadata": "importlib_metadata",
     "ipadic": "ipadic>=1.0.0,<2.0",
     "isort": "isort>=5.5.4",

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -389,7 +389,7 @@ def cached_file(
         resolved_file = try_to_load_from_cache(cache_dir, path_or_repo_id, full_filename, revision=revision)
         if resolved_file is not None:
             return resolved_file
-        if not _raise_exceptions_for_connection_errors:
+        if not _raise_exceptions_for_missing_entries or not _raise_exceptions_for_connection_errors:
             return None
         raise EnvironmentError(
             f"We couldn't connect to '{HUGGINGFACE_CO_RESOLVE_ENDPOINT}' to load this file, couldn't find it in the"

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -30,6 +30,8 @@ from typing import Optional
 
 from tqdm import auto as tqdm_lib
 
+import huggingface_hub.utils as hf_hub_utils
+
 
 _lock = threading.Lock()
 _default_handler: Optional[logging.Handler] = None
@@ -336,9 +338,11 @@ def enable_progress_bar():
     """Enable tqdm progress bar."""
     global _tqdm_active
     _tqdm_active = True
+    hf_hub_utils.enable_progress_bars()
 
 
 def disable_progress_bar():
     """Disable tqdm progress bar."""
     global _tqdm_active
     _tqdm_active = False
+    hf_hub_utils.disable_progress_bars

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -345,4 +345,4 @@ def disable_progress_bar():
     """Disable tqdm progress bar."""
     global _tqdm_active
     _tqdm_active = False
-    hf_hub_utils.disable_progress_bars
+    hf_hub_utils.disable_progress_bars()

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -14,10 +14,10 @@
 
 import os
 import unittest
-from unittest.mock import patch
 
 import transformers.models.bart.tokenization_bart
-from transformers import AutoConfig, logging
+from huggingface_hub.utils import are_progress_bars_disabled
+from transformers import logging
 from transformers.testing_utils import CaptureLogger, mockenv, mockenv_context
 from transformers.utils.logging import disable_progress_bar, enable_progress_bar
 
@@ -126,14 +126,8 @@ class HfArgumentParserTest(unittest.TestCase):
 
 
 def test_set_progress_bar_enabled():
-    TINY_MODEL = "hf-internal-testing/tiny-random-distilbert"
-    with patch("tqdm.auto.tqdm") as mock_tqdm:
-        disable_progress_bar()
-        _ = AutoConfig.from_pretrained(TINY_MODEL, force_download=True)
-        mock_tqdm.assert_not_called()
+    disable_progress_bar()
+    assert are_progress_bars_disabled()
 
-        mock_tqdm.reset_mock()
-
-        enable_progress_bar()
-        _ = AutoConfig.from_pretrained(TINY_MODEL, force_download=True)
-        mock_tqdm.assert_called()
+    enable_progress_bar()
+    assert not are_progress_bars_disabled()


### PR DESCRIPTION
# What does this PR do?

This PR uses the newly released version of `hugginface_hub` to clean up a few things introduced in #18438 (points 1 and 2 in the description of this PR). For point 3 (load from cache) there is currently a difference between Transformers' `try_to_load_from_cache` and the huggingface_hub's one, so this will a follow-up PR in `huggingface_hub` (and then to wait for the next release).