### PR TITLE
[WIP] Trainer supporting evaluation on multiple datasets

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2044,14 +2044,10 @@ class Trainer:
         if self.control.should_evaluate:
             if isinstance(self.eval_dataset, dict):
                 for eval_dataset_name, eval_dataset in self.eval_dataset.items():
-                    evaluate_kwargs = {}
-                    if isinstance(self.compute_metrics, dict):
-                        evaluate_kwargs["compute_metrics"] = self.compute_metrics[eval_dataset_name]
                     metrics = self.evaluate(
                         eval_dataset=eval_dataset,
                         ignore_keys=ignore_keys_for_eval,
                         metric_key_prefix=f"eval_{eval_dataset_name}",
-                        **evaluate_kwargs,
                     )
             else:
                 metrics = self.evaluate(ignore_keys=ignore_keys_for_eval)
@@ -2742,7 +2738,6 @@ class Trainer:
     def evaluate(
         self,
         eval_dataset: Optional[Dataset] = None,
-        compute_metrics: Optional[Callable[[EvalPrediction], Dict]] = None,
         ignore_keys: Optional[List[str]] = None,
         metric_key_prefix: str = "eval",
     ) -> Dict[str, float]:
@@ -2759,9 +2754,6 @@ class Trainer:
                 Pass a dataset if you wish to override `self.eval_dataset`. If it is a [`~datasets.Dataset`], columns
                 not accepted by the `model.forward()` method are automatically removed. It must implement the `__len__`
                 method.
-            compute_metrics (`Callable[[EvalPrediction], Dict]`, *optional*, defaults to `None`):
-                Pass a compute_metric function if you wish to override `self.compute_metrics`. Used when
-                `self.eval_dataset` holds multiple datasets.
             ignore_keys (`Lst[str]`, *optional*):
                 A list of keys in the output of your model (if it is a dictionary) that should be ignored when
                 gathering predictions.
@@ -2777,7 +2769,6 @@ class Trainer:
         self._memory_tracker.start()
 
         eval_dataloader = self.get_eval_dataloader(eval_dataset)
-        compute_metrics = compute_metrics if compute_metrics is not None else self.compute_metrics
 
         start_time = time.time()
 
@@ -2787,10 +2778,10 @@ class Trainer:
             description="Evaluation",
             # No point gathering the predictions if there are no metrics, otherwise we defer to
             # self.args.prediction_loss_only
-            prediction_loss_only=True if compute_metrics is None else None,
+            prediction_loss_only=True if self.compute_metrics is None else None,
             ignore_keys=ignore_keys,
             metric_key_prefix=metric_key_prefix,
-            compute_metrics=compute_metrics,
+            compute_metrics=self.compute_metrics,
         )
 
         total_batch_size = self.args.eval_batch_size * self.args.world_size
@@ -2882,7 +2873,6 @@ class Trainer:
         prediction_loss_only: Optional[bool] = None,
         ignore_keys: Optional[List[str]] = None,
         metric_key_prefix: str = "eval",
