### PR TITLE
`python3` instead of `python` in Push CI setup job

### DIFF
--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -117,7 +117,7 @@ jobs:
         # TODO: add `git-python` in the docker images
         run: |
           pip install --upgrade git-python
-          python utils/tests_fetcher.py --diff_with_last_commit | tee test_preparation.txt
+          python3 utils/tests_fetcher.py --diff_with_last_commit | tee test_preparation.txt
 
       - name: Report fetched tests
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
# What does this PR do?

The `setup` job in push CI uses image `transformers-all-latest-gpu-push-ci`, which should use `python3` instead of `python`.
(I forgot this detail when working on #19054)

Currently, the setup job failed, and no test to run.