### PR TITLE
Add BART DLM PyTorch pretraining example

### DIFF
--- a/examples/pytorch/language-modeling/README.md
+++ b/examples/pytorch/language-modeling/README.md
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-## Language model training
+# Language model training
 
 Fine-tuning (or training from scratch) the library models for language modeling on a text dataset for GPT, GPT-2,
 ALBERT, BERT, DistilBERT, RoBERTa, XLNet... GPT and GPT-2 are trained or fine-tuned using a causal language modeling
@@ -29,7 +29,7 @@ There are two sets of scripts provided. The first set leverages the Trainer API.
 The following examples, will run on datasets hosted on our [hub](https://huggingface.co/datasets) or with your own
 text files for training and validation. We give examples of both below.
 
-### GPT-2/GPT and causal language modeling
+## GPT-2/GPT and causal language modeling
 
 The following example fine-tunes GPT-2 on WikiText-2. We're using the raw WikiText-2 (no tokens were replaced before
 the tokenization). The loss here is that of causal language modeling.
@@ -73,7 +73,7 @@ python run_clm_no_trainer.py \
     --output_dir /tmp/test-clm
 ```
 
-### RoBERTa/BERT/DistilBERT and masked language modeling
+## RoBERTa/BERT/DistilBERT and masked language modeling
 
 The following example fine-tunes RoBERTa on WikiText-2. Here too, we're using the raw WikiText-2. The loss is different
 as BERT/RoBERTa have a bidirectional mechanism; we're therefore using the same loss that was used during their
@@ -124,11 +124,11 @@ python run_mlm_no_trainer.py \
 **Note:** On TPU, you should use the flag `--pad_to_max_length` in conjunction with the `--line_by_line` flag to make
 sure all your batches have the same length.
 
-### Whole word masking
+## Whole word masking
 
 This part was moved to `examples/research_projects/mlm_wwm`.
 
-### XLNet and permutation language modeling
+## XLNet and permutation language modeling
 
 XLNet uses a different training objective, which is permutation language modeling. It is an autoregressive method
 to learn bidirectional contexts by maximizing the expected likelihood over all permutations of the input
@@ -174,6 +174,91 @@ concatenates all texts and then splits them in blocks of the same length).
 **Note:** On TPU, you should use the flag `--pad_to_max_length` in conjunction with the `--line_by_line` flag to make
 sure all your batches have the same length.
 
+## BART and denoising language modeling
+
+BART is is an encoder-decoder that is trained on the denoising objective. The input text is corrupted and the model
+must reconstruct it. The added noise includes token masking, in-filling (replacing multiple tokens by a single mask),
+replacing tokens by random tokens, permuting sentences in a sequence, and so on. The implementation here borrows from
+heavily from the original
+[fairseq](https://github.com/facebookresearch/fairseq/blob/1bba712622b8ae4efb3eb793a8a40da386fe11d0/fairseq/data/denoising_dataset.py)
+implementation and the
+[FLAX training script](https://github.com/huggingface/transformers/blob/main/examples/flax/language-modeling/run_bart_dlm_flax.py)
+.
+
+### 1. Train a tokenizer on a dataset on the hub
+
+```shell
+python prepare_tokenizer.py \
+    oscar \
+    --dataset_config_name unshuffled_deduplicated_nl \
+    --dataset_split train \
+    --dout ./my-bart-model
+```
+
+### 2. Prepare a model config file based on an existing model
+
+```shell
+python prepare_config.py \
+    --pretrained_model_name facebook/bart-base \
+    --dout ./my-bart-model
+```
+
+### 3. Train the model and specific tokenizer and config
+
+By default, we use the denoising parameters described in
+[this post](https://github.com/facebookresearch/fairseq/issues/1899#issuecomment-1069429320). 
+
+```shell
+python run_bart_dlm.py \
+    --config_name ./my-bart-model \
+    --tokenizer_name ./my-bart-model \
+    --dataset_name oscar \
+    --dataset_config_name unshuffled_deduplicated_nl \
+    --output_dir ./my-bart-model \
+    --do_train \
+    --do_eval
+```
+
+
+### Some notes 
+
+#### Sentence splitting
+
+As part of BART, the sentences in a sample may be permuted (reordered). To detect sentences for each sample, we need
+sentence splitting. By dfault, we'll use NLTK's English punct sentence splitter but by passing a spaCy model name
+to `spacy_model` (e.g. `en_core_web_sm`) you can also rely on spaCy for better (but slower) sentence splitting.
+You can also disable sentence splitting completely with `==no_sentence_splitting`. In that case, make sure the
+sentences are already split with a padding token between them )`<pad>`_.
+
+
+#### Default values
+The defaults are set to the
+[given BART args](https://github.com/facebookresearch/fairseq/issues/1899#issuecomment-1069429320). This differs from
+the Flax defaults in one respect, namely `poisson_lambda`, which is now set to `3.5` instead of `3.0`.
+
+
+#### HF (Flax), fairseq, and current implementation
+
+There are some differences in implementation between fairseq, the HF FLAX example, and this PyTorch implementation.
+
+- `argwhere` in the Flax example
+[in this position](https://github.com/huggingface/transformers/blob/65fb71bc762c46bb067306c1fd083b1cba87a095/examples/flax/language-modeling/run_bart_dlm_flax.py#L319)
+is not the same as what is happening in fairseq. [In fairseq](https://github.com/facebookresearch/fairseq/blob/a6a63279422f846a3c2f6c45b9c96d6951cc4b82/fairseq/data/denoising_dataset.py#L230)
+we check explicitly that the previous token was not a "full stop" (padding token) but in HF we just check whether the
+current token is a full stop. In the current example I also explicitly check that the next token is not a full stop,
+in case of padding. (However, in practice that should be a non-issue since all batches/samples should have the
+same sequence length and there should not be any padding.)
+- I found that the result of sentence permutation was not consistent in terms of where the separating pad token ended
+up ([bug report](https://github.com/facebookresearch/fairseq/issues/4695)), so I have reimplemented that method so
+that sentences in a sequence are still separated by a padding token, even after permutation.
+- In HF FLAX, the token_mask is restricted to [non-special and non-padding tokens](https://github.com/huggingface/transformers/blob/65fb71bc762c46bb067306c1fd083b1cba87a095/examples/flax/language-modeling/run_bart_dlm_flax.py#L361).
+In Fairseq, by default, only the first and last tokens are excluded and [all others](https://github.com/facebookresearch/fairseq/blob/1bba712622b8ae4efb3eb793a8a40da386fe11d0/fairseq/data/denoising_dataset.py#L241)
+are prone to masking. The HF implementation seems sensible so I follow that. `get_special_tokens_mask` includes the 
+padding token, though, so no need to add that separately.
+- The Flax example does not include methods to add more noise. I have ported those as well.
+- However, I did not adapt `add_insertion_noise` to work well with padded sequences. So the inserted noise may occur
+ANYWHERE. It is unclear whether this is intended behavior.
+
 
 ## Creating a model on the fly
 
@@ -186,3 +271,4 @@ python run_clm.py --model_type gpt2 --tokenizer_name gpt2 \ --config_overrides="
 ```
 
 This feature is only available in `run_clm.py`, `run_plm.py` and `run_mlm.py`.
+

--- a/examples/pytorch/language-modeling/README.md
+++ b/examples/pytorch/language-modeling/README.md
@@ -227,8 +227,8 @@ python run_bart_dlm.py \
 As part of BART, the sentences in a sample may be permuted (reordered). To detect sentences for each sample, we need
 sentence splitting. By dfault, we'll use NLTK's English punct sentence splitter but by passing a spaCy model name
 to `spacy_model` (e.g. `en_core_web_sm`) you can also rely on spaCy for better (but slower) sentence splitting.
-You can also disable sentence splitting completely with `==no_sentence_splitting`. In that case, make sure the
-sentences are already split with a padding token between them )`<pad>`_.
+You can also disable sentence splitting completely with `--no_sentence_splitting`. In that case, make sure the
+sentences are already split with a padding token between them (`<pad>`).
 
 
 #### Default values

