### PR TITLE
Re enable Nightly CI for upcoming PyTorch 1.13

### DIFF
--- a/.github/workflows/self-nightly-scheduled.yml
+++ b/.github/workflows/self-nightly-scheduled.yml
@@ -9,8 +9,9 @@ name: Self-hosted runner (nightly)
 on:
   repository_dispatch:
 # Disable temporarily until the test suite can be run under 12 hours.
-#  schedule:
-#    - cron: "0 16 * * *"
+# Re-enable to run on Past CI runners (because ONNX tests take too long) for upcoming torch 1.13
+  schedule:
+    - cron: "0 2 * * *"
 
 env:
   HF_HOME: /mnt/cache
@@ -33,7 +34,9 @@ jobs:
           fetch-depth: 2
 
       - name: Check Runner Status
-        run: python utils/check_self_hosted_runner.py --target_runners single-gpu-scheduled-ci-runner-docker,multi-gpu-scheduled-ci-runner-docker --token ${{ secrets.ACCESS_REPO_INFO_TOKEN }}
+        # Temporarily running on Past CI runners
+        # run: python utils/check_self_hosted_runner.py --target_runners single-gpu-scheduled-ci-runner-docker,multi-gpu-scheduled-ci-runner-docker --token ${{ secrets.ACCESS_REPO_INFO_TOKEN }}
+        run: python utils/check_self_hosted_runner.py --target_runners single-gpu-past-ci-runner-docker,multi-gpu-past-ci-runner-docker --token ${{ secrets.ACCESS_REPO_INFO_TOKEN }}
 
   check_runners:
     name: Check Runners
@@ -41,7 +44,9 @@ jobs:
     strategy:
       matrix:
         machine_type: [single-gpu, multi-gpu]
-    runs-on: ${{ format('{0}-{1}', matrix.machine_type, 'docker') }}
+    # Temporarily running on Past CI runners
+    # runs-on: ${{ format('{0}-{1}', matrix.machine_type, 'docker') }}
+    runs-on: ${{ format('{0}-{1}', matrix.machine_type, 'docker-past-ci') }}
     container:
       image: huggingface/transformers-all-latest-torch-nightly-gpu
       options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
@@ -56,7 +61,9 @@ jobs:
     strategy:
       matrix:
         machine_type: [single-gpu, multi-gpu]
-    runs-on: ${{ format('{0}-{1}', matrix.machine_type, 'docker') }}
+    # Temporarily running on Past CI runners
+    # runs-on: ${{ format('{0}-{1}', matrix.machine_type, 'docker') }}
+    runs-on: ${{ format('{0}-{1}', matrix.machine_type, 'docker-past-ci') }}
     container:
       image: huggingface/transformers-all-latest-torch-nightly-gpu
       options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
@@ -92,7 +99,9 @@ jobs:
       matrix:
         folders: ${{ fromJson(needs.setup.outputs.matrix) }}
         machine_type: [single-gpu]
-    runs-on: ${{ format('{0}-{1}', matrix.machine_type, 'docker') }}
+    # Temporarily running on Past CI runners
+    # runs-on: ${{ format('{0}-{1}', matrix.machine_type, 'docker') }}
+    runs-on: ${{ format('{0}-{1}', matrix.machine_type, 'docker-past-ci') }}
     container:
       image: huggingface/transformers-all-latest-torch-nightly-gpu
       options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
@@ -145,7 +154,9 @@ jobs:
       matrix:
         folders: ${{ fromJson(needs.setup.outputs.matrix) }}
         machine_type: [multi-gpu]
-    runs-on: ${{ format('{0}-{1}', matrix.machine_type, 'docker') }}
+    # Temporarily running on Past CI runners
+    # runs-on: ${{ format('{0}-{1}', matrix.machine_type, 'docker') }}
+    runs-on: ${{ format('{0}-{1}', matrix.machine_type, 'docker-past-ci') }}
     container:
       image: huggingface/transformers-all-latest-torch-nightly-gpu
       options: --gpus all --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
@@ -197,7 +208,9 @@ jobs:
       fail-fast: false
       matrix:
         machine_type: [single-gpu, multi-gpu]
-    runs-on: ${{ format('{0}-{1}', matrix.machine_type, 'docker') }}
+    # Temporarily running on Past CI runners
+    # runs-on: ${{ format('{0}-{1}', matrix.machine_type, 'docker') }}
+    runs-on: ${{ format('{0}-{1}', matrix.machine_type, 'docker-past-ci') }}
     needs: setup
     container:
       image: huggingface/transformers-pytorch-deepspeed-nightly-gpu

--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -30,7 +30,22 @@ RUN echo torch=$VERSION
 # `torchvision` and `torchaudio` should be installed along with `torch`, especially for nightly build.
 # Currently, let's just use their latest releases (when `torch` is installed with a release version)
 # TODO: We might need to specify proper versions that work with a specific torch version (especially for past CI).
