### PR TITLE
 [Doctest] Add `configuration_data2vec_text.py`

### DIFF
--- a/src/transformers/models/data2vec/configuration_data2vec_text.py
+++ b/src/transformers/models/data2vec/configuration_data2vec_text.py
@@ -82,12 +82,12 @@ class Data2VecTextConfig(PretrainedConfig):
     Examples:
 
     ```python
-    >>> from transformers import Data2VecTextModel, Data2VecTextConfig
+    >>> from transformers import Data2VecTextConfig, Data2VecTextModel
 
     >>> # Initializing a Data2VecText facebook/data2vec-text-base style configuration
     >>> configuration = Data2VecTextConfig()
 
-    >>> # Initializing a model from the facebook/data2vec-text-base style configuration
+    >>> # Initializing a model (with random weights) from the facebook/data2vec-text-base style configuration
     >>> model = Data2VecTextModel(configuration)
 
     >>> # Accessing the model configuration

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -38,8 +38,8 @@ src/transformers/models/convnext/modeling_convnext.py
 src/transformers/models/ctrl/configuration_ctrl.py
 src/transformers/models/ctrl/modeling_ctrl.py
 src/transformers/models/cvt/modeling_cvt.py
-src/transformers/models/data2vec/modeling_data2vec_audio.py
 src/transformers/models/data2vec/configuration_data2vec_text.py
+src/transformers/models/data2vec/modeling_data2vec_audio.py
 src/transformers/models/data2vec/modeling_data2vec_vision.py
 src/transformers/models/deberta/modeling_deberta.py
 src/transformers/models/deberta_v2/modeling_deberta_v2.py

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -39,7 +39,7 @@ src/transformers/models/ctrl/configuration_ctrl.py
 src/transformers/models/ctrl/modeling_ctrl.py
 src/transformers/models/cvt/modeling_cvt.py
 src/transformers/models/data2vec/modeling_data2vec_audio.py
-src/transformers/models/data2vec/configuration_data2vec_vision.py
+src/transformers/models/data2vec/configuration_data2vec_text.py
 src/transformers/models/data2vec/modeling_data2vec_vision.py
 src/transformers/models/deberta/modeling_deberta.py
 src/transformers/models/deberta_v2/modeling_deberta_v2.py

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -39,6 +39,7 @@ src/transformers/models/ctrl/configuration_ctrl.py
 src/transformers/models/ctrl/modeling_ctrl.py
 src/transformers/models/cvt/modeling_cvt.py
 src/transformers/models/data2vec/modeling_data2vec_audio.py
+src/transformers/models/data2vec/configuration_data2vec_vision.py
 src/transformers/models/data2vec/modeling_data2vec_vision.py
 src/transformers/models/deberta/modeling_deberta.py
 src/transformers/models/deberta_v2/modeling_deberta_v2.py


### PR DESCRIPTION
Add `configuration_data2vec_text.py` to `utils/documentation_tests.txt` for doctest.

Based on issue #19487

@ydshieh could you please check it?
Thanks :)