### PR TITLE
Fix torch.fx supports (ViT Model)

### DIFF
--- a/src/transformers/models/vit/modeling_vit.py
+++ b/src/transformers/models/vit/modeling_vit.py
@@ -163,16 +163,13 @@ class ViTPatchEmbeddings(nn.Module):
 
     def forward(self, pixel_values: torch.Tensor, interpolate_pos_encoding: bool = False) -> torch.Tensor:
         batch_size, num_channels, height, width = pixel_values.shape
-        if num_channels != self.num_channels:
-            raise ValueError(
-                "Make sure that the channel dimension of the pixel values match with the one set in the configuration."
-            )
+        torch._assert(num_channels == self.num_channels,
+            "Make sure that the channel dimension of the pixel values match with the one set in the configuration.")
         if not interpolate_pos_encoding:
-            if height != self.image_size[0] or width != self.image_size[1]:
-                raise ValueError(
-                    f"Input image size ({height}*{width}) doesn't match model"
-                    f" ({self.image_size[0]}*{self.image_size[1]})."
-                )
+            expected_height, expected_width = self.image_size
+            err_message = f"Input image size ({height}*{width}) doesn't match model({self.image_size[0]}*{self.image_size[1]})."
+            torch._assert(height == expected_height, err_message)
+            torch._assert(width == expected_width, err_message)
         embeddings = self.projection(pixel_values).flatten(2).transpose(1, 2)
         return embeddings
 

--- a/src/transformers/models/vit/modeling_vit.py
+++ b/src/transformers/models/vit/modeling_vit.py
@@ -163,11 +163,15 @@ class ViTPatchEmbeddings(nn.Module):
 
     def forward(self, pixel_values: torch.Tensor, interpolate_pos_encoding: bool = False) -> torch.Tensor:
         batch_size, num_channels, height, width = pixel_values.shape
-        torch._assert(num_channels == self.num_channels,
-            "Make sure that the channel dimension of the pixel values match with the one set in the configuration.")
+        torch._assert(
+            num_channels == self.num_channels,
+            "Make sure that the channel dimension of the pixel values match with the one set in the configuration.",
+        )
         if not interpolate_pos_encoding:
             expected_height, expected_width = self.image_size
-            err_message = f"Input image size ({height}*{width}) doesn't match model({self.image_size[0]}*{self.image_size[1]})."
+            err_message = (
+                f"Input image size ({height}*{width}) doesn't match model({self.image_size[0]}*{self.image_size[1]})."
+            )
             torch._assert(height == expected_height, err_message)
             torch._assert(width == expected_width, err_message)
         embeddings = self.projection(pixel_values).flatten(2).transpose(1, 2)
@@ -246,7 +250,6 @@ class ViTSelfOutput(nn.Module):
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
     def forward(self, hidden_states: torch.Tensor, input_tensor: torch.Tensor) -> torch.Tensor:
-
         hidden_states = self.dense(hidden_states)
         hidden_states = self.dropout(hidden_states)
 
@@ -302,7 +305,6 @@ class ViTIntermediate(nn.Module):
             self.intermediate_act_fn = config.hidden_act
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-
         hidden_states = self.dense(hidden_states)
         hidden_states = self.intermediate_act_fn(hidden_states)
 


### PR DESCRIPTION
# What does this PR do?

Fixes #19209


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@michaelbenayoun 


## Contents

Originally, torch.fx was not working on vit model
because torch.fx proxy object does not working on if-statement
for example,
```if num_channels != self.num_channels:```
can raise error.

1. I replaced if-statements with torch._assert function.

2. below code should be splitted to two lines.
```
if height != self.image_size[0] or width != self.image_size[1]:
```
because `torch._assert(`statement1` and `statement2`, "error message")` will not work.
so, I wrote as below.

```
err_message = f"Input image size ({height}*{width}) doesn't match model({self.image_size[0]}*{self.image_size[1]})."
torch._assert(height == expected_height, err_message)
torch._assert(width == expected_width, err_message)
```

