### PR TITLE
Cast masks to np.unit8 before converting to PIL.Image.Image

### DIFF
--- a/src/transformers/pipelines/image_segmentation.py
+++ b/src/transformers/pipelines/image_segmentation.py
@@ -172,7 +172,7 @@ class ImageSegmentationPipeline(Pipeline):
 
             for label in labels:
                 mask = (segmentation == label) * 255
-                mask = Image.fromarray(mask, mode="L")
+                mask = Image.fromarray(mask.astype(np.uint8), mode="L")
                 label = self.model.config.id2label[label]
                 annotation.append({"score": None, "label": label, "mask": mask})
         else:

--- a/tests/pipelines/test_pipelines_image_segmentation.py
+++ b/tests/pipelines/test_pipelines_image_segmentation.py
@@ -229,12 +229,12 @@ class ImageSegmentationPipelineTests(unittest.TestCase, metaclass=PipelineTestCa
                 {
                     "score": None,
                     "label": "LABEL_0",
-                    "mask": "775518a7ed09eea888752176c6ba8f38",
+                    "mask": "42d09072282a32da2ac77375a4c1280f"
                 },
                 {
                     "score": None,
                     "label": "LABEL_1",
-                    "mask": "a12da23a46848128af68c63aa8ba7a02",
+                    "mask": "46b8cc3976732873b219f77a1213c1a5",
                 },
             ],
         )

--- a/tests/pipelines/test_pipelines_image_segmentation.py
+++ b/tests/pipelines/test_pipelines_image_segmentation.py
@@ -226,11 +226,7 @@ class ImageSegmentationPipelineTests(unittest.TestCase, metaclass=PipelineTestCa
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
-                {
-                    "score": None,
-                    "label": "LABEL_0",
-                    "mask": "42d09072282a32da2ac77375a4c1280f"
-                },
+                {"score": None, "label": "LABEL_0", "mask": "42d09072282a32da2ac77375a4c1280f"},
                 {
                     "score": None,
                     "label": "LABEL_1",


### PR DESCRIPTION
# What does this PR do?

In the recent update to the image segmentation pipeline, the numpy arrays converted to `PIL.Image.Image` with mode `"L"` weren't converted to type `np.uint8`, resulting in corrupted masks. 

Running the following: 
```
import requests
from PIL import Image
from transformers import pipeline

url = "http://images.cocodataset.org/val2017/000000039769.jpg"
image = Image.open(requests.get(url, stream=True).raw)
pipe = pipeline("image-segmentation", model="facebook/detr-resnet-50-panoptic")
results = pipe(image)
```

**Output masks on `main`:**
![main_0_cat](https://user-images.githubusercontent.com/22614925/195832894-95ef005f-3e0a-4b09-9c10-88539a732d95.png)
![main_1_couch](https://user-images.githubusercontent.com/22614925/195832898-bc40d2fc-a33e-4a26-a97e-380b0a6f37b7.png)
![main_2_remote](https://user-images.githubusercontent.com/22614925/195832899-96cdae09-864f-420b-a902-2da2482d46e4.png)
![main_3_blanket](https://user-images.githubusercontent.com/22614925/195832901-9fa9f65b-089a-4c00-b216-7eabbbcd76a8.png)


**Output masks on this branch**: 
![fix_0_cat](https://user-images.githubusercontent.com/22614925/195832923-3835a988-e0b0-4f3e-a282-011daa95f4f0.png)
![fix_1_couch](https://user-images.githubusercontent.com/22614925/195832926-b7963092-4648-456d-b863-1820ea619f09.png)
![fix_2_remote](https://user-images.githubusercontent.com/22614925/195832929-f5cc2ca9-cf51-4dca-9954-5bf1500e156e.png)
![fix_3_blanket](https://user-images.githubusercontent.com/22614925/195832932-07ecf096-1c1e-4725-97a6-cf239a83e925.png)


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?