### PR TITLE
Skip `test_export_to_onnx` for `LongT5` if `torch` < 1.11

### DIFF
--- a/tests/models/longt5/test_modeling_longt5.py
+++ b/tests/models/longt5/test_modeling_longt5.py
@@ -585,7 +585,10 @@ class LongT5ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase
             model = LongT5Model.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
-    @unittest.skipIf(is_torch_less_than_1_11, "Test failed with torch < 1.11 with an exception in a C++ file.")
+    @unittest.skipIf(
+        is_torch_available and is_torch_less_than_1_11,
+        "Test failed with torch < 1.11 with an exception in a C++ file.",
+    )
     @slow
     def test_export_to_onnx(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/models/longt5/test_modeling_longt5.py
+++ b/tests/models/longt5/test_modeling_longt5.py
@@ -586,7 +586,7 @@ class LongT5ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase
             self.assertIsNotNone(model)
 
     @unittest.skipIf(
-        is_torch_available and is_torch_less_than_1_11,
+        not is_torch_available or is_torch_less_than_1_11,
         "Test failed with torch < 1.11 with an exception in a C++ file.",
     )
     @slow

--- a/tests/models/longt5/test_modeling_longt5.py
+++ b/tests/models/longt5/test_modeling_longt5.py
@@ -28,9 +28,6 @@ from ...test_configuration_common import ConfigTester
 from ...test_modeling_common import ModelTesterMixin, ids_tensor
 
 
-is_torch_available_and_torch_less_than_1_11 = False
-
-
 if is_torch_available():
     import torch
 
@@ -43,8 +40,6 @@ if is_torch_available():
     )
     from transformers.models.longt5.modeling_longt5 import LONGT5_PRETRAINED_MODEL_ARCHIVE_LIST
     from transformers.pytorch_utils import is_torch_less_than_1_11
-
-    is_torch_available_and_torch_less_than_1_11 = is_torch_less_than_1_11
 
 
 class LongT5ModelTester:
@@ -591,7 +586,7 @@ class LongT5ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase
             self.assertIsNotNone(model)
 
     @unittest.skipIf(
-        is_torch_available_and_torch_less_than_1_11,
+        not is_torch_available() or is_torch_less_than_1_11,
         "Test failed with torch < 1.11 with an exception in a C++ file.",
     )
     @slow

--- a/tests/models/longt5/test_modeling_longt5.py
+++ b/tests/models/longt5/test_modeling_longt5.py
@@ -21,6 +21,7 @@ import unittest
 from transformers import LongT5Config, is_torch_available
 from transformers.models.auto import get_values
 from transformers.testing_utils import require_sentencepiece, require_tokenizers, require_torch, slow, torch_device
+from transformers.pytorch_utils import is_torch_less_than_1_11
 from transformers.utils import cached_property
 
 from ...generation.test_generation_utils import GenerationTesterMixin
@@ -584,6 +585,7 @@ class LongT5ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase
             model = LongT5Model.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
+    @unittest.skipif(is_torch_less_than_1_11, "Test failed with torch < 1.11 with an exception in a C++ file.")
     @slow
     def test_export_to_onnx(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/models/longt5/test_modeling_longt5.py
+++ b/tests/models/longt5/test_modeling_longt5.py
@@ -43,6 +43,7 @@ if is_torch_available():
     )
     from transformers.models.longt5.modeling_longt5 import LONGT5_PRETRAINED_MODEL_ARCHIVE_LIST
     from transformers.pytorch_utils import is_torch_less_than_1_11
+
     is_torch_available_and_torch_less_than_1_11 = is_torch_less_than_1_11
 
 

--- a/tests/models/longt5/test_modeling_longt5.py
+++ b/tests/models/longt5/test_modeling_longt5.py
@@ -20,7 +20,6 @@ import unittest
 
 from transformers import LongT5Config, is_torch_available
 from transformers.models.auto import get_values
-from transformers.pytorch_utils import is_torch_less_than_1_11
 from transformers.testing_utils import require_sentencepiece, require_tokenizers, require_torch, slow, torch_device
 from transformers.utils import cached_property
 
@@ -40,6 +39,7 @@ if is_torch_available():
         LongT5Model,
     )
     from transformers.models.longt5.modeling_longt5 import LONGT5_PRETRAINED_MODEL_ARCHIVE_LIST
+    from transformers.pytorch_utils import is_torch_less_than_1_11
 
 
 class LongT5ModelTester:

--- a/tests/models/longt5/test_modeling_longt5.py
+++ b/tests/models/longt5/test_modeling_longt5.py
@@ -20,8 +20,8 @@ import unittest
 
 from transformers import LongT5Config, is_torch_available
 from transformers.models.auto import get_values
-from transformers.testing_utils import require_sentencepiece, require_tokenizers, require_torch, slow, torch_device
 from transformers.pytorch_utils import is_torch_less_than_1_11
+from transformers.testing_utils import require_sentencepiece, require_tokenizers, require_torch, slow, torch_device
 from transformers.utils import cached_property
 
 from ...generation.test_generation_utils import GenerationTesterMixin

--- a/tests/models/longt5/test_modeling_longt5.py
+++ b/tests/models/longt5/test_modeling_longt5.py
@@ -28,6 +28,9 @@ from ...test_configuration_common import ConfigTester
 from ...test_modeling_common import ModelTesterMixin, ids_tensor
 
 
+is_torch_available_and_torch_less_than_1_11 = False
+
+
 if is_torch_available():
     import torch
 
@@ -40,6 +43,7 @@ if is_torch_available():
     )
     from transformers.models.longt5.modeling_longt5 import LONGT5_PRETRAINED_MODEL_ARCHIVE_LIST
     from transformers.pytorch_utils import is_torch_less_than_1_11
+    is_torch_available_and_torch_less_than_1_11 = is_torch_less_than_1_11
 
 
 class LongT5ModelTester:
@@ -586,7 +590,7 @@ class LongT5ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase
             self.assertIsNotNone(model)
 
     @unittest.skipIf(
-        not is_torch_available or is_torch_less_than_1_11,
+        is_torch_available_and_torch_less_than_1_11,
         "Test failed with torch < 1.11 with an exception in a C++ file.",
     )
     @slow

--- a/tests/models/longt5/test_modeling_longt5.py
+++ b/tests/models/longt5/test_modeling_longt5.py
@@ -585,7 +585,7 @@ class LongT5ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase
             model = LongT5Model.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
-    @unittest.skipif(is_torch_less_than_1_11, "Test failed with torch < 1.11 with an exception in a C++ file.")
+    @unittest.skipIf(is_torch_less_than_1_11, "Test failed with torch < 1.11 with an exception in a C++ file.")
     @slow
     def test_export_to_onnx(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()


### PR DESCRIPTION
# What does this PR do?

With torch `1.10`, We get some exception from C++ file.
```bash
Exception raised from index_select_out_cpu_ at ../aten/src/ATen/native/TensorAdvancedIndexing.cpp:887 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::string) + 0x42 (0x7f60b7f4dd62 in /home/yih_dar_huggingface_co/miniconda3/envs/py39/lib/python3.9/site-packages/torch/lib/libc10.so)
```
Skip this test for torch < 1.11: **Make past CI clean**


P.S. this test is only defined for 3 models (T5, LongT5 and FSMT), but skipped (without any condition) for T5 and FSMT.
It should be fine to remove this test, and rely on `tests/onnx`.