### PR TITLE
Organize test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,13 @@ jobs:
         parallelism: 1
         steps:
             - checkout
+            - attach_workspace:
+                at:  ~/transformers/test_preparation
+            - run: |
+                if [ ! -s test_preparation/test_list.txt ]; then
+                    echo "No tests to run, exiting early!"
+                    circleci-agent step halt
+                fi
             - restore_cache:
                   keys:
                       - v0.5-torch_and_tf-{{ checksum "setup.py" }}
@@ -103,42 +110,6 @@ jobs:
             - store_artifacts:
                   path: ~/transformers/reports
 
-    run_tests_torch_and_tf_all:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        environment:
-            OMP_NUM_THREADS: 1
-            RUN_PT_TF_CROSS_TESTS: yes
-            TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 120
-        resource_class: xlarge
-        parallelism: 1
-        steps:
-            - checkout
-            - restore_cache:
-                  keys:
-                      - v0.5-torch_and_tf-{{ checksum "setup.py" }}
-                      - v0.5-{{ checksum "setup.py" }}
-            - run: sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev espeak-ng git-lfs
-            - run: git lfs install
-            - run: pip install --upgrade pip
-            - run: pip install .[sklearn,tf-cpu,torch,testing,sentencepiece,torch-speech,vision]
-            - run: pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-1.12.0+cpu.html
-            - run: pip install tensorflow_probability
-            - run: pip install https://github.com/kpu/kenlm/archive/master.zip
-            - run: pip install git+https://github.com/huggingface/accelerate
-            - save_cache:
-                key: v0.5-{{ checksum "setup.py" }}
-                paths:
-                    - '~/.cache/pip'
-            - run: |
-                  python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_torch_and_tf tests -m is_pt_tf_cross_test --durations=0 | tee tests_output.txt
-            - store_artifacts:
-                  path: ~/transformers/tests_output.txt
-            - store_artifacts:
-                  path: ~/transformers/reports
-
     run_tests_torch_and_flax:
         working_directory: ~/transformers
         docker:
@@ -152,6 +123,13 @@ jobs:
         parallelism: 1
         steps:
             - checkout
+            - attach_workspace:
+                at:  ~/transformers/test_preparation
+            - run: |
+                if [ ! -s test_preparation/test_list.txt ]; then
+                    echo "No tests to run, exiting early!"
+                    circleci-agent step halt
+                fi
             - restore_cache:
                   keys:
                       - v0.5-torch_and_flax-{{ checksum "setup.py" }}
@@ -178,40 +156,6 @@ jobs:
             - store_artifacts:
                   path: ~/transformers/reports
 
-    run_tests_torch_and_flax_all:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        environment:
-            OMP_NUM_THREADS: 1
-            RUN_PT_FLAX_CROSS_TESTS: yes
-            TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 120
-        resource_class: xlarge
-        parallelism: 1
-        steps:
-            - checkout
-            - restore_cache:
-                  keys:
-                      - v0.5-torch_and_flax-{{ checksum "setup.py" }}
-                      - v0.5-{{ checksum "setup.py" }}
-            - run: sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev espeak-ng
-            - run: pip install --upgrade pip
-            - run: pip install .[sklearn,flax,torch,testing,sentencepiece,torch-speech,vision]
-            - run: pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-1.12.0+cpu.html
-            - run: pip install https://github.com/kpu/kenlm/archive/master.zip
-            - run: pip install git+https://github.com/huggingface/accelerate
-            - save_cache:
-                key: v0.5-{{ checksum "setup.py" }}
-                paths:
-                    - '~/.cache/pip'
-            - run: |
-                  python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_torch_and_flax tests -m is_pt_flax_cross_test --durations=0 | tee tests_output.txt
-            - store_artifacts:
-                  path: ~/transformers/tests_output.txt
-            - store_artifacts:
-                  path: ~/transformers/reports
-
     run_tests_torch:
         working_directory: ~/transformers
         docker:
@@ -223,6 +167,13 @@ jobs:
         resource_class: xlarge
         parallelism: 1
         steps:
+            - attach_workspace:
+                at:  ~/transformers/test_preparation
+            - run: |
+                if [ ! -s test_preparation/test_list.txt ]; then
+                    echo "No tests to run, exiting early!"
+                    circleci-agent step halt
+                fi
             - checkout
             - restore_cache:
                   keys:
@@ -566,6 +517,13 @@ jobs:
             TRANSFORMERS_IS_CI: yes
             PYTEST_TIMEOUT: 120
         steps:
+            - attach_workspace:
+                at:  ~/transformers/test_preparation
+            - run: |
+                if [ ! -s test_preparation/test_list.txt ]; then
+                    echo "No tests to run, exiting early!"
+                    circleci-agent step halt
+                fi
             - checkout
             - restore_cache:
                   keys:
@@ -1165,7 +1123,6 @@ jobs:
         working_directory: ~/transformers
         docker:
             - image: cimg/python:3.7.12
-        resource_class: large
         parallelism: 1
         steps:
             - attach_workspace:
@@ -1187,10 +1144,10 @@ workflows:
     version: 2
     build_and_test:
         jobs:
-            - fetch_all_tests
-            - run_tests:
+            - fetch_tests
+            - run_tests_custom_tokenizers:
                 requires:
-                  - fetch_all_tests
+                  - fetch_tests
 #            - check_code_quality
 #            - check_repository_consistency
 #            - run_examples_torch
@@ -1216,20 +1173,20 @@ workflows:
                         only:
                             - main
         jobs:
-            - run_examples_torch_all
-            - run_examples_tensorflow_all
-            - run_examples_flax_all
-            - run_tests_custom_tokenizers_all
-            - run_tests_torch_and_tf_all
-            - run_tests_torch_and_flax_all
+#            - run_examples_torch_all
+#            - run_examples_tensorflow_all
+#            - run_examples_flax_all
+#            - run_tests_custom_tokenizers_all
+#            - run_tests_torch_and_tf_all
+#            - run_tests_torch_and_flax_all
             - run_tests_torch_all
-            - run_tests_tf_all
-            - run_tests_flax_all
-            - run_tests_pipelines_torch_all
-            - run_tests_pipelines_tf_all
-            - run_tests_onnxruntime_all
-            - run_tests_hub_all
-            - run_tests_layoutlmv2_and_v3_all
+#            - run_tests_tf_all
+#            - run_tests_flax_all
+#            - run_tests_pipelines_torch_all
+#            - run_tests_pipelines_tf_all
+#            - run_tests_onnxruntime_all
+#            - run_tests_hub_all
+#            - run_tests_layoutlmv2_and_v3_all
 
 #    tpu_testing_jobs:
 #        triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1123,8 +1123,6 @@ jobs:
         working_directory: ~/transformers
         docker:
             - image: cimg/python:3.7.12
-        environment:
-            TRANSFORMERS_IS_CI: yes
         resource_class: large
         parallelism: 1
         steps:
