### PR TITLE
Separate Push CI images from Scheduled CI

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -6,6 +6,10 @@ on:
       - docker-image*
   repository_dispatch:
   workflow_call:
+    inputs:
+      image_postfix:
+        required: true
+        type: string
   schedule:
     - cron: "0 1 * * *"
 
@@ -38,10 +42,12 @@ jobs:
           build-args: |
             REF=main
           push: true
-          tags: huggingface/transformers-all-latest-gpu
+          tags: huggingface/transformers-all-latest-gpu${{ inputs.image_postfix }}
 
   latest-with-torch-nightly-docker:
     name: "Nightly PyTorch + Stable TensorFlow"
+    # Push CI doesn't need this image
+    if: inputs.image_postfix != ''
     runs-on: ubuntu-latest
     steps:
       -
@@ -91,10 +97,12 @@ jobs:
           build-args: |
             REF=main
           push: true
-          tags: huggingface/transformers-pytorch-deepspeed-latest-gpu
+          tags: huggingface/transformers-pytorch-deepspeed-latest-gpu${{ inputs.image_postfix }}
 
   nightly-torch-deepspeed-docker:
     name: "Nightly PyTorch + DeepSpeed"
+    # Push CI doesn't need this image
+    if: inputs.image_postfix != ''
     runs-on: ubuntu-latest
     steps:
       -
@@ -121,6 +129,8 @@ jobs:
 
   doc-builder:
     name: "Doc builder"
+    # Push CI doesn't need this image
+    if: inputs.image_postfix != ''
     runs-on: ubuntu-latest
     steps:
       -
@@ -145,6 +155,8 @@ jobs:
 
   latest-pytorch:
     name: "Latest PyTorch [dev]"
+    # Push CI doesn't need this image
+    if: inputs.image_postfix != ''
     runs-on: ubuntu-latest
     steps:
       -
@@ -171,6 +183,8 @@ jobs:
 
   latest-tensorflow:
     name: "Latest TensorFlow [dev]"
+    # Push CI doesn't need this image
+    if: inputs.image_postfix != ''
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -47,7 +47,7 @@ jobs:
   latest-with-torch-nightly-docker:
     name: "Nightly PyTorch + Stable TensorFlow"
     # Push CI doesn't need this image
-    if: inputs.image_postfix != ''
+    if: inputs.image_postfix != '-push-ci'
     runs-on: ubuntu-latest
     steps:
       -
@@ -102,7 +102,7 @@ jobs:
   nightly-torch-deepspeed-docker:
     name: "Nightly PyTorch + DeepSpeed"
     # Push CI doesn't need this image
-    if: inputs.image_postfix != ''
+    if: inputs.image_postfix != '-push-ci'
     runs-on: ubuntu-latest
     steps:
       -
@@ -130,7 +130,7 @@ jobs:
   doc-builder:
     name: "Doc builder"
     # Push CI doesn't need this image
-    if: inputs.image_postfix != ''
+    if: inputs.image_postfix != '-push-ci'
     runs-on: ubuntu-latest
     steps:
       -
@@ -156,7 +156,7 @@ jobs:
   latest-pytorch:
     name: "Latest PyTorch [dev]"
     # Push CI doesn't need this image
-    if: inputs.image_postfix != ''
+    if: inputs.image_postfix != '-push-ci'
     runs-on: ubuntu-latest
     steps:
       -
@@ -184,7 +184,7 @@ jobs:
   latest-tensorflow:
     name: "Latest TensorFlow [dev]"
     # Push CI doesn't need this image
-    if: inputs.image_postfix != ''
+    if: inputs.image_postfix != '-push-ci'
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/self-push-caller.yml
+++ b/.github/workflows/self-push-caller.yml
@@ -40,6 +40,8 @@ jobs:
     needs: check-for-setup
     if: (github.event_name == 'push') && (needs.check-for-setup.outputs.changed == '1')
     uses: ./.github/workflows/build-docker-images.yml
+    with:
+      image_postfix: "-push-ci"
     secrets: inherit
 
   run_push_ci:

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -47,7 +47,7 @@ jobs:
         machine_type: [single-gpu, multi-gpu]
     runs-on: [self-hosted, docker-gpu, '${{ matrix.machine_type }}']
     container:
-      image: huggingface/transformers-all-latest-gpu
+      image: huggingface/transformers-all-latest-gpu-push-ci
       options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
       - name: NVIDIA-SMI
@@ -62,7 +62,7 @@ jobs:
         machine_type: [single-gpu, multi-gpu]
     runs-on: [self-hosted, docker-gpu, '${{ matrix.machine_type }}']
     container:
-      image: huggingface/transformers-all-latest-gpu
+      image: huggingface/transformers-all-latest-gpu-push-ci
       options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -158,7 +158,7 @@ jobs:
         machine_type: [single-gpu]
     runs-on: [self-hosted, docker-gpu, '${{ matrix.machine_type }}']
     container:
-      image: huggingface/transformers-all-latest-gpu
+      image: huggingface/transformers-all-latest-gpu-push-ci
       options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
       # Necessary to get the correct branch name and commit SHA for `workflow_run` event
@@ -243,7 +243,7 @@ jobs:
         machine_type: [multi-gpu]
     runs-on: [self-hosted, docker-gpu, '${{ matrix.machine_type }}']
     container:
-      image: huggingface/transformers-all-latest-gpu
+      image: huggingface/transformers-all-latest-gpu-push-ci
       options: --gpus all --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
       # Necessary to get the correct branch name and commit SHA for `workflow_run` event
@@ -328,7 +328,7 @@ jobs:
         machine_type: [single-gpu]
     runs-on: [self-hosted, docker-gpu, '${{ matrix.machine_type }}']
     container:
-      image: huggingface/transformers-pytorch-deepspeed-latest-gpu
+      image: huggingface/transformers-pytorch-deepspeed-latest-gpu-push-ci
       options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
       # Necessary to get the correct branch name and commit SHA for `workflow_run` event
@@ -410,7 +410,7 @@ jobs:
         machine_type: [multi-gpu]
     runs-on: [self-hosted, docker-gpu, '${{ matrix.machine_type }}']
     container:
-      image: huggingface/transformers-pytorch-deepspeed-latest-gpu
+      image: huggingface/transformers-pytorch-deepspeed-latest-gpu-push-ci
       options: --gpus all --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
       # Necessary to get the correct branch name and commit SHA for `workflow_run` event


### PR DESCRIPTION
# What does this PR do?

⚠️ **Before merge, I need to build the new push CI images that have the new tags.** 

Currently, if `setup.py` is changed, Push CI will re-build the CI images before running tests.
https://github.com/huggingface/transformers/blob/7e84723fe4e9a232e5e27dc38aed373c0c7ab94a/.github/workflows/self-push-caller.yml#L39-L43

However, this may cause different jobs in a scheduled CI workflow run to use images with different versions.

Recently, when `tokenizers` is changed to `0.13`, some jobs failed in the scheduled CI due to the new image (with `tokenizers 0.13`) but the `transformers` code in those runs still required `tokenizers < 0.13`.

**This PR separates the push CI images from scheduled CI.**
