### PR TITLE
[DeepSpeed ZeRO3] Fix performance degradation in sharded models

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -424,9 +424,14 @@ def _load_state_dict_into_model(model_to_load, state_dict, start_prefix):
             # because zero3 puts placeholders in model params, this context
             # manager gathers (unpartitions) the params of the current layer, then loads from
             # the state dict and then re-partitions them again
-            with deepspeed.zero.GatheredParameters(list(module.parameters(recurse=False)), modifier_rank=0):
-                if torch.distributed.get_rank() == 0:
-                    module._load_from_state_dict(*args)
+            # 
+            # In sharded models, each shard has only part of state_dict, so only gather parameters that are in state_dict. 
+            named_parameters = dict(module.named_parameters(prefix=prefix[:-1], recurse=False))
+            params_to_fetch = [named_parameters[k] for k in state_dict.keys() if k in named_parameters]
+            if len(params_to_fetch) > 0:
+                with deepspeed.zero.GatheredParameters(params_to_fetch, modifier_rank=0):
+                    if torch.distributed.get_rank() == 0:
+                        module._load_from_state_dict(*args)
         else:
             module._load_from_state_dict(*args)
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -421,15 +421,15 @@ def _load_state_dict_into_model(model_to_load, state_dict, start_prefix):
         if is_deepspeed_zero3_enabled():
             import deepspeed
 
-            # because zero3 puts placeholders in model params, this context
-            # manager gathers (unpartitions) the params of the current layer, then loads from
-            # the state dict and then re-partitions them again
-            #
-            # In sharded models, each shard has only part of state_dict, so only gather parameters that are in state_dict.
+            # In sharded models, each shard has only part of the full state_dict, so only gather
+            # parameters that are in the current state_dict.
             named_parameters = dict(module.named_parameters(prefix=prefix[:-1], recurse=False))
-            params_to_fetch = [named_parameters[k] for k in state_dict.keys() if k in named_parameters]
-            if len(params_to_fetch) > 0:
-                with deepspeed.zero.GatheredParameters(params_to_fetch, modifier_rank=0):
+            params_to_gather = [named_parameters[k] for k in state_dict.keys() if k in named_parameters]
+            if len(params_to_gather) > 0:
+                # because zero3 puts placeholders in model params, this context
+                # manager gathers (unpartitions) the params of the current layer, then loads from
+                # the state dict and then re-partitions them again
+                with deepspeed.zero.GatheredParameters(params_to_gather, modifier_rank=0):
                     if torch.distributed.get_rank() == 0:
                         module._load_from_state_dict(*args)
         else:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -424,8 +424,8 @@ def _load_state_dict_into_model(model_to_load, state_dict, start_prefix):
             # because zero3 puts placeholders in model params, this context
             # manager gathers (unpartitions) the params of the current layer, then loads from
             # the state dict and then re-partitions them again
-            # 
-            # In sharded models, each shard has only part of state_dict, so only gather parameters that are in state_dict. 
+            #
+            # In sharded models, each shard has only part of state_dict, so only gather parameters that are in state_dict.
             named_parameters = dict(module.named_parameters(prefix=prefix[:-1], recurse=False))
             params_to_fetch = [named_parameters[k] for k in state_dict.keys() if k in named_parameters]
             if len(params_to_fetch) > 0:


### PR DESCRIPTION
When sharded models were added the deepspeed/zero3 branch of model loading of pretrained weights 

https://github.com/huggingface/transformers/blob/7d5fde991d598370d961be8cb7add6541e2b59ce/src/transformers/modeling_utils.py#L427-L429

got ~N-shards-x-slower, since it wastefully gathered weights that weren't in the `state_dict`:

**So for example with BLOOM-176 which has 72 shards, the loading was ~70x slower under deepspeed zero3 and nvme offload!**

This fix takes care of the situation with sharded models by finding an intersection of `state_dict` keys and the keys of the parameters of the current submodule that is being loaded to and thus only gathering the weights that get updated. And if there is no intersection skipping the rest of the branch altogether.

The 1-shard use case still works as the intersection should be 100%.

