### PR TITLE
Add safeguards for CUDA kernel load in Deformable DETR

### DIFF
--- a/src/transformers/models/deformable_detr/modeling_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modeling_deformable_detr.py
@@ -41,7 +41,7 @@ from ...file_utils import (
 )
 from ...modeling_outputs import BaseModelOutput
 from ...modeling_utils import PreTrainedModel
-from ...utils import logging
+from ...utils import is_ninja_available, logging
 from .configuration_deformable_detr import DeformableDetrConfig
 from .load_custom import load_cuda_kernels
 
@@ -49,9 +49,13 @@ from .load_custom import load_cuda_kernels
 logger = logging.get_logger(__name__)
 
 # Move this to not compile only when importing, this needs to happen later, like in __init__.
-if is_torch_cuda_available():
+if is_torch_cuda_available() and is_ninja_available():
     logger.info("Loading custom CUDA kernels...")
-    MultiScaleDeformableAttention = load_cuda_kernels()
+    try:
+        MultiScaleDeformableAttention = load_cuda_kernels()
+    except Exception as e:
+        logger.warning(f"Could not load the custom kernel for multi-scale deformable attention: {e}")
+        MultiScaleDeformableAttention = None
 else:
     MultiScaleDeformableAttention = None
 

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -98,6 +98,7 @@ from .import_utils import (
     is_in_notebook,
     is_ipex_available,
     is_librosa_available,
+    is_ninja_available,
     is_onnx_available,
     is_pandas_available,
     is_phonemizer_available,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -471,6 +471,10 @@ def is_apex_available():
     return importlib.util.find_spec("apex") is not None
 
 
+def is_ninja_available():
+    return importlib.util.find_spec("ninja") is not None
+
+
 def is_ipex_available():
     def get_major_and_minor_from_version(full_version):
         return str(version.parse(full_version).major) + "." + str(version.parse(full_version).minor)


### PR DESCRIPTION
# What does this PR do?

Transformers has become unusable on GPU when doing some imports since:
- deformable DETR compiles some custom CUDA kernels at init
- this require ninja which is not in the dependencies

This PR adds some additional checks before compiling the CUDA kernels, and also adds a warning instead of a hard error when that load fails.