### PR TITLE
Wrap BigBird integration test forward passes with torch.no_grad()

### DIFF
--- a/tests/models/big_bird/test_modeling_big_bird.py
+++ b/tests/models/big_bird/test_modeling_big_bird.py
@@ -627,7 +627,8 @@ class BigBirdModelIntegrationTest(unittest.TestCase):
         model.to(torch_device)
 
         input_ids = torch.tensor([[20920, 232, 328, 1437] * 1024], dtype=torch.long, device=torch_device)
-        outputs = model(input_ids)
+        with torch.no_grad():
+            outputs = model(input_ids)
         prediction_logits = outputs.prediction_logits
         seq_relationship_logits = outputs.seq_relationship_logits
 
@@ -655,7 +656,8 @@ class BigBirdModelIntegrationTest(unittest.TestCase):
         model.to(torch_device)
 
         input_ids = torch.tensor([[20920, 232, 328, 1437] * 512], dtype=torch.long, device=torch_device)
-        outputs = model(input_ids)
+        with torch.no_grad():
+            outputs = model(input_ids)
         prediction_logits = outputs.prediction_logits
         seq_relationship_logits = outputs.seq_relationship_logits
 
@@ -920,7 +922,8 @@ class BigBirdModelIntegrationTest(unittest.TestCase):
         model.eval()
 
         input_ids = torch.tensor([200 * [10] + 40 * [2] + [1]], device=torch_device, dtype=torch.long)
-        output = model(input_ids).to_tuple()[0]
+        with torch.no_grad():
+            output = model(input_ids).to_tuple()[0]
 
         # fmt: off
         target = torch.tensor(


### PR DESCRIPTION
# What does this PR do?
As proposed in issue #14642, this PR wraps forward passes in BigBird integration tests with torch.no_grad(). This way, no unnecessary gradients are computed during inference.


## Before submitting
- [ ] This PR fixes a typo or improves the docs.
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?
@LysandreJik could you please take a look at it?
Thanks :)