-        compute_metrics: Optional[Callable[[EvalPrediction], Dict]] = None,
     ) -> EvalLoopOutput:
         """
         Prediction/evaluation loop, shared by `Trainer.evaluate()` and `Trainer.predict()`.
@@ -3063,13 +3053,13 @@ class Trainer:
             all_inputs = nested_truncate(all_inputs, num_samples)
 
         # Metrics!
-        if compute_metrics is not None and all_preds is not None and all_labels is not None:
+        if self.compute_metrics is not None and all_preds is not None and all_labels is not None:
             if args.include_inputs_for_metrics:
-                metrics = compute_metrics(
+                metrics = self.compute_metrics(
                     EvalPrediction(predictions=all_preds, label_ids=all_labels, inputs=all_inputs)
                 )
             else:
-                metrics = compute_metrics(EvalPrediction(predictions=all_preds, label_ids=all_labels))
+                metrics = self.compute_metrics(EvalPrediction(predictions=all_preds, label_ids=all_labels))
         else:
             metrics = {}
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -255,8 +255,8 @@ class Trainer:
             inner layers, dropout probabilities etc).
         compute_metrics (`Union[Callable[[EvalPrediction], Dict], Dict[str, Callable[[EvalPrediction], Dict]]]`, *optional*):
             The function that will be used to compute metrics at evaluation. Must take a [`EvalPrediction`] and return
-            a dictionary string to metric values. If `eval_dataset` is a dict, each dataset can be evaluated with a seperate
-            compute function. The keys in `eval_dataset` and `compute_metrics` must match.
+            a dictionary string to metric values. If `eval_dataset` is a dict, each dataset can be evaluated with a
+            separate compute function. The keys in `eval_dataset` and `compute_metrics` must match.
         callbacks (List of [`TrainerCallback`], *optional*):
             A list of callbacks to customize the training loop. Will add those to the list of default callbacks
             detailed in [here](callback).
@@ -2051,7 +2051,7 @@ class Trainer:
                         eval_dataset=eval_dataset,
                         ignore_keys=ignore_keys_for_eval,
                         metric_key_prefix=f"eval_{eval_dataset_name}",
-                        **evaluate_kwargs
+                        **evaluate_kwargs,
                     )
             else:
                 metrics = self.evaluate(ignore_keys=ignore_keys_for_eval)
@@ -2760,7 +2760,7 @@ class Trainer:
                 not accepted by the `model.forward()` method are automatically removed. It must implement the `__len__`
                 method.
             compute_metrics (`Callable[[EvalPrediction], Dict]`, *optional*, defaults to `None`):
-                Pass a compute_metric function if you wish to override `self.compute_metrics`. Used when 
+                Pass a compute_metric function if you wish to override `self.compute_metrics`. Used when
                 `self.eval_dataset` holds multiple datasets.
             ignore_keys (`Lst[str]`, *optional*):
                 A list of keys in the output of your model (if it is a dictionary) that should be ignored when

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -238,9 +238,10 @@ class Trainer:
             `torch.Generator` for the randomization that must be identical on all processes (and the Trainer will
             manually set the seed of this `generator` at each epoch) or have a `set_epoch()` method that internally
             sets the seed of the RNGs used.
-        eval_dataset (`torch.utils.data.Dataset`, *optional*):
+        eval_dataset (Union[`torch.utils.data.Dataset`, Dict[str, `torch.utils.data.Dataset`]), *optional*):
              The dataset to use for evaluation. If it is a [`~datasets.Dataset`], columns not accepted by the
-             `model.forward()` method are automatically removed.
+             `model.forward()` method are automatically removed. If it is a dictionary, it will evaluate on each
+             dataset prepending the dictionary key to the metric name.
         tokenizer ([`PreTrainedTokenizerBase`], *optional*):
             The tokenizer used to preprocess the data. If provided, will be used to automatically pad the inputs the
             maximum length when batching inputs, and it will be saved along the model to make it easier to rerun an
@@ -252,9 +253,10 @@ class Trainer:
             The function may have zero argument, or a single one containing the optuna/Ray Tune/SigOpt trial object, to
             be able to choose different architectures according to hyper parameters (such as layer count, sizes of
             inner layers, dropout probabilities etc).
-        compute_metrics (`Callable[[EvalPrediction], Dict]`, *optional*):
+        compute_metrics (`Union[Callable[[EvalPrediction], Dict], Dict[str, Callable[[EvalPrediction], Dict]]]`, *optional*):
             The function that will be used to compute metrics at evaluation. Must take a [`EvalPrediction`] and return
-            a dictionary string to metric values.
+            a dictionary string to metric values. If `eval_dataset` is a dict, each dataset can be evaluated with a seperate
+            compute function. The keys in `eval_dataset` and `compute_metrics` must match.
         callbacks (List of [`TrainerCallback`], *optional*):
             A list of callbacks to customize the training loop. Will add those to the list of default callbacks
             detailed in [here](callback).

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2740,9 +2740,9 @@ class Trainer:
     def evaluate(
         self,
         eval_dataset: Optional[Dataset] = None,
+        compute_metrics: Optional[Callable[[EvalPrediction], Dict]] = None,
         ignore_keys: Optional[List[str]] = None,
         metric_key_prefix: str = "eval",
-        compute_metrics: Optional[Callable[[EvalPrediction], Dict]] = None,
     ) -> Dict[str, float]:
         """
         Run evaluation and returns metrics.
