### PR TITLE
Use `assertAlmostEqual` in `BloomEmbeddingTest.test_logits`

### DIFF
--- a/tests/models/bloom/test_modeling_bloom.py
+++ b/tests/models/bloom/test_modeling_bloom.py
@@ -771,8 +771,8 @@ class BloomEmbeddingTest(unittest.TestCase):
 
         output_gpu_1, output_gpu_2 = output.split(125440, dim=-1)
         if cuda_available:
-            self.assertEqual(output_gpu_1.mean().item(), MEAN_LOGITS_GPU_1)
-            self.assertEqual(output_gpu_2.mean().item(), MEAN_LOGITS_GPU_2)
+            self.assertAlmostEqual(output_gpu_1.mean().item(), MEAN_LOGITS_GPU_1, places=6)
+            self.assertAlmostEqual(output_gpu_2.mean().item(), MEAN_LOGITS_GPU_2, places=6)
         else:
             self.assertAlmostEqual(output_gpu_1.mean().item(), MEAN_LOGITS_GPU_1, places=6)  # 1e-06 precision!!
             self.assertAlmostEqual(output_gpu_2.mean().item(), MEAN_LOGITS_GPU_2, places=6)


### PR DESCRIPTION
# What does this PR do?

`BloomEmbeddingTest.test_logits` currently uses `assertEqual` to compare 2 floats. We should instead use `assertAlmostEqual`.

Currently we don't see this test failing. However, with different PyTorch versions, we might get test failure - this happens for Past CI (PyTroch 1.10), where we got
```bash
AssertionError: 1.9311904907226562e-05 != 1.9431114196777344e-05
```



