### PR TITLE
Add onnx support for VisionEncoderDecoder

### DIFF
--- a/docs/source/en/serialization.mdx
+++ b/docs/source/en/serialization.mdx
@@ -95,7 +95,7 @@ Ready-made configurations include the following architectures:
 - SegFormer
 - SqueezeBERT
 - T5
-- VisionEncoderDecoder
+- Vision Encoder decoder
 - ViT
 - XLM
 - XLM-RoBERTa

--- a/docs/source/en/serialization.mdx
+++ b/docs/source/en/serialization.mdx
@@ -302,7 +302,7 @@ in the attention blocks) that can be used for fast autoregressive decoding.
 <Tip>
 
 For `VisionEncoderDecoder` type models, the encoder and decoder parts are
-exported separately as two onnx files.
+exported separately as two ONNX files named `encoder_model.onnx` and `decoder_model.onnx` respectively.
 
 </Tip>
 

--- a/docs/source/en/serialization.mdx
+++ b/docs/source/en/serialization.mdx
@@ -299,6 +299,13 @@ in the attention blocks) that can be used for fast autoregressive decoding.
 
 </Tip>
 
+<Tip>
+
+For `VisionEncoderDecoder` type models, the encoder and decoder parts are
+exported separately as two onnx files.
+
+</Tip>
+
 
 ### Exporting a model for an unsupported architecture
 

--- a/docs/source/en/serialization.mdx
+++ b/docs/source/en/serialization.mdx
@@ -95,6 +95,7 @@ Ready-made configurations include the following architectures:
 - SegFormer
 - SqueezeBERT
 - T5
+- VisionEncoderDecoder
 - ViT
 - XLM
 - XLM-RoBERTa

--- a/src/transformers/models/vision_encoder_decoder/__init__.py
+++ b/src/transformers/models/vision_encoder_decoder/__init__.py
@@ -27,7 +27,9 @@ from ...utils import (
 )
 
 
-_import_structure = {"configuration_vision_encoder_decoder": ["VisionEncoderDecoderConfig"]}
+_import_structure = {
+    "configuration_vision_encoder_decoder": ["VisionEncoderDecoderConfig", "VisionEncoderDecoderOnnxConfig"]
+}
 
 try:
     if not is_torch_available():
@@ -54,7 +56,7 @@ else:
     _import_structure["modeling_flax_vision_encoder_decoder"] = ["FlaxVisionEncoderDecoderModel"]
 
 if TYPE_CHECKING:
-    from .configuration_vision_encoder_decoder import VisionEncoderDecoderConfig
+    from .configuration_vision_encoder_decoder import VisionEncoderDecoderConfig, VisionEncoderDecoderOnnxConfig
 
     try:
         if not is_torch_available():

--- a/src/transformers/models/vision_encoder_decoder/configuration_vision_encoder_decoder.py
+++ b/src/transformers/models/vision_encoder_decoder/configuration_vision_encoder_decoder.py
@@ -19,7 +19,6 @@ from typing import Any, Mapping, Optional, OrderedDict
 
 from packaging import version
 
-from transformers.modeling_utils import PreTrainedModel
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 from transformers.utils.generic import TensorType
 
@@ -146,7 +145,7 @@ class VisionEncoderDecoderEncoderOnnxConfig(OnnxConfig):
 
     @property
     def outputs(self) -> Mapping[str, Mapping[int, str]]:
-        return OrderedDict({"encoder_last_hidden_state": {0: "batch", 1: "encoder_sequence"}})
+        return OrderedDict({"last_hidden_state": {0: "batch", 1: "encoder_sequence"}})
 
 
 class VisionEncoderDecoderDecoderOnnxConfig(OnnxConfig):
@@ -189,23 +188,31 @@ class VisionEncoderDecoderOnnxConfig(OnnxConfig):
     def inputs(self) -> None:
         pass
 
-    def get_encoder_config(self, encoder_model: PreTrainedModel) -> OnnxConfig:
+    def get_encoder_config(self, encoder_config: PretrainedConfig) -> OnnxConfig:
         r"""
         Returns encoder Onnx config for VisionEncoderDecoder model.
+
+        Args:
+            encoder_config: The encoder model's configuration to use when exporting to ONNX
 
         Returns:
             [`VisionEncoderDecoderEncoderOnnxConfig`]: An instance of onnx configuration object
         """