@@ -2757,6 +2757,9 @@ class Trainer:
                 Pass a dataset if you wish to override `self.eval_dataset`. If it is a [`~datasets.Dataset`], columns
                 not accepted by the `model.forward()` method are automatically removed. It must implement the `__len__`
                 method.
+            compute_metrics (`Callable[[EvalPrediction], Dict]`, *optional*, defaults to `None`):
+                Pass a compute_metric function if you wish to override `self.compute_metrics`. Used when 
+                `self.eval_dataset` holds multiple datasets.
             ignore_keys (`Lst[str]`, *optional*):
                 A list of keys in the output of your model (if it is a dictionary) that should be ignored when
                 gathering predictions.

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2768,7 +2768,6 @@ class Trainer:
         self._memory_tracker.start()
 
         eval_dataloader = self.get_eval_dataloader(eval_dataset)
-
         start_time = time.time()
 
         eval_loop = self.prediction_loop if self.args.use_legacy_prediction_loop else self.evaluation_loop

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -253,10 +253,9 @@ class Trainer:
             The function may have zero argument, or a single one containing the optuna/Ray Tune/SigOpt trial object, to
             be able to choose different architectures according to hyper parameters (such as layer count, sizes of
             inner layers, dropout probabilities etc).
-        compute_metrics (`Union[Callable[[EvalPrediction], Dict], Dict[str, Callable[[EvalPrediction], Dict]]]`, *optional*):
+        compute_metrics (`Callable[[EvalPrediction], Dict]`, *optional*):
             The function that will be used to compute metrics at evaluation. Must take a [`EvalPrediction`] and return
-            a dictionary string to metric values. If `eval_dataset` is a dict, each dataset can be evaluated with a
-            separate compute function. The keys in `eval_dataset` and `compute_metrics` must match.
+            a dictionary string to metric values.
         callbacks (List of [`TrainerCallback`], *optional*):
             A list of callbacks to customize the training loop. Will add those to the list of default callbacks
             detailed in [here](callback).
@@ -2044,14 +2043,10 @@ class Trainer:
         if self.control.should_evaluate:
             if isinstance(self.eval_dataset, dict):
                 for eval_dataset_name, eval_dataset in self.eval_dataset.items():
-                    evaluate_kwargs = {}
-                    if isinstance(self.compute_metrics, dict):
-                        evaluate_kwargs["compute_metrics"] = self.compute_metrics[eval_dataset_name]
                     metrics = self.evaluate(
                         eval_dataset=eval_dataset,
                         ignore_keys=ignore_keys_for_eval,
                         metric_key_prefix=f"eval_{eval_dataset_name}",
-                        **evaluate_kwargs,
                     )
             else:
                 metrics = self.evaluate(ignore_keys=ignore_keys_for_eval)
@@ -2742,7 +2737,6 @@ class Trainer:
     def evaluate(
         self,
         eval_dataset: Optional[Dataset] = None,
-        compute_metrics: Optional[Callable[[EvalPrediction], Dict]] = None,
         ignore_keys: Optional[List[str]] = None,
         metric_key_prefix: str = "eval",
     ) -> Dict[str, float]:
@@ -2759,9 +2753,6 @@ class Trainer:
                 Pass a dataset if you wish to override `self.eval_dataset`. If it is a [`~datasets.Dataset`], columns
                 not accepted by the `model.forward()` method are automatically removed. It must implement the `__len__`
                 method.
