### PR TITLE
Reduce LR for TF MLM example test

### DIFF
--- a/examples/tensorflow/test_tensorflow_examples.py
+++ b/examples/tensorflow/test_tensorflow_examples.py
@@ -157,6 +157,7 @@ class ExamplesTests(TestCasePlus):
             --do_eval
             --prediction_loss_only
             --num_train_epochs=1
+            --learning_rate=1e-4
         """.split()
 
         with patch.object(sys, "argv", testargs):


### PR DESCRIPTION
The TF MLM example test was a little flakey, depending on the exact shuffling order of the dataset. I reduced the LR to 1e-4 and it seems to be consistently around 36 final perplexity now (compared to the test threshold of 42).

Cc @sgugger 