### PR TITLE
CLI: add import protection to datasets

### DIFF
--- a/src/transformers/commands/pt_to_tf.py
+++ b/src/transformers/commands/pt_to_tf.py
@@ -18,7 +18,6 @@ from argparse import ArgumentParser, Namespace
 from importlib import import_module
 
 import numpy as np
-from datasets import load_dataset
 from packaging import version
 
 import huggingface_hub
@@ -31,6 +30,7 @@ from .. import (
     AutoFeatureExtractor,
     AutoProcessor,
     AutoTokenizer,
+    is_datasets_available,
     is_tf_available,
     is_torch_available,
 )
@@ -45,6 +45,9 @@ if is_tf_available():
 
 if is_torch_available():
     import torch
+
+if is_datasets_available():
+    from datasets import load_dataset
 
 
 MAX_ERROR = 5e-5  # larger error tolerance than in our internal tests, to avoid flaky user-facing errors


### PR DESCRIPTION
# What does this PR do?

Add import protection to datasets -- I've seen two or three recent issues where the authors can't post their env due to `datasets` failing to import on `pt-to-tf` ([example](https://github.com/huggingface/transformers/issues/19445))