### PR TITLE
Fix test fetching for examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,8 +88,10 @@ jobs:
                 path: ~/transformers/examples_tests_fetched_summary.txt
             - run: |
                 if [ -f test_list.txt ]; then
+                    echo cat test_list.txt
                     mv test_list.txt test_preparation/examples_test_list.txt
                 else
+                    echo "No file named test_list found"
                     touch test_preparation/examples_test_list.txt
                 fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
                 path: ~/transformers/examples_tests_fetched_summary.txt
             - run: |
                 if [ -f test_list.txt ]; then
-                    echo cat test_list.txt
+                    cat test_list.txt
                     mv test_list.txt test_preparation/examples_test_list.txt
                 else
                     echo "No file named test_list found"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,7 @@ jobs:
                 root: test_preparation/
                 paths:
                     test_list.txt
+                    examples_test_list.txt
 
     # To run all tests for the nightly build
     fetch_all_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,15 @@ jobs:
                 else
                     touch test_preparation/test_list.txt
                 fi
+            - run: python utils/tests_fetcher.py --filters tests examples | tee examples_tests_fetched_summary.txt
+            - store_artifacts:
+                path: ~/transformers/examples_tests_fetched_summary.txt
+            - run: |
+                if [ -f test_list.txt ]; then
+                    mv test_list.txt test_preparation/examples_test_list.txt
+                else
+                    touch test_preparation/examples_test_list.txt
+                fi
 
             - persist_to_workspace:
                 root: test_preparation/
@@ -99,6 +108,7 @@ jobs:
             - run: |
                   mkdir test_preparation
                   echo "tests" > test_preparation/test_list.txt
+                  echo "tests" > test_preparation/examples_test_list.txt
 
             - persist_to_workspace:
                   root: test_preparation/
@@ -426,7 +436,7 @@ jobs:
             - attach_workspace:
                 at: ~/transformers/test_preparation
             - run: |
-                if [ ! -s test_preparation/test_list.txt ]; then
+                if [ ! -s test_preparation/examples_test_list.txt ]; then
                     echo "No tests to run, exiting early!"
                     circleci-agent step halt
                 fi
@@ -463,7 +473,7 @@ jobs:
             - attach_workspace:
                 at: ~/transformers/test_preparation
             - run: |
-                if [ ! -s test_preparation/test_list.txt ]; then
+                if [ ! -s test_preparation/examples_test_list.txt ]; then
                     echo "No tests to run, exiting early!"
                     circleci-agent step halt
                 fi
@@ -499,7 +509,7 @@ jobs:
             - attach_workspace:
                 at: ~/transformers/test_preparation
             - run: |
-                if [ ! -s test_preparation/test_list.txt ]; then
+                if [ ! -s test_preparation/examples_test_list.txt ]; then
                     echo "No tests to run, exiting early!"
                     circleci-agent step halt
                 fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,10 +88,8 @@ jobs:
                 path: ~/transformers/examples_tests_fetched_summary.txt
             - run: |
                 if [ -f test_list.txt ]; then
-                    cat test_list.txt
                     mv test_list.txt test_preparation/examples_test_list.txt
                 else
-                    echo "No file named test_list found"
                     touch test_preparation/examples_test_list.txt
                 fi
 

--- a/examples/pytorch/question-answering/run_qa.py
+++ b/examples/pytorch/question-answering/run_qa.py
@@ -229,6 +229,7 @@ def main():
 
     # Sending telemetry. Tracking the example usage helps us better allocate resources to maintain them. The
     # information sent is the one passed as arguments along with your Python/PyTorch versions.
+    send_example_telemetry("run_qa", model_args, data_args)
 
     # Setup logging
     logging.basicConfig(

--- a/examples/pytorch/question-answering/run_qa.py
+++ b/examples/pytorch/question-answering/run_qa.py
@@ -229,7 +229,6 @@ def main():
 
     # Sending telemetry. Tracking the example usage helps us better allocate resources to maintain them. The
     # information sent is the one passed as arguments along with your Python/PyTorch versions.
-    send_example_telemetry("run_qa", model_args, data_args)
 
     # Setup logging
     logging.basicConfig(


### PR DESCRIPTION
# What does this PR do?

When re-working the circleCI config to execute test fetching first, I didn't do anything special for the examples, which means that if only an example file is modified, no tests are run (by default only tests found in the tests subfolder are kept, for the examples we need to add `--filters tests examples`.

You can check on [this report](https://github.com/huggingface/transformers/runs/8604472112) that when only example files are modifier, the tests for all examples are still run (next step would be to properly filter between TF/Flax and PyTorch but this is going to take slightly longer).