### PR TITLE
unpin slack_sdk version

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -74,5 +74,5 @@ jobs:
           CI_SLACK_CHANNEL_ID_DAILY: ${{ secrets.CI_SLACK_CHANNEL_ID_DAILY_DOCS }}
           CI_SLACK_CHANNEL_DUMMY_TESTS: ${{ secrets.CI_SLACK_CHANNEL_DUMMY_TESTS }}
         run: |
-          pip install slack_sdk==3.18.1
+          pip install slack_sdk
           python utils/notification_service_doc_tests.py

--- a/.github/workflows/self-nightly-scheduled.yml
+++ b/.github/workflows/self-nightly-scheduled.yml
@@ -236,5 +236,5 @@ jobs:
         # We pass `needs.setup.outputs.matrix` as the argument. A processing in `notification_service.py` to change
         # `models/bert` to `models_bert` is required, as the artifact names use `_` instead of `/`.
         run: |
-          pip install slack_sdk==3.18.1
+          pip install slack_sdk
           python utils/notification_service.py "${{ needs.setup.outputs.matrix }}"

--- a/.github/workflows/self-past.yml
+++ b/.github/workflows/self-past.yml
@@ -180,7 +180,7 @@ jobs:
         # We pass `needs.setup.outputs.matrix` as the argument. A processing in `notification_service.py` to change
         # `models/bert` to `models_bert` is required, as the artifact names use `_` instead of `/`.
         run: |
-          pip install slack_sdk==3.18.1
+          pip install slack_sdk
           python utils/notification_service.py "${{ needs.setup.outputs.matrix }}"
 
       # Upload complete failure tables, as they might be big and only truncated versions could be sent to Slack.

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -533,5 +533,5 @@ jobs:
         # We pass `needs.setup.outputs.matrix` as the argument. A processing in `notification_service.py` to change
         # `models/bert` to `models_bert` is required, as the artifact names use `_` instead of `/`.
         run: |
-          pip install slack_sdk==3.18.1
+          pip install slack_sdk
           python utils/notification_service.py "${{ needs.setup.outputs.matrix }}"

--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -361,5 +361,5 @@ jobs:
         # We pass `needs.setup.outputs.matrix` as the argument. A processing in `notification_service.py` to change
         # `models/bert` to `models_bert` is required, as the artifact names use `_` instead of `/`.
         run: |
-          pip install slack_sdk==3.18.1
+          pip install slack_sdk
           python utils/notification_service.py "${{ needs.setup.outputs.matrix }}"


### PR DESCRIPTION
# What does this PR do?

The issue in Slack SDK 3.18.2 was fixed in 3.18.3, so no longer need to pin 3.18.1.

For more details, see
https://github.com/slackapi/python-slack-sdk/pull/1259#issuecomment-1237731450
https://github.com/slackapi/python-slack-sdk/issues/1261