### PR TITLE
[WIP] Add ZeroShotObjectDetectionPipeline (#18445)

### DIFF
--- a/docs/source/en/main_classes/pipelines.mdx
+++ b/docs/source/en/main_classes/pipelines.mdx
@@ -43,6 +43,7 @@ There are two categories of pipeline abstractions to be aware about:
   - [`VisualQuestionAnsweringPipeline`]
   - [`ZeroShotClassificationPipeline`]
   - [`ZeroShotImageClassificationPipeline`]
+  - [`ZeroShotObjectDetectionPipeline`]
 
 ## The pipeline abstraction
 
@@ -453,6 +454,12 @@ See [`TokenClassificationPipeline`] for all details.
 ### ZeroShotImageClassificationPipeline
 
 [[autodoc]] ZeroShotImageClassificationPipeline
+    - __call__
+    - all
+
+### ZeroShotObjectDetectionPipeline
+
+[[autodoc]] ZeroShotObjectDetectionPipeline
     - __call__
     - all
 

--- a/docs/source/en/model_doc/auto.mdx
+++ b/docs/source/en/model_doc/auto.mdx
@@ -174,6 +174,10 @@ Likewise, if your `NewModel` is a subclass of [`PreTrainedModel`], make sure its
 
 [[autodoc]] AutoModelForInstanceSegmentation
 
+## AutoModelForZeroShotObjectDetection
+
+[[autodoc]] AutoModelForZeroShotObjectDetection
+
 ## TFAutoModel
 
 [[autodoc]] TFAutoModel

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -879,6 +879,7 @@ else:
             "MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING",
             "MODEL_MAPPING",
             "MODEL_WITH_LM_HEAD_MAPPING",
+            "MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING",
             "AutoModel",
             "AutoModelForAudioClassification",
             "AutoModelForAudioFrameClassification",
@@ -906,6 +907,7 @@ else:
             "AutoModelForVision2Seq",
             "AutoModelForVisualQuestionAnswering",
             "AutoModelWithLMHead",
+            "AutoModelForZeroShotObjectDetection",
         ]
     )
     _import_structure["models.bart"].extend(
@@ -3774,6 +3776,7 @@ if TYPE_CHECKING:
             MODEL_FOR_VIDEO_CLASSIFICATION_MAPPING,
             MODEL_FOR_VISION_2_SEQ_MAPPING,
             MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING,
+            MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING,
             MODEL_MAPPING,
             MODEL_WITH_LM_HEAD_MAPPING,
             AutoModel,
@@ -3802,6 +3805,7 @@ if TYPE_CHECKING:
             AutoModelForVideoClassification,
             AutoModelForVision2Seq,
             AutoModelForVisualQuestionAnswering,
+            AutoModelForZeroShotObjectDetection,
             AutoModelWithLMHead,
         )
         from .models.bart import (

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -442,6 +442,7 @@ _import_structure = {
         "VisualQuestionAnsweringPipeline",
         "ZeroShotClassificationPipeline",
         "ZeroShotImageClassificationPipeline",
+        "ZeroShotObjectDetectionPipeline",
         "pipeline",
     ],
     "processing_utils": ["ProcessorMixin"],
@@ -3407,6 +3408,7 @@ if TYPE_CHECKING:
         VisualQuestionAnsweringPipeline,
         ZeroShotClassificationPipeline,
         ZeroShotImageClassificationPipeline,
+        ZeroShotObjectDetectionPipeline,
         pipeline,
     )
     from .processing_utils import ProcessorMixin

--- a/src/transformers/models/auto/__init__.py
+++ b/src/transformers/models/auto/__init__.py
@@ -69,6 +69,7 @@ else:
         "MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING",
         "MODEL_MAPPING",
         "MODEL_WITH_LM_HEAD_MAPPING",
+        "MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING",
         "AutoModel",
         "AutoModelForAudioClassification",
         "AutoModelForAudioFrameClassification",
@@ -96,6 +97,7 @@ else:
         "AutoModelForVisualQuestionAnswering",
         "AutoModelForDocumentQuestionAnswering",
         "AutoModelWithLMHead",
+        "AutoModelForZeroShotObjectDetection",
     ]
 
 try:
@@ -215,6 +217,7 @@ if TYPE_CHECKING:
             MODEL_FOR_VIDEO_CLASSIFICATION_MAPPING,
             MODEL_FOR_VISION_2_SEQ_MAPPING,
             MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING,
+            MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING,
             MODEL_MAPPING,
             MODEL_WITH_LM_HEAD_MAPPING,
             AutoModel,
@@ -243,6 +246,7 @@ if TYPE_CHECKING:
             AutoModelForVideoClassification,
             AutoModelForVision2Seq,
             AutoModelForVisualQuestionAnswering,
+            AutoModelForZeroShotObjectDetection,
             AutoModelWithLMHead,
         )
 

--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -468,8 +468,14 @@ MODEL_FOR_OBJECT_DETECTION_MAPPING_NAMES = OrderedDict(
         ("conditional_detr", "ConditionalDetrForObjectDetection"),
         ("deformable_detr", "DeformableDetrForObjectDetection"),
         ("detr", "DetrForObjectDetection"),
-        ("owlvit", "OwlViTForObjectDetection"),
         ("yolos", "YolosForObjectDetection"),
+    ]
+)
+
+MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING_NAMES = OrderedDict(
+    [
+        # Model for Zero Shot Object Detection mapping
+        ("owlvit", "OwlViTForObjectDetection")
     ]
 )
 
@@ -831,6 +837,9 @@ MODEL_FOR_MASKED_IMAGE_MODELING_MAPPING = _LazyAutoMapping(
     CONFIG_MAPPING_NAMES, MODEL_FOR_MASKED_IMAGE_MODELING_MAPPING_NAMES
 )
 MODEL_FOR_OBJECT_DETECTION_MAPPING = _LazyAutoMapping(CONFIG_MAPPING_NAMES, MODEL_FOR_OBJECT_DETECTION_MAPPING_NAMES)
+MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING = _LazyAutoMapping(
+    CONFIG_MAPPING_NAMES, MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING_NAMES
+)
 MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING = _LazyAutoMapping(
     CONFIG_MAPPING_NAMES, MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING_NAMES
 )
@@ -1015,6 +1024,15 @@ class AutoModelForObjectDetection(_BaseAutoModelClass):
 
 
 AutoModelForObjectDetection = auto_class_update(AutoModelForObjectDetection, head_doc="object detection")
+
+
+class AutoModelForZeroShotObjectDetection(_BaseAutoModelClass):
+    _model_mapping = MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING
+
+
+AutoModelForZeroShotObjectDetection = auto_class_update(
+    AutoModelForZeroShotObjectDetection, head_doc="zero shot object detection"
+)
 
 
 class AutoModelForVideoClassification(_BaseAutoModelClass):

--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -468,6 +468,7 @@ MODEL_FOR_OBJECT_DETECTION_MAPPING_NAMES = OrderedDict(
         ("conditional_detr", "ConditionalDetrForObjectDetection"),
         ("deformable_detr", "DeformableDetrForObjectDetection"),
         ("detr", "DetrForObjectDetection"),
+        ("owlvit", "OwlViTForObjectDetection"),
         ("yolos", "YolosForObjectDetection"),
     ]
 )

--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -1031,7 +1031,7 @@ class AutoModelForZeroShotObjectDetection(_BaseAutoModelClass):
 
 
 AutoModelForZeroShotObjectDetection = auto_class_update(
-    AutoModelForZeroShotObjectDetection, head_doc="zero shot object detection"
+    AutoModelForZeroShotObjectDetection, head_doc="zero-shot object detection"
 )
 
 

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -72,6 +72,7 @@ from .token_classification import (
 from .visual_question_answering import VisualQuestionAnsweringPipeline
 from .zero_shot_classification import ZeroShotClassificationArgumentHandler, ZeroShotClassificationPipeline
 from .zero_shot_image_classification import ZeroShotImageClassificationPipeline
+from .zero_shot_object_detection import ZeroShotObjectDetectionPipeline
 
 
 if is_tf_available():
@@ -334,6 +335,13 @@ SUPPORTED_TASKS = {
         "pt": (AutoModelForObjectDetection,) if is_torch_available() else (),
         "default": {"model": {"pt": ("facebook/detr-resnet-50", "2729413")}},
         "type": "image",
+    },
+    "zero-shot-object-detection": {
+        "impl": ZeroShotObjectDetectionPipeline,
+        "tf": (),
+        "pt": (AutoModelForObjectDetection,) if is_torch_available() else (),
+        "default": {"model": {"pt": ("google/owlvit-base-patch32", "17740e1")}},
+        "type": "multimodal",
     },
 }
 

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -125,6 +125,7 @@ if is_torch_available():
         AutoModelForTokenClassification,
         AutoModelForVision2Seq,
         AutoModelForVisualQuestionAnswering,
