### PR TITLE
Generate: add model class validation

### DIFF
--- a/src/transformers/generation_flax_utils.py
+++ b/src/transformers/generation_flax_utils.py
@@ -36,6 +36,11 @@ from .generation_flax_logits_process import (
     FlaxTopKLogitsWarper,
     FlaxTopPLogitsWarper,
 )
+from .models.auto import (
+    FLAX_MODEL_FOR_CAUSAL_LM_MAPPING,
+    FLAX_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
+    FLAX_MODEL_FOR_VISION_2_SEQ_MAPPING,
+)
 from .utils import ModelOutput, logging
 
 
@@ -162,14 +167,28 @@ class FlaxGenerationMixin:
         return logits
 
     def _validate_model_class(self):
-        """Confirms that the model class is compatible with generation."""
+        """
+        Confirms that the model class is compatible with generation. If not, raises an exception that points to the
+        right class to use.
+        """
         if not hasattr(self, "prepare_inputs_for_generation"):
-            model_class = self.__class__.__name__
-            raise TypeError(
-                f"The current model class ({model_class}) is not compatible with `.generate()`, as it doesn't have a ",
-                "language model head. The following AutoModel classes are compatible: `FlaxAutoModelForCausalLM`, ",
-                "`FlaxAutoModelForSeq2SeqLM`, `FlaxAutoModelForVision2Seq`.",
+            generate_compatible_mappings = [
+                FLAX_MODEL_FOR_CAUSAL_LM_MAPPING,
+                FLAX_MODEL_FOR_VISION_2_SEQ_MAPPING,
+                FLAX_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
+            ]
+            generate_compatible_classes = set()
+            for model_mapping in generate_compatible_mappings:
+                supported_models = model_mapping.get(type(self.config), default=None)
+                if supported_models is not None:
+                    generate_compatible_classes.add(supported_models.__name__)
+            exception_message = (
+                f"The current model class ({self.__class__.__name__}) is not compatible with `.generate()`, as "
+                "it doesn't have a language model head."
             )
+            if generate_compatible_classes:
+                exception_message += f" Please use one of the following classes instead: {generate_compatible_classes}"
+            raise TypeError(exception_message)
 
     def _validate_model_kwargs(self, model_kwargs: Dict[str, Any]):
         """Validates model kwargs for generation. Generate argument typos will also be caught here."""

--- a/src/transformers/generation_flax_utils.py
+++ b/src/transformers/generation_flax_utils.py
@@ -161,6 +161,16 @@ class FlaxGenerationMixin:
         """
         return logits
 
+    def _validate_model_class(self):
+        """Confirms that the model class is compatible with generation."""
+        if not hasattr(self, "prepare_inputs_for_generation"):
+            model_class = self.__class__.__name__
+            raise TypeError(
+                f"The current model class ({model_class}) is not compatible with `.generate()`, as it doesn't have a ",
+                "language model head. The following AutoModel classes are compatible: `FlaxAutoModelForCausalLM`, ",
+                "`FlaxAutoModelForSeq2SeqLM`, `FlaxAutoModelForVision2Seq`.",
+            )
+
     def _validate_model_kwargs(self, model_kwargs: Dict[str, Any]):
         """Validates model kwargs for generation. Generate argument typos will also be caught here."""
         unused_model_args = []
@@ -281,7 +291,8 @@ class FlaxGenerationMixin:
         >>> outputs = model.generate(input_ids=input_ids, max_length=20, top_k=30, do_sample=True)
         >>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
         ```"""
-        # Validate model kwargs
+        # Validate the `.generate()` call
+        self._validate_model_class()
         self._validate_model_kwargs(model_kwargs.copy())
 
         # set init values

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -357,12 +357,6 @@ class TFGenerationMixin:
 
     supports_xla_generation = True
 
-    def prepare_inputs_for_generation(self, inputs, **kwargs):
-        """
-        Implement in subclasses of [`TFPreTrainedModel`] for custom behavior to prepare inputs in the generate method.
-        """
-        return {"input_ids": inputs}
-
     def _use_cache(self, outputs, use_cache):
         """During generation, decide whether to pass the `past` variable to the next forward pass."""
         use_cache = getattr(self.config, "use_cache", False)

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -35,6 +35,12 @@ from .generation_tf_logits_process import (
     TFTopKLogitsWarper,
     TFTopPLogitsWarper,
 )
+from .models.auto import (
+    TF_MODEL_FOR_CAUSAL_LM_MAPPING,
+    TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
+    TF_MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING,
+    TF_MODEL_FOR_VISION_2_SEQ_MAPPING,
+)
 from .tf_utils import shape_list, stable_softmax
 from .utils import ModelOutput, logging
 
@@ -1285,14 +1291,29 @@ class TFGenerationMixin:
             return logits
 
     def _validate_model_class(self):
-        """Confirms that the model class is compatible with generation."""
+        """
+        Confirms that the model class is compatible with generation. If not, raises an exception that points to the
+        right class to use.
+        """
         if not hasattr(self, "prepare_inputs_for_generation"):
-            model_class = self.__class__.__name__
-            raise TypeError(
-                f"The current model class ({model_class}) is not compatible with `.generate()`, as it doesn't have a ",
-                "language model head. The following AutoModel classes are compatible: `TFAutoModelForCausalLM`, ",
-                "`TFAutoModelForSeq2SeqLM`, `TFAutoModelForVision2Seq`, `TFAutoModelForSpeechSeq2Seq`.",
+            generate_compatible_mappings = [
+                TF_MODEL_FOR_CAUSAL_LM_MAPPING,
+                TF_MODEL_FOR_VISION_2_SEQ_MAPPING,
+                TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
+                TF_MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING,
+            ]
+            generate_compatible_classes = set()
+            for model_mapping in generate_compatible_mappings:
+                supported_models = model_mapping.get(type(self.config), default=None)
+                if supported_models is not None:
+                    generate_compatible_classes.add(supported_models.__name__)
+            exception_message = (
+                f"The current model class ({self.__class__.__name__}) is not compatible with `.generate()`, as "
+                "it doesn't have a language model head."
             )
+            if generate_compatible_classes:
+                exception_message += f" Please use one of the following classes instead: {generate_compatible_classes}"
+            raise TypeError(exception_message)
 
     def _validate_model_kwargs(self, model_kwargs: Dict[str, Any]):
         """Validates model kwargs for generation. Generate argument typos will also be caught here."""

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -1290,6 +1290,16 @@ class TFGenerationMixin:
         else:
             return logits
 
+    def _validate_model_class(self):
+        """Confirms that the model class is compatible with generation."""
+        if not hasattr(self, "prepare_inputs_for_generation"):
+            model_class = self.__class__.__name__
+            raise TypeError(
+                f"The current model class ({model_class}) is not compatible with `.generate()`, as it doesn't have a ",
+                "language model head. The following AutoModel classes are compatible: `TFAutoModelForCausalLM`, ",
+                "`TFAutoModelForSeq2SeqLM`, `TFAutoModelForVision2Seq`, `TFAutoModelForSpeechSeq2Seq`.",
+            )
+
     def _validate_model_kwargs(self, model_kwargs: Dict[str, Any]):
         """Validates model kwargs for generation. Generate argument typos will also be caught here."""
         # Excludes arguments that are handled before calling any model function
@@ -1508,7 +1518,8 @@ class TFGenerationMixin:
         # generate sequences without allowing bad_words to be generated
         outputs = model.generate(input_ids=input_ids, max_length=100, do_sample=True, bad_words_ids=bad_words_ids)
         ```"""
-        # 0. Validate model kwargs
+        # 0. Validate the `.generate()` call
+        self._validate_model_class()
         self._validate_model_kwargs(model_kwargs.copy())
 
         # 1. Set generation parameters if not already defined

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -51,6 +51,13 @@ from .generation_stopping_criteria import (
     StoppingCriteriaList,
     validate_stopping_criteria,
 )
+from .models.auto import (
+    MODEL_FOR_CAUSAL_IMAGE_MODELING_MAPPING,
+    MODEL_FOR_CAUSAL_LM_MAPPING,
+    MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
+    MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING,
+    MODEL_FOR_VISION_2_SEQ_MAPPING,
+)
 from .pytorch_utils import torch_int_div
 from .utils import ModelOutput, logging
 
@@ -463,12 +470,6 @@ class GenerationMixin:
 
         return can_retrieve_inputs
 
-    def prepare_inputs_for_generation(self, input_ids: torch.LongTensor, **kwargs) -> Dict[str, Any]:
-        """
-        Implement in subclasses of [`PreTrainedModel`] for custom behavior to prepare inputs in the generate method.
-        """
-        return {"input_ids": input_ids}
-
     def adjust_logits_during_generation(self, logits: torch.FloatTensor, **kwargs) -> torch.FloatTensor:
         """
         Implement in subclasses of [`PreTrainedModel`] for custom behavior to adjust the logits in the generate method.
@@ -842,14 +843,30 @@ class GenerationMixin:
         return transition_scores
 
     def _validate_model_class(self):
-        """Confirms that the model class is compatible with generation."""
+        """
+        Confirms that the model class is compatible with generation. If not, raises an exception that points to the
+        right class to use.
+        """
         if not hasattr(self, "prepare_inputs_for_generation"):
-            model_class = self.__class__.__name__
-            raise TypeError(
-                f"The current model class ({model_class}) is not compatible with `.generate()`, as it doesn't have a ",
-                "language model head. The following AutoModel classes are compatible: `AutoModelForCausalLM`, ",
-                "`AutoModelForSeq2SeqLM`, `AutoModelForVision2Seq`, `AutoModelForSpeechSeq2Seq`.",
+            generate_compatible_mappings = [
+                MODEL_FOR_CAUSAL_LM_MAPPING,
+                MODEL_FOR_CAUSAL_IMAGE_MODELING_MAPPING,
+                MODEL_FOR_VISION_2_SEQ_MAPPING,
+                MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
+                MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING,
+            ]
+            generate_compatible_classes = set()
+            for model_mapping in generate_compatible_mappings:
+                supported_models = model_mapping.get(type(self.config), default=None)
+                if supported_models is not None:
+                    generate_compatible_classes.add(supported_models.__name__)
+            exception_message = (
+                f"The current model class ({self.__class__.__name__}) is not compatible with `.generate()`, as "
+                "it doesn't have a language model head."
             )
+            if generate_compatible_classes:
+                exception_message += f" Please use one of the following classes instead: {generate_compatible_classes}"
+            raise TypeError(exception_message)
 
     def _validate_model_kwargs(self, model_kwargs: Dict[str, Any]):
         """Validates model kwargs for generation. Generate argument typos will also be caught here."""

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -841,6 +841,16 @@ class GenerationMixin:
 
         return transition_scores
 
+    def _validate_model_class(self):
+        """Confirms that the model class is compatible with generation."""
+        if not hasattr(self, "prepare_inputs_for_generation"):
+            model_class = self.__class__.__name__
+            raise TypeError(
+                f"The current model class ({model_class}) is not compatible with `.generate()`, as it doesn't have a ",
+                "language model head. The following AutoModel classes are compatible: `AutoModelForCausalLM`, ",
+                "`AutoModelForSeq2SeqLM`, `AutoModelForVision2Seq`, `AutoModelForSpeechSeq2Seq`.",
+            )
+
     def _validate_model_kwargs(self, model_kwargs: Dict[str, Any]):
         """Validates model kwargs for generation. Generate argument typos will also be caught here."""
         # Excludes arguments that are handled before calling any model function
@@ -1143,7 +1153,8 @@ class GenerationMixin:
         >>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
         ['Paris ist eines der dichtesten besiedelten Gebiete Europas.']
         ```"""
-        # 0. Validate model kwargs
+        # 0. Validate the `.generate()` call
+        self._validate_model_class()
         self._validate_model_kwargs(model_kwargs.copy())
 
         # 1. Set generation parameters if not already defined

--- a/src/transformers/models/openai/modeling_openai.py
+++ b/src/transformers/models/openai/modeling_openai.py
@@ -20,7 +20,7 @@ import json
 import math
 import os
 from dataclasses import dataclass
-from typing import Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -606,6 +606,9 @@ class OpenAIGPTLMHeadModel(OpenAIGPTPreTrainedModel):
             hidden_states=transformer_outputs.hidden_states,
             attentions=transformer_outputs.attentions,
         )
+
+    def prepare_inputs_for_generation(self, input_ids: torch.LongTensor, **kwargs) -> Dict[str, Any]:
+        return {"input_ids": input_ids}
 
 
 @add_start_docstrings(

--- a/src/transformers/models/openai/modeling_tf_openai.py
+++ b/src/transformers/models/openai/modeling_tf_openai.py
@@ -633,6 +633,9 @@ class TFOpenAIGPTLMHeadModel(TFOpenAIGPTPreTrainedModel, TFCausalLanguageModelin
 
         return TFCausalLMOutput(logits=output.logits, hidden_states=hs, attentions=attns)
 
+    def prepare_inputs_for_generation(self, inputs, **kwargs):
+        return {"input_ids": inputs}
+
 
 @add_start_docstrings(
     """


### PR DESCRIPTION
# What does this PR do?

Fixes #18210 

This PR adds model class validation at the start of generate (all model classes inherit `GenerationMixin`, but few can use `generate()`). It also adds an exception that attempts to redirect the users to the right classes.