-            compute_metrics (`Callable[[EvalPrediction], Dict]`, *optional*, defaults to `None`):
-                Pass a compute_metric function if you wish to override `self.compute_metrics`. Used when
-                `self.eval_dataset` holds multiple datasets.
             ignore_keys (`Lst[str]`, *optional*):
                 A list of keys in the output of your model (if it is a dictionary) that should be ignored when
                 gathering predictions.
@@ -2777,7 +2768,6 @@ class Trainer:
         self._memory_tracker.start()
 
         eval_dataloader = self.get_eval_dataloader(eval_dataset)
-        compute_metrics = compute_metrics if compute_metrics is not None else self.compute_metrics
 
         start_time = time.time()
 
@@ -2787,10 +2777,9 @@ class Trainer:
             description="Evaluation",
             # No point gathering the predictions if there are no metrics, otherwise we defer to
             # self.args.prediction_loss_only
-            prediction_loss_only=True if compute_metrics is None else None,
+            prediction_loss_only=True if self.compute_metrics is None else None,
             ignore_keys=ignore_keys,
             metric_key_prefix=metric_key_prefix,
-            compute_metrics=compute_metrics,
         )
 
         total_batch_size = self.args.eval_batch_size * self.args.world_size
@@ -2882,7 +2871,6 @@ class Trainer:
         prediction_loss_only: Optional[bool] = None,
         ignore_keys: Optional[List[str]] = None,
         metric_key_prefix: str = "eval",
-        compute_metrics: Optional[Callable[[EvalPrediction], Dict]] = None,
     ) -> EvalLoopOutput:
         """
         Prediction/evaluation loop, shared by `Trainer.evaluate()` and `Trainer.predict()`.
@@ -3063,13 +3051,13 @@ class Trainer:
             all_inputs = nested_truncate(all_inputs, num_samples)
 
         # Metrics!
-        if compute_metrics is not None and all_preds is not None and all_labels is not None:
+        if self.compute_metrics is not None and all_preds is not None and all_labels is not None:
             if args.include_inputs_for_metrics:
-                metrics = compute_metrics(
+                metrics = self.compute_metrics(
                     EvalPrediction(predictions=all_preds, label_ids=all_labels, inputs=all_inputs)
                 )
             else:
-                metrics = compute_metrics(EvalPrediction(predictions=all_preds, label_ids=all_labels))
+                metrics = self.compute_metrics(EvalPrediction(predictions=all_preds, label_ids=all_labels))
         else:
             metrics = {}
 

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -20,7 +20,7 @@ from torch.utils.data import Dataset
 
 from .deepspeed import is_deepspeed_zero3_enabled
 from .trainer import Trainer
-from .trainer_utils import EvalPrediction, PredictionOutput
+from .trainer_utils import PredictionOutput
 from .utils import logging
 
 
@@ -31,7 +31,6 @@ class Seq2SeqTrainer(Trainer):
     def evaluate(
         self,
         eval_dataset: Optional[Dataset] = None,
-        compute_metrics: Optional[Callable[[EvalPrediction], Dict]] = None,
         ignore_keys: Optional[List[str]] = None,
         metric_key_prefix: str = "eval",
         **gen_kwargs
@@ -49,9 +48,6 @@ class Seq2SeqTrainer(Trainer):
                 Pass a dataset if you wish to override `self.eval_dataset`. If it is an [`~datasets.Dataset`], columns
                 not accepted by the `model.forward()` method are automatically removed. It must implement the `__len__`
                 method.
-            compute_metrics (`Callable[[EvalPrediction], Dict]`, *optional*, defaults to `None`):
-                Pass a compute_metric function if you wish to override `self.compute_metrics`. Used when
-                `self.eval_dataset` holds multiple datasets.
             ignore_keys (`List[str]`, *optional*):
                 A list of keys in the output of your model (if it is a dictionary) that should be ignored when
                 gathering predictions.
@@ -79,9 +75,7 @@ class Seq2SeqTrainer(Trainer):
         )
         self._gen_kwargs = gen_kwargs
 
-        return super().evaluate(
-            eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix, compute_metrics=compute_metrics
-        )
+        return super().evaluate(eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
 
     def predict(
         self,

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -50,7 +50,7 @@ class Seq2SeqTrainer(Trainer):
                 not accepted by the `model.forward()` method are automatically removed. It must implement the `__len__`
                 method.
             compute_metrics (`Callable[[EvalPrediction], Dict]`, *optional*, defaults to `None`):
-                Pass a compute_metric function if you wish to override `self.compute_metrics`. Used when 
+                Pass a compute_metric function if you wish to override `self.compute_metrics`. Used when
                 `self.eval_dataset` holds multiple datasets.
             ignore_keys (`List[str]`, *optional*):
                 A list of keys in the output of your model (if it is a dictionary) that should be ignored when
@@ -79,7 +79,9 @@ class Seq2SeqTrainer(Trainer):
         )
         self._gen_kwargs = gen_kwargs
 
-        return super().evaluate(eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix, compute_metrics=compute_metrics)
+        return super().evaluate(
+            eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix, compute_metrics=compute_metrics
+        )
 
     def predict(
         self,

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -20,7 +20,7 @@ from torch.utils.data import Dataset
 
 from .deepspeed import is_deepspeed_zero3_enabled
 from .trainer import Trainer
-from .trainer_utils import PredictionOutput
+from .trainer_utils import EvalPrediction, PredictionOutput
 from .utils import logging
 
 
@@ -33,6 +33,7 @@ class Seq2SeqTrainer(Trainer):
         eval_dataset: Optional[Dataset] = None,
         ignore_keys: Optional[List[str]] = None,
         metric_key_prefix: str = "eval",
+        compute_metrics: Optional[Callable[[EvalPrediction], Dict]] = None,
         **gen_kwargs
     ) -> Dict[str, float]:
         """
