### PR TITLE
Update Marian config default vocabulary size

### DIFF
--- a/src/transformers/models/marian/configuration_marian.py
+++ b/src/transformers/models/marian/configuration_marian.py
@@ -110,7 +110,7 @@ class MarianConfig(PretrainedConfig):
 
     def __init__(
         self,
-        vocab_size=50265,
+        vocab_size=58101,
         decoder_vocab_size=None,
         max_position_embeddings=1024,
         encoder_layers=12,

--- a/src/transformers/models/marian/configuration_marian.py
+++ b/src/transformers/models/marian/configuration_marian.py
@@ -43,7 +43,7 @@ class MarianConfig(PretrainedConfig):
 
 
     Args:
-        vocab_size (`int`, *optional*, defaults to 50265):
+        vocab_size (`int`, *optional*, defaults to 58101):
             Vocabulary size of the Marian model. Defines the number of different tokens that can be represented by the
             `inputs_ids` passed when calling [`MarianModel`] or [`TFMarianModel`].
         d_model (`int`, *optional*, defaults to 1024):


### PR DESCRIPTION
# What does this PR do?

Fixes #19296 

Looking at existing Marian models, their vocabulary size is set to pad token id + 1 ([example](https://huggingface.co/Helsinki-NLP/opus-mt-de-en/blob/main/config.json#L59)). This PR modifies the default vocabulary size such that a) it doesn't throw exceptions (must be > pad token id) and b) preserves this property.

Alternatively, the default for `decoder_start_token_id` and `pad_token_id` can be reduced 🙃 