### PR TITLE
Support depencencies from github

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -177,7 +177,7 @@ _deps = [
 # packaging: "packaging"
 #
 # some of the values are versioned whereas others aren't.
-deps = {b: a for a, b in (re.findall(r"^(([^!=<>~]+)(?:[!=<>~].*)?$)", x)[0] for x in _deps)}
+deps = {b: a for a, b in (re.findall(r"^(([^!=<>~ ]+)(?:[!=<>~ ].*)?$)", x)[0] for x in _deps)}
 
 # since we save this data in src/transformers/dependency_versions_table.py it can be easily accessed from
 # anywhere. If you need to quickly access the data from this table in a shell, you can do so easily with:


### PR DESCRIPTION
Updated the `deps` regex to support dependencies from github.

For example I often want to run the `transformers` CI but with the `main` branch of `datasets` using
```
    "datasets @ git+https://github.com/huggingface/datasets@main#egg=datasets",
```