### PR TITLE
Update Whisper docs clarifying inference support for long-form decoding

### DIFF
--- a/docs/source/en/model_doc/whisper.mdx
+++ b/docs/source/en/model_doc/whisper.mdx
@@ -25,6 +25,7 @@ Tips:
 
 - The model usually performs well without requiring any finetuning.
 - The architecture follows a classic encoder-decoder architecture, which means that it relies on the [`~generation_utils.GenerationMixin.generate`] function for inference.
+- Inference is currently only implemented for short-form i.e. audio is pre-segmented into <=30s segments. Long-form (including timestamps) will be implemented in a future release.
 - One can use [`WhisperProcessor`] to prepare audio for the model, and decode the predicted ID's back into text.
 
 This model was contributed by [Arthur Zucker](https://huggingface.co/ArthurZ). The Tensorflow version of this model was contributed by [amyeroberts](https://huggingface.co/amyeroberts).


### PR DESCRIPTION

@ArthurZucker @patrickvonplaten 
I have updated the [Whisper docs page](https://huggingface.co/docs/transformers/v4.23.1/en/model_doc/whisper#transformers.WhisperProcessor) to clarify that the current `decode()` implementation doesn't support long-form yet. Hope it'll save folks some time, vs digging in to find that out :) 