@@ -1147,6 +1145,21 @@ jobs:
                 root: test_preparation/
                 paths:
                     test_list.txt
+
+    fetch_all_tests:
+        working_directory: ~/transformers
+        docker:
+            - image: cimg/python:3.7.12
+        parallelism: 1
+        steps:
+            - run: |
+                  mkdir test_preparation
+                  echo "tests" > test_preparation/test_list.txt
+
+            - persist_to_workspace:
+                  root: test_preparation/
+                  paths:
+                      test_list.txt
 
     run_tests:
         working_directory: ~/transformers
@@ -1174,10 +1187,10 @@ workflows:
     version: 2
     build_and_test:
         jobs:
-            - fetch_tests
+            - fetch_tests_all
             - run_tests:
                 requires:
-                  - fetch_tests
+                  - fetch_tests_all
 #            - check_code_quality
 #            - check_repository_consistency
 #            - run_examples_torch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1187,10 +1187,10 @@ workflows:
     version: 2
     build_and_test:
         jobs:
-            - fetch_tests_all
+            - fetch_all_tests
             - run_tests:
                 requires:
-                  - fetch_tests_all
+                  - fetch_all_tests
 #            - check_code_quality
 #            - check_repository_consistency
 #            - run_examples_torch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1133,13 +1133,18 @@ jobs:
             - run: pip install GitPython
             - run: pip install .
             - run: mkdir -p test_preparation
-            - run: python utils/tests_fetcher.py | tee test_preparation/to_run.txt
+            - run: python utils/tests_fetcher.py | tee tests_fetched_summary.txt
             - store_artifacts:
-                  path: ~/transformers/test_preparation/to_run.txt
+                path: ~/transformers/tests_fetched_summary.txt
+            - run: |
+                if [ -f test_list.txt ]; then
+                    mv test_list.txt test_preparation/test_list.txt
+                fi
+
             - persist_to_workspace:
-                  root: test_preparation/
-                  paths:
-                      - to_run.txt
+                root: test_preparation/
+                paths:
+                    - to_run.txt
 
     run_tests:
         working_directory: ~/transformers
@@ -1150,7 +1155,13 @@ jobs:
         steps:
             - attach_workspace:
                 at:  ~/transformers/test_preparation
-            - run: cat ~/transformers/test_preparation/to_run.txt
+            - run: |
+                if [ ! -f test_preparation/test_list.txt ]; then
+                    echo "No tests to run, exiting early!"
+                    circleci-agent step halt
+                fi
+            - run: echo "Running tests!"
+            - run: cat test_preparation/test_list.txt
 
 workflow_filters: &workflow_filters
     filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1119,6 +1119,38 @@ jobs:
                   perform-login: true
             - *delete_gke_jobs
 
+    fetch_tests:
+        working_directory: ~/transformers
+        docker:
+            - image: cimg/python:3.7.12
+        environment:
+            TRANSFORMERS_IS_CI: yes
+        resource_class: large
+        parallelism: 1
+        steps:
+            - checkout
+            - run: pip install --upgrade pip
+            - run: pip install .
+            - run: mkdir -p test_preparation
+            - run: python utils/tests_fetcher.py | tee test_preparation/to_run.txt
+            - store_artifacts:
+                  path: ~/transformers/test_preparation/to_run.txt
+            - persist_to_workspace:
+                  root: test_preparation/
+                  paths:
+                      - to_run.txt
+
+    run_tests:
+        working_directory: ~/transformers
+        docker:
+            - image: cimg/python:3.7.12
+        resource_class: large
+        parallelism: 1
+        steps:
+            - attach_workspace:
+                at:  ~/transformers/test_preparation
+            - run: cat ~/transformers/test_preparation/to_run.txt
+
 workflow_filters: &workflow_filters
     filters:
         branches:
@@ -1128,22 +1160,26 @@ workflows:
     version: 2
     build_and_test:
         jobs:
-            - check_code_quality
-            - check_repository_consistency
-            - run_examples_torch
-            - run_examples_tensorflow
-            - run_examples_flax
-            - run_tests_custom_tokenizers
-            - run_tests_torch_and_tf
-            - run_tests_torch_and_flax
-            - run_tests_torch
-            - run_tests_tf
-            - run_tests_flax
-            - run_tests_pipelines_torch
-            - run_tests_pipelines_tf
-            - run_tests_onnxruntime
-            - run_tests_hub
-            - run_tests_layoutlmv2_and_v3
+            - fetch_tests
+            - run_tests
+                requires
+                  - fetch_tests
+#            - check_code_quality
+#            - check_repository_consistency
+#            - run_examples_torch
+#            - run_examples_tensorflow
+#            - run_examples_flax
+#            - run_tests_custom_tokenizers
+#            - run_tests_torch_and_tf
+#            - run_tests_torch_and_flax
+#            - run_tests_torch
+#            - run_tests_tf
+#            - run_tests_flax
+#            - run_tests_pipelines_torch
+#            - run_tests_pipelines_tf
+#            - run_tests_onnxruntime
+#            - run_tests_hub
+#            - run_tests_layoutlmv2_and_v3
     nightly:
         triggers:
             - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1130,6 +1130,7 @@ jobs:
         steps:
             - checkout
             - run: pip install --upgrade pip
+            - run: pip install GitPython
             - run: pip install .
             - run: mkdir -p test_preparation
             - run: python utils/tests_fetcher.py | tee test_preparation/to_run.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1139,12 +1139,14 @@ jobs:
             - run: |
                 if [ -f test_list.txt ]; then
                     mv test_list.txt test_preparation/test_list.txt
+                else
+                    touch test_preparation/test_list.txt
                 fi
 
             - persist_to_workspace:
                 root: test_preparation/
                 paths:
-                    - to_run.txt
+                    test_list.txt
 
     run_tests:
         working_directory: ~/transformers
@@ -1156,7 +1158,7 @@ jobs:
             - attach_workspace:
                 at:  ~/transformers/test_preparation
             - run: |
-                if [ ! -f test_preparation/test_list.txt ]; then
+                if [ ! -s test_preparation/test_list.txt ]; then
                     echo "No tests to run, exiting early!"
                     circleci-agent step halt
                 fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,49 @@ references:
 
 
 jobs:
+    # Fetch the tests to run
+    fetch_tests:
+        working_directory: ~/transformers
+        docker:
+            - image: cimg/python:3.7.12
+        parallelism: 1
+        steps:
+            - checkout
+            - run: pip install --upgrade pip
+            - run: pip install GitPython
+            - run: pip install .
+            - run: mkdir -p test_preparation
+            - run: python utils/tests_fetcher.py | tee tests_fetched_summary.txt
+            - store_artifacts:
+                path: ~/transformers/tests_fetched_summary.txt
+            - run: |
+                if [ -f test_list.txt ]; then
+                    mv test_list.txt test_preparation/test_list.txt
+                else
+                    touch test_preparation/test_list.txt
+                fi
+
+            - persist_to_workspace:
+                root: test_preparation/
+                paths:
+                    test_list.txt
+
+    # To run all tests for the nightly build
+    fetch_all_tests:
+        working_directory: ~/transformers
+        docker:
+            - image: cimg/python:3.7.12
+        parallelism: 1
+        steps:
+            - run: |
+                  mkdir test_preparation
+                  echo "tests" > test_preparation/test_list.txt
+
+            - persist_to_workspace:
+                  root: test_preparation/
+                  paths:
+                      test_list.txt
+
     run_tests_torch_and_tf:
         working_directory: ~/transformers
         docker:
