### PR TITLE
Export TensorFlow models to ONNX with dynamic input shapes

### DIFF
--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -355,11 +355,17 @@ class CLIPOnnxConfig(OnnxConfig):
     def generate_dummy_inputs(
         self,
         processor: "ProcessorMixin",
+        batch_size: int = -1,
+        seq_length: int = -1,
         framework: Optional["TensorType"] = None,
     ) -> Mapping[str, Any]:
 
-        text_input_dict = super().generate_dummy_inputs(processor.tokenizer, framework=framework)
-        image_input_dict = super().generate_dummy_inputs(processor.feature_extractor, framework=framework)
+        text_input_dict = super().generate_dummy_inputs(
+            processor.tokenizer, batch_size=batch_size, seq_length=seq_length, framework=framework
+        )
+        image_input_dict = super().generate_dummy_inputs(
+            processor.feature_extractor, batch_size=batch_size, framework=framework
+        )
         return {**text_input_dict, **image_input_dict}
 
     @property

--- a/src/transformers/models/groupvit/configuration_groupvit.py
+++ b/src/transformers/models/groupvit/configuration_groupvit.py
@@ -381,11 +381,17 @@ class GroupViTOnnxConfig(OnnxConfig):
     def generate_dummy_inputs(
         self,
         processor: "ProcessorMixin",
+        batch_size: int = -1,
+        seq_length: int = -1,
         framework: Optional["TensorType"] = None,
     ) -> Mapping[str, Any]:
 
-        text_input_dict = super().generate_dummy_inputs(processor.tokenizer, framework=framework)
-        image_input_dict = super().generate_dummy_inputs(processor.feature_extractor, framework=framework)
+        text_input_dict = super().generate_dummy_inputs(
+            processor.tokenizer, batch_size=batch_size, seq_length=seq_length, framework=framework
+        )
+        image_input_dict = super().generate_dummy_inputs(
+            processor.feature_extractor, batch_size=batch_size, framework=framework
+        )
         return {**text_input_dict, **image_input_dict}
 
     @property

--- a/src/transformers/models/owlvit/configuration_owlvit.py
+++ b/src/transformers/models/owlvit/configuration_owlvit.py
@@ -372,11 +372,17 @@ class OwlViTOnnxConfig(OnnxConfig):
     def generate_dummy_inputs(
         self,
         processor: "ProcessorMixin",
+        batch_size: int = -1,
+        seq_length: int = -1,
         framework: Optional["TensorType"] = None,
     ) -> Mapping[str, Any]:
 
-        text_input_dict = super().generate_dummy_inputs(processor.tokenizer, framework=framework)
-        image_input_dict = super().generate_dummy_inputs(processor.feature_extractor, framework=framework)
+        text_input_dict = super().generate_dummy_inputs(
+            processor.tokenizer, batch_size=batch_size, seq_length=seq_length, framework=framework
+        )
+        image_input_dict = super().generate_dummy_inputs(
+            processor.feature_extractor, batch_size=batch_size, framework=framework
+        )
         return {**text_input_dict, **image_input_dict}
 
     @property

