### PR TITLE
Fix doctests for `DeiT` and `TFGroupViT`

### DIFF
--- a/docs/source/en/model_doc/markuplm.mdx
+++ b/docs/source/en/model_doc/markuplm.mdx
@@ -95,10 +95,10 @@ This is the simplest case, in which the processor will use the feature extractor
 ...  <title>Hello world</title>
 ...  </head>
 ...  <body>
-...
+
 ...  <h1>Welcome</h1>
 ...  <p>Here is my website.</p>
-...
+
 ...  </body>
 ...  </html>"""
 
@@ -165,10 +165,10 @@ processor will use the feature extractor to get all nodes and xpaths, and create
 ...  <title>Hello world</title>
 ...  </head>
 ...  <body>
-...
+
 ...  <h1>Welcome</h1>
 ...  <p>My name is Niels.</p>
-...
+
 ...  </body>
 ...  </html>"""
 

--- a/docs/source/en/model_doc/markuplm.mdx
+++ b/docs/source/en/model_doc/markuplm.mdx
@@ -95,10 +95,10 @@ This is the simplest case, in which the processor will use the feature extractor
 ...  <title>Hello world</title>
 ...  </head>
 ...  <body>
-
+...
 ...  <h1>Welcome</h1>
 ...  <p>Here is my website.</p>
-
+...
 ...  </body>
 ...  </html>"""
 
@@ -165,10 +165,10 @@ processor will use the feature extractor to get all nodes and xpaths, and create
 ...  <title>Hello world</title>
 ...  </head>
 ...  <body>
-
+...
 ...  <h1>Welcome</h1>
 ...  <p>My name is Niels.</p>
-
+...
 ...  </body>
 ...  </html>"""
 

--- a/src/transformers/models/deit/modeling_deit.py
+++ b/src/transformers/models/deit/modeling_deit.py
@@ -731,7 +731,7 @@ class DeiTForImageClassification(DeiTPreTrainedModel):
         >>> # model predicts one of the 1000 ImageNet classes
         >>> predicted_class_idx = logits.argmax(-1).item()
         >>> print("Predicted class:", model.config.id2label[predicted_class_idx])
-        Predicted class: maillot
+        Predicted class: magpie
         ```"""
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 

--- a/src/transformers/models/groupvit/modeling_tf_groupvit.py
+++ b/src/transformers/models/groupvit/modeling_tf_groupvit.py
@@ -1955,6 +1955,7 @@ class TFGroupViTModel(TFGroupViTPreTrainedModel):
         >>> from PIL import Image
         >>> import requests
         >>> from transformers import AutoProcessor, TFGroupViTModel
+        >>> import tensorflow as tf
 
         >>> model = TFGroupViTModel.from_pretrained("nvidia/groupvit-gcc-yfcc")
         >>> processor = AutoProcessor.from_pretrained("nvidia/groupvit-gcc-yfcc")
@@ -1968,7 +1969,7 @@ class TFGroupViTModel(TFGroupViTPreTrainedModel):
 
         >>> outputs = model(**inputs)
         >>> logits_per_image = outputs.logits_per_image  # this is the image-text similarity score
-        >>> probs = logits_per_image.softmax(dim=1)  # we can take the softmax to get the label probabilities
+        >>> probs = tf.math.softmax(logits_per_image, axis=1)  # we can take the softmax to get the label probabilities
         ```"""
 
         outputs = self.groupvit(


### PR DESCRIPTION
# What does this PR do?

For `DeiT`: The parameter initialization is changed for some models in #19341. This can affect some tests where a checkpoint without head is used (so randomly initialized head). cc @alaradirik 

For `TFGroupViT`: We loved PyTorch too much (or not enough?) and want to use it in TensorFlow --> It's still too early :-)