@@ -98,13 +141,7 @@ jobs:
                 key: v0.5-{{ checksum "setup.py" }}
                 paths:
                     - '~/.cache/pip'
-            - run: python utils/tests_fetcher.py | tee test_preparation.txt
-            - store_artifacts:
-                  path: ~/transformers/test_preparation.txt
-            - run: |
-                  if [ -f test_list.txt ]; then
-                    python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_torch_and_tf $(cat test_list.txt) -m is_pt_tf_cross_test --durations=0 | tee tests_output.txt
-                  fi
+            - run: python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_torch_and_tf $(cat test_preparation/test_list.txt) -m is_pt_tf_cross_test --durations=0 | tee tests_output.txt
             - store_artifacts:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
@@ -144,13 +181,7 @@ jobs:
                 key: v0.5-{{ checksum "setup.py" }}
                 paths:
                     - '~/.cache/pip'
-            - run: python utils/tests_fetcher.py | tee test_preparation.txt
-            - store_artifacts:
-                  path: ~/transformers/test_preparation.txt
-            - run: |
-                  if [ -f test_list.txt ]; then
-                    python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_torch_and_flax $(cat test_list.txt) -m is_pt_flax_cross_test --durations=0 | tee tests_output.txt
-                  fi
+            - run: python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_torch_and_flax $(cat test_preparation/test_list.txt) -m is_pt_flax_cross_test --durations=0 | tee tests_output.txt
             - store_artifacts:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
@@ -167,6 +198,7 @@ jobs:
         resource_class: xlarge
         parallelism: 1
         steps:
+            - checkout
             - attach_workspace:
                 at:  ~/transformers/test_preparation
             - run: |
@@ -174,7 +206,6 @@ jobs:
                     echo "No tests to run, exiting early!"
                     circleci-agent step halt
                 fi
-            - checkout
             - restore_cache:
                   keys:
                       - v0.5-torch-{{ checksum "setup.py" }}
@@ -189,46 +220,7 @@ jobs:
                   key: v0.5-torch-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: python utils/tests_fetcher.py | tee test_preparation.txt
-            - store_artifacts:
-                  path: ~/transformers/test_preparation.txt
-            - run: |
-                  if [ -f test_list.txt ]; then
-                    python -m pytest -n 3 --max-worker-restart=0 --dist=loadfile -s --make-reports=tests_torch $(cat test_list.txt) | tee tests_output.txt
-                  fi
-            - store_artifacts:
-                  path: ~/transformers/tests_output.txt
-            - store_artifacts:
-                  path: ~/transformers/reports
-
-    run_tests_torch_all:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        environment:
-            OMP_NUM_THREADS: 1
-            TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 120
-        resource_class: xlarge
-        parallelism: 1
-        steps:
-            - checkout
-            - restore_cache:
-                  keys:
-                      - v0.5-torch-{{ checksum "setup.py" }}
-                      - v0.5-{{ checksum "setup.py" }}
-            - run: sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev espeak-ng
-            - run: pip install --upgrade pip
-            - run: pip install .[sklearn,torch,testing,sentencepiece,torch-speech,vision,timm]
-            - run: pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-1.12.0+cpu.html
-            - run: pip install https://github.com/kpu/kenlm/archive/master.zip
-            - run: pip install git+https://github.com/huggingface/accelerate
-            - save_cache:
-                  key: v0.5-torch-{{ checksum "setup.py" }}
-                  paths:
-                      - '~/.cache/pip'
-            - run: |
-                  python -m pytest -n 3 --max-worker-restart=0 --dist=loadfile -s --make-reports=tests_torch tests | tee tests_output.txt
+            - run: python -m pytest -n 3 --max-worker-restart=0 --dist=loadfile -s --make-reports=tests_torch $(cat test_preparation/test_list.txt) | tee tests_output.txt
             - store_artifacts:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
@@ -246,6 +238,13 @@ jobs:
         parallelism: 1
         steps:
             - checkout
+            - attach_workspace:
+                at:  ~/transformers/test_preparation
+            - run: |
+                if [ ! -s test_preparation/test_list.txt ]; then
+                    echo "No tests to run, exiting early!"
+                    circleci-agent step halt
+                fi
             - restore_cache:
                   keys:
                       - v0.5-tf-{{ checksum "setup.py" }}
@@ -259,45 +258,7 @@ jobs:
                   key: v0.5-tf-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: python utils/tests_fetcher.py | tee test_preparation.txt
-            - store_artifacts:
-                  path: ~/transformers/test_preparation.txt
-            - run: |
-                  if [ -f test_list.txt ]; then
-                    python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_tf $(cat test_list.txt) | tee tests_output.txt
-                  fi
-            - store_artifacts:
-                  path: ~/transformers/tests_output.txt
-            - store_artifacts:
-                  path: ~/transformers/reports
-
-    run_tests_tf_all:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        environment:
-            OMP_NUM_THREADS: 1
-            TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 120
-        resource_class: xlarge
-        parallelism: 1
-        steps:
-            - checkout
-            - restore_cache:
-                  keys:
-                      - v0.5-tf-{{ checksum "setup.py" }}
-                      - v0.5-{{ checksum "setup.py" }}
-            - run: sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev espeak-ng
-            - run: pip install --upgrade pip
-            - run: pip install .[sklearn,tf-cpu,testing,sentencepiece,tf-speech,vision]
-            - run: pip install tensorflow_probability
-            - run: pip install https://github.com/kpu/kenlm/archive/master.zip
-            - save_cache:
-                  key: v0.5-tf-{{ checksum "setup.py" }}
-                  paths:
-                      - '~/.cache/pip'
-            - run: |
-                  python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_tf tests | tee tests_output.txt
+            - run: python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_tf $(cat test_preparation/test_list.txt) | tee tests_output.txt
             - store_artifacts:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
@@ -315,6 +276,13 @@ jobs:
         parallelism: 1
         steps:
             - checkout
+            - attach_workspace:
+                at:  ~/transformers/test_preparation
+            - run: |
+                if [ ! -s test_preparation/test_list.txt ]; then
+                    echo "No tests to run, exiting early!"
+                    circleci-agent step halt
+                fi
             - restore_cache:
                 keys:
                     - v0.5-flax-{{ checksum "setup.py" }}
