### PR TITLE
Add Document QA pipeline metadata

### DIFF
--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -80,6 +80,11 @@ PIPELINE_TAGS_AND_AUTO_MODELS = [
         "AutoModelForAudioFrameClassification",
     ),
     ("audio-xvector", "MODEL_FOR_AUDIO_XVECTOR_MAPPING_NAMES", "AutoModelForAudioXVector"),
+    (
+        "document-question-answering",
+        "MODEL_FOR_DOCUMENT_QUESTION_ANSWERING_MAPPING_NAMES",
+        "AutoModelForDocumentQuestionAnswering",
+    ),
 ]
 
 


### PR DESCRIPTION
# What does this PR do?

This completes the table used to generate the metadata for inferring the right pipeline tags with the newly added Document QA pipeline. More are probably missing, will touch this in another PR that also adds some automatic scripting to detect missing pipelines there :-)