### PR TITLE
Added type hints to ResNetForImageClassification

### DIFF
--- a/src/transformers/models/regnet/modeling_regnet.py
+++ b/src/transformers/models/regnet/modeling_regnet.py
@@ -407,10 +407,10 @@ class RegNetForImageClassification(RegNetPreTrainedModel):
     )
     def forward(
         self,
-        pixel_values: Tensor = None,
-        labels: Tensor = None,
-        output_hidden_states: bool = None,
-        return_dict: bool = None,
+        pixel_values: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
     ) -> ImageClassifierOutputWithNoAttention:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):

--- a/src/transformers/models/resnet/modeling_resnet.py
+++ b/src/transformers/models/resnet/modeling_resnet.py
@@ -370,10 +370,10 @@ class ResNetForImageClassification(ResNetPreTrainedModel):
     )
     def forward(
         self,
-        pixel_values: Tensor = None,
-        labels: Tensor = None,
-        output_hidden_states: bool = None,
-        return_dict: bool = None,
+        pixel_values: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
     ) -> ImageClassifierOutputWithNoAttention:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):


### PR DESCRIPTION
Based on Issue #16059.

While looking into Issue #16059, I found that the `ResNetForImageClassification` model's type hints are inconsistent with the [docs](https://huggingface.co/docs/transformers/model_doc/resnet#transformers.ResNetForImageClassification.forward). Modified it to be consistent with the docs.

@Rocketknight1 Could you kindly check if this is fine?

This is my First PR for the Transformers library. Thanks in advance.
