### PR TITLE
Update Protobuf dependency version to fix known vulnerability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ _deps = [
     "packaging>=20.0",
     "parameterized",
     "phonemizer",
-    "protobuf<=3.20.1",
+    "protobuf<=3.20.2",
     "psutil",
     "pyyaml>=5.1",
     "pydantic",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -39,7 +39,7 @@ deps = {
     "packaging": "packaging>=20.0",
     "parameterized": "parameterized",
     "phonemizer": "phonemizer",
-    "protobuf": "protobuf<=3.20.1",
+    "protobuf": "protobuf<=3.20.2",
     "psutil": "psutil",
     "pyyaml": "pyyaml>=5.1",
     "pydantic": "pydantic",


### PR DESCRIPTION
# What does this PR do?
Protobuf v3.20.1 has a known security vulnerability, [described here on snyk](https://security.snyk.io/package/pip/protobuf/3.20.1). Bumping the protobuf dependency version fixes this vulnerability.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Library:
- pipelines: @LysandreJik