--- a/examples/pytorch/language-modeling/denoising_collator.py
+++ b/examples/pytorch/language-modeling/denoising_collator.py
@@ -1,0 +1,396 @@
+import math
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+from transformers import AutoTokenizer, BatchEncoding, PreTrainedTokenizerBase
+from transformers.models.bart.modeling_bart import BartForConditionalGeneration, shift_tokens_right
+
+
+@dataclass
+class DataCollatorForBartDenoisingLM:
+    """
+    Data collator used for BART denoising language modeling.
+
+    The code is modified from the original
+    <Denoising Dataset https://github.com/facebookresearch/fairseq/blob/main/fairseq/data/denoising_dataset.py>`_.
+    This implies some minute differences. As a data collator, we now work on the batch level rather than sample level.
+    This mainly has a consequence if/when we insert noise (the default BART training did not add noise, however). In
+    this event, all sequences in a batch will get the same number of added noise (num_noise). In fairseq, this is
+    implemented on the dataset-level, meaning that every sequence in a batch may have a different amount of noise.
+
+    The defaults here are based on the defaults for training BART, as indicated
+    `here <https://github.com/facebookresearch/fairseq/issues/1899#issuecomment-1069429320>`_.
+
+    Args:
+        tokenizer (:class:`~transformers.PreTrainedTokenizer` or :class:`~transformers.PreTrainedTokenizerFast`):
+            The tokenizer used for encoding the data
+        decoder_start_token_id: (:obj:`int):
+            The decoder start token id of the model
+        permute_sentence_ratio (:obj:`float`):
+            Ratio of sentences to be permuted in each document
+        mask_ratio (:obj:`float`):
+            The probability with which to (randomly) mask tokens in the input
+        random_ratio (:obj:`float`):
+            The probability with which to (randomly) replace a token by a random token
+        insert_ratio (:obj:`float`):
+            The probability with which to (randomly) insert noise. Will add `insert_ratio * input.numel()` noise
+        rotate_ratio (:obj:`float`):
+                The probability with which to (randomly) add rolling noise (i.e., shifted tokens in order)
+        poisson_lambda (:obj:`float`):
+            Mean parameter of Poisson distribution used to generate span-lengths to be masked
+        mask_length (:obj:`str`):
+            Whether to add span, word or subword masks ("span-poisson", "word", "subword")
+        mask_whole_word (:obj:`torch.Tensor`):
+            A tensor of the size of the vocabulary to indicate which of the tokens are the start of a word.
+            Also see the
+            `fairseq implementation https://github.com/facebookresearch/fairseq/blob/b5a039c292facba9c73f59ff34621ec131d82341/fairseq/tasks/multilingual_masked_lm.py#L118`_
+            of this.
+    """
+
+    tokenizer: PreTrainedTokenizerBase
+    decoder_start_token_id: int
+    permute_sentence_ratio: float = 1.0
+    mask_ratio: float = 0.3
+    random_ratio: float = 0.1
+    insert_ratio: float = 0.0
+    rotate_ratio: float = 0.0
+    poisson_lambda: float = 3.5
+    replace_length: int = 1
+    mask_length: Optional[str] = "span-poisson"
+    mask_whole_word: Optional[torch.LongTensor] = None
+
+    def __post_init__(self):
+        if self.replace_length not in [-1, 0, 1]:
+            raise ValueError(f"invalid arg: replace_length={self.replace_length}")
+        if self.mask_length not in ["subword", "word", "span-poisson"]:
+            raise ValueError(f"invalid arg: mask-length={self.mask_length}")
+        if self.mask_length == "subword" and self.replace_length not in [0, 1]:
+            raise ValueError(f"if using subwords, use replace-length=1 or 0")
+
+        self.mask_span_distribution = None
+        if self.mask_length == "span-poisson":
+            _lambda = self.poisson_lambda
+
+            lambda_to_the_k = 1
+            e_to_the_minus_lambda = math.exp(-_lambda)
+            k_factorial = 1
+            ps = []
+            for k in range(0, 128):
+                ps.append(e_to_the_minus_lambda * lambda_to_the_k / k_factorial)
+                lambda_to_the_k *= _lambda
+                k_factorial *= k + 1
+                if ps[-1] < 0.0000001:
+                    break
+            ps = torch.FloatTensor(ps)
+            self.mask_span_distribution = torch.distributions.Categorical(ps)
+
+    def __call__(self, examples: List[Dict[str, List[int]]]) -> BatchEncoding:
+        batch = BatchEncoding(
+            {k: torch.LongTensor([examples[i][k] for i in range(len(examples))]) for k, v in examples[0].items()}
+        )
+
+        batch["labels"] = batch["input_ids"].clone()
+        batch["decoder_input_ids"] = shift_tokens_right(
+            batch["labels"], self.tokenizer.pad_token_id, self.decoder_start_token_id
+        )
+
+        if self.permute_sentence_ratio > 0.0:
+            batch["input_ids"] = self.permute_sentences(batch["input_ids"])
+
+        if self.mask_ratio > 0:
+            batch["input_ids"] = self.add_whole_word_mask(batch["input_ids"])
+
+        if self.insert_ratio > 0:
+            batch["input_ids"] = self.add_insertion_noise(batch["input_ids"], self.insert_ratio)
+
+        if self.rotate_ratio > 0.0 and np.random.random() < self.rotate_ratio:
+            batch["input_ids"] = self.add_rolling_noise(batch["input_ids"])
+
+        batch["attention_mask"] = (batch["input_ids"] != self.tokenizer.pad_token_id).long()
+        batch["decoder_attention_mask"] = (batch["decoder_input_ids"] != self.tokenizer.pad_token_id).long()
+
+        return batch
+
+    def permute_sentences(self, input_ids):
+        """Different implementation than in fairseq. See
+        this issue https://github.com/facebookresearch/fairseq/issues/4695`_"""
+        all_results = input_ids.clone()
+        for seq_idx, sequence in enumerate(input_ids):
+            full_stops = sequence == self.tokenizer.pad_token_id
+
+            # Find the position of </s> EOS tokens, and mark the position before that as a full stop
+            # so that the last sentence can also be extracted as a span
+            # This approach is needed when our batches have padding (and we cannot simply target the one but last item)
+            eos_positions = (sequence == self.tokenizer.eos_token_id).roll(-1)
+            full_stops[eos_positions] = 1
+
+            # Mark sentence ends: those cases where the token is a full_stop (pad)
+            # but the previous and next ones are not
+            next_token_is_full_stop = torch.cat((full_stops[2:], torch.BoolTensor([0])))
+            sentence_ends = (full_stops[1:] * ~full_stops[:-1] * ~next_token_is_full_stop).nonzero(as_tuple=False) + 2
+            result = sequence.clone()
+
+            num_sentences = sentence_ends.size(0)
+            num_to_permute = math.ceil((num_sentences * 2 * self.permute_sentence_ratio) / 2.0)
+            substitutions = torch.randperm(num_sentences)[:num_to_permute]
+            ordering = torch.arange(0, num_sentences)
+            ordering[substitutions] = substitutions[torch.randperm(num_to_permute)]
+
+            # Ignore <bos> at start
+            index = 1
+            for order_idx, orig_sent_idx in enumerate(ordering):
+                is_last_orig = orig_sent_idx == num_sentences - 1
+                is_last_in_loop = order_idx == num_sentences - 1
+                start_idx = sentence_ends[orig_sent_idx - 1] if orig_sent_idx > 0 else 1
+                # remove last idx (pad) from last sentence of this loop but only if it is not the orig last sentence
+                end_idx = sentence_ends[orig_sent_idx] - (int(is_last_in_loop) if not is_last_orig else 0)
+                sentence = sequence[start_idx:end_idx]
+
+                # add padding token if this was the original last sentence and now it isn't anymore
+                if is_last_orig and not is_last_in_loop:
+                    sentence = torch.cat((sentence, torch.LongTensor([self.tokenizer.pad_token_id])))
+
+                result[index: index + sentence.size(0)] = sentence
+                index += sentence.size(0)
+
+            all_results[seq_idx] = result
+
+        return all_results
+
+    def get_word_starts(self, input_ids):
+        if self.mask_whole_word is not None:
+            is_word_start = self.mask_whole_word.gather(0, input_ids.view(-1)).reshape(input_ids.size())
+        else:
+            is_word_start = (~torch.BoolTensor([
+                self.tokenizer.get_special_tokens_mask(seq, already_has_special_tokens=True) for seq in input_ids
+            ])).long()
+        is_word_start[:, 0] = 0
+        is_word_start[:, -1] = 0
+        return is_word_start
+
+    def add_whole_word_mask(self, input_ids):
+        # Note that is_word_start cannot be a booltensor but has to be an int tensor as we use it to subtract
+        # from the span lengths later on
+        is_word_start = self.get_word_starts(input_ids)
+        num_to_mask = int(math.ceil(is_word_start.float().sum() * self.mask_ratio))
+
+        num_inserts = 0
+        if num_to_mask == 0:
+            return input_ids
+
+        if self.mask_span_distribution is not None:
+            lengths = self.mask_span_distribution.sample(sample_shape=(num_to_mask,))
+            # Make sure we have enough to mask
+            cum_length = torch.cumsum(lengths, 0)
+
+            while cum_length[-1] < num_to_mask:
+                lengths = torch.cat([lengths,
+                                     self.mask_span_distribution.sample(sample_shape=(num_to_mask,)),
+                                     ],
+                                    dim=0)
+                cum_length = torch.cumsum(lengths, 0)
+
+            # Trim to masking budget
+            i = 0
+            while cum_length[i] < num_to_mask:
+                i += 1
+            lengths[i] = num_to_mask - (0 if i == 0 else cum_length[i - 1])
+            num_to_mask = i + 1
+            lengths = lengths[:num_to_mask]
+
+            # Handle 0-length mask (inserts) separately
+            # For every 0-length span, we instead insert noise
+            # So we decrease the required `num_to_mask` and instead add to `num_inserts`
+            lengths = lengths[lengths > 0]
+            num_inserts = num_to_mask - lengths.size(0)
+            num_to_mask -= num_inserts
+            if num_to_mask == 0:
+                return self.add_insertion_noise(input_ids, num_inserts / input_ids.numel())
+
+            assert (lengths > 0).all()
+        else:
+            lengths = torch.ones((num_to_mask,), dtype=torch.long)
+
+        assert not is_word_start[:, 0].any()
+        assert not is_word_start[:, -1].any()
+
+        word_starts = is_word_start.nonzero(as_tuple=False)
+        indices = word_starts[
+            torch.randperm(word_starts.size(0))[:num_to_mask]
+        ]
+
+        mask_random = torch.FloatTensor(num_to_mask).uniform_() < self.random_ratio
+
+        source_length = input_ids.size(1)
+        assert source_length - 1 not in indices[:, 1]
+
+        to_keep = torch.ones_like(input_ids, dtype=torch.bool)
+        is_word_start[:, -1] = 255  # acts as a long length, so spans don't go over the end of doc
+
+        if self.replace_length == 0:
+            to_keep[indices[:, 0], indices[:, 1]] = 0
+        else:
+            # Mask some tokens with a mask token
+            for idxs in indices:
+                input_ids[tuple(idxs)] = self.tokenizer.mask_token_id
+
+            # Replace a fraction (random_ratio) with a random token
+            rand_tokens = torch.randint(
+                1, len(self.tokenizer), size=(mask_random.sum(),)
+            )
+            for idxs, tok in zip(indices[mask_random], rand_tokens):
+                input_ids[tuple(idxs)] = tok
+
+        if self.mask_span_distribution is not None:
+            lengths -= 1
+
+            while indices.size(0) > 0:
+                lengths -= is_word_start[indices[:, 0], indices[:, 1] + 1].long()
+                uncompleted = lengths >= 0
+                indices = indices[uncompleted, :]
+                indices[:, 1] += 1  # increment to keep masking the next positions
+
+                mask_random = mask_random[uncompleted]
+                lengths = lengths[uncompleted]
+
+                if self.replace_length != -1:
+                    to_keep[indices[:, 0], indices[:, 1]] = 0
+                else:
+                    # Mask some tokens with a mask token
+                    for idxs in indices:
+                        input_ids[tuple(idxs)] = self.tokenizer.mask_token_id
+
+                    # Replace a fraction (random_ratio) with a random token
+                    rand_tokens = torch.randint(
+                        1, len(self.tokenizer), size=(mask_random.sum(),)
+                    )
+                    for idxs, tok in zip(indices[mask_random], rand_tokens):
+                        input_ids[tuple(idxs)] = tok
+
+                assert source_length - 1 not in indices[:, 1]
+        else:
+            # A bit faster when all lengths are 1
+            while indices.size(0) > 0:
+                uncompleted = is_word_start[indices[:, 0], indices[:, 1] + 1] == 0
+                indices = indices[uncompleted, :]
+                indices[:, 1] += 1  # increment to keep masking the next positions
+
+                mask_random = mask_random[uncompleted]
+
+                if self.replace_length != -1:
+                    to_keep[indices[:, 0], indices[:, 1]] = 0
+                else:
+                    # Mask some tokens with a mask token
+                    for idxs in indices:
+                        input_ids[tuple(idxs)] = self.tokenizer.mask_token_id
+
+                    # Replace a fraction (random_ratio) with a random token
+                    rand_tokens = torch.randint(
+                        1, len(self.tokenizer), size=(mask_random.sum(),)
+                    )
+                    for idxs, tok in zip(indices[mask_random], rand_tokens):
+                        input_ids[tuple(idxs)] = tok
+
+                assert source_length - 1 not in indices[:, 1]
+
+        # Remove some items (e.g. consecutive masks)
+        final_ids = torch.full_like(input_ids, fill_value=self.tokenizer.pad_token_id)
+        for keeper_idx, keeper in enumerate(to_keep):
+            seq = input_ids[keeper_idx, keeper]
+            final_ids[keeper_idx, :seq.size(0)] = seq
+        input_ids = final_ids
+
+        if num_inserts > 0:
+            input_ids = self.add_insertion_noise(input_ids, num_inserts / input_ids.numel())
+
+        return input_ids
+
+    def add_rolling_noise(self, input_ids):
+        offset = torch.randint(1, max(1, input_ids.size(-1) - 1) + 1, (input_ids.size(0),))
+
+        output_ids = torch.full_like(input_ids, fill_value=self.tokenizer.pad_token_id)
+        for seq_idx in range(output_ids.size(0)):
+            output_ids[seq_idx] = torch.cat(
+                (
+                    input_ids[seq_idx, 0:1], input_ids[seq_idx, offset[seq_idx]:-1],
+                    input_ids[seq_idx, 1:offset[seq_idx]],
+                    input_ids[seq_idx, -1:]),
+                dim=0,
+            )
+        return output_ids
+
+    def add_insertion_noise(self, input_ids, p):
+        """As currently implemented, all sequences in this batch will get the same number of added noise (num_noise).
+        In fairseq, this is implemented on the dataset-level, meaning that every sequence in a batch may have a
+        different number of added noise.
+
+        In addition, because we are now in the data collator, we have to already account for sequence length. In
+        Fairseq, the dataset can output any longer length, which can be truncated later. Here, we have to truncate
+        directly at the end, after inserting noise. This means, however, that it is possible that a sequence does not
+        end with </s>.
+        """
+        if p == 0.0:
+            return input_ids
+
+        seq_num_tokens = input_ids.size(1)
+        num_noise = int(math.ceil(seq_num_tokens * p))
+        all_results = torch.full((input_ids.size(0), seq_num_tokens + num_noise),
+                                 fill_value=self.tokenizer.pad_token_id)
+        for seq_id, sequence in enumerate(input_ids):
+            # -2 and + 1 to avoid targetting first and last item?
+            noise_indices = torch.randperm(seq_num_tokens + num_noise - 2)[:num_noise] + 1
+            noise_mask = torch.zeros(size=(seq_num_tokens + num_noise,), dtype=torch.bool)
+            noise_mask[noise_indices] = 1
+
+            result = torch.LongTensor(seq_num_tokens + num_noise).fill_(-1)
+
+            num_random = int(math.ceil(num_noise * self.random_ratio))
+            result[noise_indices[num_random:]] = self.tokenizer.mask_token_id
+            result[noise_indices[:num_random]] = torch.randint(
+                low=1, high=len(self.tokenizer), size=(num_random,)
+            )
+
+            result[~noise_mask] = sequence
+
+            assert (result >= 0).all()
+            all_results[seq_id] = result
+
+        all_results = all_results[:, :seq_num_tokens]
+        return all_results
+
+
+def main():
+    class DummyDataset(torch.utils.data.Dataset):
+        def __init__(self, data):
+            self.data = data
+
+        def __getitem__(self, idx):
+            return self.data[idx]
+
+        def __len__(self):
+            return len(self.data)
+
+    tokenizer: PreTrainedTokenizerBase = AutoTokenizer.from_pretrained("facebook/bart-base")
+    # Two sequences, containing a padtoken to separate sentences
+    text = ["A cookie is a baked or cooked snack or dessert that is typically small, flat and sweet."
+            f"{tokenizer.pad_token}It usually contains flour, sugar, egg, and some type of oil, fat, or butter."
+            f"{tokenizer.pad_token}It may include other ingredients such as raisins, oats, chocolate chips, nuts, etc.",
+            "Biscuit or cookie variants include sandwich biscuits, such as custard creams."
+            f"{tokenizer.pad_token}Chewier biscuits are sometimes called cookies"]
+    max_length = max([len(tokenizer(s)["input_ids"]) for s in text])
+    encoded = [tokenizer(s, padding="max_length", truncation=True, max_length=max_length) for s in text]
+    dataset = DummyDataset(data=encoded)
+    model = BartForConditionalGeneration.from_pretrained("facebook/bart-base")
+    dl = DataLoader(dataset, collate_fn=DataCollatorForBartDenoisingLM(tokenizer, model.config.decoder_start_token_id),
+                    batch_size=2)
+
+    for b in dl:
+        print(tokenizer.batch_decode(b["labels"]))
+        print(tokenizer.batch_decode(b["input_ids"]))
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/pytorch/language-modeling/denoising_collator.py
+++ b/examples/pytorch/language-modeling/denoising_collator.py
@@ -69,7 +69,7 @@ class DataCollatorForBartDenoisingLM:
         if self.mask_length not in ["subword", "word", "span-poisson"]:
             raise ValueError(f"invalid arg: mask-length={self.mask_length}")
         if self.mask_length == "subword" and self.replace_length not in [0, 1]:
