### PR TITLE
Mark right save_load test as slow

### DIFF
--- a/tests/models/vit_mae/test_modeling_tf_vit_mae.py
+++ b/tests/models/vit_mae/test_modeling_tf_vit_mae.py
@@ -328,7 +328,6 @@ class TFViTMAEModelTest(TFModelTesterMixin, unittest.TestCase):
 
     # overwrite from common since TFViTMAEForPretraining has random masking, we need to fix the noise
     # to generate masks during test
-    @slow
     def test_keras_save_load(self):
         # make mask reproducible
         np.random.seed(2)
@@ -376,6 +375,7 @@ class TFViTMAEModelTest(TFModelTesterMixin, unittest.TestCase):
 
     # overwrite from common since TFViTMAEForPretraining has random masking, we need to fix the noise
     # to generate masks during test
+    @slow
     def test_save_load(self):
         # make mask reproducible
         np.random.seed(2)


### PR DESCRIPTION
# What does this PR do?

Tried to mark the `test_save_load` as slow for TFVitMAE with a simple commit on main, but it looks to be too complicated a task :sweat_smile: 

Sooo putting the decorator on the right tests ;-)