### PR TITLE
 missing double slash in link

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -92,4 +92,4 @@ You can open any page of the documentation as a notebook in colab (there is a bu
 
 ## Community notebooks:
 
-More notebooks developed by the community are available [here](https:hf.co/docs/transformers/community#community-notebooks).
+More notebooks developed by the community are available [here](https://hf.co/docs/transformers/community#community-notebooks).


### PR DESCRIPTION
Correcting the missing double slash in the community's notebook link