-        return VisionEncoderDecoderEncoderOnnxConfig(encoder_model.config)
+        return VisionEncoderDecoderEncoderOnnxConfig(encoder_config)
 
     def get_decoder_config(
-        self, encoder_model: PretrainedConfig, decoder_model: PretrainedConfig, task: str = "default"
+        self, encoder_config: PretrainedConfig, decoder_config: PretrainedConfig, feature: str = "default"
     ) -> OnnxConfig:
         r"""
         Returns decoder Onnx config for VisionEncoderDecoder model.
 
+        Args:
+            encoder_config: The encoder model's configuration to use when exporting to ONNX
+            decoder_config: The decoder model's configuration to use when exporting to ONNX
+            feature: The type of feature to export the model with.
+
         Returns:
             [`VisionEncoderDecoderDecoderOnnxConfig`]: An instance of onnx configuration object
         """
-        decoder_model.config.encoder_hidden_size = encoder_model.config.hidden_size
-        return VisionEncoderDecoderDecoderOnnxConfig(decoder_model.config, task)
+        decoder_config.encoder_hidden_size = encoder_config.hidden_size
+        return VisionEncoderDecoderDecoderOnnxConfig(decoder_config, feature)

--- a/src/transformers/models/vision_encoder_decoder/configuration_vision_encoder_decoder.py
+++ b/src/transformers/models/vision_encoder_decoder/configuration_vision_encoder_decoder.py
@@ -190,13 +190,14 @@ class VisionEncoderDecoderOnnxConfig(OnnxConfig):
 
     def get_encoder_config(self, encoder_config: PretrainedConfig) -> OnnxConfig:
         r"""
-        Returns encoder Onnx config for VisionEncoderDecoder model.
+        Returns ONNX encoder config for `VisionEncoderDecoder` model.
 
         Args:
-            encoder_config: The encoder model's configuration to use when exporting to ONNX
+            encoder_config (`PretrainedConfig`): 
+                The encoder model's configuration to use when exporting to ONNX.
 
         Returns:
-            [`VisionEncoderDecoderEncoderOnnxConfig`]: An instance of onnx configuration object
+            [`VisionEncoderDecoderEncoderOnnxConfig`]: An instance of the ONNX configuration object
         """
         return VisionEncoderDecoderEncoderOnnxConfig(encoder_config)
 
@@ -204,15 +205,18 @@ class VisionEncoderDecoderOnnxConfig(OnnxConfig):
         self, encoder_config: PretrainedConfig, decoder_config: PretrainedConfig, feature: str = "default"
     ) -> OnnxConfig:
         r"""
-        Returns decoder Onnx config for VisionEncoderDecoder model.
+        Returns ONNX decoder config for `VisionEncoderDecoder` model.
 
         Args:
-            encoder_config: The encoder model's configuration to use when exporting to ONNX
-            decoder_config: The decoder model's configuration to use when exporting to ONNX
-            feature: The type of feature to export the model with.
+            encoder_config (`PretrainedConfig`): 
+                The encoder model's configuration to use when exporting to ONNX.
+            decoder_config (`PretrainedConfig`): 
+                The decoder model's configuration to use when exporting to ONNX
+            feature (`str`, *optional*): 
+                The type of feature to export the model with.
 
         Returns:
-            [`VisionEncoderDecoderDecoderOnnxConfig`]: An instance of onnx configuration object
+            [`VisionEncoderDecoderDecoderOnnxConfig`]: An instance of the ONNX configuration object.
         """
         decoder_config.encoder_hidden_size = encoder_config.hidden_size
         return VisionEncoderDecoderDecoderOnnxConfig(decoder_config, feature)

--- a/src/transformers/models/vision_encoder_decoder/configuration_vision_encoder_decoder.py
+++ b/src/transformers/models/vision_encoder_decoder/configuration_vision_encoder_decoder.py
@@ -15,18 +15,18 @@
 # limitations under the License.
 
 import copy
-from typing import Any, Mapping, Optional, OrderedDict
+from typing import TYPE_CHECKING, Any, Mapping, Optional, OrderedDict
 
 from packaging import version