--- a/src/transformers/onnx/convert.py
+++ b/src/transformers/onnx/convert.py
@@ -262,7 +262,9 @@ def export_tensorflow(
     inputs_match, matched_inputs = ensure_model_and_config_inputs_match(model, model_inputs.keys())
     onnx_outputs = list(config.outputs.keys())
 
-    input_signature = [tf.TensorSpec.from_tensor(tensor, name=key) for key, tensor in model_inputs.items()]
+    input_signature = [
+        tf.TensorSpec([None] * tensor.ndim, dtype=tensor.dtype, name=key) for key, tensor in model_inputs.items()
+    ]
     onnx_model, _ = tf2onnx.convert.from_keras(model, input_signature, opset=opset)
     onnx.save(onnx_model, output.as_posix())
     config.restore_ops()
@@ -363,12 +365,23 @@ def validate_model_outputs(
         logger.info("Overwriting the `preprocessor` argument with `tokenizer` to generate dummmy inputs.")
         preprocessor = tokenizer
 
-    # TODO: generate inputs with a different batch_size and seq_len that was used for conversion to properly test
+    # generate inputs with a different batch_size and seq_len that was used for conversion to properly test
     # dynamic input shapes.
+    # TODO is adding 1 always safe?
     if is_torch_available() and issubclass(type(reference_model), PreTrainedModel):
-        reference_model_inputs = config.generate_dummy_inputs(preprocessor, framework=TensorType.PYTORCH)
+        reference_model_inputs = config.generate_dummy_inputs(
+            preprocessor,
+            batch_size=config.default_fixed_batch + 1,
+            seq_length=config.default_fixed_sequence + 1,
+            framework=TensorType.PYTORCH,
+        )
     else:
-        reference_model_inputs = config.generate_dummy_inputs(preprocessor, framework=TensorType.TENSORFLOW)
+        reference_model_inputs = config.generate_dummy_inputs(
+            preprocessor,
+            batch_size=config.default_fixed_batch + 1,
+            seq_length=config.default_fixed_sequence + 1,
+            framework=TensorType.TENSORFLOW,
+        )
 
     # Create ONNX Runtime session
     options = SessionOptions()

--- a/src/transformers/onnx/convert.py
+++ b/src/transformers/onnx/convert.py
@@ -367,7 +367,6 @@ def validate_model_outputs(
 
     # generate inputs with a different batch_size and seq_len that was used for conversion to properly test
     # dynamic input shapes.
-    # TODO is adding 1 always safe?
     if is_torch_available() and issubclass(type(reference_model), PreTrainedModel):
         reference_model_inputs = config.generate_dummy_inputs(
             preprocessor,

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -241,22 +241,13 @@ PYTORCH_EXPORT_SEQ2SEQ_WITH_PAST_MODELS = {
     # ("longt5", "google/long-t5-tglobal-base"),
 }
 
-
-def _get_features_to_test(name, skip_features=None):
-    skip_features = skip_features or ()
-    feature_config_mapping = FeaturesManager.get_supported_features_for_model_type(name)
-    features = {feature: config for feature, config in feature_config_mapping.items() if feature not in skip_features}
-    return tuple(features)
-
-
-# TODO: bert, camembert, and roberta multiple-choice fail inference with ONNX when exported with TensorFlow with error `Attempting to broadcast an axis by a dimension other than 1`
 # TODO(lewtun): Include the same model types in `PYTORCH_EXPORT_MODELS` once TensorFlow has parity with the PyTorch model implementations.
 TENSORFLOW_EXPORT_DEFAULT_MODELS = {
-    ("albert", "hf-internal-testing/tiny-albert", _get_features_to_test("albert")),
-    ("bert", "bert-base-cased", _get_features_to_test("bert", skip_features=("multiple-choice",))),
-    ("camembert", "camembert-base", _get_features_to_test("camembert", skip_features=("multiple-choice",))),
-    ("distilbert", "distilbert-base-cased", _get_features_to_test("distilbert")),
-    ("roberta", "roberta-base", _get_features_to_test("roberta", skip_features=("multiple-choice",))),
+    ("albert", "hf-internal-testing/tiny-albert"),
+    ("bert", "bert-base-cased"),
+    ("camembert", "camembert-base"),
+    ("distilbert", "distilbert-base-cased"),
+    ("roberta", "roberta-base"),
 }
 
 # TODO(lewtun): Include the same model types in `PYTORCH_EXPORT_WITH_PAST_MODELS` once TensorFlow has parity with the PyTorch model implementations.
@@ -304,6 +295,11 @@ class OnnxExportTestCaseV2(TestCase):
         # Dynamic axes aren't supported for YOLO-like models. This means they cannot be exported to ONNX on CUDA devices.
         # See: https://github.com/ultralytics/yolov5/pull/8378
         if model.__class__.__name__.startswith("Yolos") and device != "cpu":
+            return
+
+        # ONNX inference fails on bert, camembert, and roberta multiple-choice when exported with TensorFlow.
+        # Skip for now
+        if name in ("bert", "camembert", "roberta") and feature == "multiple-choice" and framework == "tf":
             return
 
         onnx_config = onnx_config_class_constructor(model.config)

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -241,13 +241,22 @@ PYTORCH_EXPORT_SEQ2SEQ_WITH_PAST_MODELS = {
     # ("longt5", "google/long-t5-tglobal-base"),
 }
 
+
+def _get_features_to_test(name, skip_features=None):
+    skip_features = skip_features or ()
+    feature_config_mapping = FeaturesManager.get_supported_features_for_model_type(name)
+    features = {feature: config for feature, config in feature_config_mapping.items() if feature not in skip_features}
+    return tuple(features)
+
+
+# TODO: bert, camembert, and roberta multiple-choice fail inference with ONNX when exported with TensorFlow with error `Attempting to broadcast an axis by a dimension other than 1`
 # TODO(lewtun): Include the same model types in `PYTORCH_EXPORT_MODELS` once TensorFlow has parity with the PyTorch model implementations.
 TENSORFLOW_EXPORT_DEFAULT_MODELS = {
-    ("albert", "hf-internal-testing/tiny-albert"),
-    ("bert", "bert-base-cased"),
-    ("camembert", "camembert-base"),
-    ("distilbert", "distilbert-base-cased"),
-    ("roberta", "roberta-base"),
+    ("albert", "hf-internal-testing/tiny-albert", _get_features_to_test("albert")),
+    ("bert", "bert-base-cased", _get_features_to_test("bert", skip_features=("multiple-choice",))),
+    ("camembert", "camembert-base", _get_features_to_test("camembert", skip_features=("multiple-choice",))),
+    ("distilbert", "distilbert-base-cased", _get_features_to_test("distilbert")),
+    ("roberta", "roberta-base", _get_features_to_test("roberta", skip_features=("multiple-choice",))),
 }
 
 # TODO(lewtun): Include the same model types in `PYTORCH_EXPORT_WITH_PAST_MODELS` once TensorFlow has parity with the PyTorch model implementations.

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -283,10 +283,12 @@ class OnnxExportTestCaseV2(TestCase):
     Integration tests ensuring supported models are correctly exported
     """
 
-    def _onnx_export(self, test_name, name, model_name, feature, onnx_config_class_constructor, device="cpu"):
+    def _onnx_export(
+        self, test_name, name, model_name, feature, onnx_config_class_constructor, device="cpu", framework="pt"
+    ):
         from transformers.onnx import export
 
-        model_class = FeaturesManager.get_model_class_for_feature(feature)
+        model_class = FeaturesManager.get_model_class_for_feature(feature, framework=framework)
         config = AutoConfig.from_pretrained(model_name)
         model = model_class.from_config(config)
 
@@ -363,13 +365,13 @@ class OnnxExportTestCaseV2(TestCase):
     @require_tf
     @require_vision
     def test_tensorflow_export(self, test_name, name, model_name, feature, onnx_config_class_constructor):
-        self._onnx_export(test_name, name, model_name, feature, onnx_config_class_constructor)
+        self._onnx_export(test_name, name, model_name, feature, onnx_config_class_constructor, framework="tf")
 
     @parameterized.expand(_get_models_to_test(TENSORFLOW_EXPORT_WITH_PAST_MODELS), skip_on_empty=True)
     @slow
     @require_tf
     def test_tensorflow_export_with_past(self, test_name, name, model_name, feature, onnx_config_class_constructor):
-        self._onnx_export(test_name, name, model_name, feature, onnx_config_class_constructor)
+        self._onnx_export(test_name, name, model_name, feature, onnx_config_class_constructor, framework="tf")
 
     @parameterized.expand(_get_models_to_test(TENSORFLOW_EXPORT_SEQ2SEQ_WITH_PAST_MODELS), skip_on_empty=True)
     @slow
@@ -377,7 +379,7 @@ class OnnxExportTestCaseV2(TestCase):
     def test_tensorflow_export_seq2seq_with_past(
         self, test_name, name, model_name, feature, onnx_config_class_constructor
     ):
-        self._onnx_export(test_name, name, model_name, feature, onnx_config_class_constructor)
+        self._onnx_export(test_name, name, model_name, feature, onnx_config_class_constructor, framework="tf")
 
 
 class StableDropoutTestCase(TestCase):

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -297,9 +297,20 @@ class OnnxExportTestCaseV2(TestCase):
         if model.__class__.__name__.startswith("Yolos") and device != "cpu":
             return
 
-        # ONNX inference fails on bert, camembert, and roberta multiple-choice when exported with TensorFlow.
-        # Skip for now
-        if name in ("bert", "camembert", "roberta") and feature == "multiple-choice" and framework == "tf":
+        # ONNX inference fails with the following name, feature, framework parameterizations
+        # See: https://github.com/huggingface/transformers/issues/19357
+        if (name, feature, framework) in {
+            ("deberta-v2", "question-answering", "pt"),
+            ("deberta-v2", "multiple-choice", "pt"),
+            ("roformer", "multiple-choice", "pt"),
+            ("groupvit", "default", "pt"),
+            ("perceiver", "masked-lm", "pt"),
+            ("perceiver", "sequence-classification", "pt"),
+            ("perceiver", "image-classification", "pt"),
+            ("bert", "multiple-choice", "tf"),
+            ("camembert", "multiple-choice", "tf"),
+            ("roberta", "multiple-choice", "tf"),
+        }:
             return
 
         onnx_config = onnx_config_class_constructor(model.config)


### PR DESCRIPTION
# What does this PR do?

This PR exports TensorFlow models to ONNX with dynamic input shapes. Previously they were being exported with static input shapes with a batch size of 2 and sequence length of 8. This should bring TensorFlow to ONNX export mostly into parity with PyTorch Models.

Fixes https://github.com/huggingface/transformers/issues/19238

* While fixing this, I noticed the TensorFlow to ONNX export tests weren't actually exporting TensorFlow models because `FeaturesManager.get_model_class_for_feature` returns a PyTorch model class by default. I've exposed a `framework` argument on these tests so that `FeaturesManager.get_model_class_for_feature` can return TensorFlow models. *NOTE*: Exporting TensorFlow to ONNX seems to be much slower than exporting PyTorch to ONNX so CI duration will increase
* I've changed `validate_model_outputs` to check with a batch size/sequence length different than used during export (now 3 and 9 respectively). There was a TODO about this, but it surfaced an error for BERT, CamemBERT, and RoBERTa multiple-choice tasks `onnxruntime.capi.onnxruntime_pybind11_state.RuntimeException: [ONNXRuntimeError] : 6 : RUNTIME_EXCEPTION : Non-zero status code returned while running Add node. Name:'tf_bert_for_multiple_choice/bert/encoder/layer_._0/attention/self/add_1' Status Message: /Users/runner/work/1/s/onnxruntime/core/providers/cpu/math/element_wise_ops.h:503 void onnxruntime::BroadcastIterator::Init(ptrdiff_t, ptrdiff_t) axis == 1 || axis == largest was false. Attempting to broadcast an axis by a dimension other than 1`, I suspect due to the way these models are defined (tracing fails to properly infer shape somewhere). IMO this is still a net improvement since the ONNX models exported under TensorFlow were previously non-functional except with their static input shapes. I'm skipping these specific configurations during testing for now, but someone should look into this


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

@Rocketknight1, @LysandreJik, @lewtun
