### PR TITLE
Build Push CI images also in a daily basis

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -43,6 +43,17 @@ jobs:
             REF=main
           push: true
           tags: huggingface/transformers-all-latest-gpu${{ inputs.image_postfix }}
+      # Push CI images still need to be re-built daily
+      -
+        name: Build and push (for Push CI)
+        if: github.event_name == 'schedule'
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker/transformers-all-latest-gpu
+          build-args: |
+            REF=main
+          push: true
+          tags: huggingface/transformers-all-latest-gpu-push-ci
 
   latest-with-torch-nightly-docker:
     name: "Nightly PyTorch + Stable TensorFlow"
@@ -98,6 +109,18 @@ jobs:
             REF=main
           push: true
           tags: huggingface/transformers-pytorch-deepspeed-latest-gpu${{ inputs.image_postfix }}
+
+      # Push CI images still need to be re-built daily
+      -
+        name: Build and push (for Push CI) in a daily basis
+        if: github.event_name == 'schedule'
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker/transformers-pytorch-deepspeed-latest-gpu
+          build-args: |
+            REF=main
+          push: true
+          tags: huggingface/transformers-pytorch-deepspeed-latest-gpu-push-ci
 
   nightly-torch-deepspeed-docker:
     name: "Nightly PyTorch + DeepSpeed"

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -45,7 +45,7 @@ jobs:
           tags: huggingface/transformers-all-latest-gpu${{ inputs.image_postfix }}
       # Push CI images still need to be re-built daily
       -
-        name: Build and push (for Push CI)
+        name: Build and push (for Push CI) in a daily basis
         if: github.event_name == 'schedule'
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -46,7 +46,9 @@ jobs:
       # Push CI images still need to be re-built daily
       -
         name: Build and push (for Push CI) in a daily basis
-        if: github.event_name == 'schedule'
+        # This condition allows `schedule` events, or `push` events that trigger this workflow NOT via `workflow_call`.
+        # The later case is useful for manual image building for debugging purpose. Use another tag in this case!
+        if: inputs.image_postfix != '-push-ci'
         uses: docker/build-push-action@v2
         with:
           context: ./docker/transformers-all-latest-gpu
@@ -109,11 +111,12 @@ jobs:
             REF=main
           push: true
           tags: huggingface/transformers-pytorch-deepspeed-latest-gpu${{ inputs.image_postfix }}
-
       # Push CI images still need to be re-built daily
       -
         name: Build and push (for Push CI) in a daily basis
-        if: github.event_name == 'schedule'
+        # This condition allows `schedule` events, or `push` events that trigger this workflow NOT via `workflow_call`.
+        # The later case is useful for manual image building for debugging purpose. Use another tag in this case!
+        if: inputs.image_postfix != '-push-ci'
         uses: docker/build-push-action@v2
         with:
           context: ./docker/transformers-pytorch-deepspeed-latest-gpu


### PR DESCRIPTION
# What does this PR do?

PR #19170 separated the images for push CI and daily CI. However, it only build the push CI images (that with the postfix `-push-ci`) when changes in `setup.py` are detected.

**We should also re-build the push CI images in a daily basis**, as 3rd party libraries might have newer versions, like `datasets`, `tokenizers` etc.