-
-from transformers.tokenization_utils_base import PreTrainedTokenizerBase
-from transformers.utils.generic import TensorType
 
 from ...configuration_utils import PretrainedConfig
 from ...onnx import OnnxConfig
 from ...utils import logging
 from ..auto.configuration_auto import AutoConfig
 
+
+if TYPE_CHECKING:
+    from ... import PreTrainedTokenizerBase, TensorType
 
 logger = logging.get_logger(__name__)
 
@@ -164,7 +164,7 @@ class VisionEncoderDecoderDecoderOnnxConfig(OnnxConfig):
         batch_size: int = -1,
         seq_length: int = -1,
         is_pair: bool = False,
-        framework: Optional[TensorType] = None,
+        framework: Optional["TensorType"] = None,
     ) -> Mapping[str, Any]:
         import torch
 
@@ -193,7 +193,7 @@ class VisionEncoderDecoderOnnxConfig(OnnxConfig):
         Returns ONNX encoder config for `VisionEncoderDecoder` model.
 
         Args:
-            encoder_config (`PretrainedConfig`): 
+            encoder_config (`PretrainedConfig`):
                 The encoder model's configuration to use when exporting to ONNX.
 
         Returns:
@@ -208,11 +208,11 @@ class VisionEncoderDecoderOnnxConfig(OnnxConfig):
         Returns ONNX decoder config for `VisionEncoderDecoder` model.
 
         Args:
-            encoder_config (`PretrainedConfig`): 
+            encoder_config (`PretrainedConfig`):
                 The encoder model's configuration to use when exporting to ONNX.
-            decoder_config (`PretrainedConfig`): 
+            decoder_config (`PretrainedConfig`):
                 The decoder model's configuration to use when exporting to ONNX
-            feature (`str`, *optional*): 
+            feature (`str`, *optional*):
                 The type of feature to export the model with.
 
         Returns:

--- a/src/transformers/models/vision_encoder_decoder/configuration_vision_encoder_decoder.py
+++ b/src/transformers/models/vision_encoder_decoder/configuration_vision_encoder_decoder.py
@@ -15,8 +15,16 @@
 # limitations under the License.
 
 import copy
+from typing import Any, Mapping, Optional, OrderedDict
+
+from packaging import version
+
+from transformers.modeling_utils import PreTrainedModel
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+from transformers.utils.generic import TensorType
 
 from ...configuration_utils import PretrainedConfig
+from ...onnx import OnnxConfig
 from ...utils import logging
 from ..auto.configuration_auto import AutoConfig
 
@@ -119,3 +127,85 @@ class VisionEncoderDecoderConfig(PretrainedConfig):
         output["decoder"] = self.decoder.to_dict()
         output["model_type"] = self.__class__.model_type
         return output