+        AutoModelForZeroShotObjectDetection,
     )
 if TYPE_CHECKING:
     from ..modeling_tf_utils import TFPreTrainedModel
@@ -339,7 +340,7 @@ SUPPORTED_TASKS = {
     "zero-shot-object-detection": {
         "impl": ZeroShotObjectDetectionPipeline,
         "tf": (),
-        "pt": (AutoModelForObjectDetection,) if is_torch_available() else (),
+        "pt": (AutoModelForZeroShotObjectDetection,) if is_torch_available() else (),
         "default": {"model": {"pt": ("google/owlvit-base-patch32", "17740e1")}},
         "type": "multimodal",
     },

--- a/src/transformers/pipelines/zero_shot_object_detection.py
+++ b/src/transformers/pipelines/zero_shot_object_detection.py
@@ -1,0 +1,134 @@
+from typing import Dict, List, Union
+
+from ..utils import add_end_docstrings, is_torch_available, is_vision_available, logging, requires_backends
+from .base import PIPELINE_INIT_ARGS, Pipeline
+
+
+if is_vision_available():
+    from PIL import Image
+
+    from ..image_utils import load_image
+
+if is_torch_available():
+    import torch
+
+logger = logging.get_logger(__name__)
+
+
+@add_end_docstrings(PIPELINE_INIT_ARGS)
+class ZeroShotObjectDetectionPipeline(Pipeline):
+    """
+    Zero shot object detection pipeline using `OwlViTForObjectDetection`. This pipeline predicts bounding boxes of
+    objects when you provide an image and a set of `candidate_labels`.
+
+    This object detection pipeline can currently be loaded from [`pipeline`] using the following task identifier:
+    `"zero-shot-object-detection"`.
+
+    See the list of available models on
+    [huggingface.co/models](https://huggingface.co/models?filter=zero-shot-object-detection).
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        requires_backends(self, "vision")
+
+    def __call__(self, images: Union[str, List[str], "Image", List["Image"]], **kwargs):
+        """
+        Detect objects (bounding boxes & classes) in the image(s) passed as inputs.
+
+        Args:
+            images (`str`, `List[str]`, `PIL.Image` or `List[PIL.Image]`):
+                The pipeline handles three types of images:
+
+                - A string containing a http link pointing to an image
+                - A string containing a local path to an image
+                - An image loaded in PIL directly
+
+            candidate_labels (`List[str]`):
+                The candidate labels for this image
+
+            hypothesis_template (`str`, *optional*, defaults to `"This is a photo of {}"`):
+                The sentence used in cunjunction with *candidate_labels* for assigning labels to predicted bounding
+                boxes by replacing the placeholder with the candidate_labels. Then likelihood is estimated by using
+                logits
+
+        Return:
+            A list of dictionaries containing result, one dictionary per proposed label. The dictionaries contain the
+            following keys:
+
+            - **label** (`str`) -- The label identified by the model. It is one of the suggested `candidate_label`.
+            - **score** (`float`) -- The score attributed by the model for that label (between 0 and 1).
+            - **box** (`List[Dict[str,int]]`) -- The bounding box of detected object in image's original size.
+        """
+        return super().__call__(images, **kwargs)
+
+    def _sanitize_parameters(self, **kwargs):
+        preprocess_params = {}
+        if "candidate_labels" in kwargs:
+            preprocess_params["candidate_labels"] = kwargs["candidate_labels"]
+        if "hypothesis_template" in kwargs:
+            preprocess_params["hypothesis_template"] = kwargs["hypothesis_template"]
+
+        postprocess_params = {}
+        if "threshold" in kwargs:
+            postprocess_params["threshold"] = kwargs["threshold"]
+        return preprocess_params, {}, postprocess_params
+
+    def preprocess(self, image, candidate_labels=[None], hypothesis_template="This is a photo of {}."):
+        image = load_image(image)
+        target_size = torch.IntTensor([[image.height, image.width]])
+        images = self.feature_extractor(images=[image], return_tensors=self.framework)
+        inputs = self.tokenizer(
+            [hypothesis_template.format(label) for label in candidate_labels],
+            return_tensors=self.framework,
+            padding=True,
+        )
+        inputs["pixel_values"] = images.pixel_values
+        inputs["target_size"] = target_size
+        return {"candidate_labels": candidate_labels, "target_size": target_size, **inputs}
+
+    def _forward(self, model_inputs):
+        target_size = model_inputs.pop("target_size")
+        candidate_labels = model_inputs.pop("candidate_labels")
+        outputs = self.model(**model_inputs)
+
+        model_outputs = outputs.__class__(
+            {"target_size": target_size, "candidate_labels": candidate_labels, **outputs}
+        )
+        return model_outputs
+
+    def postprocess(self, model_outputs, threshold=0.1):
+        text = model_outputs["candidate_labels"]
+
+        results = self.feature_extractor.post_process(outputs=model_outputs, target_sizes=model_outputs["target_size"])
+        keep = results[0]["scores"] >= threshold
+        boxes = results[0]["boxes"][keep]
+        scores = results[0]["scores"][keep].tolist()
+        labels = results[0]["labels"][keep].tolist()
+
+        return [
+            {"score": score, "label": text[label], "box": self._get_bounding_box(box)}
+            for score, label, box in zip(scores, labels, boxes)
+        ]
+
+    def _get_bounding_box(self, box: "torch.Tensor") -> Dict[str, int]:
+        """
+        Turns list [xmin, xmax, ymin, ymax] into dict { "xmin": xmin, ... }
+
+        Args:
+            box (`torch.Tensor`): Tensor containing the coordinates in corners format.
+
+        Returns:
+            bbox (`Dict[str, int]`): Dict containing the coordinates in corners format.
+        """
+        if self.framework != "pt":
+            raise ValueError("The ZeroShotObjectDetectionPipeline is only available in PyTorch.")
+        xmin, ymin, xmax, ymax = box.int().tolist()
+        bbox = {
+            "xmin": xmin,
+            "ymin": ymin,
+            "xmax": xmax,
+            "ymax": ymax,
+        }
+        return bbox

--- a/src/transformers/pipelines/zero_shot_object_detection.py
+++ b/src/transformers/pipelines/zero_shot_object_detection.py
@@ -72,12 +72,13 @@ class ZeroShotObjectDetectionPipeline(Pipeline):
             contains the text queries for the corresponding image.
 
         Return:
-            A list of dictionaries containing prediction results, one dictionary per each input image. The dictionaries contain the
-            following keys:
+            A list of dictionaries containing prediction results, one dictionary per each input image. The dictionaries
+            contain the following keys:
 
             - **labels** (`List[str]`) -- The list of text queries corresponding to the found objects.
             - **scores** (`List[float]`) -- The list of scores corresponding to each object (between 0 and 1).
-            - **boxes** (`List[Dict[str,int]]`) -- A nested list of bounding boxes of all detected objects in image's original size. Each list contains a dictionary with `x_min`, `x_max`, `y_min`, `y_max` keys.
+            - **boxes** (`List[Dict[str,int]]`) -- A nested list of bounding boxes of all detected objects in image's
+              original size. Each list contains a dictionary with `x_min`, `x_max`, `y_min`, `y_max` keys.
         """
         if isinstance(text_queries, str) or (isinstance(text_queries, List) and not isinstance(text_queries[0], List)):
             if isinstance(images, (str, Image.Image)):

--- a/src/transformers/pipelines/zero_shot_object_detection.py
+++ b/src/transformers/pipelines/zero_shot_object_detection.py
@@ -1,6 +1,17 @@
 from typing import Dict, List, Union
 
-from ..utils import add_end_docstrings, is_torch_available, is_vision_available, logging, requires_backends
+import numpy as np
+
+from ..tokenization_utils_base import BatchEncoding
+from ..utils import (
+    add_end_docstrings,
+    is_flax_available,
+    is_tf_available,
+    is_torch_available,
+    is_vision_available,
+    logging,
+    requires_backends,
+)
 from .base import PIPELINE_INIT_ARGS, Pipeline
 
 
@@ -11,6 +22,8 @@ if is_vision_available():
 
 if is_torch_available():
     import torch
+
+    from ..models.auto.modeling_auto import MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING
 
 logger = logging.get_logger(__name__)
 
@@ -31,9 +44,18 @@ class ZeroShotObjectDetectionPipeline(Pipeline):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        requires_backends(self, "vision")
+        if self.framework == "tf":
+            raise ValueError(f"The {self.__class__} is only available in PyTorch.")
 
-    def __call__(self, images: Union[str, List[str], "Image", List["Image"]], **kwargs):
+        requires_backends(self, "vision")
+        self.check_model_type(MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING)
+
+    def __call__(
+        self,
+        images: Union[str, List[str], "Image.Image", List["Image.Image"]],
+        text_queries: Union[str, List[str], List[List[str]]] = None,
+        **kwargs
+    ):
         """
         Detect objects (bounding boxes & classes) in the image(s) passed as inputs.
 
@@ -45,13 +67,9 @@ class ZeroShotObjectDetectionPipeline(Pipeline):
                 - A string containing a local path to an image
                 - An image loaded in PIL directly
 
-            candidate_labels (`List[str]`):
-                The candidate labels for this image
-
-            hypothesis_template (`str`, *optional*, defaults to `"This is a photo of {}"`):
-                The sentence used in cunjunction with *candidate_labels* for assigning labels to predicted bounding
-                boxes by replacing the placeholder with the candidate_labels. Then likelihood is estimated by using
-                logits
+            text_queries (`str` or `List[str]` or `List[List[str]]`): Text queries to query the target image with.
+            If given multiple images, `text_queries` should be provided as a list of lists, where each nested list
+            contains the text queries for the corresponding image.
 
         Return:
             A list of dictionaries containing result, one dictionary per proposed label. The dictionaries contain the
@@ -61,45 +79,53 @@ class ZeroShotObjectDetectionPipeline(Pipeline):
             - **score** (`float`) -- The score attributed by the model for that label (between 0 and 1).
             - **box** (`List[Dict[str,int]]`) -- The bounding box of detected object in image's original size.
         """
-        return super().__call__(images, **kwargs)
+        if isinstance(text_queries, str) or (isinstance(text_queries, List) and not isinstance(text_queries[0], List)):
+            if isinstance(images, (str, Image.Image)):
+                inputs = {"image": images, "text_queries": text_queries}
+            elif isinstance(images, List):
+                assert len(images) == 1, "Input text_queries and images must have correspondance"
+                inputs = {"image": images[0], "text_queries": text_queries}
+            else:
+                raise TypeError(f"Innapropriate type of images: {type(images)}")
+
+        elif isinstance(text_queries, str) or (isinstance(text_queries, List) and isinstance(text_queries[0], List)):
+            if isinstance(images, (Image.Image, str)):
+                images = [images]
+            assert len(images) == len(text_queries), "Input text_queries and images must have correspondance"
+            inputs = [{"image": image, "text_queries": text_query} for image, text_query in zip(images, text_queries)]
+        else:
+            """
+            Supports the following format
+            - {"image": image, "text_queries": text_queries}
+            - [{"image": image, "text_queries": text_queries}]
+            """
+            inputs = images
+        results = super().__call__(inputs, **kwargs)
+        return results
 
     def _sanitize_parameters(self, **kwargs):
-        preprocess_params = {}
-        if "candidate_labels" in kwargs:
-            preprocess_params["candidate_labels"] = kwargs["candidate_labels"]
-        if "hypothesis_template" in kwargs:
-            preprocess_params["hypothesis_template"] = kwargs["hypothesis_template"]
-
         postprocess_params = {}
         if "threshold" in kwargs:
             postprocess_params["threshold"] = kwargs["threshold"]
-        return preprocess_params, {}, postprocess_params
+        return {}, {}, postprocess_params
 
-    def preprocess(self, image, candidate_labels=[None], hypothesis_template="This is a photo of {}."):
-        image = load_image(image)
+    def preprocess(self, inputs):
+        image = load_image(inputs["image"])
+        text_queries = inputs["text_queries"]
         target_size = torch.IntTensor([[image.height, image.width]])
-        images = self.feature_extractor(images=[image], return_tensors=self.framework)
-        inputs = self.tokenizer(
-            [hypothesis_template.format(label) for label in candidate_labels],
-            return_tensors=self.framework,
-            padding=True,
-        )
-        inputs["pixel_values"] = images.pixel_values
-        inputs["target_size"] = target_size
-        return {"candidate_labels": candidate_labels, "target_size": target_size, **inputs}
+        inputs = self._processor(text=inputs["text_queries"], images=image, return_tensors="pt")
+        return {"target_size": target_size, "text_queries": text_queries, **inputs}
 
     def _forward(self, model_inputs):
         target_size = model_inputs.pop("target_size")
-        candidate_labels = model_inputs.pop("candidate_labels")
+        text_queries = model_inputs.pop("text_queries")
         outputs = self.model(**model_inputs)
 
-        model_outputs = outputs.__class__(
-            {"target_size": target_size, "candidate_labels": candidate_labels, **outputs}
-        )
+        model_outputs = outputs.__class__({"target_size": target_size, "text_queries": text_queries, **outputs})
         return model_outputs
 
     def postprocess(self, model_outputs, threshold=0.1):
-        text = model_outputs["candidate_labels"]
+        text = model_outputs["text_queries"]
 
         results = self.feature_extractor.post_process(outputs=model_outputs, target_sizes=model_outputs["target_size"])
         keep = results[0]["scores"] >= threshold
@@ -132,3 +158,99 @@ class ZeroShotObjectDetectionPipeline(Pipeline):
             "ymax": ymax,
         }
         return bbox
