### PR TITLE
fix misspelled word in ensure_valid_input docstring 

### DIFF
--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -133,7 +133,7 @@ def check_onnxruntime_requirements(minimum_version: Version):
 
 def ensure_valid_input(model, tokens, input_names):
     """
-    Ensure input are presented in the correct order, without any Non
+    Ensure inputs are presented in the correct order, without any Non
 
     Args:
         model: The model used to forward the input data


### PR DESCRIPTION
This PR fixes misspelled docstring for `ensure_valid_input` function in `convert_graph_to_onnx.py`.
Fixes https://github.com/huggingface/transformers/issues/19362
