### PR TITLE
Fix `XGLMModelLanguageGenerationTest.test_batched_nan_fp16`

### DIFF
--- a/src/transformers/models/m2m_100/modeling_m2m_100.py
+++ b/src/transformers/models/m2m_100/modeling_m2m_100.py
@@ -152,7 +152,7 @@ class M2M100SinusoidalPositionalEmbedding(nn.Module):
         if padding_idx is not None:
             emb[padding_idx, :] = 0
 
-        return emb
+        return emb.to(torch.get_default_dtype())
 
     @torch.no_grad()
     def forward(

--- a/src/transformers/models/speech_to_text/modeling_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/modeling_speech_to_text.py
@@ -165,7 +165,7 @@ class Speech2TextSinusoidalPositionalEmbedding(nn.Module):
             emb = torch.cat([emb, torch.zeros(num_embeddings, 1)], dim=1)
         if padding_idx is not None:
             emb[padding_idx, :] = 0
-        return emb
+        return emb.to(torch.get_default_dtype())
 
     @torch.no_grad()
     def forward(self, input_ids: torch.Tensor, past_key_values_length: int = 0):

--- a/src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
+++ b/src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
@@ -111,7 +111,7 @@ class Speech2Text2SinusoidalPositionalEmbedding(nn.Module):
             emb = torch.cat([emb, torch.zeros(num_embeddings, 1)], dim=1)
         if padding_idx is not None:
             emb[padding_idx, :] = 0
-        return emb
+        return emb.to(torch.get_default_dtype())
 
     @torch.no_grad()
     def forward(self, input_ids: torch.Tensor, past_key_values_length: int = 0):

--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -126,7 +126,7 @@ class TrOCRSinusoidalPositionalEmbedding(nn.Module):
         if padding_idx is not None:
             emb[padding_idx, :] = 0
 
-        return emb
+        return emb.to(torch.get_default_dtype())
 
     @torch.no_grad()
     def forward(self, input_ids: torch.Tensor, past_key_values_length: int = 0):

--- a/src/transformers/models/xglm/modeling_xglm.py
+++ b/src/transformers/models/xglm/modeling_xglm.py
@@ -194,7 +194,7 @@ class XGLMSinusoidalPositionalEmbedding(nn.Module):
         if padding_idx is not None:
             emb[padding_idx, :] = 0
 
-        return emb
+        return emb.to(torch.get_default_dtype())
 
     @torch.no_grad()
     def forward(
@@ -709,8 +709,8 @@ class XGLMModel(XGLMPreTrainedModel):
             # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]
             encoder_attention_mask = _expand_mask(encoder_attention_mask, inputs_embeds.dtype, tgt_len=input_shape[-1])
 
-        # embed positions, cast from float32 to `inputs_embeds.dtype`
-        positions = self.embed_positions(input_ids, inputs_embeds, past_key_values_length).to(inputs_embeds.dtype)
+        # embed positions
+        positions = self.embed_positions(input_ids, inputs_embeds, past_key_values_length)
 
         hidden_states = inputs_embeds + positions
 

--- a/src/transformers/models/xglm/modeling_xglm.py
+++ b/src/transformers/models/xglm/modeling_xglm.py
@@ -709,8 +709,8 @@ class XGLMModel(XGLMPreTrainedModel):
             # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]
             encoder_attention_mask = _expand_mask(encoder_attention_mask, inputs_embeds.dtype, tgt_len=input_shape[-1])
 
-        # embed positions
-        positions = self.embed_positions(input_ids, inputs_embeds, past_key_values_length)
+        # embed positions, cast from float32 to `inputs_embeds.dtype`
+        positions = self.embed_positions(input_ids, inputs_embeds, past_key_values_length).to(inputs_embeds.dtype)
 
         hidden_states = inputs_embeds + positions
 


### PR DESCRIPTION
# What does this PR do?

#18057 added this test to test running with fp16.

However, `from_pretrained(model_name, torch_dtype=torch.float16` seems **not able to change the dtype** for weights registered below:
https://github.com/huggingface/transformers/blob/a7bc4221c0c09857b30ac467e7de86d3f5a7c482/src/transformers/models/xglm/modeling_xglm.py#L168-L176
and `hidden_states` becomes again `float32` (because `position` is) at
https://github.com/huggingface/transformers/blob/a7bc4221c0c09857b30ac467e7de86d3f5a7c482/src/transformers/models/xglm/modeling_xglm.py#L715
and finally failed at `hidden_states = self.self_attn_layer_norm(hidden_states)` with
```bash
RuntimeError: expected scalar type Float but found Half
```
