### PR TITLE
Fix `FlaubertTokenizer.__init__`

### DIFF
--- a/src/transformers/models/flaubert/tokenization_flaubert.py
+++ b/src/transformers/models/flaubert/tokenization_flaubert.py
@@ -261,7 +261,8 @@ class FlaubertTokenizer(PreTrainedTokenizer):
             lang2id=lang2id,
             id2lang=id2lang,
             do_lowercase_and_remove_accent=do_lowercase_and_remove_accent,
-            do_lowercase=do_lowercase**kwargs,
+            do_lowercase=do_lowercase,
+            **kwargs,
         )
 
         try:


### PR DESCRIPTION
# What does this PR do?

There was a tiny error in #19330

```python
do_lowercase=do_lowercase**kwargs,
```