### PR TITLE
Catch `HFValidationError` in `TrainingSummary`

### DIFF
--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -26,7 +26,7 @@ from typing import Any, Dict, List, Optional, Union
 import requests
 import yaml
 from huggingface_hub import model_info
-from huggingface_hub.utils import HfValidationError
+from huggingface_hub.utils import HFValidationError
 
 from . import __version__
 from .models.auto.modeling_auto import (
@@ -379,7 +379,7 @@ class TrainingSummary:
                 for tag in info.tags:
                     if tag.startswith("license:"):
                         self.license = tag[8:]
-            except (requests.exceptions.HTTPError, HfValidationError):
+            except (requests.exceptions.HTTPError, HFValidationError):
                 pass
 
     def create_model_index(self, metric_mapping):

--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Optional, Union
 import requests
 import yaml
 from huggingface_hub import model_info
+from huggingface_hub.utils import HfValidationError
 
 from . import __version__
 from .models.auto.modeling_auto import (
@@ -378,7 +379,7 @@ class TrainingSummary:
                 for tag in info.tags:
                     if tag.startswith("license:"):
                         self.license = tag[8:]
-            except requests.exceptions.HTTPError:
+            except (requests.exceptions.HTTPError, HfValidationError):
                 pass
 
     def create_model_index(self, metric_mapping):


### PR DESCRIPTION
# What does this PR do?

`transformers` now uses `huggingface_hub 0.10` for testing. We have a few `deepspeed` failing tests ([see here](https://github.com/huggingface/transformers/actions/runs/3148346207/jobs/5118805294]) or the error below).

According to @Wauplin We should catch `HFValidationError` in `TrainingSummary.__post_init__()` too in order to keep the test  passing. Ran those tests with this PR and confirmed they pass now.

#### errors without this PR
```bash
E             File "/workspace/transformers/examples/pytorch/translation/run_translation.py", line 645, in main
E               trainer.create_model_card(**kwargs)
E             File "/workspace/transformers/src/transformers/trainer.py", line 3332, in create_model_card
E               training_summary = TrainingSummary.from_trainer(
E             File "/workspace/transformers/src/transformers/modelcard.py", line 600, in from_trainer
E               return cls(
E             File "<string>", line 17, in __init__
E             File "/workspace/transformers/src/transformers/modelcard.py", line 377, in __post_init__
E               info = model_info(self.finetuned_from)
E             File "/opt/conda/lib/python3.8/site-packages/huggingface_hub/utils/_validators.py", line 92, in _inner_fn
E               validate_repo_id(arg_value)
E             File "/opt/conda/lib/python3.8/site-packages/huggingface_hub/utils/_validators.py", line 136, in validate_repo_id
E               raise HFValidationError(
E           huggingface_hub.utils._validators.HFValidationError: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/tmp/tmph2e0bt7a'. Use `repo_type` argument if needed.
```


