### PR TITLE
Add a decorator for flaky tests

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -16,7 +16,6 @@ import collections
 import contextlib
 import functools
 import inspect
-import logging
 import os
 import re
 import shlex

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -88,8 +88,6 @@ from .utils import (
 )
 
 
-logger = transformers_logging.get_logger(__name__)
-
 SMALL_MODEL_IDENTIFIER = "julien-c/bert-xsmall-dummy"
 DUMMY_UNKNOWN_IDENTIFIER = "julien-c/dummy-unknown"
 DUMMY_DIFF_TOKENIZER_IDENTIFIER = "julien-c/dummy-diff-tokenizer"
@@ -1662,7 +1660,7 @@ def is_flaky(max_attempts: int = 5, wait_before_retry: Optional[float] = None):
                     return test_func_ref(*args, **kwargs)
 
                 except Exception as err:
-                    logger.error(f"Test failed with {err} at try {retry_count}/{max_attempts}.")
+                    print(f"Test failed with {err} at try {retry_count}/{max_attempts}.", file=sys.stderr)
                     if wait_before_retry is not None:
                         time.sleep(wait_before_retry)
                     retry_count += 1

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -16,6 +16,7 @@ import collections
 import contextlib
 import functools
 import inspect
+import logging
 import os
 import re
 import shlex
@@ -84,11 +85,10 @@ from .utils import (
     is_torchaudio_available,
     is_torchdynamo_available,
     is_vision_available,
-    logging,
 )
 
 
-logger = logging.get_logger(__name__)
+logger = transformers_logging.get_logger(__name__)
 
 SMALL_MODEL_IDENTIFIER = "julien-c/bert-xsmall-dummy"
 DUMMY_UNKNOWN_IDENTIFIER = "julien-c/dummy-unknown"

--- a/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
+++ b/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
@@ -20,7 +20,7 @@ import unittest
 
 from huggingface_hub import hf_hub_download
 from transformers import is_torch_available
-from transformers.testing_utils import require_torch, slow, torch_device
+from transformers.testing_utils import is_flaky, require_torch, slow, torch_device
 
 from ...test_configuration_common import ConfigTester
 from ...test_modeling_common import ModelTesterMixin, floats_tensor, ids_tensor
@@ -358,6 +358,10 @@ class TimeSeriesTransformerModelTest(ModelTesterMixin, unittest.TestCase):
             list(self_attentions[0].shape[-3:]),
             [self.model_tester.num_attention_heads, encoder_seq_length, encoder_seq_length],
         )
+
+    @is_flaky()
+    def test_retain_grad_hidden_states_attentions(self):
+        super().test_retain_grad_hidden_states_attentions()
 
 
 def prepare_batch(filename="train-batch.pt"):

--- a/tests/models/wav2vec2/test_modeling_flax_wav2vec2.py
+++ b/tests/models/wav2vec2/test_modeling_flax_wav2vec2.py
@@ -305,7 +305,7 @@ class FlaxWav2Vec2ModelTest(FlaxModelTesterMixin, unittest.TestCase):
             self.assertIsNotNone(outputs)
 
     @is_pt_flax_cross_test
-    @is_flaky
+    @is_flaky()
     def test_pt_flax_equivalence(self):
         super().test_pt_flax_equivalence()
 

--- a/tests/models/wav2vec2/test_modeling_flax_wav2vec2.py
+++ b/tests/models/wav2vec2/test_modeling_flax_wav2vec2.py
@@ -21,7 +21,9 @@ from datasets import load_dataset
 
 from transformers import Wav2Vec2Config, is_flax_available
 from transformers.testing_utils import (
+    is_flaky,
     is_librosa_available,
+    is_pt_flax_cross_test,
     is_pyctcdecode_available,
     require_flax,
     require_librosa,
@@ -301,6 +303,11 @@ class FlaxWav2Vec2ModelTest(FlaxModelTesterMixin, unittest.TestCase):
             model = model_class_name.from_pretrained("facebook/wav2vec2-large-960h-lv60-self", from_pt=True)
             outputs = model(np.ones((1, 1024), dtype="f4"))
             self.assertIsNotNone(outputs)
+
+    @is_pt_flax_cross_test
+    @is_flaky
+    def test_pt_flax_equivalence(self):
+        super().test_pt_flax_equivalence()
 
 
 @require_flax

--- a/tests/models/wav2vec2/test_modeling_flax_wav2vec2.py
+++ b/tests/models/wav2vec2/test_modeling_flax_wav2vec2.py
@@ -307,7 +307,7 @@ class FlaxWav2Vec2ModelTest(FlaxModelTesterMixin, unittest.TestCase):
     @is_pt_flax_cross_test
     @is_flaky()
     def test_equivalence_pt_to_flax(self):
-        super().ttest_equivalence_pt_to_flax()
+        super().test_equivalence_pt_to_flax()
 
 
 @require_flax

--- a/tests/models/wav2vec2/test_modeling_flax_wav2vec2.py
+++ b/tests/models/wav2vec2/test_modeling_flax_wav2vec2.py
@@ -306,8 +306,8 @@ class FlaxWav2Vec2ModelTest(FlaxModelTesterMixin, unittest.TestCase):
 
     @is_pt_flax_cross_test
     @is_flaky()
-    def test_pt_flax_equivalence(self):
-        super().test_pt_flax_equivalence()
+    def test_equivalence_pt_to_flax(self):
+        super().ttest_equivalence_pt_to_flax()
 
 
 @require_flax

--- a/tests/models/wav2vec2/test_modeling_tf_wav2vec2.py
+++ b/tests/models/wav2vec2/test_modeling_tf_wav2vec2.py
@@ -26,7 +26,7 @@ from datasets import load_dataset
 
 from huggingface_hub import snapshot_download
 from transformers import Wav2Vec2Config, is_tf_available
-from transformers.testing_utils import require_librosa, require_pyctcdecode, require_tf, slow
+from transformers.testing_utils import is_flaky, require_librosa, require_pyctcdecode, require_tf, slow
 from transformers.utils import is_librosa_available, is_pyctcdecode_available
 
 from ...test_configuration_common import ConfigTester
@@ -309,6 +309,7 @@ class TFWav2Vec2ModelTest(TFModelTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.check_ctc_loss(*config_and_inputs)
 
+    @is_flaky()
     def test_labels_out_of_vocab(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.check_labels_out_of_vocab(*config_and_inputs)


### PR DESCRIPTION
# What does this PR do?

This PR adds a new decorator to mark flaky tests, which will then automatically re-run them up to five times each time they fail (that param can be adapted). I've marked as flaky three tests I have seen recently fail for no reason as a demo.