### PR TITLE
[VideoMAE] Improve code examples

### DIFF
--- a/src/transformers/models/videomae/modeling_videomae.py
+++ b/src/transformers/models/videomae/modeling_videomae.py
@@ -598,21 +598,18 @@ class VideoMAEModel(VideoMAEPreTrainedModel):
         >>> file_path = hf_hub_download(
         ...     repo_id="nielsr/video-demo", filename="eating_spaghetti.mp4", repo_type="dataset"
         ... )
-        >>> vr = VideoReader(file_path, num_threads=1, ctx=cpu(0))
+        >>> videoreader = VideoReader(file_path, num_threads=1, ctx=cpu(0))
 
         >>> # sample 16 frames
-        >>> vr.seek(0)
-        >>> indices = sample_frame_indices(clip_len=16, frame_sample_rate=4, seg_len=len(vr))
-        >>> buffer = vr.get_batch(indices).asnumpy()
-
-        >>> # create a list of NumPy arrays
-        >>> video = [buffer[i] for i in range(buffer.shape[0])]
+        >>> videoreader.seek(0)
+        >>> indices = sample_frame_indices(clip_len=16, frame_sample_rate=4, seg_len=len(videoreader))
+        >>> video = videoreader.get_batch(indices).asnumpy()
 
         >>> feature_extractor = VideoMAEFeatureExtractor.from_pretrained("MCG-NJU/videomae-base")
         >>> model = VideoMAEModel.from_pretrained("MCG-NJU/videomae-base")
 
         >>> # prepare video for the model
-        >>> inputs = feature_extractor(video, return_tensors="pt")
+        >>> inputs = feature_extractor(list(video), return_tensors="pt")
 
         >>> # forward pass
         >>> outputs = model(**inputs)
@@ -961,20 +958,17 @@ class VideoMAEForVideoClassification(VideoMAEPreTrainedModel):
         >>> file_path = hf_hub_download(
         ...     repo_id="nielsr/video-demo", filename="eating_spaghetti.mp4", repo_type="dataset"
         ... )
-        >>> vr = VideoReader(file_path, num_threads=1, ctx=cpu(0))
+        >>> videoreader = VideoReader(file_path, num_threads=1, ctx=cpu(0))
 
         >>> # sample 16 frames
-        >>> vr.seek(0)
-        >>> indices = sample_frame_indices(clip_len=16, frame_sample_rate=4, seg_len=len(vr))
-        >>> buffer = vr.get_batch(indices).asnumpy()
-
-        >>> # create a list of NumPy arrays
-        >>> video = [buffer[i] for i in range(buffer.shape[0])]
+        >>> videoreader.seek(0)
+        >>> indices = sample_frame_indices(clip_len=16, frame_sample_rate=4, seg_len=len(videoreader))
+        >>> video = videoreader.get_batch(indices).asnumpy()
 
         >>> feature_extractor = VideoMAEFeatureExtractor.from_pretrained("MCG-NJU/videomae-base-finetuned-kinetics")
         >>> model = VideoMAEForVideoClassification.from_pretrained("MCG-NJU/videomae-base-finetuned-kinetics")
 
-        >>> inputs = feature_extractor(video, return_tensors="pt")
+        >>> inputs = feature_extractor(list(video), return_tensors="pt")
 
         >>> with torch.no_grad():
         ...     outputs = model(**inputs)

--- a/src/transformers/models/videomae/modeling_videomae.py
+++ b/src/transformers/models/videomae/modeling_videomae.py
@@ -940,9 +940,12 @@ class VideoMAEForVideoClassification(VideoMAEPreTrainedModel):
         ```python
         >>> from decord import VideoReader, cpu
         >>> import torch
+        >>> import numpy as np
 
         >>> from transformers import VideoMAEFeatureExtractor, VideoMAEForVideoClassification
         >>> from huggingface_hub import hf_hub_download
+
+        >>> np.random.seed(0)
 
 
         >>> def sample_frame_indices(clip_len, frame_sample_rate, seg_len):


### PR DESCRIPTION
# What does this PR do?

This PR simplifies the code examples of VideoMAE, and adds a seed to make sure the video classifier always predicts "eating spaghetti" on the video (as, due to the sampling of frames, it may occur the model predicts another class, like "eating ice cream"):

```
1019 
1020         >>> inputs = feature_extractor(list(video), return_tensors="pt")
1021 
1022         >>> with torch.no_grad():
1023         ...     outputs = model(**inputs)
1024         ...     logits = outputs.logits
1025 
1026         >>> # model predicts one of the 400 Kinetics-400 classes
1027         >>> predicted_label = logits.argmax(-1).item()
1028         >>> print(model.config.id2label[predicted_label])
Expected:
    eating spaghetti
Got:
    eating ice cream
```

Weirdly, this wasn't caught by the doc test CI. It could have to do with the addition of i`mport numpy as np` to the code snippet.