### PR TITLE
fix position bias related logic after prune heads in T5 model

### DIFF
--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -513,7 +513,7 @@ class T5Attention(nn.Module):
         if position_bias is None:
             if not self.has_relative_attention_bias:
                 position_bias = torch.zeros(
-                    (1, self.n_heads, real_seq_length, key_length), device=scores.device, dtype=scores.dtype
+                    (1, self.n_heads + len(self.pruned_heads), real_seq_length, key_length), device=scores.device, dtype=scores.dtype
                 )
                 if self.gradient_checkpointing and self.training:
                     position_bias.requires_grad = True


### PR DESCRIPTION
# What does this PR do?

A follow up pr after #17968

If the attention layer `self.has_relative_attention_bias == False`, then the position bias shape will be wrong, the head number should be the original model (before prune heads) head number `self.n_heads + len(self.pruned_heads)`

## Who can review?

- t5: @patrickvonplaten @patil-suraj