### PR TITLE
Fix the wrong schedule in runner check CI

### DIFF
--- a/.github/workflows/check_runner_status.yml
+++ b/.github/workflows/check_runner_status.yml
@@ -10,7 +10,7 @@ on:
   repository_dispatch:
   schedule:
     # run per hour
-    - cron: "* */1 * * *"
+    - cron: "0 */1 * * *"
 
 env:
   TRANSFORMERS_IS_CI: yes


### PR DESCRIPTION
# What does this PR do?

The current (wrong) schedule in `check_runner_status.yml`:
`* */1 * * *` -> “At every minute past every hour.”
But we want
`0 */1 * * *` -> “At minute 0 past every hour.”
