### PR TITLE
Fix fairseq wav2vec2-xls-r pretrained weights conversion scripts

### DIFF
--- a/src/transformers/models/wav2vec2/convert_wav2vec2_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/wav2vec2/convert_wav2vec2_original_pytorch_checkpoint_to_pytorch.py
@@ -246,7 +246,7 @@ def convert_wav2vec2_checkpoint(
             [checkpoint_path], arg_overrides={"data": "/".join(dict_path.split("/")[:-1])}
         )
     else:
-        task_arg = argparse.Namespace(task='audio_pretraining')
+        task_arg = argparse.Namespace(task="audio_pretraining")
         task = fairseq.tasks.setup_task(task_arg)
 
         model, _, _ = fairseq.checkpoint_utils.load_model_ensemble_and_task([checkpoint_path], task=task)

--- a/src/transformers/models/wav2vec2/convert_wav2vec2_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/wav2vec2/convert_wav2vec2_original_pytorch_checkpoint_to_pytorch.py
@@ -246,7 +246,10 @@ def convert_wav2vec2_checkpoint(
             [checkpoint_path], arg_overrides={"data": "/".join(dict_path.split("/")[:-1])}
         )
     else:
-        model, _, _ = fairseq.checkpoint_utils.load_model_ensemble_and_task([checkpoint_path])
+        task_arg = argparse.Namespace(task='audio_pretraining')
+        task = fairseq.tasks.setup_task(task_arg)
+
+        model, _, _ = fairseq.checkpoint_utils.load_model_ensemble_and_task([checkpoint_path], task=task)
 
     model = model[0].eval()
 

--- a/src/transformers/models/wav2vec2_conformer/convert_wav2vec2_conformer_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/wav2vec2_conformer/convert_wav2vec2_conformer_original_pytorch_checkpoint_to_pytorch.py
@@ -283,7 +283,10 @@ def convert_wav2vec2_conformer_checkpoint(
             [checkpoint_path], arg_overrides={"data": "/".join(dict_path.split("/")[:-1])}
         )
     else:
-        model, _, _ = fairseq.checkpoint_utils.load_model_ensemble_and_task([checkpoint_path])
+        task_arg = argparse.Namespace(task='audio_pretraining')
+        task = fairseq.tasks.setup_task(task_arg)
+
+        model, _, _ = fairseq.checkpoint_utils.load_model_ensemble_and_task([checkpoint_path], task=task)
 
     model = model[0].eval()
 

--- a/src/transformers/models/wav2vec2_conformer/convert_wav2vec2_conformer_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/wav2vec2_conformer/convert_wav2vec2_conformer_original_pytorch_checkpoint_to_pytorch.py
@@ -283,7 +283,7 @@ def convert_wav2vec2_conformer_checkpoint(
             [checkpoint_path], arg_overrides={"data": "/".join(dict_path.split("/")[:-1])}
         )
     else:
-        task_arg = argparse.Namespace(task='audio_pretraining')
+        task_arg = argparse.Namespace(task="audio_pretraining")
         task = fairseq.tasks.setup_task(task_arg)
 
         model, _, _ = fairseq.checkpoint_utils.load_model_ensemble_and_task([checkpoint_path], task=task)


### PR DESCRIPTION
# What does this PR do?
Fixes:  #19319

This PR fixes some bug on wav2vec2 fairseq weights conversion scripts, that [wav2vec2-xls-r-kind](https://github.com/facebookresearch/fairseq/tree/main/examples/wav2vec/xlsr) weights files fail to be loaded on this line.

https://github.com/huggingface/transformers/blob/bc21aaca789f1a366c05e8b5e111632944886393/src/transformers/models/wav2vec2/convert_wav2vec2_original_pytorch_checkpoint_to_pytorch.py#L249

This can be resolved by specifying fairseq task as `audio_pretraining`, and loading fairseq weights with the task context.

This change follows the way of fairseq library, which loads pretrained model weights via passing `task` argument on cli. 
Conversion of other non-finetuned weights works without any side effects. (tested with [wav2vec2-base](https://dl.fbaipublicfiles.com/fairseq/wav2vec/wav2vec_small.pt), [wav2vec2-conformer](dl.fbaipublicfiles.com/fairseq/conformer/wav2vec2/librilight/LL_relpos_PT_no_FT)) 

Referenced model weights are in the following url: https://github.com/facebookresearch/fairseq/tree/main/examples/wav2vec

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sanchit-gandhi
@patrickvonplaten 
