### PR TITLE
[Doctest] Add configuration_big_bird.py

### DIFF
--- a/src/transformers/models/big_bird/configuration_big_bird.py
+++ b/src/transformers/models/big_bird/configuration_big_bird.py
@@ -94,12 +94,12 @@ class BigBirdConfig(PretrainedConfig):
 
     ```
 
-        >>> from transformers import BigBirdModel, BigBirdConfig
+        >>> from transformers import BigBirdConfig, BigBirdModel
 
         >>> # Initializing a BigBird google/bigbird-roberta-base style configuration >>> configuration =
         BigBirdConfig()
 
-        >>> # Initializing a model from the google/bigbird-roberta-base style configuration >>> model =
+        >>> # Initializing a model (with random weights) from the google/bigbird-roberta-base style configuration >>> model =
         BigBirdModel(configuration)
 
         >>> # Accessing the model configuration >>> configuration = model.config

--- a/src/transformers/models/bigbird_pegasus/configuration_bigbird_pegasus.py
+++ b/src/transformers/models/bigbird_pegasus/configuration_bigbird_pegasus.py
@@ -112,12 +112,12 @@ class BigBirdPegasusConfig(PretrainedConfig):
 
     ```
 
-        >>> from transformers import BigBirdPegasusModel, BigBirdPegasusConfig
+        >>> from transformers import BigBirdPegasusConfig, BigBirdPegasusModel 
 
         >>> # Initializing a BigBirdPegasus bigbird-pegasus-base style configuration >>> configuration =
         BigBirdPegasusConfig()
 
-        >>> # Initializing a model from the bigbird-pegasus-base style configuration >>> model =
+        >>> # Initializing a model (with random weights) from the bigbird-pegasus-base style configuration >>> model =
         BigBirdPegasusModel(configuration)
 
         >>> # Accessing the model configuration >>> configuration = model.config

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -24,6 +24,7 @@ src/transformers/models/bert/modeling_bert.py
 src/transformers/models/bert/modeling_tf_bert.py
 src/transformers/models/bert_generation/configuration_bert_generation.py
 src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
+src/transformers/models/big_bird/configuration_big_bird.py
 src/transformers/models/big_bird/modeling_big_bird.py
 src/transformers/models/blenderbot/configuration_blenderbot.py
 src/transformers/models/blenderbot/modeling_blenderbot.py

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -78,6 +78,7 @@ src/transformers/models/mobilevit/modeling_tf_mobilevit.py
 src/transformers/models/opt/modeling_opt.py
 src/transformers/models/opt/modeling_tf_opt.py
 src/transformers/models/owlvit/modeling_owlvit.py
+src/transformers/models/bigbird_pegasus/configuration_bigbird_pegasus.py
 src/transformers/models/pegasus/modeling_pegasus.py
 src/transformers/models/perceiver/modeling_perceiver.py
 src/transformers/models/plbart/modeling_plbart.py


### PR DESCRIPTION
1. Change the import order of the model and configuration classes
2. Add `configuration_big_bird.py` to `utils/documentation_tests.txt` for doctest.

Documentation edit according to #19487

@sgugger could you have a look on this?