### PR TITLE
Re-add support for single url files in objects download

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -32,7 +32,9 @@ from .utils import (
     PushToHubMixin,
     cached_file,
     copy_func,
+    download_url,
     extract_commit_hash,
+    is_remote_url,
     is_torch_available,
     logging,
 )
@@ -592,9 +594,12 @@ class PretrainedConfig(PushToHubMixin):
 
         is_local = os.path.isdir(pretrained_model_name_or_path)
         if os.path.isfile(os.path.join(subfolder, pretrained_model_name_or_path)):
-            # Soecial case when pretrained_model_name_or_path is a local file
+            # Special case when pretrained_model_name_or_path is a local file
             resolved_config_file = pretrained_model_name_or_path
             is_local = True
+        elif is_remote_url(pretrained_model_name_or_path):
+            configuration_file = pretrained_model_name_or_path
+            resolved_config_file = download_url(pretrained_model_name_or_path)
         else:
             configuration_file = kwargs.pop("_configuration_file", CONFIG_NAME)
 

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -31,8 +31,10 @@ from .utils import (
     TensorType,
     cached_file,
     copy_func,
+    download_url,
     is_flax_available,
     is_offline_mode,
+    is_remote_url,
     is_tf_available,
     is_torch_available,
     logging,
@@ -386,6 +388,9 @@ class FeatureExtractionMixin(PushToHubMixin):
         if os.path.isfile(pretrained_model_name_or_path):
             resolved_feature_extractor_file = pretrained_model_name_or_path
             is_local = True
+        elif is_remote_url(pretrained_model_name_or_path):
+            feature_extractor_file = pretrained_model_name_or_path
+            resolved_feature_extractor_file = download_url(pretrained_model_name_or_path)
         else:
             feature_extractor_file = FEATURE_EXTRACTOR_NAME
             try:

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -47,8 +47,10 @@ from .utils import (
     add_start_docstrings_to_model_forward,
     cached_file,
     copy_func,
+    download_url,
     has_file,
     is_offline_mode,
+    is_remote_url,
     logging,
     replace_return_docstrings,
 )
@@ -677,6 +679,9 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
             elif os.path.isfile(pretrained_model_name_or_path):
                 archive_file = pretrained_model_name_or_path
                 is_local = True
+            elif is_remote_url(pretrained_model_name_or_path):
+                archive_file = pretrained_model_name_or_path
+                resolved_archive_file = download_url(pretrained_model_name_or_path)
             else:
                 filename = WEIGHTS_NAME if from_pt else FLAX_WEIGHTS_NAME
                 try:

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -54,9 +54,11 @@ from .utils import (
     ModelOutput,
     PushToHubMixin,
     cached_file,
+    download_url,
     find_labels,
     has_file,
     is_offline_mode,
+    is_remote_url,
     logging,
     requires_backends,
     working_or_temp_dir,
@@ -2345,6 +2347,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             elif os.path.isfile(pretrained_model_name_or_path + ".index"):
                 archive_file = pretrained_model_name_or_path + ".index"
                 is_local = True
+            elif is_remote_url(pretrained_model_name_or_path):
+                archive_file = pretrained_model_name_or_path
+                resolved_archive_file = download_url(pretrained_model_name_or_path)
             else:
                 # set correct filename
                 filename = WEIGHTS_NAME if from_pt else TF2_WEIGHTS_NAME

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -59,10 +59,12 @@ from .utils import (
     PushToHubMixin,
     cached_file,
     copy_func,
+    download_url,
     has_file,
     is_accelerate_available,
     is_bitsandbytes_available,
     is_offline_mode,
+    is_remote_url,
     logging,
     replace_return_docstrings,
 )
@@ -1998,6 +2000,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     )
                 archive_file = os.path.join(subfolder, pretrained_model_name_or_path + ".index")
                 is_local = True
+            elif is_remote_url(pretrained_model_name_or_path):
+                archive_file = pretrained_model_name_or_path
+                resolved_archive_file = download_url(pretrained_model_name_or_path)
             else:
                 # set correct filename
                 if from_tf:

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -42,9 +42,11 @@ from .utils import (
     add_end_docstrings,
     cached_file,
     copy_func,
+    download_url,
     extract_commit_hash,
     is_flax_available,
     is_offline_mode,
+    is_remote_url,
     is_tf_available,
     is_tokenizers_available,
     is_torch_available,
@@ -1680,6 +1682,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 FutureWarning,
             )
             file_id = list(cls.vocab_files_names.keys())[0]
+
             vocab_files[file_id] = pretrained_model_name_or_path
         else:
             # At this point pretrained_model_name_or_path is either a directory or a model identifier name
@@ -1723,6 +1726,8 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         for file_id, file_path in vocab_files.items():
             if file_path is None:
                 resolved_vocab_files[file_id] = None
+            elif is_remote_url(file_path):
+                resolved_vocab_files[file_id] = download_url(file_path, proxies=proxies)
             else:
                 resolved_vocab_files[file_id] = cached_file(
                     pretrained_model_name_or_path,

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -63,6 +63,7 @@ from .hub import (
     cached_file,
     default_cache_path,
     define_sagemaker_information,
+    download_url,
     extract_commit_hash,
     get_cached_models,
     get_file_from_repo,
@@ -70,6 +71,7 @@ from .hub import (
     has_file,
     http_user_agent,
     is_offline_mode,
+    is_remote_url,
     move_cache,
     send_example_telemetry,
 )


### PR DESCRIPTION
# What does this PR do?

During the cache revamp done in #18438, we accidentally lost support for single urls in `from_pretrained` methods (something like `config = AutoConfig.from_pretrained("http://my_custom_config.json")`. This is not something we want to support in the long run as users should use the Hub to store their objects, but this is still a breaking change.

This PR adds support for this corner case with proper deprecation warnings. Note that such urls are not cached anymore.