### PR TITLE
Enabling custom TF signature draft

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -2097,6 +2097,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         saved_model=False,
         version=1,
         push_to_hub=False,
+        signatures=None,
         max_shard_size: Union[int, str] = "10GB",
         create_pr: bool = False,
         **kwargs
@@ -2118,6 +2119,8 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                 Whether or not to push your model to the Hugging Face model hub after saving it. You can specify the
                 repository you want to push to with `repo_id` (will default to the name of `save_directory` in your
                 namespace).
+            signatures (`dict` or `tf.function`, *optional*, defaults to `None`):
+                Model's signature used for serving.
             max_shard_size (`int` or `str`, *optional*, defaults to `"10GB"`):
                 The maximum size for a checkpoint before being sharded. Checkpoints shard will then be each of size
                 lower than this size. If expressed as a string, needs to be digits followed by a unit (like `"5MB"`).
@@ -2148,8 +2151,10 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             files_timestamps = self._get_files_timestamps(save_directory)
 
         if saved_model:
+            if not signatures:
+                signatures = self.serving
             saved_model_dir = os.path.join(save_directory, "saved_model", str(version))
-            self.save(saved_model_dir, include_optimizer=False, signatures=self.serving)
+            self.save(saved_model_dir, include_optimizer=False, signatures=signatures)
             logger.info(f"Saved model created in {saved_model_dir}")
 
         # Save configuration file

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -2151,7 +2151,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             files_timestamps = self._get_files_timestamps(save_directory)
 
         if saved_model:
-            if signatures is not None:
+            if signatures is None:
                 signatures = self.serving
             saved_model_dir = os.path.join(save_directory, "saved_model", str(version))
             self.save(saved_model_dir, include_optimizer=False, signatures=signatures)

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -2119,8 +2119,8 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                 Whether or not to push your model to the Hugging Face model hub after saving it. You can specify the
                 repository you want to push to with `repo_id` (will default to the name of `save_directory` in your
                 namespace).
-            signatures (`dict` or `tf.function`, *optional*, defaults to `None`):
-                Model's signature used for serving.
+            signatures (`dict` or `tf.function`, *optional*):
+                Model's signature used for serving. This will be passed to the `signatures` argument of model.save().
             max_shard_size (`int` or `str`, *optional*, defaults to `"10GB"`):
                 The maximum size for a checkpoint before being sharded. Checkpoints shard will then be each of size
                 lower than this size. If expressed as a string, needs to be digits followed by a unit (like `"5MB"`).
@@ -2151,7 +2151,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             files_timestamps = self._get_files_timestamps(save_directory)
 
         if saved_model:
-            if not signatures:
+            if signatures is not None:
                 signatures = self.serving
             saved_model_dir = os.path.join(save_directory, "saved_model", str(version))
             self.save(saved_model_dir, include_optimizer=False, signatures=signatures)

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -2236,17 +2236,17 @@ class UtilsFunctionsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             # Using default signature (default behavior)
             model.save_pretrained(tmp_dir, saved_model=True, signatures=None)
-            model_loaded = tf.keras.models.load_model(tmp_dir)
+            model_loaded = tf.keras.models.load_model(f"{tmp_dir}/saved_model/1")
             self.assertTrue(len(list(model_loaded.signatures.keys())) > 0)
 
             # Providing custom signature function
             model.save_pretrained(tmp_dir, saved_model=True, signatures=serving_fn)
-            model_loaded = tf.keras.models.load_model(tmp_dir)
+            model_loaded = tf.keras.models.load_model(f"{tmp_dir}/saved_model/1")
             self.assertTrue(len(list(model_loaded.signatures.keys())) > 0)
 
             # Providing custom signature function (dict input)
             model.save_pretrained(tmp_dir, saved_model=True, signatures={"serving_default": serving_fn})
-            model_loaded = tf.keras.models.load_model(tmp_dir)
+            model_loaded = tf.keras.models.load_model(f"{tmp_dir}/saved_model/1")
             self.assertTrue(len(list(model_loaded.signatures.keys())) > 0)
 
 

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -2237,23 +2237,24 @@ class UtilsFunctionsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             model.save_pretrained(tmp_dir, saved_model=True, signatures=None)
             model_loaded = tf.keras.models.load_model(f"{tmp_dir}/saved_model/1")
-            self.assertTrue('serving_default' in list(model_loaded.signatures.keys()))
+            self.assertTrue("serving_default" in list(model_loaded.signatures.keys()))
 
         # Providing custom signature function
         with tempfile.TemporaryDirectory() as tmp_dir:
             model.save_pretrained(tmp_dir, saved_model=True, signatures={"custom_signature": serving_fn})
             model_loaded = tf.keras.models.load_model(f"{tmp_dir}/saved_model/1")
-            self.assertTrue('custom_signature' in list(model_loaded.signatures.keys()))
+            self.assertTrue("custom_signature" in list(model_loaded.signatures.keys()))
 
         # Providing multiple custom signature function
         with tempfile.TemporaryDirectory() as tmp_dir:
-            model.save_pretrained(tmp_dir, saved_model=True, signatures={
-                                                                        "custom_signature_1": serving_fn, 
-                                                                        "custom_signature_2": serving_fn
-                                                                        })
+            model.save_pretrained(
+                tmp_dir,
+                saved_model=True,
+                signatures={"custom_signature_1": serving_fn, "custom_signature_2": serving_fn},
+            )
             model_loaded = tf.keras.models.load_model(f"{tmp_dir}/saved_model/1")
-            self.assertTrue('custom_signature_1' in list(model_loaded.signatures.keys()))
-            self.assertTrue('custom_signature_2' in list(model_loaded.signatures.keys()))
+            self.assertTrue("custom_signature_1" in list(model_loaded.signatures.keys()))
+            self.assertTrue("custom_signature_2" in list(model_loaded.signatures.keys()))
 
 
 @require_tf

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -2216,6 +2216,22 @@ class UtilsFunctionsTest(unittest.TestCase):
                 for p1, p2 in zip(model.weights, new_model.weights):
                     self.assertTrue(np.allclose(p1.numpy(), p2.numpy()))
 
+    def test_save_pretrained_signatures(self):
+        model = TFBertModel.from_pretrained("hf-internal-testing/tiny-random-bert")
+
+        # Short custom TF signature function
+        @tf.function
+        def serving_fn(input):
+            return {"preds": model(input)}
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Using default signature (default behavior)
+            model.save_pretrained(tmp_dir, saved_model=True, signatures=None)
+            # Providing custom signature function
+            model.save_pretrained(tmp_dir, saved_model=True, signatures=serving_fn)
+            # Providing custom signature function (dict input)
+            model.save_pretrained(tmp_dir, saved_model=True, signatures={"serving_default": serving_fn})
+
 
 @require_tf
 @is_staging_test


### PR DESCRIPTION
# What does this PR do?
This PR is related to the discussion on issue #19094 , which is related to `transformers` enabling users to provide custom signatures for models while saving them with [save_pretrained](https://github.com/huggingface/transformers/blob/ca485e562b675341409e3e27724072fb11e10af7/src/transformers/modeling_tf_utils.py#L2085).

Fixes #19094 


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [x] Did you write any new necessary tests?