### PR TITLE
Fix confusing working directory in Push CI

### DIFF
--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -96,11 +96,6 @@ jobs:
           echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
           echo "env.CI_SHA = ${{ env.CI_SHA }}"
 
-      - name: Checkout transformers
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
-
       - name: Update clone using environment variables
         working-directory: /transformers
         run: |
@@ -111,12 +106,14 @@ jobs:
           echo "log = $(git log -n 1)"
 
       - name: Cleanup
+        working-directory: /transformers
         run: |
           rm -rf tests/__pycache__
           rm -rf tests/models/__pycache__
           rm -rf reports
 
       - name: Fetch the tests to run
+        working-directory: /transformers
         # TODO: add `git-python` in the docker images
         run: |
           pip install --upgrade git-python
@@ -126,10 +123,11 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: test_fetched
-          path: test_preparation.txt
+          path: /transformers/test_preparation.txt
 
       - id: set-matrix
         name: Organize tests into models
+        working-directory: /transformers
         # The `keys` is used as GitHub actions matrix for jobs, i.e. `models/bert`, `tokenization`, `pipeline`, etc.
         # The `test_map` is used to get the actual identified test files under each key.
         # If no test to run (so no `test_map.json` file), create a dummy map (empty matrix will fail)


### PR DESCRIPTION
# What does this PR do?

⚠️ ~~Let me launch a tiny run to make sure before merge~~ 🙏

Previously, the job `setup` (to prepare the tests to run) in push CI ran on `ubuntu-latest` runners, and has to clone `transformers` with `actions/checkout@v2`.

In #19054, it is changed to use the docker image (and run on our runner). This is no particular reason for it, just to make the sequence of jobs looks more linear.

But I forgot to change the working directory in #19054. The job still run without failure (as the 2 `transformers` directory exist at the same time), but it looks somehow confusing. This PR is to clean this.