### PR TITLE
TF: TFBart embedding initialization

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1019,9 +1019,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
     _keys_to_ignore_on_load_unexpected = None
     _requires_load_weight_prefix = False
 
-    # Used to standardize the multiple configuration variable names that may be used to set an initialization range.
-    _initializer_range_name = None
-
     @property
     def dummy_inputs(self) -> Dict[str, tf.Tensor]:
         """
@@ -1755,23 +1752,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         """
         return None
 
-    def _get_initialization_range(self) -> float:
-        """
-        Scans the configuration file for the weight initialization range, as different configuration classes use
-        different names for this parameter.
-
-        Return:
-            `float`: The initialization range to use for the weights of the model.
-        """
-        potential_initialization_variable_names = [
-            "initializer_range",  # most common
-            "initializer_factor",  # e.g. T5
-            "init_std",  # e.g BART
-        ]
-        for var_name in potential_initialization_variable_names:
-            if hasattr(self.config, var_name):
-                return getattr(self.config, var_name)
-
     def resize_token_embeddings(
         self, new_num_tokens: Optional[int] = None
     ) -> Union[tf.keras.layers.Embedding, tf.Variable]:
@@ -2079,11 +2059,23 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         Return:
             `tf.keras.layers.Embedding`: Resized Embedding layer.
         """
+
+        # Get the initialization range for the embeddings
+        init_range = 0.02  # default value
+        potential_initialization_variable_names = [
+            "initializer_range",  # most common
+            "initializer_factor",  # e.g. T5
+            "init_std",  # e.g BART
+        ]
+        for var_name in potential_initialization_variable_names:
+            if hasattr(self.config, var_name):
+                init_range = getattr(self.config, var_name)
+
         # Get a new (initialized) embeddings layer
         new_embeddings = tf.keras.layers.Embedding(
             input_dim=new_num_tokens,
             output_dim=old_embeddings.output_dim,
-            embeddings_initializer=get_initializer(self._get_initialization_range()),
+            embeddings_initializer=tf.keras.initializers.TruncatedNormal(stddev=init_range),
             name=old_embeddings.embeddings.name[:-13],  # exact same scoped name except "/embeddings:0"
         )
         new_embeddings(tf.constant([[0]]))

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -463,7 +463,6 @@ class TFBartDecoderLayer(tf.keras.layers.Layer):
 class TFBartPretrainedModel(TFPreTrainedModel):
     config_class = BartConfig
     base_model_prefix = "model"
-    _initializer_range_name = "init_std"
 
     @property
     def dummy_inputs(self):
@@ -1058,7 +1057,7 @@ class TFBartMainLayer(tf.keras.layers.Layer):
             input_dim=config.vocab_size,
             output_dim=config.d_model,
             embeddings_initializer=tf.keras.initializers.TruncatedNormal(stddev=self.config.init_std),
-            name="model.shared"
+            name="model.shared",
         )
         # Additional attribute to specify the expected name scope of the layer (for loading/storing weights)
         self.shared.load_weight_prefix = "model.shared" if load_weight_prefix is None else load_weight_prefix

--- a/src/transformers/models/bart/modeling_tf_bart.py
+++ b/src/transformers/models/bart/modeling_tf_bart.py
@@ -463,6 +463,7 @@ class TFBartDecoderLayer(tf.keras.layers.Layer):
 class TFBartPretrainedModel(TFPreTrainedModel):
     config_class = BartConfig
     base_model_prefix = "model"
+    _initializer_range_name = "init_std"
 
     @property
     def dummy_inputs(self):
@@ -1053,7 +1054,12 @@ class TFBartMainLayer(tf.keras.layers.Layer):
     def __init__(self, config: BartConfig, load_weight_prefix=None, **kwargs):
         super().__init__(**kwargs)
         self.config = config
-        self.shared = tf.keras.layers.Embedding(config.vocab_size, config.d_model, name="model.shared")
+        self.shared = tf.keras.layers.Embedding(
+            input_dim=config.vocab_size,
+            output_dim=config.d_model,
+            embeddings_initializer=tf.keras.initializers.TruncatedNormal(stddev=self.config.init_std),
+            name="model.shared"
+        )
         # Additional attribute to specify the expected name scope of the layer (for loading/storing weights)
         self.shared.load_weight_prefix = "model.shared" if load_weight_prefix is None else load_weight_prefix
 

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -711,46 +711,6 @@ class TFModelTesterMixin:
             if tf_inputs_dict_with_labels:
                 self.check_pt_tf_models(tf_model, pt_model, tf_inputs_dict_with_labels)
 
-    # @tooslow  # TODO (Joao): tagged so as to not run on CI. Remove when most test cases get fixed.
-    @is_pt_tf_cross_test
-    def test_pt_tf_weight_initialization(self):
-        import transformers
-
-        for model_class in self.all_model_classes:
-            config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-
-            pt_model_class_name = model_class.__name__[2:]  # Skip the "TF" at the beginning
-            pt_model_class = getattr(transformers, pt_model_class_name)
-
-            # The two models will be initialized with random weights. They will be different, but should be drawn from
-            # the same distribution.
-            tf_model = model_class(config)
-            tf_model(tf_model.dummy_inputs)
-            tf_weights_dict = {weight.name: weight.value() for weight in tf_model.weights}
-
-            # Load the random PT weights into a TF model for simpler comparison logic
-            pt_model = pt_model_class(config)
-            tf_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
-            tf_from_pt_model = transformers.load_pytorch_model_in_tf2_model(
-                tf_model, pt_model, tf_inputs=tf_inputs_dict
-            )
-            pt_weights_dict = {weight.name: weight.value() for weight in tf_from_pt_model.weights}
-
-            # Iterate over the two TF models and compare statistical properties of the weights
-            mismatched_initializations = []
-            for weight_name in tf_weights_dict:
-                tf_weight_norm = tf.norm(tf_weights_dict[weight_name])
-                pt_weight_norm = tf.norm(pt_weights_dict[weight_name])
-                norm_difference = tf.abs(tf_weight_norm - pt_weight_norm)
-                # large tolerance relative to the PT weights (which should be correctly set) to focus on large
-                # mismatches
-                norm_tolerance = pt_weight_norm * 2.0
-                if norm_difference > norm_tolerance:
-                    mismatched_initializations.append(weight_name)
-
-            breakpoint()
-            self.assertListEqual(mismatched_initializations, [])
-
     def test_compile_tf_model(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         max_input = getattr(self.model_tester, "max_position_embeddings", 512)


### PR DESCRIPTION
# What does this PR do?

### Context
We were initializing the embeddings as `TFSharedEmbeddings(config.vocab_size, config.d_model, config.pad_token_id, name="model.shared")`. Notice the 3rd argument, the pad token id, which is the 3rd argument in `nn.Embedding`. However, for `TFSharedEmbeddings`, [the 3rd argument is the initializer range](https://github.com/huggingface/transformers/blob/4c962d5e790d06c142af35aad165c74c0bcf861a/src/transformers/modeling_tf_utils.py#L2837). This means that some models, like TFMarian, were initializing the embeddings with very [large values](https://github.com/huggingface/transformers/blob/4c962d5e790d06c142af35aad165c74c0bcf861a/src/transformers/models/marian/configuration_marian.py#L135) (stddev=58100).

### Changes
This PR correctly sets the embedding initialization according to the configuration parameter related to weight initialization range. It includes proper weight initialization when the embeddings are resized.

This PR will be used as a reference for embedding weight initialization, regarding the embedding update that is happening in the codebase at the moment.

### Discussion for the future
PT sets the weights in a top-down fashion, with `_init_weights` conveniently fetching information from the `config` and then initializing the weights. On TF, weight initialization is defined in a bottom-up fashion. This means that if we want to replicate the PT initialization for all TF weights, we need to pass the `config` all the way down to the individual layers (= verbose and needs manual changes in many places for all models) 😅 Alternativelly, we can replicate the `_init_weights` logic in TF, and manually set the weights after initializing the model. IMO that would be much cleaner, despite not being the way Keras expects weights to be set.