### PR TITLE
Fixed a non-working hyperlink in the README.md file

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -92,4 +92,4 @@ You can open any page of the documentation as a notebook in colab (there is a bu
 
 ## Community notebooks:
 
-More notebooks developed by the community are available [here](https:hf.co/docs/transformers/community#community-notebooks).
+More notebooks developed by the community are available [here](https://huggingface.co/docs/transformers/community?fbclid=IwAR212-24ICaByqEham5YbJ3AC0y4sqXejYICCf1FK2MSWjRLm05F0ho02Is).

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -92,4 +92,4 @@ You can open any page of the documentation as a notebook in colab (there is a bu
 
 ## Community notebooks:
 
-More notebooks developed by the community are available [here](https://huggingface.co/docs/transformers/community?fbclid=IwAR212-24ICaByqEham5YbJ3AC0y4sqXejYICCf1FK2MSWjRLm05F0ho02Is).
+More notebooks developed by the community are available [here](https://hf.co/docs/transformers/community#community-notebooks).


### PR DESCRIPTION
The hyperlink to the community notebooks was outdated.