### PR TITLE
Remove `MarkupLMForMaskedLM` from `MAPPING`

### DIFF
--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -253,7 +253,6 @@ MODEL_WITH_LM_HEAD_MAPPING_NAMES = OrderedDict(
         ("luke", "LukeForMaskedLM"),
         ("m2m_100", "M2M100ForConditionalGeneration"),
         ("marian", "MarianMTModel"),
-        ("markuplm", "MarkupLMForMaskedLM"),
         ("megatron-bert", "MegatronBertForCausalLM"),
         ("mobilebert", "MobileBertForMaskedLM"),
         ("mpnet", "MPNetForMaskedLM"),


### PR DESCRIPTION
# What does this PR do?

There is no `MarkupLMForMaskedLM`.

BTW, could we check if the arguments passed to the recursive call are identical to the inputs: if so, don't call recursively.
https://github.com/huggingface/transformers/blob/4edb3e49f6bd3d1a4f6862452ecaf07108d62ff7/src/transformers/models/auto/auto_factory.py#L548-L558

I  can work on that if you are OK, @sgugger .

I freak out when I see
```bash
RecursionError: maximum recursion depth exceeded while calling a Python object
```