### PR TITLE
Fix typo in image-classification/README.md

### DIFF
--- a/examples/pytorch/image-classification/README.md
+++ b/examples/pytorch/image-classification/README.md
@@ -23,8 +23,8 @@ This directory contains 2 scripts that showcase how to fine-tune any model suppo
 Try out the inference widget here: https://huggingface.co/google/vit-base-patch16-224
 
 Content:
-- [PyTorch version, Trainer](#pytorch-version-no-trainer)
-- [PyTorch version, no Trainer](#pytorch-version-trainer)
+- [PyTorch version, Trainer](#pytorch-version-trainer)
+- [PyTorch version, no Trainer](#pytorch-version-no-trainer)
 
 ## PyTorch version, Trainer
 


### PR DESCRIPTION
Fix link typo of the following content.
PyTorch version, Trainer
PyTorch version, no Trainer

# What does this PR do?
Fixes a typo

## Who can review?
@sgugger @NielsRogge 
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

