### PR TITLE
Wrap ConvBert integration test forward passes with torch.no_grad()

### DIFF
--- a/tests/models/convbert/test_modeling_convbert.py
+++ b/tests/models/convbert/test_modeling_convbert.py
@@ -444,7 +444,8 @@ class ConvBertModelIntegrationTest(unittest.TestCase):
     def test_inference_no_head(self):
         model = ConvBertModel.from_pretrained("YituTech/conv-bert-base")
         input_ids = torch.tensor([[1, 2, 3, 4, 5, 6]])
-        output = model(input_ids)[0]
+        with torch.no_grad():
+            output = model(input_ids)[0]
 
         expected_shape = torch.Size((1, 6, 768))
         self.assertEqual(output.shape, expected_shape)


### PR DESCRIPTION
# What does this PR do?
This PR wraps forward passes in ConvBert integration tests with `torch.no_grad()`, as proposed in issue #14642. This avoids the computation of unnecessary gradients during inference.

## Before submitting
- [ ] This PR fixes a typo or improves the docs.
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?
@LysandreJik could you please check it?
Thanks :)