### PR TITLE
Update PT to TF CLI for audio models

### DIFF
--- a/src/transformers/commands/pt_to_tf.py
+++ b/src/transformers/commands/pt_to_tf.py
@@ -208,9 +208,9 @@ class PTtoTFCommand(BaseTransformersCLICommand):
             sample_images = load_dataset("cifar10", "plain_text", split="test")[:2]["img"]
             processor_inputs.update({"images": sample_images})
         if "input_features" in model_forward_signature:
-            processor_inputs.update({"raw_speech": _get_audio_input(), "padding": True})
+            processor_inputs.update({"audio": _get_audio_input(), "padding": "max_length"})
         if "input_values" in model_forward_signature:  # Wav2Vec2 audio input
-            processor_inputs.update({"raw_speech": _get_audio_input(), "padding": True})
+            processor_inputs.update({"audio": _get_audio_input(), "padding": True})
 
         model_config_class = type(pt_model.config)
         if model_config_class in PROCESSOR_MAPPING:

--- a/src/transformers/commands/pt_to_tf.py
+++ b/src/transformers/commands/pt_to_tf.py
@@ -194,24 +194,6 @@ class PTtoTFCommand(BaseTransformersCLICommand):
             raw_samples = [x["array"] for x in speech_samples]
             return raw_samples
 
-        model_forward_signature = set(inspect.signature(pt_model.forward).parameters.keys())
-        processor_inputs = {}
-        if "input_ids" in model_forward_signature:
-            processor_inputs.update(
-                {
-                    "text": ["Hi there!", "I am a batch with more than one row and different input lengths."],
-                    "padding": True,
-                    "truncation": True,
-                }
-            )
-        if "pixel_values" in model_forward_signature:
-            sample_images = load_dataset("cifar10", "plain_text", split="test")[:2]["img"]
-            processor_inputs.update({"images": sample_images})
-        if "input_features" in model_forward_signature:
-            processor_inputs.update({"audio": _get_audio_input(), "padding": "max_length"})
-        if "input_values" in model_forward_signature:  # Wav2Vec2 audio input
-            processor_inputs.update({"audio": _get_audio_input(), "padding": True})
-
         model_config_class = type(pt_model.config)
         if model_config_class in PROCESSOR_MAPPING:
             processor = AutoProcessor.from_pretrained(self._local_dir)
@@ -226,6 +208,30 @@ class PTtoTFCommand(BaseTransformersCLICommand):
         else:
             raise ValueError(f"Unknown data processing type (model config type: {model_config_class})")
 
+        model_forward_signature = set(inspect.signature(pt_model.forward).parameters.keys())
+        processor_inputs = {}
+        if "input_ids" in model_forward_signature:
+            processor_inputs.update(
+                {
+                    "text": ["Hi there!", "I am a batch with more than one row and different input lengths."],
+                    "padding": True,
+                    "truncation": True,
+                }
+            )
+        if "pixel_values" in model_forward_signature:
+            sample_images = load_dataset("cifar10", "plain_text", split="test")[:2]["img"]
+            processor_inputs.update({"images": sample_images})
+        if "input_features" in model_forward_signature:
+            feature_extractor_signature = inspect.signature(processor.feature_extractor).parameters
+            # Pad to the largest input length by default but take feature extractor default
+            # padding value if it exists e.g. "max_length" and is not False
+            if "padding" in feature_extractor_signature:
+                padding_strategy = feature_extractor_signature["padding"].default or True
+            else:
+                padding_strategy = True
+            processor_inputs.update({"audio": _get_audio_input(), "padding": padding_strategy})
+        if "input_values" in model_forward_signature:  # Wav2Vec2 audio input
+            processor_inputs.update({"audio": _get_audio_input(), "padding": True})
         pt_input = processor(**processor_inputs, return_tensors="pt")
         tf_input = processor(**processor_inputs, return_tensors="tf")
 

--- a/src/transformers/commands/pt_to_tf.py
+++ b/src/transformers/commands/pt_to_tf.py
@@ -224,9 +224,13 @@ class PTtoTFCommand(BaseTransformersCLICommand):
         if "input_features" in model_forward_signature:
             feature_extractor_signature = inspect.signature(processor.feature_extractor).parameters
             # Pad to the largest input length by default but take feature extractor default
-            # padding value if it exists e.g. "max_length" and is not False
+            # padding value if it exists e.g. "max_length" and is not False or None
             if "padding" in feature_extractor_signature:
-                padding_strategy = feature_extractor_signature["padding"].default or True
+                default_strategy = feature_extractor_signature["padding"].default
+                if default_strategy is not False and default_strategy is not None:
+                    padding_strategy = default_strategy
+                else:
+                    padding_strategy = True
             else:
                 padding_strategy = True
             processor_inputs.update({"audio": _get_audio_input(), "padding": padding_strategy})


### PR DESCRIPTION
# What does this PR do?

Fixes small issues which prevented converting checkpoints for the whisper model with the pt-to-tf CLI.  

* `"raw_speech"` -> `"audio"`: updates the name of the inputs fed to the processor. This reflects the deprecation of `raw_speech` in [the audio processors](https://github.com/huggingface/transformers/blob/331ea019d7053924ee4d9d4d30282a2c74c272a6/src/transformers/models/wav2vec2/processing_wav2vec2.py#L79)
* Takes the feature extractor's default padding strategy if it's not False. Otherwise sets it to True. This was needed as whisper models must be padded to the max sequence length (not to the max sequence in the batch). Whereas other speech models' feature extractors can run with `padding=True` but don't have max length set by default so will fail if `padding="max_length"` e.g. `"facebook/s2t-small-librispeech-asr"` 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
