### PR TITLE
add missing `require_tf` for `TFOPTGenerationTest` 

### DIFF
--- a/tests/models/opt/test_modeling_tf_opt.py
+++ b/tests/models/opt/test_modeling_tf_opt.py
@@ -315,6 +315,7 @@ class TFOPTEmbeddingsTest(unittest.TestCase):
         self.assertTrue(np.allclose(logits, logits_meta, atol=1e-4))
 
 
+@require_tf
 @slow
 class TFOPTGenerationTest(unittest.TestCase):
     @property


### PR DESCRIPTION
# What does this PR do?

On scheduled CI, it was fine, as the docker image have TF installed.
On past CI project, it failed due to the lack of TF.

In any case, we should have `require_tf` for this test.