@@ -327,47 +295,11 @@ jobs:
                   key: v0.5-flax-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: python utils/tests_fetcher.py | tee test_preparation.txt
-            - store_artifacts:
-                  path: ~/transformers/test_preparation.txt
-            - run: |
-                  if [ -f test_list.txt ]; then
-                    python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_flax $(cat test_list.txt) | tee tests_output.txt
-                  fi
+            - run: python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_flax $(cat test_preparation/test_list.txt) | tee tests_output.txt
             - store_artifacts:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
                   path: ~/transformers/reports
-
-    run_tests_flax_all:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        environment:
-            OMP_NUM_THREADS: 1
-            TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 120
-        resource_class: xlarge
-        parallelism: 1
-        steps:
-            - checkout
-            - restore_cache:
-                keys:
-                    - v0.5-flax-{{ checksum "setup.py" }}
-                    - v0.5-{{ checksum "setup.py" }}
-            - run: sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev espeak-ng
-            - run: pip install --upgrade pip
-            - run: pip install .[flax,testing,sentencepiece,vision,flax-speech]
-            - run: pip install https://github.com/kpu/kenlm/archive/master.zip
-            - save_cache:
-                  key: v0.5-flax-{{ checksum "setup.py" }}
-                  paths:
-                      - '~/.cache/pip'
-            - run: |
-                  python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_flax tests | tee tests_output.txt
-            - store_artifacts:
-                  path: ~/transformers/tests_output.txt
-            - store_artifacts:
                   path: ~/transformers/reports
 
     run_tests_pipelines_torch:
@@ -383,6 +315,13 @@ jobs:
         parallelism: 1
         steps:
             - checkout
+            - attach_workspace:
+                at:  ~/transformers/test_preparation
+            - run: |
+                if [ ! -s test_preparation/test_list.txt ]; then
+                    echo "No tests to run, exiting early!"
+                    circleci-agent step halt
+                fi
             - restore_cache:
                   keys:
                       - v0.5-torch-{{ checksum "setup.py" }}
@@ -396,46 +335,7 @@ jobs:
                   key: v0.5-torch-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: python utils/tests_fetcher.py | tee test_preparation.txt
-            - store_artifacts:
-                  path: ~/transformers/test_preparation.txt
-            - run: |
-                  if [ -f test_list.txt ]; then
-                    python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_pipelines_torch -m is_pipeline_test $(cat test_list.txt) | tee tests_output.txt
-                  fi
-            - store_artifacts:
-                  path: ~/transformers/tests_output.txt
-            - store_artifacts:
-                  path: ~/transformers/reports
-
-    run_tests_pipelines_torch_all:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        environment:
-            OMP_NUM_THREADS: 1
-            RUN_PIPELINE_TESTS: yes
-            TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 120
-        resource_class: xlarge
-        parallelism: 1
-        steps:
-            - checkout
-            - restore_cache:
-                  keys:
-                      - v0.5-torch-{{ checksum "setup.py" }}
-                      - v0.5-{{ checksum "setup.py" }}
-            - run: sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev espeak-ng
-            - run: pip install --upgrade pip
-            - run: pip install .[sklearn,torch,testing,sentencepiece,torch-speech,vision,timm]
-            - run: pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-1.12.0+cpu.html
-            - run: pip install https://github.com/kpu/kenlm/archive/master.zip
-            - save_cache:
-                  key: v0.5-torch-{{ checksum "setup.py" }}
-                  paths:
-                      - '~/.cache/pip'
-            - run: |
-                  python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_pipelines_torch -m is_pipeline_test tests | tee tests_output.txt
+            - run: python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_pipelines_torch -m is_pipeline_test $(cat test_preparation/test_list.txt) | tee tests_output.txt
             - store_artifacts:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
@@ -454,6 +354,13 @@ jobs:
         parallelism: 1
         steps:
             - checkout
+            - attach_workspace:
+                at:  ~/transformers/test_preparation
+            - run: |
+                if [ ! -s test_preparation/test_list.txt ]; then
+                    echo "No tests to run, exiting early!"
+                    circleci-agent step halt
+                fi
             - restore_cache:
                   keys:
                       - v0.5-tf-{{ checksum "setup.py" }}
@@ -465,44 +372,7 @@ jobs:
                   key: v0.5-tf-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: python utils/tests_fetcher.py | tee test_preparation.txt
-            - store_artifacts:
-                  path: ~/transformers/test_preparation.txt
-            - run: |
-                  if [ -f test_list.txt ]; then
-                    python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_pipelines_tf $(cat test_list.txt) -m is_pipeline_test | tee tests_output.txt
-                  fi
-            - store_artifacts:
-                  path: ~/transformers/tests_output.txt
-            - store_artifacts:
-                  path: ~/transformers/reports
-
-    run_tests_pipelines_tf_all:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        environment:
-            OMP_NUM_THREADS: 1
-            RUN_PIPELINE_TESTS: yes
-            TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 120
-        resource_class: xlarge
-        parallelism: 1
-        steps:
-            - checkout
-            - restore_cache:
-                  keys:
-                      - v0.5-tf-{{ checksum "setup.py" }}
-                      - v0.5-{{ checksum "setup.py" }}
-            - run: pip install --upgrade pip
-            - run: pip install .[sklearn,tf-cpu,testing,sentencepiece]
-            - run: pip install tensorflow_probability
-            - save_cache:
-                  key: v0.5-tf-{{ checksum "setup.py" }}
-                  paths:
-                      - '~/.cache/pip'
-            - run: |
-                  python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_pipelines_tf tests -m is_pipeline_test | tee tests_output.txt
+            - run: python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -rA -s --make-reports=tests_pipelines_tf $(cat test_preparation/test_list.txt) -m is_pipeline_test | tee tests_output.txt
             - store_artifacts:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
@@ -517,6 +387,7 @@ jobs:
             TRANSFORMERS_IS_CI: yes
             PYTEST_TIMEOUT: 120
         steps:
+            - checkout
             - attach_workspace:
                 at:  ~/transformers/test_preparation
             - run: |
@@ -524,40 +395,6 @@ jobs:
                     echo "No tests to run, exiting early!"
                     circleci-agent step halt
                 fi
-            - checkout
-            - restore_cache:
-                  keys:
-                      - v0.5-custom_tokenizers-{{ checksum "setup.py" }}
-                      - v0.5-{{ checksum "setup.py" }}
-            - run: pip install --upgrade pip
-            - run: pip install .[ja,testing,sentencepiece,jieba,spacy,ftfy,rjieba]
-            - run: python -m unidic download
-            - save_cache:
-                  key: v0.5-custom_tokenizers-{{ checksum "setup.py" }}
-                  paths:
-                      - '~/.cache/pip'
-            - run: python utils/tests_fetcher.py | tee test_preparation.txt
-            - store_artifacts:
-                  path: ~/transformers/test_preparation.txt
-            - run: |
-                  if [ -f test_list.txt ]; then
-                    python -m pytest --max-worker-restart=0 -s --make-reports=tests_custom_tokenizers ./tests/models/bert_japanese/test_tokenization_bert_japanese.py ./tests/models/openai/test_tokenization_openai.py ./tests/models/clip/test_tokenization_clip.py | tee tests_output.txt
-                  fi
-            - store_artifacts:
-                  path: ~/transformers/tests_output.txt
-            - store_artifacts:
-                  path: ~/transformers/reports
-
-    run_tests_custom_tokenizers_all:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        environment:
-            RUN_CUSTOM_TOKENIZERS: yes
-            TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 120
-        steps:
-            - checkout
             - restore_cache:
                   keys:
                       - v0.5-custom_tokenizers-{{ checksum "setup.py" }}
