### PR TITLE
Fix `DocumentQuestionAnsweringPipelineTests`

### DIFF
--- a/tests/pipelines/test_pipelines_document_question_answering.py
+++ b/tests/pipelines/test_pipelines_document_question_answering.py
@@ -219,8 +219,8 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {"score": 0.9998, "answer": "us-001", "start": 15, "end": 15},
-                {"score": 0.0, "answer": "INVOICE # us-001", "start": 13, "end": 15},
+                {'score': 0.4251, 'answer': 'us-001', 'start': 16, 'end': 16},
+                {'score': 0.0819, 'answer': '1110212019', 'start': 23, 'end': 23},
             ],
         )
 
@@ -228,8 +228,8 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {"score": 0.9998, "answer": "us-001", "start": 15, "end": 15},
-                {"score": 0.0, "answer": "INVOICE # us-001", "start": 13, "end": 15},
+                {'score': 0.4251, 'answer': 'us-001', 'start': 16, 'end': 16},
+                {'score': 0.0819, 'answer': '1110212019', 'start': 23, 'end': 23},
             ],
         )
 
@@ -240,8 +240,8 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
             nested_simplify(outputs, decimals=4),
             [
                 [
-                    {"score": 0.9998, "answer": "us-001", "start": 15, "end": 15},
-                    {"score": 0.0, "answer": "INVOICE # us-001", "start": 13, "end": 15},
+                    {'score': 0.4251, 'answer': 'us-001', 'start': 16, 'end': 16},
+                    {'score': 0.0819, 'answer': '1110212019', 'start': 23, 'end': 23},
                 ]
             ]
             * 2,
@@ -254,8 +254,8 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {"score": 0.9998, "answer": "us-001", "start": 15, "end": 15},
-                {"score": 0.0, "answer": "INVOICE # us-001", "start": 13, "end": 15},
+                {'score': 0.4251, 'answer': 'us-001', 'start': 16, 'end': 16},
+                {'score': 0.0819, 'answer': '1110212019', 'start': 23, 'end': 23},
             ],
         )
 

--- a/tests/pipelines/test_pipelines_document_question_answering.py
+++ b/tests/pipelines/test_pipelines_document_question_answering.py
@@ -170,8 +170,8 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {"score": 0.9966, "answer": "us-001", "start": 15, "end": 15},
-                {"score": 0.0009, "answer": "us-001", "start": 15, "end": 15},
+                {'score': 0.9944, 'answer': 'us-001', 'start': 16, 'end': 16},
+                {'score': 0.0009, 'answer': 'us-001', 'start': 16, 'end': 16},
             ],
         )
 

--- a/tests/pipelines/test_pipelines_document_question_answering.py
+++ b/tests/pipelines/test_pipelines_document_question_answering.py
@@ -113,13 +113,8 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
         question = "How many cats are there?"
 
         expected_output = [
-            {
-                "score": 0.0001,
-                "answer": "2312/2019 DUE DATE 26102/2019 ay DESCRIPTION UNIT PRICE",
-                "start": 38,
-                "end": 45,
-            },
-            {"score": 0.0001, "answer": "2312/2019 DUE", "start": 38, "end": 39},
+            {'score': 0.0001, 'answer': 'oy 2312/2019', 'start': 38, 'end': 39},
+            {'score': 0.0001, 'answer': 'oy 2312/2019 DUE', 'start': 38, 'end': 40},
         ]
         outputs = dqa_pipeline(image=image, question=question, top_k=2)
         self.assertEqual(nested_simplify(outputs, decimals=4), expected_output)

--- a/tests/pipelines/test_pipelines_document_question_answering.py
+++ b/tests/pipelines/test_pipelines_document_question_answering.py
@@ -179,8 +179,8 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {"score": 0.9966, "answer": "us-001", "start": 15, "end": 15},
-                {"score": 0.0009, "answer": "us-001", "start": 15, "end": 15},
+                {'score': 0.9944, 'answer': 'us-001', 'start': 16, 'end': 16},
+                {'score': 0.0009, 'answer': 'us-001', 'start': 16, 'end': 16},
             ],
         )
 
@@ -191,8 +191,8 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
             nested_simplify(outputs, decimals=4),
             [
                 [
-                    {"score": 0.9966, "answer": "us-001", "start": 15, "end": 15},
-                    {"score": 0.0009, "answer": "us-001", "start": 15, "end": 15},
+                    {'score': 0.9944, 'answer': 'us-001', 'start': 16, 'end': 16},
+                    {'score': 0.0009, 'answer': 'us-001', 'start': 16, 'end': 16},
                 ],
             ]
             * 2,