+
+
+class VisionEncoderDecoderEncoderOnnxConfig(OnnxConfig):
+    torch_onnx_minimum_version = version.parse("1.11")
+
+    @property
+    def inputs(self) -> Mapping[str, Mapping[int, str]]:
+        return OrderedDict(
+            [
+                ("pixel_values", {0: "batch", 1: "num_channels", 2: "height", 3: "width"}),
+            ]
+        )
+
+    @property
+    def atol_for_validation(self) -> float:
+        return 1e-4
+
+    @property
+    def outputs(self) -> Mapping[str, Mapping[int, str]]:
+        return OrderedDict({"last_hidden_state": {0: "batch", 1: "encoder_sequence"}})
+
+
+class VisionEncoderDecoderDecoderOnnxConfig(OnnxConfig):
+    @property
+    def inputs(self) -> Mapping[str, Mapping[int, str]]:
+        common_inputs = OrderedDict()
+        common_inputs["input_ids"] = {0: "batch", 1: "past_decoder_sequence + sequence"}
+        common_inputs["attention_mask"] = {0: "batch", 1: "past_decoder_sequence + sequence"}
+        common_inputs["encoder_hidden_states"] = {0: "batch", 1: "encoder_sequence"}
+
+        return common_inputs
+
+    def generate_dummy_inputs(
+        self,
+        tokenizer: "PreTrainedTokenizerBase",
+        batch_size: int = -1,
+        seq_length: int = -1,
+        is_pair: bool = False,
+        framework: Optional[TensorType] = None,
+    ) -> Mapping[str, Any]:
+        import torch
+
+        common_inputs = OrderedDict()
+
+        dummy_input = super().generate_dummy_inputs(
+            tokenizer, batch_size=batch_size, seq_length=seq_length, is_pair=is_pair, framework=framework
+        )
+
+        batch, encoder_sequence = dummy_input["input_ids"].shape
+        encoder_hidden_states_shape = (batch, encoder_sequence, self._config.encoder_hidden_size)
+        common_inputs["input_ids"] = dummy_input.pop("input_ids")
+        common_inputs["attention_mask"] = dummy_input.pop("attention_mask")
+        common_inputs["encoder_hidden_states"] = torch.zeros(encoder_hidden_states_shape)
+
+        return common_inputs
+
+
+class VisionEncoderDecoderOnnxConfig(OnnxConfig):
+    @property
+    def inputs(self) -> None:
+        pass
+
+    def get_encoder_config(self, encoder_model: PreTrainedModel) -> OnnxConfig:
+        r"""
+        Returns encoder Onnx config for VisionEncoderDecoder model.
+
+        Returns:
+            [`VisionEncoderDecoderEncoderOnnxConfig`]: An instance of onnx configuration object
+        """
+        return VisionEncoderDecoderEncoderOnnxConfig(encoder_model.config)
+
+    def get_decoder_config(
+        self, encoder_model: PretrainedConfig, decoder_model: PretrainedConfig, task: str = "default"
+    ) -> OnnxConfig:
+        r"""
+        Returns decoder Onnx config for VisionEncoderDecoder model.
+
+        Returns:
+            [`VisionEncoderDecoderDecoderOnnxConfig`]: An instance of onnx configuration object
+        """
+        decoder_model.config.encoder_hidden_size = encoder_model.config.hidden_size
+        return VisionEncoderDecoderDecoderOnnxConfig(decoder_model.config, task)

--- a/src/transformers/models/vision_encoder_decoder/configuration_vision_encoder_decoder.py
+++ b/src/transformers/models/vision_encoder_decoder/configuration_vision_encoder_decoder.py
@@ -146,7 +146,7 @@ class VisionEncoderDecoderEncoderOnnxConfig(OnnxConfig):
 
     @property
     def outputs(self) -> Mapping[str, Mapping[int, str]]:
-        return OrderedDict({"last_hidden_state": {0: "batch", 1: "encoder_sequence"}})
+        return OrderedDict({"encoder_last_hidden_state": {0: "batch", 1: "encoder_sequence"}})
 
 
 class VisionEncoderDecoderDecoderOnnxConfig(OnnxConfig):

--- a/src/transformers/onnx/__main__.py
+++ b/src/transformers/onnx/__main__.py
@@ -65,48 +65,108 @@ def main():
     if not args.output.parent.exists():
         args.output.parent.mkdir(parents=True)
 
-    # Instantiate the appropriate preprocessor
-    if args.preprocessor == "auto":
-        preprocessor = get_preprocessor(args.model)
-    elif args.preprocessor == "tokenizer":
-        preprocessor = AutoTokenizer.from_pretrained(args.model)
-    elif args.preprocessor == "feature_extractor":
-        preprocessor = AutoFeatureExtractor.from_pretrained(args.model)
-    elif args.preprocessor == "processor":
-        preprocessor = AutoProcessor.from_pretrained(args.model)
-    else:
-        raise ValueError(f"Unknown preprocessor type '{args.preprocessor}'")
-
     # Allocate the model
     model = FeaturesManager.get_model_from_feature(
         args.feature, args.model, framework=args.framework, cache_dir=args.cache_dir
     )
+
     model_kind, model_onnx_config = FeaturesManager.check_supported_model_or_raise(model, feature=args.feature)
     onnx_config = model_onnx_config(model.config)
 
-    # Ensure the requested opset is sufficient
-    if args.opset is None:
-        args.opset = onnx_config.default_onnx_opset
+    if model_kind == "vision-encoder-decoder":
+        encoder_model = model.get_encoder()
+        decoder_model = model.get_decoder()
 
