### PR TITLE
[Doctest] Add `configuration_reformer.py`

### DIFF
--- a/src/transformers/models/reformer/configuration_reformer.py
+++ b/src/transformers/models/reformer/configuration_reformer.py
@@ -146,12 +146,12 @@ class ReformerConfig(PretrainedConfig):
     Examples:
 
     ```python
-    >>> from transformers import ReformerModel, ReformerConfig
+    >>> from transformers import ReformerConfig, ReformerModel
 
     >>> # Initializing a Reformer configuration
     >>> configuration = ReformerConfig()
 
-    >>> # Initializing a Reformer model
+    >>> # Initializing a Reformer model (with random weights)
     >>> model = ReformerModel(configuration)
 
     >>> # Accessing the model configuration

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -71,6 +71,7 @@ src/transformers/models/pegasus/modeling_pegasus.py
 src/transformers/models/perceiver/modeling_perceiver.py
 src/transformers/models/plbart/modeling_plbart.py
 src/transformers/models/poolformer/modeling_poolformer.py
+src/transformers/models/reformer/configuration_reformer.py
 src/transformers/models/reformer/modeling_reformer.py
 src/transformers/models/regnet/modeling_regnet.py
 src/transformers/models/regnet/modeling_tf_regnet.py


### PR DESCRIPTION
Add `configuration_reformer.py` to `utils/documentation_tests.txt` for doctest.

Based on issue #19487

@ydshieh could you check it?
Thanks :)