### PR TITLE
Update default revision for document-question-answering

### DIFF
--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -910,7 +910,7 @@ class AutoModelForDocumentQuestionAnswering(_BaseAutoModelClass):
 AutoModelForDocumentQuestionAnswering = auto_class_update(
     AutoModelForDocumentQuestionAnswering,
     head_doc="document question answering",
-    checkpoint_for_example='impira/layoutlm-document-qa", revision="3dc6de3',
+    checkpoint_for_example='impira/layoutlm-document-qa", revision="52e01b3',
 )
 
 

--- a/src/transformers/models/auto/modeling_tf_auto.py
+++ b/src/transformers/models/auto/modeling_tf_auto.py
@@ -532,7 +532,7 @@ class TFAutoModelForDocumentQuestionAnswering(_BaseAutoModelClass):
 TFAutoModelForDocumentQuestionAnswering = auto_class_update(
     TFAutoModelForDocumentQuestionAnswering,
     head_doc="document question answering",
-    checkpoint_for_example='impira/layoutlm-document-qa", revision="3dc6de3',
+    checkpoint_for_example='impira/layoutlm-document-qa", revision="52e01b3',
 )
 
 

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -222,7 +222,7 @@ SUPPORTED_TASKS = {
         "pt": (AutoModelForDocumentQuestionAnswering,) if is_torch_available() else (),
         "tf": (),
         "default": {
-            "model": {"pt": ("impira/layoutlm-document-qa", "3a93017")},
+            "model": {"pt": ("impira/layoutlm-document-qa", "52e01b3")},
         },
         "type": "multimodal",
     },


### PR DESCRIPTION
# What does this PR do?

Prior to this change, users needed to instantiate a tokenizer themselves while using `impira/layoutlm-document-qa` to set the `add_prefix_space=True` parameter. I made this the default in the tokenizer's config [here](https://huggingface.co/impira/layoutlm-document-qa/commit/52e01b37ccf248953eb527c1d96e9ec1750f3c3c), and this change simply updates the pinned revision to reference it.

After this change, the following commands work:

```
In [1]: from transformers import AutoTokenizer, pipeline
In [2]: nlp = pipeline('document-question-answering')
In [3]: nlp(
   ...:     "https://templates.invoicehome.com/invoice-template-us-neat-750px.png",
   ...:     "What is the invoice number?"
   ...: )
Out[3]: {'score': 0.9998127222061157, 'answer': 'us-001', 'start': 15, 'end': 15}
```

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@NielsRogge 