### PR TITLE
[Doctest] - Fixing doctest bert_generation configuration

### DIFF
--- a/src/transformers/models/bert_generation/configuration_bert_generation.py
+++ b/src/transformers/models/bert_generation/configuration_bert_generation.py
@@ -72,7 +72,7 @@ class BertGenerationConfig(PretrainedConfig):
     >>> # Initializing a BertGeneration config
     >>> configuration = BertGenerationConfig()
 
-    >>> # Initializing a model from the config
+    >>> # Initializing a model (with random weights) from the config
     >>> model = BertGenerationEncoder(configuration)
 
     >>> # Accessing the model configuration

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -22,6 +22,7 @@ src/transformers/models/beit/modeling_beit.py
 src/transformers/models/bert/configuration_bert.py
 src/transformers/models/bert/modeling_bert.py
 src/transformers/models/bert/modeling_tf_bert.py
+src/transformers/models/bert_generation/configuration_bert_generation.py
 src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
 src/transformers/models/big_bird/modeling_big_bird.py
 src/transformers/models/blenderbot/modeling_blenderbot.py


### PR DESCRIPTION
# What does this PR do?
Fixing doctest in bert_generation configuration. Issue : #19487

## Fixes # (issue)
Added (`with random weights)` in `modeling_ber_generation.py`.
Added `modeling_ber_generation.py` in `documentation_tests.txt`

## Who can review?
@ydshieh @sgugger 