+
+    # Replication of OwlViTProcessor __call__ method, since pipelines don't auto infer processor's yet!
+    def _processor(self, text=None, images=None, padding="max_length", return_tensors="np", **kwargs):
+        """
+        Main method to prepare for the model one or several text(s) and image(s). This method forwards the `text` and
+        `kwargs` arguments to CLIPTokenizerFast's [`~CLIPTokenizerFast.__call__`] if `text` is not `None` to encode:
+        the text. To prepare the image(s), this method forwards the `images` and `kwrags` arguments to
+        CLIPFeatureExtractor's [`~CLIPFeatureExtractor.__call__`] if `images` is not `None`. Please refer to the
+        doctsring of the above two methods for more information.
+        Args:
+            text (`str`, `List[str]`, `List[List[str]]`):
+                The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
+                (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
+                `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
+            images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`,
+            `List[torch.Tensor]`):
+                The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
+                tensor. In case of a NumPy array/PyTorch tensor, each image should be of shape (C, H, W), where C is a
+                number of channels, H and W are image height and width.
+            return_tensors (`str` or [`~utils.TensorType`], *optional*):
+                If set, will return tensors of a particular framework. Acceptable values are:
+                - `'tf'`: Return TensorFlow `tf.constant` objects.
+                - `'pt'`: Return PyTorch `torch.Tensor` objects.
+                - `'np'`: Return NumPy `np.ndarray` objects.
+                - `'jax'`: Return JAX `jnp.ndarray` objects.
+        Returns:
+            [`BatchEncoding`]: A [`BatchEncoding`] with the following fields:
+            - **input_ids** -- List of token ids to be fed to a model. Returned when `text` is not `None`.
+            - **attention_mask** -- List of indices specifying which tokens should be attended to by the model (when
+              `return_attention_mask=True` or if *"attention_mask"* is in `self.model_input_names` and if `text` is not
+              `None`).
+            - **pixel_values** -- Pixel values to be fed to a model. Returned when `images` is not `None`.
+        """
+
+        if text is None and images is None:
+            raise ValueError("You have to specify at least one text or image. Both cannot be none.")
+
+        if text is not None:
+            if isinstance(text, str) or (isinstance(text, List) and not isinstance(text[0], List)):
+                encodings = [self.tokenizer(text, padding=padding, return_tensors=return_tensors, **kwargs)]
+
+            elif isinstance(text, List) and isinstance(text[0], List):
+                encodings = []
+
+                # Maximum number of queries across batch
+                max_num_queries = max([len(t) for t in text])
+
+                # Pad all batch samples to max number of text queries
+                for t in text:
+                    if len(t) != max_num_queries:
+                        t = t + [" "] * (max_num_queries - len(t))
+
+                    encoding = self.tokenizer(t, padding=padding, return_tensors=return_tensors, **kwargs)
+                    encodings.append(encoding)
+            else:
+                raise TypeError("Input text should be a string, a list of strings or a nested list of strings")
+
+            if return_tensors == "np":
+                input_ids = np.concatenate([encoding["input_ids"] for encoding in encodings], axis=0)
+                attention_mask = np.concatenate([encoding["attention_mask"] for encoding in encodings], axis=0)
+
+            elif return_tensors == "jax" and is_flax_available():
+                import jax.numpy as jnp
+
+                input_ids = jnp.concatenate([encoding["input_ids"] for encoding in encodings], axis=0)
+                attention_mask = jnp.concatenate([encoding["attention_mask"] for encoding in encodings], axis=0)
+
+            elif return_tensors == "pt" and is_torch_available():
+                import torch
+
+                input_ids = torch.cat([encoding["input_ids"] for encoding in encodings], dim=0)
+                attention_mask = torch.cat([encoding["attention_mask"] for encoding in encodings], dim=0)
+
+            elif return_tensors == "tf" and is_tf_available():
+                import tensorflow as tf
+
+                input_ids = tf.stack([encoding["input_ids"] for encoding in encodings], axis=0)
+                attention_mask = tf.stack([encoding["attention_mask"] for encoding in encodings], axis=0)
+
+            else:
+                raise ValueError("Target return tensor type could not be returned")
+
+            encoding = BatchEncoding()
+            encoding["input_ids"] = input_ids
+            encoding["attention_mask"] = attention_mask
+
+        if images is not None:
+            image_features = self.feature_extractor(images, return_tensors=return_tensors, **kwargs)
+
+        if text is not None and images is not None:
+            encoding["pixel_values"] = image_features.pixel_values
+            return encoding
+        elif text is not None:
+            return encoding
+        else:
+            return BatchEncoding(data=dict(**image_features), tensor_type=return_tensors)

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -427,9 +427,6 @@ MODEL_MAPPING = None
 MODEL_WITH_LM_HEAD_MAPPING = None
 
 
-MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING = None
-
-
 class AutoModel(metaclass=DummyObject):
     _backends = ["torch"]
 
@@ -620,13 +617,6 @@ class AutoModelForZeroShotObjectDetection(metaclass=DummyObject):
 
 
 class AutoModelWithLMHead(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class AutoModelForZeroShotObjectDetection(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -424,6 +424,9 @@ MODEL_MAPPING = None
 MODEL_WITH_LM_HEAD_MAPPING = None
 
 
+MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING = None
+
+
 class AutoModel(metaclass=DummyObject):
     _backends = ["torch"]
 
@@ -607,6 +610,13 @@ class AutoModelForVisualQuestionAnswering(metaclass=DummyObject):
 
 
 class AutoModelWithLMHead(metaclass=DummyObject):
+    _backends = ["torch"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torch"])
+
+
+class AutoModelForZeroShotObjectDetection(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -418,6 +418,9 @@ MODEL_FOR_VISION_2_SEQ_MAPPING = None
 MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING = None
 
 
+MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING = None
+
+
 MODEL_MAPPING = None
 
 
@@ -603,6 +606,13 @@ class AutoModelForVision2Seq(metaclass=DummyObject):
 
 
 class AutoModelForVisualQuestionAnswering(metaclass=DummyObject):
+    _backends = ["torch"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torch"])
+
+
+class AutoModelForZeroShotObjectDetection(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):

--- a/tests/pipelines/test_pipelines_zero_shot_object_detection.py
+++ b/tests/pipelines/test_pipelines_zero_shot_object_detection.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from transformers import is_vision_available, pipeline
+from transformers import MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING, is_vision_available, pipeline
 from transformers.testing_utils import (
     is_pipeline_test,
     nested_simplify,
@@ -24,7 +24,7 @@ from transformers.testing_utils import (
     slow,
 )
 
-from .test_pipelines_common import PipelineTestCaseMeta
+from .test_pipelines_common import ANY, PipelineTestCaseMeta
 
 
 if is_vision_available():
@@ -41,52 +41,40 @@ else:
 @require_torch
 @is_pipeline_test
 class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta):
-    # Deactivating auto tests since we don't have a good MODEL_FOR_XX mapping,
-    # and only OwlViTForObjectDetection would be there for now.
-    # model_mapping = {OwlViTConfig: OwlViTForObjectDetection}
 
-    # def get_test_pipeline(self, model, tokenizer, feature_extractor):
-    #     object_detector = pipeline("zero-shot-object-detection", model="hf-internal-testing/tiny-random-owlvit")
+    model_mapping = MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING
 
-    #     return object_detector, ["./tests/fixtures/tests_samples/COCO/000000039769.png"]
+    def get_test_pipeline(self, model, tokenizer, feature_extractor):
+        object_detector = pipeline(
+            "zero-shot-object-detection", model="hf-internal-testing/tiny-random-owlvit-object-detection"
+        )
 
-    # def run_pipeline_test(self, object_detector, examples):
-    #     outputs = object_detector(
-    #         Image.open("./tests/fixtures/tests_samples/COCO/000000039769.png"),
-    #         candidate_labels=["cat", "remote", "couch"],
-    #         threshold=0.0,
-    #     )
+        examples = [
+            {
+                "image": "./tests/fixtures/tests_samples/COCO/000000039769.png",
+                "text_queries": ["cat", "remote", "couch"],
+            }
+        ]
+        return object_detector, examples
 
-    #     self.assertGreater(len(outputs), 0)
-    #     for detected_object in outputs:
-    #         self.assertEqual(
-    #             detected_object,
-    #             {
-    #                 "score": ANY(float),
-    #                 "label": ANY(str),
-    #                 "box": {"xmin": ANY(int), "ymin": ANY(int), "xmax": ANY(int), "ymax": ANY(int)},
-    #             },
-    #         )
+    def run_pipeline_test(self, object_detector, examples):
+        batch_outputs = object_detector(
+            examples,
+            threshold=0.0,
+        )
 
-    #     batch = [
-    #         Image.open("./tests/fixtures/tests_samples/COCO/000000039769.png"),
-    #         "http://images.cocodataset.org/val2017/000000039769.jpg",
-    #     ] * 4
-    #     batch_outputs = object_detector(batch, candidate_labels=["cat", "remote", "couch"], threshold=0.0)
-
-    #     self.assertEqual(len(batch), len(batch_outputs))
-
-    #     for outputs in batch_outputs:
-    #         self.assertGreater(len(outputs), 0)
-    #         for detected_object in outputs:
-    #             self.assertEqual(
-    #                 detected_object,
-    #                 {
-    #                     "score": ANY(float),
-    #                     "label": ANY(str),
-    #                     "box": {"xmin": ANY(int), "ymin": ANY(int), "xmax": ANY(int), "ymax": ANY(int)},
-    #                 },
-    #             )
+        self.assertEqual(len(examples), len(batch_outputs))
+        for outputs in batch_outputs:
+            self.assertGreater(len(outputs), 0)
+            for detected_object in outputs:
+                self.assertEqual(
+                    detected_object,
+                    {
+                        "score": ANY(float),
+                        "label": ANY(str),
+                        "box": {"xmin": ANY(int), "ymin": ANY(int), "xmax": ANY(int), "ymax": ANY(int)},
+                    },
+                )
 
     @require_tf
     @unittest.skip("Zero Shot Object Detection not implemented in TF")
@@ -94,21 +82,58 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         pass
 
     @require_torch
-    @unittest.skip("Using hf-internal-testing/tiny-random-owlvit throws error")
     def test_small_model_pt(self):
-        object_detector = pipeline("zero-shot-object-detection", model="hf-internal-testing/tiny-random-owlvit")
+        object_detector = pipeline(
+            "zero-shot-object-detection", model="hf-internal-testing/tiny-random-owlvit-object-detection"
+        )
 
         outputs = object_detector(
             "./tests/fixtures/tests_samples/COCO/000000039769.png",
-            candidate_labels=["cat", "remote", "couch"],
-            threshold=0.1,
+            text_queries=["cat", "remote", "couch"],
+            threshold=0.64,
         )
 
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {"score": 0.3376, "label": "LABEL_0", "box": {"xmin": 159, "ymin": 120, "xmax": 480, "ymax": 359}},
-                {"score": 0.3376, "label": "LABEL_0", "box": {"xmin": 159, "ymin": 120, "xmax": 480, "ymax": 359}},
+                {"score": 0.6748, "label": "remote", "box": {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103}},
+                {"score": 0.6456, "label": "remote", "box": {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127}},
+                {"score": 0.7235, "label": "cat", "box": {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190}},
+                {"score": 0.642, "label": "remote", "box": {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297}},
+            ],
+        )
+
+        outputs = object_detector(
+            ["./tests/fixtures/tests_samples/COCO/000000039769.png"],
+            text_queries=["cat", "remote", "couch"],
+            threshold=0.64,
+        )
+
+        self.assertEqual(
+            nested_simplify(outputs, decimals=4),
+            [
+                {"score": 0.6748, "label": "remote", "box": {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103}},
+                {"score": 0.6456, "label": "remote", "box": {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127}},
+                {"score": 0.7235, "label": "cat", "box": {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190}},
+                {"score": 0.642, "label": "remote", "box": {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297}},
+            ],
+        )
+
+        outputs = object_detector(
+            "./tests/fixtures/tests_samples/COCO/000000039769.png",
+            text_queries=[["cat", "remote", "couch"]],
+            threshold=0.64,
+        )
+
+        self.assertEqual(
+            nested_simplify(outputs, decimals=4),
+            [
+                [
+                    {"score": 0.6748, "label": "remote", "box": {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103}},
+                    {"score": 0.6456, "label": "remote", "box": {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127}},
+                    {"score": 0.7235, "label": "cat", "box": {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190}},
+                    {"score": 0.642, "label": "remote", "box": {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297}},
+                ]
             ],
         )
 
@@ -117,20 +142,24 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
                 "./tests/fixtures/tests_samples/COCO/000000039769.png",
                 "http://images.cocodataset.org/val2017/000000039769.jpg",
             ],
-            candidate_labels=["cat", "remote", "couch"],
-            threshold=0.0,
+            text_queries=[["cat", "remote", "couch"], ["cat", "remote", "couch"]],
+            threshold=0.64,
         )
 
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
                 [
-                    {"score": 0.3376, "label": "LABEL_0", "box": {"xmin": 159, "ymin": 120, "xmax": 480, "ymax": 359}},
-                    {"score": 0.3376, "label": "LABEL_0", "box": {"xmin": 159, "ymin": 120, "xmax": 480, "ymax": 359}},
+                    {"score": 0.6748, "label": "remote", "box": {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103}},
+                    {"score": 0.6456, "label": "remote", "box": {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127}},
+                    {"score": 0.7235, "label": "cat", "box": {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190}},
+                    {"score": 0.642, "label": "remote", "box": {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297}},
                 ],
                 [
-                    {"score": 0.3376, "label": "LABEL_0", "box": {"xmin": 159, "ymin": 120, "xmax": 480, "ymax": 359}},
-                    {"score": 0.3376, "label": "LABEL_0", "box": {"xmin": 159, "ymin": 120, "xmax": 480, "ymax": 359}},
+                    {"score": 0.6748, "label": "remote", "box": {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103}},
+                    {"score": 0.6456, "label": "remote", "box": {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127}},
+                    {"score": 0.7235, "label": "cat", "box": {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190}},
+                    {"score": 0.642, "label": "remote", "box": {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297}},
                 ],
             ],
         )
