### PR TITLE
update black target version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 119
-target-version = ['py37']
+target-version = ['py35']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 119
-target-version = ['py35']
+target-version = ['py37']

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ if stale_egg_info.exists():
 _deps = [
     "Pillow",
     "accelerate>=0.10.0",
-    "black==22.3",
+    "black==22.3",  # after updating to black 2023, also update Python version in pyproject.toml to 3.7
     "codecarbon==1.2.0",
     "cookiecutter==1.7.3",
     "dataclasses",


### PR DESCRIPTION
Considering that setup.yp requires Python 3.7 or higher:

https://github.com/huggingface/transformers/blob/22f72185601d5167a747104b4aca102d0e92524c/setup.py#L417

it might make sense to also have black target only Python 3.7. Just a suggestion though.

Unsurprisingly, this PR may trigger quality check errors.

Note sure who to tag, so assuming for general repo things: @sgugger and @LysandreJik 

