### PR TITLE
Fix tokenizer load from one file

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1726,6 +1726,8 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         for file_id, file_path in vocab_files.items():
             if file_path is None:
                 resolved_vocab_files[file_id] = None
+            elif os.path.isfile(file_path):
+                resolved_vocab_files[file_id] = file_path
             elif is_remote_url(file_path):
                 resolved_vocab_files[file_id] = download_url(file_path, proxies=proxies)
             else:

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
 
 from huggingface_hub import HfFolder, delete_repo, set_access_token
+from huggingface_hub.file_download import http_get
 from parameterized import parameterized
 from requests.exceptions import HTTPError
 from transformers import (
@@ -3888,6 +3889,16 @@ class TokenizerUtilTester(unittest.TestCase):
             _ = BertTokenizer.from_pretrained("hf-internal-testing/tiny-random-bert")
             # This check we did call the fake head request
             mock_head.assert_called()
+
+    def test_legacy_load_from_one_file(self):
+        try:
+            tmp_file = tempfile.mktemp()
+            with open(tmp_file, "wb") as f:
+                http_get("https://huggingface.co/albert-base-v1/resolve/main/spiece.model", f)
+
+            tokenizer = AlbertTokenizer.from_pretrained(tmp_file)
+        finally:
+            os.remove(tmp_file)
 
 
 @is_staging_test

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -3896,7 +3896,7 @@ class TokenizerUtilTester(unittest.TestCase):
             with open(tmp_file, "wb") as f:
                 http_get("https://huggingface.co/albert-base-v1/resolve/main/spiece.model", f)
 
-            tokenizer = AlbertTokenizer.from_pretrained(tmp_file)
+            AlbertTokenizer.from_pretrained(tmp_file)
         finally:
             os.remove(tmp_file)
 


### PR DESCRIPTION
# What does this PR do?

#18438 broke the (deprecated) API allowing a user to load a tokenizer from the path to a given file when said tokenizer only needs one file. This PR should fix it.

Fixes #19057 