### PR TITLE
 [Doctest] Add `configuration_resnet.py`

### DIFF
--- a/src/transformers/models/resnet/configuration_resnet.py
+++ b/src/transformers/models/resnet/configuration_resnet.py
@@ -68,7 +68,7 @@ class ResNetConfig(PretrainedConfig):
 
     >>> # Initializing a model (with random weights) from the resnet-50 style configuration
     >>> model = ResNetModel(configuration)
-    
+
     >>> # Accessing the model configuration
     >>> configuration = model.config
     ```

--- a/src/transformers/models/resnet/configuration_resnet.py
+++ b/src/transformers/models/resnet/configuration_resnet.py
@@ -65,8 +65,10 @@ class ResNetConfig(PretrainedConfig):
 
     >>> # Initializing a ResNet resnet-50 style configuration
     >>> configuration = ResNetConfig()
+
     >>> # Initializing a model (with random weights) from the resnet-50 style configuration
     >>> model = ResNetModel(configuration)
+    
     >>> # Accessing the model configuration
     >>> configuration = model.config
     ```

--- a/src/transformers/models/resnet/configuration_resnet.py
+++ b/src/transformers/models/resnet/configuration_resnet.py
@@ -65,7 +65,7 @@ class ResNetConfig(PretrainedConfig):
 
     >>> # Initializing a ResNet resnet-50 style configuration
     >>> configuration = ResNetConfig()
-    >>> # Initializing a model from the resnet-50 style configuration
+    >>> # Initializing a model (with random weights) from the resnet-50 style configuration
     >>> model = ResNetModel(configuration)
     >>> # Accessing the model configuration
     >>> configuration = model.config

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -87,6 +87,7 @@ src/transformers/models/reformer/configuration_reformer.py
 src/transformers/models/reformer/modeling_reformer.py
 src/transformers/models/regnet/modeling_regnet.py
 src/transformers/models/regnet/modeling_tf_regnet.py
+src/transformers/models/resnet/configuration_resnet.py
 src/transformers/models/resnet/modeling_resnet.py
 src/transformers/models/resnet/modeling_tf_resnet.py
 src/transformers/models/roberta/configuration_roberta.py


### PR DESCRIPTION
Add `configuration_resnet.py` to `utils/documentation_tests.txt` for doctest.

Based on issue #19487

@ydshieh could you take a look at it?
Thanks =)