### PR TITLE
Document and validate typical_p in generation

### DIFF
--- a/src/transformers/generation_logits_process.py
+++ b/src/transformers/generation_logits_process.py
@@ -236,6 +236,19 @@ class TopKLogitsWarper(LogitsWarper):
 
 
 class TypicalLogitsWarper(LogitsWarper):
+    r"""
+    [`LogitsWarper`] that performs typical decoding. See [Typical Decoding for Natural Language
+    Generation](https://arxiv.org/abs/2202.00666) for more information.
+
+    Args:
+        mass (`float`):
+            Value of typical_p between 0 and 1 inclusive, defaults to 0.9.
+        filter_value (`float`, *optional*, defaults to `-float("Inf")`):
+            All filtered values will be set to this float value.
+        min_tokens_to_keep (`int`, *optional*, defaults to 1):
+            Minimum number of tokens that cannot be filtered.
+    """
+
     def __init__(self, mass: float = 0.9, filter_value: float = -float("Inf"), min_tokens_to_keep: int = 1):
         mass = float(mass)
         if not (mass > 0 and mass < 1):

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -392,8 +392,8 @@ class GenerationMixin:
           `do_sample=False`.
         - *multinomial sampling* by calling [`~generation_utils.GenerationMixin.sample`] if `num_beams=1` and
           `do_sample=True`.
-        - *typical decoding* by calling [`~generation_utils.GenerationMixin.sample`] if `typical_p` between 0 and 1, and
-          `do_sample=True`.
+        - *typical decoding* by calling [`~generation_utils.GenerationMixin.sample`] if `typical_p` between 0 and 1,
+          and `do_sample=True`.
         - *beam-search decoding* by calling [`~generation_utils.GenerationMixin.beam_search`] if `num_beams>1` and
           `do_sample=False`.
         - *beam-search multinomial sampling* by calling [`~generation_utils.GenerationMixin.beam_sample`] if

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -392,8 +392,6 @@ class GenerationMixin:
           `do_sample=False`.
         - *multinomial sampling* by calling [`~generation_utils.GenerationMixin.sample`] if `num_beams=1` and
           `do_sample=True`.
-        - *typical decoding* by calling [`~generation_utils.GenerationMixin.sample`] if `typical_p` between 0 and 1,
-          and `do_sample=True`.
         - *beam-search decoding* by calling [`~generation_utils.GenerationMixin.beam_search`] if `num_beams>1` and
           `do_sample=False`.
         - *beam-search multinomial sampling* by calling [`~generation_utils.GenerationMixin.beam_sample`] if
@@ -1318,17 +1316,6 @@ class GenerationMixin:
                 "Diverse beam search cannot be used in sampling mode. Make sure that `do_sample` is set to `False`."
             )
 
-        if typical_p is not None:
-            if typical_p < 0 or typical_p > 1:
-                raise ValueError("Value of typical_p must be between 0 and 1.")
-            elif do_sample is False:
-                raise ValueError(
-                    "Decoder argument `typical_p` must be used in sampling mode. "
-                    "Make sure that `do_sample` is set to `True`."
-                )
-            elif is_group_beam_gen_mode is True:
-                raise ValueError("Decoder argument `typical_p` is not supported with beam groups.")
-
         # 7. prepare distribution pre_processing samplers
         logits_processor = self._get_logits_processor(
             repetition_penalty=repetition_penalty,
@@ -1498,6 +1485,9 @@ class GenerationMixin:
 
             if stopping_criteria.max_length is None:
                 raise ValueError("`max_length` needs to be a stopping_criteria for now.")
+
+            if typical_p is not None:
+                raise ValueError("Decoder argument `typical_p` is not supported with beam groups.")
 
             # 10. prepare beam search scorer
             beam_scorer = BeamSearchScorer(

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -392,6 +392,8 @@ class GenerationMixin:
           `do_sample=False`.
         - *multinomial sampling* by calling [`~generation_utils.GenerationMixin.sample`] if `num_beams=1` and
           `do_sample=True`.
+        - *typical decoding* by calling [`~generation_utils.GenerationMixin.sample`] if `typical_p` between 0 and 1, and
+          `do_sample=True`.
         - *beam-search decoding* by calling [`~generation_utils.GenerationMixin.beam_search`] if `num_beams>1` and
           `do_sample=False`.
         - *beam-search multinomial sampling* by calling [`~generation_utils.GenerationMixin.beam_sample`] if
@@ -1315,6 +1317,17 @@ class GenerationMixin:
             raise ValueError(
                 "Diverse beam search cannot be used in sampling mode. Make sure that `do_sample` is set to `False`."
             )
+
+        if typical_p is not None:
+            if typical_p < 0 or typical_p > 1:
+                raise ValueError("Value of typical_p must be between 0 and 1.")
+            elif do_sample is False:
+                raise ValueError(
+                    "Decoder argument `typical_p` must be used in sampling mode. "
+                    "Make sure that `do_sample` is set to `True`."
+                )
+            elif is_group_beam_gen_mode is True:
+                raise ValueError("Decoder argument `typical_p` is not supported with beam groups.")
 
         # 7. prepare distribution pre_processing samplers
         logits_processor = self._get_logits_processor(


### PR DESCRIPTION
# What does this PR do?

Throws a `ValueError` when `typical_p` argument is provided to text-generation, but its value or `do_sample=False` prevent typical decoding from happening as intended. Adds a line documenting typical decoding.

Most arguments to generate were previously covered in #18261 , but not `typical_p`.
