### PR TITLE
`MCTCTFeatureExtractor` requires `torchaudio >= 0.10`

### DIFF
--- a/src/transformers/models/mctct/feature_extraction_mctct.py
+++ b/src/transformers/models/mctct/feature_extraction_mctct.py
@@ -21,6 +21,7 @@ from typing import List, Optional, Union
 import numpy as np
 import torch
 import torchaudio
+from packaging import version
 
 from ...feature_extraction_sequence_utils import SequenceFeatureExtractor
 from ...feature_extraction_utils import BatchFeature
@@ -29,6 +30,13 @@ from ...utils import logging
 
 
 logger = logging.get_logger(__name__)
+
+parsed_torchaudio_version_base = version.parse(version.parse(torchaudio.__version__).base_version)
+if not parsed_torchaudio_version_base >= version.parse("0.10"):
+    logger.warning(
+        f"You are using torchaudio=={torchaudio.__version__}, but torchaudio>=0.10.0 is required to use "
+        "MCTCTFeatureExtractor. This requires torch>=1.10.0. Please upgrade torch and torchaudio."
+    )
 
 
 class MCTCTFeatureExtractor(SequenceFeatureExtractor):


### PR DESCRIPTION
# What does this PR do?

In past CI with PyTorch 1.9, we got for `MCTCTFeatureExtractor` 
```bash
AttributeError: module 'torchaudio.functional' has no attribute 'melscale_fbanks'
```

This PR only adds a warning in `feature_extraction_mctct`, so we have this information tracked. Let's discuss if we should skip the corresponding tests.