### PR TITLE
remove RobertaConfig inheritance from MarkupLMConfig

### DIFF
--- a/src/transformers/models/markuplm/configuration_markuplm.py
+++ b/src/transformers/models/markuplm/configuration_markuplm.py
@@ -32,7 +32,7 @@ class MarkupLMConfig(PretrainedConfig):
     This is the configuration class to store the configuration of a [`MarkupLMModel`]. It is used to instantiate a
     MarkupLM model according to the specified arguments, defining the model architecture. Instantiating a configuration
     with the defaults will yield a similar configuration to that of the MarkupLM
-    [microsft/markuplm-base-uncased](https://huggingface.co/microsoft/markuplm-base-uncased) architecture.
+    [microsoft/markuplm-base-uncased](https://huggingface.co/microsoft/markuplm-base-uncased) architecture.
 
     Configuration objects inherit from [`BertConfig`] and can be used to control the model outputs. Read the
     documentation from [`BertConfig`] for more information.

--- a/src/transformers/models/markuplm/configuration_markuplm.py
+++ b/src/transformers/models/markuplm/configuration_markuplm.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 """ MarkupLM model configuration"""
 
-from transformers.models.roberta.configuration_roberta import RobertaConfig
 from transformers.utils import logging
+
+from ...configuration_utils import PretrainedConfig
 
 
 logger = logging.get_logger(__name__)
@@ -26,12 +27,12 @@ MARKUPLM_PRETRAINED_CONFIG_ARCHIVE_MAP = {
 }
 
 
-class MarkupLMConfig(RobertaConfig):
+class MarkupLMConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`MarkupLMModel`]. It is used to instantiate a
     MarkupLM model according to the specified arguments, defining the model architecture. Instantiating a configuration
     with the defaults will yield a similar configuration to that of the MarkupLM
-    [microsoft/markuplm-base-uncased](https://huggingface.co/microsoft/markuplm-base-uncased) architecture.
+    [microsft/markuplm-base-uncased](https://huggingface.co/microsoft/markuplm-base-uncased) architecture.
 
     Configuration objects inherit from [`BertConfig`] and can be used to control the model outputs. Read the
     documentation from [`BertConfig`] for more information.
@@ -116,6 +117,8 @@ class MarkupLMConfig(RobertaConfig):
         initializer_range=0.02,
         layer_norm_eps=1e-12,
         pad_token_id=0,
+        bos_token_id=0,
+        eos_token_id=2,
         gradient_checkpointing=False,
         max_xpath_tag_unit_embeddings=256,
         max_xpath_subs_unit_embeddings=1024,
@@ -123,25 +126,33 @@ class MarkupLMConfig(RobertaConfig):
         subs_pad_id=1001,
         xpath_unit_hidden_size=32,
         max_depth=50,
+        position_embedding_type="absolute",
+        use_cache=True,
+        classifier_dropout=None,
         **kwargs
     ):
         super().__init__(
-            vocab_size=vocab_size,
-            hidden_size=hidden_size,
-            num_hidden_layers=num_hidden_layers,
-            num_attention_heads=num_attention_heads,
-            intermediate_size=intermediate_size,
-            hidden_act=hidden_act,
-            hidden_dropout_prob=hidden_dropout_prob,
-            attention_probs_dropout_prob=attention_probs_dropout_prob,
-            max_position_embeddings=max_position_embeddings,
-            type_vocab_size=type_vocab_size,
-            initializer_range=initializer_range,
-            layer_norm_eps=layer_norm_eps,
             pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
             gradient_checkpointing=gradient_checkpointing,
             **kwargs,
         )
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.hidden_act = hidden_act
+        self.intermediate_size = intermediate_size
+        self.hidden_dropout_prob = hidden_dropout_prob
+        self.attention_probs_dropout_prob = attention_probs_dropout_prob
+        self.max_position_embeddings = max_position_embeddings
+        self.type_vocab_size = type_vocab_size
+        self.initializer_range = initializer_range
+        self.layer_norm_eps = layer_norm_eps
+        self.position_embedding_type = position_embedding_type
+        self.use_cache = use_cache
+        self.classifier_dropout = classifier_dropout
         # additional properties
         self.max_depth = max_depth
         self.max_xpath_tag_unit_embeddings = max_xpath_tag_unit_embeddings


### PR DESCRIPTION
# What does this PR do?
Related to #19303

Removes `RobertaConfig` and `BertConfig` dependency from `MarkupLMConfig`. Even though `RobertaConfig` inherits from `BertConfig`, I have changed `MarkupLMConfig` to directly inherit from `PretrainedConfig`.

Added the following arguments in `__init__`:

- `bos_token_id = 0`
- `eos_token_id = 2`
- `position_embedding_type="absolute"`
- `use_cache=True`
- `classifier_dropout=None`

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@sgugger 
