### PR TITLE
Wrap TAPAS integration test forward passes with torch.no_grad()

### DIFF
--- a/tests/models/tapas/test_modeling_tapas.py
+++ b/tests/models/tapas/test_modeling_tapas.py
@@ -570,7 +570,8 @@ class TapasModelIntegrationTest(unittest.TestCase):
         table, queries = prepare_tapas_single_inputs_for_inference()
         inputs = tokenizer(table=table, queries=queries, return_tensors="pt")
         inputs = {k: v.to(torch_device) for k, v in inputs.items()}
-        outputs = model(**inputs)
+        with torch.no_grad():
+            outputs = model(**inputs)
         # test the sequence output
         expected_slice = torch.tensor(
             [
@@ -608,7 +609,8 @@ class TapasModelIntegrationTest(unittest.TestCase):
         table, queries = prepare_tapas_single_inputs_for_inference()
         inputs = tokenizer(table=table, queries=queries, return_tensors="pt")
         inputs = {k: v.to(torch_device) for k, v in inputs.items()}
-        outputs = model(**inputs)
+        with torch.no_grad():
+            outputs = model(**inputs)
         # test the logits
         logits = outputs.logits
         expected_shape = torch.Size((1, 21))
@@ -657,7 +659,8 @@ class TapasModelIntegrationTest(unittest.TestCase):
         table, queries = prepare_tapas_single_inputs_for_inference()
         inputs = tokenizer(table=table, queries=queries, return_tensors="pt")
         inputs = {k: v.to(torch_device) for k, v in inputs.items()}
-        outputs = model(**inputs)
+        with torch.no_grad():
+            outputs = model(**inputs)
         # test the logits
         logits = outputs.logits
         expected_shape = torch.Size((1, 21))
@@ -705,7 +708,8 @@ class TapasModelIntegrationTest(unittest.TestCase):
         inputs = tokenizer(table=table, queries=queries, padding="longest", return_tensors="pt")
         inputs_on_device = {k: v.to(torch_device) for k, v in inputs.items()}
 
-        outputs = model(**inputs_on_device)
+        with torch.no_grad():
+            outputs = model(**inputs_on_device)
         # test the logits
         logits = outputs.logits
         expected_shape = torch.Size((2, 28))
@@ -774,15 +778,16 @@ class TapasModelIntegrationTest(unittest.TestCase):
         float_answer = torch.FloatTensor(float_answer).to(torch_device)
 
         # forward pass to get loss + logits:
-        outputs = model(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            token_type_ids=token_type_ids,
-            labels=labels,
-            numeric_values=numeric_values,
-            numeric_values_scale=numeric_values_scale,
-            float_answer=float_answer,
-        )
+        with torch.no_grad():
+            outputs = model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                token_type_ids=token_type_ids,
+                labels=labels,
+                numeric_values=numeric_values,
+                numeric_values_scale=numeric_values_scale,
+                float_answer=float_answer,
+            )
 
         # test the loss
         loss = outputs.loss
@@ -829,7 +834,8 @@ class TapasModelIntegrationTest(unittest.TestCase):
         table, queries = prepare_tapas_single_inputs_for_inference()
         inputs = tokenizer(table=table, queries=queries, return_tensors="pt")
         inputs = {k: v.to(torch_device) for k, v in inputs.items()}
-        outputs = model(**inputs)
+        with torch.no_grad():
+            outputs = model(**inputs)
         # test the logits
         logits = outputs.logits
         expected_shape = torch.Size((1, 21))
@@ -884,7 +890,8 @@ class TapasModelIntegrationTest(unittest.TestCase):
         table, queries = prepare_tapas_single_inputs_for_inference()
         inputs = tokenizer(table=table, queries=queries, padding="longest", return_tensors="pt")
         inputs = {k: v.to(torch_device) for k, v in inputs.items()}
-        outputs = model(**inputs)
+        with torch.no_grad():
+            outputs = model(**inputs)
 
         # test the classification logits
         logits = outputs.logits


### PR DESCRIPTION
# What does this PR do?
This PR wraps forward passes in TAPAS integration tests with `torch.no_grad()`, as proposed in issue #14642. This avoids the computation of unnecessary gradients during inference.

## Before submitting
- [ ] This PR fixes a typo or improves the docs.
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?
@LysandreJik could you please check it?
Thanks :)