### PR TITLE
Use `hf_raise_for_status` instead of deprecated `_raise_for_status`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ _deps = [
     "fugashi>=1.0",
     "GitPython<3.1.19",
     "hf-doc-builder>=0.3.0",
-    "huggingface-hub>=0.9.0,<1.0",
+    "huggingface-hub>=0.10.0,<1.0",
     "importlib_metadata",
     "ipadic>=1.0.0,<2.0",
     "isort>=5.5.4",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -22,7 +22,7 @@ deps = {
     "fugashi": "fugashi>=1.0",
     "GitPython": "GitPython<3.1.19",
     "hf-doc-builder": "hf-doc-builder>=0.3.0",
-    "huggingface-hub": "huggingface-hub>=0.9.0,<1.0",
+    "huggingface-hub": "huggingface-hub>=0.10.0,<1.0",
     "importlib_metadata": "importlib_metadata",
     "ipadic": "ipadic>=1.0.0,<2.0",
     "isort": "isort>=5.5.4",

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -45,6 +45,7 @@ from huggingface_hub.utils import (
     LocalEntryNotFoundError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
+    hf_raise_for_status,
 )
 from requests.exceptions import HTTPError
 from transformers.utils.logging import tqdm
@@ -607,7 +608,7 @@ def has_file(
 
     r = requests.head(url, headers=headers, allow_redirects=False, proxies=proxies, timeout=10)
     try:
-        huggingface_hub.utils._errors._raise_for_status(r)
+        hf_raise_for_status(r)
         return True
     except RepositoryNotFoundError as e:
         logger.error(e)
@@ -993,7 +994,7 @@ def get_hub_metadata(url, token=None):
     r = huggingface_hub.file_download._request_with_retry(
         method="HEAD", url=url, headers=headers, allow_redirects=False
     )
-    huggingface_hub.file_download._raise_for_status(r)
+    hf_raise_for_status(r)
     commit_hash = r.headers.get(HUGGINGFACE_HEADER_X_REPO_COMMIT)
     etag = r.headers.get(HUGGINGFACE_HEADER_X_LINKED_ETAG) or r.headers.get("ETag")
     if etag is not None:


### PR DESCRIPTION
# What does this PR do?

Replace `huggingface_hub.utils._errors._raise_for_status` by the officially supported `huggingface_hub.utils.hf_raise_for_status`.

Related to https://github.com/huggingface/huggingface_hub/pull/1019#issuecomment-1233864547.

Requires `huggingface_hub>=0.10.0`.