### PR TITLE
Added OnnxConfig for MPNet models

### DIFF
--- a/docs/source/en/serialization.mdx
+++ b/docs/source/en/serialization.mdx
@@ -83,6 +83,7 @@ Ready-made configurations include the following architectures:
 - mBART
 - MobileBERT
 - MobileViT
+- MPNet
 - MT5
 - OpenAI GPT-2
 - OWL-ViT

--- a/src/transformers/models/mpnet/__init__.py
+++ b/src/transformers/models/mpnet/__init__.py
@@ -29,7 +29,7 @@ from ...utils import (
 
 
 _import_structure = {
-    "configuration_mpnet": ["MPNET_PRETRAINED_CONFIG_ARCHIVE_MAP", "MPNetConfig"],
+    "configuration_mpnet": ["MPNET_PRETRAINED_CONFIG_ARCHIVE_MAP", "MPNetConfig", "MPNetOnnxConfig"],
     "tokenization_mpnet": ["MPNetTokenizer"],
 }
 
@@ -80,7 +80,7 @@ else:
 
 
 if TYPE_CHECKING:
-    from .configuration_mpnet import MPNET_PRETRAINED_CONFIG_ARCHIVE_MAP, MPNetConfig
+    from .configuration_mpnet import MPNET_PRETRAINED_CONFIG_ARCHIVE_MAP, MPNetConfig, MPNetOnnxConfig
     from .tokenization_mpnet import MPNetTokenizer
 
     try:

--- a/src/transformers/models/mpnet/configuration_mpnet.py
+++ b/src/transformers/models/mpnet/configuration_mpnet.py
@@ -14,8 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ MPNet model configuration"""
+from collections import OrderedDict
+from typing import Mapping
 
 from ...configuration_utils import PretrainedConfig
+from ...onnx import OnnxConfig
 from ...utils import logging
 
 
@@ -114,3 +117,22 @@ class MPNetConfig(PretrainedConfig):
         self.initializer_range = initializer_range
         self.layer_norm_eps = layer_norm_eps
         self.relative_attention_num_buckets = relative_attention_num_buckets
+
+
+class MPNetOnnxConfig(OnnxConfig):
+    @property
+    def inputs(self) -> Mapping[str, Mapping[int, str]]:
+        if self.task == "multiple-choice":
+            dynamic_axis = {0: "batch", 1: "choice", 2: "sequence"}
+        else:
+            dynamic_axis = {0: "batch", 1: "sequence"}
+        return OrderedDict(
+            [
+                ("input_ids", dynamic_axis),
+                ("attention_mask", dynamic_axis),
+            ]
+        )
+
+    @property
+    def default_onnx_opset(self) -> int:
+        return 12

--- a/src/transformers/models/mpnet/modeling_mpnet.py
+++ b/src/transformers/models/mpnet/modeling_mpnet.py
@@ -86,7 +86,7 @@ class MPNetEmbeddings(nn.Module):
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
         self.register_buffer("position_ids", torch.arange(config.max_position_embeddings).expand((1, -1)))
 
-    def forward(self, input_ids=None, position_ids=None, inputs_embeds=None, **kwargs):
+    def forward(self, input_ids=None, position_ids=None, inputs_embeds=None, *args, **kwargs):
         if position_ids is None:
             if input_ids is not None:
                 position_ids = create_position_ids_from_input_ids(input_ids, self.padding_idx)
@@ -162,6 +162,7 @@ class MPNetSelfAttention(nn.Module):
         head_mask=None,
         position_bias=None,
         output_attentions=False,
+        *args,
         **kwargs,
     ):
 
@@ -236,6 +237,7 @@ class MPNetAttention(nn.Module):
         head_mask=None,
         position_bias=None,
         output_attentions=False,
+        *args,
         **kwargs,
     ):
         self_outputs = self.attn(
@@ -295,6 +297,7 @@ class MPNetLayer(nn.Module):
         head_mask=None,
         position_bias=None,
         output_attentions=False,
+        *args,
         **kwargs,
     ):
         self_attention_outputs = self.attention(
@@ -329,6 +332,7 @@ class MPNetEncoder(nn.Module):
         output_attentions=False,
         output_hidden_states=False,
         return_dict=False,
+        *args,
         **kwargs,
     ):
         position_bias = self.compute_position_bias(hidden_states)
@@ -344,6 +348,7 @@ class MPNetEncoder(nn.Module):
                 head_mask[i],
                 position_bias,
                 output_attentions=output_attentions,
+                *args,
                 **kwargs,
             )
             hidden_states = layer_outputs[0]
@@ -526,6 +531,7 @@ class MPNetModel(MPNetPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
+        *args,
         **kwargs,
     ) -> Union[Tuple[torch.Tensor], BaseModelOutputWithPooling]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
@@ -664,7 +670,7 @@ class MPNetLMHead(nn.Module):
         # Need a link between the two variables so that the bias is correctly resized with `resize_token_embeddings`
         self.decoder.bias = self.bias
 
-    def forward(self, features, **kwargs):
+    def forward(self, features, *args, **kwargs):
         x = self.dense(features)
         x = gelu(x)
         x = self.layer_norm(x)
@@ -951,7 +957,7 @@ class MPNetClassificationHead(nn.Module):
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
         self.out_proj = nn.Linear(config.hidden_size, config.num_labels)
 
-    def forward(self, features, **kwargs):
+    def forward(self, features, *args, **kwargs):
         x = features[:, 0, :]  # take <s> token (equiv. to BERT's [CLS] token)
         x = self.dropout(x)
         x = self.dense(x)

--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -406,6 +406,15 @@ class FeaturesManager:
             "image-classification",
             onnx_config_cls="models.mobilevit.MobileViTOnnxConfig",
         ),
+        "mpnet": supported_features_mapping(
+            "default",
+            "masked-lm",
+            "sequence-classification",
+            "multiple-choice",
+            "token-classification",
+            "question-answering",
+            onnx_config_cls="models.mpnet.MPNetOnnxConfig",
+        ),
         "mt5": supported_features_mapping(
             "default",
             "default-with-past",

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -200,6 +200,7 @@ PYTORCH_EXPORT_MODELS = {
     ("squeezebert", "squeezebert/squeezebert-uncased"),
     ("mobilebert", "google/mobilebert-uncased"),
     ("mobilevit", "apple/mobilevit-small"),
+    ("mpnet", "hf-internal-testing/tiny-random-mpnet"),
     ("xlm", "xlm-clm-ende-1024"),
     ("xlm-roberta", "xlm-roberta-base"),
     ("layoutlm", "microsoft/layoutlm-base-uncased"),


### PR DESCRIPTION
# What does this PR do?

This PR Adds `OnnxConfig` for MPNet based models. 

In order for the conversion to be compatible with some older versions of PyTorch (In my case 1.11.0), I had to add `*args`, to the signature of `forward` functions that were using `**kwargs`. This was because `_decide_input_format` in PyTorch considered `**kwargs` as a normal parameter so it added an additional (unexpected) positional argument (with value None).

https://github.com/pytorch/pytorch/blob/33bb8ae350611760139457b85842b1d7edf9aa11/torch/onnx/utils.py#L793

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. #16308 
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@ChainYo 
