### PR TITLE
[doc] Fix link in `PreTrainedModel.save_pretrained` documentation

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1472,7 +1472,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
     ):
         """
         Save a model and its configuration file to a directory, so that it can be re-loaded using the
-        `[`~PreTrainedModel.from_pretrained`]` class method.
+        [`~PreTrainedModel.from_pretrained`] class method.
 
         Arguments:
             save_directory (`str` or `os.PathLike`):


### PR DESCRIPTION
# What does this PR do?
Prevent a hyperlink from displaying as the full markdown representation near the bottom of the [PreTrainedModel.save_pretrained](https://huggingface.co/docs/transformers/main/en/main_classes/model#transformers.PreTrainedModel.save_pretrained) documentation. Currently, the additional backticks cause the body to be deemed a code block, preventing it from becoming a link like it should be.

## The current situation
![image](https://user-images.githubusercontent.com/37621491/190603300-fc50647b-0f5f-44ce-b7c6-e65d20a33622.png)

## The new situation
See [here](https://moon-ci-docs.huggingface.co/docs/transformers/pr_19065/en/main_classes/model#transformers.PreTrainedModel.save_pretrained) for the documentation after this PR.
![image](https://user-images.githubusercontent.com/37621491/190614737-564f28b8-eda2-419c-8d26-37c0a9a2216c.png)


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?
@sgugger

- Tom Aarsen