### PR TITLE
Fix XLA fp16 and bf16 error checking

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -93,6 +93,15 @@ def get_int_from_env(env_keys, default):
     return default
 
 
+def get_xla_device_type(device: torch.device) -> Optional[str]:
+    """
+    Returns the xla device type (CPU|GPU|TPU) or None if the device is a non-xla device.
+    """
+    if is_torch_tpu_available():
+        return xm.xla_real_devices([device])[0].split(":")[0]
+    return None
+
+
 class OptimizerNames(ExplicitEnum):
     """
     Stores the acceptable string identifiers for optimizers.
@@ -1108,7 +1117,7 @@ class TrainingArguments:
             self.framework == "pt"
             and is_torch_available()
             and (self.device.type != "cuda")
-            and not (self.device.type == "xla" and "GPU_NUM_DEVICES" in os.environ)
+            and (get_xla_device_type(self.device) != "GPU")
             and (self.fp16 or self.fp16_full_eval)
         ):
             raise ValueError(
@@ -1120,7 +1129,7 @@ class TrainingArguments:
             self.framework == "pt"
             and is_torch_available()
             and (self.device.type != "cuda")
-            and not (self.device.type == "xla" and "GPU_NUM_DEVICES" in os.environ)
+            and (get_xla_device_type(self.device) != "GPU")
             and (self.device.type != "cpu")
             and (self.bf16 or self.bf16_full_eval)
         ):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -93,7 +93,7 @@ def get_int_from_env(env_keys, default):
     return default
 
 
-def get_xla_device_type(device: torch.device) -> Optional[str]:
+def get_xla_device_type(device: "torch.device") -> Optional[str]:
     """
     Returns the xla device type (CPU|GPU|TPU) or None if the device is a non-xla device.
     """


### PR DESCRIPTION
This PR fixed a bug introduced in https://github.com/huggingface/transformers/pull/15022 that will wrongfully throw an error when training with XLA device + fp16. `GPU_NUM_DEVICES` is unset by torch_xla in distributed training [here](https://github.com/pytorch/xla/blob/master/torch_xla/distributed/xla_multiprocessing.py#L229).

Tested using the following scripts:
```sh
GPU_NUM_DEVICES=8 python -m torch_xla.distributed.xla_spawn --num_gpus 8 language-modeling/run_mlm.py \
    --model_name_or_path bert-base-uncased \
    --dataset_name wikitext \
    --dataset_config_name wikitext-2-raw-v1 \
    --overwrite_output_dir true \
    --output_dir /tmp/test-mlm \
    --per_device_train_batch_size 10 \
    --do_eval \
    --fp16 true \
    --do_train \
    --num_train_epochs 3 \
    --optim adamw_torch_xla
```

Thanks to @Lokiiiiii @comaniac for reporting this issue.

cc @sgugger