@@ -587,6 +424,13 @@ jobs:
         parallelism: 1
         steps:
             - checkout
+            - attach_workspace:
+                at:  ~/transformers/test_preparation
+            - run: |
+                if [ ! -s test_preparation/test_list.txt ]; then
+                    echo "No tests to run, exiting early!"
+                    circleci-agent step halt
+                fi
             - restore_cache:
                   keys:
                       - v0.5-torch_examples-{{ checksum "setup.py" }}
@@ -599,44 +443,7 @@ jobs:
                   key: v0.5-torch_examples-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: python utils/tests_fetcher.py --filters examples tests | tee test_preparation.txt
-            - store_artifacts:
-                  path: ~/transformers/test_preparation.txt
-            - run: |
-                  if [ -f test_list.txt ]; then
-                    python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -s --make-reports=examples_torch ./examples/pytorch/ | tee tests_output.txt
-                  fi
-            - store_artifacts:
-                  path: ~/transformers/examples_output.txt
-            - store_artifacts:
-                  path: ~/transformers/reports
-
-    run_examples_torch_all:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        environment:
-            OMP_NUM_THREADS: 1
-            TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 120
-        resource_class: xlarge
-        parallelism: 1
-        steps:
-            - checkout
-            - restore_cache:
-                  keys:
-                      - v0.5-torch_examples-{{ checksum "setup.py" }}
-                      - v0.5-{{ checksum "setup.py" }}
-            - run: sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev espeak-ng
-            - run: pip install --upgrade pip
-            - run: pip install .[sklearn,torch,sentencepiece,testing,torch-speech]
-            - run: pip install -r examples/pytorch/_tests_requirements.txt
-            - save_cache:
-                  key: v0.5-torch_examples-{{ checksum "setup.py" }}
-                  paths:
-                      - '~/.cache/pip'
-            - run: |
-                  TRANSFORMERS_IS_CI=1 python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -s --make-reports=examples_torch ./examples/pytorch/ | tee examples_output.txt
+            - run: python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -s --make-reports=examples_torch ./examples/pytorch/ | tee tests_output.txt
             - store_artifacts:
                   path: ~/transformers/examples_output.txt
             - store_artifacts:
@@ -654,6 +461,13 @@ jobs:
         parallelism: 1
         steps:
             - checkout
+            - attach_workspace:
+                at:  ~/transformers/test_preparation
+            - run: |
+                if [ ! -s test_preparation/test_list.txt ]; then
+                    echo "No tests to run, exiting early!"
+                    circleci-agent step halt
+                fi
             - restore_cache:
                   keys:
                       - v0.5-tensorflow_examples-{{ checksum "setup.py" }}
@@ -665,43 +479,7 @@ jobs:
                   key: v0.5-tensorflow_examples-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: python utils/tests_fetcher.py --filters examples tests | tee test_preparation.txt
-            - store_artifacts:
-                  path: ~/transformers/test_preparation.txt
-            - run: |
-                  if [ -f test_list.txt ]; then
-                    python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -s --make-reports=examples_tensorflow ./examples/tensorflow/ | tee tests_output.txt
-                  fi
-            - store_artifacts:
-                  path: ~/transformers/tensorflow_examples_output.txt
-            - store_artifacts:
-                  path: ~/transformers/reports
-
-    run_examples_tensorflow_all:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        environment:
-            OMP_NUM_THREADS: 1
-            TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 120
-        resource_class: xlarge
-        parallelism: 1
-        steps:
-            - checkout
-            - restore_cache:
-                  keys:
-                      - v0.5-tensorflow_examples-{{ checksum "setup.py" }}
-                      - v0.5-{{ checksum "setup.py" }}
-            - run: pip install --upgrade pip
-            - run: pip install .[sklearn,tensorflow,sentencepiece,testing]
-            - run: pip install -r examples/tensorflow/_tests_requirements.txt
-            - save_cache:
-                  key: v0.5-tensorflow_examples-{{ checksum "setup.py" }}
-                  paths:
-                      - '~/.cache/pip'
-            - run: |
-                  TRANSFORMERS_IS_CI=1 python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -s --make-reports=examples_tensorflow ./examples/tensorflow/ | tee examples_output.txt
+            - run: python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -s --make-reports=examples_tensorflow ./examples/tensorflow/ | tee tests_output.txt
             - store_artifacts:
                   path: ~/transformers/tensorflow_examples_output.txt
             - store_artifacts:
@@ -719,6 +497,13 @@ jobs:
         parallelism: 1
         steps:
             - checkout
+            - attach_workspace:
+                at:  ~/transformers/test_preparation
+            - run: |
+                if [ ! -s test_preparation/test_list.txt ]; then
+                    echo "No tests to run, exiting early!"
+                    circleci-agent step halt
+                fi
             - restore_cache:
                 keys:
                     - v0.5-flax_examples-{{ checksum "setup.py" }}
@@ -730,43 +515,7 @@ jobs:
                   key: v0.5-flax_examples-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: python utils/tests_fetcher.py --filters examples tests | tee test_preparation.txt
-            - store_artifacts:
-                  path: ~/transformers/test_preparation.txt
-            - run: |
-                  if [ -f test_list.txt ]; then
-                    python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -s --make-reports=examples_flax ./examples/flax/ | tee tests_output.txt
-                  fi
-            - store_artifacts:
-                  path: ~/transformers/flax_examples_output.txt
-            - store_artifacts:
-                  path: ~/transformers/reports
-
-    run_examples_flax_all:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        environment:
-            OMP_NUM_THREADS: 1
-            TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 120
-        resource_class: xlarge
-        parallelism: 1
-        steps:
-            - checkout
-            - restore_cache:
-                keys:
-                    - v0.5-flax_examples-{{ checksum "setup.py" }}
-                    - v0.5-{{ checksum "setup.py" }}
-            - run: pip install --upgrade pip
-            - run: pip install .[flax,testing,sentencepiece]
-            - run: pip install -r examples/flax/_tests_requirements.txt
-            - save_cache:
-                  key: v0.5-flax_examples-{{ checksum "setup.py" }}
-                  paths:
-                      - '~/.cache/pip'
-            - run: |
-                  TRANSFORMERS_IS_CI=1 python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -s --make-reports=examples_flax ./examples/flax/ | tee examples_output.txt
+            - run: python -m pytest -n 8 --max-worker-restart=0 --dist=loadfile -s --make-reports=examples_flax ./examples/flax/ | tee tests_output.txt
             - store_artifacts:
                   path: ~/transformers/flax_examples_output.txt
             - store_artifacts:
