### PR TITLE
Fix tokenizer class for `XLMRobertaXL`

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -271,7 +271,13 @@ else:
                     "XLMRobertaTokenizerFast" if is_tokenizers_available() else None,
                 ),
             ),
-            ("xlm-roberta-xl", ("RobertaTokenizer", "RobertaTokenizerFast" if is_tokenizers_available() else None)),
+            (
+                "xlm-roberta-xl",
+                (
+                    "XLMRobertaTokenizer" if is_sentencepiece_available() else None,
+                    "XLMRobertaTokenizerFast" if is_tokenizers_available() else None,
+                ),
+            ),
             (
                 "xlnet",
                 (

--- a/src/transformers/models/xlm_roberta_xl/modeling_xlm_roberta_xl.py
+++ b/src/transformers/models/xlm_roberta_xl/modeling_xlm_roberta_xl.py
@@ -54,7 +54,7 @@ logger = logging.get_logger(__name__)
 
 _CHECKPOINT_FOR_DOC = "xlm-roberta-xlarge"
 _CONFIG_FOR_DOC = "XLMRobertaXLConfig"
-_TOKENIZER_FOR_DOC = "RobertaTokenizer"
+_TOKENIZER_FOR_DOC = "XLMRobertaTokenizer"
 
 XLM_ROBERTA_XL_PRETRAINED_MODEL_ARCHIVE_LIST = [
     "facebook/xlm-roberta-xl",


### PR DESCRIPTION
# What does this PR do?

The 2 checkpoints for `XLMRobertaXL` use `XLMRobertaTokenizer` as `tokenizer_class`. In my PR #16857, I only checked `_CONFIG_FOR_DOC` in the modeling file at that time, and took `RobertaTokenizer` from there, which was wrong.