### PR TITLE
[OWL-ViT] Add model to the appropriate section

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -365,8 +365,6 @@
         title: MaskFormer
       - local: model_doc/mobilevit
         title: MobileViT
-      - local: model_doc/owlvit
-        title: OWL-ViT
       - local: model_doc/poolformer
         title: PoolFormer
       - local: model_doc/regnet
@@ -441,6 +439,8 @@
         title: LayoutXLM
       - local: model_doc/lxmert
         title: LXMERT
+      - local: model_doc/owlvit
+        title: OWL-ViT
       - local: model_doc/perceiver
         title: Perceiver
       - local: model_doc/speech-encoder-decoder


### PR DESCRIPTION
# What does this PR do?

This PR moves OWL-ViT to the "multimodal" section in the docs, as the model isn't vision-only.

cc @stevhliu 