### PR TITLE
Fix MaskFormer failing postprocess tests

### DIFF
--- a/src/transformers/models/maskformer/feature_extraction_maskformer.py
+++ b/src/transformers/models/maskformer/feature_extraction_maskformer.py
@@ -774,7 +774,7 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
             if mask_probs_item.shape[0] <= 0:
                 height, width = target_sizes[i] if target_sizes is not None else mask_probs_item.shape[1:]
                 segmentation = torch.zeros((height, width)) - 1
-                segments: List[Dict] = []
+                results.append({"segmentation": segmentation, "segments_info": []})
                 continue
 
             # Get segmentation map and segment information of batch item
@@ -863,7 +863,7 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
             if mask_probs_item.shape[0] <= 0:
                 height, width = target_sizes[i] if target_sizes is not None else mask_probs_item.shape[1:]
                 segmentation = torch.zeros((height, width)) - 1
-                segments: List[Dict] = []
+                results.append({"segmentation": segmentation, "segments_info": []})
                 continue
 
             # Get segmentation map and segment information of batch item

--- a/src/transformers/models/maskformer/feature_extraction_maskformer.py
+++ b/src/transformers/models/maskformer/feature_extraction_maskformer.py
@@ -772,8 +772,7 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
 
             # No mask found
             if mask_probs_item.shape[0] <= 0:
-                segmentation = torch.zeros(target_sizes[i])
-                segmentation -= 1
+                segmentation = torch.zeros(target_sizes[i]) - 1
                 segments: List[Dict] = []
                 continue
 
@@ -861,8 +860,7 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
 
             # No mask found
             if mask_probs_item.shape[0] <= 0:
-                segmentation = torch.zeros(target_sizes[i])
-                segmentation -= 1
+                segmentation = torch.zeros(target_sizes[i]) - 1
                 segments: List[Dict] = []
                 continue
 

--- a/src/transformers/models/maskformer/feature_extraction_maskformer.py
+++ b/src/transformers/models/maskformer/feature_extraction_maskformer.py
@@ -772,7 +772,8 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
 
             # No mask found
             if mask_probs_item.shape[0] <= 0:
-                segmentation = None
+                segmentation = torch.zeros(target_sizes[i])
+                segmentation -= 1
                 segments: List[Dict] = []
                 continue
 
@@ -860,7 +861,8 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
 
             # No mask found
             if mask_probs_item.shape[0] <= 0:
-                segmentation = None
+                segmentation = torch.zeros(target_sizes[i])
+                segmentation -= 1
                 segments: List[Dict] = []
                 continue
 

--- a/src/transformers/models/maskformer/feature_extraction_maskformer.py
+++ b/src/transformers/models/maskformer/feature_extraction_maskformer.py
@@ -772,7 +772,8 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
 
             # No mask found
             if mask_probs_item.shape[0] <= 0:
-                segmentation = torch.zeros(target_sizes[i]) - 1
+                height, width = target_sizes[i] if target_sizes is not None else mask_probs_item.shape[1:]
+                segmentation = torch.zeros((height, width)) - 1
                 segments: List[Dict] = []
                 continue
 
@@ -860,7 +861,8 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
 
             # No mask found
             if mask_probs_item.shape[0] <= 0:
-                segmentation = torch.zeros(target_sizes[i]) - 1
+                height, width = target_sizes[i] if target_sizes is not None else mask_probs_item.shape[1:]
+                segmentation = torch.zeros((height, width)) - 1
                 segments: List[Dict] = []
                 continue
 

--- a/tests/models/maskformer/test_feature_extraction_maskformer.py
+++ b/tests/models/maskformer/test_feature_extraction_maskformer.py
@@ -400,10 +400,11 @@ class MaskFormerFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest
         self.assertEqual(segmentation[0].shape, target_sizes[0])
 
     def test_post_process_panoptic_segmentation(self):
-        fature_extractor = self.feature_extraction_class(num_labels=self.feature_extract_tester.num_classes)
+        feature_extractor = self.feature_extraction_class(num_labels=self.feature_extract_tester.num_classes)
         outputs = self.feature_extract_tester.get_fake_maskformer_outputs()
-        segmentation = fature_extractor.post_process_panoptic_segmentation(outputs, threshold=0)
-
+        segmentation = feature_extractor.post_process_panoptic_segmentation(outputs, threshold=0)
+        print(len(segmentation))
+        print(self.feature_extract_tester.batch_size)
         self.assertTrue(len(segmentation) == self.feature_extract_tester.batch_size)
         for el in segmentation:
             self.assertTrue("segmentation" in el)


### PR DESCRIPTION
# What does this PR do?
Ensures post_process_instance_segmentation and post_process_panoptic_segmentation methods return a tensor of shape (target_height, target_width) filled with -1 values if no segment with score > threshold is found.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
