### PR TITLE
Set `use_cache` to `True` in `trocr` model

### DIFF
--- a/src/transformers/models/trocr/configuration_trocr.py
+++ b/src/transformers/models/trocr/configuration_trocr.py
@@ -117,7 +117,7 @@ class TrOCRConfig(PretrainedConfig):
         classifier_dropout=0.0,
         init_std=0.02,
         decoder_layerdrop=0.0,
-        use_cache=False,
+        use_cache=True,
         scale_embedding=False,
         use_learned_position_embeddings=True,
         layernorm_embedding=True,


### PR DESCRIPTION
# What does this PR do?

- set `use_cache` to `True` for consistency with other `transformers` models
- With the PR https://github.com/huggingface/transformers/pull/18843 being merged, `trocr` became the last model in `transformers` that has `use_cache` set to `True`. 
- Except if there is any specific reason to let it to `False`, following #18843 , we think that it would be nice to set it to `True` for consistency with other models in `transformers` 
- All slow tests for `trocr` pass with this change

cc @stas00 @NielsRogge 

Thanks!