### PR TITLE
[Doctest] Add configuartion_longformer.py

### DIFF
--- a/src/transformers/models/flava/configuration_flava.py
+++ b/src/transformers/models/flava/configuration_flava.py
@@ -16,7 +16,7 @@
 
 import copy
 import os
-from typing import Any, Dict, Union
+from typing import Union, Dict, Any
 
 from ...configuration_utils import PretrainedConfig
 from ...utils import logging

--- a/src/transformers/models/flava/configuration_flava.py
+++ b/src/transformers/models/flava/configuration_flava.py
@@ -37,7 +37,7 @@ class FlavaImageConfig(PretrainedConfig):
     Instantiating a configuration with the defaults will yield a similar configuration to that of the FLAVA
     [facebook/flava-full](https://huggingface.co/facebook/flava-full) architecture.
 
-    Configuration objects inherit from [`PretrainedConfig`] and can be used to control the model outputs. Read the
+    Configuration objects (with random weights)inherit from [`PretrainedConfig`] and can be used to control the model outputs. Read the
     documentation from [`PretrainedConfig`] for more information.
 
 

--- a/src/transformers/models/longformer/configuration_longformer.py
+++ b/src/transformers/models/longformer/configuration_longformer.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """ Longformer configuration"""
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Union
+from typing import Union,Optional,Mapping,List,Any,TYPE_CHECKING
 
 from ...configuration_utils import PretrainedConfig
 from ...onnx import OnnxConfig
@@ -45,7 +45,7 @@ LONGFORMER_PRETRAINED_CONFIG_ARCHIVE_MAP = {
 
 class LongformerConfig(PretrainedConfig):
     r"""
-    This is the configuration class to store the configuration of a [`LongformerModel`] or a [`TFLongformerModel`]. It
+    This is the configuration class (with random weights) to store the configuration of a [`LongformerModel`] or a [`TFLongformerModel`]. It
     is used to instantiate a Longformer model according to the specified arguments, defining the model architecture.
 
     This is the configuration class to store the configuration of a [`LongformerModel`]. It is used to instantiate an

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -25,6 +25,7 @@ src/transformers/models/bert/modeling_tf_bert.py
 src/transformers/models/bert_generation/configuration_bert_generation.py
 src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
 src/transformers/models/big_bird/modeling_big_bird.py
+src/transformers/models/blenderbot/configuration_flava.py
 src/transformers/models/blenderbot/configuration_blenderbot.py
 src/transformers/models/blenderbot/modeling_blenderbot.py
 src/transformers/models/blenderbot_small/configuration_blenderbot_small.py

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -25,7 +25,6 @@ src/transformers/models/bert/modeling_tf_bert.py
 src/transformers/models/bert_generation/configuration_bert_generation.py
 src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
 src/transformers/models/big_bird/modeling_big_bird.py
-src/transformers/models/blenderbot/configuration_flava.py
 src/transformers/models/blenderbot/configuration_blenderbot.py
 src/transformers/models/blenderbot/modeling_blenderbot.py
 src/transformers/models/blenderbot_small/configuration_blenderbot_small.py
@@ -49,6 +48,7 @@ src/transformers/models/detr/modeling_detr.py
 src/transformers/models/dpt/modeling_dpt.py
 src/transformers/models/electra/modeling_electra.py
 src/transformers/models/electra/modeling_tf_electra.py
+src/transformers/models/flava/configuration_flava.py
 src/transformers/models/glpn/modeling_glpn.py
 src/transformers/models/gpt2/configuration_gpt2.py
 src/transformers/models/gpt2/modeling_gpt2.py
@@ -57,7 +57,6 @@ src/transformers/models/groupvit/modeling_groupvit.py
 src/transformers/models/groupvit/modeling_tf_groupvit.py
 src/transformers/models/hubert/modeling_hubert.py
 src/transformers/models/imagegpt/configuration_imagegpt.py
-
 src/transformers/models/longformer/configuration_longformer.py
 src/transformers/models/layoutlm/modeling_layoutlm.py
 src/transformers/models/layoutlm/modeling_tf_layoutlm.py

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -57,6 +57,8 @@ src/transformers/models/groupvit/modeling_groupvit.py
 src/transformers/models/groupvit/modeling_tf_groupvit.py
 src/transformers/models/hubert/modeling_hubert.py
 src/transformers/models/imagegpt/configuration_imagegpt.py
+
+src/transformers/models/longformer/configuration_longformer.py
 src/transformers/models/layoutlm/modeling_layoutlm.py
 src/transformers/models/layoutlm/modeling_tf_layoutlm.py
 src/transformers/models/layoutlmv2/modeling_layoutlmv2.py


### PR DESCRIPTION
# What does this PR do?
Fixes # 19487

Add configuration_longformer.py to utils/documentation_tests.txt for doctest.

Based on issue https://github.com/huggingface/transformers/issues/19487

@sgugger could you take a look at it?
Thanks :)