@@ -785,6 +534,13 @@ jobs:
         parallelism: 1
         steps:
             - checkout
+            - attach_workspace:
+                at:  ~/transformers/test_preparation
+            - run: |
+                if [ ! -s test_preparation/test_list.txt ]; then
+                    echo "No tests to run, exiting early!"
+                    circleci-agent step halt
+                fi
             - restore_cache:
                   keys:
                       - v0.5-hub-{{ checksum "setup.py" }}
@@ -799,47 +555,7 @@ jobs:
                   key: v0.5-hub-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: python utils/tests_fetcher.py | tee test_preparation.txt
-            - store_artifacts:
-                  path: ~/transformers/test_preparation.txt
-            - run: |
-                  if [ -f test_list.txt ]; then
-                    python -m pytest --max-worker-restart=0 -sv --make-reports=tests_hub $(cat test_list.txt) -m is_staging_test | tee tests_output.txt
-                  fi
-            - store_artifacts:
-                  path: ~/transformers/tests_output.txt
-            - store_artifacts:
-                  path: ~/transformers/reports
-
-    run_tests_hub_all:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        environment:
-            HUGGINGFACE_CO_STAGING: yes
-            RUN_GIT_LFS_TESTS: yes
-            TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 120
-        resource_class: xlarge
-        parallelism: 1
-        steps:
-            - checkout
-            - restore_cache:
-                  keys:
-                      - v0.5-hub-{{ checksum "setup.py" }}
-                      - v0.5-{{ checksum "setup.py" }}
-            - run: sudo apt-get -y update && sudo apt-get install git-lfs
-            - run: |
-                git config --global user.email "ci@dummy.com"
-                git config --global user.name "ci"
-            - run: pip install --upgrade pip
-            - run: pip install .[torch,sentencepiece,testing]
-            - save_cache:
-                  key: v0.5-hub-{{ checksum "setup.py" }}
-                  paths:
-                      - '~/.cache/pip'
-            - run: |
-                  python -m pytest --max-worker-restart=0 -sv --make-reports=tests_hub tests -m is_staging_test | tee tests_output.txt
+            - run: python -m pytest --max-worker-restart=0 -sv --make-reports=tests_hub $(cat test_preparation/test_list.txt) -m is_staging_test | tee tests_output.txt
             - store_artifacts:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
@@ -857,6 +573,13 @@ jobs:
         parallelism: 1
         steps:
             - checkout
+            - attach_workspace:
+                at:  ~/transformers/test_preparation
+            - run: |
+                if [ ! -s test_preparation/test_list.txt ]; then
+                    echo "No tests to run, exiting early!"
+                    circleci-agent step halt
+                fi
             - restore_cache:
                   keys:
                       - v0.5-torch-{{ checksum "setup.py" }}
@@ -867,42 +590,8 @@ jobs:
                   key: v0.5-onnx-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
-            - run: python utils/tests_fetcher.py | tee test_preparation.txt
-            - store_artifacts:
-                  path: ~/transformers/test_preparation.txt
-            - run: |
-                  if [ -f test_list.txt ]; then
-                    python -m pytest -n 1 --max-worker-restart=0 --dist=loadfile -s --make-reports=tests_onnx $(cat test_list.txt) -k onnx | tee tests_output.txt
-                  fi
-            - store_artifacts:
-                  path: ~/transformers/tests_output.txt
-            - store_artifacts:
-                  path: ~/transformers/reports
+            - run: python -m pytest -n 1 --max-worker-restart=0 --dist=loadfile -s --make-reports=tests_onnx $(cat test_preparation/test_list.txt) -k onnx | tee tests_output.txt
 
-    run_tests_onnxruntime_all:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        environment:
-            OMP_NUM_THREADS: 1
-            TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 120
-        resource_class: xlarge
-        parallelism: 1
-        steps:
-            - checkout
-            - restore_cache:
-                  keys:
-                      - v0.5-torch-{{ checksum "setup.py" }}
-                      - v0.5-{{ checksum "setup.py" }}
-            - run: pip install --upgrade pip
-            - run: pip install .[torch,tf,testing,sentencepiece,onnxruntime,vision]
-            - save_cache:
-                  key: v0.5-onnx-{{ checksum "setup.py" }}
-                  paths:
-                      - '~/.cache/pip'
-            - run: |
-                  python -m pytest -n 1 --max-worker-restart=0 --dist=loadfile -s --make-reports=tests_onnx tests -k onnx | tee tests_output.txt
             - store_artifacts:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
@@ -980,48 +669,13 @@ jobs:
         parallelism: 1
         steps:
             - checkout
-            - restore_cache:
-                  keys:
-                      - v0.5-torch-{{ checksum "setup.py" }}
-                      - v0.5-{{ checksum "setup.py" }}
-            - run: sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev
-            - run: pip install --upgrade pip
-            - run: pip install .[torch,testing,vision]
-            - run: pip install torchvision
-            # The commit `36a65a0907d90ed591479b2ebaa8b61cfa0b4ef0` in `detectron2` break things.
-            # See https://github.com/facebookresearch/detectron2/commit/36a65a0907d90ed591479b2ebaa8b61cfa0b4ef0#comments.
-            # TODO: Revert this change back once the above issue is fixed.
-            - run: python -m pip install 'git+https://github.com/facebookresearch/detectron2.git'
-            - run: sudo apt install tesseract-ocr
-            - run: pip install pytesseract
-            - save_cache:
-                  key: v0.5-torch-{{ checksum "setup.py" }}
-                  paths:
-                      - '~/.cache/pip'
-            - run: python utils/tests_fetcher.py | tee test_preparation.txt
-            - store_artifacts:
-                  path: ~/transformers/test_preparation.txt
+            - attach_workspace:
+                at:  ~/transformers/test_preparation
             - run: |
