### PR TITLE
Removes Roberta and Bert config dependencies from Longformer

### DIFF
--- a/src/transformers/models/longformer/configuration_longformer.py
+++ b/src/transformers/models/longformer/configuration_longformer.py
@@ -18,11 +18,10 @@ from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Union
 
 from ...onnx import OnnxConfig
 from ...utils import TensorType, logging
-from ..roberta.configuration_roberta import RobertaConfig
+from ...configuration_utils import PretrainedConfig
 
 
 if TYPE_CHECKING:
-    from ...configuration_utils import PretrainedConfig
     from ...onnx.config import PatchingSpec
     from ...tokenization_utils_base import PreTrainedTokenizerBase
 
@@ -44,7 +43,7 @@ LONGFORMER_PRETRAINED_CONFIG_ARCHIVE_MAP = {
 }
 
 
-class LongformerConfig(RobertaConfig):
+class LongformerConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`LongformerModel`] or a [`TFLongformerModel`]. It
     is used to instantiate a Longformer model according to the specified arguments, defining the model architecture.
@@ -55,10 +54,48 @@ class LongformerConfig(RobertaConfig):
     [allenai/longformer-base-4096](https://huggingface.co/allenai/longformer-base-4096) architecture with a sequence
     length 4,096.
 
-    The [`LongformerConfig`] class directly inherits [`RobertaConfig`]. It reuses the same defaults. Please check the
-    parent class for more information.
+    Configuration objects inherit from [`PretrainedConfig`] and can be used to control the model outputs. Read the
+    documentation from [`PretrainedConfig`] for more information.
 
     Args:
+        vocab_size (`int`, *optional*, defaults to 30522):
+            Vocabulary size of the BERT model. Defines the number of different tokens that can be represented by the
+            `inputs_ids` passed when calling [`BertModel`] or [`TFBertModel`].
+        hidden_size (`int`, *optional*, defaults to 768):
+            Dimensionality of the encoder layers and the pooler layer.
+        num_hidden_layers (`int`, *optional*, defaults to 12):
+            Number of hidden layers in the Transformer encoder.
+        num_attention_heads (`int`, *optional*, defaults to 12):
+            Number of attention heads for each attention layer in the Transformer encoder.
+        intermediate_size (`int`, *optional*, defaults to 3072):
+            Dimensionality of the "intermediate" (often named feed-forward) layer in the Transformer encoder.
+        hidden_act (`str` or `Callable`, *optional*, defaults to `"gelu"`):
+            The non-linear activation function (function or string) in the encoder and pooler. If string, `"gelu"`,
+            `"relu"`, `"silu"` and `"gelu_new"` are supported.
+        hidden_dropout_prob (`float`, *optional*, defaults to 0.1):
+            The dropout probability for all fully connected layers in the embeddings, encoder, and pooler.
+        attention_probs_dropout_prob (`float`, *optional*, defaults to 0.1):
+            The dropout ratio for the attention probabilities.
+        max_position_embeddings (`int`, *optional*, defaults to 512):
+            The maximum sequence length that this model might ever be used with. Typically set this to something large
+            just in case (e.g., 512 or 1024 or 2048).
+        type_vocab_size (`int`, *optional*, defaults to 2):
+            The vocabulary size of the `token_type_ids` passed when calling [`BertModel`] or [`TFBertModel`].
+        initializer_range (`float`, *optional*, defaults to 0.02):
+            The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
+        layer_norm_eps (`float`, *optional*, defaults to 1e-12):
+            The epsilon used by the layer normalization layers.
+        position_embedding_type (`str`, *optional*, defaults to `"absolute"`):
+            Type of position embedding. Choose one of `"absolute"`, `"relative_key"`, `"relative_key_query"`. For
+            positional embeddings use `"absolute"`. For more information on `"relative_key"`, please refer to
+            [Self-Attention with Relative Position Representations (Shaw et al.)](https://arxiv.org/abs/1803.02155).
+            For more information on `"relative_key_query"`, please refer to *Method 4* in [Improve Transformer Models
+            with Better Relative Position Embeddings (Huang et al.)](https://arxiv.org/abs/2009.13658).
+        use_cache (`bool`, *optional*, defaults to `True`):
+            Whether or not the model should return the last key/values attentions (not used by all models). Only
+            relevant if `config.is_decoder=True`.
+        classifier_dropout (`float`, *optional*):
+            The dropout ratio for the classification head.
         attention_window (`int` or `List[int]`, *optional*, defaults to 512):
             Size of an attention window around each token. If an `int`, use the same size for all layers. To specify a
             different window size for each layer, use a `List[int]` where `len(attention_window) == num_hidden_layers`.
@@ -80,10 +117,52 @@ class LongformerConfig(RobertaConfig):
     model_type = "longformer"
 
     def __init__(
-        self, attention_window: Union[List[int], int] = 512, sep_token_id: int = 2, onnx_export: bool = False, **kwargs
+            self,
+            attention_window: Union[List[int], int] = 512,  # Longformer Default
+            sep_token_id: int = 2,                          # Longformer Default
+            pad_token_id: int = 1,                          # Roberta Default
+            bos_token_id: int = 0,                          # Roberta Default
+            eos_token_id: int = 2,                          # Roberta Default
+            vocab_size: int = 30522,                        # Bert Default
+            hidden_size: int = 768,                         # Bert Default
+            num_hidden_layers: int = 12,                    # Bert Default
+            num_attention_heads: int = 12,                  # Bert Default
+            intermediate_size: int = 3072,                  # Bert Default
+            hidden_act: str = "gelu",                       # Bert Default
+            hidden_dropout_prob: float = 0.1,               # Bert Default
+            attention_probs_dropout_prob: float = 0.1,      # Bert Default
+            max_position_embeddings: int = 512,             # Bert Default
+            type_vocab_size: int = 2,                       # Bert Default
+            initializer_range: float = 0.02,                # Bert Default
+            layer_norm_eps: float = 1e-12,                  # Bert Default
+            position_embedding_type: str = "absolute",      # Bert Default
+            use_cache: bool = True,                         # Bert Default
+            classifier_dropout: float = None,               # Bert Default
+            onnx_export: bool = False,
+            **kwargs
     ):
-        super().__init__(sep_token_id=sep_token_id, **kwargs)
+        """Constructs LongformerConfig."""
+        super().__init__(pad_token_id=pad_token_id, **kwargs)
+
         self.attention_window = attention_window
+        self.sep_token_id = sep_token_id
+        self.bos_token_id = bos_token_id
+        self.eos_token_id = eos_token_id
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.hidden_act = hidden_act
+        self.intermediate_size = intermediate_size
+        self.hidden_dropout_prob = hidden_dropout_prob
+        self.attention_probs_dropout_prob = attention_probs_dropout_prob
+        self.max_position_embeddings = max_position_embeddings
+        self.type_vocab_size = type_vocab_size
+        self.initializer_range = initializer_range
+        self.layer_norm_eps = layer_norm_eps
+        self.position_embedding_type = position_embedding_type
+        self.use_cache = use_cache
+        self.classifier_dropout = classifier_dropout
         self.onnx_export = onnx_export
 
 

--- a/src/transformers/models/longformer/configuration_longformer.py
+++ b/src/transformers/models/longformer/configuration_longformer.py
@@ -59,8 +59,8 @@ class LongformerConfig(PretrainedConfig):
 
     Args:
         vocab_size (`int`, *optional*, defaults to 30522):
-            Vocabulary size of the Longformer model. Defines the number of different tokens that can be represented by the
-            `inputs_ids` passed when calling [`LongformerModel`] or [`TFLongformerModel`].
+            Vocabulary size of the Longformer model. Defines the number of different tokens that can be represented by
+            the `inputs_ids` passed when calling [`LongformerModel`] or [`TFLongformerModel`].
         hidden_size (`int`, *optional*, defaults to 768):
             Dimensionality of the encoder layers and the pooler layer.
         num_hidden_layers (`int`, *optional*, defaults to 12):
@@ -80,7 +80,8 @@ class LongformerConfig(PretrainedConfig):
             The maximum sequence length that this model might ever be used with. Typically set this to something large
             just in case (e.g., 512 or 1024 or 2048).
         type_vocab_size (`int`, *optional*, defaults to 2):
-            The vocabulary size of the `token_type_ids` passed when calling [`LongformerModel`] or [`TFLongformerModel`].
+            The vocabulary size of the `token_type_ids` passed when calling [`LongformerModel`] or
+            [`TFLongformerModel`].
         initializer_range (`float`, *optional*, defaults to 0.02):
             The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
         layer_norm_eps (`float`, *optional*, defaults to 1e-12):

--- a/src/transformers/models/longformer/configuration_longformer.py
+++ b/src/transformers/models/longformer/configuration_longformer.py
@@ -43,6 +43,8 @@ LONGFORMER_PRETRAINED_CONFIG_ARCHIVE_MAP = {
 }
 
 
+# Copied from transformers.models.bert.configuration_bert.BertConfig
+# Copied from transformers.models.roberta.configuration_roberta.RobertaConfig
 class LongformerConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`LongformerModel`] or a [`TFLongformerModel`]. It

--- a/src/transformers/models/longformer/configuration_longformer.py
+++ b/src/transformers/models/longformer/configuration_longformer.py
@@ -16,9 +16,9 @@
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Union
 
+from ...configuration_utils import PretrainedConfig
 from ...onnx import OnnxConfig
 from ...utils import TensorType, logging
-from ...configuration_utils import PretrainedConfig
 
 
 if TYPE_CHECKING:
@@ -43,8 +43,6 @@ LONGFORMER_PRETRAINED_CONFIG_ARCHIVE_MAP = {
 }
 
 
-# Copied from transformers.models.bert.configuration_bert.BertConfig
-# Copied from transformers.models.roberta.configuration_roberta.RobertaConfig
 class LongformerConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`LongformerModel`] or a [`TFLongformerModel`]. It
@@ -119,29 +117,29 @@ class LongformerConfig(PretrainedConfig):
     model_type = "longformer"
 
     def __init__(
-            self,
-            attention_window: Union[List[int], int] = 512,  # Longformer Default
-            sep_token_id: int = 2,                          # Longformer Default
-            pad_token_id: int = 1,                          # Roberta Default
-            bos_token_id: int = 0,                          # Roberta Default
-            eos_token_id: int = 2,                          # Roberta Default
-            vocab_size: int = 30522,                        # Bert Default
-            hidden_size: int = 768,                         # Bert Default
-            num_hidden_layers: int = 12,                    # Bert Default
-            num_attention_heads: int = 12,                  # Bert Default
-            intermediate_size: int = 3072,                  # Bert Default
-            hidden_act: str = "gelu",                       # Bert Default
-            hidden_dropout_prob: float = 0.1,               # Bert Default
-            attention_probs_dropout_prob: float = 0.1,      # Bert Default
-            max_position_embeddings: int = 512,             # Bert Default
-            type_vocab_size: int = 2,                       # Bert Default
-            initializer_range: float = 0.02,                # Bert Default
-            layer_norm_eps: float = 1e-12,                  # Bert Default
-            position_embedding_type: str = "absolute",      # Bert Default
-            use_cache: bool = True,                         # Bert Default
-            classifier_dropout: float = None,               # Bert Default
-            onnx_export: bool = False,
-            **kwargs
+        self,
+        attention_window: Union[List[int], int] = 512,  # Longformer Default
+        sep_token_id: int = 2,  # Longformer Default
+        pad_token_id: int = 1,  # Roberta Default
+        bos_token_id: int = 0,  # Roberta Default
+        eos_token_id: int = 2,  # Roberta Default
+        vocab_size: int = 30522,  # Bert Default
+        hidden_size: int = 768,  # Bert Default
+        num_hidden_layers: int = 12,  # Bert Default
+        num_attention_heads: int = 12,  # Bert Default
+        intermediate_size: int = 3072,  # Bert Default
+        hidden_act: str = "gelu",  # Bert Default
+        hidden_dropout_prob: float = 0.1,  # Bert Default
+        attention_probs_dropout_prob: float = 0.1,  # Bert Default
+        max_position_embeddings: int = 512,  # Bert Default
+        type_vocab_size: int = 2,  # Bert Default
+        initializer_range: float = 0.02,  # Bert Default
+        layer_norm_eps: float = 1e-12,  # Bert Default
+        position_embedding_type: str = "absolute",  # Bert Default
+        use_cache: bool = True,  # Bert Default
+        classifier_dropout: float = None,  # Bert Default
+        onnx_export: bool = False,
+        **kwargs
     ):
         """Constructs LongformerConfig."""
         super().__init__(pad_token_id=pad_token_id, **kwargs)

--- a/src/transformers/models/longformer/configuration_longformer.py
+++ b/src/transformers/models/longformer/configuration_longformer.py
@@ -59,8 +59,8 @@ class LongformerConfig(PretrainedConfig):
 
     Args:
         vocab_size (`int`, *optional*, defaults to 30522):
-            Vocabulary size of the BERT model. Defines the number of different tokens that can be represented by the
-            `inputs_ids` passed when calling [`BertModel`] or [`TFBertModel`].
+            Vocabulary size of the Longformer model. Defines the number of different tokens that can be represented by the
+            `inputs_ids` passed when calling [`LongformerModel`] or [`TFLongformerModel`].
         hidden_size (`int`, *optional*, defaults to 768):
             Dimensionality of the encoder layers and the pooler layer.
         num_hidden_layers (`int`, *optional*, defaults to 12):
@@ -80,7 +80,7 @@ class LongformerConfig(PretrainedConfig):
             The maximum sequence length that this model might ever be used with. Typically set this to something large
             just in case (e.g., 512 or 1024 or 2048).
         type_vocab_size (`int`, *optional*, defaults to 2):
-            The vocabulary size of the `token_type_ids` passed when calling [`BertModel`] or [`TFBertModel`].
+            The vocabulary size of the `token_type_ids` passed when calling [`LongformerModel`] or [`TFLongformerModel`].
         initializer_range (`float`, *optional*, defaults to 0.02):
             The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
         layer_norm_eps (`float`, *optional*, defaults to 1e-12):
@@ -118,26 +118,26 @@ class LongformerConfig(PretrainedConfig):
 
     def __init__(
         self,
-        attention_window: Union[List[int], int] = 512,  # Longformer Default
-        sep_token_id: int = 2,  # Longformer Default
-        pad_token_id: int = 1,  # Roberta Default
-        bos_token_id: int = 0,  # Roberta Default
-        eos_token_id: int = 2,  # Roberta Default
-        vocab_size: int = 30522,  # Bert Default
-        hidden_size: int = 768,  # Bert Default
-        num_hidden_layers: int = 12,  # Bert Default
-        num_attention_heads: int = 12,  # Bert Default
-        intermediate_size: int = 3072,  # Bert Default
-        hidden_act: str = "gelu",  # Bert Default
-        hidden_dropout_prob: float = 0.1,  # Bert Default
-        attention_probs_dropout_prob: float = 0.1,  # Bert Default
-        max_position_embeddings: int = 512,  # Bert Default
-        type_vocab_size: int = 2,  # Bert Default
-        initializer_range: float = 0.02,  # Bert Default
-        layer_norm_eps: float = 1e-12,  # Bert Default
-        position_embedding_type: str = "absolute",  # Bert Default
-        use_cache: bool = True,  # Bert Default
-        classifier_dropout: float = None,  # Bert Default
+        attention_window: Union[List[int], int] = 512,
+        sep_token_id: int = 2,
+        pad_token_id: int = 1,
+        bos_token_id: int = 0,
+        eos_token_id: int = 2,
+        vocab_size: int = 30522,
+        hidden_size: int = 768,
+        num_hidden_layers: int = 12,
+        num_attention_heads: int = 12,
+        intermediate_size: int = 3072,
+        hidden_act: str = "gelu",
+        hidden_dropout_prob: float = 0.1,
+        attention_probs_dropout_prob: float = 0.1,
+        max_position_embeddings: int = 512,
+        type_vocab_size: int = 2,
+        initializer_range: float = 0.02,
+        layer_norm_eps: float = 1e-12,
+        position_embedding_type: str = "absolute",
+        use_cache: bool = True,
+        classifier_dropout: float = None,
         onnx_export: bool = False,
         **kwargs
     ):


### PR DESCRIPTION
# What does this PR do?

@sgugger , 

Per the issue #19303, the Roberta and Bert config dependencies are removed from `LongformerConfig` and it now directly inherits from `PretrainedConfig`.  

- `LongformerConfig` depends on `RobertaConfig` and `RobertaConfig` in turn inherits from `BertConfig`. 
-  So I've copied over the defaults (`pad_token_id`, `bos_token_id`, `eos_token_id`) from RobertaConfig and the rest of the defaults from BertConfig that are not conflicting with roberta.  
- The docstrings from BertConfig are copied over as well. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
