### PR TITLE
Generation: fix TopPLogitsWarper edge case

### DIFF
--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -194,18 +194,18 @@ class TopPLogitsWarper(LogitsWarper):
         sorted_logits, sorted_indices = torch.sort(scores, descending=True)
         cumulative_probs = sorted_logits.softmax(dim=-1).cumsum(dim=-1)
 
-        # Remove tokens with cumulative top_p above the threshold (token with 0 are kept)
-        sorted_indices_to_remove = cumulative_probs > self.top_p
+        # Keep tokens with cumulative top_p below the threshold
+        sorted_indices_to_keep = cumulative_probs < self.top_p
         if self.min_tokens_to_keep > 1:
             # Keep at least min_tokens_to_keep (set to min_tokens_to_keep-1 because we add the first one below)
-            sorted_indices_to_remove[..., : self.min_tokens_to_keep - 1] = 0
+            sorted_indices_to_keep[..., : self.min_tokens_to_keep - 1] = 1
         # Shift the indices to the right to keep also the first token above the threshold
-        sorted_indices_to_remove[..., 1:] = sorted_indices_to_remove[..., :-1].clone()
-        sorted_indices_to_remove[..., 0] = 0
+        sorted_indices_to_keep[..., 1:] = sorted_indices_to_keep[..., :-1].clone()
+        sorted_indices_to_keep[..., 0] = 1
 
         # scatter sorted tensors to original indexing
-        indices_to_remove = sorted_indices_to_remove.scatter(1, sorted_indices, sorted_indices_to_remove)
-        scores = scores.masked_fill(indices_to_remove, self.filter_value)
+        indices_to_keep = sorted_indices_to_keep.scatter(1, sorted_indices, sorted_indices_to_keep)
+        scores = scores.masked_fill(~indices_to_keep, self.filter_value)
         return scores
 
 

--- a/tests/generation/test_generation_flax_logits_process.py
+++ b/tests/generation/test_generation_flax_logits_process.py
@@ -110,7 +110,8 @@ class LogitsProcessorTest(unittest.TestCase):
         # create distribution and take log (inverse to Softmax as taken in TopPLogitsWarper)
         dist = np.log(np.array([[0.3, 0.1, 0.1, 0.5], [0.15, 0.3, 0.3, 0.25]]))
 
-        top_p_warp = FlaxTopPLogitsWarper(0.7)
+        # top_p = 0.8 is an edge case for the 1st test -- exact sum of the two most likely tokens
+        top_p_warp = FlaxTopPLogitsWarper(0.8)
         filtered_dist = np.exp(top_p_warp(input_ids, dist, cur_len=None))
 
         # dist should be filtered to keep min num values so that sum is >= 0.7

--- a/tests/generation/test_generation_logits_process.py
+++ b/tests/generation/test_generation_logits_process.py
@@ -169,7 +169,7 @@ class LogitsProcessorTest(unittest.TestCase):
             torch.tensor([[0.3, 0.1, 0.1, 0.5], [0.15, 0.3, 0.3, 0.25]], device=torch_device, dtype=torch.float)
         )
 
-        top_p_warp = TopPLogitsWarper(0.7)
+        top_p_warp = TopPLogitsWarper(0.8)  # 0.8 is an edge case for the 1st test (sum of the two most likely tokens)
         filtered_dist = torch.exp(top_p_warp(input_ids, dist))
 
         # dist should be filtered to keep min num values so that sum is >= 0.7

--- a/tests/generation/test_generation_logits_process.py
+++ b/tests/generation/test_generation_logits_process.py
@@ -169,7 +169,8 @@ class LogitsProcessorTest(unittest.TestCase):
             torch.tensor([[0.3, 0.1, 0.1, 0.5], [0.15, 0.3, 0.3, 0.25]], device=torch_device, dtype=torch.float)
         )
 
-        top_p_warp = TopPLogitsWarper(0.8)  # 0.8 is an edge case for the 1st test (sum of the two most likely tokens)
+        # top_p = 0.8 is an edge case for the 1st test -- exact sum of the two most likely tokens
+        top_p_warp = TopPLogitsWarper(0.8)
         filtered_dist = torch.exp(top_p_warp(input_ids, dist))
 
         # dist should be filtered to keep min num values so that sum is >= 0.7

--- a/tests/generation/test_generation_tf_logits_process.py
+++ b/tests/generation/test_generation_tf_logits_process.py
@@ -189,7 +189,8 @@ class TFLogitsProcessorTest(unittest.TestCase):
         # create distribution and take log (inverse to Softmax as taken in TFTopPLogitsWarper)
         dist = np.log(np.array([[0.3, 0.1, 0.1, 0.5], [0.15, 0.3, 0.3, 0.25]], dtype=np.float32))
 
-        top_p_warp = TFTopPLogitsWarper(0.7)
+        # top_p = 0.8 is an edge case for the 1st test -- exact sum of the two most likely tokens
+        top_p_warp = TFTopPLogitsWarper(0.8)
         if use_xla:
             top_p_warp = tf.function(top_p_warp, jit_compile=True)
         filtered_dist = tf.exp(top_p_warp(input_ids, dist, cur_len))


### PR DESCRIPTION
# What does this PR do?

As raised by @ekagra-ranjan in #18976, the PT implementation for `TopPLogitsWarper` is failing in the case where the sum of the top tokens is exactly `top_p` (the current implementation adds an additional token). TF and FLAX's implementation does not suffer from this, so PT's implementation is changed to match it.

It also adds a test for the edge case, to ensure we don't regress.

Fixes #18976 