### PR TITLE
Stop relying on huggingface_hub's private methods

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -34,12 +34,11 @@ from huggingface_hub import (
     HfFolder,
     create_commit,
     create_repo,
+    get_hf_file_metadata,
     hf_hub_download,
     hf_hub_url,
     whoami,
-    get_hf_file_metadata,
 )
-from huggingface_hub.constants import HUGGINGFACE_HEADER_X_LINKED_ETAG, HUGGINGFACE_HEADER_X_REPO_COMMIT
 from huggingface_hub.file_download import REGEX_COMMIT_HASH, http_get
 from huggingface_hub.utils import (
     EntryNotFoundError,

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -37,6 +37,7 @@ from huggingface_hub import (
     hf_hub_download,
     hf_hub_url,
     whoami,
+    get_hf_file_metadata,
 )
 from huggingface_hub.constants import HUGGINGFACE_HEADER_X_LINKED_ETAG, HUGGINGFACE_HEADER_X_REPO_COMMIT
 from huggingface_hub.file_download import REGEX_COMMIT_HASH, http_get
@@ -982,26 +983,6 @@ def get_all_cached_files(cache_dir=None):
     return cached_files
 
 
-def get_hub_metadata(url, token=None):
-    """
-    Returns the commit hash and associated etag for a given url.
-    """
-    if token is None:
-        token = HfFolder.get_token()
-    headers = {"user-agent": http_user_agent()}
-    headers["authorization"] = f"Bearer {token}"
-
-    r = huggingface_hub.file_download._request_with_retry(
-        method="HEAD", url=url, headers=headers, allow_redirects=False
-    )
-    hf_raise_for_status(r)
-    commit_hash = r.headers.get(HUGGINGFACE_HEADER_X_REPO_COMMIT)
-    etag = r.headers.get(HUGGINGFACE_HEADER_X_LINKED_ETAG) or r.headers.get("ETag")
-    if etag is not None:
-        etag = huggingface_hub.file_download._normalize_etag(etag)
-    return etag, commit_hash
-
-
 def extract_info_from_url(url):
     """
     Extract repo_name, revision and filename from an url.
@@ -1069,11 +1050,11 @@ def move_cache(cache_dir=None, new_cache_dir=None, token=None):
         url = file_info.pop("url")
         if url not in hub_metadata:
             try:
-                hub_metadata[url] = get_hub_metadata(url, token=token)
+                hub_metadata[url] = get_hf_file_metadata(url, use_auth_token=token)
             except requests.HTTPError:
                 continue
 
-        etag, commit_hash = hub_metadata[url]
+        etag, commit_hash = hub_metadata[url].etag, hub_metadata[url].commit_hash
         if etag is None or commit_hash is None:
             continue
 


### PR DESCRIPTION
Updates the `move_cache` method to stop relying on `huggingface_hub`'s private methods.