### PR TITLE
Wrap FNet integration test forward passes with torch.no_grad()

### DIFF
--- a/tests/models/fnet/test_modeling_fnet.py
+++ b/tests/models/fnet/test_modeling_fnet.py
@@ -493,7 +493,8 @@ class FNetModelIntegrationTest(unittest.TestCase):
         model.to(torch_device)
 
         input_ids = torch.tensor([[0, 1, 2, 3, 4, 5]], device=torch_device)
-        output = model(input_ids)[0]
+        with torch.no_grad():
+            output = model(input_ids)[0]
 
         vocab_size = 32000
 
@@ -536,7 +537,8 @@ class FNetModelIntegrationTest(unittest.TestCase):
         model.to(torch_device)
 
         input_ids = torch.tensor([[0, 1, 2, 3, 4, 5]], device=torch_device)
-        output = model(input_ids)[0]
+        with torch.no_grad():
+            output = model(input_ids)[0]
 
         expected_shape = torch.Size((1, 2))
         self.assertEqual(output.shape, expected_shape)
@@ -551,7 +553,8 @@ class FNetModelIntegrationTest(unittest.TestCase):
         model.to(torch_device)
 
         input_ids = torch.tensor([[0, 1, 2, 3, 4, 5]], device=torch_device)
-        output = model(input_ids)[0]
+        with torch.no_grad():
+            output = model(input_ids)[0]
 
         expected_shape = torch.Size((1, 6, model.config.hidden_size))
         self.assertEqual(output.shape, expected_shape)


### PR DESCRIPTION
# What does this PR do?
As proposed in issue #14642, this PR wraps forward passes in FNet integration tests with torch.no_grad(). This way, no unnecessary gradients are computed during inference.


## Before submitting
- [ ] This PR fixes a typo or improves the docs.
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?
@LysandreJik could you please take a look at it?
Thanks :)