### PR TITLE
Fix M-CTC-T chunking

### DIFF
--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -327,13 +327,13 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             out = {"tokens": tokens}
         else:
             stride = model_inputs.pop("stride", None)
-            input_values = (
+            inputs = (
                 model_inputs.pop("input_values")
                 if "input_values" in model_inputs
                 else model_inputs.pop("input_features")
             )
             attention_mask = model_inputs.pop("attention_mask", None)
-            outputs = self.model(input_values, attention_mask=attention_mask)
+            outputs = self.model(inputs, attention_mask=attention_mask)
             logits = outputs.logits
 
             if self.type == "ctc_with_lm":


### PR DESCRIPTION
## Summary

Chunking doesn't currently work for the M-CTC-T architecture, which this PR attempts to fix. The change is fairly minor but I am not an expert on how M-CTC-T works, so definitely open to feedback. In my usage, it works as intended.

Paging @patrickvonplaten since I think you originally implemented the chunking mechanism. :slightly_smiling_face:

I will add some PR comments explaining the changes.

## Testing

I added one test to cover the ASR pipeline with M-CTC-T. I also ran these tests:

```shell
RUN_SLOW=True RUN_PIPELINE_TESTS=True pytest \
    tests/models/mctct \
    tests/pipelines/test_pipelines_automatic_speech_recognition.py \
    tests/pipelines/test_pipelines_common.py
```

Some of these tests fail, but I was able to confirm they're also failing on the main branch. Here are the failures:

```
FAILED tests/pipelines/test_pipelines_common.py::CommonPipelineTest::test_iterator_data_tf - tensorflow.python.framework.errors_impl.InternalError: Exception encountered when calling layer...
FAILED tests/pipelines/test_pipelines_common.py::PipelineUtilsTest::test_load_default_pipelines_tf - tensorflow.python.framework.errors_impl.InternalError: Exception encountered when calli...
FAILED tests/pipelines/test_pipelines_automatic_speech_recognition.py::AutomaticSpeechRecognitionPipelineTests::test_chunking_fast_with_lm - AssertionError: 'e<s>eh' != '<s> <s'
FAILED tests/pipelines/test_pipelines_automatic_speech_recognition.py::AutomaticSpeechRecognitionPipelineTests::test_large_model_pt_with_lm - AssertionError: 'ctc' != 'ctc_with_lm'
FAILED tests/pipelines/test_pipelines_automatic_speech_recognition.py::AutomaticSpeechRecognitionPipelineTests::test_with_lm_fast - AssertionError: 'ctc' != 'ctc_with_lm'
FAILED tests/pipelines/test_pipelines_automatic_speech_recognition.py::AutomaticSpeechRecognitionPipelineTests::test_with_local_lm_fast - AssertionError: 'ctc' != 'ctc_with_lm'
FAILED tests/models/mctct/test_modeling_mctct.py::MCTCTModelIntegrationTest::test_inference_ctc_normal - RuntimeError: CUDA out of memory. Tried to allocate 20.00 MiB (GPU 0; 14.76 GiB tot...
FAILED tests/models/mctct/test_modeling_mctct.py::MCTCTModelIntegrationTest::test_inference_ctc_normal_batched - RuntimeError: CUDA out of memory. Tried to allocate 20.00 MiB (GPU 0; 14.76...
FAILED tests/models/mctct/test_modeling_mctct.py::MCTCTModelIntegrationTest::test_inference_ctc_robust_batched - RuntimeError: CUDA out of memory. Tried to allocate 20.00 MiB (GPU 0; 14.76...
```

Some of these look to just be issues with my machine (memory errors).
