### PR TITLE
Fix formatting in DataCollator docs

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -1236,14 +1236,14 @@ class DataCollatorForPermutationLanguageModeling(DataCollatorMixin):
         """
         The masked tokens to be predicted for a particular sequence are determined by the following algorithm:
 
-            0. Start from the beginning of the sequence by setting `cur_len = 0` (number of tokens processed so far).
-            1. Sample a `span_length` from the interval `[1, max_span_length]` (length of span of tokens to be masked)
-            2. Reserve a context of length `context_length = span_length / plm_probability` to surround span to be
-               masked
-            3. Sample a starting point `start_index` from the interval `[cur_len, cur_len + context_length -
-               span_length]` and mask tokens `start_index:start_index + span_length`
-            4. Set `cur_len = cur_len + context_length`. If `cur_len < max_len` (i.e. there are tokens remaining in the
-               sequence to be processed), repeat from Step 1.
+        1. Start from the beginning of the sequence by setting `cur_len = 0` (number of tokens processed so far).
+        2. Sample a `span_length` from the interval `[1, max_span_length]` (length of span of tokens to be masked).
+        3. Reserve a context of length `context_length = span_length / plm_probability` to surround span to be
+            masked.
+        4. Sample a starting point `start_index` from the interval `[cur_len, cur_len + context_length -
+            span_length]` and mask tokens `start_index:start_index + span_length`.
+        5. Set `cur_len = cur_len + context_length`. If `cur_len < max_len` (i.e. there are tokens remaining in the
+            sequence to be processed), repeat from Step 1.
         """
         import torch
 
@@ -1335,14 +1335,14 @@ class DataCollatorForPermutationLanguageModeling(DataCollatorMixin):
         """
         The masked tokens to be predicted for a particular sequence are determined by the following algorithm:
 
-            0. Start from the beginning of the sequence by setting `cur_len = 0` (number of tokens processed so far).
-            1. Sample a `span_length` from the interval `[1, max_span_length]` (length of span of tokens to be masked)
-            2. Reserve a context of length `context_length = span_length / plm_probability` to surround span to be
-               masked
-            3. Sample a starting point `start_index` from the interval `[cur_len, cur_len + context_length -
-               span_length]` and mask tokens `start_index:start_index + span_length`
-            4. Set `cur_len = cur_len + context_length`. If `cur_len < max_len` (i.e. there are tokens remaining in the
-               sequence to be processed), repeat from Step 1.
+        1. Start from the beginning of the sequence by setting `cur_len = 0` (number of tokens processed so far).
+        2. Sample a `span_length` from the interval `[1, max_span_length]` (length of span of tokens to be masked).
+        3. Reserve a context of length `context_length = span_length / plm_probability` to surround span to be
+            masked.
+        4. Sample a starting point `start_index` from the interval `[cur_len, cur_len + context_length -
+            span_length]` and mask tokens `start_index:start_index + span_length`.
+        5. Set `cur_len = cur_len + context_length`. If `cur_len < max_len` (i.e. there are tokens remaining in the
+            sequence to be processed), repeat from Step 2.
         """
         from random import randint
 
@@ -1445,14 +1445,14 @@ class DataCollatorForPermutationLanguageModeling(DataCollatorMixin):
         """
         The masked tokens to be predicted for a particular sequence are determined by the following algorithm:
 
-            0. Start from the beginning of the sequence by setting `cur_len = 0` (number of tokens processed so far).
-            1. Sample a `span_length` from the interval `[1, max_span_length]` (length of span of tokens to be masked)
-            2. Reserve a context of length `context_length = span_length / plm_probability` to surround span to be
-               masked
-            3. Sample a starting point `start_index` from the interval `[cur_len, cur_len + context_length -
-               span_length]` and mask tokens `start_index:start_index + span_length`
-            4. Set `cur_len = cur_len + context_length`. If `cur_len < max_len` (i.e. there are tokens remaining in the
-               sequence to be processed), repeat from Step 1.
+        1. Start from the beginning of the sequence by setting `cur_len = 0` (number of tokens processed so far).
+        2. Sample a `span_length` from the interval `[1, max_span_length]` (length of span of tokens to be masked).
+        3. Reserve a context of length `context_length = span_length / plm_probability` to surround span to be
+            masked.
+        4. Sample a starting point `start_index` from the interval `[cur_len, cur_len + context_length -
+            span_length]` and mask tokens `start_index:start_index + span_length`.
+        5. Set `cur_len = cur_len + context_length`. If `cur_len < max_len` (i.e. there are tokens remaining in the
+            sequence to be processed), repeat from Step 2.
         """
         from random import randint
 


### PR DESCRIPTION
Noticed the `x_mask_tokens` functions in the data collator docs look a bit strange with the numbered bullets so this PR removes them:

![Screen Shot 2022-09-30 at 12 06 19 PM](https://user-images.githubusercontent.com/59462357/193339707-326cdf8a-7242-4057-aba9-d813eae25ce6.png)