@@ -75,7 +76,7 @@ class Seq2SeqTrainer(Trainer):
         )
         self._gen_kwargs = gen_kwargs
 
-        return super().evaluate(eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
+        return super().evaluate(eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix, compute_metrics=compute_metrics)
 
     def predict(
         self,

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -31,9 +31,9 @@ class Seq2SeqTrainer(Trainer):
     def evaluate(
         self,
         eval_dataset: Optional[Dataset] = None,
+        compute_metrics: Optional[Callable[[EvalPrediction], Dict]] = None,
         ignore_keys: Optional[List[str]] = None,
         metric_key_prefix: str = "eval",
-        compute_metrics: Optional[Callable[[EvalPrediction], Dict]] = None,
         **gen_kwargs
     ) -> Dict[str, float]:
         """
@@ -49,6 +49,9 @@ class Seq2SeqTrainer(Trainer):
                 Pass a dataset if you wish to override `self.eval_dataset`. If it is an [`~datasets.Dataset`], columns
                 not accepted by the `model.forward()` method are automatically removed. It must implement the `__len__`
                 method.
+            compute_metrics (`Callable[[EvalPrediction], Dict]`, *optional*, defaults to `None`):
+                Pass a compute_metric function if you wish to override `self.compute_metrics`. Used when 
+                `self.eval_dataset` holds multiple datasets.
             ignore_keys (`List[str]`, *optional*):
                 A list of keys in the output of your model (if it is a dictionary) that should be ignored when
                 gathering predictions.


### PR DESCRIPTION
# What does this PR do?
With this PR `Trainer` and `Seq2SeqTrainer` support evaluating on multiple datasets. For this, the `eval_dataset` and `compute_metrics` parameters have been updated. In order to evaluate on multiple datasets, `eval_dataset` should be a dict mapping a dataset name to a Dataset. In `_maybe_log_save_evaluate` we then loop over the dict, calling `evaluate` with each Dataset. The metric prefix is also updated to contain the dataset name. Furthermore, each eval dataset can optionally have its own `compute_metrics` function. For this, `compute_metrics` should be a dict where the keys match with `eval_dataset`.

Fixes #15857


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
 @sgugger 