### PR TITLE
Change document question answering pipeline to always return an array

### DIFF
--- a/src/transformers/pipelines/document_question_answering.py
+++ b/src/transformers/pipelines/document_question_answering.py
@@ -383,8 +383,6 @@ class DocumentQuestionAnsweringPipeline(Pipeline):
             answers = self.postprocess_extractive_qa(model_outputs, top_k=top_k, **kwargs)
 
         answers = sorted(answers, key=lambda x: x.get("score", 0), reverse=True)[:top_k]
-        if len(answers) == 1:
-            return answers[0]
         return answers
 
     def postprocess_donut(self, model_outputs, **kwargs):

--- a/tests/pipelines/test_pipelines_document_question_answering.py
+++ b/tests/pipelines/test_pipelines_document_question_answering.py
@@ -267,7 +267,7 @@ class DocumentQuestionAnsweringPipelineTests(unittest.TestCase, metaclass=Pipeli
         image = INVOICE_URL
         question = "What is the invoice number?"
         outputs = dqa_pipeline(image=image, question=question, top_k=2)
-        self.assertEqual(nested_simplify(outputs, decimals=4), {"answer": "us-001"})
+        self.assertEqual(nested_simplify(outputs, decimals=4), [{"answer": "us-001"}])
 
     @require_tf
     @unittest.skip("Document question answering not implemented in TF")


### PR DESCRIPTION
# What does this PR do?

Updates the DocumentQuestionAnsweringPipeline to always return an array, to fix the inference widget, and also be easier to use in general.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- x[ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x ] Did you write any new necessary tests?


## Who can review?

@Narsil @mishig25 

