### PR TITLE
Fix shift_right for padded sequences in MBART

### DIFF
--- a/src/transformers/models/mbart/modeling_mbart.py
+++ b/src/transformers/models/mbart/modeling_mbart.py
@@ -88,7 +88,7 @@ def shift_tokens_right(input_ids: torch.Tensor, pad_token_id: int):
 
     shifted = torch.full_like(input_ids, pad_token_id)
     for b_idx in range(input_ids.size(0)):
-        shifted[b_idx, 1:index_of_eos[b_idx]+1] = prev_output_tokens[b_idx, :index_of_eos[b_idx]].clone()
+        shifted[b_idx, 1 : index_of_eos[b_idx] + 1] = prev_output_tokens[b_idx, : index_of_eos[b_idx]].clone()
 
     shifted[:, 0] = decoder_start_tokens
 


### PR DESCRIPTION
# What does this PR do?

While `shift_tokens_right` indicates that it accounts for padding tokens, it does not do so correctly when padded tokens are at the end of a sequence. In the example below you'll see that the current implementation does not correctly account for the padding tokens when replacing the tokens. This means that the special LID token is not removed/replaced by a padding token when there are padding tokens to start with.

Below an example to show the comparison between the current HF implementation and this PR.

```python
import torch
from transformers import MBartTokenizer
from transformers.models.mbart.modeling_mbart import shift_tokens_right


def shift_tokens_right_mbart(input_ids: torch.Tensor, pad_token_id: int):
    """
    Shift input ids one token to the right, and wrap the last non pad token (the <LID> token) Note that MBart does not
    have a single `decoder_start_token_id` in contrast to other Bart-like models.
    """
    prev_output_tokens = input_ids.clone()

    if pad_token_id is None:
        raise ValueError("self.model.config.pad_token_id has to be defined.")

    # replace possible -100 values in labels by `pad_token_id`
    prev_output_tokens.masked_fill_(prev_output_tokens == -100, pad_token_id)
    index_of_eos = (prev_output_tokens.ne(pad_token_id).sum(dim=1) - 1).unsqueeze(-1)
    decoder_start_tokens = prev_output_tokens.gather(1, index_of_eos).squeeze()

    shifted = torch.full_like(input_ids, pad_token_id)
    for b_idx in range(input_ids.size(0)):
        shifted[b_idx, 1:index_of_eos[b_idx]+1] = prev_output_tokens[b_idx, :index_of_eos[b_idx]].clone()

    shifted[:, 0] = decoder_start_tokens

    return shifted


def main():
    text = ["UN Chief Says There Is No Military Solution in Syria"]

    # MBART
    tokenizer = MBartTokenizer.from_pretrained("facebook/mbart-large-cc25", src_lang="en_XX")
    input_ids = tokenizer(text)["input_ids"]
    input_ids[0] += [tokenizer.pad_token_id] * 4
    input_ids = torch.LongTensor(input_ids)

    print("original input", tokenizer.batch_decode(input_ids))
    shifted_hf = shift_tokens_right(input_ids, tokenizer.pad_token_id)
    print("HF implementation", tokenizer.batch_decode(shifted_hf))
    shifted = shift_tokens_right_mbart(input_ids, tokenizer.pad_token_id)
    print("Fixed implementation", tokenizer.batch_decode(shifted))



if __name__ == '__main__':
    main()
```

Output:

```
original input ['UN Chief Says There Is No Military Solution in Syria</s>en_XX<pad><pad><pad><pad>']
HF implementation ['en_XX UN Chief Says There Is No Military Solution in Syria</s>en_XX<pad><pad><pad>']
Fixed implementation ['en_XX UN Chief Says There Is No Military Solution in Syria</s><pad><pad><pad><pad>']
```

I think this has not come up yet because one would typically train (M)BART on batches without padding (multiple sentences). But because the implementation explicitly mentions padding, I found it odd that it does not seem to work correctly when a padded sequence is used.

If this PR is accepted, the regular BART `shift_tokens_right` may also need a similar fix.

## Who can review?

- bart: @patrickvonplaten, @patil-suraj