@@ -141,16 +170,16 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         object_detector = pipeline("zero-shot-object-detection")
 
         outputs = object_detector(
-            "http://images.cocodataset.org/val2017/000000039769.jpg", candidate_labels=["cat", "remote", "couch"]
+            "http://images.cocodataset.org/val2017/000000039769.jpg", text_queries=["cat", "remote", "couch"]
         )
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {"score": 0.2754, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
-                {"score": 0.1969, "label": "remote", "box": {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187}},
-                {"score": 0.4931, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
-                {"score": 0.4973, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
-                {"score": 0.1327, "label": "couch", "box": {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476}},
+                {"score": 0.277, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
+                {"score": 0.1474, "label": "remote", "box": {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187}},
+                {"score": 0.2868, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
+                {"score": 0.2537, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
+                {"score": 0.1208, "label": "couch", "box": {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476}},
             ],
         )
 
@@ -159,24 +188,24 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
                 "http://images.cocodataset.org/val2017/000000039769.jpg",
                 "http://images.cocodataset.org/val2017/000000039769.jpg",
             ],
-            candidate_labels=["cat", "remote", "couch"],
+            text_queries=[["cat", "remote", "couch"], ["cat", "remote", "couch"]],
         )
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
                 [
-                    {"score": 0.2754, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
-                    {"score": 0.1969, "label": "remote", "box": {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187}},
-                    {"score": 0.4931, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
-                    {"score": 0.4973, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
-                    {"score": 0.1327, "label": "couch", "box": {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476}},
+                    {"score": 0.277, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
+                    {"score": 0.1474, "label": "remote", "box": {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187}},
+                    {"score": 0.2868, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
+                    {"score": 0.2537, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
+                    {"score": 0.1208, "label": "couch", "box": {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476}},
                 ],
                 [
-                    {"score": 0.2754, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
-                    {"score": 0.1969, "label": "remote", "box": {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187}},
-                    {"score": 0.4931, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
-                    {"score": 0.4973, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
-                    {"score": 0.1327, "label": "couch", "box": {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476}},
+                    {"score": 0.277, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
+                    {"score": 0.1474, "label": "remote", "box": {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187}},
+                    {"score": 0.2868, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
+                    {"score": 0.2537, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
+                    {"score": 0.1208, "label": "couch", "box": {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476}},
                 ],
             ],
         )
@@ -189,18 +218,19 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
     @require_torch
     @slow
     def test_threshold(self):
-        threshold = 0.4
+        threshold = 0.2
         object_detector = pipeline("zero-shot-object-detection")
 
         outputs = object_detector(
             "http://images.cocodataset.org/val2017/000000039769.jpg",
-            candidate_labels=["cat", "remote", "couch"],
+            text_queries=["cat", "remote", "couch"],
             threshold=threshold,
         )
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {"score": 0.4931, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
-                {"score": 0.4973, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
+                {"score": 0.277, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
+                {"score": 0.2868, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
+                {"score": 0.2537, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
             ],
         )

--- a/tests/pipelines/test_pipelines_zero_shot_object_detection.py
+++ b/tests/pipelines/test_pipelines_zero_shot_object_detection.py
@@ -51,7 +51,7 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
 
         examples = [
             {
-                "image": "./tests/fixtures/tests_samples/COCO/000000039769.png",
+                "images": "./tests/fixtures/tests_samples/COCO/000000039769.png",
                 "text_queries": ["cat", "remote", "couch"],
             }
         ]
@@ -65,16 +65,19 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
 
         self.assertEqual(len(examples), len(batch_outputs))
         for outputs in batch_outputs:
-            self.assertGreater(len(outputs), 0)
-            for detected_object in outputs:
-                self.assertEqual(
-                    detected_object,
-                    {
-                        "score": ANY(float),
-                        "label": ANY(str),
-                        "box": {"xmin": ANY(int), "ymin": ANY(int), "xmax": ANY(int), "ymax": ANY(int)},
-                    },
-                )
+            for output_per_image in outputs:
+                scores = output_per_image["scores"]
+                labels = output_per_image["labels"]
+                boxes = output_per_image["boxes"]
+
+                assert len(scores) == len(boxes) and len(boxes) == len(labels)
+
+                for score in scores:
+                    self.assertEqual(score, ANY(float))
+                for label in labels:
+                    self.assertEqual(label, ANY(str))
+                for box in boxes:
+                    self.assertEqual(box, {"xmin": ANY(int), "ymin": ANY(int), "xmax": ANY(int), "ymax": ANY(int)})
 
     @require_tf
     @unittest.skip("Zero Shot Object Detection not implemented in TF")
@@ -96,10 +99,16 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {"score": 0.6748, "label": "remote", "box": {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103}},
-                {"score": 0.6456, "label": "remote", "box": {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127}},
-                {"score": 0.7235, "label": "cat", "box": {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190}},
-                {"score": 0.642, "label": "remote", "box": {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297}},
+                {
+                    "scores": [0.6748, 0.6456, 0.7235, 0.642],
+                    "labels": ["remote", "remote", "cat", "remote"],
+                    "boxes": [
+                        {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103},
+                        {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127},
+                        {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190},
+                        {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297},
+                    ],
+                }
             ],
         )
 
@@ -112,10 +121,16 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {"score": 0.6748, "label": "remote", "box": {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103}},
-                {"score": 0.6456, "label": "remote", "box": {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127}},
-                {"score": 0.7235, "label": "cat", "box": {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190}},
-                {"score": 0.642, "label": "remote", "box": {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297}},
+                {
+                    "scores": [0.6748, 0.6456, 0.7235, 0.642],
+                    "labels": ["remote", "remote", "cat", "remote"],
+                    "boxes": [
+                        {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103},
+                        {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127},
+                        {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190},
+                        {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297},
+                    ],
+                }
             ],
         )
 
@@ -128,12 +143,16 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                [
-                    {"score": 0.6748, "label": "remote", "box": {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103}},
-                    {"score": 0.6456, "label": "remote", "box": {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127}},
-                    {"score": 0.7235, "label": "cat", "box": {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190}},
-                    {"score": 0.642, "label": "remote", "box": {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297}},
-                ]
+                {
+                    "scores": [0.6748, 0.6456, 0.7235, 0.642],
+                    "labels": ["remote", "remote", "cat", "remote"],
+                    "boxes": [
+                        {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103},
+                        {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127},
+                        {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190},
+                        {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297},
+                    ],
+                }
             ],
         )
 
@@ -149,18 +168,26 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                [
-                    {"score": 0.6748, "label": "remote", "box": {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103}},
-                    {"score": 0.6456, "label": "remote", "box": {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127}},
-                    {"score": 0.7235, "label": "cat", "box": {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190}},
-                    {"score": 0.642, "label": "remote", "box": {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297}},
-                ],
-                [
-                    {"score": 0.6748, "label": "remote", "box": {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103}},
-                    {"score": 0.6456, "label": "remote", "box": {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127}},
-                    {"score": 0.7235, "label": "cat", "box": {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190}},
-                    {"score": 0.642, "label": "remote", "box": {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297}},
-                ],
+                {
+                    "scores": [0.6748, 0.6456, 0.7235, 0.642],
+                    "labels": ["remote", "remote", "cat", "remote"],
+                    "boxes": [
+                        {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103},
+                        {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127},
+                        {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190},
+                        {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297},
+                    ],
+                },
+                {
+                    "scores": [0.6748, 0.6456, 0.7235, 0.642],
+                    "labels": ["remote", "remote", "cat", "remote"],
+                    "boxes": [
+                        {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103},
+                        {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127},
+                        {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190},
+                        {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297},
+                    ],
+                },
             ],
         )
 
@@ -175,11 +202,17 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {"score": 0.277, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
-                {"score": 0.1474, "label": "remote", "box": {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187}},
-                {"score": 0.2868, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
-                {"score": 0.2537, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
-                {"score": 0.1208, "label": "couch", "box": {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476}},
+                {
+                    "scores": [0.277, 0.1474, 0.2868, 0.2537, 0.1208],
+                    "labels": ["remote", "remote", "cat", "cat", "couch"],
+                    "boxes": [
+                        {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115},
+                        {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187},
+                        {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373},
+                        {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472},
+                        {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476},
+                    ],
+                }
             ],
         )
 
@@ -193,20 +226,28 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                [
-                    {"score": 0.277, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
-                    {"score": 0.1474, "label": "remote", "box": {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187}},
-                    {"score": 0.2868, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
-                    {"score": 0.2537, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
-                    {"score": 0.1208, "label": "couch", "box": {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476}},
-                ],
-                [
-                    {"score": 0.277, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
-                    {"score": 0.1474, "label": "remote", "box": {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187}},
-                    {"score": 0.2868, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
-                    {"score": 0.2537, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
-                    {"score": 0.1208, "label": "couch", "box": {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476}},
-                ],
+                {
+                    "scores": [0.277, 0.1474, 0.2868, 0.2537, 0.1208],
+                    "labels": ["remote", "remote", "cat", "cat", "couch"],
+                    "boxes": [
+                        {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115},
+                        {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187},
+                        {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373},
+                        {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472},
+                        {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476},
+                    ],
+                },
+                {
+                    "scores": [0.277, 0.1474, 0.2868, 0.2537, 0.1208],
+                    "labels": ["remote", "remote", "cat", "cat", "couch"],
+                    "boxes": [
+                        {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115},
+                        {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187},
+                        {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373},
+                        {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472},
+                        {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476},
+                    ],
+                },
             ],
         )
 
@@ -229,8 +270,14 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {"score": 0.277, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
-                {"score": 0.2868, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
-                {"score": 0.2537, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
+                {
+                    "scores": [0.277, 0.2868, 0.2537],
+                    "labels": ["remote", "cat", "cat"],
+                    "boxes": [
+                        {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115},
+                        {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373},
+                        {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472},
+                    ],
+                }
             ],
         )

--- a/tests/pipelines/test_pipelines_zero_shot_object_detection.py
+++ b/tests/pipelines/test_pipelines_zero_shot_object_detection.py
@@ -1,0 +1,206 @@
+# Copyright 2021 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from transformers import is_vision_available, pipeline
+from transformers.testing_utils import (
+    is_pipeline_test,
+    nested_simplify,
+    require_tf,
+    require_torch,
+    require_vision,
+    slow,
+)
+
+from .test_pipelines_common import PipelineTestCaseMeta
+
+
+if is_vision_available():
+    from PIL import Image
+else:
+
+    class Image:
+        @staticmethod
+        def open(*args, **kwargs):
+            pass
+
+
+@require_vision
+@require_torch
+@is_pipeline_test
+class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta):
+    # Deactivating auto tests since we don't have a good MODEL_FOR_XX mapping,
+    # and only OwlViTForObjectDetection would be there for now.
+    # model_mapping = {OwlViTConfig: OwlViTForObjectDetection}
+
+    # def get_test_pipeline(self, model, tokenizer, feature_extractor):
+    #     object_detector = pipeline("zero-shot-object-detection", model="hf-internal-testing/tiny-random-owlvit")
+
+    #     return object_detector, ["./tests/fixtures/tests_samples/COCO/000000039769.png"]
+
+    # def run_pipeline_test(self, object_detector, examples):
+    #     outputs = object_detector(
+    #         Image.open("./tests/fixtures/tests_samples/COCO/000000039769.png"),
+    #         candidate_labels=["cat", "remote", "couch"],
+    #         threshold=0.0,
+    #     )
+
+    #     self.assertGreater(len(outputs), 0)
+    #     for detected_object in outputs:
+    #         self.assertEqual(
+    #             detected_object,
+    #             {
+    #                 "score": ANY(float),
+    #                 "label": ANY(str),
+    #                 "box": {"xmin": ANY(int), "ymin": ANY(int), "xmax": ANY(int), "ymax": ANY(int)},
+    #             },
+    #         )
+
+    #     batch = [
+    #         Image.open("./tests/fixtures/tests_samples/COCO/000000039769.png"),
+    #         "http://images.cocodataset.org/val2017/000000039769.jpg",
+    #     ] * 4
+    #     batch_outputs = object_detector(batch, candidate_labels=["cat", "remote", "couch"], threshold=0.0)
+
+    #     self.assertEqual(len(batch), len(batch_outputs))
+
+    #     for outputs in batch_outputs:
+    #         self.assertGreater(len(outputs), 0)
+    #         for detected_object in outputs:
+    #             self.assertEqual(
+    #                 detected_object,
+    #                 {
+    #                     "score": ANY(float),
+    #                     "label": ANY(str),
+    #                     "box": {"xmin": ANY(int), "ymin": ANY(int), "xmax": ANY(int), "ymax": ANY(int)},
+    #                 },
+    #             )
+
+    @require_tf
+    @unittest.skip("Zero Shot Object Detection not implemented in TF")
+    def test_small_model_tf(self):
+        pass
+
+    @require_torch
+    @unittest.skip("Using hf-internal-testing/tiny-random-owlvit throws error")
+    def test_small_model_pt(self):
+        object_detector = pipeline("zero-shot-object-detection", model="hf-internal-testing/tiny-random-owlvit")
+
+        outputs = object_detector(
+            "./tests/fixtures/tests_samples/COCO/000000039769.png",
+            candidate_labels=["cat", "remote", "couch"],
+            threshold=0.1,
+        )
+
+        self.assertEqual(
+            nested_simplify(outputs, decimals=4),
+            [
+                {"score": 0.3376, "label": "LABEL_0", "box": {"xmin": 159, "ymin": 120, "xmax": 480, "ymax": 359}},
+                {"score": 0.3376, "label": "LABEL_0", "box": {"xmin": 159, "ymin": 120, "xmax": 480, "ymax": 359}},
+            ],
+        )
+
+        outputs = object_detector(
+            [
+                "./tests/fixtures/tests_samples/COCO/000000039769.png",
+                "http://images.cocodataset.org/val2017/000000039769.jpg",
+            ],
+            candidate_labels=["cat", "remote", "couch"],
+            threshold=0.0,
+        )
+
+        self.assertEqual(
+            nested_simplify(outputs, decimals=4),
+            [
+                [
+                    {"score": 0.3376, "label": "LABEL_0", "box": {"xmin": 159, "ymin": 120, "xmax": 480, "ymax": 359}},
+                    {"score": 0.3376, "label": "LABEL_0", "box": {"xmin": 159, "ymin": 120, "xmax": 480, "ymax": 359}},
+                ],
+                [
+                    {"score": 0.3376, "label": "LABEL_0", "box": {"xmin": 159, "ymin": 120, "xmax": 480, "ymax": 359}},
+                    {"score": 0.3376, "label": "LABEL_0", "box": {"xmin": 159, "ymin": 120, "xmax": 480, "ymax": 359}},
+                ],
+            ],
+        )
+
+    @require_torch
+    @slow
+    def test_large_model_pt(self):
+        object_detector = pipeline("zero-shot-object-detection")
+
+        outputs = object_detector(
+            "http://images.cocodataset.org/val2017/000000039769.jpg", candidate_labels=["cat", "remote", "couch"]
+        )
+        self.assertEqual(
+            nested_simplify(outputs, decimals=4),
+            [
+                {"score": 0.2754, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
+                {"score": 0.1969, "label": "remote", "box": {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187}},
+                {"score": 0.4931, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
+                {"score": 0.4973, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
+                {"score": 0.1327, "label": "couch", "box": {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476}},
+            ],
+        )
+
+        outputs = object_detector(
+            [
+                "http://images.cocodataset.org/val2017/000000039769.jpg",
+                "http://images.cocodataset.org/val2017/000000039769.jpg",
+            ],
+            candidate_labels=["cat", "remote", "couch"],
+        )
+        self.assertEqual(
+            nested_simplify(outputs, decimals=4),
+            [
+                [
+                    {"score": 0.2754, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
+                    {"score": 0.1969, "label": "remote", "box": {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187}},
+                    {"score": 0.4931, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
+                    {"score": 0.4973, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
+                    {"score": 0.1327, "label": "couch", "box": {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476}},
+                ],
+                [
+                    {"score": 0.2754, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
+                    {"score": 0.1969, "label": "remote", "box": {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187}},
+                    {"score": 0.4931, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
+                    {"score": 0.4973, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
+                    {"score": 0.1327, "label": "couch", "box": {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476}},
+                ],
+            ],
+        )
+
+    @require_tf
+    @unittest.skip("Zero Shot Object Detection not implemented in TF")
+    def test_large_model_tf(self):
+        pass
+
+    @require_torch
+    @slow
+    def test_threshold(self):
+        threshold = 0.4
+        object_detector = pipeline("zero-shot-object-detection")
+
+        outputs = object_detector(
+            "http://images.cocodataset.org/val2017/000000039769.jpg",
+            candidate_labels=["cat", "remote", "couch"],
+            threshold=threshold,
+        )
+        self.assertEqual(
+            nested_simplify(outputs, decimals=4),
+            [
+                {"score": 0.4931, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
+                {"score": 0.4973, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
+            ],
+        )

--- a/tests/pipelines/test_pipelines_zero_shot_object_detection.py
+++ b/tests/pipelines/test_pipelines_zero_shot_object_detection.py
@@ -58,26 +58,21 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         return object_detector, examples
 
     def run_pipeline_test(self, object_detector, examples):
-        batch_outputs = object_detector(
-            examples,
-            threshold=0.0,
-        )
+        batch_outputs = object_detector(examples, threshold=0.0)
 
         self.assertEqual(len(examples), len(batch_outputs))
         for outputs in batch_outputs:
             for output_per_image in outputs:
-                scores = output_per_image["scores"]
-                labels = output_per_image["labels"]
-                boxes = output_per_image["boxes"]
-
-                assert len(scores) == len(boxes) and len(boxes) == len(labels)
-
-                for score in scores:
-                    self.assertEqual(score, ANY(float))
-                for label in labels:
-                    self.assertEqual(label, ANY(str))
-                for box in boxes:
-                    self.assertEqual(box, {"xmin": ANY(int), "ymin": ANY(int), "xmax": ANY(int), "ymax": ANY(int)})
+                self.assertGreater(len(output_per_image), 0)
+                for detected_object in output_per_image:
+                    self.assertEqual(
+                        detected_object,
+                        {
+                            "score": ANY(float),
+                            "label": ANY(str),
+                            "box": {"xmin": ANY(int), "ymin": ANY(int), "xmax": ANY(int), "ymax": ANY(int)},
+                        },
+                    )
 
     @require_tf
     @unittest.skip("Zero Shot Object Detection not implemented in TF")
@@ -99,16 +94,12 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {
-                    "scores": [0.6748, 0.6456, 0.7235, 0.642],
-                    "labels": ["remote", "remote", "cat", "remote"],
-                    "boxes": [
-                        {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103},
-                        {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127},
-                        {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190},
-                        {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297},
-                    ],
-                }
+                [
+                    {"score": 0.7235, "label": "cat", "box": {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190}},
+                    {"score": 0.6748, "label": "remote", "box": {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103}},
+                    {"score": 0.6456, "label": "remote", "box": {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127}},
+                    {"score": 0.642, "label": "remote", "box": {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297}},
+                ]
             ],
         )
 
@@ -121,16 +112,12 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {
-                    "scores": [0.6748, 0.6456, 0.7235, 0.642],
-                    "labels": ["remote", "remote", "cat", "remote"],
-                    "boxes": [
-                        {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103},
-                        {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127},
-                        {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190},
-                        {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297},
-                    ],
-                }
+                [
+                    {"score": 0.7235, "label": "cat", "box": {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190}},
+                    {"score": 0.6748, "label": "remote", "box": {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103}},
+                    {"score": 0.6456, "label": "remote", "box": {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127}},
+                    {"score": 0.642, "label": "remote", "box": {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297}},
+                ]
             ],
         )
 
@@ -143,16 +130,12 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {
-                    "scores": [0.6748, 0.6456, 0.7235, 0.642],
-                    "labels": ["remote", "remote", "cat", "remote"],
-                    "boxes": [
-                        {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103},
-                        {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127},
-                        {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190},
-                        {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297},
-                    ],
-                }
+                [
+                    {"score": 0.7235, "label": "cat", "box": {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190}},
+                    {"score": 0.6748, "label": "remote", "box": {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103}},
+                    {"score": 0.6456, "label": "remote", "box": {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127}},
+                    {"score": 0.642, "label": "remote", "box": {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297}},
+                ]
             ],
         )
 
@@ -168,26 +151,18 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {
-                    "scores": [0.6748, 0.6456, 0.7235, 0.642],
-                    "labels": ["remote", "remote", "cat", "remote"],
-                    "boxes": [
-                        {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103},
-                        {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127},
-                        {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190},
-                        {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297},
-                    ],
-                },
-                {
-                    "scores": [0.6748, 0.6456, 0.7235, 0.642],
-                    "labels": ["remote", "remote", "cat", "remote"],
-                    "boxes": [
-                        {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103},
-                        {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127},
-                        {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190},
-                        {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297},
-                    ],
-                },
+                [
+                    {"score": 0.7235, "label": "cat", "box": {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190}},
+                    {"score": 0.6748, "label": "remote", "box": {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103}},
+                    {"score": 0.6456, "label": "remote", "box": {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127}},
+                    {"score": 0.642, "label": "remote", "box": {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297}},
+                ],
+                [
+                    {"score": 0.7235, "label": "cat", "box": {"xmin": 204, "ymin": 167, "xmax": 232, "ymax": 190}},
+                    {"score": 0.6748, "label": "remote", "box": {"xmin": 571, "ymin": 83, "xmax": 598, "ymax": 103}},
+                    {"score": 0.6456, "label": "remote", "box": {"xmin": 494, "ymin": 105, "xmax": 521, "ymax": 127}},
+                    {"score": 0.642, "label": "remote", "box": {"xmin": 67, "ymin": 274, "xmax": 93, "ymax": 297}},
+                ],
             ],
         )
 
@@ -202,17 +177,13 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {
-                    "scores": [0.277, 0.1474, 0.2868, 0.2537, 0.1208],
-                    "labels": ["remote", "remote", "cat", "cat", "couch"],
-                    "boxes": [
-                        {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115},
-                        {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187},
-                        {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373},
-                        {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472},
-                        {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476},
-                    ],
-                }
+                [
+                    {"score": 0.2868, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
+                    {"score": 0.277, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
+                    {"score": 0.2537, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
+                    {"score": 0.1474, "label": "remote", "box": {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187}},
+                    {"score": 0.1208, "label": "couch", "box": {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476}},
+                ]
             ],
         )
 
@@ -226,28 +197,20 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {
-                    "scores": [0.277, 0.1474, 0.2868, 0.2537, 0.1208],
-                    "labels": ["remote", "remote", "cat", "cat", "couch"],
-                    "boxes": [
-                        {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115},
-                        {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187},
-                        {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373},
-                        {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472},
-                        {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476},
-                    ],
-                },
-                {
-                    "scores": [0.277, 0.1474, 0.2868, 0.2537, 0.1208],
-                    "labels": ["remote", "remote", "cat", "cat", "couch"],
-                    "boxes": [
-                        {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115},
-                        {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187},
-                        {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373},
-                        {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472},
-                        {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476},
-                    ],
-                },
+                [
+                    {"score": 0.2868, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
+                    {"score": 0.277, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
+                    {"score": 0.2537, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
+                    {"score": 0.1474, "label": "remote", "box": {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187}},
+                    {"score": 0.1208, "label": "couch", "box": {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476}},
+                ],
+                [
+                    {"score": 0.2868, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
+                    {"score": 0.277, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
+                    {"score": 0.2537, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
+                    {"score": 0.1474, "label": "remote", "box": {"xmin": 335, "ymin": 74, "xmax": 371, "ymax": 187}},
+                    {"score": 0.1208, "label": "couch", "box": {"xmin": 4, "ymin": 0, "xmax": 642, "ymax": 476}},
+                ],
             ],
         )
 
@@ -270,14 +233,31 @@ class ZeroShotObjectDetectionPipelineTests(unittest.TestCase, metaclass=Pipeline
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {
-                    "scores": [0.277, 0.2868, 0.2537],
-                    "labels": ["remote", "cat", "cat"],
-                    "boxes": [
-                        {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115},
-                        {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373},
-                        {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472},
-                    ],
-                }
+                [
+                    {"score": 0.2868, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
+                    {"score": 0.277, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
+                    {"score": 0.2537, "label": "cat", "box": {"xmin": 1, "ymin": 55, "xmax": 315, "ymax": 472}},
+                ]
+            ],
+        )
+
+    @require_torch
+    @slow
+    def test_top_k(self):
+        top_k = 2
+        object_detector = pipeline("zero-shot-object-detection")
+
+        outputs = object_detector(
+            "http://images.cocodataset.org/val2017/000000039769.jpg",
+            text_queries=["cat", "remote", "couch"],
+            top_k=top_k,
+        )
+        self.assertEqual(
+            nested_simplify(outputs, decimals=4),
+            [
+                [
+                    {"score": 0.2868, "label": "cat", "box": {"xmin": 324, "ymin": 20, "xmax": 640, "ymax": 373}},
+                    {"score": 0.277, "label": "remote", "box": {"xmin": 40, "ymin": 72, "xmax": 177, "ymax": 115}},
+                ]
             ],
         )

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -58,7 +58,11 @@ PIPELINE_TAGS_AND_AUTO_MODELS = [
     ("image-segmentation", "MODEL_FOR_IMAGE_SEGMENTATION_MAPPING_NAMES", "AutoModelForImageSegmentation"),
     ("fill-mask", "MODEL_FOR_MASKED_LM_MAPPING_NAMES", "AutoModelForMaskedLM"),
     ("object-detection", "MODEL_FOR_OBJECT_DETECTION_MAPPING_NAMES", "AutoModelForObjectDetection"),
-    ("zero-shot-object-detection", "MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING_NAMES", "AutoModelForZeroShotObjectDetection"),
+    (
+        "zero-shot-object-detection",
+        "MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING_NAMES",
+        "AutoModelForZeroShotObjectDetection",
+    ),
     ("question-answering", "MODEL_FOR_QUESTION_ANSWERING_MAPPING_NAMES", "AutoModelForQuestionAnswering"),
     ("text2text-generation", "MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING_NAMES", "AutoModelForSeq2SeqLM"),
     ("text-classification", "MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES", "AutoModelForSequenceClassification"),

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -58,6 +58,7 @@ PIPELINE_TAGS_AND_AUTO_MODELS = [
     ("image-segmentation", "MODEL_FOR_IMAGE_SEGMENTATION_MAPPING_NAMES", "AutoModelForImageSegmentation"),
     ("fill-mask", "MODEL_FOR_MASKED_LM_MAPPING_NAMES", "AutoModelForMaskedLM"),
     ("object-detection", "MODEL_FOR_OBJECT_DETECTION_MAPPING_NAMES", "AutoModelForObjectDetection"),
+    ("zero-shot-object-detection", "MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING_NAMES", "AutoModelForZeroShotObjectDetection"),
     ("question-answering", "MODEL_FOR_QUESTION_ANSWERING_MAPPING_NAMES", "AutoModelForQuestionAnswering"),
     ("text2text-generation", "MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING_NAMES", "AutoModelForSeq2SeqLM"),
     ("text-classification", "MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES", "AutoModelForSequenceClassification"),


### PR DESCRIPTION
# What does this PR do?

This PR adds the `ZeroShotObjectDetectionPipeline`. It is tested on `OwlViTForObjectDetection` model and should enable the inference following inference API

```
from transformers import pipeline

pipe = pipeline("zero-shot-object-detection")
pipe("cats.png", ["cat", "remote"])
```

This pipeline could default to the [https://huggingface.co/google/owlvit-base-patch32](https://huggingface.co/google/owlvit-base-patch32) checkpoint

Fixes # (`18445`)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Link to the [Issue](https://github.com/huggingface/transformers/issues/18445)
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
@alaradirik @Narsil 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