-    if args.opset < onnx_config.default_onnx_opset:
-        raise ValueError(
-            f"Opset {args.opset} is not sufficient to export {model_kind}. "
-            f"At least  {onnx_config.default_onnx_opset} is required."
+        encoder_onnx_config = onnx_config.get_encoder_config(encoder_model)
+        decoder_onnx_config = onnx_config.get_decoder_config(encoder_model, decoder_model, task=args.feature)
+
+        if args.opset is None:
+            args.opset = max(encoder_onnx_config.default_onnx_opset, decoder_onnx_config.default_onnx_opset)
+
+        if args.opset < min(encoder_onnx_config.default_onnx_opset, decoder_onnx_config.default_onnx_opset):
+            raise ValueError(
+                f"Opset {args.opset} is not sufficient to export {model_kind}. At least "
+                f" {min(encoder_onnx_config.default_onnx_opset, decoder_onnx_config.default_onnx_opset)} is required."
+            )
+
+        preprocessor = AutoFeatureExtractor.from_pretrained(args.model)
+
+        onnx_inputs, onnx_outputs = export(
+            preprocessor,
+            encoder_model,
+            encoder_onnx_config,
+            args.opset,
+            args.output.parent.joinpath("encoder_model.onnx"),
         )
 
-    onnx_inputs, onnx_outputs = export(
-        preprocessor,
-        model,
-        onnx_config,
-        args.opset,
-        args.output,
-    )
+        validate_model_outputs(
+            encoder_onnx_config,
+            preprocessor,
+            encoder_model,
+            args.output.parent.joinpath("encoder_model.onnx"),
+            onnx_outputs,
+            args.atol if args.atol else encoder_onnx_config.atol_for_validation,
+        )
 
-    if args.atol is None:
-        args.atol = onnx_config.atol_for_validation
+        preprocessor = AutoTokenizer.from_pretrained(args.model)
 
-    validate_model_outputs(onnx_config, preprocessor, model, args.output, onnx_outputs, args.atol)
-    logger.info(f"All good, model saved at: {args.output.as_posix()}")
+        onnx_inputs, onnx_outputs = export(
+            preprocessor,
+            decoder_model,
+            decoder_onnx_config,
+            args.opset,
+            args.output.parent.joinpath("decoder_model.onnx"),
+        )
+
+        validate_model_outputs(
+            decoder_onnx_config,
+            preprocessor,
+            decoder_model,
+            args.output.parent.joinpath("decoder_model.onnx"),
+            onnx_outputs,
+            args.atol if args.atol else decoder_onnx_config.atol_for_validation,
+        )
+        logger.info(
+            f"All good, model saved at: {args.output.parent.joinpath('encoder_model.onnx').as_posix()},"
+            f" {args.output.parent.joinpath('decoder_model.onnx').as_posix()}"
+        )
+
+    else:
+        # Instantiate the appropriate preprocessor
+        if args.preprocessor == "auto":
+            preprocessor = get_preprocessor(args.model)
+        elif args.preprocessor == "tokenizer":
+            preprocessor = AutoTokenizer.from_pretrained(args.model)
+        elif args.preprocessor == "feature_extractor":
+            preprocessor = AutoFeatureExtractor.from_pretrained(args.model)
+        elif args.preprocessor == "processor":
+            preprocessor = AutoProcessor.from_pretrained(args.model)
+        else:
+            raise ValueError(f"Unknown preprocessor type '{args.preprocessor}'")
+
+        # Ensure the requested opset is sufficient
+        if args.opset is None:
+            args.opset = onnx_config.default_onnx_opset
+
+        if args.opset < onnx_config.default_onnx_opset:
+            raise ValueError(
+                f"Opset {args.opset} is not sufficient to export {model_kind}. "
+                f"At least  {onnx_config.default_onnx_opset} is required."
+            )
+
+        onnx_inputs, onnx_outputs = export(
+            preprocessor,
+            model,
+            onnx_config,
+            args.opset,
+            args.output,
+        )
+
+        if args.atol is None:
+            args.atol = onnx_config.atol_for_validation
+
+        validate_model_outputs(onnx_config, preprocessor, model, args.output, onnx_outputs, args.atol)
+        logger.info(f"All good, model saved at: {args.output.as_posix()}")
 
 
 if __name__ == "__main__":

--- a/src/transformers/onnx/__main__.py
+++ b/src/transformers/onnx/__main__.py
@@ -22,6 +22,9 @@ from .convert import export, validate_model_outputs
 from .features import FeaturesManager
 
 
+ENCODER_DECODER_MODELS = ["vision-encoder-decoder"]
+
+
 def main():
     parser = ArgumentParser("Hugging Face Transformers ONNX exporter")
     parser.add_argument(
@@ -73,12 +76,14 @@ def main():
     model_kind, model_onnx_config = FeaturesManager.check_supported_model_or_raise(model, feature=args.feature)
     onnx_config = model_onnx_config(model.config)
 
-    if model_kind == "vision-encoder-decoder":
+    if model_kind in ENCODER_DECODER_MODELS:
         encoder_model = model.get_encoder()
         decoder_model = model.get_decoder()
 
-        encoder_onnx_config = onnx_config.get_encoder_config(encoder_model)
-        decoder_onnx_config = onnx_config.get_decoder_config(encoder_model, decoder_model, task=args.feature)
+        encoder_onnx_config = onnx_config.get_encoder_config(encoder_model.config)
+        decoder_onnx_config = onnx_config.get_decoder_config(
+            encoder_model.config, decoder_model.config, feature=args.feature
+        )
 
         if args.opset is None:
             args.opset = max(encoder_onnx_config.default_onnx_opset, decoder_onnx_config.default_onnx_opset)

--- a/src/transformers/onnx/config.py
+++ b/src/transformers/onnx/config.py
@@ -103,6 +103,7 @@ class OnnxConfig(ABC):
         "seq2seq-lm": OrderedDict({"logits": {0: "batch", 1: "decoder_sequence"}}),
         "sequence-classification": OrderedDict({"logits": {0: "batch"}}),
         "token-classification": OrderedDict({"logits": {0: "batch", 1: "sequence"}}),
+        "vision2seq-lm": OrderedDict({"logits": {0: "batch", 1: "sequence"}}),
     }
 
     def __init__(self, config: "PretrainedConfig", task: str = "default", patching_specs: List[PatchingSpec] = None):
@@ -451,7 +452,6 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
         is_pair: bool = False,
         framework: Optional[TensorType] = None,
     ) -> Mapping[str, Any]:
