### PR TITLE
Fix grad loss computation

### DIFF
--- a/examples/flax/summarization/run_summarization_flax.py
+++ b/examples/flax/summarization/run_summarization_flax.py
@@ -796,29 +796,23 @@ def main():
             logits = state.apply_fn(**batch, params=params, dropout_rng=dropout_rng, train=True)[0]
             loss = loss_fn(logits, labels, batch["decoder_attention_mask"], label_smoothing_factor)
             return loss
-        
+
         weight = batch["decoder_attention_mask"].sum()
-        
+
         grad_fn = jax.value_and_grad(compute_loss)
         loss, grad = grad_fn(state.params)
-        
-        loss, grad = jax.tree_util.tree_map(
-            lambda x: x * weight, (loss, grad)
-        )
-        
+
+        loss, grad = jax.tree_util.tree_map(lambda x: x * weight, (loss, grad))
+
         total_weight = jax.lax.psum(weight, "batch")
         grad = jax.lax.psum(grad, "batch")
-        grad = jax.tree_util.tree_map(
-            lambda x: x / total_weight, grad
-        )
+        grad = jax.tree_util.tree_map(lambda x: x / total_weight, grad)
 
         new_state = state.apply_gradients(grads=grad, dropout_rng=new_dropout_rng)
-        
+
         metrics = {"loss": loss, "learning_rate": linear_decay_lr_schedule_fn(state.step) * weight}
         metrics = jax.lax.psum(metrics, axis_name="batch")
-        metrics = jax.tree_util.tree_map(
-            lambda x: x / total_weight, metrics
-        )
+        metrics = jax.tree_util.tree_map(lambda x: x / total_weight, metrics)
 
         return new_state, metrics
 
@@ -827,17 +821,15 @@ def main():
         labels = batch.pop("labels")
         logits = model(**batch, params=params, train=False)[0]
         loss = loss_fn(logits, labels, batch["decoder_attention_mask"], label_smoothing_factor)
-        
+
         weight = batch["decoder_attention_mask"].sum()
         total_weight = jax.lax.psum(weight, axis_name="batch")
 
         # summarize metrics
         metrics = {"loss": loss * weight}
         metrics = jax.lax.psum(metrics, axis_name="batch")
-        metrics = jax.tree_util.tree_map(
-            lambda x: x / total_weight, metrics
-        )
-        
+        metrics = jax.tree_util.tree_map(lambda x: x / total_weight, metrics)
+
         return metrics
 
     # Define generation function


### PR DESCRIPTION
In the flax summarization fine-tuning example, the loss is only computed where the decoder_attention_mask is 1. Different batches on different devices will have different decoder_attention_masks, and `jax.lax.pmean(loss, axis_name="batch")` doesn't take this into account, so it won't be equivalent to if the loss was computed on all batches put together on a single device. To fix this, this PR computes the number of tokens for which the loss was computed on each device, and multiply the per-device losses and gradients by these weights, then `lax.psum` the losses, gradients and weights before then dividing by the psummed weights.


- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@patil-suraj @sgugger 