### PR TITLE
Throw an error if `getattribute_from_module` can't find anything

### DIFF
--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -560,7 +560,7 @@ def getattribute_from_module(module, attr):
         try:
             return getattribute_from_module(transformers_module, attr)
         except ValueError:
-            raise ValueError(f"Could not find {attr} neither {module} in nor in {transformers_module}!")
+            raise ValueError(f"Could not find {attr} neither in {module} nor in {transformers_module}!")
     else:
         raise ValueError(f"Could not find {attr} in {transformers_module}!")
 

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -556,10 +556,13 @@ def getattribute_from_module(module, attr):
     # object at the top level.
     transformers_module = importlib.import_module("transformers")
 
-    if transformers_module == module:
-        raise ValueError(f"Could not find {attr} in neither {module} nor {transformers_module}!")
-
-    return getattribute_from_module(transformers_module, attr)
+    if module != transformers_module:
+        try:
+            return getattribute_from_module(transformers_module, attr)
+        except ValueError:
+            raise ValueError(f"Could not find {attr} neither {module} in nor in {transformers_module}!")
+    else:
+        raise ValueError(f"Could not find {attr} in {transformers_module}!")
 
 
 class _LazyAutoMapping(OrderedDict):

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -557,7 +557,7 @@ def getattribute_from_module(module, attr):
     transformers_module = importlib.import_module("transformers")
 
     if transformers_module == module:
-        return None
+        raise ValueError(f"Could not find {attr} in neither {module} nor {transformers_module}!")
 
     return getattribute_from_module(transformers_module, attr)
 

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -555,6 +555,10 @@ def getattribute_from_module(module, attr):
     # Some of the mappings have entries model_type -> object of another model type. In that case we try to grab the
     # object at the top level.
     transformers_module = importlib.import_module("transformers")
+
+    if transformers_module == module:
+        return None
+
     return getattribute_from_module(transformers_module, attr)
 
 

--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -17,7 +17,10 @@ import copy
 import sys
 import tempfile
 import unittest
+from collections import OrderedDict
 from pathlib import Path
+
+import pytest
 
 from transformers import BertConfig, is_torch_available
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING
@@ -372,3 +375,14 @@ class AutoModelTest(unittest.TestCase):
             self.assertEqual(counter.get_request_count, 0)
             self.assertEqual(counter.head_request_count, 1)
             self.assertEqual(counter.other_request_count, 0)
+
+    def test_attr_not_existing(self):
+
+        from transformers.models.auto.auto_factory import _LazyAutoMapping
+
+        _CONFIG_MAPPING_NAMES = OrderedDict([("bert", "BertConfig")])
+        _MODEL_MAPPING_NAMES = OrderedDict([("bert", "GhostModel")])
+        _MODEL_MAPPING = _LazyAutoMapping(_CONFIG_MAPPING_NAMES, _MODEL_MAPPING_NAMES)
+
+        with pytest.raises(ValueError, match=r"Could not find GhostModel neither in .* nor in .*!"):
+            _MODEL_MAPPING[BertConfig]

--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import pytest
 
-from transformers import BertConfig, BertModel, GPT2Model, is_torch_available
+from transformers import BertConfig, GPT2Model, is_torch_available
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 from transformers.testing_utils import (
     DUMMY_UNKNOWN_IDENTIFIER,

--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import pytest
 
-from transformers import BertConfig, is_torch_available
+from transformers import BertConfig, BertModel, GPT2Model, is_torch_available
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 from transformers.testing_utils import (
     DUMMY_UNKNOWN_IDENTIFIER,
@@ -386,3 +386,11 @@ class AutoModelTest(unittest.TestCase):
 
         with pytest.raises(ValueError, match=r"Could not find GhostModel neither in .* nor in .*!"):
             _MODEL_MAPPING[BertConfig]
+
+        _MODEL_MAPPING_NAMES = OrderedDict([("bert", "BertModel")])
+        _MODEL_MAPPING = _LazyAutoMapping(_CONFIG_MAPPING_NAMES, _MODEL_MAPPING_NAMES)
+        self.assertEqual(_MODEL_MAPPING[BertConfig], BertModel)
+
+        _MODEL_MAPPING_NAMES = OrderedDict([("bert", "GPT2Model")])
+        _MODEL_MAPPING = _LazyAutoMapping(_CONFIG_MAPPING_NAMES, _MODEL_MAPPING_NAMES)
+        self.assertEqual(_MODEL_MAPPING[BertConfig], GPT2Model)


### PR DESCRIPTION
# What does this PR do?

Throw an error if `getattribute_from_module` can't find anything - to avoid `RecursionError: maximum recursion depth exceeded while calling a Python object`.


**New error:**

```bash
ValueError: Could not find MarkupLMForMaskedLM neither <module 'transformers.models.markuplm' from '/home/yih_dar_huggingface_co/transformers-ydshieh/src/transformers/models/markuplm/__init__.py'> in nor in <module 'transformers' from 'src/transformers/__init__.py'>!
```