-RUN [ "$PYTORCH" != "pre" ] && python3 -m pip install --no-cache-dir -U $VERSION torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/$CUDA || python3 -m pip install --no-cache-dir -U --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/$CUDA
+# ----------------------------------------------------------------------------------------------------
+# Should be re-enabled later
+
+# RUN [ "$PYTORCH" != "pre" ] && python3 -m pip install --no-cache-dir -U $VERSION torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/$CUDA || python3 -m pip install --no-cache-dir -U --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/$CUDA
+
+# ----------------------------------------------------------------------------------------------------
+# Temporarily trick to install specific nightly version for torch 1.13 pre-release
+# Should be removed later
+
+RUN [ "$PYTORCH" != "pre" ] && python3 -m pip install --no-cache-dir -U $VERSION torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/$CUDA || echo "Nightly version"
+
+RUN [ "$PYTORCH" == "pre" ] && python3 -m pip install --no-cache-dir -U torch==1.13.0.dev20220914+cu113 --extra-index-url https://download.pytorch.org/whl/nightly/cu113 || echo "torch"
+RUN [ "$PYTORCH" == "pre" ] && python3 -m pip install --no-cache-dir -U torchvision==0.14.0.dev20220914+cu113 --extra-index-url https://download.pytorch.org/whl/nightly/cu113 || echo "torchvision"
+RUN [ "$PYTORCH" == "pre" ] && python3 -m pip install --no-cache-dir -U torchaudio==0.13.0.dev20220914+cu113 --extra-index-url https://download.pytorch.org/whl/nightly/cu113 || echo "torchaudio"
+
+# ----------------------------------------------------------------------------------------------------
 
 RUN python3 -m pip install --no-cache-dir -U tensorflow
 RUN python3 -m pip install --no-cache-dir -U tensorflow_probability

--- a/docker/transformers-pytorch-deepspeed-nightly-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-nightly-gpu/Dockerfile
@@ -16,12 +16,21 @@ RUN git clone https://github.com/huggingface/transformers && cd transformers && 
 # Install **nightly** release PyTorch (flag `--pre`)
 # (PyTorch must be installed before pre-compiling any DeepSpeed c++/cuda ops.)
 # (https://www.deepspeed.ai/tutorials/advanced-install/#pre-install-deepspeed-ops)
+
+# ----------------------------------------------------------------------------------------------------
+# Should be re-enabled later
+
 # RUN python3 -m pip install --no-cache-dir -U --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/$CUDA
 
-# To run for the upcoming torch 1.13
+# ----------------------------------------------------------------------------------------------------
+# Temporarily trick to install specific nightly version for torch 1.13 pre-release
+# Should be removed later
+
 RUN python3 -m pip install --no-cache-dir -U torch==1.13.0.dev20220914+cu113 --extra-index-url https://download.pytorch.org/whl/nightly/cu113
 RUN python3 -m pip install --no-cache-dir -U torchvision==0.14.0.dev20220914+cu113 --extra-index-url https://download.pytorch.org/whl/nightly/cu113
 RUN python3 -m pip install --no-cache-dir -U torchaudio==0.13.0.dev20220914+cu113 --extra-index-url https://download.pytorch.org/whl/nightly/cu113
+
+# ----------------------------------------------------------------------------------------------------
 
 RUN python3 -m pip install --no-cache-dir ./transformers[deepspeed-testing]
 

--- a/docker/transformers-pytorch-deepspeed-nightly-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-nightly-gpu/Dockerfile
@@ -16,7 +16,12 @@ RUN git clone https://github.com/huggingface/transformers && cd transformers && 
 # Install **nightly** release PyTorch (flag `--pre`)
 # (PyTorch must be installed before pre-compiling any DeepSpeed c++/cuda ops.)
 # (https://www.deepspeed.ai/tutorials/advanced-install/#pre-install-deepspeed-ops)
-RUN python3 -m pip install --no-cache-dir -U --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/$CUDA
+# RUN python3 -m pip install --no-cache-dir -U --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/$CUDA
+
+# To run for the upcoming torch 1.13
+RUN python3 -m pip install --no-cache-dir -U torch==1.13.0.dev20220914+cu113 --extra-index-url https://download.pytorch.org/whl/nightly/cu113
+RUN python3 -m pip install --no-cache-dir -U torchvision==0.14.0.dev20220914+cu113 --extra-index-url https://download.pytorch.org/whl/nightly/cu113
+RUN python3 -m pip install --no-cache-dir -U torchaudio==0.13.0.dev20220914+cu113 --extra-index-url https://download.pytorch.org/whl/nightly/cu113
 
 RUN python3 -m pip install --no-cache-dir ./transformers[deepspeed-testing]
 


### PR DESCRIPTION
# What does this PR do?

Re enable Nightly CI for upcoming PyTorch 1.13.

This is the minimal changes. We might need to check if the docker image could be built with these versions.