--- a/tests/pipelines/test_pipelines_document_question_answering.py
+++ b/tests/pipelines/test_pipelines_document_question_answering.py
@@ -113,8 +113,8 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
         question = "How many cats are there?"
 
         expected_output = [
-            {'score': 0.0001, 'answer': 'oy 2312/2019', 'start': 38, 'end': 39},
-            {'score': 0.0001, 'answer': 'oy 2312/2019 DUE', 'start': 38, 'end': 40},
+            {"score": 0.0001, "answer": "oy 2312/2019", "start": 38, "end": 39},
+            {"score": 0.0001, "answer": "oy 2312/2019 DUE", "start": 38, "end": 40},
         ]
         outputs = dqa_pipeline(image=image, question=question, top_k=2)
         self.assertEqual(nested_simplify(outputs, decimals=4), expected_output)
@@ -165,8 +165,8 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {'score': 0.9944, 'answer': 'us-001', 'start': 16, 'end': 16},
-                {'score': 0.0009, 'answer': 'us-001', 'start': 16, 'end': 16},
+                {"score": 0.9944, "answer": "us-001", "start": 16, "end": 16},
+                {"score": 0.0009, "answer": "us-001", "start": 16, "end": 16},
             ],
         )
 
@@ -174,8 +174,8 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {'score': 0.9944, 'answer': 'us-001', 'start': 16, 'end': 16},
-                {'score': 0.0009, 'answer': 'us-001', 'start': 16, 'end': 16},
+                {"score": 0.9944, "answer": "us-001", "start": 16, "end": 16},
+                {"score": 0.0009, "answer": "us-001", "start": 16, "end": 16},
             ],
         )
 
@@ -186,8 +186,8 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
             nested_simplify(outputs, decimals=4),
             [
                 [
-                    {'score': 0.9944, 'answer': 'us-001', 'start': 16, 'end': 16},
-                    {'score': 0.0009, 'answer': 'us-001', 'start': 16, 'end': 16},
+                    {"score": 0.9944, "answer": "us-001", "start": 16, "end": 16},
+                    {"score": 0.0009, "answer": "us-001", "start": 16, "end": 16},
                 ],
             ]
             * 2,
@@ -214,8 +214,8 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {'score': 0.4251, 'answer': 'us-001', 'start': 16, 'end': 16},
-                {'score': 0.0819, 'answer': '1110212019', 'start': 23, 'end': 23},
+                {"score": 0.4251, "answer": "us-001", "start": 16, "end": 16},
+                {"score": 0.0819, "answer": "1110212019", "start": 23, "end": 23},
             ],
         )
 
@@ -223,8 +223,8 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {'score': 0.4251, 'answer': 'us-001', 'start': 16, 'end': 16},
-                {'score': 0.0819, 'answer': '1110212019', 'start': 23, 'end': 23},
+                {"score": 0.4251, "answer": "us-001", "start": 16, "end": 16},
+                {"score": 0.0819, "answer": "1110212019", "start": 23, "end": 23},
             ],
         )
 
@@ -235,8 +235,8 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
             nested_simplify(outputs, decimals=4),
             [
                 [
-                    {'score': 0.4251, 'answer': 'us-001', 'start': 16, 'end': 16},
-                    {'score': 0.0819, 'answer': '1110212019', 'start': 23, 'end': 23},
+                    {"score": 0.4251, "answer": "us-001", "start": 16, "end": 16},
+                    {"score": 0.0819, "answer": "1110212019", "start": 23, "end": 23},
                 ]
             ]
             * 2,
@@ -249,8 +249,8 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {'score': 0.4251, 'answer': 'us-001', 'start': 16, 'end': 16},
-                {'score': 0.0819, 'answer': '1110212019', 'start': 23, 'end': 23},
+                {"score": 0.4251, "answer": "us-001", "start": 16, "end": 16},
+                {"score": 0.0819, "answer": "1110212019", "start": 23, "end": 23},
             ],
         )
 


### PR DESCRIPTION
# What does this PR do?

Fix failing tests in `DocumentQuestionAnsweringPipelineTests` by updating the expected values.

This pipeline is added on Sep 7, and these tests are failing since then.