### PR TITLE
Generate: add warning when left padding should be used

### DIFF
--- a/src/transformers/generation_flax_utils.py
+++ b/src/transformers/generation_flax_utils.py
@@ -326,6 +326,13 @@ class FlaxGenerationMixin:
         if decoder_start_token_id is None and self.config.is_encoder_decoder:
             raise ValueError("`decoder_start_token_id` has to be defined for encoder-decoder generation.")
 
+        # decoder-only models should use left-padding for generation
+        if not self.config.is_encoder_decoder and jnp.sum(input_ids[:, -1] == pad_token_id) > 0:
+            logger.warning(
+                "A decoder-only architecture is being used, but right-padding was detected! For correct generation "
+                "results, please set `padding_side='left'` when initializing the tokenizer."
+            )
+
         if self.config.is_encoder_decoder:
             # add encoder_outputs to model_kwargs
             if model_kwargs.get("encoder_outputs") is None:

--- a/src/transformers/generation_flax_utils.py
+++ b/src/transformers/generation_flax_utils.py
@@ -326,12 +326,13 @@ class FlaxGenerationMixin:
         if decoder_start_token_id is None and self.config.is_encoder_decoder:
             raise ValueError("`decoder_start_token_id` has to be defined for encoder-decoder generation.")
 
-        # decoder-only models should use left-padding for generation
-        if not self.config.is_encoder_decoder and jnp.sum(input_ids[:, -1] == pad_token_id) > 0:
-            logger.warning(
-                "A decoder-only architecture is being used, but right-padding was detected! For correct generation "
-                "results, please set `padding_side='left'` when initializing the tokenizer."
-            )
+        # decoder-only models should use left-padding for generation (can't be checked with `trace=True`)
+        if not self.config.is_encoder_decoder and not trace:
+            if pad_token_id is not None and jnp.sum(input_ids[:, -1] == pad_token_id) > 0:
+                logger.warning(
+                    "A decoder-only architecture is being used, but right-padding was detected! For correct "
+                    "generation results, please set `padding_side='left'` when initializing the tokenizer."
+                )
 
         if self.config.is_encoder_decoder:
             # add encoder_outputs to model_kwargs

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -1606,11 +1606,12 @@ class TFGenerationMixin:
             )
 
         # decoder-only models should use left-padding for generation
-        if not self.config.is_encoder_decoder and tf.math.reduce_any(input_ids[:, -1] == pad_token_id):
-            logger.warning(
-                "A decoder-only architecture is being used, but right-padding was detected! For correct generation "
-                "results, please set `padding_side='left'` when initializing the tokenizer."
-            )
+        if not self.config.is_encoder_decoder:
+            if pad_token_id is not None and tf.math.reduce_any(input_ids[:, -1] == pad_token_id):
+                logger.warning(
+                    "A decoder-only architecture is being used, but right-padding was detected! For correct "
+                    "generation results, please set `padding_side='left'` when initializing the tokenizer."
+                )
 
         # 4. Prepare model inputs which will be used for auto-regressive generation
         if self.config.is_encoder_decoder:

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -1605,6 +1605,13 @@ class TFGenerationMixin:
                 input_ids, pad_token_id, eos_token_id
             )
 
+        # decoder-only models should use left-padding for generation
+        if not self.config.is_encoder_decoder and tf.math.reduce_any(input_ids[:, -1] == pad_token_id):
+            logger.warning(
+                "A decoder-only architecture is being used, but right-padding was detected! For correct generation "
+                "results, please set `padding_side='left'` when initializing the tokenizer."
+            )
+
         # 4. Prepare model inputs which will be used for auto-regressive generation
         if self.config.is_encoder_decoder:
             # if encoder-decoder, we create encoder_outputs and add to `model_kwargs`

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -1230,6 +1230,13 @@ class GenerationMixin:
                 inputs_tensor, pad_token_id, eos_token_id
             )
 
+        # decoder-only models should use left-padding for generation
+        if not self.config.is_encoder_decoder and torch.sum(inputs_tensor[:, -1] == pad_token_id) > 0:
+            logger.warning(
+                "A decoder-only architecture is being used, but right-padding was detected! For correct generation "
+                "results, please set `padding_side='left'` when initializing the tokenizer."
+            )
+
         if self.config.is_encoder_decoder and "encoder_outputs" not in model_kwargs:
             # if model is encoder decoder encoder_outputs are created
             # and added to `model_kwargs`

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -1231,11 +1231,12 @@ class GenerationMixin:
             )
 
         # decoder-only models should use left-padding for generation
-        if not self.config.is_encoder_decoder and torch.sum(inputs_tensor[:, -1] == pad_token_id) > 0:
-            logger.warning(
-                "A decoder-only architecture is being used, but right-padding was detected! For correct generation "
-                "results, please set `padding_side='left'` when initializing the tokenizer."
-            )
+        if not self.config.is_encoder_decoder:
+            if pad_token_id is not None and torch.sum(inputs_tensor[:, -1] == pad_token_id) > 0:
+                logger.warning(
+                    "A decoder-only architecture is being used, but right-padding was detected! For correct "
+                    "generation results, please set `padding_side='left'` when initializing the tokenizer."
+                )
 
         if self.config.is_encoder_decoder and "encoder_outputs" not in model_kwargs:
             # if model is encoder decoder encoder_outputs are created


### PR DESCRIPTION
# What does this PR do?

As the title describes: add a warning when left padding should be used. Incorrect use of right padding is detected when:
1. the model is decoder-only;
2. there is a padding token in the last member of the sequence.