-            raise ValueError(f"if using subwords, use replace-length=1 or 0")
+            raise ValueError("if using subwords, use replace-length=1 or 0")
 
         self.mask_span_distribution = None
         if self.mask_length == "span-poisson":

--- a/examples/pytorch/language-modeling/prepare_config.py
+++ b/examples/pytorch/language-modeling/prepare_config.py
@@ -5,12 +5,12 @@ from os import PathLike
 from pathlib import Path
 from typing import Union
 
-
 from transformers import BartConfig
 
 
-def prepare_config(pretrained_model_name: str = "facebook/bart-base", vocab_size: int = 50265,
-                   dout: Union[str, PathLike] = "."):
+def prepare_config(
+    pretrained_model_name: str = "facebook/bart-base", vocab_size: int = 50265, dout: Union[str, PathLike] = "."
+):
     config = BartConfig.from_pretrained(pretrained_model_name, vocab_size=vocab_size)
 
     # Save to disk
@@ -21,10 +21,14 @@ def prepare_config(pretrained_model_name: str = "facebook/bart-base", vocab_size
 
 def main():
     import argparse
+
     cparser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-    cparser.add_argument("--pretrained_model_name", default="facebook/bart-base",
-                         help="Name of the config to use for tokenizer training")
+    cparser.add_argument(
+        "--pretrained_model_name",
+        default="facebook/bart-base",
+        help="Name of the config to use for tokenizer training",
+    )
     cparser.add_argument("--vocab_size", type=int, default=50265, help="Vocabulary size")
     cparser.add_argument("--dout", default=".", help="Path to directory to save tokenizer.json file")
 

--- a/examples/pytorch/language-modeling/prepare_config.py
+++ b/examples/pytorch/language-modeling/prepare_config.py
@@ -1,0 +1,35 @@
+"""Prepare a config file based on a pretrained model.
+This script is adaptated from the Transformers example in https://github.com/huggingface/transformers/tree/main/examples/flax/language-modeling
+"""
+from os import PathLike
+from pathlib import Path
+from typing import Union
+
+
+from transformers import BartConfig
+
+
+def prepare_config(pretrained_model_name: str = "facebook/bart-base", vocab_size: int = 50265,
+                   dout: Union[str, PathLike] = "."):
+    config = BartConfig.from_pretrained(pretrained_model_name, vocab_size=vocab_size)
+
+    # Save to disk
+    pdout = Path(dout).resolve()
+    pdout.mkdir(exist_ok=True, parents=True)
+    config.save_pretrained(str(pdout))
+
+
+def main():
+    import argparse
+    cparser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    cparser.add_argument("--pretrained_model_name", default="facebook/bart-base",
+                         help="Name of the config to use for tokenizer training")
+    cparser.add_argument("--vocab_size", type=int, default=50265, help="Vocabulary size")
+    cparser.add_argument("--dout", default=".", help="Path to directory to save tokenizer.json file")
+
+    prepare_config(**vars(cparser.parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pytorch/language-modeling/prepare_tokenizer.py
+++ b/examples/pytorch/language-modeling/prepare_tokenizer.py
@@ -1,0 +1,59 @@
+"""Train a ByteLevelBPETokenizer based on a given dataset. The dataset must be on the HF Hub.
+This script is adaptated from the Transformers example in https://github.com/huggingface/transformers/tree/main/examples/flax/language-modeling
+"""
+from os import PathLike
+from pathlib import Path
+from typing import Sequence, Union
+
+from datasets import load_dataset
+from tokenizers import ByteLevelBPETokenizer
+
+
+def train_tokenizer(dataset_name: str = "oscar", dataset_config_name: str = "unshuffled_deduplicated_nl",
+                    dataset_split: str = "train", dataset_textcol: str = "text",
+                    vocab_size: int = 50265,  min_frequency: int = 2,
+                    special_tokens: Sequence[str] = ("<s>", "<pad>", "</s>", "<unk>", "<mask>"),
+                    dout: Union[str, PathLike] = "."):
+    # load dataset
+    dataset = load_dataset(dataset_name, dataset_config_name, split=dataset_split)
+    # Instantiate tokenizer
+    tokenizer = ByteLevelBPETokenizer()
+
+    def batch_iterator(batch_size=1024):
+        for i in range(0, len(dataset), batch_size):
+            yield dataset[i: i + batch_size][dataset_textcol]
+
+    # Customized training
+    tokenizer.train_from_iterator(batch_iterator(), vocab_size=vocab_size, min_frequency=min_frequency,
+                                  special_tokens=special_tokens)
+
+    # Save to disk
+    pdout = Path(dout).resolve()
+    pdout.mkdir(exist_ok=True, parents=True)
+    tokenizer.save_model(str(pdout))
+
+
+def main():
+    import argparse
+    cparser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    cparser.add_argument("dataset_name", help="Name of dataset to use for tokenizer training")
+    cparser.add_argument("--dataset_config_name", default=None,
+                         help="Name of the config to use for tokenizer training")
+    cparser.add_argument("--dataset_split", default=None,
+                         help="Name of the split to use for tokenizer training (typically 'train')")
+    cparser.add_argument("--dataset_textcol", default="text",
+                         help="Name of the text column to use for tokenizer training")
+    cparser.add_argument("--vocab_size", type=int, default=50265, help="Vocabulary size")
+    cparser.add_argument("--min_frequency", type=int, default=2, help="Minimal frequency of tokens")
+    cparser.add_argument("--special_tokens", nargs="+", default=["<s>", "<pad>", "</s>", "<unk>", "<mask>"],
+                         help="Special tokens to add. Useful for specific training objectives. Note that if you wish"
+                              " to use this tokenizer with a default transformers.BartConfig, then make sure that the"
+                              " order of at least these special tokens are correct: BOS (0), padding (1), EOS (2)")
+    cparser.add_argument("--dout", default=".", help="Path to directory to save tokenizer.json file")
+
+    train_tokenizer(**vars(cparser.parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pytorch/language-modeling/prepare_tokenizer.py
+++ b/examples/pytorch/language-modeling/prepare_tokenizer.py
@@ -6,14 +6,20 @@ from pathlib import Path
 from typing import Sequence, Union
 
 from datasets import load_dataset
+
 from tokenizers import ByteLevelBPETokenizer
 
 
-def train_tokenizer(dataset_name: str = "oscar", dataset_config_name: str = "unshuffled_deduplicated_nl",
-                    dataset_split: str = "train", dataset_textcol: str = "text",
-                    vocab_size: int = 50265,  min_frequency: int = 2,
-                    special_tokens: Sequence[str] = ("<s>", "<pad>", "</s>", "<unk>", "<mask>"),
-                    dout: Union[str, PathLike] = "."):
+def train_tokenizer(
+    dataset_name: str = "oscar",
+    dataset_config_name: str = "unshuffled_deduplicated_nl",
+    dataset_split: str = "train",
+    dataset_textcol: str = "text",
+    vocab_size: int = 50265,
+    min_frequency: int = 2,
+    special_tokens: Sequence[str] = ("<s>", "<pad>", "</s>", "<unk>", "<mask>"),
+    dout: Union[str, PathLike] = ".",
+):
     # load dataset
     dataset = load_dataset(dataset_name, dataset_config_name, split=dataset_split)
     # Instantiate tokenizer
@@ -21,11 +27,12 @@ def train_tokenizer(dataset_name: str = "oscar", dataset_config_name: str = "uns
 
     def batch_iterator(batch_size=1024):
         for i in range(0, len(dataset), batch_size):
-            yield dataset[i: i + batch_size][dataset_textcol]
+            yield dataset[i : i + batch_size][dataset_textcol]
 
     # Customized training
-    tokenizer.train_from_iterator(batch_iterator(), vocab_size=vocab_size, min_frequency=min_frequency,
-                                  special_tokens=special_tokens)
+    tokenizer.train_from_iterator(
+        batch_iterator(), vocab_size=vocab_size, min_frequency=min_frequency, special_tokens=special_tokens
+    )
 
     # Save to disk
     pdout = Path(dout).resolve()
@@ -35,21 +42,31 @@ def train_tokenizer(dataset_name: str = "oscar", dataset_config_name: str = "uns
 
 def main():
     import argparse
+
     cparser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     cparser.add_argument("dataset_name", help="Name of dataset to use for tokenizer training")
-    cparser.add_argument("--dataset_config_name", default=None,
-                         help="Name of the config to use for tokenizer training")
-    cparser.add_argument("--dataset_split", default=None,
-                         help="Name of the split to use for tokenizer training (typically 'train')")
-    cparser.add_argument("--dataset_textcol", default="text",
-                         help="Name of the text column to use for tokenizer training")
+    cparser.add_argument(
+        "--dataset_config_name", default=None, help="Name of the config to use for tokenizer training"
+    )
+    cparser.add_argument(
+        "--dataset_split", default=None, help="Name of the split to use for tokenizer training (typically 'train')"
+    )
+    cparser.add_argument(
+        "--dataset_textcol", default="text", help="Name of the text column to use for tokenizer training"
+    )
     cparser.add_argument("--vocab_size", type=int, default=50265, help="Vocabulary size")
     cparser.add_argument("--min_frequency", type=int, default=2, help="Minimal frequency of tokens")
-    cparser.add_argument("--special_tokens", nargs="+", default=["<s>", "<pad>", "</s>", "<unk>", "<mask>"],
-                         help="Special tokens to add. Useful for specific training objectives. Note that if you wish"
-                              " to use this tokenizer with a default transformers.BartConfig, then make sure that the"
-                              " order of at least these special tokens are correct: BOS (0), padding (1), EOS (2)")
+    cparser.add_argument(
+        "--special_tokens",
+        nargs="+",
+        default=["<s>", "<pad>", "</s>", "<unk>", "<mask>"],
+        help=(
+            "Special tokens to add. Useful for specific training objectives. Note that if you wish"
+            " to use this tokenizer with a default transformers.BartConfig, then make sure that the"
+            " order of at least these special tokens are correct: BOS (0), padding (1), EOS (2)"
+        ),
+    )
     cparser.add_argument("--dout", default=".", help="Path to directory to save tokenizer.json file")
 
     train_tokenizer(**vars(cparser.parse_args()))

--- a/examples/pytorch/language-modeling/run_bart_dlm.py
+++ b/examples/pytorch/language-modeling/run_bart_dlm.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env python
+# coding=utf-8
+# Copyright 2021 The HuggingFace Team All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pretraining models for denoising language modeling on a text file or a dataset.
+"""
+import hashlib
+import logging
+import math
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from itertools import chain
+from typing import Optional, Union
+
+import evaluate
+import datasets
+import transformers
+from datasets import load_dataset
+
+from transformers import (
+    BartTokenizer,
+    BartConfig,
+    BartForConditionalGeneration,
+    HfArgumentParser,
+    Trainer, TrainingArguments,
+    is_torch_tpu_available, set_seed,
+)
+from transformers.trainer_utils import get_last_checkpoint
+
+from denoising_collator import DataCollatorForBartDenoisingLM
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ModelArguments:
+    """
+    Arguments pertaining to which model/config/tokenizer we are going to fine-tune, or train from scratch.
+    """
+
+    model_name_or_path: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": (
+                "The model checkpoint for weights initialization.Don't set if you want to train a model from scratch."
+            )
+        },
+    )
+    config_name: Optional[str] = field(
+        default=None, metadata={"help": "Pretrained config name or path if not the same as model_name"}
+    )
+    tokenizer_name: Optional[str] = field(
+        default=None, metadata={"help": "Pretrained tokenizer name or path if not the same as model_name"}
+    )
+    cache_dir: Optional[str] = field(
+        default=None,
+        metadata={"help": "Where do you want to store the pretrained models downloaded from huggingface.co"},
+    )
+    use_fast_tokenizer: bool = field(
+        default=True,
+        metadata={"help": "Whether to use one of the fast tokenizer (backed by the tokenizers library) or not."},
+    )
+    model_revision: str = field(
+        default="main",
+        metadata={"help": "The specific model version to use (can be a branch name, tag name or commit id)."},
+    )
+    use_auth_token: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Will use the token generated when running `huggingface-cli login` (necessary to use this script "
+                "with private models)."
+            )
+        },
+    )
+
+
+@dataclass
+class DataTrainingArguments:
+    """
+    Arguments pertaining to what data we are going to input our model for training and eval.
+    """
+
+    dataset_name: Optional[str] = field(
+        default=None, metadata={"help": "The name of the dataset to use (via the datasets library)."}
+    )
+    dataset_config_name: Optional[str] = field(
+        default=None, metadata={"help": "The configuration name of the dataset to use (via the datasets library)."}
+    )
+    train_file: Optional[str] = field(default=None, metadata={"help": "The input training data file (a text file)."})
+    validation_file: Optional[str] = field(
+        default=None,
+        metadata={"help": "An optional input evaluation data file to evaluate the perplexity on (a text file)."},
+    )
+    overwrite_cache: bool = field(
+        default=False, metadata={"help": "Overwrite the cached training and evaluation sets"}
+    )
+    validation_split_percentage: Optional[int] = field(
+        default=5,
+        metadata={
+            "help": "The percentage of the train set used as validation set in case there's no validation split"
+        },
+    )
+    max_seq_length: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "The maximum total input sequence length after tokenization and masking. Sequences longer than this"
+                " will be truncated. Default to the max input length of the model."
+            )
+        },
+    )
+    preprocessing_num_workers: Optional[int] = field(
+        default=None,
+        metadata={"help": "The number of processes to use for the preprocessing."},
+    )
+    max_train_samples: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "For debugging purposes or quicker training, truncate the number of training examples to this "
+                "value if set."
+            )
+        },
+    )
+    max_eval_samples: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "For debugging purposes or quicker training, truncate the number of evaluation examples to this "
+                "value if set."
+            )
+        },
+    )
+    spacy_model: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "By default, an English NLTK punct model is used for sentence splitting. If you give a spacy_model"
+                    " name instead, we'll use that for sentence splitting. Note that spaCy and the chosen model have"
+                    " to be installed."
+        }
+    )
+    no_sentence_splitting: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": "By default, an English NLTK punct model is used for sentence splitting, or with 'spacy_model' you"
+                    " can specify a spaCy model for splitting. If you decide to do sentence splitting yourself, you"
+                    " can disable any sentence splitting in this script with this flag. Note that sentences need to be"
+                    " split and then joined together again with the tokenizer's padding token."
+        }
+    )
+    mask_ratio: float = field(
+        default=0.3, metadata={"help": "Ratio of tokens to mask for span masked language modeling loss"}
+    )
+    random_ratio: float = field(
+        default=0.1, metadata={"help": "The probability with which to (randomly) replace a token by a random token"}
+    )
+    insert_ratio: float = field(
+        default=0.0, metadata={"help": "The probability with which to (randomly) insert noise. Will add"
+                                       " `insert_ratio * input.numel()` noise"}
+    )
+    rotate_ratio: float = field(
+        default=0.0, metadata={"help": "The probability with which to (randomly) add rolling noise (i.e., shifted"
+                                       " tokens in order)"}
+    )
+    permute_sentence_ratio: float = field(
+        default=1.0, metadata={"help": "Ratio of sentences to be permuted in each document"}
+    )
+    poisson_lambda: float = field(
+        default=3.5, metadata={"help": "Mean of Poisson distribution used to generate span-lengths to be masked"}
+    )
+
+    def __post_init__(self):
+        if self.dataset_name is None and self.train_file is None and self.validation_file is None:
+            raise ValueError("Need either a dataset name or a training/validation file.")
+        else:
+            if self.train_file is not None:
+                extension = self.train_file.split(".")[-1]
+                if extension not in {"csv", "json", "txt"}:
+                    raise ValueError("`train_file` should be a csv, a json or a txt file.")
+            if self.validation_file is not None:
+                extension = self.validation_file.split(".")[-1]
+                if extension not in {"csv", "json", "txt"}:
+                    raise ValueError("`validation_file` should be a csv, a json or a txt file.")
+
+
+def clean_fingerprint(fingerprint: str):
+    return re.sub(r"[<>:/\\|?*.]", "", fingerprint)
+
+
+def hash_fingerprint(text: Optional[str], length: int = 49) -> Union[None, str]:
+    if text is None:
+        return None
+    # Using a length of 49: max. length in datasets for fingerprint is 64
+    # and by using multiple workers, an additional fingerprint like `_00000_of_00004`
+    # is added to the end. So we just have room for 49
+    return str(int(hashlib.sha256(text.encode("utf-8")).hexdigest(), 16) % 10 ** length)
+
+
+def main():
+    parser = HfArgumentParser((ModelArguments, DataTrainingArguments, TrainingArguments))
+    if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
+        # If we pass only one argument to the script and it's the path to a json file,
+        # let's parse it to get our arguments.
+        model_args, data_args, training_args = parser.parse_json_file(json_file=os.path.abspath(sys.argv[1]))
+    else:
+        model_args, data_args, training_args = parser.parse_args_into_dataclasses()
+
+    if (
+            os.path.exists(training_args.output_dir)
+            and os.listdir(training_args.output_dir)
+            and training_args.do_train
+            and not training_args.overwrite_output_dir
+    ):
+        raise ValueError(
+            f"Output directory ({training_args.output_dir}) already exists and is not empty."
+            "Use --overwrite_output_dir to overcome."
+        )
+
+    # Setup logging
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+        datefmt="%m/%d/%Y %H:%M:%S",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+
+    log_level = training_args.get_process_log_level()
+    logger.setLevel(log_level)
+    datasets.utils.logging.set_verbosity(log_level)
+    transformers.utils.logging.set_verbosity(log_level)
+    transformers.utils.logging.enable_default_handler()
+    transformers.utils.logging.enable_explicit_format()
+
+    # Log on each process the small summary:
+    logger.warning(
+        f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
+        + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
+    )
+    # Set the verbosity to info of the Transformers logger (on main process only):
+    logger.info(f"Training/evaluation parameters {training_args}")
+
+    # Detecting last checkpoint.
+    last_checkpoint = None
+    if os.path.isdir(training_args.output_dir) and training_args.do_train and not training_args.overwrite_output_dir:
+        last_checkpoint = get_last_checkpoint(training_args.output_dir)
+        if last_checkpoint is None and len(os.listdir(training_args.output_dir)) > 0:
+            raise ValueError(
+                f"Output directory ({training_args.output_dir}) already exists and is not empty. "
+                "Use --overwrite_output_dir to overcome."
+            )
+        elif last_checkpoint is not None and training_args.resume_from_checkpoint is None:
+            logger.info(
+                f"Checkpoint detected, resuming training at {last_checkpoint}. To avoid this behavior, change "
+                "the `--output_dir` or add `--overwrite_output_dir` to train from scratch."
+            )
+
+    # Set seed before initializing model.
+    set_seed(training_args.seed)
+
+    # Get the datasets: you can either provide your own CSV/JSON/TXT training and evaluation files (see below)
+    # or just provide the name of one of the public datasets available on the hub at https://huggingface.co/datasets/
+    # (the dataset will be downloaded automatically from the datasets Hub).
+    #
+    # For CSV/JSON files, this script will use the column called 'text' or the first column if no column called
+    # 'text' is found. You can easily tweak this behavior (see below).
+    if data_args.dataset_name is not None:
+        # Downloading and loading a dataset from the hub.
+        loaded_ds = load_dataset(
+            data_args.dataset_name,
+            data_args.dataset_config_name,
+            cache_dir=model_args.cache_dir,
+            use_auth_token=True if model_args.use_auth_token else None,
+        )
+        if "validation" not in loaded_ds.keys():
+            loaded_ds["validation"] = load_dataset(
+                data_args.dataset_name,
+                data_args.dataset_config_name,
+                split=f"train[:{data_args.validation_split_percentage}%]",
+                cache_dir=model_args.cache_dir,
+                use_auth_token=True if model_args.use_auth_token else None,
+            )
+            loaded_ds["train"] = load_dataset(
+                data_args.dataset_name,
+                data_args.dataset_config_name,
+                split=f"train[{data_args.validation_split_percentage}%:]",
+                cache_dir=model_args.cache_dir,
+                use_auth_token=True if model_args.use_auth_token else None,
+            )
+    else:
+        data_files = {}
+        extension = None
+        if data_args.train_file is not None:
+            data_files["train"] = data_args.train_file
+            extension = data_args.train_file.split(".")[-1]
+        if data_args.validation_file is not None:
+            data_files["validation"] = data_args.validation_file
+            extension = data_args.validation_file.split(".")[-1]
+        if extension == "txt":
+            extension = "text"
+        loaded_ds = load_dataset(
+            extension,
+            data_files=data_files,
+            cache_dir=model_args.cache_dir,
+            use_auth_token=True if model_args.use_auth_token else None,
+        )
+
+        # If no validation data is there, validation_split_percentage will be used to divide the dataset.
+        if "validation" not in loaded_ds.keys():
+            loaded_ds["validation"] = load_dataset(
+                extension,
+                data_files=data_files,
+                split=f"train[:{data_args.validation_split_percentage}%]",
+                cache_dir=model_args.cache_dir,
+                use_auth_token=True if model_args.use_auth_token else None,
+            )
+            loaded_ds["train"] = load_dataset(
+                extension,
+                data_files=data_files,
+                split=f"train[{data_args.validation_split_percentage}%:]",
+                cache_dir=model_args.cache_dir,
+                use_auth_token=True if model_args.use_auth_token else None,
+            )
+
+    ############################
+    # Load tokenizer and model #
+    ############################
+    # TOKENIZER
+    tokenizer_kwargs = {
+        "cache_dir": model_args.cache_dir,
+        "use_fast": model_args.use_fast_tokenizer,
+        "revision": model_args.model_revision,
+        "use_auth_token": True if model_args.use_auth_token else None,
+    }
+    if model_args.tokenizer_name:
+        tokenizer = BartTokenizer.from_pretrained(model_args.tokenizer_name, **tokenizer_kwargs)
+    elif model_args.model_name_or_path:
+        tokenizer = BartTokenizer.from_pretrained(model_args.model_name_or_path, **tokenizer_kwargs)
+        model_args.tokenizer_name = model_args.model_name_or_path
+    else:
+        raise ValueError(
+            "You are instantiating a new tokenizer from scratch. This is not supported by this script."
+            "You can do it from another script, save it, and load it from here, using --tokenizer_name."
+        )
+
+    # CONFIG
+    config_kwargs = {
+        "cache_dir": model_args.cache_dir,
+        "revision": model_args.model_revision,
+        "use_auth_token": True if model_args.use_auth_token else None,
+    }
+    if model_args.config_name:
+        config = BartConfig.from_pretrained(model_args.config_name, vocab_size=len(tokenizer), **config_kwargs)
+    elif model_args.model_name_or_path:
+        config = BartConfig.from_pretrained(model_args.model_name_or_path, **config_kwargs)
+    else:
+        config = BartConfig()
+        logger.warning("You are instantiating a new config instance from scratch.")
+
+    # MODEL
+    if model_args.model_name_or_path:
+        model = BartForConditionalGeneration.from_pretrained(
+            model_args.model_name_or_path,
+            config=config
+        )
+    else:
+        config.vocab_size = len(tokenizer)
+        model = BartForConditionalGeneration(config)
+
+    model.resize_token_embeddings(len(tokenizer))
+
+    #######################
+    # Preprocess datasets #
+    #######################
+    # First we tokenize all the texts.
+    if training_args.do_train:
+        column_names = loaded_ds["train"].column_names
+    else:
+        column_names = loaded_ds["validation"].column_names
+    text_column_name = "text" if "text" in column_names else column_names[0]
+
+    # Set max length
+    if data_args.max_seq_length is None:
+        max_seq_length = tokenizer.model_max_length
+        if max_seq_length > 1024:
+            logger.warning(
+                f"The tokenizer picked seems to have a very large `model_max_length` ({tokenizer.model_max_length}). "
+                "Picking 1024 instead. You can change that default value by passing --max_seq_length xxx."
+            )
+            max_seq_length = 1024
+    else:
+        if data_args.max_seq_length > tokenizer.model_max_length:
+            logger.warning(
+                f"The max_seq_length passed ({data_args.max_seq_length}) is larger than the maximum length for the"
+                f"model ({tokenizer.model_max_length}). Using max_seq_length={tokenizer.model_max_length}."
+            )
+        max_seq_length = min(data_args.max_seq_length, tokenizer.model_max_length)
+
+    # Caching is not working well with spaCy so we use explicit fingerprints
+    # Looping over splits because we cannot use new_fingerprint on DatasetDict
+    for k in loaded_ds.keys():
+        fingerprint = f"{k}@{data_args.dataset_name}{data_args.dataset_config_name}" if data_args.dataset_name else None
+
+        if not data_args.no_sentence_splitting:
+            # Do sentence splitting
+            sentence_tokenizer = None
+            if data_args.spacy_model:
+                import spacy
+                spacy.prefer_gpu()
+                # Only load the parser (depparse) which will set sentence boundaries
+                sentence_tokenizer = spacy.load(data_args.spacy_model,
+                                                exclude=["tagger", "ner", "lemmatizer", "textcat"])
+            else:
+                import nltk
+                # Use Punkt Sentence Tokenizer to divide a document into a list of sentences
+                nltk.download("punkt")
+                sentence_tokenizer = nltk.data.load("tokenizers/punkt/english.pickle")
+
+            def sentence_split(examples):
+                if data_args.spacy_model:
+                    docs = sentence_tokenizer.pipe(examples["text"])
+                    doc_sents = [map(str, doc.sents) for doc in docs]
+                else:
+                    doc_sents = [[s for s in sentence_tokenizer.tokenize(t)] for t in examples["text"]]
+
+                # use pad token as end of sentence indicator
+                new_texts = [f"{tokenizer.bos_token}{tokenizer.pad_token.join(sents)}{tokenizer.eos_token}" for sents
+                             in doc_sents]
+                return {"text": new_texts}
+
+            with training_args.main_process_first(desc="Sentence splitting"):
+                # If using spaCy, we don't run multiple workers here but pass that to spacy's pipe
+                fingerprint = clean_fingerprint(f"{fingerprint}+ss{data_args.spacy_model}") if fingerprint else None
+                loaded_ds[k] = loaded_ds[k].map(
+                    sentence_split,
+                    batched=True,
+                    num_proc=data_args.preprocessing_num_workers,
+                    remove_columns=column_names,
+                    load_from_cache_file=not data_args.overwrite_cache,
+                    desc="Sentence splitting",
+                    new_fingerprint=hash_fingerprint(fingerprint)
+                )
+                del sentence_tokenizer
+
+        # Tokenize (subword) every text, then concatenate them together before splitting them in smaller parts.
+        # Attention masks will be added in the collator
+        def tokenize_function(examples):
+            return tokenizer(examples[text_column_name], add_special_tokens=False, return_attention_mask=False)
+
+        with training_args.main_process_first(desc="Subword tokenization"):
+            fingerprint = clean_fingerprint(f"{fingerprint}+tok{model_args.tokenizer_name}") if fingerprint else None
+            loaded_ds[k] = loaded_ds[k].map(
+                tokenize_function,
+                batched=True,
+                num_proc=data_args.preprocessing_num_workers,
+                remove_columns=text_column_name,
+                load_from_cache_file=not data_args.overwrite_cache,
+                desc="Tokenizing",
+                new_fingerprint=hash_fingerprint(fingerprint)
+            )
+
+        # Main data processing function that will concatenate all texts from our dataset and generate chunks of
+        # max_seq_length.
+        def group_texts(examples):
+            # Concatenate all texts.
+            concatenated_examples = {k: list(chain(*examples[k])) for k in examples.keys()}
+            total_length = len(concatenated_examples[list(examples.keys())[0]])
+            # We drop the small remainder, we could add padding if the model supported it instead of this drop, you can
+            # customize this part to your needs.
+            if total_length >= max_seq_length:
+                total_length = (total_length // max_seq_length) * max_seq_length
+            # Split by chunks of max_len.
+            result = {
+                k: [t[i: i + max_seq_length] for i in range(0, total_length, max_seq_length)]
+                for k, t in concatenated_examples.items()
+            }
+            return result
+
+        with training_args.main_process_first(desc="Grouping"):
+            fingerprint = clean_fingerprint(f"{fingerprint}+group{max_seq_length}") if fingerprint else None
+            loaded_ds[k] = loaded_ds[k].map(
+                group_texts,
+                batched=True,
+                num_proc=data_args.preprocessing_num_workers,
+                load_from_cache_file=not data_args.overwrite_cache,
+                desc=f"Grouping in blocks of {max_seq_length}",
+                new_fingerprint=hash_fingerprint(fingerprint)
+            )
+
+    train_dataset = None
+    if training_args.do_train:
+        if "train" not in loaded_ds:
+            raise ValueError("--do_train requires a train dataset")
+        train_dataset = loaded_ds["train"]
+        if data_args.max_train_samples is not None:
+            max_train_samples = min(len(train_dataset), data_args.max_train_samples)
+            train_dataset = train_dataset.select(range(max_train_samples))
+
+    eval_dataset = None
+    if training_args.do_eval:
+        if "validation" not in loaded_ds:
+            raise ValueError("--do_eval requires a validation dataset")
+        eval_dataset = loaded_ds["validation"]
+        if data_args.max_eval_samples is not None:
+            max_eval_samples = min(len(eval_dataset), data_args.max_eval_samples)
+            eval_dataset = eval_dataset.select(range(max_eval_samples))
+
+    # Data collator will take care of randomly masking the tokens/spans, permuting sentences, adding noise
+    data_collator = DataCollatorForBartDenoisingLM(
+        tokenizer=tokenizer,
+        decoder_start_token_id=model.config.decoder_start_token_id,
+        mask_ratio=data_args.mask_ratio,
+        random_ratio=data_args.random_ratio,
+        insert_ratio=data_args.insert_ratio,
+        rotate_ratio=data_args.rotate_ratio,
+        permute_sentence_ratio=data_args.permute_sentence_ratio,
+        poisson_lambda=data_args.poisson_lambda,
+    )
+
+    # Some trainer-specific submethods that may be relevant:
+    def preprocess_logits_for_metrics(logits, labels):
+        if isinstance(logits, tuple):
+            # Depending on the model and config, logits may contain extra tensors,
+            # like past_key_values, but logits always come first
+            logits = logits[0]
+        return logits.argmax(dim=-1)
+
+    metric = evaluate.load("accuracy")
+
+    def compute_metrics(eval_preds):
+        preds, labels = eval_preds
+        # preds have the same shape as the labels, after the argmax(-1) has been calculated
+        # by preprocess_logits_for_metrics
+        labels = labels.reshape(-1)
+        preds = preds.reshape(-1)
+        mask = labels != -100
+        labels = labels[mask]
+        preds = preds[mask]
+        return metric.compute(predictions=preds, references=labels)
+
+    # Initialize our Trainer
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        tokenizer=tokenizer,
+        data_collator=data_collator,
+        compute_metrics=compute_metrics if training_args.do_eval and not is_torch_tpu_available() else None,
+        preprocess_logits_for_metrics=preprocess_logits_for_metrics
+        if training_args.do_eval and not is_torch_tpu_available()
+        else None,
+    )
+
+    # Training
+    if training_args.do_train:
+        checkpoint = None
+        if training_args.resume_from_checkpoint is not None:
+            checkpoint = training_args.resume_from_checkpoint
+        elif last_checkpoint is not None:
+            checkpoint = last_checkpoint
+        train_result = trainer.train(resume_from_checkpoint=checkpoint)
+        trainer.save_model()  # Saves the tokenizer too for easy upload
+        metrics = train_result.metrics
+
+        max_train_samples = (
+            data_args.max_train_samples if data_args.max_train_samples is not None else len(train_dataset)
+        )
+        metrics["train_samples"] = min(max_train_samples, len(train_dataset))
+
+        trainer.log_metrics("train", metrics)
+        trainer.save_metrics("train", metrics)
+        trainer.save_state()
+
+    # Evaluation
+    if training_args.do_eval:
+        logger.info("*** Evaluate ***")
+
+        metrics = trainer.evaluate()
+
+        max_eval_samples = data_args.max_eval_samples if data_args.max_eval_samples is not None else len(eval_dataset)
+        metrics["eval_samples"] = min(max_eval_samples, len(eval_dataset))
+        try:
+            perplexity = math.exp(metrics["eval_loss"])
+        except OverflowError:
+            perplexity = float("inf")
+        metrics["perplexity"] = perplexity
+
+        trainer.log_metrics("eval", metrics)
+        trainer.save_metrics("eval", metrics)
+
+        kwargs = {"finetuned_from": model_args.model_name_or_path, "tasks": "text2text-generation"}
+        if data_args.dataset_name is not None:
+            kwargs["dataset_tags"] = data_args.dataset_name
+            if data_args.dataset_config_name is not None:
+                kwargs["dataset_args"] = data_args.dataset_config_name
+                kwargs["dataset"] = f"{data_args.dataset_name} {data_args.dataset_config_name}"
+            else:
+                kwargs["dataset"] = data_args.dataset_name
+
+        if training_args.push_to_hub:
+            trainer.push_to_hub(**kwargs)
+        else:
+            trainer.create_model_card(**kwargs)
+
+
+def _mp_fn(index):
+    # For xla_spawn (TPUs)
+    main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements a pretraining example for BART (denoising language model). Big focus on getting the data denoising as close to the original fairseq as possible but instead of on the dataset level on the dataloader level.

Heavily inspired by the fairseq implementation and the FLAX implementation. (See `HF (Flax), fairseq, and current implementation`.) Looking for some feedback. Please see `Questions/Uncertainties`.

# Some notes 

## Default values
The defaults are set to the [given BART args](https://github.com/facebookresearch/fairseq/issues/1899#issuecomment-1069429320). This differs from the Flax defaults in one respect, namely `poisson_lambda`, which is now set to `3.5` instead of `3.0`.


## HF (Flax), fairseq, and current implementation

There are some differences in implementation between fairseq, the HF FLAX example, and this PyTorch implementation.

- `argwhere` in the Flax example
[in this position](https://github.com/huggingface/transformers/blob/65fb71bc762c46bb067306c1fd083b1cba87a095/examples/flax/language-modeling/run_bart_dlm_flax.py#L319)
is not the same as what is happening in fairseq. [In fairseq](https://github.com/facebookresearch/fairseq/blob/a6a63279422f846a3c2f6c45b9c96d6951cc4b82/fairseq/data/denoising_dataset.py#L230)
we check explicitly that the previous token was not a "full stop" (padding token) but in HF we just check whether the
current token is a full stop. In the current example I also explicitly check that the next token is not a full stop,
in case of padding. (However, in practice that should be a non-issue since all batches/samples should have the
same sequence length and there should not be any padding.)
- I found that the result of sentence permutation was not consistent in terms of where the separating pad token ended
up ([bug report](https://github.com/facebookresearch/fairseq/issues/4695)), so I have reimplemented that method so
that sentences in a sequence are still separated by a padding token, even after permutation.
- In HF FLAX, the token_mask is restricted to [non-special and non-padding tokens](https://github.com/huggingface/transformers/blob/65fb71bc762c46bb067306c1fd083b1cba87a095/examples/flax/language-modeling/run_bart_dlm_flax.py#L361).
In Fairseq, by default, only the first and last tokens are excluded and [all others](https://github.com/facebookresearch/fairseq/blob/1bba712622b8ae4efb3eb793a8a40da386fe11d0/fairseq/data/denoising_dataset.py#L241)
are prone to masking. The HF implementation seems sensible so I follow that. `get_special_tokens_mask` includes the 
padding token, though, so no need to add that separately.
- The Flax example does not include methods to add more noise. I have ported those as well.
- However, I did not adapt `add_insertion_noise` to work well with padded sequences. So the inserted noise may occur
ANYWHERE. It is unclear whether this is intended behavior.

Alternatively, we could implement all this processing on the dataset level and use `Dataset.map`. This has some
advantages:

- more true to fairseq implementation (sample level rather than batch level);
- cached.

... and disadvantages:

- potentially slower (not batched), although we can integrate a batched approach. But as discussed above, this will be
less true to the original fairseq implementation in `add_insertion_noise`
- every sample is always processed the same. So in small datasets which are seen multiple times by the model, the 
same sample will always be processed the same. In a dataloader, that will not be the case because the processing
occurs on every iteration rather than once before training.

## Questions/Uncertainties
- Do the padding tokens still serve a purpose after permutation? (Teaching the model to learn to detect sentence boundaries?) They _can_ get masked and noised.
- It seems that `add_insertion_noise` can insert noise _anywhere_ (also in fairseq), which means that it will also overwrite special
tokens and that sequence don't necessarily end with a EOS token. Is that a problem?
- I have now added auxiliary scripts for config/tokenizer creation when pre-training. Should I remove those? In the FLAX example, these steps are [described inline](https://github.com/huggingface/transformers/tree/main/examples/flax/language-modeling#bart-denoising-language-modeling) but without a given script. So we could also just do that.
- I have explicitly added fingerprints (hashed) because in the past I've come to encounter issues when using spaCy and Dataset.map (every time you load a spaCy model, it has a different hash so the processing will happen every time). I don't see a better way but feel free to share ideas. Maybe someone of the `datasets` team can chime in, too.


# Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? https://github.com/huggingface/transformers/issues/5096#issuecomment-1237227809
- [x] Did you make sure to update the documentation with your changes? 



# Who can review?

- bart: @patrickvonplaten @patil-suraj
- maintained examples (not research project or legacy): @patil-suraj
- flax implementation authors: @sanchit-gandhi @duongna21

