### PR TITLE
Change `BloomConfig` docstring

### DIFF
--- a/src/transformers/models/bloom/configuration_bloom.py
+++ b/src/transformers/models/bloom/configuration_bloom.py
@@ -54,9 +54,10 @@ class BloomConfig(PretrainedConfig):
 
     Args:
         vocab_size (`int`, *optional*, defaults to 250880):
-            Vocabulary size of the Bloom model. Defines the maximum number of different tokens that can be represented by the
-            `inputs_ids` passed when calling [`BloomModel`]. Check [this discussion](https://huggingface.co/bigscience/bloom/discussions/120#633d28389addb8530b406c2a) on how the `vocab_size`
-            has been defined.
+            Vocabulary size of the Bloom model. Defines the maximum number of different tokens that can be represented
+            by the `inputs_ids` passed when calling [`BloomModel`]. Check [this
+            discussion](https://huggingface.co/bigscience/bloom/discussions/120#633d28389addb8530b406c2a) on how the
+            `vocab_size` has been defined.
         hidden_size (`int`, *optional*, defaults to 64):
             Dimensionality of the embeddings and hidden states.
         n_layer (`int`, *optional*, defaults to 2):

--- a/src/transformers/models/bloom/configuration_bloom.py
+++ b/src/transformers/models/bloom/configuration_bloom.py
@@ -55,8 +55,7 @@ class BloomConfig(PretrainedConfig):
     Args:
         vocab_size (`int`, *optional*, defaults to 250880):
             Vocabulary size of the Bloom model. Defines the number of different tokens that can be represented by the
-            `inputs_ids` passed when calling [`BloomModel`]. Check
-            https://huggingface.co/bigscience/bloom/discussions/120#633d28389addb8530b406c2a on how the `vocab_size`
+            `inputs_ids` passed when calling [`BloomModel`]. Check [this discussion](https://huggingface.co/bigscience/bloom/discussions/120#633d28389addb8530b406c2a) on how the `vocab_size`
             has been defined.
         hidden_size (`int`, *optional*, defaults to 64):
             Dimensionality of the embeddings and hidden states.

--- a/src/transformers/models/bloom/configuration_bloom.py
+++ b/src/transformers/models/bloom/configuration_bloom.py
@@ -53,14 +53,16 @@ class BloomConfig(PretrainedConfig):
 
 
     Args:
-        vocab_size (`int`, *optional*, defaults to 50257):
+        vocab_size (`int`, *optional*, defaults to 250880):
             Vocabulary size of the Bloom model. Defines the number of different tokens that can be represented by the
-            `inputs_ids` passed when calling [`BloomModel`].
-        hidden_size (`int`, *optional*, defaults to 768):
+            `inputs_ids` passed when calling [`BloomModel`]. Check
+            https://huggingface.co/bigscience/bloom/discussions/120#633d28389addb8530b406c2a on how the `vocab_size`
+            has been defined.
+        hidden_size (`int`, *optional*, defaults to 64):
             Dimensionality of the embeddings and hidden states.
-        n_layer (`int`, *optional*, defaults to 12):
+        n_layer (`int`, *optional*, defaults to 2):
             Number of hidden layers in the Transformer encoder.
-        n_head (`int`, *optional*, defaults to 12):
+        n_head (`int`, *optional*, defaults to 8):
             Number of attention heads for each attention layer in the Transformer encoder.
         layer_norm_epsilon (`float`, *optional*, defaults to 1e-5):
             The epsilon to use in the layer normalization layers.

--- a/src/transformers/models/bloom/configuration_bloom.py
+++ b/src/transformers/models/bloom/configuration_bloom.py
@@ -54,7 +54,7 @@ class BloomConfig(PretrainedConfig):
 
     Args:
         vocab_size (`int`, *optional*, defaults to 250880):
-            Vocabulary size of the Bloom model. Defines the number of different tokens that can be represented by the
+            Vocabulary size of the Bloom model. Defines the maximum number of different tokens that can be represented by the
             `inputs_ids` passed when calling [`BloomModel`]. Check [this discussion](https://huggingface.co/bigscience/bloom/discussions/120#633d28389addb8530b406c2a) on how the `vocab_size`
             has been defined.
         hidden_size (`int`, *optional*, defaults to 64):


### PR DESCRIPTION
# What does this PR do?

This PR addresses small changes on the `BloomConfig` docstring that might be slightly confusing.
Original discussion from: https://huggingface.co/bigscience/bloom/discussions/120 

Thanks! 
cc @sgugger @VictorSanh @SaulLu 