### PR TITLE
Fix dummy creation for multi-frameworks objects

### DIFF
--- a/utils/check_dummies.py
+++ b/utils/check_dummies.py
@@ -26,7 +26,7 @@ PATH_TO_TRANSFORMERS = "src/transformers"
 _re_backend = re.compile(r"is\_([a-z_]*)_available()")
 # Matches from xxx import bla
 _re_single_line_import = re.compile(r"\s+from\s+\S*\s+import\s+([^\(\s].*)\n")
-_re_test_backend = re.compile(r"^\s+if\s+not\s+is\_[a-z_]*\_available\(\)")
+_re_test_backend = re.compile(r"^\s+if\s+not\s+\(?is\_[a-z_]*\_available\(\)")
 
 
 DUMMY_CONSTANT = """


### PR DESCRIPTION
# What does this PR do?

Follow-up from #17304, this finishes fixing the dummy creation script when there is more than one framework on which the object depends.

The problem is that it does not recognize the lines in the init like:
```
    if not (is_sentencepiece_available() and is_tokenizers_available()):
```

To check the change, after the PR the following passes:
```py
import sys

# Adapt to where the repo is
sys.path.append("../git/transformers/utils")
from check_dummies import find_backend

assert find_backend("    if not is_tokenizers_available():") == "tokenizers"
assert find_backend("    if not (is_sentencepiece_available() and is_tokenizers_available()):") == "sentencepiece_and_tokenizers"
```

Before this PR only the first test passes.

I will work on adding unit tests such as the one above for all of our quality scripts.