### PR TITLE
Fix `check_decoder_model_past_large_inputs` for `class TFBartModelTest`

### DIFF
--- a/tests/models/bart/test_modeling_tf_bart.py
+++ b/tests/models/bart/test_modeling_tf_bart.py
@@ -125,21 +125,10 @@ class TFBartModelTester:
         next_input_ids = tf.concat([input_ids, next_tokens], axis=-1)
         next_attention_mask = tf.concat([attention_mask, next_attn_mask], axis=-1)
 
-        decoder_position_ids = tf.cast(tf.cumsum(next_attention_mask, axis=1, exclusive=True), dtype=tf.int32)
-        output_from_no_past = model(
-            next_input_ids, attention_mask=next_attention_mask, position_ids=decoder_position_ids
-        )
+        output_from_no_past = model(next_input_ids, attention_mask=next_attention_mask)
         output_from_no_past = output_from_no_past[0]
 
-        decoder_position_ids = (
-            tf.cast(tf.cumsum(next_attn_mask, axis=1, exclusive=True), dtype=tf.int32) + past_key_values[0][0].shape[2]
-        )
-        output_from_past = model(
-            next_tokens,
-            attention_mask=next_attention_mask,
-            past_key_values=past_key_values,
-            position_ids=decoder_position_ids,
-        )
+        output_from_past = model(next_tokens, attention_mask=next_attention_mask, past_key_values=past_key_values)
         output_from_past = output_from_past[0]
 
         self.parent.assertEqual(next_tokens.shape[1], output_from_past.shape[1])


### PR DESCRIPTION
# What does this PR do?

The usage of `decoder_position_ids` in `check_decoder_model_past_large_inputs` will produce different results **when the initial attention mask (i.e. the called `past`) contains `0`**, and makes the test flaky.

This PR remove `check_decoder_model_past_large_inputs` from this test. This also makes the test identical to its PT equivalent test, as well as the test implemented in other TF models.

