### PR TITLE
oneccl_bindings_for_pytorch 1.12.0 prebuilt wheel does not work with …

### DIFF
--- a/docs/source/en/perf_train_cpu_many.mdx
+++ b/docs/source/en/perf_train_cpu_many.mdx
@@ -38,15 +38,25 @@ where `{pytorch_version}` should be your PyTorch version, for instance 1.12.0.
 Check more approaches for [oneccl_bind_pt installation](https://github.com/intel/torch-ccl).
 Versions of oneCCL and PyTorch must match.
 
+ Note: oneccl_bindings_for_pytorch 1.12.0 prebuilt wheel does not work with PyTorch 1.12.1 (it is for PyTorch 1.12.0)
+
 ## Intel® MPI library
 Use this standards-based MPI implementation to deliver flexible, efficient, scalable cluster messaging on Intel® architecture. This component is part of the Intel® oneAPI HPC Toolkit.
-It can be installed via [MPI](https://www.intel.com/content/www/us/en/developer/articles/tool/oneapi-standalone-components.html#mpi).
 
-Please set the environment by following command before using it.
+oneccl_bindings_for_pytorch is installed along with the MPI tool set. Need to source the environment before using it.
 
+for Intel® oneCCL 1.12.0
 ```
-source /opt/intel/oneapi/setvars.sh
+oneccl_bindings_for_pytorch_path=$(python -c "from oneccl_bindings_for_pytorch import cwd; print(cwd)")
+source $oneccl_bindings_for_pytorch_path/env/setvars.sh
 ```
+
+for Intel® oneCCL whose version < 1.12.0
+```
+torch_ccl_path=$(python -c "import torch; import torch_ccl; import os;  print(os.path.abspath(os.path.dirname(torch_ccl.__file__)))")
+source $torch_ccl_path/env/setvars.sh
+```
+
 
 The following "Usage in Trainer" takes mpirun in Intel® MPI library as an example.
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -51,6 +51,7 @@ from .utils import (
     logging,
     requires_backends,
     torch_required,
+    torch_version,
 )
 
 
@@ -1345,6 +1346,11 @@ class TrainingArguments:
                 if self.xpu_backend == "ccl":
                     requires_backends(self, "oneccl_bind_pt")
                     if ccl_version >= "1.12":
+                        if "1.12.0" in ccl_version and torch_version == version.parse("1.12.1"):
+                            raise ValueError(
+                                "oneccl_bindings_for_pytorch 1.12.0 prebuilt wheel does not work with PyTorch 1.12.1. "
+                                "Please use torch 1.12.0 to work with oneccl_bindings_for_pytorch 1.12.0."
+                            )
                         import oneccl_bindings_for_pytorch  # noqa: F401
                     else:
                         import torch_ccl  # noqa: F401
@@ -1353,7 +1359,6 @@ class TrainingArguments:
                             "CPU distributed training backend is ccl. but CCL_WORKER_COUNT is not correctly set. "
                             "Please use like 'export CCL_WORKER_COUNT = 1' to set."
                         )
-
                 # Try to get launch configuration from environment variables set by MPI launcher - works for Intel MPI, OpenMPI and MVAPICH
                 rank = get_int_from_env(["RANK", "PMI_RANK", "OMPI_COMM_WORLD_RANK", "MV2_COMM_WORLD_RANK"], 0)
                 size = get_int_from_env(["WORLD_SIZE", "PMI_SIZE", "OMPI_COMM_WORLD_SIZE", "MV2_COMM_WORLD_SIZE"], 1)


### PR DESCRIPTION
…PyTorch 1.12.1

raise error in this condition and update the doc

Signed-off-by: Wang, Yi A <yi.a.wang@intel.com>

Fixes # (issue)
torch 1.12.1 does not work with intel ccl 1.12.0

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@sgugger
