### PR TITLE
Enable numpy behaviour across the TF codebase

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -84,6 +84,8 @@ TFModelInputType = Union[
     KerasTensor,
 ]
 
+tf.experimental.numpy.experimental_enable_numpy_behavior(prefer_float32=True)
+
 
 def dummy_loss(y_true, y_pred):
     return tf.reduce_mean(y_pred)


### PR DESCRIPTION
This PR enables TF Numpy behaviour for all of our models, which will hopefully reduce the number of PRs we have to make to fix dtype incompatibilities. This flag mainly relates to type promotion (TensorFlow is strict by default, and won't automatically promote if you e.g. add an `int32` tensor to an `int64`), but it also enables some Numpy-like indexing that the standard TF indexing doesn't allow.

It shouldn't break anything, and despite being marked as experimental it's been in TF since 2.4 and actively promoted by Chollet on his Twitter, so I think it's stable and here to stay.

Relevant TF documentation is [here](https://www.tensorflow.org/api_docs/python/tf/experimental/numpy/experimental_enable_numpy_behavior)