-
         # TODO: should we set seq_length = 1 when self.use_past = True?
         common_inputs = super().generate_dummy_inputs(
             tokenizer, batch_size=batch_size, seq_length=seq_length, is_pair=is_pair, framework=framework
@@ -577,7 +577,6 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
         is_pair: bool = False,
         framework: Optional[TensorType] = None,
     ) -> Mapping[str, Any]:
-
         encoder_inputs = super(OnnxConfigWithPast, self).generate_dummy_inputs(
             tokenizer, batch_size=batch_size, seq_length=seq_length, is_pair=is_pair, framework=framework
         )

--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -113,7 +113,6 @@ class FeaturesManager:
             "multiple-choice": TFAutoModelForMultipleChoice,
             "question-answering": TFAutoModelForQuestionAnswering,
             "semantic-segmentation": TFAutoModelForSemanticSegmentation,
-            "vision2seq-lm": TFAutoModelForVision2Seq,
         }
 
     # Set of model topologies we support associated to the features supported by each topology and the factory

--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -30,6 +30,7 @@ if is_torch_available():
         AutoModelForSeq2SeqLM,
         AutoModelForSequenceClassification,
         AutoModelForTokenClassification,
+        AutoModelForVision2Seq,
     )
 if is_tf_available():
     from transformers.models.auto import (
@@ -42,6 +43,7 @@ if is_tf_available():
         TFAutoModelForSeq2SeqLM,
         TFAutoModelForSequenceClassification,
         TFAutoModelForTokenClassification,
+        TFAutoModelForVision2Seq,
     )
 if not is_torch_available() and not is_tf_available():
     logger.warning(
@@ -98,6 +100,7 @@ class FeaturesManager:
             "image-segmentation": AutoModelForImageSegmentation,
             "masked-im": AutoModelForMaskedImageModeling,
             "semantic-segmentation": AutoModelForSemanticSegmentation,
+            "vision2seq-lm": AutoModelForVision2Seq,
         }
     if is_tf_available():
         _TASKS_TO_TF_AUTOMODELS = {
@@ -110,6 +113,7 @@ class FeaturesManager:
             "multiple-choice": TFAutoModelForMultipleChoice,
             "question-answering": TFAutoModelForQuestionAnswering,
             "semantic-segmentation": TFAutoModelForSemanticSegmentation,
+            "vision2seq-lm": TFAutoModelForVision2Seq,
         }
 
     # Set of model topologies we support associated to the features supported by each topology and the factory
