### PR TITLE
Wrap Deit integration test forward passes with torch.no_grad()

### DIFF
--- a/tests/models/deit/test_modeling_deit.py
+++ b/tests/models/deit/test_modeling_deit.py
@@ -384,7 +384,8 @@ class DeiTModelIntegrationTest(unittest.TestCase):
         inputs = feature_extractor(images=image, return_tensors="pt").to(torch_device)
 
         # forward pass
-        outputs = model(**inputs)
+        with torch.no_grad():
+            outputs = model(**inputs)
 
         # verify the logits
         expected_shape = torch.Size((1, 1000))


### PR DESCRIPTION
# What does this PR do?
As proposed in issue #14642, this PR wraps forward passes in Deit integration tests with torch.no_grad(). This way, no unnecessary gradients are computed during inference.


## Before submitting
- [ ] This PR fixes a typo or improves the docs.
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?
@LysandreJik could you please take a look at it?
Thanks :)