### PR TITLE
Avoid Push CI failing to report due to many commits being merged

### DIFF
--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -528,6 +528,7 @@ jobs:
       - uses: actions/checkout@v2
         # To avoid failure when multiple commits are merged into `main` in a short period of time.
         # Checking out to an old commit beyond the fetch depth will get an error `fatal: reference is not a tree: ...
+        # (Only required for `workflow_run` event, where we get the latest HEAD on `main` instead of the event commit)
         with:
           fetch-depth: 20
 

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -526,6 +526,10 @@ jobs:
           echo "env.CI_SHA = ${{ env.CI_SHA }}"
 
       - uses: actions/checkout@v2
+        # To avoid failure when multiple commits are merged into `main` in a short period of time.
+        # Checking out to an old commit beyond the fetch depth will get an error `fatal: reference is not a tree: ...
+        with:
+          fetch-depth: 20
 
       - name: Update clone using environment variables
         run: |


### PR DESCRIPTION
# What does this PR do?

We have increasing commits merged recently, and when it happens in a very period of short time (4 merges in ~ 1min yesterday), we get an error when using `actions/checkout@v2` in the `workflow_run` event for **Push CI**

```bash
fatal: reference is not a tree: 5f5e264a12956bd7cce47dcb422b80ed68e4c24e
```

So this PR increases the fetch depth to 20, and hopefully we are safe with this number 😆 
```
fetch-depth: 20
```