### PR TITLE
Don't automatically add bug label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,5 @@
 name: "\U0001F41B Bug Report"
 description: Submit a bug report to help us improve transformers
-labels: [ "bug" ]
 body:
   - type: textarea
     id: system-info


### PR DESCRIPTION
# What does this PR do?

This PR removes the auto-added "bug" label in issues created with the Bug template. It's better if we had said label ourselves since those issues range from questions, to bug in the user's code and not always correspond to a bug in the library.