### PR TITLE
Explain why loading config JSON fails

### DIFF
--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -421,9 +421,9 @@ class FeatureExtractionMixin(PushToHubMixin):
                 text = reader.read()
             feature_extractor_dict = json.loads(text)
 
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
             raise EnvironmentError(
-                f"It looks like the config file at '{resolved_feature_extractor_file}' is not a valid JSON file."
+                f"It looks like there was a problem with the config file at '{resolved_feature_extractor_file}': {e.msg}."
             )
 
         if is_local:

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -423,7 +423,8 @@ class FeatureExtractionMixin(PushToHubMixin):
 
         except json.JSONDecodeError as e:
             raise EnvironmentError(
-                f"It looks like there was a problem with the config file at '{resolved_feature_extractor_file}': {e.msg}."
+                f"It looks like there was a problem with the config file at '{resolved_feature_extractor_file}':"
+                f" {e.msg}."
             )
 
         if is_local:


### PR DESCRIPTION
This PR improves the exception message thrown when reading configuration fails to include the information provided by the exception itself (line/column numbers, etc.). This can spare the reader of the message some trouble debugging it. See [this thread here](https://github.com/CompVis/stable-diffusion/issues/247) for background.