### PR TITLE
Fix `ViTMSNForImageClassification` doctest

### DIFF
--- a/src/transformers/models/vit_msn/modeling_vit_msn.py
+++ b/src/transformers/models/vit_msn/modeling_vit_msn.py
@@ -632,7 +632,7 @@ class ViTMSNForImageClassification(ViTMSNPreTrainedModel):
         >>> from PIL import Image
         >>> import requests
 
-        >>> torch.manual_seed(2)
+        >>> torch.manual_seed(2)  # doctest: +IGNORE_RESULT
 
         >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw)


### PR DESCRIPTION
# What does this PR do?

`>>> torch.manual_seed`  requires `# doctest: +IGNORE_RESULT`, otherwise we get 

```
Expected nothing
Got:
    <torch._C.Generator object at 0x7fe914fdbcd0>
```
I missed this detail when reviewing #19183

Confirmed it works now (on GCP CPU VM)