### PR TITLE
Pin minimum PyTorch version for BLOOM ONNX export

### DIFF
--- a/src/transformers/models/bloom/configuration_bloom.py
+++ b/src/transformers/models/bloom/configuration_bloom.py
@@ -16,6 +16,8 @@
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, List, Mapping, Optional
 
+from packaging import version
+
 from transformers import is_torch_available
 
 
@@ -154,6 +156,9 @@ class BloomConfig(PretrainedConfig):
 
 
 class BloomOnnxConfig(OnnxConfigWithPast):
+
+    torch_onnx_minimum_version = version.parse("1.12")
+
     def __init__(
         self,
         config: PretrainedConfig,


### PR DESCRIPTION
# What does this PR do?

Due to the deprecation of `position_ids` in https://github.com/huggingface/transformers/pull/18342, the BLOOM ONNX export fails unless the `torch` version is >= 1.12

This PR fixes that by pinning the minimum required version in the ONNX configuration (the user gets a warning now).
