### PR TITLE
Wrap FlauBERT integration test forward passes with torch.no_grad()

### DIFF
--- a/tests/models/flaubert/test_modeling_flaubert.py
+++ b/tests/models/flaubert/test_modeling_flaubert.py
@@ -437,7 +437,8 @@ class FlaubertModelIntegrationTest(unittest.TestCase):
     def test_inference_no_head_absolute_embedding(self):
         model = FlaubertModel.from_pretrained("flaubert/flaubert_base_cased")
         input_ids = torch.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 1588, 2]])
-        output = model(input_ids)[0]
+        with torch.no_grad():
+            output = model(input_ids)[0]
         expected_shape = torch.Size((1, 11, 768))
         self.assertEqual(output.shape, expected_shape)
         expected_slice = torch.tensor(


### PR DESCRIPTION
# What does this PR do?
This PR wraps forward passes in FlauBERT integration tests with `torch.no_grad()`, as proposed in issue #14642. This avoids the computation of unnecessary gradients during inference.

## Before submitting
- [ ] This PR fixes a typo or improves the docs.
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?
@LysandreJik could you please take a look at it?
Thanks :)