### PR TITLE
Fix TF start docstrings

### DIFF
--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -701,11 +701,10 @@ ALBERT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -714,7 +713,7 @@ ALBERT_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -694,22 +694,28 @@ ALBERT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -704,18 +704,18 @@ ALBERT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -525,18 +525,18 @@ BART_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -515,22 +515,28 @@ BART_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -522,11 +522,10 @@ BART_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -535,7 +534,7 @@ BART_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -964,22 +964,28 @@ BERT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -971,11 +971,10 @@ BERT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -984,7 +983,7 @@ BERT_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -974,18 +974,18 @@ BERT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/blenderbot/modeling_tf_blenderbot.py
+++ b/src/transformers/models/blenderbot/modeling_tf_blenderbot.py
@@ -524,18 +524,18 @@ BLENDERBOT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/blenderbot/modeling_tf_blenderbot.py
+++ b/src/transformers/models/blenderbot/modeling_tf_blenderbot.py
@@ -521,11 +521,10 @@ BLENDERBOT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -534,7 +533,7 @@ BLENDERBOT_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/blenderbot/modeling_tf_blenderbot.py
+++ b/src/transformers/models/blenderbot/modeling_tf_blenderbot.py
@@ -514,22 +514,28 @@ BLENDERBOT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/blenderbot_small/modeling_tf_blenderbot_small.py
+++ b/src/transformers/models/blenderbot_small/modeling_tf_blenderbot_small.py
@@ -521,11 +521,10 @@ BLENDERBOT_SMALL_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -534,7 +533,7 @@ BLENDERBOT_SMALL_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/blenderbot_small/modeling_tf_blenderbot_small.py
+++ b/src/transformers/models/blenderbot_small/modeling_tf_blenderbot_small.py
@@ -514,22 +514,28 @@ BLENDERBOT_SMALL_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/blenderbot_small/modeling_tf_blenderbot_small.py
+++ b/src/transformers/models/blenderbot_small/modeling_tf_blenderbot_small.py
@@ -524,18 +524,18 @@ BLENDERBOT_SMALL_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/camembert/modeling_tf_camembert.py
+++ b/src/transformers/models/camembert/modeling_tf_camembert.py
@@ -57,18 +57,18 @@ CAMEMBERT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/camembert/modeling_tf_camembert.py
+++ b/src/transformers/models/camembert/modeling_tf_camembert.py
@@ -54,11 +54,10 @@ CAMEMBERT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -67,7 +66,7 @@ CAMEMBERT_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/camembert/modeling_tf_camembert.py
+++ b/src/transformers/models/camembert/modeling_tf_camembert.py
@@ -47,22 +47,28 @@ CAMEMBERT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/clip/modeling_tf_clip.py
+++ b/src/transformers/models/clip/modeling_tf_clip.py
@@ -912,22 +912,28 @@ CLIP_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
-      `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
+    `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
-      `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/clip/modeling_tf_clip.py
+++ b/src/transformers/models/clip/modeling_tf_clip.py
@@ -919,11 +919,10 @@ CLIP_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -932,7 +931,7 @@ CLIP_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/clip/modeling_tf_clip.py
+++ b/src/transformers/models/clip/modeling_tf_clip.py
@@ -922,18 +922,18 @@ CLIP_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/convbert/modeling_tf_convbert.py
+++ b/src/transformers/models/convbert/modeling_tf_convbert.py
@@ -648,18 +648,18 @@ CONVBERT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/convbert/modeling_tf_convbert.py
+++ b/src/transformers/models/convbert/modeling_tf_convbert.py
@@ -645,11 +645,10 @@ CONVBERT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -658,7 +657,7 @@ CONVBERT_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/convbert/modeling_tf_convbert.py
+++ b/src/transformers/models/convbert/modeling_tf_convbert.py
@@ -638,22 +638,28 @@ CONVBERT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/convnext/modeling_tf_convnext.py
+++ b/src/transformers/models/convnext/modeling_tf_convnext.py
@@ -406,11 +406,10 @@ CONVNEXT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `pixel_values` only and nothing else: `model(pixel_values)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -419,7 +418,7 @@ CONVNEXT_START_DOCSTRING = r"""
     `model({"pixel_values": pixel_values, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/convnext/modeling_tf_convnext.py
+++ b/src/transformers/models/convnext/modeling_tf_convnext.py
@@ -399,13 +399,28 @@ CONVNEXT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
+
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
+
+    - a single Tensor with `pixel_values` only and nothing else: `model(pixel_values)`
+    - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
+    `model([pixel_values, attention_mask])` or `model([pixel_values, attention_mask, token_type_ids])`
+    - a dictionary with one or several input Tensors associated to the input names given in the docstring:
+    `model({"pixel_values": pixel_values, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/convnext/modeling_tf_convnext.py
+++ b/src/transformers/models/convnext/modeling_tf_convnext.py
@@ -409,18 +409,18 @@ CONVNEXT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `pixel_values` only and nothing else: `model(pixel_values)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([pixel_values, attention_mask])` or `model([pixel_values, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"pixel_values": pixel_values, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/ctrl/modeling_tf_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_tf_ctrl.py
@@ -425,11 +425,10 @@ CTRL_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -438,7 +437,7 @@ CTRL_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/ctrl/modeling_tf_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_tf_ctrl.py
@@ -428,18 +428,18 @@ CTRL_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/ctrl/modeling_tf_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_tf_ctrl.py
@@ -418,22 +418,28 @@ CTRL_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/data2vec/modeling_tf_data2vec_vision.py
+++ b/src/transformers/models/data2vec/modeling_tf_data2vec_vision.py
@@ -816,13 +816,28 @@ DATA2VEC_VISION_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
+
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
+
+    - a single Tensor with `pixel_values` only and nothing else: `model(pixel_values)`
+    - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
+    `model([pixel_values, attention_mask])` or `model([pixel_values, attention_mask, token_type_ids])`
+    - a dictionary with one or several input Tensors associated to the input names given in the docstring:
+    `model({"pixel_values": pixel_values, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/data2vec/modeling_tf_data2vec_vision.py
+++ b/src/transformers/models/data2vec/modeling_tf_data2vec_vision.py
@@ -826,18 +826,18 @@ DATA2VEC_VISION_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `pixel_values` only and nothing else: `model(pixel_values)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([pixel_values, attention_mask])` or `model([pixel_values, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"pixel_values": pixel_values, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/data2vec/modeling_tf_data2vec_vision.py
+++ b/src/transformers/models/data2vec/modeling_tf_data2vec_vision.py
@@ -823,11 +823,10 @@ DATA2VEC_VISION_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `pixel_values` only and nothing else: `model(pixel_values)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -836,7 +835,7 @@ DATA2VEC_VISION_START_DOCSTRING = r"""
     `model({"pixel_values": pixel_values, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/deberta/modeling_tf_deberta.py
+++ b/src/transformers/models/deberta/modeling_tf_deberta.py
@@ -1011,11 +1011,10 @@ DEBERTA_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -1024,7 +1023,7 @@ DEBERTA_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/deberta/modeling_tf_deberta.py
+++ b/src/transformers/models/deberta/modeling_tf_deberta.py
@@ -1014,18 +1014,18 @@ DEBERTA_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/deberta/modeling_tf_deberta.py
+++ b/src/transformers/models/deberta/modeling_tf_deberta.py
@@ -1004,22 +1004,28 @@ DEBERTA_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
@@ -1104,11 +1104,10 @@ DEBERTA_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -1117,7 +1116,7 @@ DEBERTA_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
@@ -1107,18 +1107,18 @@ DEBERTA_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_tf_deberta_v2.py
@@ -1097,22 +1097,28 @@ DEBERTA_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/distilbert/modeling_tf_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_tf_distilbert.py
@@ -454,11 +454,10 @@ DISTILBERT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -467,7 +466,7 @@ DISTILBERT_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/distilbert/modeling_tf_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_tf_distilbert.py
@@ -447,22 +447,28 @@ DISTILBERT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
-    `model([input_ids, attention_mask])`
+    `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
-    `model({"input_ids": input_ids})`
+    `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/distilbert/modeling_tf_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_tf_distilbert.py
@@ -457,18 +457,18 @@ DISTILBERT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/dpr/modeling_tf_dpr.py
+++ b/src/transformers/models/dpr/modeling_tf_dpr.py
@@ -414,18 +414,18 @@ TF_DPR_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/dpr/modeling_tf_dpr.py
+++ b/src/transformers/models/dpr/modeling_tf_dpr.py
@@ -411,11 +411,10 @@ TF_DPR_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -424,7 +423,7 @@ TF_DPR_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/dpr/modeling_tf_dpr.py
+++ b/src/transformers/models/dpr/modeling_tf_dpr.py
@@ -404,22 +404,28 @@ TF_DPR_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/electra/modeling_tf_electra.py
+++ b/src/transformers/models/electra/modeling_tf_electra.py
@@ -848,11 +848,10 @@ ELECTRA_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -861,7 +860,7 @@ ELECTRA_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/electra/modeling_tf_electra.py
+++ b/src/transformers/models/electra/modeling_tf_electra.py
@@ -851,18 +851,18 @@ ELECTRA_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/electra/modeling_tf_electra.py
+++ b/src/transformers/models/electra/modeling_tf_electra.py
@@ -841,22 +841,28 @@ ELECTRA_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/flaubert/modeling_tf_flaubert.py
+++ b/src/transformers/models/flaubert/modeling_tf_flaubert.py
@@ -80,11 +80,10 @@ FLAUBERT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -93,7 +92,7 @@ FLAUBERT_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/flaubert/modeling_tf_flaubert.py
+++ b/src/transformers/models/flaubert/modeling_tf_flaubert.py
@@ -83,18 +83,18 @@ FLAUBERT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/flaubert/modeling_tf_flaubert.py
+++ b/src/transformers/models/flaubert/modeling_tf_flaubert.py
@@ -73,22 +73,28 @@ FLAUBERT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -1025,18 +1025,18 @@ FUNNEL_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -1022,11 +1022,10 @@ FUNNEL_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -1035,7 +1034,7 @@ FUNNEL_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/funnel/modeling_tf_funnel.py
+++ b/src/transformers/models/funnel/modeling_tf_funnel.py
@@ -1015,22 +1015,28 @@ FUNNEL_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/gpt2/modeling_tf_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_tf_gpt2.py
@@ -614,11 +614,10 @@ GPT2_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -627,7 +626,7 @@ GPT2_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/gpt2/modeling_tf_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_tf_gpt2.py
@@ -617,18 +617,18 @@ GPT2_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/gpt2/modeling_tf_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_tf_gpt2.py
@@ -607,22 +607,28 @@ GPT2_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/gptj/modeling_tf_gptj.py
+++ b/src/transformers/models/gptj/modeling_tf_gptj.py
@@ -557,11 +557,10 @@ GPTJ_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -570,7 +569,7 @@ GPTJ_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/gptj/modeling_tf_gptj.py
+++ b/src/transformers/models/gptj/modeling_tf_gptj.py
@@ -550,22 +550,28 @@ GPTJ_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/gptj/modeling_tf_gptj.py
+++ b/src/transformers/models/gptj/modeling_tf_gptj.py
@@ -560,18 +560,18 @@ GPTJ_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/hubert/modeling_tf_hubert.py
+++ b/src/transformers/models/hubert/modeling_tf_hubert.py
@@ -1357,18 +1357,18 @@ HUBERT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_values` only and nothing else: `model(input_values)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_values, attention_mask])` or `model([input_values, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_values": input_values, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/hubert/modeling_tf_hubert.py
+++ b/src/transformers/models/hubert/modeling_tf_hubert.py
@@ -1347,22 +1347,28 @@ HUBERT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_values` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_values` only and nothing else: `model(input_values)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_values, attention_mask])` or `model([input_values, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_values": input_values, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/hubert/modeling_tf_hubert.py
+++ b/src/transformers/models/hubert/modeling_tf_hubert.py
@@ -1354,11 +1354,10 @@ HUBERT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_values` only and nothing else: `model(input_values)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -1367,7 +1366,7 @@ HUBERT_START_DOCSTRING = r"""
     `model({"input_values": input_values, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
+++ b/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
@@ -817,22 +817,28 @@ LAYOUTLM_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
+++ b/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
@@ -824,11 +824,10 @@ LAYOUTLM_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -837,7 +836,7 @@ LAYOUTLM_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
+++ b/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
@@ -827,18 +827,18 @@ LAYOUTLM_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/layoutlmv3/modeling_tf_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/modeling_tf_layoutlmv3.py
@@ -1026,11 +1026,10 @@ LAYOUTLMV3_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -1039,7 +1038,7 @@ LAYOUTLMV3_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/layoutlmv3/modeling_tf_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/modeling_tf_layoutlmv3.py
@@ -1019,13 +1019,28 @@ LAYOUTLMV3_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
+
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
+
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
+    - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
+    `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
+    - a dictionary with one or several input Tensors associated to the input names given in the docstring:
+    `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/layoutlmv3/modeling_tf_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/modeling_tf_layoutlmv3.py
@@ -1029,18 +1029,18 @@ LAYOUTLMV3_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/led/modeling_tf_led.py
+++ b/src/transformers/models/led/modeling_tf_led.py
@@ -1553,22 +1553,28 @@ LED_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/led/modeling_tf_led.py
+++ b/src/transformers/models/led/modeling_tf_led.py
@@ -1560,11 +1560,10 @@ LED_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -1573,7 +1572,7 @@ LED_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/led/modeling_tf_led.py
+++ b/src/transformers/models/led/modeling_tf_led.py
@@ -1563,18 +1563,18 @@ LED_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -1911,22 +1911,28 @@ LONGFORMER_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -1918,11 +1918,10 @@ LONGFORMER_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -1931,7 +1930,7 @@ LONGFORMER_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/longformer/modeling_tf_longformer.py
+++ b/src/transformers/models/longformer/modeling_tf_longformer.py
@@ -1921,18 +1921,18 @@ LONGFORMER_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/lxmert/modeling_tf_lxmert.py
+++ b/src/transformers/models/lxmert/modeling_tf_lxmert.py
@@ -836,11 +836,10 @@ LXMERT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -849,7 +848,7 @@ LXMERT_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/lxmert/modeling_tf_lxmert.py
+++ b/src/transformers/models/lxmert/modeling_tf_lxmert.py
@@ -829,22 +829,28 @@ LXMERT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/lxmert/modeling_tf_lxmert.py
+++ b/src/transformers/models/lxmert/modeling_tf_lxmert.py
@@ -839,18 +839,18 @@ LXMERT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/marian/modeling_tf_marian.py
+++ b/src/transformers/models/marian/modeling_tf_marian.py
@@ -553,22 +553,28 @@ MARIAN_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/marian/modeling_tf_marian.py
+++ b/src/transformers/models/marian/modeling_tf_marian.py
@@ -560,11 +560,10 @@ MARIAN_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -573,7 +572,7 @@ MARIAN_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/marian/modeling_tf_marian.py
+++ b/src/transformers/models/marian/modeling_tf_marian.py
@@ -563,18 +563,18 @@ MARIAN_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/mbart/modeling_tf_mbart.py
+++ b/src/transformers/models/mbart/modeling_tf_mbart.py
@@ -518,22 +518,28 @@ MBART_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/mbart/modeling_tf_mbart.py
+++ b/src/transformers/models/mbart/modeling_tf_mbart.py
@@ -525,11 +525,10 @@ MBART_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -538,7 +537,7 @@ MBART_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/mbart/modeling_tf_mbart.py
+++ b/src/transformers/models/mbart/modeling_tf_mbart.py
@@ -528,18 +528,18 @@ MBART_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -846,18 +846,18 @@ MOBILEBERT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -836,22 +836,28 @@ MOBILEBERT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
+++ b/src/transformers/models/mobilebert/modeling_tf_mobilebert.py
@@ -843,11 +843,10 @@ MOBILEBERT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -856,7 +855,7 @@ MOBILEBERT_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/mobilevit/modeling_tf_mobilevit.py
+++ b/src/transformers/models/mobilevit/modeling_tf_mobilevit.py
@@ -785,11 +785,10 @@ MOBILEVIT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `pixel_values` only and nothing else: `model(pixel_values)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -798,7 +797,7 @@ MOBILEVIT_START_DOCSTRING = r"""
     `model({"pixel_values": pixel_values, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/mobilevit/modeling_tf_mobilevit.py
+++ b/src/transformers/models/mobilevit/modeling_tf_mobilevit.py
@@ -778,13 +778,28 @@ MOBILEVIT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
+
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
+
+    - a single Tensor with `pixel_values` only and nothing else: `model(pixel_values)`
+    - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
+    `model([pixel_values, attention_mask])` or `model([pixel_values, attention_mask, token_type_ids])`
+    - a dictionary with one or several input Tensors associated to the input names given in the docstring:
+    `model({"pixel_values": pixel_values, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/mobilevit/modeling_tf_mobilevit.py
+++ b/src/transformers/models/mobilevit/modeling_tf_mobilevit.py
@@ -788,18 +788,18 @@ MOBILEVIT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `pixel_values` only and nothing else: `model(pixel_values)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([pixel_values, attention_mask])` or `model([pixel_values, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"pixel_values": pixel_values, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -594,18 +594,18 @@ MPNET_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -584,22 +584,28 @@ MPNET_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensor in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
-    `model([input_ids, attention_mask])`
+    `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
-    `model({"input_ids": input_ids, "attention_mask": attention_mask})`
+    `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/mpnet/modeling_tf_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_tf_mpnet.py
@@ -591,11 +591,10 @@ MPNET_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -604,7 +603,7 @@ MPNET_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/openai/modeling_tf_openai.py
+++ b/src/transformers/models/openai/modeling_tf_openai.py
@@ -421,18 +421,18 @@ OPENAI_GPT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/openai/modeling_tf_openai.py
+++ b/src/transformers/models/openai/modeling_tf_openai.py
@@ -418,11 +418,10 @@ OPENAI_GPT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -431,7 +430,7 @@ OPENAI_GPT_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/openai/modeling_tf_openai.py
+++ b/src/transformers/models/openai/modeling_tf_openai.py
@@ -411,22 +411,28 @@ OPENAI_GPT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/opt/modeling_tf_opt.py
+++ b/src/transformers/models/opt/modeling_tf_opt.py
@@ -388,18 +388,18 @@ OPT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/opt/modeling_tf_opt.py
+++ b/src/transformers/models/opt/modeling_tf_opt.py
@@ -378,22 +378,28 @@ OPT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/opt/modeling_tf_opt.py
+++ b/src/transformers/models/opt/modeling_tf_opt.py
@@ -385,11 +385,10 @@ OPT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -398,7 +397,7 @@ OPT_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/pegasus/modeling_tf_pegasus.py
+++ b/src/transformers/models/pegasus/modeling_tf_pegasus.py
@@ -561,11 +561,10 @@ PEGASUS_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -574,7 +573,7 @@ PEGASUS_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/pegasus/modeling_tf_pegasus.py
+++ b/src/transformers/models/pegasus/modeling_tf_pegasus.py
@@ -554,22 +554,28 @@ PEGASUS_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/pegasus/modeling_tf_pegasus.py
+++ b/src/transformers/models/pegasus/modeling_tf_pegasus.py
@@ -564,18 +564,18 @@ PEGASUS_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/rembert/modeling_tf_rembert.py
+++ b/src/transformers/models/rembert/modeling_tf_rembert.py
@@ -843,22 +843,28 @@ REMBERT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/rembert/modeling_tf_rembert.py
+++ b/src/transformers/models/rembert/modeling_tf_rembert.py
@@ -853,18 +853,18 @@ REMBERT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/rembert/modeling_tf_rembert.py
+++ b/src/transformers/models/rembert/modeling_tf_rembert.py
@@ -850,11 +850,10 @@ REMBERT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -863,7 +862,7 @@ REMBERT_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -828,11 +828,10 @@ ROBERTA_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -841,7 +840,7 @@ ROBERTA_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -831,18 +831,18 @@ ROBERTA_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/roberta/modeling_tf_roberta.py
+++ b/src/transformers/models/roberta/modeling_tf_roberta.py
@@ -821,22 +821,28 @@ ROBERTA_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/roformer/modeling_tf_roformer.py
+++ b/src/transformers/models/roformer/modeling_tf_roformer.py
@@ -718,11 +718,10 @@ ROFORMER_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -731,7 +730,7 @@ ROFORMER_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/roformer/modeling_tf_roformer.py
+++ b/src/transformers/models/roformer/modeling_tf_roformer.py
@@ -711,22 +711,28 @@ ROFORMER_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/roformer/modeling_tf_roformer.py
+++ b/src/transformers/models/roformer/modeling_tf_roformer.py
@@ -721,18 +721,18 @@ ROFORMER_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/speech_to_text/modeling_tf_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/modeling_tf_speech_to_text.py
@@ -637,11 +637,10 @@ SPEECH_TO_TEXT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -650,7 +649,7 @@ SPEECH_TO_TEXT_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/speech_to_text/modeling_tf_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/modeling_tf_speech_to_text.py
@@ -640,18 +640,18 @@ SPEECH_TO_TEXT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/speech_to_text/modeling_tf_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/modeling_tf_speech_to_text.py
@@ -630,22 +630,28 @@ SPEECH_TO_TEXT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -961,11 +961,10 @@ T5_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -974,7 +973,7 @@ T5_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -954,22 +954,28 @@ T5_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/t5/modeling_tf_t5.py
+++ b/src/transformers/models/t5/modeling_tf_t5.py
@@ -964,18 +964,18 @@ T5_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/tapas/modeling_tf_tapas.py
+++ b/src/transformers/models/tapas/modeling_tf_tapas.py
@@ -898,18 +898,18 @@ TAPAS_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/tapas/modeling_tf_tapas.py
+++ b/src/transformers/models/tapas/modeling_tf_tapas.py
@@ -895,11 +895,10 @@ TAPAS_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -908,7 +907,7 @@ TAPAS_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/tapas/modeling_tf_tapas.py
+++ b/src/transformers/models/tapas/modeling_tf_tapas.py
@@ -888,22 +888,28 @@ TAPAS_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
+++ b/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
@@ -816,18 +816,18 @@ TRANSFO_XL_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
+++ b/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
@@ -806,22 +806,28 @@ TRANSFO_XL_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
+++ b/src/transformers/models/transfo_xl/modeling_tf_transfo_xl.py
@@ -813,11 +813,10 @@ TRANSFO_XL_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -826,7 +825,7 @@ TRANSFO_XL_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/vit/modeling_tf_vit.py
+++ b/src/transformers/models/vit/modeling_tf_vit.py
@@ -593,13 +593,28 @@ VIT_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
+
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
+
+    - a single Tensor with `pixel_values` only and nothing else: `model(pixel_values)`
+    - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
+    `model([pixel_values, attention_mask])` or `model([pixel_values, attention_mask, token_type_ids])`
+    - a dictionary with one or several input Tensors associated to the input names given in the docstring:
+    `model({"pixel_values": pixel_values, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/vit/modeling_tf_vit.py
+++ b/src/transformers/models/vit/modeling_tf_vit.py
@@ -600,11 +600,10 @@ VIT_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `pixel_values` only and nothing else: `model(pixel_values)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -613,7 +612,7 @@ VIT_START_DOCSTRING = r"""
     `model({"pixel_values": pixel_values, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/vit/modeling_tf_vit.py
+++ b/src/transformers/models/vit/modeling_tf_vit.py
@@ -603,18 +603,18 @@ VIT_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `pixel_values` only and nothing else: `model(pixel_values)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([pixel_values, attention_mask])` or `model([pixel_values, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"pixel_values": pixel_values, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/vit_mae/modeling_tf_vit_mae.py
+++ b/src/transformers/models/vit_mae/modeling_tf_vit_mae.py
@@ -737,13 +737,28 @@ VIT_MAE_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
+
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
+
+    - a single Tensor with `pixel_values` only and nothing else: `model(pixel_values)`
+    - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
+    `model([pixel_values, attention_mask])` or `model([pixel_values, attention_mask, token_type_ids])`
+    - a dictionary with one or several input Tensors associated to the input names given in the docstring:
+    `model({"pixel_values": pixel_values, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/vit_mae/modeling_tf_vit_mae.py
+++ b/src/transformers/models/vit_mae/modeling_tf_vit_mae.py
@@ -744,11 +744,10 @@ VIT_MAE_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `pixel_values` only and nothing else: `model(pixel_values)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -757,7 +756,7 @@ VIT_MAE_START_DOCSTRING = r"""
     `model({"pixel_values": pixel_values, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/vit_mae/modeling_tf_vit_mae.py
+++ b/src/transformers/models/vit_mae/modeling_tf_vit_mae.py
@@ -747,18 +747,18 @@ VIT_MAE_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `pixel_values` only and nothing else: `model(pixel_values)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([pixel_values, attention_mask])` or `model([pixel_values, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"pixel_values": pixel_values, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py
@@ -1380,22 +1380,28 @@ WAV_2_VEC_2_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_values` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_values` only and nothing else: `model(input_values)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_values, attention_mask])` or `model([input_values, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_values": input_values, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py
@@ -1387,11 +1387,10 @@ WAV_2_VEC_2_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_values` only and nothing else: `model(input_values)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -1400,7 +1399,7 @@ WAV_2_VEC_2_START_DOCSTRING = r"""
     `model({"input_values": input_values, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_tf_wav2vec2.py
@@ -1390,18 +1390,18 @@ WAV_2_VEC_2_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_values` only and nothing else: `model(input_values)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_values, attention_mask])` or `model([input_values, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_values": input_values, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/xglm/modeling_tf_xglm.py
+++ b/src/transformers/models/xglm/modeling_tf_xglm.py
@@ -672,22 +672,28 @@ XGLM_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/xglm/modeling_tf_xglm.py
+++ b/src/transformers/models/xglm/modeling_tf_xglm.py
@@ -682,18 +682,18 @@ XGLM_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/xglm/modeling_tf_xglm.py
+++ b/src/transformers/models/xglm/modeling_tf_xglm.py
@@ -679,11 +679,10 @@ XGLM_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -692,7 +691,7 @@ XGLM_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/xlm/modeling_tf_xlm.py
+++ b/src/transformers/models/xlm/modeling_tf_xlm.py
@@ -582,11 +582,10 @@ XLM_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -595,7 +594,7 @@ XLM_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/xlm/modeling_tf_xlm.py
+++ b/src/transformers/models/xlm/modeling_tf_xlm.py
@@ -585,18 +585,18 @@ XLM_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/xlm/modeling_tf_xlm.py
+++ b/src/transformers/models/xlm/modeling_tf_xlm.py
@@ -575,22 +575,28 @@ XLM_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/xlm_roberta/modeling_tf_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/modeling_tf_xlm_roberta.py
@@ -54,11 +54,10 @@ XLM_ROBERTA_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -67,7 +66,7 @@ XLM_ROBERTA_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/src/transformers/models/xlm_roberta/modeling_tf_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/modeling_tf_xlm_roberta.py
@@ -57,18 +57,18 @@ XLM_ROBERTA_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/xlm_roberta/modeling_tf_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/modeling_tf_xlm_roberta.py
@@ -47,22 +47,28 @@ XLM_ROBERTA_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/xlnet/modeling_tf_xlnet.py
+++ b/src/transformers/models/xlnet/modeling_tf_xlnet.py
@@ -1020,22 +1020,28 @@ XLNET_START_DOCSTRING = r"""
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all the
-    tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in the
-    first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 

--- a/src/transformers/models/xlnet/modeling_tf_xlnet.py
+++ b/src/transformers/models/xlnet/modeling_tf_xlnet.py
@@ -1030,18 +1030,18 @@ XLNET_START_DOCSTRING = r"""
     pass your inputs and labels in any format that `model.fit()` supports!
 
     If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you
-    can use to gather all the input Tensors in the first positional argument:
+    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
+    the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
-    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
-    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
-    function!
+
+    Note that when creating models and layers with
+    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>
 

--- a/src/transformers/models/xlnet/modeling_tf_xlnet.py
+++ b/src/transformers/models/xlnet/modeling_tf_xlnet.py
@@ -1027,11 +1027,10 @@ XLNET_START_DOCSTRING = r"""
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
-    your own layers or models with the Keras `Functional` API, there are three possibilities you can use to gather all
-    the input Tensors in the first positional argument:
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second
+    format outside of Keras methods like `fit()` and `predict()`, such as when creating your own layers or models with
+    the Keras `Functional` API, there are three possibilities you can use to gather all the input Tensors in the first
+    positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
@@ -1040,7 +1039,7 @@ XLNET_START_DOCSTRING = r"""
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
 
     Note that when creating models and layers with
-    (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/] then you don't need to worry
+    [subclassing](https://keras.io/guides/making_new_layers_and_models_via_subclassing/) then you don't need to worry
     about any of this, as you can just pass inputs like you would to any other Python function!
 
     </Tip>

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -841,9 +841,7 @@ class TF{{cookiecutter.camelcase_modelname}}PreTrainedModel(TFPreTrainedModel):
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
     your own layers or models with the Keras `Functional` API, there are three possibilities you
     can use to gather all the input Tensors in the first positional argument:
 
@@ -2114,9 +2112,7 @@ class TF{{cookiecutter.camelcase_modelname}}PreTrainedModel(TFPreTrainedModel):
 
     The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
     and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
-    pass your inputs and labels in any format that `model.fit()` supports!
-
-    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    pass your inputs and labels in any format that `model.fit()` supports! If, however, you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
     your own layers or models with the Keras `Functional` API, there are three possibilities you
     can use to gather all the input Tensors in the first positional argument:
 

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -852,7 +852,7 @@ class TF{{cookiecutter.camelcase_modelname}}PreTrainedModel(TFPreTrainedModel):
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
+
     Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
     then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
     function!
@@ -2125,7 +2125,7 @@ class TF{{cookiecutter.camelcase_modelname}}PreTrainedModel(TFPreTrainedModel):
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
-    
+
     Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
     then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
     function!

--- a/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
+++ b/templates/adding_a_new_model/cookiecutter-template-{{cookiecutter.modelname}}/modeling_tf_{{cookiecutter.lowercase_modelname}}.py
@@ -834,22 +834,28 @@ class TF{{cookiecutter.camelcase_modelname}}PreTrainedModel(TFPreTrainedModel):
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having
-    all the tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors
-    in the first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
-    - a single Tensor with `input_ids` only and nothing else: `model(inputs_ids)`
+    - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 
@@ -2101,22 +2107,28 @@ class TF{{cookiecutter.camelcase_modelname}}PreTrainedModel(TFPreTrainedModel):
 
     <Tip>
 
-    TF 2.0 models accepts two formats as inputs:
+    TensorFlow models and layers in `transformers` accept two formats as input:
 
     - having all inputs as keyword arguments (like PyTorch models), or
-    - having all inputs as a list, tuple or dict in the first positional arguments.
+    - having all inputs as a list, tuple or dict in the first positional argument.
 
-    This second option is useful when using [`tf.keras.Model.fit`] method which currently requires having all
-    the tensors in the first argument of the model call function: `model(inputs)`.
+    The reason the second format is supported is that Keras methods prefer this format when passing inputs to models
+    and layers. Because of this support, when using methods like `model.fit()` things should "just work" for you - just
+    pass your inputs and labels in any format that `model.fit()` supports!
 
-    If you choose this second option, there are three possibilities you can use to gather all the input Tensors in
-    the first positional argument :
+    If you want to use the second format outside of Keras methods like `fit()` and `predict()`, such as when creating
+    your own layers or models with the Keras `Functional` API, there are three possibilities you
+    can use to gather all the input Tensors in the first positional argument:
 
     - a single Tensor with `input_ids` only and nothing else: `model(input_ids)`
     - a list of varying length with one or several input Tensors IN THE ORDER given in the docstring:
     `model([input_ids, attention_mask])` or `model([input_ids, attention_mask, token_type_ids])`
     - a dictionary with one or several input Tensors associated to the input names given in the docstring:
     `model({"input_ids": input_ids, "token_type_ids": token_type_ids})`
+    
+    Note that when creating models and layers with (subclassing)[https://keras.io/guides/making_new_layers_and_models_via_subclassing/]
+    then you don't need to worry about any of this, as you can just pass inputs like you would to any other Python
+    function!
 
     </Tip>
 


### PR DESCRIPTION
(This is not an urgent fix and can wait until after the release)

Our TF models include a cookie-cutter docstring explaining how inputs can be passed, which is very prominent in the online docs. Parts of this are old and confusing, and it had a few errors, both grammar and variable names. I rewrote it, which should hopefully reduce user confusion in future!