### PR TITLE
Improve error messaging for ASR pipeline.

### DIFF
--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -187,10 +187,6 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
         preprocess_params = {}
         if "chunk_length_s" in kwargs:
             preprocess_params["chunk_length_s"] = kwargs["chunk_length_s"]
-            if self.type not in {"ctc", "ctc_with_lm"}:
-                raise ValueError(
-                    "`chunk_length_s` is only valid for CTC models, use other chunking options for other models"
-                )
         if "stride_length_s" in kwargs:
             preprocess_params["stride_length_s"] = kwargs["stride_length_s"]
 
@@ -199,11 +195,6 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             postprocess_params["decoder_kwargs"] = kwargs["decoder_kwargs"]
         if "return_timestamps" in kwargs:
             postprocess_params["return_timestamps"] = kwargs["return_timestamps"]
-
-            if self.type == "seq2seq":
-                raise ValueError("We cannot return_timestamps yet on non-ctc models !")
-            if postprocess_params["return_timestamps"] == "char" and self.type == "ctc_with_lm":
-                raise ValueError("CTC with LM cannot return `char` timestamps, only `words`")
 
         return preprocess_params, {}, postprocess_params
 
@@ -259,7 +250,10 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             raise ValueError("We expect a single channel audio input for AutomaticSpeechRecognitionPipeline")
 
         if chunk_length_s:
-
+            if self.type not in {"ctc", "ctc_with_lm"}:
+                raise ValueError(
+                    "`chunk_length_s` is only valid for CTC models, use other chunking options for other models"
+                )
             if stride_length_s is None:
                 stride_length_s = chunk_length_s / 6
 
@@ -350,6 +344,11 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
     def postprocess(self, model_outputs, decoder_kwargs: Optional[Dict] = None, return_timestamps=None):
         # Optional return types
         optional = {}
+
+        if return_timestamps and self.type == "seq2seq":
+            raise ValueError("We cannot return_timestamps yet on non-ctc models !")
+        if return_timestamps == "char" and self.type == "ctc_with_lm":
+            raise ValueError("CTC with LM cannot return `char` timestamps, only `words`")
 
         final_items = []
         key = "logits" if self.type == "ctc_with_lm" else "tokens"

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -118,9 +118,18 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase, metaclass=Pipel
                 },
             )
         else:
+            import ipdb
+
+            ipdb.set_trace()
+            # Non CTC models cannot use chunk_length
+            with self.assertRaises(ValueError) as v:
+                outputs = speech_recognizer(audio, chunk_length_s=10)
+            self.assertEqual(v.exception, "")
+
             # Non CTC models cannot use return_timestamps
-            with self.assertRaises(ValueError):
+            with self.assertRaises(ValueError) as v:
                 outputs = speech_recognizer(audio, return_timestamps="char")
+            self.assertEqual(v.exception, "")
 
     @require_torch
     @slow
@@ -138,6 +147,17 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase, metaclass=Pipel
         waveform = np.tile(np.arange(1000, dtype=np.float32), 34)
         output = speech_recognizer(waveform)
         self.assertEqual(output, {"text": "(Applaudissements)"})
+        with self.assertRaises(ValueError) as v:
+            _ = speech_recognizer(waveform, chunk_length_s=10)
+        self.assertEqual(
+            str(v.exception),
+            "`chunk_length_s` is only valid for CTC models, use other chunking options for other models",
+        )
+
+        # Non CTC models cannot use return_timestamps
+        with self.assertRaises(ValueError) as v:
+            _ = speech_recognizer(waveform, return_timestamps="char")
+        self.assertEqual(str(v.exception), "We cannot return_timestamps yet on non-ctc models !")
 
     @require_torch
     def test_small_model_pt_seq2seq(self):

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -118,9 +118,6 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase, metaclass=Pipel
                 },
             )
         else:
-            import ipdb
-
-            ipdb.set_trace()
             # Non CTC models cannot use chunk_length
             with self.assertRaises(ValueError) as v:
                 outputs = speech_recognizer(audio, chunk_length_s=10)


### PR DESCRIPTION
# What does this PR do?

- ~~Raise error early (in `_sanitize`) so users don't waste time trying to
  run queries with invalid params.~~ This is not easy unfortunately because the order of resolution of objection is tricky.

- Fix the error was after using `config.inputs_to_logits_ratio` so our
  check was masked by the failing property does not exist.

- Added some manual check on s2t for the error message.
  No non ctc model seems to be used by the default runner (they are all
  skipped).



<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sgugger  @ArthurZucker 
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->