### PR TITLE
Fix TrainingArguments documentation

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -119,7 +119,6 @@ class OptimizerNames(ExplicitEnum):
 
 @dataclass
 class TrainingArguments:
-    framework = "pt"
     """
     TrainingArguments is the subset of the arguments we use in our example scripts **which relate to the training loop
     itself**.
@@ -500,6 +499,7 @@ class TrainingArguments:
             Whether to use Apple Silicon chip based `mps` device.
     """
 
+    framework = "pt"
     output_dir: str = field(
         metadata={"help": "The output directory where the model predictions and checkpoints will be written."},
     )

--- a/src/transformers/training_args_tf.py
+++ b/src/transformers/training_args_tf.py
@@ -28,7 +28,6 @@ if is_tf_available():
 
 @dataclass
 class TFTrainingArguments(TrainingArguments):
-    framework = "tf"
     """
     TrainingArguments is the subset of the arguments we use in our example scripts **which relate to the training loop
     itself**.
@@ -162,6 +161,7 @@ class TFTrainingArguments(TrainingArguments):
             Whether to activate the XLA compilation or not.
     """
 
+    framework = "tf"
     tpu_name: Optional[str] = field(
         default=None,
         metadata={"help": "Name of TPU"},


### PR DESCRIPTION
# What does this PR do?

@Rocketknight1 added a new class variable for `TrainingArguments` but put it before the docstring, which erased all doc for this class :grimacing: This PR fixes that.