### PR TITLE
Starts on a list of external deps required for dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,7 +172,7 @@ Follow these steps to start contributing ([supported Python versions](https://gi
    If you have already cloned that repo, you might need to `git pull` to get the most recent changes in the `datasets`
    library.
    
-   You may need to install some external libraries, as well, if the `pip` installation fails.
+   Depending on your OS, you might need to install some external libraries, as well, if the `pip` installation fails.
    
    For macOS, you will likely need [MeCab](https://taku910.github.io/mecab/), which can be installed from Homebrew:
    

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,6 +171,14 @@ Follow these steps to start contributing ([supported Python versions](https://gi
 
    If you have already cloned that repo, you might need to `git pull` to get the most recent changes in the `datasets`
    library.
+   
+   You may need to install some external libraries, as well, if the `pip` installation fails.
+   
+   For macOS, you will likely need [MeCab](https://taku910.github.io/mecab/), which can be installed from Homebrew:
+   
+   ```bash
+   brew install mecab
+   ```
 
 5. Develop the features on your branch.
 


### PR DESCRIPTION
I've found that I need to install MeCab manually on my AS Mac while working on #18702.

# What does this PR do?

Adds nudge to install MeCab from Homebrew to dev contributing instructions.

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
-  [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Documentation: @sgugger

