### PR TITLE
Fix push ci workflow file

### DIFF
--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -102,6 +102,7 @@ jobs:
           fetch-depth: 2
 
       - name: Update clone using environment variables
+        working-directory: /transformers
         run: |
           echo "original branch = $(git branch --show-current)"
           git fetch && git checkout ${{ env.CI_BRANCH }}


### PR DESCRIPTION
# What does this PR do?

#19054 breaks push CI due to a missing working dir in CI workflow file. Sorry. 