### PR TITLE
Add `beautifulsoup4` to the dependency list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,7 @@ _deps = [
     "unidic>=1.0.2",
     "unidic_lite>=1.0.7",
     "uvicorn",
+    "beautifulsoup4",
 ]
 
 
@@ -302,6 +303,7 @@ extras["testing"] = (
         "sacremoses",
         "rjieba",
         "safetensors",
+        "beautifulsoup4",
     )
     + extras["retrieval"]
     + extras["modelcreation"]

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -75,4 +75,5 @@ deps = {
     "unidic": "unidic>=1.0.2",
     "unidic_lite": "unidic_lite>=1.0.7",
     "uvicorn": "uvicorn",
+    "beautifulsoup4": "beautifulsoup4",
 }


### PR DESCRIPTION
# What does this PR do?

Add `beautifulsoup4` to the dependency list - to enable the tests `MarkupLMFeatureExtractionTest` and `MarkupLMProcessorIntegrationTests`

On CircleCI, we now can have the following tested (those have `@require_bs4`)
```bash
PASSED tests/models/markuplm/test_feature_extraction_markuplm.py::MarkupLMFeatureExtractionTest::test_call
PASSED tests/models/markuplm/test_feature_extraction_markuplm.py::MarkupLMFeatureExtractionTest::test_feat_extract_from_and_save_pretrained
PASSED tests/models/markuplm/test_feature_extraction_markuplm.py::MarkupLMFeatureExtractionTest::test_feat_extract_to_json_file
PASSED tests/models/markuplm/test_feature_extraction_markuplm.py::MarkupLMFeatureExtractionTest::test_feat_extract_to_json_string
PASSED tests/models/markuplm/test_feature_extraction_markuplm.py::MarkupLMFeatureExtractionTest::test_init_without_params
```