### PR TITLE
[FIX] Document Question Answer warning with Donut model

### DIFF
--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -625,6 +625,7 @@ MODEL_FOR_DOCUMENT_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
         ("layoutlm", "LayoutLMForQuestionAnswering"),
         ("layoutlmv2", "LayoutLMv2ForQuestionAnswering"),
         ("layoutlmv3", "LayoutLMv3ForQuestionAnswering"),
+        ("donut-swin", "DonutSwinModel"),
     ]
 )
 


### PR DESCRIPTION
# What does this PR do?

Currently if you try to use the Document Question Answering pipeline with Donut model a warning is thrown telling that the model is not supported. However, the model appears as supported in the documentation.

Reviewers:

Models:

- donut: @NielsRogge 

Library:

- pipelines: @ankrgyl 

