### PR TITLE
Add warning in `generate` & `device_map=auto` & half precision models

### DIFF
--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -1980,14 +1980,12 @@ class GenerationMixin:
             warnings.warn(
                 "You are calling .generate() with the `input_ids` being on a device type different"
                 f" than your model's device. `input_ids` is on {input_ids.device.type}, whereas the model"
-                f" is on {self.device.type}. You may experience unexpected behaviors."
+                f" is on {self.device.type}. You may experience unexpected behaviors or slower generation."
                 " Please make sure that you have put `input_ids` to the"
                 " correct GPU by calling for example input_ids = input_ids.to('cuda') before"
                 " running `.generate()`.",
                 UserWarning,
             )
-            # retrieve the first device for accelerate compatibility - self.device should return the first device
-            input_ids = input_ids.to(self.device)
 
         # init values
         logits_processor = logits_processor if logits_processor is not None else LogitsProcessorList()

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -1986,8 +1986,8 @@ class GenerationMixin:
                 " running `.generate()`.",
                 UserWarning,
             )
-            first_device = list(self.parameters())[0].device  # retrieve the first device for accelerate compatibility
-            input_ids = input_ids.to(first_device)
+            # retrieve the first device for accelerate compatibility - self.device should return the first device
+            input_ids = input_ids.to(self.device)
 
         # init values
         logits_processor = logits_processor if logits_processor is not None else LogitsProcessorList()

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -1976,6 +1976,18 @@ class GenerationMixin:
         >>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
         ['Today is a beautiful day, and a wonderful day.\n\nI was lucky enough to meet the']
         ```"""
+        if self.device.type != input_ids.device.type:
+            warnings.warn(
+                "You are calling .generate() with the `input_ids` being on a device type different"
+                f" than your model's device. `input_ids` is on {input_ids.device.type}, whereas the model"
+                f" is on {self.device.type}. You may experience unexpected behaviors."
+                " Please make sure that you have put `input_ids` to the"
+                " correct GPU by calling for example input_ids = input_ids.to('cuda') before"
+                " running `.generate()`.",
+                UserWarning,
+            )
+            first_device = list(self.parameters())[0].device # retrieve the first device for accelerate compatibility
+            input_ids = input_ids.to(first_device)
 
         # init values
         logits_processor = logits_processor if logits_processor is not None else LogitsProcessorList()
@@ -2038,6 +2050,7 @@ class GenerationMixin:
                 output_attentions=output_attentions,
                 output_hidden_states=output_hidden_states,
             )
+
 
             if synced_gpus and this_peer_finished:
                 continue  # don't waste resources running the code we don't need

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -1986,7 +1986,7 @@ class GenerationMixin:
                 " running `.generate()`.",
                 UserWarning,
             )
-            first_device = list(self.parameters())[0].device # retrieve the first device for accelerate compatibility
+            first_device = list(self.parameters())[0].device  # retrieve the first device for accelerate compatibility
             input_ids = input_ids.to(first_device)
 
         # init values
@@ -2050,7 +2050,6 @@ class GenerationMixin:
                 output_attentions=output_attentions,
                 output_hidden_states=output_hidden_states,
             )
-
 
             if synced_gpus and this_peer_finished:
                 continue  # don't waste resources running the code we don't need

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -1982,7 +1982,7 @@ class GenerationMixin:
                 f" than your model's device. `input_ids` is on {input_ids.device.type}, whereas the model"
                 f" is on {self.device.type}. You may experience unexpected behaviors or slower generation."
                 " Please make sure that you have put `input_ids` to the"
-                " correct GPU by calling for example input_ids = input_ids.to('cuda') before"
+                f" correct device by calling for example input_ids = input_ids.to({self.device.type}) before"
                 " running `.generate()`.",
                 UserWarning,
             )

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -1349,6 +1349,17 @@ class GenerationMixin:
                 "Diverse beam search cannot be used in sampling mode. Make sure that `do_sample` is set to `False`."
             )
 
+        if self.device.type != input_ids.device.type:
+            warnings.warn(
+                "You are calling .generate() with the `input_ids` being on a device type different"
+                f" than your model's device. `input_ids` is on {input_ids.device.type}, whereas the model"
+                f" is on {self.device.type}. You may experience unexpected behaviors or slower generation."
+                " Please make sure that you have put `input_ids` to the"
+                f" correct device by calling for example input_ids = input_ids.to('{self.device.type}') before"
+                " running `.generate()`.",
+                UserWarning,
+            )
+
         # 7. prepare distribution pre_processing samplers
         logits_processor = self._get_logits_processor(
             repetition_penalty=repetition_penalty,
@@ -1976,17 +1987,6 @@ class GenerationMixin:
         >>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
         ['Today is a beautiful day, and a wonderful day.\n\nI was lucky enough to meet the']
         ```"""
-        if self.device.type != input_ids.device.type:
-            warnings.warn(
-                "You are calling .generate() with the `input_ids` being on a device type different"
-                f" than your model's device. `input_ids` is on {input_ids.device.type}, whereas the model"
-                f" is on {self.device.type}. You may experience unexpected behaviors or slower generation."
-                " Please make sure that you have put `input_ids` to the"
-                f" correct device by calling for example input_ids = input_ids.to({self.device.type}) before"
-                " running `.generate()`.",
-                UserWarning,
-            )
-
         # init values
         logits_processor = logits_processor if logits_processor is not None else LogitsProcessorList()
         stopping_criteria = stopping_criteria if stopping_criteria is not None else StoppingCriteriaList()

--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -107,21 +107,6 @@ class MixedInt8Test(BaseMixedInt8Test):
 
         self.assertEqual(self.tokenizer.decode(output_sequences[0], skip_special_tokens=True), self.EXPECTED_OUTPUT)
 
-    def test_generate_sample(self):
-        r"""
-        Test that the generation works correctly with no expected behaviors when running generate using `do_sample=True`.
-
-        Related issues:
-            - https://github.com/huggingface/transformers/issues/19445
-            - https://github.com/TimDettmers/bitsandbytes/issues/42
-        """
-        encoded_input = self.tokenizer(self.input_text, return_tensors="pt")
-        _ = self.model_8bit.generate(input_ids=encoded_input["input_ids"], max_new_tokens=10, do_sample=True)
-        _ = self.model_8bit.generate(
-            input_ids=encoded_input["input_ids"], max_new_tokens=10, do_sample=True, top_p=0.7
-        )
-        _ = self.model_8bit.generate(input_ids=encoded_input["input_ids"], max_new_tokens=10, do_sample=True, top_k=5)
-
 
 class MixedInt8ModelClassesTest(BaseMixedInt8Test):
     def setUp(self):

--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -107,6 +107,21 @@ class MixedInt8Test(BaseMixedInt8Test):
 
         self.assertEqual(self.tokenizer.decode(output_sequences[0], skip_special_tokens=True), self.EXPECTED_OUTPUT)
 
+    def test_generate_sample(self):
+        r"""
+        Test that the generation works correctly with no expected behaviors when running generate using `do_sample=True`.
+
+        Related issues:
+            - https://github.com/huggingface/transformers/issues/19445
+            - https://github.com/TimDettmers/bitsandbytes/issues/42
+        """
+        encoded_input = self.tokenizer(self.input_text, return_tensors="pt")
+        _ = self.model_8bit.generate(input_ids=encoded_input["input_ids"], max_new_tokens=10, do_sample=True)
+        _ = self.model_8bit.generate(
+            input_ids=encoded_input["input_ids"], max_new_tokens=10, do_sample=True, top_p=0.7
+        )
+        _ = self.model_8bit.generate(input_ids=encoded_input["input_ids"], max_new_tokens=10, do_sample=True, top_k=5)
+
 
 class MixedInt8ModelClassesTest(BaseMixedInt8Test):
     def setUp(self):


### PR DESCRIPTION
# What does this PR do?

This PR fixes mainly 2 issues that are : 
- https://github.com/TimDettmers/bitsandbytes/issues/42 
- https://github.com/huggingface/transformers/issues/19445

This issue seems to be unrelated to `bitsandbytes` 8-bit models but slightly more tricky than that. When instantiating a model using `device_map=auto` (EDIT: regardless the `dtype`), the model returns the logits on the same device as the input. I think that this is expected since this is how `accelerate` builds its hooks for each module. So I don"t expect the fix to be done on `accelerate` but more on `transformers` side.

Therefore, if a user calls `generate` or just a simple forward function with a half-precision model that has been instantiated with `device_map=auto` and if the input is initially on the CPU, they may encounter unexpected behaviours such as `top-k-cpu not implemented for Half` since the sampling operations (`top_k`, `top_p`, etc) are done on the same device as the logits - that are in this specific case on CPU. 

This PR addresses this fix by forcing the logits to be on the same device as the **first** module of the model (in case the model is sharded across multiple devices, it makes sense to have the `input_ids` to be on the `device` of the first module). The PR also adds a warning message, suggesting the user to explicitly put the `input_ids` on the same device type as the model.

The PR also adds a slow `bnb` test to make sure this situation will not happen in the future!

# How to reproduce the issue? 

With this simple snippet you can reproduce the issue:
```
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer

MAX_NEW_TOKENS = 128
model_name = 'gpt2'

text = """
Q: On average Joe throws 25 punches per minute. A fight lasts 5 rounds of 3 minutes. 
How many punches did he throw?\n
A: Let’s think step by step.\n"""
tokenizer = AutoTokenizer.from_pretrained(model_name)
input_ids = tokenizer(text, return_tensors="pt").input_ids

model = AutoModelForCausalLM.from_pretrained(
  model_name,
  device_map='auto',
  torch_dtype=torch.float16
)
generated_ids = model.generate(input_ids, max_length=len(input_ids[0])+25, do_sample=True, top_p=0.7)
print(tokenizer.decode(generated_ids[0]))
```

Thanks!
cc @sgugger @ydshieh @Narsil 