### PR TITLE
fixes bugs to handle non-dict output

### DIFF
--- a/src/transformers/models/owlvit/modeling_owlvit.py
+++ b/src/transformers/models/owlvit/modeling_owlvit.py
@@ -1277,7 +1277,7 @@ class OwlViTForObjectDetection(OwlViTPreTrainedModel):
         )
 
         # Resize class token
-        image_embeds = outputs.image_embeds
+        image_embeds = outputs[-3]
         new_size = tuple(np.array(image_embeds.shape) - np.array((0, 1, 0)))
         class_token_out = torch.broadcast_to(image_embeds[:, :1, :], new_size)
 
@@ -1293,11 +1293,11 @@ class OwlViTForObjectDetection(OwlViTPreTrainedModel):
             image_embeds.shape[-1],
         )
         image_embeds = image_embeds.reshape(new_size)
-        text_embeds = outputs.text_embeds
+        text_embeds = outputs[-4]
 
         # Last hidden states from text and vision transformers
-        text_model_last_hidden_state = outputs.text_model_output.last_hidden_state
-        vision_model_last_hidden_state = outputs.vision_model_output.last_hidden_state
+        text_model_last_hidden_state = outputs[-2][0]
+        vision_model_last_hidden_state = outputs[-1][0]
 
         return (text_embeds, image_embeds, text_model_last_hidden_state, vision_model_last_hidden_state)
 


### PR DESCRIPTION
# What does this PR do?
Fixes OWL-ViT's failing slow tests: `test_torchscript_simple`, `test_torchscript_output_attentions`, `test_torchscript_output_hidden_state`.

The failures were due to explicitly calling output keys instead of calling by the index. The bugs were introduced in this [PR](https://github.com/huggingface/transformers/pull/18734). Switching to indexing to fix the issue: `output.last_hidden_state` -> `output[0]`

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

