### PR TITLE
Fix doctest for `TFDeiTForImageClassification`

### DIFF
--- a/src/transformers/models/deit/modeling_tf_deit.py
+++ b/src/transformers/models/deit/modeling_tf_deit.py
@@ -922,7 +922,6 @@ class TFDeiTForImageClassification(TFDeiTPreTrainedModel, TFSequenceClassificati
         >>> from PIL import Image
         >>> import requests
 
-        >>> tf.random.set_seed(3)  # doctest: +IGNORE_RESULT
         >>> tf.keras.utils.set_random_seed(3)  # doctest: +IGNORE_RESULT
         >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw)

--- a/src/transformers/models/deit/modeling_tf_deit.py
+++ b/src/transformers/models/deit/modeling_tf_deit.py
@@ -923,6 +923,7 @@ class TFDeiTForImageClassification(TFDeiTPreTrainedModel, TFSequenceClassificati
         >>> import requests
 
         >>> tf.random.set_seed(3)  # doctest: +IGNORE_RESULT
+        >>> tf.keras.utils.set_random_seed(3)  # doctest: +IGNORE_RESULT
         >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw)
 
@@ -937,7 +938,7 @@ class TFDeiTForImageClassification(TFDeiTPreTrainedModel, TFSequenceClassificati
         >>> # model predicts one of the 1000 ImageNet classes
         >>> predicted_class_idx = tf.math.argmax(logits, axis=-1)[0]
         >>> print("Predicted class:", model.config.id2label[int(predicted_class_idx)])
-        Predicted class: ptarmigan
+        Predicted class: little blue heron, Egretta caerulea
         ```"""
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 


### PR DESCRIPTION
# What does this PR do?

Since TF 2.10, `tf.random.set_seed` with a fixed seed won't give the same model weights anymore. See the [release note](https://github.com/tensorflow/tensorflow/releases/tag/v2.10.0). We need `tf.keras.utils.set_random_seed()` for this purpose.

This PR fixes the doctest for `TFDeiTForImageClassification` by using the above solution.

- I have to update the expected value however.
- I get the new expected value on a CPU VM. It should work on the GPU VM too, but let's keep an eye on the CI result.