-                  if [ -f test_list.txt ]; then
-                    python -m pytest -n 1 --max-worker-restart=0 tests/models/*layoutlmv* --dist=loadfile -s --make-reports=tests_layoutlmv2_and_v3 --durations=100
-                  fi
-            - store_artifacts:
-                  path: ~/transformers/tests_output.txt
-            - store_artifacts:
-                  path: ~/transformers/reports
-
-    run_tests_layoutlmv2_and_v3_all:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        environment:
-            OMP_NUM_THREADS: 1
-            TRANSFORMERS_IS_CI: yes
-            PYTEST_TIMEOUT: 120
-        resource_class: xlarge
-        parallelism: 1
-        steps:
-            - checkout
+                if [ ! -s test_preparation/test_list.txt ]; then
+                    echo "No tests to run, exiting early!"
+                    circleci-agent step halt
+                fi
             - restore_cache:
                   keys:
                       - v0.5-torch-{{ checksum "setup.py" }}
@@ -1077,48 +731,6 @@ jobs:
                   perform-login: true
             - *delete_gke_jobs
 
-    fetch_tests:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        resource_class: large
-        parallelism: 1
-        steps:
-            - checkout
-            - run: pip install --upgrade pip
-            - run: pip install GitPython
-            - run: pip install .
-            - run: mkdir -p test_preparation
-            - run: python utils/tests_fetcher.py | tee tests_fetched_summary.txt
-            - store_artifacts:
-                path: ~/transformers/tests_fetched_summary.txt
-            - run: |
-                if [ -f test_list.txt ]; then
-                    mv test_list.txt test_preparation/test_list.txt
-                else
-                    touch test_preparation/test_list.txt
-                fi
-
-            - persist_to_workspace:
-                root: test_preparation/
-                paths:
-                    test_list.txt
-
-    fetch_all_tests:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        parallelism: 1
-        steps:
-            - run: |
-                  mkdir test_preparation
-                  echo "tests" > test_preparation/test_list.txt
-
-            - persist_to_workspace:
-                  root: test_preparation/
-                  paths:
-                      test_list.txt
-
     run_tests:
         working_directory: ~/transformers
         docker:
@@ -1144,26 +756,51 @@ workflows:
     version: 2
     build_and_test:
         jobs:
+            - check_code_quality
+            - check_repository_consistency
             - fetch_tests
+            - run_examples_torch:
+                requires:
+                  - fetch_tests
+            - run_examples_tensorflow:
+                requires:
+                  - fetch_tests
+            - run_examples_flax:
+                requires:
+                  - fetch_tests
             - run_tests_custom_tokenizers:
                 requires:
                   - fetch_tests
-#            - check_code_quality
-#            - check_repository_consistency
-#            - run_examples_torch
-#            - run_examples_tensorflow
-#            - run_examples_flax
-#            - run_tests_custom_tokenizers
-#            - run_tests_torch_and_tf
-#            - run_tests_torch_and_flax
-#            - run_tests_torch
-#            - run_tests_tf
-#            - run_tests_flax
-#            - run_tests_pipelines_torch
-#            - run_tests_pipelines_tf
-#            - run_tests_onnxruntime
-#            - run_tests_hub
-#            - run_tests_layoutlmv2_and_v3
+            - run_tests_torch_and_tf:
+                requires:
+                  - fetch_tests
+            - run_tests_torch_and_flax:
+                requires:
+                  - fetch_tests
+            - run_tests_torch:
+                requires:
+                  - fetch_tests
+            - run_tests_tf:
+                requires:
+                  - fetch_tests
+            - run_tests_flax:
+                requires:
+                  - fetch_tests
+            - run_tests_pipelines_torch:
+                requires:
+                  - fetch_tests
+            - run_tests_pipelines_tf:
+                requires:
+                  - fetch_tests
+            - run_tests_onnxruntime:
+                requires:
+                  - fetch_tests
+            - run_tests_hub:
+                requires:
+                  - fetch_tests
+            - run_tests_layoutlmv2_and_v3:
+                requires:
+                  - fetch_tests
     nightly:
         triggers:
             - schedule:
@@ -1173,20 +810,49 @@ workflows:
                         only:
                             - main
         jobs:
-#            - run_examples_torch_all
-#            - run_examples_tensorflow_all
-#            - run_examples_flax_all
-#            - run_tests_custom_tokenizers_all
-#            - run_tests_torch_and_tf_all
-#            - run_tests_torch_and_flax_all
-            - run_tests_torch_all
-#            - run_tests_tf_all
-#            - run_tests_flax_all
-#            - run_tests_pipelines_torch_all
-#            - run_tests_pipelines_tf_all
-#            - run_tests_onnxruntime_all
-#            - run_tests_hub_all
-#            - run_tests_layoutlmv2_and_v3_all
+            - fetch_all_tests
+            - run_examples_torch:
+                requires:
+                  - fetch_all_tests
+            - run_examples_tensorflow:
+                requires:
+                  - fetch_all_tests
+            - run_examples_flax:
+                requires:
+                  - fetch_all_tests
+            - run_tests_custom_tokenizers:
+                requires:
+                  - fetch_all_tests
+            - run_tests_torch_and_tf:
+                requires:
+                  - fetch_all_tests
+            - run_tests_torch_and_flax:
+                requires:
+                  - fetch_all_tests
+            - run_tests_torch:
+                requires:
+                  - fetch_all_tests
+            - run_tests_tf:
+                requires:
+                  - fetch_all_tests
+            - run_tests_flax:
+                requires:
+                  - fetch_all_tests
+            - run_tests_pipelines_torch:
+                requires:
+                  - fetch_all_tests
+            - run_tests_pipelines_tf:
+                requires:
+                  - fetch_all_tests
+            - run_tests_onnxruntime:
+                requires:
+                  - fetch_all_tests
+            - run_tests_hub:
+                requires:
+                  - fetch_all_tests
+            - run_tests_layoutlmv2_and_v3:
+                requires:
+                  - fetch_all_tests
 
 #    tpu_testing_jobs:
 #        triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,7 +300,6 @@ jobs:
                   path: ~/transformers/tests_output.txt
             - store_artifacts:
                   path: ~/transformers/reports
-                  path: ~/transformers/reports
 
     run_tests_pipelines_torch:
         working_directory: ~/transformers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1161,8 +1161,8 @@ workflows:
     build_and_test:
         jobs:
             - fetch_tests
-            - run_tests
-                requires
+            - run_tests:
+                requires:
                   - fetch_tests
 #            - check_code_quality
 #            - check_repository_consistency

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
         steps:
             - checkout
             - attach_workspace:
-                at:  ~/transformers/test_preparation
+                at: ~/transformers/test_preparation
             - run: |
                 if [ ! -s test_preparation/test_list.txt ]; then
                     echo "No tests to run, exiting early!"
@@ -161,7 +161,7 @@ jobs:
         steps:
             - checkout
             - attach_workspace:
-                at:  ~/transformers/test_preparation
+                at: ~/transformers/test_preparation
             - run: |
                 if [ ! -s test_preparation/test_list.txt ]; then
                     echo "No tests to run, exiting early!"
@@ -200,7 +200,7 @@ jobs:
         steps:
             - checkout
             - attach_workspace:
-                at:  ~/transformers/test_preparation
+                at: ~/transformers/test_preparation
             - run: |
                 if [ ! -s test_preparation/test_list.txt ]; then
                     echo "No tests to run, exiting early!"
@@ -239,7 +239,7 @@ jobs:
         steps:
             - checkout
             - attach_workspace:
-                at:  ~/transformers/test_preparation
+                at: ~/transformers/test_preparation
             - run: |
                 if [ ! -s test_preparation/test_list.txt ]; then
                     echo "No tests to run, exiting early!"
@@ -277,7 +277,7 @@ jobs:
         steps:
             - checkout
             - attach_workspace:
-                at:  ~/transformers/test_preparation
+                at: ~/transformers/test_preparation
             - run: |
                 if [ ! -s test_preparation/test_list.txt ]; then
                     echo "No tests to run, exiting early!"
@@ -315,7 +315,7 @@ jobs:
         steps:
             - checkout
             - attach_workspace:
-                at:  ~/transformers/test_preparation
+                at: ~/transformers/test_preparation
             - run: |
                 if [ ! -s test_preparation/test_list.txt ]; then
                     echo "No tests to run, exiting early!"
@@ -354,7 +354,7 @@ jobs:
         steps:
             - checkout
             - attach_workspace:
-                at:  ~/transformers/test_preparation
+                at: ~/transformers/test_preparation
             - run: |
                 if [ ! -s test_preparation/test_list.txt ]; then
                     echo "No tests to run, exiting early!"
@@ -388,7 +388,7 @@ jobs:
         steps:
             - checkout
             - attach_workspace:
-                at:  ~/transformers/test_preparation
+                at: ~/transformers/test_preparation
             - run: |
                 if [ ! -s test_preparation/test_list.txt ]; then
                     echo "No tests to run, exiting early!"
@@ -424,7 +424,7 @@ jobs:
         steps:
             - checkout
             - attach_workspace:
-                at:  ~/transformers/test_preparation
+                at: ~/transformers/test_preparation
             - run: |
                 if [ ! -s test_preparation/test_list.txt ]; then
                     echo "No tests to run, exiting early!"
@@ -461,7 +461,7 @@ jobs:
         steps:
             - checkout
             - attach_workspace:
-                at:  ~/transformers/test_preparation
+                at: ~/transformers/test_preparation
             - run: |
                 if [ ! -s test_preparation/test_list.txt ]; then
                     echo "No tests to run, exiting early!"
@@ -497,7 +497,7 @@ jobs:
         steps:
             - checkout
             - attach_workspace:
-                at:  ~/transformers/test_preparation
+                at: ~/transformers/test_preparation
             - run: |
                 if [ ! -s test_preparation/test_list.txt ]; then
                     echo "No tests to run, exiting early!"
@@ -534,7 +534,7 @@ jobs:
         steps:
             - checkout
             - attach_workspace:
-                at:  ~/transformers/test_preparation
+                at: ~/transformers/test_preparation
             - run: |
                 if [ ! -s test_preparation/test_list.txt ]; then
                     echo "No tests to run, exiting early!"
@@ -573,7 +573,7 @@ jobs:
         steps:
             - checkout
             - attach_workspace:
-                at:  ~/transformers/test_preparation
+                at: ~/transformers/test_preparation
             - run: |
                 if [ ! -s test_preparation/test_list.txt ]; then
                     echo "No tests to run, exiting early!"
@@ -669,7 +669,7 @@ jobs:
         steps:
             - checkout
             - attach_workspace:
-                at:  ~/transformers/test_preparation
+                at: ~/transformers/test_preparation
             - run: |
                 if [ ! -s test_preparation/test_list.txt ]; then
                     echo "No tests to run, exiting early!"
@@ -729,22 +729,6 @@ jobs:
                   cluster: $GKE_CLUSTER
                   perform-login: true
             - *delete_gke_jobs
-
-    run_tests:
-        working_directory: ~/transformers
-        docker:
-            - image: cimg/python:3.7.12
-        parallelism: 1
-        steps:
-            - attach_workspace:
-                at:  ~/transformers/test_preparation
-            - run: |
-                if [ ! -s test_preparation/test_list.txt ]; then
-                    echo "No tests to run, exiting early!"
-                    circleci-agent step halt
-                fi
-            - run: echo "Running tests!"
-            - run: cat test_preparation/test_list.txt
 
 workflow_filters: &workflow_filters
     filters:

--- a/setup.py
+++ b/setup.py
@@ -236,6 +236,7 @@ class DepsTableUpdateCommand(Command):
 
 
 extras = {}
+extras["blob"] = []
 
 extras["ja"] = deps_list("fugashi", "ipadic", "unidic_lite", "unidic")
 extras["sklearn"] = deps_list("scikit-learn")

--- a/setup.py
+++ b/setup.py
@@ -236,7 +236,6 @@ class DepsTableUpdateCommand(Command):
 
 
 extras = {}
-extras["blob"] = []
 
 extras["ja"] = deps_list("fugashi", "ipadic", "unidic_lite", "unidic")
 extras["sklearn"] = deps_list("scikit-learn")

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -150,6 +150,7 @@ from .utils import (
 from .utils.generic import ContextManagers
 
 
+_is_native_cpu_amp_available = True
 _is_native_cpu_amp_available = is_torch_greater_or_equal_than_1_10
 
 DEFAULT_CALLBACKS = [DefaultFlowCallback]

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -150,7 +150,6 @@ from .utils import (
 from .utils.generic import ContextManagers
 
 
-_is_native_cpu_amp_available = True
 _is_native_cpu_amp_available = is_torch_greater_or_equal_than_1_10
 
 DEFAULT_CALLBACKS = [DefaultFlowCallback]


### PR DESCRIPTION
# What does this PR do?

This PR reorganizes the jobs run on CircleCI to avoid launching setups and running the test fetcher multiple times when there is no tests found to run.

More precisely, it always run the three following jobs:
- `check_code_quality`
- `check_repo_consistency`
- `fetch_tests`
Then the actual tests jobs are run after `fetch_tests` and are immediately cancelled graciously if the `fetch_tests` job didn't find any tests. All of them read the list of tests found by `fetch_tests` and don't re-run the test_fetcher.

This also introduces a `fetch_all_tests` job which creates the file all jobs are looking for and fill it with all the tests, so the nightly run can reuse the same jobs as the standard one. As a result, all jobs `xxx_all` can be safely deleted.

To see the result of a run with one py modified, look at this [report](https://github.com/huggingface/transformers/runs/8381129029) (commit [With a modification in one file only](https://github.com/huggingface/transformers/pull/19058/commits/44c3a39d420a9118dc3586104fe0d3fcaf7c2321) below). Some of the tests are run only on the impacted tests like others (examples, custom tokenizers, layout lm tests) are run on specific tests as long as there was at least a modification warranting some tests. This is the same behavior as before.

To see the result of a run with no code modification, look at this [report](https://github.com/huggingface/transformers/pull/19058/checks?check_run_id=8381322343) (commit [No change, no tests](https://github.com/huggingface/transformers/pull/19058/commits/4497731b550ee7db9f82f0d6d5384e352b51b904) below). All jobs are still run but take a couple of seconds only.

To see the result of a run with all tests run, look at the CI report of this PR (which cleans up a modification I added in the setup and merged by mistake).