### PR TITLE
Added Type hints for VIT MAE

### DIFF
--- a/src/transformers/models/vit_mae/modeling_vit_mae.py
+++ b/src/transformers/models/vit_mae/modeling_vit_mae.py
@@ -665,12 +665,12 @@ class ViTMAEModel(ViTMAEPreTrainedModel):
     @replace_return_docstrings(output_type=ViTMAEModelOutput, config_class=_CONFIG_FOR_DOC)
     def forward(
         self,
-        pixel_values: Optional[torch.FloatTensor]=None,
-        noise: Optional[torch.FloatTensor]=None,
-        head_mask: Optional[torch.FloatTensor]=None,
-        output_attentions: Optional[bool]=None,
-        output_hidden_states: Optional[bool]=None,
-        return_dict: Optional[bool]=None,
+        pixel_values: Optional[torch.FloatTensor] = None,
+        noise: Optional[torch.FloatTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
     ) -> Union[Tuple, ViTMAEModelOutput]:
         r"""
         Returns:
@@ -957,12 +957,12 @@ class ViTMAEForPreTraining(ViTMAEPreTrainedModel):
     @replace_return_docstrings(output_type=ViTMAEForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
     def forward(
         self,
-        pixel_values: Optional[torch.FloatTensor]=None,
-        noise: Optional[torch.FloatTensor]=None,
-        head_mask: Optional[torch.FloatTensor]=None,
-        output_attentions: Optional[bool]=None,
-        output_hidden_states: Optional[bool]=None,
-        return_dict: Optional[bool]=None,
+        pixel_values: Optional[torch.FloatTensor] = None,
+        noise: Optional[torch.FloatTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
     ) -> Union[Tuple, ViTMAEForPreTrainingOutput]:
         r"""
         Returns:

--- a/src/transformers/models/vit_mae/modeling_vit_mae.py
+++ b/src/transformers/models/vit_mae/modeling_vit_mae.py
@@ -665,13 +665,13 @@ class ViTMAEModel(ViTMAEPreTrainedModel):
     @replace_return_docstrings(output_type=ViTMAEModelOutput, config_class=_CONFIG_FOR_DOC)
     def forward(
         self,
-        pixel_values=None,
-        noise=None,
-        head_mask=None,
-        output_attentions=None,
-        output_hidden_states=None,
-        return_dict=None,
-    ):
+        pixel_values: Optional[torch.FloatTensor]=None,
+        noise: Optional[torch.FloatTensor]=None,
+        head_mask: Optional[torch.FloatTensor]=None,
+        output_attentions: Optional[bool]=None,
+        output_hidden_states: Optional[bool]=None,
+        return_dict: Optional[bool]=None,
+    ) -> Union[Tuple, ViTMAEModelOutput]:
         r"""
         Returns:
 
@@ -957,13 +957,13 @@ class ViTMAEForPreTraining(ViTMAEPreTrainedModel):
     @replace_return_docstrings(output_type=ViTMAEForPreTrainingOutput, config_class=_CONFIG_FOR_DOC)
     def forward(
         self,
-        pixel_values=None,
-        noise=None,
-        head_mask=None,
-        output_attentions=None,
-        output_hidden_states=None,
-        return_dict=None,
-    ):
+        pixel_values: Optional[torch.FloatTensor]=None,
+        noise: Optional[torch.FloatTensor]=None,
+        head_mask: Optional[torch.FloatTensor]=None,
+        output_attentions: Optional[bool]=None,
+        output_hidden_states: Optional[bool]=None,
+        return_dict: Optional[bool]=None,
+    ) -> Union[Tuple, ViTMAEForPreTrainingOutput]:
         r"""
         Returns:
 


### PR DESCRIPTION
Based on Issue #16059 

While looking through the codebase, I found that the ViTMAE model doesn't had the type hints as suggested in Issue #16059. Added type hints for [ViTMAEModel](https://huggingface.co/docs/transformers/model_doc/vit_mae#transformers.ViTMAEModel) and [ViTMAEForPreTraining](https://huggingface.co/docs/transformers/model_doc/vit_mae#transformers.ViTMAEForPreTraining) models.

@Rocketknight1 Could you kindly check if this is fine?

Thanks in advance.