### PR TITLE
pin Slack SDK to 3.18.1 to avoid failing issue

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -74,5 +74,5 @@ jobs:
           CI_SLACK_CHANNEL_ID_DAILY: ${{ secrets.CI_SLACK_CHANNEL_ID_DAILY_DOCS }}
           CI_SLACK_CHANNEL_DUMMY_TESTS: ${{ secrets.CI_SLACK_CHANNEL_DUMMY_TESTS }}
         run: |
-          pip install slack_sdk
+          pip install slack_sdk==3.18.1
           python utils/notification_service_doc_tests.py

--- a/.github/workflows/self-nightly-scheduled.yml
+++ b/.github/workflows/self-nightly-scheduled.yml
@@ -233,5 +233,5 @@ jobs:
         # We pass `needs.setup.outputs.matrix` as the argument. A processing in `notification_service.py` to change
         # `models/bert` to `models_bert` is required, as the artifact names use `_` instead of `/`.
         run: |
-          pip install slack_sdk
+          pip install slack_sdk==3.18.1
           python utils/notification_service.py "${{ needs.setup.outputs.matrix }}"

--- a/.github/workflows/self-past.yml
+++ b/.github/workflows/self-past.yml
@@ -180,7 +180,7 @@ jobs:
         # We pass `needs.setup.outputs.matrix` as the argument. A processing in `notification_service.py` to change
         # `models/bert` to `models_bert` is required, as the artifact names use `_` instead of `/`.
         run: |
-          pip install slack_sdk
+          pip install slack_sdk==3.18.1
           python utils/notification_service.py "${{ needs.setup.outputs.matrix }}"
 
       # Upload complete failure tables, as they might be big and only truncated versions could be sent to Slack.

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -527,5 +527,5 @@ jobs:
         # We pass `needs.setup.outputs.matrix` as the argument. A processing in `notification_service.py` to change
         # `models/bert` to `models_bert` is required, as the artifact names use `_` instead of `/`.
         run: |
-          pip install slack_sdk
+          pip install slack_sdk==3.18.1
           python utils/notification_service.py "${{ needs.setup.outputs.matrix }}"

--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -358,5 +358,5 @@ jobs:
         # We pass `needs.setup.outputs.matrix` as the argument. A processing in `notification_service.py` to change
         # `models/bert` to `models_bert` is required, as the artifact names use `_` instead of `/`.
         run: |
-          pip install slack_sdk
+          pip install slack_sdk==3.18.1
           python utils/notification_service.py "${{ needs.setup.outputs.matrix }}"


### PR DESCRIPTION
# What does this PR do?

Currently CI Slack reports failed to be sent due to an error
```bash
The server responded with: {'ok': False, 'error': 'invalid_blocks_format'}
```
It happens since `slack-sdk-3.18.2`. This PR pin `slack-sdk-3.18.1` so we can receive the reports.