### PR TITLE
Use `math.pi` instead of `torch.pi` in `MaskFormer`

### DIFF
--- a/src/transformers/models/maskformer/modeling_maskformer.py
+++ b/src/transformers/models/maskformer/modeling_maskformer.py
@@ -30,7 +30,7 @@ from transformers.utils import logging
 from ...activations import ACT2FN
 from ...modeling_outputs import BaseModelOutputWithCrossAttentions
 from ...modeling_utils import ModuleUtilsMixin, PreTrainedModel
-from ...pytorch_utils import find_pruneable_heads_and_indices, is_torch_greater_or_equal_than_1_10, prune_linear_layer
+from ...pytorch_utils import find_pruneable_heads_and_indices, prune_linear_layer
 from ...utils import (
     ModelOutput,
     add_code_sample_docstrings,
@@ -50,11 +50,6 @@ if is_scipy_available():
 
 logger = logging.get_logger(__name__)
 
-if not is_torch_greater_or_equal_than_1_10:
-    logger.warning(
-        f"You are using torch=={torch.__version__}, but torch>=1.10.0 is required to use "
-        "MaskFormerModel. Please upgrade torch."
-    )
 
 _CONFIG_FOR_DOC = "MaskFormerConfig"
 _CHECKPOINT_FOR_DOC = "facebook/maskformer-swin-base-ade"
@@ -2107,7 +2102,7 @@ class MaskFormerSinePositionEmbedding(nn.Module):
         self.num_pos_feats = num_pos_feats
         self.temperature = temperature
         self.normalize = normalize
-        self.scale = 2 * torch.pi if scale is None else scale
+        self.scale = 2 * math.pi if scale is None else scale
 
     def forward(self, x: Tensor, mask: Optional[Tensor] = None) -> Tensor:
         if mask is None:

--- a/src/transformers/models/maskformer/modeling_maskformer.py
+++ b/src/transformers/models/maskformer/modeling_maskformer.py
@@ -30,7 +30,7 @@ from transformers.utils import logging
 from ...activations import ACT2FN
 from ...modeling_outputs import BaseModelOutputWithCrossAttentions
 from ...modeling_utils import ModuleUtilsMixin, PreTrainedModel
-from ...pytorch_utils import find_pruneable_heads_and_indices, prune_linear_layer
+from ...pytorch_utils import find_pruneable_heads_and_indices, is_torch_greater_or_equal_than_1_10, prune_linear_layer
 from ...utils import (
     ModelOutput,
     add_code_sample_docstrings,
@@ -50,6 +50,11 @@ if is_scipy_available():
 
 logger = logging.get_logger(__name__)
 
+if not is_torch_greater_or_equal_than_1_10:
+    logger.warning(
+        f"You are using torch=={torch.__version__}, but torch>=1.10.0 is required to use "
+        "MaskFormerModel. Please upgrade torch."
+    )
 
 _CONFIG_FOR_DOC = "MaskFormerConfig"
 _CHECKPOINT_FOR_DOC = "facebook/maskformer-swin-base-ade"


### PR DESCRIPTION
# What does this PR do?

`MaskFormer` uses `torch.pi` which is only available in `torch >= 1.10`. The Past CI with PyTorch 1.9 gives
```bash
AttributeError: module 'torch' has no attribute 'pi'
``` 
This PR adds a warning if PT <= 1.9 for this model, similar in `ViltModel` https://github.com/huggingface/transformers/blob/71fc33174664738d8c8d93025ebc810180e69c20/src/transformers/models/vilt/modeling_vilt.py#L44


**Question: Should we also skip the whole test suite for  `MaskFormer` depending on the torch version? The objective is to make Past CI cleaner if we ever run it again with previous torch version.**