### PR TITLE
Add doctest info in testingmdx

### DIFF
--- a/docs/source/en/testing.mdx
+++ b/docs/source/en/testing.mdx
@@ -179,7 +179,7 @@ pytest -k "test and ada" tests/test_optimization.py
 ### Run documentation tests 
 
 In order to test whether the documentation examples are correct, you should checkt that the `doctests` are passing. 
-As an example, let's use [`WhisperModel.forward`'s docstring](https://github.com/huggingface/transformers/blob/main/src/transformers/models/whisper/modeling_whisper.py#L1016-L1034): 
+As an example, let's use [`WhisperModel.forward`'s docstring](https://github.com/huggingface/transformers/blob/main/src/transformers/models/whisper/modeling_whisper.py#L1017-L1035): 
 
 ```python 
 r"""
@@ -201,7 +201,6 @@ Example:
     >>> list(last_hidden_state.shape)
     [1, 2, 512]
     ```"""
-
 ```
 3 steps are required to debug the docstring examples : 
 1. In order to properly run the test, **an extra line has to be added** at the end of the docstring. This can be automatically done on any file using : 

--- a/docs/source/en/testing.mdx
+++ b/docs/source/en/testing.mdx
@@ -201,6 +201,7 @@ Example:
     >>> list(last_hidden_state.shape)
     [1, 2, 512]
     ```"""
+
 ```
 3 steps are required to debug the docstring examples : 
 1. In order to properly run the test, **an extra line has to be added** at the end of the docstring. This can be automatically done on any file using : 

--- a/docs/source/en/testing.mdx
+++ b/docs/source/en/testing.mdx
@@ -176,6 +176,46 @@ If you want to include only tests that include both patterns, `and` is to be use
 ```bash
 pytest -k "test and ada" tests/test_optimization.py
 ```
+### Run documentation tests 
+
+In order to test whether the documentation examples are correct, you should checkt that the `doctests` are passing. 
+As an example, let's use [`WhisperModel.forward`'s docstring](https://github.com/huggingface/transformers/blob/main/src/transformers/models/whisper/modeling_whisper.py#L1016-L1034): 
+
+```python 
+r"""
+Returns:
+
+Example:
+    ```python
+    >>> import torch
+    >>> from transformers import WhisperModel, WhisperFeatureExtractor
+    >>> from datasets import load_dataset
+
+    >>> model = WhisperModel.from_pretrained("openai/whisper-base")
+    >>> feature_extractor = WhisperFeatureExtractor.from_pretrained("openai/whisper-base")
+    >>> ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
+    >>> inputs = feature_extractor(ds[0]["audio"]["array"], return_tensors="pt")
+    >>> input_features = inputs.input_features
+    >>> decoder_input_ids = torch.tensor([[1, 1]]) * model.config.decoder_start_token_id
+    >>> last_hidden_state = model(input_features, decoder_input_ids=decoder_input_ids).last_hidden_state
+    >>> list(last_hidden_state.shape)
+    [1, 2, 512]
+    ```"""
+```
+3 steps are required to debug the docstring examples : 
+1. In order to properly run the test, **an extra line has to be added** at the end of the docstring. This can be automatically done on any file using : 
+```bash 
+python utils/prepare_for_doc_test.py <path_to_file_or_dir>
+```
+
+2. Then, you can use the following line to automatically test every docstring example in the desired file : 
+```bash 
+pytest --doctest-modules <path_to_file_or_dir>
+```
+3. Once you are done debugging, you need to remove the extra line added in step **1.** by running the follwing : 
+```bash 
+python utils/prepare_for_doc_test.py <path_to_file_or_dir> --remove_new_line
+```
 
 ### Run only modified tests
 


### PR DESCRIPTION
# What does this PR do?

Finding information on how to properly test the docstring is currently pretty hard! As far as I know, the only good explanation is in `transformers/utils/prepare_for_doc_test.py` but it does not appear in the doc. I hope this will help people debug their docstring examples. 