@@ -478,6 +482,9 @@ class FeaturesManager:
             "seq2seq-lm-with-past",
             onnx_config_cls="models.t5.T5OnnxConfig",
         ),
+        "vision-encoder-decoder": supported_features_mapping(
+            "vision2seq-lm", onnx_config_cls="models.vision_encoder_decoder.VisionEncoderDecoderOnnxConfig"
+        ),
         "vit": supported_features_mapping(
             "default", "image-classification", "masked-im", onnx_config_cls="models.vit.ViTOnnxConfig"
         ),
@@ -579,6 +586,7 @@ class FeaturesManager:
             raise KeyError(
                 f"Unknown task: {feature}. Possible values are {list(FeaturesManager._TASKS_TO_AUTOMODELS.values())}"
             )
+
         return task_to_automodel[task]
 
     @staticmethod

--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -43,7 +43,6 @@ if is_tf_available():
         TFAutoModelForSeq2SeqLM,
         TFAutoModelForSequenceClassification,
         TFAutoModelForTokenClassification,
-        TFAutoModelForVision2Seq,
     )
 if not is_torch_available() and not is_tf_available():
     logger.warning(

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -161,7 +161,6 @@ class OnnxConfigWithPastTestCaseV2(TestCase):
         """
         for name, config in OnnxConfigWithPastTestCaseV2.SUPPORTED_WITH_PAST_CONFIGS:
             with self.subTest(name):
-
                 # without past
                 onnx_config_default = OnnxConfigWithPast.from_model_config(config())
                 self.assertIsNotNone(onnx_config_default.values_override, "values_override should not be None")
@@ -208,6 +207,7 @@ PYTORCH_EXPORT_MODELS = {
     ("levit", "facebook/levit-128S"),
     ("owlvit", "google/owlvit-base-patch32"),
     ("vit", "google/vit-base-patch16-224"),
+    ("vision-encoder-decoder", "nlpconnect/vit-gpt2-image-captioning"),
     ("deit", "facebook/deit-small-patch16-224"),
     ("beit", "microsoft/beit-base-patch16-224"),
     ("data2vec-text", "facebook/data2vec-text-base"),

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -207,7 +207,6 @@ PYTORCH_EXPORT_MODELS = {
     ("levit", "facebook/levit-128S"),
     ("owlvit", "google/owlvit-base-patch32"),
     ("vit", "google/vit-base-patch16-224"),
-    ("vision-encoder-decoder", "nlpconnect/vit-gpt2-image-captioning"),
     ("deit", "facebook/deit-small-patch16-224"),
     ("beit", "microsoft/beit-base-patch16-224"),
     ("data2vec-text", "facebook/data2vec-text-base"),
@@ -217,6 +216,10 @@ PYTORCH_EXPORT_MODELS = {
     ("longformer", "allenai/longformer-base-4096"),
     ("yolos", "hustvl/yolos-tiny"),
     ("segformer", "nvidia/segformer-b0-finetuned-ade-512-512"),
+}
+
+PYTORCH_EXPORT_ENCODER_DECODER_MODELS = {
+    ("vision-encoder-decoder", "nlpconnect/vit-gpt2-image-captioning"),
 }
 
 PYTORCH_EXPORT_WITH_PAST_MODELS = {
@@ -328,6 +331,70 @@ class OnnxExportTestCaseV2(TestCase):
             except (RuntimeError, ValueError) as e:
                 self.fail(f"{name}, {feature} -> {e}")
 
+    def _onnx_export_encoder_decoder_models(
+        self, test_name, name, model_name, feature, onnx_config_class_constructor, device="cpu"
+    ):
+        from transformers import AutoFeatureExtractor, AutoTokenizer
+        from transformers.onnx import export
+
+        model_class = FeaturesManager.get_model_class_for_feature(feature)
+        config = AutoConfig.from_pretrained(model_name)
+        model = model_class.from_config(config)
+
+        onnx_config = onnx_config_class_constructor(model.config)
+
+        if is_torch_available():
+            from transformers.utils import torch_version
+
+            if torch_version < onnx_config.torch_onnx_minimum_version:
+                pytest.skip(
+                    "Skipping due to incompatible PyTorch version. Minimum required is"
+                    f" {onnx_config.torch_onnx_minimum_version}, got: {torch_version}"
+                )
+
+        encoder_model = model.get_encoder()
+        decoder_model = model.get_decoder()
+
+        encoder_onnx_config = onnx_config.get_encoder_config(encoder_model.config)
+        decoder_onnx_config = onnx_config.get_decoder_config(encoder_model.config, decoder_model.config, feature)
+
+        preprocessor = AutoFeatureExtractor.from_pretrained(model_name)
+
+        onnx_opset = max(encoder_onnx_config.default_onnx_opset, decoder_onnx_config.default_onnx_opset)
+
+        with NamedTemporaryFile("w") as encoder_output:
+            onnx_inputs, onnx_outputs = export(
+                preprocessor, encoder_model, encoder_onnx_config, onnx_opset, Path(encoder_output.name), device=device
+            )
+            validate_model_outputs(
+                encoder_onnx_config,
+                preprocessor,
+                encoder_model,
+                Path(encoder_output.name),
+                onnx_outputs,
+                encoder_onnx_config.atol_for_validation,
+            )
+
+        preprocessor = AutoTokenizer.from_pretrained(model_name)
+
+        with NamedTemporaryFile("w") as decoder_output:
+            onnx_inputs, onnx_outputs = export(
+                preprocessor,
+                decoder_model,
+                decoder_onnx_config,
+                onnx_config.default_onnx_opset,
+                Path(decoder_output.name),
+                device=device,
+            )
+            validate_model_outputs(
+                decoder_onnx_config,
+                preprocessor,
+                decoder_model,
+                Path(decoder_output.name),
+                onnx_outputs,
+                decoder_onnx_config.atol_for_validation,
+            )
+
     @parameterized.expand(_get_models_to_test(PYTORCH_EXPORT_MODELS))
     @slow
     @require_torch
@@ -343,6 +410,28 @@ class OnnxExportTestCaseV2(TestCase):
     @require_rjieba
     def test_pytorch_export_on_cuda(self, test_name, name, model_name, feature, onnx_config_class_constructor):
         self._onnx_export(test_name, name, model_name, feature, onnx_config_class_constructor, device="cuda")
+
+    @parameterized.expand(_get_models_to_test(PYTORCH_EXPORT_ENCODER_DECODER_MODELS))
+    @slow
+    @require_torch
+    @require_vision
+    @require_rjieba
+    def test_pytorch_export_encoder_decoder_models(
+        self, test_name, name, model_name, feature, onnx_config_class_constructor
+    ):
+        self._onnx_export_encoder_decoder_models(test_name, name, model_name, feature, onnx_config_class_constructor)
+
+    @parameterized.expand(_get_models_to_test(PYTORCH_EXPORT_ENCODER_DECODER_MODELS))
+    @slow
+    @require_torch
+    @require_vision
+    @require_rjieba
+    def test_pytorch_export_encoder_decoder_models_on_cuda(
+        self, test_name, name, model_name, feature, onnx_config_class_constructor
+    ):
+        self._onnx_export_encoder_decoder_models(
+            test_name, name, model_name, feature, onnx_config_class_constructor, device="cuda"
+        )
 
     @parameterized.expand(_get_models_to_test(PYTORCH_EXPORT_WITH_PAST_MODELS))
     @slow


### PR DESCRIPTION
# What does this PR do?

Fixes #14812 
This PR enables the export of VisionEncoderDecoder models to ONNX.

The VisionEncoderDecoder models contains two parts, a vision transformer encoder and language modelling decoder. Both the models are exported to onnx separately as `encoder_model.onnx` and `decoder_model.onnx`.

To enable the export of the model, the export call in the __main__ file is segregated based on the model_kind.

Usage
```python
model_ckpt = "nlpconnect/vit-gpt2-image-captioning"
!python -m transformers.onnx --model={model_ckpt} --feature=vision2seq-lm onnx/ --atol 1e-3
```