### PR TITLE
[Doctest] Add `configuration_yolos.py`

### DIFF
--- a/src/transformers/models/yolos/configuration_yolos.py
+++ b/src/transformers/models/yolos/configuration_yolos.py
@@ -102,7 +102,6 @@ class YolosConfig(PretrainedConfig):
 
     >>> # Accessing the model configuration
     >>> configuration = model.config
-
     ```"""
     model_type = "yolos"
 

--- a/src/transformers/models/yolos/configuration_yolos.py
+++ b/src/transformers/models/yolos/configuration_yolos.py
@@ -92,16 +92,17 @@ class YolosConfig(PretrainedConfig):
     Example:
 
     ```python
-    >>> from transformers import YolosModel, YolosConfig
+    >>> from transformers import YolosConfig, YolosModel
 
     >>> # Initializing a YOLOS hustvl/yolos-base style configuration
     >>> configuration = YolosConfig()
 
-    >>> # Initializing a model from the hustvl/yolos-base style configuration
+    >>> # Initializing a model (with random weights) from the hustvl/yolos-base style configuration
     >>> model = YolosModel(configuration)
 
     >>> # Accessing the model configuration
     >>> configuration = model.config
+
     ```"""
     model_type = "yolos"
 

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -101,5 +101,6 @@ src/transformers/models/wav2vec2_with_lm/processing_wav2vec2_with_lm.py
 src/transformers/models/wavlm/modeling_wavlm.py
 src/transformers/models/whisper/modeling_whisper.py
 src/transformers/models/whisper/modeling_tf_whisper.py
+src/transformers/models/yolos/configuration_yolos.py
 src/transformers/models/yolos/modeling_yolos.py
 src/transformers/models/x_clip/modeling_x_clip.py


### PR DESCRIPTION
Add `configuration_yolos.py` to `utils/documentation_tests.txt` for doctest.

Based on issue #19487

@sgugger could you please take a look at it?
Thanks =)