### PR TITLE
Add and save job names in Past CI artifacts

### DIFF
--- a/.github/workflows/self-past.yml
+++ b/.github/workflows/self-past.yml
@@ -15,6 +15,11 @@ on:
       version:
         required: true
         type: string
+      # Use this to control the commit to test against
+      sha:
+        default: 'main'
+        required: false
+        type: string
 
 env:
   HF_HOME: /mnt/cache
@@ -67,18 +72,19 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - name: Checkout transformers
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
+      - name: Update clone
+        working-directory: /transformers
+        run: git fetch && git checkout ${{ inputs.sha }}
 
       - name: Cleanup
+        working-directory: /transformers
         run: |
           rm -rf tests/__pycache__
           rm -rf tests/models/__pycache__
           rm -rf reports
 
       - id: set-matrix
+        working-directory: /transformers
         name: Identify models to test
         run: |
           cd tests
@@ -99,7 +105,7 @@ jobs:
     steps:
       - name: Update clone
         working-directory: /transformers
-        run: git fetch && git checkout ${{ github.sha }}
+        run: git fetch && git checkout ${{ inputs.sha }}
 
       - name: Echo folder ${{ matrix.folders }}
         shell: bash
@@ -129,6 +135,15 @@ jobs:
         if: ${{ failure() }}
         continue-on-error: true
         run: cat /transformers/reports/${{ matrix.machine_type }}_tests_gpu_${{ matrix.folders }}/failures_short.txt
+
+      - name: Save job name
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          matrix_folders=${matrix_folders/'models_'/'models/'}
+          job_name="Model tests ($matrix_folders, ${{ matrix.machine_type }})"
+          echo "$job_name"
+          echo "$job_name" > /transformers/reports/${{ matrix.machine_type }}_tests_gpu_${{ matrix.folders }}/job_name.txt
 
       - name: Test suite reports artifacts
         if: ${{ always() }}
@@ -152,7 +167,7 @@ jobs:
     steps:
       - name: Update clone
         working-directory: /transformers
-        run: git fetch && git checkout ${{ github.sha }}
+        run: git fetch && git checkout ${{ inputs.sha }}
 
       - name: Echo folder ${{ matrix.folders }}
         shell: bash
@@ -182,6 +197,15 @@ jobs:
         if: ${{ failure() }}
         continue-on-error: true
         run: cat /transformers/reports/${{ matrix.machine_type }}_tests_gpu_${{ matrix.folders }}/failures_short.txt
+
+      - name: Save job name
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          matrix_folders=${matrix_folders/'models_'/'models/'}
+          job_name="Model tests ($matrix_folders, ${{ matrix.machine_type }})"
+          echo "$job_name"
+          echo "$job_name" > /transformers/reports/${{ matrix.machine_type }}_tests_gpu_${{ matrix.folders }}/job_name.txt
 
       - name: Test suite reports artifacts
         if: ${{ always() }}


### PR DESCRIPTION
# What does this PR do?

In order to ease the fix process for Past CI, it would be very helpful to have links to jobs for the failed tests.

The GitHub API could give a list of jobs and a list of artifacts, but there is no ensured and easy way to get the  correspondence between each artifact/job, see [jobs here](https://api.github.com/repos/huggingface/transformers/actions/runs/3145556680/jobs) and [artifacts here](https://api.github.com/repos/huggingface/transformers/actions/runs/3145556680/artifacts).

Moreover, when the jobs are running, there is no context evn. variable that gives the job run link (or anything helpful to get this information)

However, the list of jobs given by the API contains the **job names** and the **job run page** link (given by `html_url`).

This PR therefore saves the job names in the corresponding test artifacts. Once the past CI is done:

- we extract the error information together the job names
- we fetch the list of jobs
- For each artifact, we find the corresponding job in the job list using the job name saved in the artifact
- We get the job run link by looking `html_url`
- We add the job run link in the error info.**

To check the effect of this PR, see the contents in the artifacts in [this run](https://github.com/huggingface/transformers/actions/runs/3145556680)