### PR TITLE
Fix `ImageToTextPipelineTests.test_small_model_tf`

### DIFF
--- a/tests/pipelines/test_pipelines_image_to_text.py
+++ b/tests/pipelines/test_pipelines_image_to_text.py
@@ -64,12 +64,7 @@ class ImageToTextPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta
             outputs,
             [
                 {
-                    "generated_text": (
-                        " intermedi intermedi intermedi intermedi intermedi "
-                        "explorer explorer explorer explorer explorer explorer "
-                        "explorer medicine medicine medicine medicine medicine "
-                        "medicine medicine"
-                    )
+                    "generated_text": "growthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthGOGO"
                 },
             ],
         )
@@ -80,23 +75,13 @@ class ImageToTextPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta
             [
                 [
                     {
-                        "generated_text": (
-                            " intermedi intermedi intermedi intermedi intermedi "
-                            "explorer explorer explorer explorer explorer explorer "
-                            "explorer medicine medicine medicine medicine medicine "
-                            "medicine medicine"
-                        )
-                    },
+                        "generated_text": "growthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthGOGO"
+                    }
                 ],
                 [
                     {
-                        "generated_text": (
-                            " intermedi intermedi intermedi intermedi intermedi "
-                            "explorer explorer explorer explorer explorer explorer "
-                            "explorer medicine medicine medicine medicine medicine "
-                            "medicine medicine"
-                        )
-                    },
+                        "generated_text": "growthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthGOGO"
+                    }
                 ],
             ],
         )


### PR DESCRIPTION
# What does this PR do?

`ImageToTextPipelineTests::test_[small/large]_model_[pt/tf]` were all skipped before. I believe it was enabled after #19366 (or its child commit - BTW, thank you @sgugger !).

We have to update the wrong expected values.